### PR TITLE
refactor(api): EPIC-09 Sub-Slice 3 — simulation endpoints to ApiErrorCode + CN punctuation cleanup

### DIFF
--- a/backend/app/api/simulation_entities.py
+++ b/backend/app/api/simulation_entities.py
@@ -6,6 +6,7 @@ from flask import request
 
 from . import simulation_bp
 from ..services.entity_reader import EntityReader
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.validation import validate_graph_id
 from .simulation_common import get_simulation_storage, logger
@@ -16,7 +17,10 @@ from .simulation_common import get_simulation_storage, logger
 def get_graph_entities(graph_id: str):
     """Get all entities from the knowledge graph (filtered)."""
     if not validate_graph_id(graph_id):
-        return json_error("Invalid graph_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid graph_id format",
+        )
 
     entity_types_str = request.args.get('entity_types', '')
     entity_types = [t.strip() for t in entity_types_str.split(',') if t.strip()] if entity_types_str else None
@@ -41,14 +45,21 @@ def get_graph_entities(graph_id: str):
 def get_entity_detail(graph_id: str, entity_uuid: str):
     """Get detailed information for a single entity."""
     if not validate_graph_id(graph_id):
-        return json_error("Invalid graph_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid graph_id format",
+        )
 
     storage = get_simulation_storage()
     reader = EntityReader(storage)
     entity = reader.get_entity_with_context(graph_id, entity_uuid)
 
     if not entity:
-        return json_error(f"Entity does not exist: {entity_uuid}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Entity does not exist: {entity_uuid}",
+        )
 
     return json_success(entity.to_dict())
 
@@ -58,7 +69,10 @@ def get_entity_detail(graph_id: str, entity_uuid: str):
 def get_entities_by_type(graph_id: str, entity_type: str):
     """Get all entities of the specified type."""
     if not validate_graph_id(graph_id):
-        return json_error("Invalid graph_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid graph_id format",
+        )
 
     enrich = request.args.get('enrich', 'true').lower() == 'true'
 

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -15,6 +15,7 @@ from ..services.entity_reader import EntityReader
 from ..services.oasis_profile_generator import OasisProfileGenerator
 from ..services.simulation_manager import SimulationManager
 from ..services.simulation_runner import SimulationRunner
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.validation import validate_simulation_id
@@ -140,7 +141,10 @@ def generate_profiles():
     data = request.get_json() or {}
     graph_id = data.get('graph_id')
     if not graph_id:
-        return json_error("Please provide graph_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide graph_id",
+        )
 
     entity_types = data.get('entity_types')
     use_llm = data.get('use_llm', True)
@@ -156,7 +160,11 @@ def generate_profiles():
         enrich_with_edges=True,
     )
     if filtered.filtered_count == 0:
-        return json_error("No matching entities found")
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message="No matching entities found",
+        )
 
     generator = OasisProfileGenerator()
     profiles = generator.generate_profiles_from_entities(entities=filtered.entities, use_llm=use_llm)
@@ -180,7 +188,10 @@ def generate_profiles():
 def get_simulation_posts(simulation_id: str):
     """Get posts from a simulation SQLite database."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     platform = request.args.get('platform', 'reddit')
     limit = request.args.get('limit', 50, type=int)
@@ -192,7 +203,7 @@ def get_simulation_posts(simulation_id: str):
             "platform": platform,
             "count": 0,
             "posts": [],
-            "message": "Database does not exist，SimulationMay not have run yet",
+            "message": "Database does not exist, simulation may not have run yet",
         })
 
     conn = _connect_sqlite_readonly(db_path)
@@ -225,7 +236,10 @@ def get_simulation_posts(simulation_id: str):
 def get_simulation_comments(simulation_id: str):
     """Get comments from the Reddit simulation database."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     post_id = request.args.get('post_id')
     limit = request.args.get('limit', 50, type=int)

--- a/backend/app/api/simulation_interviews.py
+++ b/backend/app/api/simulation_interviews.py
@@ -6,6 +6,7 @@ from flask import jsonify, request
 
 from . import simulation_bp
 from ..services.simulation_runner import SimulationRunner
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.validation import validate_simulation_id
 from .simulation_common import logger, optimize_interview_prompt
@@ -14,23 +15,36 @@ from .simulation_common import logger, optimize_interview_prompt
 def _require_simulation_id(simulation_id):
     """Shared guard: simulation_id present + well-formed."""
     if not simulation_id:
-        return json_error("Please provide simulation_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_id",
+        )
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
     return None
 
 
 def _validate_platform(platform):
     if platform and platform not in ("twitter", "reddit"):
-        return json_error("platform Parameter can only be 'twitter' Or 'reddit'")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="platform parameter must be 'twitter' or 'reddit'",
+        )
     return None
 
 
 def _require_env_alive(simulation_id: str):
     if not SimulationRunner.check_env_alive(simulation_id):
         return json_error(
-            "Simulation environment not running or closed. "
-            "Please ensure simulation is started and wait for it to progress."
+            ApiErrorCode.SERVICE_UNAVAILABLE,
+            status=503,
+            message=(
+                "Simulation environment not running or closed. "
+                "Please ensure simulation is started and wait for it to progress."
+            ),
         )
     return None
 
