### PR TITLE
docs(review): archive v0.9.0 repo review + folge-slice-plan (Slice 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ### Docs
 
+- **Slice 6 (Repo-Review-Umsetzung): Review archiviert + Folge-Sub-Slice-Plan.** Externer Repo-Review aus `claude/v0.9.0-frontend-version` (Commit `e375d42`) als Audit-Artefakt unter `docu/2026-05-01-v0.9.0-repository-review.md` archiviert: vorangestellter Statusblock referenziert pro Action-Plan-Punkt (PR 1–5) den umsetzenden Commit (`28a5f2d`, `4bda1d8`, `821b4dd`, `21028d7`, `aace638`) plus Followups (`95cfee6`, `9d566b1`); Test-Cross-Check-Tabelle (12 Forderungen vs. Bestand in `backend/tests/`) und Doku-Cross-Check-Tabelle (8 Forderungen vs. `docu/`) machen Restpunkte sichtbar. Folge-Plan `docu/2026-05-01-v0.9.0-review-folge-slices-plan.md` definiert sechs Sub-Slices F1–F6 (Deployment-Doku Dev/Prod, Threat-Model, Operations + Backup/Restore, Release-Process, Test-Lücken SSRF/Upload/Cypher-Sanitizer, Branch-Cleanup). Quell-Branch wird in F6 gelöscht; `rolle-du-bist-temporal-otter.md` bewusst nicht ins Repo übernommen. Arbeitsprotokoll: `docu/2026-05-01-slice-6-review-archivierung-arbeitsprotokoll.md`.
+
 - **Slice 0 (Repo-Review-Umsetzung): README/Doku-Sync auf v0.9.0.** README-Status-Block, deutsche und englische Engineering-Stand-Sektionen, Testzahlen-Block (519 → 711, 488 → 671 Backend, 31 → 40 Frontend) und Release-Notes-Verweis auf v0.9.0 / Vorgänger v0.8.0 aktualisiert. Schnellstart-Sektion um expliziten Hardening-Drift-Hinweis ergänzt: `docker-compose.yml` baut aktuell den `prod`-Stage statt `dev`, Neo4j (`7474`/`7687`), Backend (`5001`) und Vite (`5173`) binden noch auf `0.0.0.0` — wird in Slice 2 entschärft. Arbeitsprotokoll: `docu/2026-05-01-slice-0-readme-v090-sync-arbeitsprotokoll.md`.
 
 ## [0.9.0] — 2026-05-01

--- a/docu/2026-05-01-slice-6-review-archivierung-arbeitsprotokoll.md
+++ b/docu/2026-05-01-slice-6-review-archivierung-arbeitsprotokoll.md
@@ -1,0 +1,63 @@
+# Slice 6 (Repo-Review-Umsetzung): Review archivieren + Folge-Sub-Slice-Plan
+
+**Datum:** 2026-05-01
+**Branch:** `claude/angry-napier-b3059a` (Worktree)
+**Bezug:** Repo-Review aus `claude/v0.9.0-frontend-version` (Commit `e375d42`).
+
+## Ziel
+
+Den externen Repo-Review nicht als „offenen Action Plan“ in main ablegen (PRs 1–5 sind längst umgesetzt), sondern als **Audit-Artefakt** mit klarem Statusblock plus Folge-Plan für die noch offenen Doku-/Test-Punkte.
+
+## Ausgangslage
+
+- `claude/v0.9.0-frontend-version` ist 1 Doku-Commit vor `origin/main`:
+  - `e375d42 feat(docs): add repository review and action plan for v0.9.0`
+  - Inhalt: `agora_repository_review.md` (Review) + `rolle-du-bist-temporal-otter.md` (Rollenbeschreibung, gehört nicht ins Repo).
+- Action-Plan PR 1–5 vollständig in main:
+  - Slice 0: `4edf5d3` README-Sync v0.9.0
+  - Slice 1 / PR 1: `28a5f2d` Secure Defaults
+  - Slice 2 / PR 2: `4bda1d8` Compose Dev/Prod-Trennung
+  - Slice 3 / PR 3: `821b4dd` Redis-Tickets
+  - Slice 4 / PR 4: `21028d7` CVE-Risk-Register
+  - Slice 5 / PR 5: `aace638` Frontend-Token + auth.md
+  - Followups: `95cfee6` PR127-Blocker, `9d566b1` Redis-Logging
+- PR #119 (v0.9.0 Version-Bump) bereits gemerged.
+
+## Vorgehen
+
+1. Inhalt des Reviews aus `e375d42` extrahiert (`git show origin/claude/v0.9.0-frontend-version:agora_repository_review.md`).
+2. Neue archivierte Fassung als `docu/2026-05-01-v0.9.0-repository-review.md` angelegt:
+   - **Audit-Header** kennzeichnet das Dokument als historisches Artefakt.
+   - **Statusblock** mit Tabelle: Action-Plan-Punkt → Commit-Hash + Commit-Message.
+   - **Test-Cross-Check-Tabelle**: Review-Forderung vs. Bestand in `backend/tests/` (12 Zeilen, 7×✅, 1×⚠️, 4×❌/prüfen).
+   - **Doku-Cross-Check-Tabelle**: Review-Forderung vs. Bestand in `docu/` (8 Zeilen, 2×✅, 6×❌).
+   - **Original-Inhalt unverändert** unterhalb des Statusblocks erhalten.
+3. Folge-Plan als `docu/2026-05-01-v0.9.0-review-folge-slices-plan.md` angelegt:
+   - 6 Sub-Slices (F1–F6) mit Scope, Akzeptanzkriterien, Aufwand.
+   - F1 Deployment-Doku (dev + prod-like).
+   - F2 Security-Threat-Model.
+   - F3 Operations + Backup/Restore.
+   - F4 Release-Process.
+   - F5 Test-Lücken (SSRF, Upload, Cypher-Sanitizer, Anonymous-Healthcheck).
+   - F6 Branch-Cleanup (`claude/v0.9.0-frontend-version` löschen, README-Doku-Index).
+4. `CHANGELOG.md` `[Unreleased] / Docs` erweitert um Slice-6-Eintrag.
+
+## Bewusst nicht übernommen
+
+- `rolle-du-bist-temporal-otter.md` aus dem Quell-Branch — Rollen-/Persona-Beschreibungen gehören nicht ins Projekt-Repo.
+- Die Datei `agora_repository_review.md` im Repo-Root — Doku-Artefakte gehören nach `docu/`, nicht in den Root.
+
+## Branch-Strategie
+
+- Nach Merge dieses Sub-Slices in `main` wird `claude/v0.9.0-frontend-version` gelöscht (lokal + remote). Geplant in **Sub-Slice F6**.
+- Linearer Git-Flow: dieser Sub-Slice geht direkt gegen `main` (fast-forward, 1 Commit, 1 PR).
+
+## Verifikation
+
+- `npm run check` (Backend-Tests + Frontend-Lint + Build): siehe Commit-Log.
+- Manuelle Cross-Checks der Status-/Doku-/Test-Tabellen gegen `git log origin/main` und `ls docu/` / `ls backend/tests/`.
+
+## Issues / Milestone
+
+- Kein Issue für diesen Doku-Sub-Slice (Aufräum-/Archivierungs-Arbeit).
+- Folge-Sub-Slices F1–F5 sind Kandidaten für eigene Issues, falls gewünscht.

--- a/docu/2026-05-01-v0.9.0-repository-review.md
+++ b/docu/2026-05-01-v0.9.0-repository-review.md
@@ -1,0 +1,433 @@
+# Repository Review: arn0ld87/agora (v0.9.0)
+
+> **Audit-Artefakt — Stand 2026-05-01.**
+> Dieses Dokument ist die archivierte Fassung des externen Repository-Reviews,
+> der ursprünglich als `agora_repository_review.md` im Branch
+> `claude/v0.9.0-frontend-version` (Commit `e375d42`) abgelegt war. Es wird hier
+> nur als historischer Befund-Bericht beibehalten — der ursprünglich darin
+> formulierte Action Plan (PR 1–5) ist zum Zeitpunkt der Archivierung bereits
+> vollständig umgesetzt (siehe Statusblock).
+
+---
+
+## Umsetzungs-Statusblock (2026-05-01)
+
+| Action-Plan-Punkt | Status | Commit / Artefakt |
+|---|---|---|
+| Slice 0: README/Doku-Sync auf v0.9.0 | ✅ erledigt | [`4edf5d3`](../../../commit/4edf5d3) — `docs: sync README to v0.9.0 + flag known compose/neo4j drift (Slice 0)` |
+| PR 1 / Slice 1: Secure Defaults + Config-Validation | ✅ erledigt | [`28a5f2d`](../../../commit/28a5f2d) — `feat(security): reject placeholder secrets and empty token in non-debug` |
+| PR 2 / Slice 2: Docker Compose Dev/Prod-Trennung | ✅ erledigt | [`4bda1d8`](../../../commit/4bda1d8) — `feat(deploy): split dev/prod compose, lock ports to loopback` |
+| PR 3 / Slice 3: Redis-basierte Single-Use-Tickets | ✅ erledigt | [`821b4dd`](../../../commit/821b4dd) — `fix(security): redis-backed single-use tickets for multi-worker gunicorn` |
+| PR 4 / Slice 4: CVE-Baseline aktiv abbauen | ✅ erledigt | [`21028d7`](../../../commit/21028d7) — `chore(security): track ignored CVEs in risk register, link CI ignores to issues` |
+| PR 5 / Slice 5: Frontend-Token-Härtung + auth.md | ✅ erledigt | [`aace638`](../../../commit/aace638) — `feat(security): memory-token mode + auth.md, confirm xss regression` |
+| Review-Followup: PR127 Review-Blocker | ✅ erledigt | [`95cfee6`](../../../commit/95cfee6) — `fix(review): address PR127 review blockers` |
+| Review-Followup: Redis-Logging + Security-Fixtures | ✅ erledigt | [`9d566b1`](../../../commit/9d566b1) — `fix(review): harden redis logging and security fixtures` |
+
+**Test-Cross-Check (Review-Forderung vs. Bestand in `backend/tests/`):**
+
+| Geforderter Test | Status | Datei |
+|---|---|---|
+| `Config.validate()` lehnt Placeholder-Secrets im Nicht-Debug ab | ✅ | `test_config_security.py` (12 Cases) |
+| `FLASK_DEBUG=true` + leerer Token → Warning + Dev-only-Markierung | ⚠️ teils | `test_auth.py` deckt Token-Pflicht; explizite Warning-Assertion offen |
+| `AGORA_ALLOW_ANONYMOUS=true` in Prod-Healthcheck sichtbar | ❌ offen | — |
+| `?token=` in Prod deaktivierbar / Deprecation-Metrik | ❌ offen | — |
+| Signed-Ticket Replay mit mehreren Worker-Kontexten | ✅ | `test_signed_ticket_redis.py` (6 Cases inkl. Multi-Worker-Race) |
+| Redis-Ticket-Redemption `SET NX EX` | ✅ | `test_signed_ticket_redis.py` |
+| `docker compose config` Snapshot-Test für `target: dev` | ✅ | `test_compose_snapshot.py` (8 Cases, skip-if-no-docker) |
+| Neo4j-Port-Bindings nur Loopback in Dev | ✅ | `test_compose_snapshot.py` |
+| Markdown-XSS: `<script>`, `<img onerror>`, `javascript:` | ✅ | `frontend/src/utils/__tests__/markdown.test.js` (9 Regressions) |
+| Upload-Grenzen: Endung, PDF-Header, 50 MB, Path-Traversal | ❌ prüfen | bestehender Schutz im Code, dezidierte Tests offen |
+| SSRF-Blocker: `localhost`, `127.0.0.1`, `169.254.169.254`, IPv6 `::1` | ❌ prüfen | Code in `web_tools.py`, Test-Coverage zu verifizieren |
+| Cypher-Label-Sanitizer gegen Backticks / ungültige Entity-Typen | ❌ prüfen | — |
+| Report-/Simulation-Logs ohne Tokens | ✅ | `test_logger_redaction.py` |
+
+**Doku-Cross-Check (Review-Forderung vs. Bestand in `docu/`):**
+
+| Geforderte Doku | Status |
+|---|---|
+| `docu/auth.md` — Token-Header, Ticket-Flow, Query-Token-Deprecation | ✅ (Slice 5) |
+| `docu/dependency-risk-register.md` — ignorierte CVEs, Owner, Frist | ✅ (Slice 4) |
+| `docu/security-threat-model.md` — Assets, Trust Boundaries, Restrisiken | ❌ offen |
+| `docu/deployment-dev.md` — lokaler Dev-Betrieb Vite + Flask | ❌ offen |
+| `docu/deployment-prod-like.md` — Gunicorn, Reverse Proxy, Tailscale | ❌ offen |
+| `docu/backup-restore.md` — Neo4j, Uploads, Reports, Simulationen | ❌ offen |
+| `docu/operations.md` — Logs, Healthchecks, Ausfälle | ❌ offen |
+| `docu/release-process.md` — Versionsquellen, Changelog, Tags | ❌ offen |
+
+**Folge-Plan:** siehe [`2026-05-01-v0.9.0-review-folge-slices-plan.md`](2026-05-01-v0.9.0-review-folge-slices-plan.md).
+
+---
+
+# Original-Review-Inhalt (unverändert)
+
+## Kurzbewertung
+
+| Bereich | Bewertung | Begründung |
+|---|---:|---|
+| Architektur | 7.5/10 | Klare Trennung zwischen Flask-API, Service-Layer, GraphStorage/Neo4j, Event-Bus und Frontend. Die README dokumentiert die Zielarchitektur und die API-Aufteilung nachvollziehbar. |
+| Codequalität | 7/10 | Gute Modularisierung, Retry-Wrapper, Validierungsfunktionen und zentrale API-Envelopes. Einzelne Versionen/Runtime-Kommentare sind inkonsistent, und einige Pfade bleiben experimentell. |
+| Sicherheit | 6/10 | Viele sinnvolle Härtungen sind vorhanden: restriktives CORS, optionaler Token-Guard, SSRF-Blocker, DOMPurify, Secret-Redaction, Upload-Schutz. Kritisch bleiben Default-Debug/Auth-Setup, schwacher Beispiel-SECRET_KEY, Token in localStorage, bekannte CVE-Ignores und Multi-Worker-Ticket-Replay-Lücke. |
+| Tests | 8/10 | CI führt Backend-Tests, Frontend-Tests, Ruff, ESLint, Build, npm audit, pip-audit und Gitleaks aus. Laut README existieren 488 Backend- und 31 Frontend-Tests. Ich habe die Tests nicht ausgeführt. |
+| Dokumentation | 7/10 | README und Security-Doku sind ungewöhnlich ausführlich. Problematisch sind widersprüchliche Versionsangaben und falsche/unklare Docker-Compose-Aussagen. |
+| Deployment | 5.5/10 | Compose, Dockerfile und Prod-Override existieren, aber Default-Compose und Dockerfile-Ziel passen erkennbar nicht sauber zusammen. Neo4j-Ports werden offen gemappt. |
+| Wartbarkeit | 7/10 | Gute Refactoring-Spuren, DI-Container, zentrale Composables, API-Module. Risiko durch komplexe Pipeline, OASIS-Subprozesse, lokale Artefakte und Versionsdrift. |
+
+## Gesamturteil
+
+Das Projekt ist **MVP-tauglich für lokale, vertrauenswürdige Single-User-Setups** und technisch deutlich über einem reinen Prototyp. Es ist aber **nicht produktionsnah**, wenn „produktionsnah“ öffentlich erreichbar, multi-user-fähig, dauerhaft betreibbar und sauber gehärtet bedeutet.
+
+- **Größter technischer Vorteil:** Architektur und Refactoring-Stand sind erstaunlich ordentlich: Service-Layer, DI-Container, Redis/File-Event-Bus, API-Envelopes, Frontend-Composables und CI-Gates sind vorhanden.
+- **Größtes Risiko:** Das Default-Betriebsmodell kann zu offen sein: `.env.example` setzt `FLASK_DEBUG=true`, `AGORA_AUTH_TOKEN` ist auskommentiert, Docker bindet intern auf `0.0.0.0`, Compose veröffentlicht Ports. Das ist für lokale Entwicklung bequem, aber als Sicherheitsmodell ungefähr so beruhigend wie ein Haustürschlüssel unter der Fußmatte.
+
+## Faktenbasis
+
+Geprüfte zentrale Dateien:
+
+- `README.md`
+- `package.json`
+- `frontend/package.json`
+- `backend/pyproject.toml`
+- `.env.example`
+- `Dockerfile`
+- `docker-compose.yml`
+- `docker-compose.prod.yml`
+- `.github/workflows/ci.yml`
+- `backend/app/__init__.py`
+- `backend/app/config.py`
+- `backend/app/utils/auth.py`
+- `backend/app/utils/signed_ticket.py`
+- `backend/app/api/auth.py`
+- `backend/app/api/graph.py`
+- `backend/app/api/report.py`
+- `backend/app/models/project.py`
+- `backend/app/utils/file_parser.py`
+- `backend/app/utils/llm_client.py`
+- `backend/app/services/web_tools.py`
+- `backend/app/storage/neo4j_storage.py`
+- `backend/app/storage/neo4j_write.py`
+- `frontend/src/api/index.js`
+- `frontend/src/components/Step4Report.vue`
+- `frontend/src/utils/markdown.js`
+- `docu/security-hardening.md`
+
+Nicht bewertet durch Ausführung:
+
+- Tests wurden nicht lokal ausgeführt.
+- Docker-Image wurde nicht gebaut.
+- Dependency-Audit wurde nicht live ausgeführt.
+- Laufzeitverhalten mit Ollama/Neo4j/Redis wurde nicht gestartet.
+- Vollständige Historie und alle Commits wurden nicht manuell geprüft.
+
+## Kritische Probleme
+
+### 1. Unsicheres Default-Setup bei Kopie von `.env.example`
+
+**Problem:** `.env.example` setzt `FLASK_DEBUG=true`, lässt `AGORA_AUTH_TOKEN` auskommentiert und enthält einen öffentlichen Platzhalter für `SECRET_KEY`.
+
+**Datei/Pfad:**
+
+- `.env.example`
+- `backend/app/config.py`
+- `backend/app/utils/auth.py`
+- `Dockerfile`
+- `docker-compose.yml`
+
+**Risiko:**
+
+Bei `cp .env.example .env` und anschließendem Docker-Start kann das Backend im Debug-Modus ohne API-Token laufen. `Config.validate()` erzwingt `AGORA_AUTH_TOKEN` nur im Nicht-Debug-Modus. `auth.py` macht den Guard zum No-Op, wenn `AGORA_AUTH_TOKEN` leer ist. Docker setzt `FLASK_HOST=0.0.0.0`, Compose veröffentlicht Backend/Frontend-Ports.
+
+**Empfohlener Fix:**
+
+- `.env.example`: `FLASK_DEBUG=false` als sichtbaren Default setzen.
+- `Config.validate()` muss bekannte Platzhalter wie `change-me-use-token_urlsafe-32`, `change-me`, `agora`, `password` im Nicht-Debug-Modus hart ablehnen.
+- Compose-Beispiele für lokale Entwicklung und Produktivbetrieb strikt trennen.
+- API-Port im Default-Compose auf Loopback binden:
+
+```yaml
+ports:
+  - "127.0.0.1:${AGORA_BACKEND_PORT:-5001}:5001"
+  - "127.0.0.1:${AGORA_FRONTEND_PORT:-5173}:5173"
+```
+
+### 2. Dockerfile/Compose-Target inkonsistent
+
+**Problem:** `Dockerfile` definiert `dev`, `prod-builder` und `prod`; der letzte Stage ist `prod`. `docker-compose.yml` nutzt nur `build: .` ohne `target: dev`, mappt aber Port `5173` und kommentiert Dev-Verhalten. Ohne explizites Target baut Docker standardmäßig den letzten Stage.
+
+**Datei/Pfad:**
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `docker-compose.prod.yml`
+- `README.md`
+
+**Risiko:**
+
+Der dokumentierte Schnellstart „Frontend unter localhost:5173“ kann mit dem Default-Compose fehlschlagen, wenn tatsächlich der `prod`-Stage gebaut wird und nur Gunicorn auf `5001` läuft.
+
+**Empfohlener Fix:**
+
+Entweder Default-Compose eindeutig als Dev definieren:
+
+```yaml
+services:
+  agora:
+    build:
+      context: .
+      target: dev
+```
+
+oder Default-Compose produktiv machen und Frontend nicht auf `5173` veröffentlichen.
+
+### 3. Signierte Tickets sind bei Gunicorn mit zwei Workern nicht global single-use
+
+**Problem:** `signed_ticket.py` hält eingelöste Tickets in einem prozesslokalen `_seen`-Dict. Die Doku im Code sagt selbst, dass Multi-Worker-Deployments die Single-Use-Garantie pro Worker verlieren. Der Prod-CMD startet Gunicorn mit `--workers 2`.
+
+**Datei/Pfad:**
+
+- `backend/app/utils/signed_ticket.py`
+- `Dockerfile`
+
+**Risiko:**
+
+Ein Ticket kann bei zwei Workern theoretisch mehrfach akzeptiert werden, wenn Requests auf unterschiedliche Worker fallen.
+
+**Empfohlener Fix:**
+
+- Ticket-Redemption in Redis speichern, z. B. `SET ticket:<sig> 1 NX EX <ttl>`.
+- Alternativ `--workers 1` für Single-User-Local-Deployments explizit dokumentieren, aber das ist nur ein Workaround.
+
+### 4. Bekannte Dependency-Advisories werden in CI ignoriert
+
+**Problem:** Der CI-Security-Job ignoriert sechs CVEs wegen `camel-oasis`, `camel-ai`, `sentence-transformers` und verwandter Pins.
+
+**Datei/Pfad:**
+
+- `.github/workflows/ci.yml`
+- `docu/security-hardening.md`
+
+**Risiko:**
+
+Das ist als temporäre Baseline nachvollziehbar, aber produktionsnah ist es nicht. Ignorierte CVEs müssen aktiv getrackt werden, sonst wird „temporär“ zur berühmten permanenten Übergangslösung, also zur eigentlichen IT-Kulturleistung.
+
+**Empfohlener Fix:**
+
+- GitHub Issues je Advisory anlegen.
+- CI-Kommentar um Ablaufdatum ergänzen.
+- Monatlichen Dependency-Upgrade-Job einführen.
+- Prüfen, ob `camel-*` isoliert oder ersetzt werden kann.
+
+### 5. Neo4j-Ports werden offen veröffentlicht
+
+**Problem:** Compose mappt `7474:7474` und `7687:7687`.
+
+**Datei/Pfad:**
+
+- `docker-compose.yml`
+
+**Risiko:**
+
+Auf einem Server sind Neo4j Browser und Bolt je nach Firewall/LAN/Tailnet erreichbar. Auth ist vorhanden, aber unnötige Exposition bleibt Angriffsfläche.
+
+**Empfohlener Fix:**
+
+Für lokale Nutzung:
+
+```yaml
+ports:
+  - "127.0.0.1:7474:7474"
+  - "127.0.0.1:7687:7687"
+```
+
+Für echten Betrieb: keine Host-Port-Veröffentlichung, nur internes Docker-Netz.
+
+## Wichtige Verbesserungen
+
+| Priorität | Bereich | Maßnahme | Aufwand | Wirkung |
+|---|---|---|---|---|
+| Hoch | Security | `.env.example` und `Config.validate()` gegen Debug/Placeholder-Defaults härten | niedrig | Verhindert offene Fehlkonfigurationen |
+| Hoch | Deployment | `docker-compose.yml` mit explizitem `target: dev` oder produktiver Port-Strategie korrigieren | niedrig | Schnellstart wird reproduzierbar |
+| Hoch | Security | Redis-basierte Ticket-Redemption statt prozesslokalem `_seen` | mittel | Single-use Tickets funktionieren mit mehreren Workern |
+| Hoch | Dependencies | CVE-Baseline in Issues überführen und Upgrade-Plan für `camel-*` | mittel | Sicherheitsrisiko wird steuerbar |
+| Mittel | Network Security | Neo4j-Ports nur auf Loopback oder gar nicht veröffentlichen | niedrig | Weniger Angriffsfläche |
+| Mittel | Frontend Security | Token nicht dauerhaft in `localStorage` ablegen | mittel | XSS-Folgeschaden sinkt |
+| Mittel | Versionierung | Versionen in README, root package, frontend, backend und `__version__` synchronisieren | niedrig | Weniger Betriebs-/Release-Verwirrung |
+| Mittel | Tests | Security-Regressions für Debug/Auth/Token/Ticket/Port-Doku ergänzen | mittel | Kritische Defaults bleiben stabil |
+| Niedrig | Dokumentation | Betriebsmodi „local dev“, „trusted LAN“, „prod-like“ trennen | niedrig | Weniger Fehlbedienung |
+
+## Konkreter Refactoring-Plan
+
+### PR 1: Secure Defaults und Config-Validation
+
+**Ziel:** Keine offene API durch versehentlich übernommene Beispielwerte.
+
+**Änderungen:**
+
+- `.env.example`: `FLASK_DEBUG=false`.
+- `Config.validate()` lehnt bekannte Platzhalter in Nicht-Debug hart ab.
+- Neue Tests für:
+  - Debug false + fehlender Token → Fehler.
+  - Debug false + Placeholder `SECRET_KEY` → Fehler.
+  - Debug true + fehlender Token → erlaubt, aber Warning.
+- README-Schnellstart mit explizitem lokalen Dev-Hinweis.
+
+**Akzeptanzkriterien:**
+
+- `uv run pytest tests/test_config_security.py` grün.
+- App startet in Nicht-Debug nicht mit Placeholder-Secret.
+- README zeigt sicheren Token-Setup-Befehl.
+
+### PR 2: Docker Compose klar in Dev und Prod trennen
+
+**Ziel:** Reproduzierbarer Start ohne falsche Port-Erwartung.
+
+**Änderungen:**
+
+- `docker-compose.yml` als Dev-Compose mit `target: dev`.
+- `docker-compose.prod.yml` als Prod-Override mit nur Backend-Port oder Reverse-Proxy-Hinweis.
+- Neo4j-Ports im Dev-Compose auf `127.0.0.1` binden.
+- README-Schnellstart korrigieren.
+
+**Akzeptanzkriterien:**
+
+- `docker compose config` zeigt `target: dev`.
+- `docker compose up -d --build` startet Vite auf `5173`.
+- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` zeigt keinen Frontend-Port `5173`.
+
+### PR 3: Ticket-Redemption in Redis
+
+**Ziel:** Single-use-Tickets funktionieren über mehrere Gunicorn-Worker.
+
+**Änderungen:**
+
+- `signed_ticket.consume()` optional mit Redis-Backend.
+- Fallback auf In-Memory nur im File-/Dev-Modus.
+- Tests für Replay über simulierten Shared Store.
+- Doku in `security-hardening.md` aktualisieren.
+
+**Akzeptanzkriterien:**
+
+- Zweiter Consume desselben Tickets schlägt auch bei separater Prozesssimulation fehl.
+- Ohne Redis bleibt lokaler Dev lauffähig, aber mit Warning bei mehreren Workern.
+
+### PR 4: Dependency-Baseline abbauen
+
+**Ziel:** Ignorierte CVEs nicht im CI-Kommentar verrotten lassen.
+
+**Änderungen:**
+
+- Je ignorierter CVE ein Issue mit Paket, Upstream-Pin, Risiko, Zielversion.
+- `pip-audit`-Ignore-Liste mit Kommentar `expires`.
+- Evaluieren, ob `camel-oasis` isoliert in Subprozess/Container mit restriktiveren Rechten laufen kann.
+
+**Akzeptanzkriterien:**
+
+- CI bleibt grün.
+- Security-Issues existieren.
+- Doku nennt Verantwortlichkeit und Prüffrequenz.
+
+### PR 5: Frontend-Token-Härtung
+
+**Ziel:** Weniger Schaden bei XSS oder Browser-Plugin-Zugriff.
+
+**Änderungen:**
+
+- `localStorage` nur als Dev-Fallback dokumentieren.
+- Für Prod: Token per Runtime-Input nur im Memory halten oder Backend-Session mit HttpOnly-Cookie einführen.
+- DOMPurify-Konfiguration mit Tests gegen `<script>`, `onerror`, `javascript:`.
+
+**Akzeptanzkriterien:**
+
+- Bestehender Dev-Flow funktioniert.
+- Tests prüfen Markdown-XSS-Regression.
+- Prod-Doku empfiehlt kein dauerhaftes `localStorage`-Token.
+
+## Security-Fixes
+
+Konkrete Maßnahmen ohne Codeänderung:
+
+1. `.env` für Betrieb sofort härten:
+
+```env
+FLASK_DEBUG=false
+SECRET_KEY=<token_urlsafe_32_oder_länger>
+AGORA_AUTH_TOKEN=<token_urlsafe_32_oder_länger>
+AGORA_ALLOW_ANONYMOUS=false
+AGORA_CORS_ALLOW_ALL=false
+NEO4J_PASSWORD=<starkes_passwort>
+```
+
+2. Neo4j nur lokal binden:
+
+```yaml
+neo4j:
+  ports:
+    - "127.0.0.1:7474:7474"
+    - "127.0.0.1:7687:7687"
+```
+
+3. Backend-Port nicht ungefiltert veröffentlichen:
+
+```yaml
+agora:
+  ports:
+    - "127.0.0.1:${AGORA_BACKEND_PORT:-5001}:5001"
+```
+
+4. Bei Tailscale/WireGuard nur explizite Origins setzen:
+
+```env
+AGORA_EXTRA_ORIGINS=https://agora.tailnet.example
+```
+
+5. CVE-Ignores nicht „akzeptieren“, sondern tracken.
+
+## Tests, die ergänzt werden sollten
+
+- `Config.validate()` lehnt Placeholder-Secrets im Nicht-Debug-Modus ab.
+- `FLASK_DEBUG=true` + leerer Token erzeugt Warning und wird als Dev-only markiert.
+- `AGORA_ALLOW_ANONYMOUS=true` ist im Prod-Healthcheck sichtbar.
+- `?token=` wird in Prod deaktivierbar oder erzeugt Deprecation-Metrik.
+- Signed Ticket Replay mit mehreren Worker-Kontexten.
+- Redis-Ticket-Redemption `SET NX EX`.
+- `docker compose config` Snapshot-Test für `target: dev`.
+- Neo4j-Port-Bindings nur Loopback in Dev.
+- Markdown-XSS: `<script>`, `<img onerror>`, `[x](javascript:alert(1))`.
+- Upload-Grenzen: Dateiendung, PDF-Header, 50-MB-Limit, Path-Traversal-Dateiname.
+- SSRF-Blocker: `localhost`, `127.0.0.1`, `10.0.0.1`, `169.254.169.254`, IPv6 `::1`.
+- Cypher-Label-Sanitizer gegen Backticks und lange/ungültige Entity-Typen.
+- Report-/Simulation-Logs dürfen keine Tokens enthalten.
+
+## Fehlende Dokumentation
+
+Exakt ergänzen:
+
+- `docu/deployment-dev.md`: lokaler Dev-Betrieb mit Vite + Flask.
+- `docu/deployment-prod-like.md`: Gunicorn, Reverse Proxy, Auth, CORS, Tailscale/WireGuard.
+- `docu/security-threat-model.md`: Assets, Trust Boundaries, Angreifer, bekannte Restrisiken.
+- `docu/dependency-risk-register.md`: ignorierte CVEs, Owner, Zielversion, Frist.
+- `docu/auth.md`: Token-Header, Ticket-Flow, Query-Token-Deprecation, localStorage-Risiko.
+- `docu/backup-restore.md`: Neo4j-Daten, Upload-Artefakte, Reports, Simulationen.
+- `docu/operations.md`: Logs, Healthchecks, Ressourcenbedarf, Redis/Neo4j/Ollama-Ausfall.
+- `docu/release-process.md`: Versionsquellen synchronisieren, Changelog, Tags, Container-Images.
+
+## Empfehlung
+
+- **Weiterentwickeln:** Ja, aber als lokales/trusted-network MVP.
+- **Erst refactoren:** Ja, zuerst Config/Compose/Auth-Defaults.
+- **Security-Fixes priorisieren:** Ja, PR 1 bis PR 4 vor weiteren Features.
+- **Tests nachziehen:** Ja, besonders Security-Regression und Compose-Snapshot.
+- **Deployment verbessern:** Ja, Dev/Prod sauber trennen und Neo4j nicht offen veröffentlichen.
+
+## Klare technische Empfehlung
+
+**Erst Security- und Deployment-Basis stabilisieren, dann Features bauen.**
+
+Reihenfolge:
+
+1. Secure Defaults + Placeholder-Validation.
+2. Docker Compose Target/Ports korrigieren.
+3. Ticket-Redemption mit Redis.
+4. CVE-Baseline aktiv abbauen.
+5. Frontend-Token-Handling verbessern.
+
+Danach ist das Projekt stark genug für private Demos, kontrollierte Testnutzer und weitere Produktentwicklung. Für öffentliche Nutzung fehlen echte AuthN/AuthZ, Rollenmodell, Secrets-Management, Dependency-Risikoreduktion und belastbare Betriebsdokumentation.

--- a/docu/2026-05-01-v0.9.0-review-folge-slices-plan.md
+++ b/docu/2026-05-01-v0.9.0-review-folge-slices-plan.md
@@ -1,0 +1,131 @@
+# Folge-Sub-Slice-Plan: Repo-Review-Restpunkte (post v0.9.0)
+
+**Stand:** 2026-05-01
+**Bezug:** [`2026-05-01-v0.9.0-repository-review.md`](2026-05-01-v0.9.0-repository-review.md)
+**Vorgehen:** Slice-Workflow nach `MEMORY.md` — pro Sub-Slice 1 Commit, 1 Arbeitsprotokoll, `npm run check` als Gate, `CHANGELOG.md` `[Unreleased]` pflegen, Issue/Milestone-Check.
+
+---
+
+## Status
+
+- Action-Plan PR 1–5 sind ✅ in `main` (Slices 1–5 + zwei Review-Followups). Siehe Statusblock im Review-Dokument.
+- Offen sind nur noch (a) **fehlende Doku** (5 Dateien) und (b) **fehlende Test-Coverage** für drei Bereiche, die laut Review explizit gefordert wurden, aber im Bestand nur indirekt belegt sind.
+
+---
+
+## Sub-Slice F1 — Deployment-Doku Dev/Prod
+
+**Scope:** Zwei neue Dateien ergänzen.
+
+- `docu/deployment-dev.md`
+  - Lokaler Dev-Betrieb (Vite + Flask, ohne Docker).
+  - Docker-Compose-Dev-Pfad (`target: dev`, Loopback-Ports, Hot-Reload).
+  - Voraussetzungen: `uv`, `pnpm`/`npm`, Neo4j (lokal oder Docker), Redis (optional).
+  - Verweis auf `auth.md` für Dev-Token-Setup.
+- `docu/deployment-prod-like.md`
+  - Gunicorn (`--workers 2`), Reverse Proxy (Traefik/Nginx), Tailscale/WireGuard-Pattern.
+  - CORS-/Auth-Config (Hard-Reject Placeholder, kein `AGORA_CORS_ALLOW_ALL`).
+  - Compose-Prod-Override (Frontend-Port nicht veröffentlicht).
+  - Neo4j: keine Host-Port-Veröffentlichung.
+  - Verweis auf `dependency-risk-register.md` für CVE-Baseline.
+
+**Akzeptanz:** README verlinkt beide Dokumente; `npm run check` grün.
+**Aufwand:** ~1 h.
+
+---
+
+## Sub-Slice F2 — Security-Threat-Model
+
+**Scope:** Eine neue Datei.
+
+- `docu/security-threat-model.md`
+  - Assets: Neo4j-Daten, Uploads, Reports, OASIS-Artefakte, Auth-Token, Tickets.
+  - Trust Boundaries: Browser ↔ Frontend, Frontend ↔ Backend, Backend ↔ Neo4j/Redis/Ollama, Backend ↔ Outbound-HTTP.
+  - Angreifer-Modelle: untrusted LAN, kompromittierter Browser-Plugin/XSS-Gadget, supply-chain Dep, geleakter Token.
+  - Bekannte Restrisiken: kein echtes AuthN/AuthZ, kein Rollenmodell, keine Secrets-Rotation, OASIS-Subprozess-Vertrauen.
+  - Verweis auf Slice 1/3/5 für umgesetzte Mitigations.
+
+**Akzeptanz:** Doku konsistent mit `auth.md`, `dependency-risk-register.md`, `security-hardening.md`; `npm run check` grün.
+**Aufwand:** ~1.5 h.
+
+---
+
+## Sub-Slice F3 — Operations + Backup/Restore
+
+**Scope:** Zwei neue Dateien (gebündelt, da inhaltlich verwandt).
+
+- `docu/operations.md`
+  - Logs: `agora.log`, `agora.config`-Warnings, Logger-Redaction.
+  - Healthcheck-Endpunkte (`/api/health`, ggf. `/api/health/auth`).
+  - Ressourcenbedarf: RAM/CPU pro Komponente, GPU-Probe für Embedding.
+  - Ausfälle: Neo4j down, Redis down (Ticket-Fallback), Ollama down (LLM-Pfad).
+- `docu/backup-restore.md`
+  - Neo4j: `neo4j-admin database dump`, Restore-Pfad.
+  - Upload-Artefakte (`backend/uploads/`), Reports, Simulationen.
+  - Cron-Strategie (täglicher Dump, wöchentliche Rotation).
+  - Restore-Drill-Empfehlung.
+
+**Akzeptanz:** Beide Dateien existieren, README/Operations-Sektion verlinkt; `npm run check` grün.
+**Aufwand:** ~1.5 h.
+
+---
+
+## Sub-Slice F4 — Release-Process-Doku
+
+**Scope:** Eine neue Datei.
+
+- `docu/release-process.md`
+  - Versionsquellen: `package.json` (root), `frontend/package.json`, `backend/pyproject.toml`, `backend/app/__version__.py`, README-Status-Block, Frontend-Startseite-Badge.
+  - Reihenfolge: CHANGELOG `[Unreleased]` → SemVer-Bump → Synchronisierung aller Quellen → Tag → Release-Notes → optional Container-Image-Build.
+  - Verweis auf existierende Release-Notes in `docu/2026-05-01-v0.9.0-release-notes.md` als Vorlage.
+
+**Akzeptanz:** Doku liefert reproduzierbares Rezept; `npm run check` grün.
+**Aufwand:** ~45 min.
+
+---
+
+## Sub-Slice F5 — Test-Coverage-Lücken (Security-Regression)
+
+**Scope:** Tests für drei explizit im Review geforderte Bereiche, deren Code zwar existiert, aber Tests entweder fehlen oder nur indirekt vorhanden sind.
+
+- `backend/tests/test_ssrf_blocker.py`
+  - Cases: `localhost`, `127.0.0.1`, `10.0.0.1`, `169.254.169.254`, IPv6 `::1`, IPv6 link-local, valider externer Host (Negativ-Kontrolle).
+  - Targeting: `backend/app/services/web_tools.py`.
+- `backend/tests/test_upload_limits.py`
+  - Cases: zu große Datei (>50 MB), falsche Endung, PDF-ohne-Magic-Header, Path-Traversal-Filename (`../../etc/passwd`), zulässige Datei (Negativ-Kontrolle).
+  - Targeting: `backend/app/utils/file_parser.py` + Upload-Endpoint.
+- `backend/tests/test_cypher_label_sanitizer.py`
+  - Cases: Backticks im Entity-Type, übermäßig lange Labels, Sonderzeichen, leere Strings, regulärer Label (Negativ-Kontrolle).
+  - Targeting: `backend/app/storage/neo4j_write.py` Label-Sanitizer.
+- Bonus: `test_anonymous_in_healthcheck.py` (kurz) — `AGORA_ALLOW_ANONYMOUS=true` taucht im Health-Endpoint auf.
+
+**Akzeptanz:** Alle neuen Tests grün, bestehende Tests grün, `npm run check` grün, Test-Counter im README-Status-Block aktualisiert.
+**Aufwand:** ~2.5 h.
+
+---
+
+## Sub-Slice F6 — Branch-Cleanup + README-Update
+
+**Scope:** Aufräumen.
+
+- Lokal + Remote löschen: `claude/v0.9.0-frontend-version` (Branch wird durch dieses Archiv-Dokument ersetzt; `rolle-du-bist-temporal-otter.md` gehört nicht ins Repo).
+- Optional: weitere abgeschlossene Slice-Branches mit `git branch -d` aufräumen (vorher `git branch --merged main` checken).
+- README: `docu/`-Index oder Doku-Sektion auf neue Dateien (F1–F4) verweisen.
+
+**Akzeptanz:** `git branch -a | grep v0.9.0-frontend-version` leer; README-Doku-Liste aktuell.
+**Aufwand:** ~30 min.
+
+---
+
+## Reihenfolge-Empfehlung
+
+| Sub-Slice | Begründung |
+|---|---|
+| F1 | Größte Hebelwirkung, fehlt am sichtbarsten. |
+| F2 | Bündelt sicherheitsrelevante Doku, verweist auf F1. |
+| F4 | Release-Process kurz, hilft beim nächsten Bump. |
+| F3 | Ops/Backup wichtiger sobald jemand außer dir das Ding betreibt. |
+| F5 | Tests; greifen erst, wenn jemand am Code rührt. |
+| F6 | Aufräumen ganz am Schluss. |
+
+**Alle Sub-Slices arbeiten gegen `main` direkt** (linearer Git-Flow, fast-forward, 1 Commit / 1 PR pro Sub-Slice).


### PR DESCRIPTION
## Summary

- Archiviert den externen Repo-Review aus `claude/v0.9.0-frontend-version` (Commit `e375d42`) als Audit-Artefakt unter `docu/2026-05-01-v0.9.0-repository-review.md`.
- Vorangestellter Statusblock referenziert pro Action-Plan-Punkt (PR 1-5) den umsetzenden Commit; Test-/Doku-Cross-Check-Tabellen machen Restpunkte sichtbar.
- Folge-Plan `docu/2026-05-01-v0.9.0-review-folge-slices-plan.md` definiert sechs Sub-Slices F1–F6 (Deployment-Doku Dev/Prod, Threat-Model, Operations + Backup/Restore, Release-Process, Test-Lücken SSRF/Upload/Cypher-Sanitizer, Branch-Cleanup).
- `rolle-du-bist-temporal-otter.md` aus Quell-Branch **bewusst nicht** ins Repo übernommen.
- `CHANGELOG.md` `[Unreleased]/Docs` ergänzt; Arbeitsprotokoll: `docu/2026-05-01-slice-6-review-archivierung-arbeitsprotokoll.md`.

## Verifikation

- `npm run check` ✅ grün (Backend 690 passed / 9 skipped, Frontend Lint, Frontend Tests, Frontend Build).
- Reine Doku-Änderung, kein Code angefasst.

## Test plan

- [x] Backend-Tests grün (690/9 skipped — `test_event_bus_redis`, `test_subprocess_redis_bridge`, `test_compose_snapshot` skips wie erwartet ohne Redis/`.env`)
- [x] Frontend-Lint grün
- [x] Frontend-Tests grün
- [x] Frontend-Build grün
- [x] Statusblock-Commits manuell gegen `git log origin/main` verifiziert
- [x] Test-Cross-Check gegen `ls backend/tests/` verifiziert
- [x] Doku-Cross-Check gegen `ls docu/` verifiziert

## Folge-Aktionen (außerhalb dieses PRs)

- Nach Merge: Branch `claude/v0.9.0-frontend-version` lokal + remote löschen (Sub-Slice F6).
- Sub-Slices F1–F5 als eigene Sub-Slices nachziehen (siehe Folge-Plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)