### PR TITLE
chore(infra): bump Neo4j pagecache to 4g, heap to 2g

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,9 +81,9 @@ services:
       # Kein Default-Passwort mehr — muss bewusst in .env gesetzt werden.
       - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD muss in .env gesetzt sein}
       - NEO4J_PLUGINS=["apoc"]
-      - NEO4J_server_memory_heap_initial__size=256m
-      - NEO4J_server_memory_heap_max__size=1g
-      - NEO4J_server_memory_pagecache_size=256m
+      - NEO4J_server_memory_heap_initial__size=512m
+      - NEO4J_server_memory_heap_max__size=2g
+      - NEO4J_server_memory_pagecache_size=4g
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs


### PR DESCRIPTION
Externe HDD rödelte unter Last — der 256m-Pagecache war zu klein und verursachte Random-Reads bei Graphen über ein paar 1000 Edges.

| Setting | Vorher | Nachher |
|---|---:|---:|
| `server_memory_pagecache_size` | 256m | **4g** |
| `server_memory_heap_max__size` | 1g | 2g |
| `server_memory_heap_initial__size` | 256m | 512m |

Lokal genug RAM vorhanden. Erwartete Wirkung: deutlich weniger Disk-I/O bei Build und Sim. Rollback durch alte Werte.