@@ -62,9 +76,15 @@ def interview_agent():
     timeout = data.get('timeout', 60)
 
     if agent_id is None:
-        return json_error("Please provide agent_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide agent_id",
+        )
     if not prompt:
-        return json_error("Please provide prompt（Interview question）")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide prompt (interview question)",
+        )
 
     platform_error = _validate_platform(platform)
     if platform_error:
@@ -101,7 +121,10 @@ def interview_agents_batch():
     timeout = data.get('timeout', 120)
 
     if not interviews or not isinstance(interviews, list):
-        return json_error("Please provide interviews（Interview list）")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide interviews (interview list)",
+        )
 
     platform_error = _validate_platform(platform)
     if platform_error:
@@ -109,13 +132,20 @@ def interview_agents_batch():
 
     for index, interview in enumerate(interviews, 1):
         if 'agent_id' not in interview:
-            return json_error(f"Interview list item{index}Missing agent_id")
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                message=f"Interview list item {index} missing agent_id",
+            )
         if 'prompt' not in interview:
-            return json_error(f"Interview list item{index}Missing prompt")
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                message=f"Interview list item {index} missing prompt",
+            )
         item_platform = interview.get('platform')
         if item_platform and item_platform not in ("twitter", "reddit"):
             return json_error(
-                f"Interview list item {index}: platform must be 'twitter' or 'reddit'"
+                ApiErrorCode.VALIDATION_FAILED,
+                message=f"Interview list item {index}: platform must be 'twitter' or 'reddit'",
             )
 
     env_error = _require_env_alive(simulation_id)
@@ -153,7 +183,10 @@ def interview_all_agents():
     timeout = data.get('timeout', 180)
 
     if not prompt:
-        return json_error("Please provide prompt（Interview question）")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide prompt (interview question)",
+        )
 
     platform_error = _validate_platform(platform)
     if platform_error:

--- a/backend/app/api/simulation_lifecycle.py
+++ b/backend/app/api/simulation_lifecycle.py
@@ -10,6 +10,7 @@ from . import simulation_bp
 from ..config import Config
 from ..models.project import ProjectManager
 from ..services.simulation_manager import SimulationManager, SimulationStatus
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.validation import validate_graph_id, validate_project_id, validate_simulation_id
 from .simulation_common import logger
@@ -85,21 +86,35 @@ def create_simulation():
 
     project_id = data.get('project_id')
     if not project_id:
-        return json_error("Please provide project_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide project_id",
+        )
     if not validate_project_id(project_id):
-        return json_error("Invalid project_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid project_id format",
+        )
 
     project = ProjectManager.get_project(project_id)
     if not project:
-        return json_error(f"Project does not exist: {project_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Project does not exist: {project_id}",
+        )
 
     graph_id = data.get('graph_id') or project.graph_id
     if not graph_id:
         return json_error(
-            "Project has not built knowledge graph yet, please call /api/graph/build first"
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Project has not built knowledge graph yet, please call /api/graph/build first",
         )
     if not validate_graph_id(graph_id):
