### PR TITLE
chore(release): v0.8.0 release notes, version bump, public docu/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,26 +60,11 @@ context.md
 /PLAN.md
 /REFACTORING_PLAN.md
 /SECURITY_REVIEW.md
-/CHANGELOG.md
-/docu/*
-!/docu/api-contracts.md
-!/docu/2026-05-01-v0.7.0-release-notes.md
-!/docu/2026-05-01-epic02-api-split-status.md
-!/docu/2026-05-01-issue34-sub21-graphhints-arbeitsprotokoll.md
-!/docu/2026-05-01-issue34-sub22-graphtoolbar-arbeitsprotokoll.md
-!/docu/2026-05-01-issue34-sub23-graphcanvas-arbeitsprotokoll.md
-!/docu/2026-05-01-issue35-usegraphrender-arbeitsprotokoll.md
-!/docu/2026-05-01-issue37-usepolling-status.md
-!/docu/2026-05-01-issue38-usepolling-migration-arbeitsprotokoll.md
-!/docu/2026-05-01-issue68-persona-review-ui-status.md
-!/docu/2026-05-01-issue40-sse-strategy-status.md
-!/docu/2026-05-01-issue39-useincrementallogpolling-arbeitsprotokoll.md
-!/docu/2026-05-01-issue36-graph-dto-normalisierung-arbeitsprotokoll.md
-!/docu/2026-05-01-issue84-composable-tests-arbeitsprotokoll.md
+# docu/ ist seit v0.8.0 öffentlich (Portfolio-Material).
+# .github/ enthält die CI- und Docker-Image-Workflows — getrackt und aktiv.
 /docs/
 /Agora_design/
 /scripts/logs/
-# /.github/ — jetzt getrackt (CI-Workflows)
 /.codex
 /.gitleaksignore
 /docker-compose.override.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-01
+
+Milestone „Frontend Consolidation" abgeschlossen — 13/13 Issues geschlossen, **519 Tests grün** (488 Backend + 31 Frontend). Schwerpunkt: 933-zeiliges `GraphPanel.vue` zerlegt in fünf Subkomponenten plus ein Render-Composable, Polling-Stack vereinheitlicht (alle 12 Polling-Stellen über `usePolling`, drei Log-Stellen über `useIncrementalLogPolling`), Composable-Test-Coverage von 11 auf 31 hochgezogen, EPIC-02 (Backend-API-Splitting) und EPIC-05-ST-01 (`usePolling`) retrospektiv als bereits erledigt dokumentiert. Vier weitere v0.8.0-Story-Issues (#37, #40, #68, alle EPIC-02-Stories) wurden durch Status-Dokus geschlossen — der eigentliche Code-Stand der Anwendung ist seit v0.6.0/v0.7.0 schon dort.
+
 ### Hinzugefügt
 
 - **`frontend/src/components/graph/GraphHints.vue`** — neue rein präsentationale Komponente für Building-/Simulating-Hint und Simulation-Finished-Hint. Erste Etappe von Issue #34 (EPIC-04-ST-01: GraphPanel zerlegen). Props: `currentPhase`, `isSimulating`, `showFinishedHint`. Emits: `dismiss-finished`. Styles 1:1 aus `GraphPanel.vue` übernommen, kein Visual-Diff. Sub-Slice 2.1 von 3.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Fork von [nikmcfly/MiroFish-Offline](https://github.com/nikmcfly/MiroFish-Offline), basierend auf [MiroFish](https://github.com/666ghj/MiroFish).
 
-> **v0.7.0 released:** [Release Notes](docu/2026-05-01-v0.7.0-release-notes.md) — 13/13 Issues geschlossen, 499 Tests grün (488 Backend + 11 Frontend).
+> **v0.8.0 released:** [Release Notes](docu/2026-05-01-v0.8.0-release-notes.md) — 13/13 Issues geschlossen, **519 Tests grün** (488 Backend + 31 Frontend). Vorgänger: [v0.7.0](docu/2026-05-01-v0.7.0-release-notes.md).
 
 [![Repository](https://img.shields.io/badge/GitHub-arn0ld87%2Fagora-111?style=flat-square&logo=github)](https://github.com/arn0ld87/agora)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue?style=flat-square)](./LICENSE)
@@ -21,7 +21,7 @@ Fork von [nikmcfly/MiroFish-Offline](https://github.com/nikmcfly/MiroFish-Offlin
 
 ---
 
-> ## Status: v0.7.0 — released 2026-05-01
+> ## Status: v0.8.0 — released 2026-05-01
 >
 > Agora ist ein aktiver, **experimenteller Fork**. Graph-Build, Simulation und
 > Report-Pipeline können bei ungünstigen Bedingungen (langsame Ollama-Cloud,
@@ -51,9 +51,9 @@ Agora ist eine lokale Multi-Agenten-Simulation für öffentliche Reaktionen, Mar
 
 Du lädst ein Dokument hoch, Agora extrahiert daraus einen Wissensgraphen, erzeugt Agenten-Personas mit Rollen, Haltungen und Aktivitätsprofilen, simuliert Diskussionen auf Social-Media-artigen Plattformen und erstellt danach einen Report. Das System läuft lokal mit Neo4j und Ollama, kann aber auch OpenAI-kompatible Cloud-Endpunkte verwenden.
 
-### Engineering-Stand v0.7.0
+### Engineering-Stand v0.8.0
 
-- **Quality-Gates vorhanden**: `npm run check` führt Backend-Linting (default-strict auf `app/ tests/`), Backend-Tests, Frontend-Lint, Frontend-Tests und Frontend-Build aus (**488 Backend-Tests**, 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL`).
+- **Quality-Gates vorhanden**: `npm run check` führt Backend-Linting (default-strict auf `app/ tests/`), Backend-Tests, Frontend-Lint, Frontend-Tests (Vitest auf `jsdom`) und Frontend-Build aus (**488 Backend + 31 Frontend Tests**, 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL`).
 - **Design-System konsolidiert (Slice 1)**: `tokens.css` als Source-of-Truth, UI-Komponenten (`Btn`, `Badge`, `Field`, `Card`, `Select`) auf Tokens umgestellt, harte Farbwerte in Views/Layouts durch Token-Referenzen ersetzt.
 - **Persona Review (Slice 2)**: Generierte Personas sind vor Simulationsstart prüfbar, editierbar und freigebbar. Quality-Heuristiken (Dubletten, fehlende Kernfelder, Rollen-Diversität) liefern Badges. `PERSONA_REVIEW_ENABLED=true` blockt Simulationsstart bis alle Personas approved sind.
 - **Run Dashboard (Slice 3)**: Zentrale `/runs`-View mit Status, Datum, Modell, Dokument, Graph-ID, Persona-Anzahl. Detail-Drawer für Fehler, Artefakte und Copy-Buttons. Runs-Persistenz über `RunRegistry`.
@@ -342,7 +342,7 @@ Lizenz: AGPL-3.0, siehe [LICENSE](./LICENSE).
 
 ## English
 
-> **Status: v0.7.0 — released 2026-05-01.** Agora is an active experimental
+> **Status: v0.8.0 — released 2026-05-01.** Agora is an active experimental
 > fork. Graph build, simulation, and report pipeline can fail when Ollama is slow,
 > JSON mode misbehaves, or models are switched mid-run. Not production-ready.
 > The HTTP API has an optional `AGORA_AUTH_TOKEN` guard and localhost-locked CORS
@@ -359,9 +359,9 @@ Agora is a local-first multi-agent simulation engine for public reaction, market
 
 Upload a document, extract a knowledge graph, generate agent personas, simulate social-media-like interactions, and produce a structured report. Agora runs locally with Neo4j and Ollama by default, but can also use any OpenAI-compatible cloud endpoint.
 
-### Engineering status in v0.7.0
+### Engineering status in v0.8.0
 
-- **Quality gates are in place** via `npm run check` (**488 backend tests**, 2 Redis integration tests skip cleanly without `TEST_REDIS_URL`).
+- **Quality gates are in place** via `npm run check` (**488 backend + 31 frontend tests**, Vitest on `jsdom`, 2 Redis integration tests skip cleanly without `TEST_REDIS_URL`).
 - **Design system consolidated (Slice 1)**: `tokens.css` as source of truth, UI components (`Btn`, `Badge`, `Field`, `Card`, `Select`) tokenized, hardcoded colors replaced with token references.
 - **Persona review (Slice 2)**: Generated personas can be inspected, edited, and approved before simulation start. Quality heuristics (duplicates, missing fields, role diversity) provide badges. `PERSONA_REVIEW_ENABLED=true` gates simulation start until all personas are approved.
 - **Run dashboard (Slice 3)**: Central `/runs` view with status, date, model, document, graph ID, persona count. Detail drawer for errors, artifacts, and copy buttons. Run persistence via `RunRegistry`.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -22,7 +22,7 @@ from .utils.logger import (  # noqa: E402
     get_logger,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.8.0"
 
 
 def create_app(config_class=Config):

--- a/docu/2026-05-01-v0.8.0-release-notes.md
+++ b/docu/2026-05-01-v0.8.0-release-notes.md
@@ -1,0 +1,51 @@
+# Release Notes — v0.8.0 „Frontend Consolidation"
+
+**Release-Datum:** 2026-05-01
+**Vorgängerversion:** [v0.7.0 (2026-05-01)](2026-05-01-v0.7.0-release-notes.md)
+**Milestone:** [v0.8.0 — Frontend Consolidation](https://github.com/arn0ld87/Agora/milestone/2) — 13/13 Issues geschlossen.
+
+---
+
+## Highlights
+
+- **`GraphPanel.vue` von 933 auf 98 Zeilen** zerlegt — pure Kompositionsdatei. Fünf Subkomponenten (`GraphHints`, `GraphToolbar`, `GraphCanvas` plus die schon bestehenden `GraphLegend` und `GraphDetailPanel`) plus ein Render-Composable (`useGraphRender.js`) ersetzen den Monolithen.
+- **Polling-Stack vollständig vereinheitlicht.** Alle 12 Polling-Stellen im Frontend gehen über das zentrale `usePolling`-Composable; vier raw-`setInterval`-Stellen in `MainView`/`SimulationRunView` wurden migriert. Drei duplizierte Log-Polling-Pfade (Step3 Console, Step4 Agent + Console) konsumieren jetzt das neue `useIncrementalLogPolling`-Composable mit einer einzigen Append-/Cursor-/Auto-Scroll-Stelle.
+- **Composable-Test-Coverage erstmals real.** Vitest läuft jetzt auf `jsdom`, mit `@vue/test-utils` und Lifecycle-aware Tests für `usePolling`, `useEventStream`, `useWorkspaceStatus`. **20 neue Tests, gesamt 31** (vorher 11 Smoke-Coverage auf `envelope.ts`).
+- **Graph-DTO-ViewModels dokumentiert.** `GraphNodeViewModel`/`GraphEdgeViewModel` als JSDoc-Types, `normalizeEdgeAliases()` als einzige Stelle für die Backend-Aliasse `fact_type` ↔ `name` aus der NER-Pipeline.
+- **Vier Issues retrospektiv als bereits erledigt geschlossen** (EPIC-02 Backend-API-Split: #29-#33; EPIC-05-ST-01 `usePolling`: #37; EPIC-05-ST-04 SSE-Strategie: #40; EPIC-13-ST-01 Persona Review UI: #68). Saubere Status-Dokus mit Quellverweisen statt leere PRs.
+
+## Was ist neu für Frontend-Entwickler
+
+- **`useGraphRender.js`** kapselt das D3-Force-Rendering komplett. Konsument liefert `svgRef`, `containerRef`, `graphData`, `entityTypes`, `showEdgeLabels`; bekommt `selectedItem` (Output-Ref) und `render` (manueller Trigger). Lifecycle, `window.resize`-Listener, deep-watch und Live-Toggle der Edge-Labels sind im Composable verdrahtet.
+- **`useIncrementalLogPolling.js`** — Vertrag: `{ fetcher, intervalMs, parseLine }` → `{ lines, containerRef, polling, reset, tick }`. Konsument hängt nur seinen `containerRef` an das Log-Element und liest `lines`. Cursor `since_line` und Auto-Scroll-Logik leben jetzt an einer Stelle.
+- **`GraphCanvas` exposed Export-Methoden via `defineExpose`** (`downloadGraphml`, `downloadSvg`, `downloadPng`, `printPdf`). Toolbar-Click-Events fließen via `canvasRef.value.X()`-Aufrufe vom Composer in den Canvas — Standard-Vue-3-Idiom für Parent → Child-Aktionen.
+- **Test-Pattern für Composables**: Dummy-`defineComponent({ setup() { exposed = composable(...) } })` plus `mount(Comp)` aus `@vue/test-utils` — echter Vue-Lifecycle, Composable-API über `exposed` inspizierbar. Mocks für `vue-i18n`, `../../api/stream`, plus `vi.useFakeTimers()` für Pacing.
+
+## Was ist neu für Backend-Entwickler
+
+Keine direkten Backend-Änderungen in v0.8.0. EPIC-02 (Backend-API-Splitting) wurde retrospektiv geschlossen — der Split war bereits in v0.4.0 vollständig umgesetzt; v0.8.0 hat nur den IST-Zustand dokumentiert.
+
+## Test-Stand
+
+- **Backend: 488 passed, 2 skipped** (Redis-Integrationstests ohne `TEST_REDIS_URL`). Stabil seit v0.7.0.
+- **Frontend: 31 passed** in 22 s. Anstieg von 11 → 31 durch 20 neue Composable-Tests in EPIC-10-ST-07.
+- **`npm run check` 5/5 grün**: lint:backend → test:backend → lint:frontend → test:frontend → build:frontend.
+
+## Migrations-Hinweise
+
+Keine Breaking-Changes für Konsumenten. Komponentenstrukturen wurden umorganisiert, aber `GraphPanel.vue` hat dieselben externen Props (`graphData`, `loading`, `currentPhase`, `isSimulating`) und Emits (`refresh`, `toggle-maximize`).
+
+Frontend-Test-Setup wechselt von `node` auf `jsdom`. Wer eigene Vitest-Specs hat, profitiert ohne Aufwand.
+
+Versionsstrings in `package.json`, `frontend/package.json` und `backend/app/__init__.py` springen von `0.6.1` direkt auf `0.8.0` — das v0.7.0-Versions-Bump-Versäumnis wird hier mit aufgeräumt.
+
+## Bekannte Limitierungen
+
+- **`useEventStream.getId()`-Edge-Case**: bei `ref(null)` gibt der `null ?? simulationIdRef`-Fallback das Ref-Objekt selbst zurück, das als truthy durchgeht. In der Praxis bisher nicht beobachtbar (Konsumenten passen leere Strings); Test umgeht das mit `ref('')` und der Edge-Case ist im Test-Kommentar dokumentiert. Fix-Kandidat für v0.9.0.
+- **Composable-Tests decken nur die drei in der Story genannten ab** (`usePolling`, `useEventStream`, `useWorkspaceStatus`). Tests für `useGraphRender`, `useIncrementalLogPolling`, `useWorkspaceMode`, `useSystemLog`, `usePersonaReview` sind Kandidaten für v0.9.0.
+
+## Verweise
+
+- [`CHANGELOG.md`](../CHANGELOG.md) — vollständiger Diff zu v0.7.0
+- [Milestone v0.8.0 auf GitHub](https://github.com/arn0ld87/Agora/milestone/2)
+- PRs: [#89](https://github.com/arn0ld87/agora/pull/89) (EPIC-02), [#90](https://github.com/arn0ld87/agora/pull/90)/[#91](https://github.com/arn0ld87/agora/pull/91)/[#92](https://github.com/arn0ld87/agora/pull/92) (#34), [#93](https://github.com/arn0ld87/agora/pull/93) (#35), [#94](https://github.com/arn0ld87/agora/pull/94) (#37), [#95](https://github.com/arn0ld87/agora/pull/95) (#38), [#96](https://github.com/arn0ld87/agora/pull/96) (#39), [#97](https://github.com/arn0ld87/agora/pull/97) (#36), [#98](https://github.com/arn0ld87/agora/pull/98) (#84)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -84,7 +84,7 @@
     "lead": "Agora baut aus deinem Text einen Wissensgraphen, bevölkert ihn mit hunderten Agenten — jeder mit eigener Biografie, Haltung, Blase — und lässt sie diskutieren, teilen, streiten. Du siehst in Echtzeit, wie sich Narrative ausbreiten, wo Gegenwind entsteht und welche Stimmen den Diskurs kippen. Vollständig lokal. Dein Laptop, dein Neo4j, dein Ollama.",
     "tags": {
       "engine": "Schwarm-Engine",
-      "version": "v0.6.1 alpha"
+      "version": "v0.8.0 alpha"
     },
     "system": {
       "kicker": "№ 02 — SYSTEM",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,7 +84,7 @@
     "lead": "Agora turns your text into a knowledge graph, populates it with hundreds of agents — each with their own biography, stance, bubble — and lets them debate, share, argue. You see in real time how narratives spread, where resistance forms, and which voices tip the discourse. Fully local. Your laptop, your Neo4j, your Ollama.",
     "tags": {
       "engine": "Swarm Engine",
-      "version": "v0.6.1 alpha"
+      "version": "v0.8.0 alpha"
     },
     "system": {
       "kicker": "№ 02 — SYSTEM",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora",
-  "version": "0.6.1",
+  "version": "0.8.0",
   "description": "Agora — local-first swarm intelligence engine (Neo4j + Ollama)",
   "author": "Alexander Schneider <https://alexle135.de>",
   "homepage": "https://alexle135.de",


### PR DESCRIPTION
## Release-Slice v0.8.0

Milestone „Frontend Consolidation" abgeschlossen — 13/13 Issues geschlossen, **519 Tests grün** (488 Backend + 31 Frontend).

## Änderungen

- **`docu/2026-05-01-v0.8.0-release-notes.md`** mit Highlights, Test-Stand, Migrations-Hinweisen und Entwickler-Notizen.
- **`CHANGELOG.md`**: `[Unreleased]`-Block als `[0.8.0] — 2026-05-01` versiegelt mit Milestone-Summary.
- **Versionsbumps** von `0.6.1` (Versäumnis aus v0.7.0-Release) direkt auf **`0.8.0`**: `package.json`, `frontend/package.json`, `backend/app/__init__.py`.
- **Frontend-i18n version-tag** `de.json`/`en.json`: `"v0.6.1 alpha"` → `"v0.8.0 alpha"`. Beseitigt die falsche `v0.6.1`-Anzeige im Home-View (vom User gemeldet — siehe Screenshot im Slice-Verlauf).
- **`README.md`**: v0.7.0-Erwähnungen auf v0.8.0 (DE + EN), Test-Counts auf 488 + 31, Vitest-on-`jsdom`-Hinweis.
- **`.gitignore` aufgeräumt**: `/docu/*`-Block + alle Negativ-Whitelist-Einträge raus. **Der Ordner ist seit v0.8.0 öffentlich** (Portfolio-Material). Kommentar-Hinweise auf `.github/`-Tracking und Source-of-Truth bleiben.

## Verifikation

`npm run check` 5/5 grün:

| Stage | Ergebnis |
|---|---|
| `lint:backend` | 0 |
| `test:backend` | 488 passed, 2 skipped |
| `lint:frontend` | 0 |
| `test:frontend` | 31 passed |
| `build:frontend` | 736 modules, 2,77 s |

## Folge

- Tag `v0.8.0` setzen
- Milestone v0.8.0 auf GitHub schließen