### PR TITLE
feat(api): EPIC-09 ST-01 — ApiErrorCode catalogue

### DIFF
--- a/backend/app/utils/api_errors.py
+++ b/backend/app/utils/api_errors.py
@@ -1,0 +1,88 @@
+"""Zentraler Katalog für API-Fehlercodes plus deutsche Default-Messages.
+
+Codes sind ``StrEnum`` und können überall dort verwendet werden, wo bisher
+String-Literale wie ``code="not_found"`` standen — Vergleich mit Strings bleibt
+funktionsgleich (Backwards-Compat).
+
+Verwendung::
+
+    from app.utils.api_errors import ApiErrorCode
+    from app.utils.api_responses import json_error
+
+    return json_error(ApiErrorCode.INVALID_ID, status=400)
+    # → {"success": false, "code": "invalid_id", "error": "Ungültige ID"}
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ApiErrorCode(StrEnum):
+    """Enumerierter Code-Katalog. Wert == lowercase Name."""
+
+    INVALID_ID = "invalid_id"
+    NOT_FOUND = "not_found"
+    VALIDATION_FAILED = "validation_failed"
+    BAD_REQUEST = "bad_request"
+    METHOD_NOT_ALLOWED = "method_not_allowed"
+
+    AUTH_REQUIRED = "auth_required"
+    AUTH_INVALID = "auth_invalid"
+    AUTH_FORBIDDEN = "auth_forbidden"
+
+    RATE_LIMITED = "rate_limited"
+    TIMEOUT = "timeout"
+
+    SERVICE_UNAVAILABLE = "service_unavailable"
+    NEO4J_UNAVAILABLE = "neo4j_unavailable"
+    LLM_UNAVAILABLE = "llm_unavailable"
+
+    ONTOLOGY_MISSING = "ontology_missing"
+    ONTOLOGY_GENERATION_FAILED = "ontology_generation_failed"
+
+    SIMULATION_NOT_PREPARED = "simulation_not_prepared"
+    SIMULATION_ALREADY_RUNNING = "simulation_already_running"
+    PERSONA_REVIEW_REQUIRED = "persona_review_required"
+
+    UPLOAD_TOO_LARGE = "upload_too_large"
+    UNSUPPORTED_FORMAT = "unsupported_format"
+
+    INTERNAL_ERROR = "internal_error"
+    NOT_IMPLEMENTED = "not_implemented"
+
+
+DEFAULT_MESSAGES: dict[ApiErrorCode, str] = {
+    ApiErrorCode.INVALID_ID: "Ungültige ID",
+    ApiErrorCode.NOT_FOUND: "Nicht gefunden",
+    ApiErrorCode.VALIDATION_FAILED: "Eingabe ungültig",
+    ApiErrorCode.BAD_REQUEST: "Ungültige Anfrage",
+    ApiErrorCode.METHOD_NOT_ALLOWED: "Methode nicht erlaubt",
+
+    ApiErrorCode.AUTH_REQUIRED: "Authentifizierung erforderlich",
+    ApiErrorCode.AUTH_INVALID: "Authentifizierung ungültig",
+    ApiErrorCode.AUTH_FORBIDDEN: "Zugriff verweigert",
+
+    ApiErrorCode.RATE_LIMITED: "Zu viele Anfragen",
+    ApiErrorCode.TIMEOUT: "Zeitüberschreitung",
+
+    ApiErrorCode.SERVICE_UNAVAILABLE: "Dienst nicht verfügbar",
+    ApiErrorCode.NEO4J_UNAVAILABLE: "Neo4j nicht erreichbar",
+    ApiErrorCode.LLM_UNAVAILABLE: "LLM-Endpoint nicht erreichbar",
+
+    ApiErrorCode.ONTOLOGY_MISSING: "Ontologie fehlt",
+    ApiErrorCode.ONTOLOGY_GENERATION_FAILED: "Ontologie-Generierung fehlgeschlagen",
+
+    ApiErrorCode.SIMULATION_NOT_PREPARED: "Simulation noch nicht vorbereitet",
+    ApiErrorCode.SIMULATION_ALREADY_RUNNING: "Simulation läuft bereits",
+    ApiErrorCode.PERSONA_REVIEW_REQUIRED: "Persona-Review erforderlich",
+
+    ApiErrorCode.UPLOAD_TOO_LARGE: "Upload zu groß",
+    ApiErrorCode.UNSUPPORTED_FORMAT: "Format nicht unterstützt",
+
+    ApiErrorCode.INTERNAL_ERROR: "Interner Serverfehler",
+    ApiErrorCode.NOT_IMPLEMENTED: "Nicht implementiert",
+}
+
+
+__all__ = ["ApiErrorCode", "DEFAULT_MESSAGES"]

--- a/backend/app/utils/api_responses.py
+++ b/backend/app/utils/api_responses.py
@@ -31,6 +31,7 @@ from werkzeug.exceptions import HTTPException
 
 from ..config import Config
 from ..utils.logger import get_logger
+from .api_errors import DEFAULT_MESSAGES, ApiErrorCode
 
 
 _default_logger = get_logger("agora.api")
@@ -65,22 +66,39 @@ def json_success(data: Any = None, *, status: int = 200, **extra: Any):
 
 
 def json_error(
-    message: str,
+    error: str | ApiErrorCode,
     status: int = 400,
     *,
     code: str | None = None,
+    message: str | None = None,
     include_traceback: bool = False,
     extra: Mapping[str, Any] | None = None,
 ):
     """
     Build a standard error envelope.
 