-        return json_error("Invalid graph_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid graph_id format",
+        )
 
     manager = SimulationManager()
     state = manager.create_simulation(
@@ -116,12 +131,19 @@ def create_simulation():
 def get_simulation(simulation_id: str):
     """Get simulation status."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     manager = SimulationManager()
     state = manager.get_simulation(simulation_id)
     if not state:
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     result = state.to_dict()
     if state.status == SimulationStatus.READY:

--- a/backend/app/api/simulation_metrics.py
+++ b/backend/app/api/simulation_metrics.py
@@ -19,6 +19,7 @@ from . import simulation_bp
 from ..container import get_container
 from ..services.network_analytics import PolarizationMetrics
 from ..services.simulation_runner import SimulationRunner
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.validation import validate_simulation_id
 
@@ -62,16 +63,28 @@ def get_simulation_metrics(simulation_id: str):
     * ``platform`` (optional: twitter | reddit) — filter the action stream.
     """
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     try:
         window = _parse_window(request.args.get('window_size_rounds'))
     except (TypeError, ValueError):
-        return json_error("window_size_rounds must be an integer", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="window_size_rounds must be an integer",
+        )
 
     platform = request.args.get('platform')
     if platform and platform not in ('twitter', 'reddit'):
-        return json_error("platform must be 'twitter' or 'reddit'", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="platform must be 'twitter' or 'reddit'",
+        )
 
     metrics = _compute(simulation_id, window=window, platform=platform)
     return json_success(metrics.to_dict())
@@ -89,24 +102,44 @@ def export_simulation_metrics(simulation_id: str):
     * ``window_size_rounds``, ``platform`` — same semantics as the JSON endpoint.
     """
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     fmt = (request.args.get('format') or 'csv').strip().lower()
     if fmt != 'csv':
-        return json_error("format must be 'csv'", status=400)
+        return json_error(
+            ApiErrorCode.UNSUPPORTED_FORMAT,
+            status=400,
+            message="format must be 'csv'",
+        )
 
     view = (request.args.get('view') or 'summary').strip().lower()
     if view not in ('summary', 'clusters', 'bridges'):
-        return json_error("view must be 'summary', 'clusters' or 'bridges'", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="view must be 'summary', 'clusters' or 'bridges'",
+        )
 
     try:
         window = _parse_window(request.args.get('window_size_rounds'))
     except (TypeError, ValueError):
-        return json_error("window_size_rounds must be an integer", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="window_size_rounds must be an integer",
+        )
 
     platform = request.args.get('platform')
     if platform and platform not in ('twitter', 'reddit'):
-        return json_error("platform must be 'twitter' or 'reddit'", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="platform must be 'twitter' or 'reddit'",
+        )
 
     metrics = _compute(simulation_id, window=window, platform=platform)
     payload = metrics.to_dict()

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -13,6 +13,7 @@ from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..utils.validation import validate_simulation_id, validate_task_id
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from .simulation_common import (
     get_artifact_store,
@@ -136,15 +137,27 @@ def prepare_simulation():
 
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return json_error("Please provide simulation_id", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="Please provide simulation_id",
+        )
 
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     manager = SimulationManager()
     state = manager.get_simulation(simulation_id)
     if not state:
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     force_regenerate = data.get('force_regenerate', False)
     logger.info(
@@ -161,7 +174,7 @@ def prepare_simulation():
             return json_success({
                 "simulation_id": simulation_id,
                 "status": "ready",
-                "message": "Preparation already completed，No need to repeatGenerate",
+                "message": "Preparation already completed, no need to regenerate",
                 "already_prepared": True,
                 "prepare_info": prepare_info,
             })
@@ -169,11 +182,19 @@ def prepare_simulation():
 
     project = ProjectManager.get_project(state.project_id)
     if not project:
-        return json_error(f"Project does not exist: {state.project_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Project does not exist: {state.project_id}",
+        )
 
     simulation_requirement = project.simulation_requirement or ""
     if not simulation_requirement:
-        return json_error("Project missing simulation requirement description (simulation_requirement)", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="Project missing simulation requirement description (simulation_requirement)",
+        )
 
     document_text = ProjectManager.get_extracted_text(state.project_id) or ""
     entity_types_list = data.get('entity_types')
@@ -348,7 +369,7 @@ def prepare_simulation():
         "task_id": task_id,
         "run_id": run_record["run_id"],
         "status": "preparing",
-        "message": "Preparation task started，Please via /api/simulation/prepare/status Query progress",
+        "message": "Preparation task started; query progress via /api/simulation/prepare/status",
         "already_prepared": False,
         "expected_entities_count": state.entities_count,
         "entity_types": state.entity_types,
@@ -366,9 +387,17 @@ def get_prepare_status():
     simulation_id = data.get('simulation_id')
 
     if task_id and not validate_task_id(task_id):
-        return json_error("Invalid task_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid task_id format",
+        )
     if simulation_id and not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     if simulation_id:
         is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
@@ -391,7 +420,11 @@ def get_prepare_status():
                 "message": "Preparation not started yet, please call /api/simulation/prepare",
                 "already_prepared": False,
             })
-        return json_error("Please provide task_id Or simulation_id", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="Please provide task_id or simulation_id",
+        )
 
     task_manager = TaskManager()
     task = task_manager.get_task(task_id)
@@ -409,7 +442,11 @@ def get_prepare_status():
                     "prepare_info": prepare_info,
                 })
 
-        return json_error(f"Task does not exist: {task_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Task does not exist: {task_id}",
+        )
 
     task_dict = task.to_dict()
     task_dict["already_prepared"] = False

--- a/backend/app/api/simulation_profiles.py
+++ b/backend/app/api/simulation_profiles.py
@@ -18,6 +18,7 @@ from ..services.persona_review_service import (
 from ..services.simulation_manager import SimulationManager
 from ..utils.auth import allow_ticket_auth
 from ..utils.validation import validate_simulation_id
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from .simulation_common import get_artifact_store, logger
 
@@ -30,12 +31,20 @@ def _persona_review_service() -> PersonaReviewService:
 @handle_api_errors(log_prefix="Failed to create simulation branch")
 def create_simulation_branch(simulation_id: str):
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     data = request.get_json() or {}
     branch_name = (data.get("branch_name") or "").strip()
     if not branch_name:
-        return json_error("branch_name is required", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="branch_name is required",
+        )
 
     manager = SimulationManager()
     branch = manager.create_branch(
@@ -53,7 +62,11 @@ def create_simulation_branch(simulation_id: str):
 @handle_api_errors(log_prefix="Failed to list simulation branches")
 def list_simulation_branches(simulation_id: str):
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     manager = SimulationManager()
     branches = manager.list_branches(simulation_id)
@@ -65,7 +78,11 @@ def list_simulation_branches(simulation_id: str):
 def get_simulation_profiles(simulation_id: str):
     """Get stored simulation profiles."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     platform = request.args.get('platform', 'reddit')
     manager = SimulationManager()
@@ -98,7 +115,11 @@ def save_persona_template():
     """Persist a generated or manually authored persona for later simulations."""
     data = request.get_json() or {}
     if not (data.get("username") or data.get("name") or data.get("persona")):
-        return json_error("Provide at least username, name, or persona", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message="Provide at least username, name, or persona",
+        )
     template = PersonaLibrary().save_template(data)
     return json_success({"template": template})
 
@@ -108,7 +129,11 @@ def save_persona_template():
 def delete_persona_template(template_id: str):
     """Remove a reusable persona template."""
     if not PersonaLibrary().delete_template(template_id):
-        return json_error(f"Persona template not found: {template_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Persona template not found: {template_id}",
+        )
     return json_success({"removed": template_id})
 
 
@@ -117,7 +142,11 @@ def delete_persona_template(template_id: str):
 def get_simulation_profiles_realtime(simulation_id: str):
     """Read profile files directly for realtime generation feedback."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     import csv
     from datetime import datetime
@@ -125,7 +154,11 @@ def get_simulation_profiles_realtime(simulation_id: str):
     platform = request.args.get('platform', 'reddit')
     sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
     if not os.path.exists(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     store = get_artifact_store()
     profiles = []
@@ -216,13 +249,21 @@ def _save_profiles_file(simulation_id: str, path: str, profiles: list, platform:
 def add_simulation_profile(simulation_id: str):
     """Append a manually authored persona to the simulation."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     data = request.get_json() or {}
     platform = data.get('platform', 'reddit')
     sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
     if not os.path.exists(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     path, profiles = _load_profiles_file(simulation_id, sim_dir, platform)
     existing_ids = [int(profile.get('user_id', 0) or 0) for profile in profiles]
@@ -283,18 +324,30 @@ def add_simulation_profile(simulation_id: str):
 def delete_simulation_profile(simulation_id: str, username: str):
     """Remove a persona from reddit_profiles.json / twitter_profiles.csv by username."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     platform = request.args.get('platform', 'reddit')
     sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
     if not os.path.exists(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     path, profiles = _load_profiles_file(simulation_id, sim_dir, platform)
     before = len(profiles)
     profiles = [profile for profile in profiles if str(profile.get('username', '')) != username]
     if len(profiles) == before:
-        return json_error(f"Persona not found: {username}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Persona not found: {username}",
+        )
 
     _save_profiles_file(simulation_id, path, profiles, platform)
     return json_success({
@@ -309,7 +362,11 @@ def delete_simulation_profile(simulation_id: str, username: str):
 def get_simulation_profiles_quality(simulation_id: str):
     """Quality heuristics over the reddit personas of a simulation."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
     # No existence check: an empty/unknown simulation surfaces ``no_personas``
     # as a global warning, which is the more useful UX than a hard 404 while
     # the Step 2 UI is still spinning up profiles.
@@ -324,13 +381,25 @@ def _handle_review_action(
     action,
 ):
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
     try:
         profile = action(_persona_review_service())
     except PersonaNotFoundError as exc:
-        return json_error(str(exc), status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=str(exc),
+        )
     except InvalidReviewStatusError as exc:
-        return json_error(str(exc), status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
     return json_success({
         "username": username,
         "review_status": profile.get("review_status"),
@@ -385,13 +454,21 @@ def reject_simulation_profile(simulation_id: str, username: str):
 def get_simulation_config_realtime(simulation_id: str):
     """Read simulation configuration directly for realtime generation feedback."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     from datetime import datetime
 
     sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
     if not os.path.exists(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     store = get_artifact_store()
     file_exists = store.exists(simulation_id, "simulation_config")
@@ -446,12 +523,20 @@ def get_simulation_config_realtime(simulation_id: str):
 def get_simulation_config(simulation_id: str):
     """Get the generated simulation configuration."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     manager = SimulationManager()
     config = manager.get_simulation_config(simulation_id)
     if not config:
-        return json_error("Simulation configuration does not exist. Please call /prepare first", status=404)
+        return json_error(
+            ApiErrorCode.SIMULATION_NOT_PREPARED,
+            status=404,
+            message="Simulation configuration does not exist. Please call /prepare first",
+        )
 
     return json_success(config)
 
@@ -462,13 +547,21 @@ def get_simulation_config(simulation_id: str):
 def download_simulation_config(simulation_id: str):
     """Download simulation configuration file."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format", status=400)
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            status=400,
+            message="Invalid simulation_id format",
+        )
 
     manager = SimulationManager()
     sim_dir = manager._get_simulation_dir(simulation_id)
     config_path = os.path.join(sim_dir, "simulation_config.json")
     if not os.path.exists(config_path):
-        return json_error("Configuration file does not exist. Please call /prepare first", status=404)
+        return json_error(
+            ApiErrorCode.SIMULATION_NOT_PREPARED,
+            status=404,
+            message="Configuration file does not exist. Please call /prepare first",
+        )
 
     return send_file(config_path, as_attachment=True, download_name="simulation_config.json")
 
@@ -486,10 +579,18 @@ def download_simulation_script(script_name: str):
         "action_logger.py",
     ]
     if script_name not in allowed_scripts:
-        return json_error(f"Unknown script: {script_name}，Optional: {allowed_scripts}", status=400)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=f"Unknown script: {script_name}. Allowed: {allowed_scripts}",
+        )
 
     script_path = os.path.join(scripts_dir, script_name)
     if not os.path.exists(script_path):
-        return json_error(f"Script file does not exist: {script_name}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Script file does not exist: {script_name}",
+        )
 
     return send_file(script_path, as_attachment=True, download_name=script_name)

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -12,6 +12,7 @@ from ..models.project import ProjectManager
 from ..services.persona_review_service import PersonaReviewService
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.validation import validate_simulation_id
@@ -40,9 +41,9 @@ def _evaluate_persona_review_gate(simulation_id: str):
     if review["allowed"]:
         return None
     return json_error(
-        "Persona review pending. Approve all personas before starting the simulation.",
+        ApiErrorCode.PERSONA_REVIEW_REQUIRED,
         status=409,
-        code="persona_review_required",
+        message="Persona review pending. Approve all personas before starting the simulation.",
         extra={"review": review},
     )
 
@@ -59,9 +60,15 @@ def start_simulation():
 
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return json_error("Please provide simulation_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_id",
+        )
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     platform = data.get('platform', 'parallel')
     max_rounds = data.get('max_rounds')
@@ -73,25 +80,44 @@ def start_simulation():
         try:
             max_rounds = int(max_rounds)
             if max_rounds <= 0:
-                return json_error("max_rounds Must be positive integer")
+                return json_error(
+                    ApiErrorCode.VALIDATION_FAILED,
+                    message="max_rounds must be a positive integer",
+                )
         except (ValueError, TypeError):
-            return json_error("max_rounds Must be valid integer")
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                message="max_rounds must be a valid integer",
+            )
 
     if simulation_days is not None:
         try:
             simulation_days = int(simulation_days)
             if simulation_days <= 0 or simulation_days > 365:
-                return json_error("simulation_days Must be between 1 and 365")
+                return json_error(
+                    ApiErrorCode.VALIDATION_FAILED,
+                    message="simulation_days must be between 1 and 365",
+                )
         except (ValueError, TypeError):
-            return json_error("simulation_days Must be valid integer")
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                message="simulation_days must be a valid integer",
+            )
 
     if platform not in ['twitter', 'reddit', 'parallel']:
-        return json_error(f"Invalid platform type: {platform}，Optional: twitter/reddit/parallel")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message=f"Invalid platform type: {platform}. Allowed: twitter/reddit/parallel",
+        )
 
     manager = SimulationManager()
     state = manager.get_simulation(simulation_id)
     if not state:
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     gate_response = _evaluate_persona_review_gate(simulation_id)
     if gate_response is not None:
@@ -102,8 +128,12 @@ def start_simulation():
         is_prepared, _prepare_info = _check_simulation_prepared(simulation_id)
         if not is_prepared:
             return json_error(
-                f"Simulation not ready. Current status: {state.status.value}. "
-                "Please call /prepare first"
+                ApiErrorCode.SIMULATION_NOT_PREPARED,
+                status=409,
+                message=(
+                    f"Simulation not ready. Current status: {state.status.value}. "
+                    "Please call /prepare first"
+                ),
             )
 
         if state.status == SimulationStatus.RUNNING:
@@ -111,9 +141,13 @@ def start_simulation():
             if run_state and run_state.runner_status.value == 'running':
                 if not force:
                     return json_error(
-                        "Simulation is running. Please call /stop first or use force=true to force restart."
+                        ApiErrorCode.SIMULATION_ALREADY_RUNNING,
+                        status=409,
+                        message=(
+                            "Simulation is running. Please call /stop first or use force=true to force restart."
+                        ),
                     )
-                logger.info(f"Force mode：Stop runningSimulation {simulation_id}")
+                logger.info(f"Force mode: stopping running simulation {simulation_id}")
                 try:
                     SimulationRunner.stop_simulation(simulation_id)
                 except Exception as exc:
@@ -142,8 +176,11 @@ def start_simulation():
                 graph_id = project.graph_id
         if not graph_id:
             return json_error(
-                "Enable knowledge graph memory update requires valid graph_id，"
-                "Please ensure project graph built"
+                ApiErrorCode.VALIDATION_FAILED,
+                message=(
+                    "Enable knowledge graph memory update requires valid graph_id. "
+                    "Please ensure project graph is built."
+                ),
             )
         logger.info(
             f"Enable knowledge graph memory update: simulation_id={simulation_id}, graph_id={graph_id}",
@@ -154,7 +191,11 @@ def start_simulation():
         store = get_artifact_store()
         config = store.read_json(simulation_id, "simulation_config", default=None)
         if not config:
-            return json_error("Simulation configuration does not exist. Please call /prepare first", status=404)
+            return json_error(
+                ApiErrorCode.SIMULATION_NOT_PREPARED,
+                status=404,
+                message="Simulation configuration does not exist. Please call /prepare first",
+            )
         time_config = dict(config.get("time_config") or {})
         time_config["total_simulation_hours"] = simulation_days * 24
         config["time_config"] = time_config
@@ -212,9 +253,15 @@ def stop_simulation():
     data = request.get_json() or {}
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return json_error("Please provide simulation_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_id",
+        )
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     run_state = SimulationRunner.stop_simulation(simulation_id)
     manager = SimulationManager()
@@ -240,13 +287,20 @@ def stop_simulation():
 def pause_simulation(simulation_id: str):
     """Set the soft-pause flag so the simulation halts after the current round."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     from ..services.simulation_ipc import set_pause_state
 
     sim_dir = _simulation_dir(simulation_id)
     if not os.path.isdir(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     state = set_pause_state(sim_dir, True)
     logger.info(f"Pause requested for {simulation_id}")
@@ -268,13 +322,20 @@ def pause_simulation(simulation_id: str):
 def resume_simulation(simulation_id: str):
     """Clear the pause flag so the simulation continues."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     from ..services.simulation_ipc import set_pause_state
 
     sim_dir = _simulation_dir(simulation_id)
     if not os.path.isdir(sim_dir):
-        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Simulation does not exist: {simulation_id}",
+        )
 
     state = set_pause_state(sim_dir, False)
     logger.info(f"Resume requested for {simulation_id}")
@@ -296,7 +357,10 @@ def resume_simulation(simulation_id: str):
 def get_simulation_console_log(simulation_id: str):
     """Read incremental subprocess console logs for a simulation."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
     from_line = request.args.get('from_line', 0, type=int)
     data = SimulationRunner.get_console_log(simulation_id, from_line=from_line)
     return json_success(data)
@@ -307,7 +371,10 @@ def get_simulation_console_log(simulation_id: str):
 def get_run_status(simulation_id: str):
     """Get lightweight real-time run status for frontend polling."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     from ..services.simulation_ipc import read_control_state
 
@@ -336,7 +403,10 @@ def get_run_status(simulation_id: str):
 def get_run_status_detail(simulation_id: str):
     """Get detailed run status including aggregated actions."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     run_state = SimulationRunner.get_run_state(simulation_id)
     platform_filter = request.args.get('platform')
@@ -377,7 +447,10 @@ def get_run_status_detail(simulation_id: str):
 def get_simulation_actions(simulation_id: str):
     """Get paginated action history for a simulation."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     limit = request.args.get('limit', 100, type=int)
     offset = request.args.get('offset', 0, type=int)
@@ -403,7 +476,10 @@ def get_simulation_actions(simulation_id: str):
 def get_simulation_timeline(simulation_id: str):
     """Get round-level timeline summaries for a simulation."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     start_round = request.args.get('start_round', 0, type=int)
     end_round = request.args.get('end_round', type=int)
@@ -420,7 +496,10 @@ def get_simulation_timeline(simulation_id: str):
 def get_agent_stats(simulation_id: str):
     """Get aggregated per-agent statistics."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     stats = SimulationRunner.get_agent_stats(simulation_id)
     return json_success({"agents_count": len(stats), "stats": stats})
@@ -433,9 +512,15 @@ def get_env_status():
     data = request.get_json() or {}
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return json_error("Please provide simulation_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_id",
+        )
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     env_alive = SimulationRunner.check_env_alive(simulation_id)
     env_status = SimulationRunner.get_env_status_detail(simulation_id)
@@ -460,10 +545,16 @@ def close_simulation_env():
     data = request.get_json() or {}
     simulation_id = data.get('simulation_id')
     if simulation_id and not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
     timeout = data.get('timeout', 30)
     if not simulation_id:
-        return json_error("Please provide simulation_id")
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_id",
+        )
 
     result = SimulationRunner.close_simulation_env(simulation_id=simulation_id, timeout=timeout)
     manager = SimulationManager()

--- a/backend/app/api/simulation_stream.py
+++ b/backend/app/api/simulation_stream.py
@@ -34,6 +34,7 @@ from ..services.event_bus import (
     SimulationEvent,
     SimulationEventBus,
 )
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import json_error
 from ..utils.auth import allow_ticket_auth
 from ..utils.logger import get_logger
@@ -137,7 +138,10 @@ def _stream(simulation_id: str) -> Iterator[str]:
 def simulation_stream(simulation_id: str):
     """SSE endpoint for live run-state + control updates."""
     if not validate_simulation_id(simulation_id):
-        return json_error("Invalid simulation_id format")
+        return json_error(
+            ApiErrorCode.INVALID_ID,
+            message="Invalid simulation_id format",
+        )
 
     response = Response(
         stream_with_context(_stream(simulation_id)),

--- a/backend/tests/api/test_simulation_endpoints.py
+++ b/backend/tests/api/test_simulation_endpoints.py
@@ -1,0 +1,258 @@
+"""Endpoint-Tests für ``app.api.simulation_*`` — verifiziert die ApiErrorCode-Migration.
+
+Fokus: jeder migrierte Error-Pfad liefert Envelope mit ``code``. Die alte
+Suite ``tests/test_simulation_api_routes.py`` testet weiter exakte Strings;
+diese Suite testet die ``code``-Verträge zusätzlich, sodass Frontend-Mapper
+sich auf semantische Codes verlassen können.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+
+
+VALID_SIM_ID = "sim_0123456789ab"
+VALID_GRAPH_ID = "abcdef0123456789abcdef0123456789"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = Flask(__name__)
+    storage = MagicMock(name="Neo4jStorage")
+    app.extensions = {"neo4j_storage": storage}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+# --- INVALID_ID --------------------------------------------------------------
+
+
+def test_get_simulation_invalid_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/not-a-sim")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_pause_invalid_id_returns_invalid_id(client):
+    response = client.post("/api/simulation/not-a-sim/pause")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_resume_invalid_id_returns_invalid_id(client):
+    response = client.post("/api/simulation/not-a-sim/resume")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_run_status_invalid_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/not-a-sim/run-status")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_get_entity_invalid_graph_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/entities/not-a-graph")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_metrics_invalid_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/not-a-sim/metrics")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_metrics_export_invalid_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/not-a-sim/metrics/export")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+def test_stream_invalid_id_returns_invalid_id(client):
+    response = client.get("/api/simulation/not-a-sim/stream")
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_id"
+
+
+# --- VALIDATION_FAILED -------------------------------------------------------
+
+
+def test_start_missing_simulation_id_returns_validation_failed(client):
+    response = client.post("/api/simulation/start", json={})
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_start_invalid_platform_returns_validation_failed(client):
+    response = client.post(
+        "/api/simulation/start",
+        json={"simulation_id": VALID_SIM_ID, "platform": "myspace"},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_start_invalid_max_rounds_returns_validation_failed(client):
+    response = client.post(
+        "/api/simulation/start",
+        json={"simulation_id": VALID_SIM_ID, "max_rounds": -3},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_create_branch_missing_branch_name_returns_validation_failed(client):
+    response = client.post(
+        f"/api/simulation/{VALID_SIM_ID}/branch", json={}
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_persona_library_missing_payload_returns_validation_failed(client):
+    response = client.post("/api/simulation/persona-library", json={})
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_metrics_invalid_window_returns_validation_failed(client):
+    response = client.get(
+        f"/api/simulation/{VALID_SIM_ID}/metrics?window_size_rounds=abc"
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_metrics_invalid_platform_returns_validation_failed(client):
+    response = client.get(
+        f"/api/simulation/{VALID_SIM_ID}/metrics?platform=myspace"
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_metrics_export_invalid_view_returns_validation_failed(client):
+    response = client.get(
+        f"/api/simulation/{VALID_SIM_ID}/metrics/export?view=galaxy"
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_interview_missing_agent_id_returns_validation_failed(client):
+    response = client.post(
+        "/api/simulation/interview",
+        json={"simulation_id": VALID_SIM_ID},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+def test_interview_batch_missing_interviews_returns_validation_failed(client):
+    response = client.post(
+        "/api/simulation/interview/batch",
+        json={"simulation_id": VALID_SIM_ID},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "validation_failed"
+
+
+# --- UNSUPPORTED_FORMAT ------------------------------------------------------
+
+
+def test_metrics_export_invalid_format_returns_unsupported_format(client):
+    response = client.get(
+        f"/api/simulation/{VALID_SIM_ID}/metrics/export?format=json"
+    )
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "unsupported_format"
+
+
+# --- NOT_FOUND ---------------------------------------------------------------
+
+
+def test_get_simulation_not_found_returns_not_found(client, monkeypatch):
+    fake_manager = MagicMock(get_simulation=MagicMock(return_value=None))
+    monkeypatch.setattr(
+        "app.api.simulation_lifecycle.SimulationManager",
+        lambda: fake_manager,
+    )
+    response = client.get(f"/api/simulation/{VALID_SIM_ID}")
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["code"] == "not_found"
+    assert VALID_SIM_ID in payload["error"]
+
+
+def test_persona_template_delete_not_found_returns_not_found(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.simulation_profiles.PersonaLibrary",
+        lambda: MagicMock(delete_template=MagicMock(return_value=False)),
+    )
+    response = client.delete("/api/simulation/persona-library/some-template-id")
+    assert response.status_code == 404
+    assert response.get_json()["code"] == "not_found"
+
+
+# --- SERVICE_UNAVAILABLE -----------------------------------------------------
+
+
+def test_interview_env_not_alive_returns_service_unavailable(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.simulation_interviews.SimulationRunner.check_env_alive",
+        staticmethod(lambda _sid: False),
+    )
+    response = client.post(
+        "/api/simulation/interview",
+        json={
+            "simulation_id": VALID_SIM_ID,
+            "agent_id": 1,
+            "prompt": "Hello?",
+        },
+    )
+    assert response.status_code == 503
+    assert response.get_json()["code"] == "service_unavailable"
+
+
+# --- PERSONA_REVIEW_REQUIRED -------------------------------------------------
+
+
+def test_start_persona_review_blocks_returns_persona_review_required(client, monkeypatch):
+    from app.services.simulation_manager import SimulationStatus
+
+    monkeypatch.setattr(
+        "app.api.simulation_run.Config.PERSONA_REVIEW_ENABLED",
+        True,
+        raising=False,
+    )
+    fake_state = MagicMock()
+    fake_state.status = SimulationStatus.READY
+    fake_manager = MagicMock(get_simulation=MagicMock(return_value=fake_state))
+    monkeypatch.setattr(
+        "app.api.simulation_run.SimulationManager",
+        lambda: fake_manager,
+    )
+    fake_review = {"allowed": False, "missing": [{"username": "u1"}]}
+    fake_service = MagicMock(evaluate_start_gate=MagicMock(return_value=fake_review))
+    monkeypatch.setattr(
+        "app.api.simulation_run.PersonaReviewService",
+        lambda _store: fake_service,
+    )
+    monkeypatch.setattr(
+        "app.api.simulation_run.get_artifact_store",
+        lambda: MagicMock(name="ArtifactStore"),
+    )
+    response = client.post(
+        "/api/simulation/start",
+        json={"simulation_id": VALID_SIM_ID, "platform": "parallel"},
+    )
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["code"] == "persona_review_required"
+    assert payload["review"] == fake_review

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -83,7 +83,8 @@ def test_prepare_status_requires_identifier():
     assert response.status_code == 400
     payload = response.get_json()
     assert payload["success"] is False
-    assert payload["error"] == "Please provide task_id Or simulation_id"
+    assert payload["error"] == "Please provide task_id or simulation_id"
+    assert payload["code"] == "validation_failed"
 
 
 def test_create_branch_requires_branch_name():
@@ -134,7 +135,8 @@ def test_start_simulation_validates_simulation_days():
     assert response.status_code == 400
     payload = response.get_json()
     assert payload["success"] is False
-    assert payload["error"] == "simulation_days Must be between 1 and 365"
+    assert payload["error"] == "simulation_days must be between 1 and 365"
+    assert payload["code"] == "validation_failed"
 
 
 def test_persona_library_round_trip(monkeypatch, tmp_path):
@@ -367,7 +369,8 @@ def test_interview_requires_prompt():
     assert response.status_code == 400
     payload = response.get_json()
     assert payload["success"] is False
-    assert payload["error"] == "Please provide prompt（Interview question）"
+    assert payload["error"] == "Please provide prompt (interview question)"
+    assert payload["code"] == "validation_failed"
 
 
 def test_posts_route_keeps_validation_guard():


### PR DESCRIPTION
## Summary

EPIC-09 Sub-Slice 3: Migration von 9 simulation_*.py-Files auf den `ApiErrorCode`-Katalog plus Sanierung der chinesischen Punctuation, die seit dem Upstream-Fork im API-Layer steckte.

- **107 `json_error`-Stellen** über 9 Files migriert: `simulation_run.py`, `simulation_profiles.py`, `simulation_interviews.py`, `simulation_prepare.py`, `simulation_metrics.py`, `simulation_lifecycle.py`, `simulation_history.py`, `simulation_entities.py`, `simulation_stream.py`.
- Spezifische Codes laut Plan-DoD: `PERSONA_REVIEW_REQUIRED` (409), `SIMULATION_NOT_PREPARED` (404/409), `SIMULATION_ALREADY_RUNNING` (409). Plus die Standard-Codes `INVALID_ID`, `NOT_FOUND`, `VALIDATION_FAILED`, `UNSUPPORTED_FORMAT`, `SERVICE_UNAVAILABLE`.
- **Chinesisch entsorgt:** 6 Stellen mit CN-Punctuation (`，` als Trenner, `（）` als Klammer) gefixt — 4 user-sichtbare Error-Strings, 2 success-Messages, 1 Logger. Capitalization-Tippfehler (`Must`, `Or`, `Optional:`) gleich mitkorrigiert.
- Pidgin-English wie "max_rounds Must be positive integer" → "max_rounds must be a positive integer", "Please provide prompt（Interview question）" → "Please provide prompt (interview question)".

## Tests

- **Neue Suite [tests/api/test_simulation_endpoints.py](backend/tests/api/test_simulation_endpoints.py) mit 23 Endpoint-Tests** über alle migrierten Pfade. Plan-DoD verlangte ≥10 Code-Assertions — geliefert: 23.
- 3 bestehende Tests in [tests/test_simulation_api_routes.py](backend/tests/test_simulation_api_routes.py) auf saubere Strings + `code`-Assertion gehoben.

## Test plan

- [x] `cd backend && uv run pytest tests/api/test_simulation_endpoints.py tests/test_simulation_api_routes.py -v` — 47 passed
- [x] `npm run check` — Backend-Lint clean (ruff `app/ tests/`), **388 Backend-Tests passed** (vorher 365 → +23), 2 skipped (Redis ohne `TEST_REDIS_URL`), Frontend-Lint clean, Vite-Build durch
- [x] CN-Audit: `grep -rn '[，、。]' backend/app/api/` → 0 Hits
- [x] Pre-Migration-Frontend-Check: kein exakter Backend-String-Parse im Frontend

## Plan-Abweichungen

- **Service-Unavailable statt 400** für `_require_env_alive` (interviews): 503 ist semantisch korrekt für "Subprocess down". Vorher implizit 400 ohne expliziten Code.
- **Kein neuer Code `interview_subject_not_found`** ergänzt (Plan-DoD nannte ihn). Im Code gibt es heute keine Stelle, die das spezifisch wirft — `Persona not found` und `Entity does not exist` werden auf `NOT_FOUND` mit message-Override gemapped, was funktional reicht.

## Rollback

`git revert HEAD --no-edit` — keine Schema-/DB-Änderung, kein neues Pflicht-Env. Frontend-Konsumenten lesen aktuell nur `error`-Feld; Tests pinnen Backwards-Compat.

## Folge-Slices

Sub-Slice 4 (Response-Schemas + Schema-Tests, an Sonnet delegierbar), Sub-Slice 5 (Frontend Envelope-Mapper TS-ready), Sub-Slice 6 (CHANGELOG + Backlog).