### PR TITLE
chore(release): bump startseite version badge to v0.9.0

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -84,7 +84,7 @@
     "lead": "Agora baut aus deinem Text einen Wissensgraphen, bevölkert ihn mit hunderten Agenten — jeder mit eigener Biografie, Haltung, Blase — und lässt sie diskutieren, teilen, streiten. Du siehst in Echtzeit, wie sich Narrative ausbreiten, wo Gegenwind entsteht und welche Stimmen den Diskurs kippen. Vollständig lokal. Dein Laptop, dein Neo4j, dein Ollama.",
     "tags": {
       "engine": "Schwarm-Engine",
-      "version": "v0.8.0 alpha"
+      "version": "v0.9.0 alpha"
     },
     "system": {
       "kicker": "№ 02 — SYSTEM",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,7 +84,7 @@
     "lead": "Agora turns your text into a knowledge graph, populates it with hundreds of agents — each with their own biography, stance, bubble — and lets them debate, share, argue. You see in real time how narratives spread, where resistance forms, and which voices tip the discourse. Fully local. Your laptop, your Neo4j, your Ollama.",
     "tags": {
       "engine": "Swarm Engine",
-      "version": "v0.8.0 alpha"
+      "version": "v0.9.0 alpha"
     },
     "system": {
       "kicker": "№ 02 — SYSTEM",


### PR DESCRIPTION
## Summary

Mini-Fix nach dem v0.9.0-Release: der Version-Badge auf der Startseite (`frontend/src/views/Home.vue` Z.185, gerendert aus `home.tags.version`) zeigte noch `v0.8.0 alpha`. Beide Locales (`de.json`, `en.json`, jeweils Z.87) auf `v0.9.0 alpha` gebumpt.

## Test plan

- [x] `npm run check` 5/5 grün auf `72c9ce4` (671 backend, 40 frontend, build ok)
- [x] Diff = 2 Zeilen, eine pro Locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)