+    Two call styles:
+
+    - ``json_error("Frei formulierter Text", status=400)`` — Legacy-Pfad,
+      Body ohne ``code`` (oder mit explizit übergebenem ``code=...``).
+    - ``json_error(ApiErrorCode.INVALID_ID, status=400)`` — Code-Pfad,
+      ``code`` und Default-Message werden aus dem Katalog gezogen. Über
+      ``message="..."`` lässt sich die Default-Message punktuell überschreiben,
+      ohne den Code zu verlieren.
+
     Keeps the ``traceback`` field opt-in so that internal server errors can
     surface the trace in debug mode without changing the shape for 4xx errors.
     """
-    payload: dict[str, Any] = {"success": False, "error": message}
-    if code:
-        payload["code"] = code
+    if isinstance(error, ApiErrorCode):
+        resolved_code = code or error.value
+        resolved_text = message if message is not None else DEFAULT_MESSAGES[error]
+    else:
+        resolved_code = code
+        resolved_text = message if message is not None else error
+
+    payload: dict[str, Any] = {"success": False, "error": resolved_text}
+    if resolved_code:
+        payload["code"] = resolved_code
     if include_traceback:
         payload["traceback"] = traceback.format_exc()
     if extra:

--- a/backend/tests/utils/test_api_errors.py
+++ b/backend/tests/utils/test_api_errors.py
@@ -1,0 +1,121 @@
+"""Tests for app.utils.api_errors — ApiErrorCode catalogue + json_error integration."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+from app.utils.api_errors import DEFAULT_MESSAGES, ApiErrorCode
+from app.utils.api_responses import json_error
+
+
+REQUIRED_CODES = {
+    "invalid_id",
+    "not_found",
+    "validation_failed",
+    "auth_required",
+    "auth_invalid",
+    "auth_forbidden",
+    "rate_limited",
+    "service_unavailable",
+    "neo4j_unavailable",
+    "llm_unavailable",
+    "ontology_missing",
+    "ontology_generation_failed",
+    "simulation_not_prepared",
+    "simulation_already_running",
+    "persona_review_required",
+    "upload_too_large",
+    "unsupported_format",
+    "timeout",
+    "internal_error",
+    "not_implemented",
+    "bad_request",
+    "method_not_allowed",
+}
+
+
+def _ctx():
+    return Flask(__name__).test_request_context()
+
+
+def test_catalogue_covers_required_codes():
+    have = {c.value for c in ApiErrorCode}
+    missing = REQUIRED_CODES - have
+    assert not missing, f"missing codes: {sorted(missing)}"
+    assert len(have) >= 20
+
+
+def test_each_code_has_non_empty_default_message():
+    for code in ApiErrorCode:
+        msg = DEFAULT_MESSAGES.get(code)
+        assert msg, f"missing default message for {code}"
+        assert isinstance(msg, str)
+        assert msg.strip() == msg, f"message for {code} has leading/trailing whitespace"
+        assert not msg.endswith("."), f"message for {code} ends with period: {msg!r}"
+
+
+def test_str_enum_compares_equal_to_literal_string():
+    # Backwards-compat: existing call sites pass code="not_found" as str literal.
+    assert ApiErrorCode.NOT_FOUND == "not_found"
+    assert "invalid_id" == ApiErrorCode.INVALID_ID
+    # Membership against a set of strings still works.
+    assert ApiErrorCode.TIMEOUT in {"timeout", "other"}
+
+
+def test_str_enum_value_matches_member_name_lowercased():
+    for code in ApiErrorCode:
+        assert code.value == code.name.lower(), (
+            f"{code.name} value {code.value!r} should be lowercase of name"
+        )
+
+
+def test_json_error_with_api_error_code_uses_default_message_and_sets_code():
+    with _ctx():
+        response, status = json_error(ApiErrorCode.INVALID_ID)
+        payload = response.get_json()
+    assert status == 400
+    assert payload == {
+        "success": False,
+        "error": DEFAULT_MESSAGES[ApiErrorCode.INVALID_ID],
+        "code": "invalid_id",
+    }
+
+
+def test_json_error_with_api_error_code_respects_explicit_status():
+    with _ctx():
+        response, status = json_error(ApiErrorCode.NOT_FOUND, status=404)
+        payload = response.get_json()
+    assert status == 404
+    assert payload["code"] == "not_found"
+    assert payload["error"] == DEFAULT_MESSAGES[ApiErrorCode.NOT_FOUND]
+
+
+def test_json_error_with_api_error_code_allows_explicit_message_override():
+    with _ctx():
+        response, status = json_error(
+            ApiErrorCode.SIMULATION_NOT_PREPARED,
+            status=409,
+            message="Bitte erst Personas reviewen",
+        )
+        payload = response.get_json()
+    assert status == 409
+    assert payload["code"] == "simulation_not_prepared"
+    assert payload["error"] == "Bitte erst Personas reviewen"
+
+
+def test_json_error_with_string_message_is_unchanged():
+    # Backwards-compat: bestehende string-basierte Aufrufe bleiben gültig.
+    with _ctx():
+        response, status = json_error("specific legacy message", status=400)
+        payload = response.get_json()
+    assert status == 400
+    assert payload == {"success": False, "error": "specific legacy message"}
+
+
+def test_json_error_string_with_explicit_code_is_unchanged():
+    with _ctx():
+        response, status = json_error("legacy", status=500, code="legacy_code")
+        payload = response.get_json()
+    assert status == 500
+    assert payload["code"] == "legacy_code"
+    assert payload["error"] == "legacy"


