### PR TITLE
security: add security review & refactoring plan; remove default Neo4j password

### DIFF
--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -1,0 +1,37 @@
+# Refactoring Plan
+
+## Current Problems
+
+- Security-relevante Defaults sind teilweise zu permissiv (Auth optional, historischer Passwort-Default).
+- API-Auth ist technisch zentralisiert, aber Policy (wann zwingend?) ist nicht als klarer Betriebsmodus codiert.
+- Security-Checks sind nicht fest im Standard-Check-Flow verankert.
+- Einige Risiko-Themen sind dokumentiert, aber nicht in klare, kleine Umsetzungspakete zerlegt.
+
+## Recommended Target Structure
+
+- **Config Policy Layer**: explizite Sicherheitsmodi (`development`, `hardened`, `production`) mit Fail-Fast-Regeln.
+- **Auth Surface**: zentraler Guard bleibt, aber URL-Token nur noch über signierte Kurzzeit-Tickets.
+- **CI Security Stage**: reproduzierbare, cachbare Dependency- und Secret-Scans als eigener Pipeline-Abschnitt.
+- **Dokumentation**: Security-Baseline als lebende Checkliste (`SECURITY_REVIEW.md` + issue-getriebene Umsetzung).
+
+## Refactoring Tasks
+
+| Priority | Task | Reason | Risk | Suggested PR |
+|---|---|---|---|---|
+| P0 | Auth in Non-Debug standardmäßig erzwingen oder explizites Allow-Flag einführen | verhindert offene API-Deployments | Mittel (Deployment-Anpassung nötig) | `security/repo-hardening` |
+| P0 | SSE/Download Auth von Query-Token auf kurzlebige signed tickets migrieren | reduziert Token-Leakage in URLs/Logs | Mittel | `security/repo-hardening` |
+| P1 | Security-Scans in CI integrieren (`npm audit`, Python-Audit, Secret Scan) | frühzeitige Erkennung neuer Risiken | Niedrig | `ci/add-security-checks` |
+| P1 | Einheitliche Error-Envelope inkl. Security-safe Fehlermeldungen prüfen/erzwingen | konsistente API + weniger Info-Leaks | Niedrig-Mittel | `refactor/code-quality-pass` |
+| P2 | Logging-Review auf Secret-Redaction und Token-Schutz | verhindert versehentliche Secret-Exposition | Niedrig | `refactor/code-quality-pass` |
+
+## Safe First Steps
+
+1. Insecure Defaults entfernen (umgesetzt: `NEO4J_PASSWORD` ohne statischen Fallback).
+2. Security-Review und priorisierte Tasks dokumentieren.
+3. Kleine, nicht-breaking Härtungsänderungen in getrennten PRs durchführen.
+
+## Larger Follow-Up Work
+
+- Signed URL/Ticket-System für SSE und Artefakt-Downloads.
+- Harte Auth-Policy in Prod inklusive klarer Migrationshinweise.
+- Security-Regression-Tests (z. B. Auth required, CORS policy, token leakage checks).

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -12,7 +12,7 @@ Das Repository hat bereits gute Baseline-Härtung (nicht-root Container-User, ze
 | Medium | Secret Handling | Token-Fallback über Query-Parameter (`?token=`) | Token kann in Reverse-Proxy-Logs, Browser-History, Monitoring auftauchen | Kurzfristig dokumentieren + Log-Redaction; mittelfristig kurzlebige Signed URLs/one-time tokens |
 | Medium | Configuration | Historischer Neo4j-Passwort-Default (`agora`) in Code | Risiko schwacher/vergessener Defaults in lokalen/CI-Setups | Default entfernen, Passwort zwingend via Env setzen |
 | Low | Dependency Security | Kein durchgängiger Security-Scan im `npm run check` Flow | Schwachstellen werden ggf. spät entdeckt | CI-Job mit `npm audit` + `pip-audit` (oder OSV-Scan) ergänzen |
-| Info | Container Hardening | Container läuft als non-root User (`agora`) | Positiv: reduziert Impact bei Container-Komprimittierung | Beibehalten, zusätzlich read-only rootfs + capabilities drop prüfen |
+| Info | Container Hardening | Container läuft als non-root User (agora) | Positiv: reduziert Impact bei Container-Kompromittierung | Beibehalten, zusätzlich read-only rootfs + capabilities drop prüfen |
 
 ## Findings
 

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,76 @@
+# Security Review
+
+## Summary
+
+Das Repository hat bereits gute Baseline-Härtung (nicht-root Container-User, zentrale Token-Guard-Option, restriktive CORS-Defaults, Upload-Größenlimit, Healthchecks). Die wichtigsten Risiken liegen aktuell in **unsicheren Dev-Defaults** (API offen ohne Token) und in der **Query-Token-Nutzung für SSE/Downloads** (Leakage-Risiko in URL-basierten Logs/Proxies). Zusätzlich fehlt ein automatisierter Security-Scan in der Standard-Quality-Gate-Pipeline.
+
+## Risk Table
+
+| Severity | Area | Finding | Impact | Recommendation |
+|---|---|---|---|---|
+| High | AuthN/AuthZ | API ist standardmäßig offen, wenn `AGORA_AUTH_TOKEN` nicht gesetzt ist | Unautorisierter Zugriff auf `/api/*` in falsch konfigurierten Deployments | Secure-by-default erzwingen (Prod-Fail ohne Token) oder expliziten `ALLOW_UNAUTH_DEV=true` Schalter nutzen |
+| Medium | Secret Handling | Token-Fallback über Query-Parameter (`?token=`) | Token kann in Reverse-Proxy-Logs, Browser-History, Monitoring auftauchen | Kurzfristig dokumentieren + Log-Redaction; mittelfristig kurzlebige Signed URLs/one-time tokens |
+| Medium | Configuration | Historischer Neo4j-Passwort-Default (`agora`) in Code | Risiko schwacher/vergessener Defaults in lokalen/CI-Setups | Default entfernen, Passwort zwingend via Env setzen |
+| Low | Dependency Security | Kein durchgängiger Security-Scan im `npm run check` Flow | Schwachstellen werden ggf. spät entdeckt | CI-Job mit `npm audit` + `pip-audit` (oder OSV-Scan) ergänzen |
+| Info | Container Hardening | Container läuft als non-root User (`agora`) | Positiv: reduziert Impact bei Container-Komprimittierung | Beibehalten, zusätzlich read-only rootfs + capabilities drop prüfen |
+
+## Findings
+
+### Finding 1: API standardmäßig offen ohne gesetztes Auth-Token
+
+- Severity: High
+- File(s): `backend/app/utils/auth.py`, `backend/app/__init__.py`
+- Description: Der Guard wird nur aktiv, wenn `AGORA_AUTH_TOKEN` gesetzt ist; sonst werden alle `/api/*` Requests ohne Auth akzeptiert.
+- Risk: Fehlkonfigurierte Deployments können unabsichtlich öffentliche API-Endpunkte bereitstellen.
+- Evidence: `_expected_token()` nutzt leere Default-Variable und `install_blueprint_guard` ist dann No-Op.
+- Recommendation: In Nicht-Debug-Umgebungen einen Start-Abbruch ohne Token erzwingen oder explizites `AGORA_ALLOW_UNAUTHENTICATED=true` nur für lokale Dev erlauben.
+- Suggested Fix: Konfigurationsvalidierung um Auth-Policy ergänzen (Follow-up-PR).
+
+### Finding 2: Query-Token-Fallback erhöht Leakage-Risiko
+
+- Severity: Medium
+- File(s): `backend/app/utils/auth.py`, `frontend/src/api/stream.js`
+- Description: Token kann per `?token=` übergeben werden, da `EventSource` keine Custom-Header setzt.
+- Risk: URL-basierte Tokens können in Browser-History, Referrer, Proxy/Edge-Logs landen.
+- Evidence: `_extract_token()` liest `request.args['token']`; Frontend hängt Token an SSE-URL an.
+- Recommendation: Kurzfristig klare Ops-Doku + Log-Redaction; mittelfristig signed short-lived stream URLs oder serverseitige Session-Cookies.
+- Suggested Fix: Security-Backlog-Issue für Signed stream tickets (TTL, one-time use, scope-bound).
+
+### Finding 3: Insecure Neo4j Passwort-Default (behoben)
+
+- Severity: Medium
+- File(s): `backend/app/config.py`
+- Description: Das Passwort hatte einen statischen Fallback (`agora`).
+- Risk: Erhöht Wahrscheinlichkeit schwacher oder unbeabsichtigter Standard-Credentials.
+- Evidence: Konfigurationswert im Code-Default.
+- Recommendation: Kein Passwort-Default im Code.
+- Suggested Fix: **Umgesetzt** — Default auf leer gesetzt, damit `validate()` fehlende Credentials erkennt.
+
+## Dependency Review
+
+- `npm audit --json`: keine bekannten Vulnerabilities im Root-Node-Set.
+- `pip-audit` via `uv run pip-audit`: im aktuellen Environment nicht vollständig abgeschlossen (massiver Erstinstall inkl. großer ML/GPU-Artefakte, Laufzeit-/Ressourcenaufwand hoch).
+
+Assumption:
+Python-Dependency-Risiken sind nicht vollständig verifiziert.
+Evidence:
+Audit-Lauf startete mit umfangreichen Download-/Build-Schritten und konnte in sinnvoller Review-Zeit nicht final abgeschlossen werden.
+Recommended verification:
+Dedizierten CI-Job mit gecachtem `uv sync` + `pip-audit` (oder `osv-scanner`) einführen.
+
+## Configuration Review
+
+- Positiv: `SECRET_KEY` ist verpflichtend außerhalb Debug; CORS per Default auf localhost eingeschränkt; Upload-Limit (`50MB`) gesetzt.
+- Risiko: Offene API im Default ohne `AGORA_AUTH_TOKEN`.
+- Fix umgesetzt: Entfernen des statischen `NEO4J_PASSWORD`-Defaults.
+
+## CI/CD Review
+
+- Vorhandene lokale Quality-Gate-Skripte (`npm run check`) sind gut, aber Security-Scans sind nicht verpflichtender Teil.
+- Empfehlung: CI um Security-Stufe erweitern (`npm audit`, Python-Audit, ggf. Secret-Scanner wie `gitleaks`).
+
+## Open Questions
+
+1. Soll in Production ein hartes Auth-Requirement gelten (Start-Fail ohne `AGORA_AUTH_TOKEN`)?
+2. Welches Zielbild ist gewünscht für SSE-Auth ohne Query-Token (signed URLs vs Cookie-basiert)?
+3. Soll ein offizieller Secret-Scanning-Workflow in CI verpflichtend werden?

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -78,7 +78,8 @@ class Config:
     # Neo4j configuration
     NEO4J_URI = os.environ.get('NEO4J_URI', 'bolt://localhost:7687')
     NEO4J_USER = os.environ.get('NEO4J_USER', 'neo4j')
-    NEO4J_PASSWORD = os.environ.get('NEO4J_PASSWORD', 'agora')
+    # No insecure default password. Must be provided via environment (.env / secret manager).
+    NEO4J_PASSWORD = os.environ.get('NEO4J_PASSWORD', '')
 
     # Agent tool-use during simulation. Experimental and intentionally opt-in.
     ENABLE_AGENT_TOOLS = os.environ.get('ENABLE_AGENT_TOOLS', 'false').lower() in ('true', '1', 'yes')


### PR DESCRIPTION
### Motivation

- Improve repository security posture by documenting findings and creating an actionable refactoring roadmap. 
- Eliminate an insecure default credential to avoid accidental weak deployments by forcing operators to provide `NEO4J_PASSWORD` via environment/secret store. 
- Prepare small, safe follow-up PRs (auth hardening, SSE ticketing, CI scans) by centralizing recommended tasks.

### Description

- Added a repository-level security artefact `SECURITY_REVIEW.md` that contains OWASP-aligned findings, a risk table, dependency/config/CI notes and recommended fixes. 
- Added a prioritized `REFACTORING_PLAN.md` that maps problems to small, scoped PRs and lists safe first steps and larger follow-ups. 
- Hardened config by changing `backend/app/config.py` so `NEO4J_PASSWORD` no longer defaults to the insecure string and must be supplied via environment (removed the `'agora'` fallback). 
- Changes were committed and a PR was prepared that bundles the documentation and the low-risk config hardening.

### Testing

- Ran backend linting with `npm run lint:backend` and it passed successfully. 
- Ran frontend linting with `npm run lint:frontend` and it passed successfully. 
- Executed `npm audit --json` at repo root and it reported no known vulnerabilities in the root Node dependency set. 
- Attempted `cd backend && uv run pip-audit` but the first-time dependency resolution/download was large and the audit could not be completed in the review window, so Python dependency auditing remains to be run in CI with caching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1998f7950832888bd0fd3f9a6daa1)