### PR DESCRIPTION
## Summary

EPIC-09 Sub-Slice 1: zentraler Error-Code-Katalog als Basis für die kommende API-Contract-Standardisierung.

- Neuer Modul `backend/app/utils/api_errors.py`: `ApiErrorCode(StrEnum)` mit 22 Codes (Plan-DoD ≥20) und `DEFAULT_MESSAGES`-Dict (deutsche Texte, knapp, kein End-Punkt).
- `json_error()` in `backend/app/utils/api_responses.py` erkennt jetzt `ApiErrorCode`-Instanzen und zieht Default-Message + Code automatisch; neuer optionaler `message=`-Kwarg für Override.
- Backwards-Compat: alle 198 bestehenden positional-string-Aufrufe von `json_error("text", status=...)` funktionieren unverändert. StrEnum vergleicht equal mit Stringliteralen, daher bricht auch `code="not_found"`-Logik nirgends.
- Tests: neuer Pfad `backend/tests/utils/test_api_errors.py` mit 9 Tests — Code-Vollständigkeit, Default-Message-Sanity, StrEnum-Compat, Code-/String-Pfade von `json_error`.

## Folge-Slices auf diesem Branch geplant

Sub-Slice 2 (graph.py auf Codes umstellen), Sub-Slice 3 (simulation_*.py + Chinesisch raus), Sub-Slice 4 (Response-Schemas dokumentieren + Schema-Tests), Sub-Slice 5 (Frontend Envelope-Mapper, TS-ready), Sub-Slice 6 (CHANGELOG + Backlog-Update). PLAN.md im Hauptrepo (gitignored).

## Test plan

- [x] `cd backend && uv run pytest tests/utils/test_api_errors.py tests/test_api_responses.py -v` — 24 passed
- [x] `npm run check` — Backend-Lint clean, **349 Backend-Tests passed** (vorher 340 → +9), 2 skipped (Redis ohne `TEST_REDIS_URL` — bekannt), Frontend-Lint clean, Vite-Build 2.64 s
- [ ] Smoke folgt mit Sub-Slice 2 (Upload-Flow + GraphPanel laden)

## Rollback

`git revert HEAD --no-edit` — pure additive Änderung, kein Schema-/DB-Touch.