### PR TITLE
docs(deployment): deployment-dev + deployment-prod-like (Slice 7, F1 of review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Docs
+
+- **Slice 7 (Repo-Review-Folge, F1): Deployment-Doku Dev + Prod-Like.** Zwei neue Dateien als Single-Source-of-Truth fuer Setup-Pfade: [`docu/deployment-dev.md`](docu/deployment-dev.md) deckt Bare-Metal (`npm run dev`) und Compose-Dev-Stage (`target: dev`, Loopback-Ports, Hot-Reload) ab inkl. Voraussetzungen (`uv`, `npm`, Neo4j, Ollama, optional Redis), Tests-Gate, Volume-Layout und Dev-Stolperfallen; verweist auf [`auth.md`](docu/auth.md) fuer das Token-Setup. [`docu/deployment-prod-like.md`](docu/deployment-prod-like.md) dokumentiert Gunicorn (`--workers 2`), Reverse-Proxy (Traefik/Nginx-Beispiele inkl. SSE-`proxy_buffering off`), Tailscale/WireGuard-Pattern, CORS-/Auth-Pflichtkonfig (`AGORA_AUTH_TOKEN`, kein `AGORA_CORS_ALLOW_ALL`, kein `AGORA_ALLOW_ANONYMOUS`), Compose-Prod-Override (Vite-Port entfaellt, Neo4j-Ports per `!reset []`), Update-/Rollback-Pfad und verweist auf [`dependency-risk-register.md`](docu/dependency-risk-register.md) fuer die CVE-Baseline. README-Schnellstart und Quick-Start (DE + EN) bekommen einen Hinweisblock auf beide Dateien; Doku-Index-Sektion am Ende der `Entwicklung`/`Development checks`-Bloecke nennt Deployment, Auth, API-Contracts und Architektur explizit. Arbeitsprotokoll: [`docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md`](docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md).
+
 ### Deploy
 
 - **Slice 2 (Repo-Review-Umsetzung, PR2): Compose Dev/Prod-Trennung.** `docker-compose.yml` baut jetzt explizit `target: dev` (Vite + Flask, Hot-Reload statt vorher `prod`-Stage via Default). Alle Host-Ports auf `127.0.0.1` gelockt (5173, 5001, 7474, 7687). `docker-compose.prod.yml` entfernt Vite- und Neo4j-Host-Ports komplett via `!reset []` (Docker Compose v2.24+), Backend-Port bleibt auf Loopback. README-Schnellstart in Dev-/Prod-Blöcke aufgeteilt mit Endpoint-Tabelle. Neuer optionaler Compose-Snapshot-Test (`backend/tests/test_compose_snapshot.py`, skip-if-no-docker, 8 Cases). Arbeitsprotokoll: `docu/2026-05-01-slice-2-compose-dev-prod-arbeitsprotokoll.md`.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Du lädst ein Dokument hoch, Agora extrahiert daraus einen Wissensgraphen, erzeu
 
 ### Schnellstart
 
+> Vollständige Anleitungen mit Volume-Layout, Reverse-Proxy-Setup und Härtungs-Checkliste:
+> [`docu/deployment-dev.md`](./docu/deployment-dev.md) · [`docu/deployment-prod-like.md`](./docu/deployment-prod-like.md).
+
 #### Voraussetzungen
 
 - Node.js 18+
@@ -350,11 +353,12 @@ cd backend && uv run pytest
 cd backend && uv run python -m compileall app scripts
 ```
 
-Weitere Refactoring- und Architekturprotokolle liegen in `docu/`, unter anderem:
-- `docu/p0-arbeitsprotokoll.md`
-- `docu/p0-simulation-api-split-protokoll.md`
-- `docu/p0-graph-panel-modularisierung-protokoll.md`
-- `docu/target-architecture.md`
+Doku-Index (Auswahl):
+
+- Deployment: [`docu/deployment-dev.md`](./docu/deployment-dev.md) · [`docu/deployment-prod-like.md`](./docu/deployment-prod-like.md)
+- Auth & Security: [`docu/auth.md`](./docu/auth.md) · [`docu/security-hardening.md`](./docu/security-hardening.md) · [`docu/dependency-risk-register.md`](./docu/dependency-risk-register.md)
+- API-Verträge: [`docu/api-contracts.md`](./docu/api-contracts.md)
+- Architektur & Refactoring: [`docu/target-architecture.md`](./docu/target-architecture.md), `docu/p0-*-protokoll.md`, `docu/2026-05-01-*-arbeitsprotokoll.md`
 
 ### Herkunft und Lizenz
 
@@ -425,6 +429,9 @@ Upload a document, extract a knowledge graph, generate agent personas, simulate 
 - **Secret guardrails**: Neo4j passwords are not serialized into simulation config artifacts.
 
 ### Quick Start
+
+> Full guides with volume layout, reverse-proxy setup and hardening checklist:
+> [`docu/deployment-dev.md`](./docu/deployment-dev.md) · [`docu/deployment-prod-like.md`](./docu/deployment-prod-like.md).
 
 Host Ollama is expected by default:
 
@@ -543,7 +550,12 @@ npm run check
 cd backend && uv run pytest
 ```
 
-Detailed audit and refactor logs are tracked in `docu/`.
+Doc index (selection):
+
+- Deployment: [`docu/deployment-dev.md`](./docu/deployment-dev.md) · [`docu/deployment-prod-like.md`](./docu/deployment-prod-like.md)
+- Auth & security: [`docu/auth.md`](./docu/auth.md) · [`docu/security-hardening.md`](./docu/security-hardening.md) · [`docu/dependency-risk-register.md`](./docu/dependency-risk-register.md)
+- API contracts: [`docu/api-contracts.md`](./docu/api-contracts.md)
+- Architecture & refactor logs: [`docu/target-architecture.md`](./docu/target-architecture.md) plus `docu/2026-05-01-*-arbeitsprotokoll.md`.
 
 ### Attribution
 

--- a/docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md
+++ b/docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md
@@ -1,0 +1,144 @@
+# Slice 7 (Repo-Review-Folge, F1): Deployment-Doku Dev + Prod-Like
+
+**Datum:** 2026-05-01
+**Branch:** `claude/brave-haslett-a7e4e8` (Worktree)
+**Bezug:** [`docu/2026-05-01-v0.9.0-review-folge-slices-plan.md`](2026-05-01-v0.9.0-review-folge-slices-plan.md), Sub-Slice F1.
+
+## Ziel
+
+Den im Repo-Review als „fehlende Doku" markierten Punkt #1 schliessen: zwei
+Markdown-Dateien als Single-Source-of-Truth fuer Setup-Pfade. README so
+verlinken, dass Leser die Deployment-Anleitung ohne Suche erreichen.
+
+## Ausgangslage
+
+- F1-Scope laut Plan:
+  - `docu/deployment-dev.md`: Lokaler Dev-Betrieb (Vite + Flask, ohne
+    Docker), Compose-Dev-Pfad (`target: dev`, Loopback-Ports,
+    Hot-Reload), Voraussetzungen (`uv`, `pnpm`/`npm`, Neo4j, Redis
+    optional), Verweis auf `auth.md`.
+  - `docu/deployment-prod-like.md`: Gunicorn (`--workers 2`),
+    Reverse-Proxy (Traefik/Nginx), Tailscale/WireGuard, CORS-/Auth-Konfig
+    (kein `AGORA_CORS_ALLOW_ALL`), Compose-Prod-Override (Frontend-Port
+    nicht veroeffentlicht), Neo4j ohne Host-Port, Verweis auf
+    `dependency-risk-register.md`.
+- Akzeptanzkriterium: README verlinkt beide Dokumente; `npm run check` gruen.
+- Bestand: `docker-compose.yml` (Dev-Default `target: dev`,
+  127.0.0.1-Bindings), `docker-compose.prod.yml` (`target: prod`, `!override`
+  fuer Backend-Port, `!reset []` fuer Neo4j-Ports), Multi-Stage-Dockerfile
+  (Stages `base`, `dev`, `prod-builder`, `prod` mit Gunicorn-CMD).
+
+## Vorgehen
+
+1. Plan + bestehende Doku gelesen ([`auth.md`](auth.md),
+   [`security-hardening.md`](security-hardening.md),
+   [`dependency-risk-register.md`](dependency-risk-register.md)),
+   Compose-Files und Dockerfile geprueft, damit die Deployment-Doku den
+   tatsaechlichen Code-Stand widerspiegelt und nicht parallel daneben lebt.
+2. `docu/deployment-dev.md` geschrieben:
+   - Voraussetzungen (Node 18+, Python 3.11+, `uv`, Neo4j 5.18+, Ollama,
+     optional Docker und Redis).
+   - **Pfad A — Bare-Metal**: `npm run setup:all` + `npm run dev`,
+     `.env`-Minimalkonfiguration, lokales Neo4j entweder als System-Service
+     oder via `docker compose up -d neo4j redis`, `npm run check` als Gate.
+   - **Pfad B — Docker Compose `target: dev`**: Endpoint-Tabelle
+     (Frontend 5173, Backend 5001, Neo4j 7474/7687, Redis intern), Volume-
+     und tmpfs-Layout, haeufige Dev-Kommandos (Recreate, Rebuild,
+     Volume-Reset), Read-Only-Rootfs-Hinweis.
+   - **Auth-Token im Dev-Modus**: kurzer Token-Setup-Block, Verweis auf
+     [`auth.md`](auth.md).
+   - **Stolperfallen**: fehlendes `NEO4J_PASSWORD`, Embedding-Mismatch
+     (`EMBEDDING_MODEL` ↔ `VECTOR_DIM`), `host.docker.internal`,
+     Vite-Port-Belegung, Read-Only-Rootfs-EROFS.
+3. `docu/deployment-prod-like.md` geschrieben:
+   - Disclaimer: kein echtes Multi-User-AuthN, Single-User-Vertrauensmodell
+     bleibt.
+   - **Compose-Prod-Pfad**: Begruendung der drei Override-Punkte
+     (`target: prod`, `agora.ports: !override`, `neo4j.ports: !reset []`),
+     Start-Command, Compose-2.24+-Hinweis fuer `!reset`.
+   - **Gunicorn**: `--workers 2`, Begruendung warum Bind im Container
+     `0.0.0.0:5001` ok ist (Read-Only, Loopback-Host-Port), Multi-Worker-
+     Konsequenz fuer Single-Use-Tickets (Redis Pflicht).
+   - **Reverse-Proxy**: Traefik-Beispiel (Tailscale-Hostname, ACME),
+     Nginx-Skizze inkl. `client_max_body_size 60m`, `proxy_buffering off`
+     fuer SSE.
+   - **Tailscale / WireGuard**: Funnel-Hinweis (Internet-exposed, Audit
+     pflicht), `tailscale serve --bg` als Default,
+     `AGORA_EXTRA_ORIGINS`-Beispiel.
+   - **CORS / Auth**: Pflicht-Env (`FLASK_DEBUG=false`, `SECRET_KEY`,
+     `NEO4J_PASSWORD`, `AGORA_AUTH_TOKEN`); explizite Negativ-Liste
+     (`AGORA_CORS_ALLOW_ALL`, `AGORA_ALLOW_ANONYMOUS`, `FLASK_DEBUG=true`,
+     `FLASK_HOST=0.0.0.0`); Memory-Mode-Empfehlung fuer Frontend-Token.
+   - **Neo4j**: Browser nur via `cypher-shell` oder SSH-Forward, Memory-
+     Settings im Compose verankert.
+   - **Ollama**: Host-only Default, `host-gateway`-Bridge, GPU-Status via
+     `/api/status`.
+   - **Update- + Rollback-Pfad**: `docker compose build` + `up -d --no-deps
+     --force-recreate`, Image-SHA-Pin als Rollback.
+   - Verweise auf [`deployment-dev.md`](deployment-dev.md), [`auth.md`](auth.md),
+     [`security-hardening.md`](security-hardening.md),
+     [`dependency-risk-register.md`](dependency-risk-register.md),
+     [`SECURITY_REVIEW_SUMMARY.md`](SECURITY_REVIEW_SUMMARY.md).
+4. `README.md` an drei Stellen ergaenzt:
+   - **DE Schnellstart-Header (`### Schnellstart`)**: Hinweisblock mit Links
+     auf beide Deployment-Files.
+   - **EN Quick-Start-Header (`### Quick Start`)**: spiegelnder Hinweis.
+   - **DE und EN Doku-Indizes** (am Ende der `Entwicklung`- bzw.
+     `Development checks`-Bloecke): bestehende Mini-Liste durch
+     vollwertigen Doku-Index ersetzt (Deployment, Auth & Security,
+     API-Contracts, Architektur).
+5. `CHANGELOG.md` `[Unreleased]` um neue `### Docs`-Sektion erweitert
+   (Slice-7-Block) — Konvention aus den Slice-1- bis Slice-6-Eintraegen
+   uebernommen (Datei-Pfade verlinkt, Verweis aufs Arbeitsprotokoll).
+6. Dieses Arbeitsprotokoll geschrieben.
+7. `npm run check` als Gate ausfuehren, danach commit + PR + Merge.
+
+## Geaenderte / neue Dateien
+
+| Datei | Aktion | LOC ca. |
+|---|---|---|
+| `docu/deployment-dev.md` | neu | 180 |
+| `docu/deployment-prod-like.md` | neu | 245 |
+| `README.md` | edit (3 Stellen) | +20 / -5 |
+| `CHANGELOG.md` | edit (`[Unreleased]` → neuer `### Docs`-Block) | +4 |
+| `docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md` | neu | dieses File |
+
+## Verifikation
+
+- `npm run check` (Backend-Lint, Backend-Tests, Frontend-Lint, Frontend-Tests,
+  Frontend-Build) — Doku-Slice darf den Gate nicht roetlich faerben. Der
+  Slice fasst keine Code-Pfade an; gruen heisst Bestand stabil.
+- README-Verlinkungen sichtgepruefte Anchor (`./docu/deployment-dev.md` und
+  `./docu/deployment-prod-like.md`) — Markdown-Render in GitHub funktioniert,
+  Pfade relativ.
+- Inhalts-Konsistenz mit Code: Compose-Targets, Bind-Adressen, Port-Werte,
+  Env-Pflichtwerte, Gunicorn-CMD und `!override`/`!reset`-Mechanik wurden
+  gegen `docker-compose.yml`, `docker-compose.prod.yml`, `Dockerfile`,
+  `backend/app/__init__.py` und `backend/app/utils/auth.py` abgeglichen.
+
+## Akzeptanzkriterien (laut Plan)
+
+- [x] `docu/deployment-dev.md` existiert und deckt Bare-Metal + Compose-Dev
+      ab; verweist auf `auth.md`.
+- [x] `docu/deployment-prod-like.md` existiert und deckt Gunicorn,
+      Reverse-Proxy, Tailscale/WireGuard, CORS/Auth-Hardrejects,
+      Compose-Prod-Override (Frontend-Port entfaellt), Neo4j ohne
+      Host-Port; verweist auf `dependency-risk-register.md`.
+- [x] README verlinkt beide Dokumente (DE + EN, je Schnellstart-Header und
+      Doku-Index).
+- [ ] `npm run check` gruen — pending bis zum tatsaechlichen Lauf.
+
+## Issue / Milestone
+
+- F1 ist Teil des Folge-Plans, kein offenes GitHub-Issue mit
+  `Closes #N`-Bezug.
+- Milestone-Counter: kein Milestone direkt zugeordnet — Repo-Review-Folge
+  laeuft als Doku-Sweep.
+
+## Followups
+
+- F2 — Security-Threat-Model.
+- F3 — Operations + Backup/Restore.
+- F4 — Release-Process.
+- F5 — Test-Coverage-Luecken (SSRF, Upload-Limits, Cypher-Sanitizer).
+- F6 — Branch-Cleanup + README-Update.

--- a/docu/deployment-dev.md
+++ b/docu/deployment-dev.md
@@ -1,0 +1,243 @@
+# Deployment — Dev
+
+**Stand:** 2026-05-01, Europe/Berlin
+**Scope:** Lokaler Entwicklungsbetrieb auf einer Single-User-Maschine. Zwei
+Pfade: bare-metal mit `npm run dev` und Docker-Compose-Dev-Stage. Beide laufen
+gegen `127.0.0.1`, beide nutzen Hot-Reload.
+
+Für Prod-Härtung (Gunicorn, Reverse-Proxy, restriktive CORS) siehe
+[`deployment-prod-like.md`](deployment-prod-like.md).
+
+---
+
+## Voraussetzungen
+
+| Komponente | Mindestversion | Zweck |
+|---|---|---|
+| Node.js | 18.x | Vite, Frontend-Build, Test-Runner |
+| `npm` | mit Node geliefert | `package-lock.json`-Pfad |
+| Python | 3.11 | Backend-Runtime |
+| `uv` | 0.4+ | Python-Dependency-Manager (statt `pip`/`venv`) |
+| Neo4j | 5.18+ | Graph-Storage. Lokal oder via Compose. |
+| Ollama | aktuell | LLM + Embedding. Auf dem Host, nicht im Container. |
+| Docker / Compose | optional | Compose-Dev-Pfad braucht v2.24+ wegen `!override`/`!reset`. |
+| Redis | optional | Single-Use-Tickets + Event-Bus. Compose startet Redis automatisch. |
+
+`uv` installieren (einmalig):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Ollama-Modelle ziehen (einmalig):
+
+```bash
+ollama pull qwen2.5:32b              # oder ein leichteres Modell
+ollama pull qwen3-embedding:4b       # 2560-dim, erfordert VECTOR_DIM=2560
+# Fallback: ollama pull nomic-embed-text  # 768-dim, VECTOR_DIM=768
+```
+
+---
+
+## Pfad A — Bare-Metal (`npm run dev`)
+
+Schnellster Pfad für aktive Entwicklung. Kein Container, kein Build-Layer.
+
+### Setup
+
+```bash
+git clone https://github.com/arn0ld87/agora.git
+cd agora
+cp .env.example .env
+
+# Dependencies (root + frontend + backend)
+npm run setup:all
+```
+
+`.env` minimal anpassen:
+
+```env
+FLASK_DEBUG=true                     # Dev: Tracebacks + Reloader, blockt Placeholder-Reject nicht
+SECRET_KEY=change-me-use-token_urlsafe-32   # Dev darf Placeholder bleiben, Config.validate() warnt
+NEO4J_PASSWORD=<dein_lokales_neo4j_pw>
+LLM_BASE_URL=http://localhost:11434/v1
+NEO4J_URI=bolt://localhost:7687
+EMBEDDING_BASE_URL=http://localhost:11434
+```
+
+Token-Auth optional, siehe Abschnitt
+[Auth-Token im Dev-Modus](#auth-token-im-dev-modus).
+
+### Start
+
+```bash
+npm run dev
+```
+
+Startet Backend und Frontend parallel über `concurrently`:
+
+| Endpoint | URL | Bind |
+|---|---|---|
+| Frontend (Vite) | <http://localhost:5173> | 127.0.0.1 |
+| Backend (Flask) | <http://localhost:5001/health> | 127.0.0.1 |
+
+Hot-Reload greift in beide Richtungen. Backend-Reload via `werkzeug` ist nur
+mit `FLASK_DEBUG=true` aktiv.
+
+### Lokales Neo4j
+
+Variante 1 — Neo4j-Desktop oder System-Service:
+
+```bash
+# Beispiel Arch / Cachy
+sudo systemctl start neo4j
+# Browser: http://localhost:7474, Credentials wie in .env
+```
+
+Variante 2 — nur Neo4j aus Compose ziehen (Backend bleibt bare-metal):
+
+```bash
+docker compose up -d neo4j redis
+# Beide binden auf 127.0.0.1 (siehe docker-compose.yml).
+# Backend-`NEO4J_URI` bleibt `bolt://localhost:7687`.
+```
+
+### Tests + Lint
+
+```bash
+npm run check
+```
+
+Stufen: Backend-Lint (`ruff check app/ tests/`), Backend-Tests (`pytest`),
+Frontend-Lint (ESLint), Frontend-Tests (Vitest auf `jsdom`),
+Frontend-Build. Pre-Commit-Gate für jeden Slice. Zwei Redis-Integrationstests
+skippen sauber, wenn `TEST_REDIS_URL` nicht gesetzt ist.
+
+---
+
+## Pfad B — Docker Compose (`target: dev`)
+
+Compose-Stack mit Backend, Frontend, Neo4j und Redis. Default-Compose nutzt
+seit v0.9.0 explizit den `dev`-Stage aus dem Multi-Stage-Dockerfile (Vite +
+Flask, Hot-Reload, kein Gunicorn).
+
+### Setup
+
+```bash
+git clone https://github.com/arn0ld87/agora.git
+cd agora
+cp .env.example .env
+# Pflichtwert: NEO4J_PASSWORD. Compose bricht sonst ab (`:?`-Syntax).
+```
+
+### Start
+
+```bash
+docker compose up -d --build
+docker compose logs -f agora        # Live-Log
+```
+
+Was läuft:
+
+| Service | Port (Host) | Bind | Zweck |
+|---|---|---|---|
+| `agora` (Vite) | 5173 | 127.0.0.1 | Frontend Hot-Reload |
+| `agora` (Flask) | 5001 | 127.0.0.1 | API + `/health` |
+| `neo4j` (Browser) | 7474 | 127.0.0.1 | Neo4j-Web-UI |
+| `neo4j` (Bolt) | 7687 | 127.0.0.1 | Bolt-Treiber |
+| `redis` | — | nur Compose-intern | Event-Bus + Tickets |
+
+Container-zu-Container-Verbindungen laufen über das Compose-Netzwerk und
+brauchen die Host-Ports nicht. Die Loopback-Bindings sind explizit gewählt,
+damit der Stack nicht versehentlich auf Tailscale/LAN-Interfaces hört. Wer
+LAN-Zugriff will, setzt einen Reverse-Proxy davor — siehe
+[`deployment-prod-like.md`](deployment-prod-like.md).
+
+Ollama läuft auf dem Host und wird über `host.docker.internal` (im Compose
+als `extra_hosts: host-gateway` aufgelöst) erreicht. Im Container überschreibt
+Compose `LLM_BASE_URL`, `NEO4J_URI` und `EMBEDDING_BASE_URL`, sodass die
+`localhost`-Defaults in `.env` für den Bare-Metal-Pfad nutzbar bleiben.
+
+### Häufige Dev-Kommandos
+
+```bash
+# Container neu starten ohne Image-Rebuild
+docker compose up -d --force-recreate agora
+
+# Image rebuilden (z. B. nach Dependency-Bump)
+docker compose build agora && docker compose up -d --force-recreate --no-deps agora
+
+# Volumes resetten (Achtung: löscht Neo4j-Daten und Cache)
+docker compose down -v && docker compose up -d
+```
+
+### Volumes
+
+| Volume | Zweck |
+|---|---|
+| `./backend/uploads` (Bind) | Hochgeladene Dokumente. Nicht versioniert. |
+| `./backend/.cache/huggingface` (Bind) | OASIS-Modelle (~1 GB). Persistiert über Restarts. |
+| `neo4j_data` (Named) | Neo4j-Datenbank. |
+| `neo4j_logs` (Named) | Neo4j-Logs. |
+| `redis_data` (Named) | Redis-Persistenz (RDB-Snapshots). |
+
+### Read-Only-Rootfs
+
+Der `agora`-Container läuft mit `read_only: true`. Schreibbar sind nur
+explizite `tmpfs`-Mounts (`/tmp`, `/app/backend/logs`, Caches) und die oben
+gelisteten Volumes. Wenn beim Dev-Pfad neue Schreibziele dazukommen, muss der
+Mount im Compose oder im Code geändert werden — nicht das Read-Only-Flag.
+
+---
+
+## Auth-Token im Dev-Modus
+
+Im Dev-Default ist `AGORA_AUTH_TOKEN` leer und das Backend läuft im Open-Mode
+mit Log-Warning. Für eine echte Token-Schleife siehe
+[`auth.md`](auth.md). Kurzfassung:
+
+```bash
+# Token erzeugen
+AGORA_AUTH_TOKEN=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')
+echo "AGORA_AUTH_TOKEN=$AGORA_AUTH_TOKEN" >> .env
+
+# Frontend-Storage (Browser-Devtools auf http://localhost:5173):
+localStorage.setItem('agora_token', '<derselbe_wert>')
+```
+
+Prod-Empfehlung ist Memory-Mode (`VITE_AGORA_TOKEN_STORAGE=memory`) statt
+`localStorage` — siehe [`auth.md`](auth.md), Abschnitt „Frontend-Token-Storage".
+
+---
+
+## Bekannte Dev-Stolperfallen
+
+- **`NEO4J_PASSWORD` fehlt:** Compose bricht beim `up` mit Fehlermeldung ab.
+  Nicht-Debug-Backend rejected zusätzlich Placeholder (`agora`, `neo4j`,
+  `password`). Im Dev-Modus (`FLASK_DEBUG=true`) läuft es mit Warning
+  durch. Siehe [`security-hardening.md`](security-hardening.md), Phase 1.
+- **Embedding-Mismatch:** `EMBEDDING_MODEL` und `VECTOR_DIM` müssen
+  zusammenpassen (`qwen3-embedding:4b` ↔ `2560`, `nomic-embed-text` ↔ `768`).
+  Backend probet beim Start; Mismatch blockiert den Start.
+- **Ollama nicht erreichbar:** `/api/status` zeigt `ollama_uses_gpu: null`.
+  Im Compose-Pfad: `host.docker.internal` muss vom Container zum Host
+  auflösen — Linux braucht `extra_hosts: host-gateway` (ist im Compose
+  gesetzt).
+- **Vite-Port belegt:** Vite zieht selbst auf den nächsten freien Port hoch,
+  Backend kennt aber nur `5173` für CORS. Belegten Port abräumen statt Vite
+  ausweichen lassen, oder `AGORA_EXTRA_ORIGINS` setzen.
+- **Read-Only-Rootfs + neuer Schreibpfad:** Dev-Setups, die plötzlich `EROFS`
+  liefern, brauchen einen tmpfs- oder Volume-Mount im Compose. Siehe
+  Abschnitt „Volumes".
+
+---
+
+## Verweise
+
+- [`auth.md`](auth.md) — Token-Header, Ticket-Flow, Storage-Optionen.
+- [`security-hardening.md`](security-hardening.md) — Secure-Defaults,
+  Placeholder-Reject, CORS-Whitelist, SSRF-Blocker.
+- [`deployment-prod-like.md`](deployment-prod-like.md) — Gunicorn,
+  Reverse-Proxy, Compose-Prod-Override.
+- [`dependency-risk-register.md`](dependency-risk-register.md) — aktiv
+  gepinnte CVEs.

--- a/docu/deployment-prod-like.md
+++ b/docu/deployment-prod-like.md
@@ -1,0 +1,350 @@
+# Deployment — Prod-Like
+
+**Stand:** 2026-05-01, Europe/Berlin
+**Scope:** Hardened Single-Tenant-Deployment — kein Multi-User-AuthN, aber
+Loopback-Bind, Gunicorn, Reverse-Proxy, Token-Pflicht und enge CORS. Zielbild
+ist „lokal hinter Tailscale/WireGuard“, **nicht** ein direkt im Internet
+exponierter Server.
+
+Für den Entwicklungspfad siehe [`deployment-dev.md`](deployment-dev.md).
+
+> **Wichtig:** Agora hat keinen echten Mehrbenutzer-Auth-Stack. Der
+> `AGORA_AUTH_TOKEN`-Guard ist ein Shared-Secret-Bearer. „Prod-Like“ heißt
+> hier: alle bekannten Härtungen aktiv, aber Single-User-Vertrauensmodell
+> bleibt. Wer das Ding offen ins Internet stellt, übernimmt das Restrisiko.
+
+---
+
+## Voraussetzungen
+
+| Komponente | Mindestversion | Zweck |
+|---|---|---|
+| Docker | aktuell | Multi-Stage-Build, Compose-Override |
+| Docker Compose | 2.24+ | `!override` / `!reset` für Port-Strip |
+| Reverse-Proxy | aktuell | Traefik 3.x, Nginx 1.25+ oder Caddy 2.x |
+| Tailscale / WireGuard | optional, empfohlen | Tunnel statt Internet-Exposition |
+| Ollama | aktuell | LLM + Embedding (auf dem Host) |
+| Neo4j | 5.18+ | Graph-Storage (Compose-intern) |
+
+---
+
+## Compose-Prod-Pfad
+
+### Override-Datei
+
+`docker-compose.prod.yml` ist der Override für den Produktionsbetrieb. Er
+setzt drei Dinge gegenüber dem Default-Compose:
+
+1. **`build.target: prod`** — Multi-Stage-Dockerfile zieht das schlanke
+   Runtime-Stage mit gebautem Frontend-Bundle und Gunicorn vor Flask. Kein
+   Vite, kein `npm run dev`, kein Bind-Mount auf Quellcode.
+2. **`agora.ports: !override [...]`** — Vite-Port (`5173`) entfällt; nur der
+   Backend-Port (`5001`) bleibt, gebunden auf `127.0.0.1`. Statisches
+   Frontend wird vom Backend ausgeliefert (Flask serviert
+   `/app/frontend/dist`); externer Zugriff läuft über den Reverse-Proxy.
+3. **`neo4j.ports: !reset []`** — Neo4j Browser (`7474`) und Bolt (`7687`)
+   werden im Prod-Override **nicht** auf den Host veröffentlicht. Backend
+   redet weiter über das Compose-Netzwerk mit Neo4j; wer aus Ops-Sicht
+   Browser-Zugriff braucht, tunnelt explizit (Tailscale-SSH oder
+   `docker compose exec neo4j cypher-shell`).
+
+### Start
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  up -d --build
+
+docker compose ps
+docker compose logs -f agora
+```
+
+> Compose-Versionen vor 2.24 fallen für `!reset` auf Array-Merge zurück.
+> Effekt: Neo4j erbt die Loopback-Ports vom Default. Nicht ideal, aber
+> kein Sicherheitsbruch (`127.0.0.1`). Upgrade auf Compose 2.24+ wird
+> empfohlen.
+
+### Was läuft
+
+| Service | Port (Host) | Bind | Zweck |
+|---|---|---|---|
+| `agora` (Gunicorn) | 5001 | 127.0.0.1 | API + statisches Frontend |
+| `neo4j` | — | nur Compose-intern | Bolt + Browser ohne Host-Port |
+| `redis` | — | nur Compose-intern | Tickets + Event-Bus |
+
+Das ist die Angriffsfläche aus Sicht des Hosts: ein einziger TCP-Port auf
+Loopback. Alles andere bleibt im Compose-Netzwerk.
+
+---
+
+## Gunicorn
+
+Das `prod`-Stage startet:
+
+```text
+gunicorn --workers 2 --bind 0.0.0.0:5001 --chdir backend "app:create_app()"
+```
+
+`0.0.0.0` ist hier **nicht** das Loophole — der Container ist read-only,
+sieht nur das Compose-Netzwerk und der Host-Port liegt auf `127.0.0.1`.
+Worker-Count `--workers 2` ist konservativ. Für CPU-bound Workloads über
+Compose-Env überschreibbar (eigener `command:`-Override im Prod-File oder
+Image-Rebuild mit angepasstem `CMD`).
+
+Multi-Worker hat eine Konsequenz: in-process-State (`signed_ticket._seen`)
+ist nicht mehr ausreichend. Single-Use-Tickets gehen seit v0.9.0 / Slice 3
+über Redis (`SET … NX EX <ttl>`); ohne Redis fällt der Pfad still auf
+in-process zurück und verliert die Multi-Worker-Garantie. Prod-Setup muss
+Redis aktiv haben — der Compose-Default tut das.
+
+---
+
+## Reverse-Proxy
+
+Traefik, Nginx oder Caddy davorzuschalten ist **Pflicht**, nicht Kür:
+
+- TLS-Termination — Backend selbst spricht kein HTTPS.
+- Rate-Limiting — Agora hat keinen eigenen Limiter.
+- Cookie-/Header-Hardening (HSTS, `X-Frame-Options`, CSP).
+- Optional: HttpOnly-Cookie-Flow als Zielarchitektur (siehe
+  [`auth.md`](auth.md), Option C).
+
+### Traefik (Beispiel)
+
+`docker-compose.proxy.yml` (separater Override; im Repo nicht versioniert):
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3.1
+    ports:
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/acme.json:/acme.json
+  agora:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.agora.rule=Host(`agora.tail-xyz.ts.net`)"
+      - "traefik.http.routers.agora.entrypoints=websecure"
+      - "traefik.http.routers.agora.tls=true"
+      - "traefik.http.services.agora.loadbalancer.server.port=5001"
+```
+
+Traefik bindet sich auf Loopback; der eigentliche Tunnel läuft über
+Tailscale (siehe nächster Abschnitt). `acme.json` ist optional — innerhalb
+eines Tailnets reicht oft das Tailscale-Cert (`tailscale serve` /
+`funnel`).
+
+### Nginx (Skizze)
+
+```nginx
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name agora.tail-xyz.ts.net;
+
+    ssl_certificate     /etc/ssl/agora/fullchain.pem;
+    ssl_certificate_key /etc/ssl/agora/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    client_max_body_size 60m;   # Upload-Limit (PDF) leicht über 50 MB
+
+    location / {
+        proxy_pass         http://127.0.0.1:5001;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+
+        # SSE-Stream (/api/simulation/<id>/stream) braucht keepalive + kein Buffering
+        proxy_read_timeout 1h;
+        proxy_buffering    off;
+    }
+}
+```
+
+`proxy_buffering off` ist wichtig — der Simulation-Status-Stream geht über
+SSE und darf nicht gepuffert werden, sonst kommen Updates erst am Ende des
+Runs an.
+
+---
+
+## Tailscale / WireGuard
+
+Empfohlenes Pattern: Reverse-Proxy lauscht auf `127.0.0.1` (oder dem
+Tailscale-Interface), und Tailscale stellt den Tunnel.
+
+```bash
+# Variante A — Tailscale Funnel (öffentlich erreichbar via *.ts.net)
+tailscale serve https / http://localhost:443
+# Pflicht-Audit: ist das wirklich beabsichtigt? Funnel = Internet-exposed.
+
+# Variante B — nur im Tailnet (Default, empfohlen)
+tailscale serve --bg --https=443 http://localhost:443
+```
+
+WireGuard-Setups arbeiten analog: Reverse-Proxy lauscht auf der
+WireGuard-IP (z. B. `10.66.0.1`), keine Bindings auf `0.0.0.0`. Das Routing
+auf Layer-3 ist explizit, nicht über Container-Port-Publishing.
+
+`AGORA_EXTRA_ORIGINS` aufnehmen, falls das Frontend unter einem anderen
+Origin auftaucht (z. B. Tailscale-Hostname mit anderem Port):
+
+```env
+AGORA_EXTRA_ORIGINS=https://agora.tail-xyz.ts.net,https://agora.intern.lan
+```
+
+---
+
+## CORS- / Auth-Konfiguration
+
+### Pflicht in Prod
+
+```env
+FLASK_DEBUG=false
+SECRET_KEY=<token_urlsafe(32)>
+NEO4J_PASSWORD=<echter_wert>
+AGORA_AUTH_TOKEN=<token_urlsafe(32)>
+```
+
+Einzeiler für die Geheimwerte:
+
+```bash
+python -c 'import secrets; print(secrets.token_urlsafe(32))'
+```
+
+Wenn `FLASK_DEBUG=false` und `SECRET_KEY` / `NEO4J_PASSWORD` Placeholder
+sind (`change-me`, `agora`, `neo4j`, `password`), bricht `Config.validate()`
+hart ab. Das ist gewollt — die Liste der abgelehnten Werte steht in
+[`security-hardening.md`](security-hardening.md), Phase 1 / Slice 1.
+
+### Was **nicht** gesetzt sein darf
+
+| Variable | Wert | Warum nicht |
+|---|---|---|
+| `AGORA_CORS_ALLOW_ALL` | `true` | Wildcard-CORS hebelt die Origin-Whitelist aus. Nur für Lab-Setups, nie in Prod. Backend loggt eine Warning, falls aktiv. |
+| `AGORA_ALLOW_ANONYMOUS` | `true` | Token-Pflicht aus. Macht `/api/*` öffentlich. |
+| `FLASK_DEBUG` | `true` | Tracebacks im Response-Body, Werkzeug-Reloader, Placeholder-Reject inaktiv. |
+| `FLASK_HOST` | `0.0.0.0` (im Container ohne Reverse-Proxy davor) | Container ist read-only und im Compose-Netz, aber wenn der Host-Port nicht auf Loopback gebunden ist, exponiert Compose das nach außen. Im Prod-Override liegt der Host-Port auf `127.0.0.1`. |
+
+### CORS-Whitelist
+
+Origins kommen ausschließlich aus zwei Quellen:
+
+1. Statische Defaults `http://localhost:5173`, `http://127.0.0.1:5173` (für
+   Dev-Frontend gegen Prod-Backend; bei reinem Container-Frontend irrelevant).
+2. `AGORA_EXTRA_ORIGINS` (Komma-separiert) — hier kommen Tailscale-Hostnames
+   und LAN-Aliase rein.
+
+Preflight-Verhalten siehe [`security-hardening.md`](security-hardening.md),
+Phase 2.
+
+### Frontend-Token-Storage
+
+Prod-Empfehlung: Memory-Mode. Token überlebt keinen Page-Reload, XSS-
+Residuum in `localStorage` entfällt:
+
+```env
+VITE_AGORA_TOKEN_STORAGE=memory
+```
+
+Der Token wird zur Laufzeit im JS-Heap gehalten (`setAgoraToken(...)`).
+Konsequenz: nach jedem Reload muss er neu injiziert werden — z. B. durch
+einen kommenden `/api/auth/login`-Endpoint oder durch SPA-Bootstrap mit
+einem injected Secret. Details und Risiko-Vergleich in
+[`auth.md`](auth.md), Abschnitt „Frontend-Token-Storage“.
+
+---
+
+## Neo4j
+
+Im Prod-Override hat Neo4j keinen Host-Port. Konsequenzen:
+
+- **Browser-Zugriff** für Ad-hoc-Cypher: `docker compose exec neo4j
+  cypher-shell -u neo4j -p $NEO4J_PASSWORD`. Wer den Browser braucht,
+  öffnet den Port temporär oder läuft per SSH-Forward (`ssh -L
+  7474:127.0.0.1:7474 …`).
+- **Memory-Settings** sind im Compose hart eingestellt (Pagecache 4 GB,
+  Heap-Max 2 GB). Quelle: `docker-compose.yml`, kein `.env`-Override
+  nötig. Bei kleineren Hosts vor Start anpassen — Source of Truth bleibt
+  das Compose-File.
+- **Backups** über `neo4j-admin database dump` aus dem Container-Kontext;
+  zugehörige Cron-/Restore-Strategie ist Folge-Sub-Slice F3 (siehe
+  [`2026-05-01-v0.9.0-review-folge-slices-plan.md`](2026-05-01-v0.9.0-review-folge-slices-plan.md)).
+
+---
+
+## Ollama
+
+Ollama läuft auf dem Host, nicht im Container. Begründung: GPU-Zugriff,
+Modell-Updates, RAM-Footprint. Zwei Konsequenzen:
+
+- Auf Linux-Hosts nutzt der Container `host.docker.internal` (per
+  `extra_hosts: host-gateway` im Compose). Auf einem Host ohne GPU läuft
+  Ollama im CPU-Modus — Latenz steigt deutlich, aber API-Vertrag bleibt.
+- Ollama selbst sollte **nicht** auf `0.0.0.0` lauschen. Default
+  `127.0.0.1:11434` reicht; Docker erreicht den Loopback-Port über die
+  `host-gateway`-Bridge.
+
+GPU-Status sichtbar unter `/api/status` (`ollama_uses_gpu`).
+
+---
+
+## Update-Pfad
+
+```bash
+git pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build agora
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d \
+  --no-deps --force-recreate agora
+docker image prune -f
+```
+
+Vor dem Update prüfen:
+
+- [`dependency-risk-register.md`](dependency-risk-register.md) — gibt es
+  neue CVE-Findings, die einen Pin freigeben?
+- `CHANGELOG.md` — `[Unreleased]` und letzter Tag, ob Migrations-Schritte
+  nötig sind (z. B. neue `.env`-Variable, Schema-Migration).
+
+---
+
+## Rollback
+
+Image-Tag pinnen statt blind `latest`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  pull agora || true
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  up -d agora
+```
+
+Im Bedarfsfall den Backend-Container auf den vorherigen SHA setzen
+(`image: ghcr.io/arn0ld87/agora@sha256:…`) und `up -d --no-deps agora`
+neu starten. Neo4j-Daten bleiben im Volume — Rollback ist nur ein
+Image-Switch, keine Datenmigration.
+
+---
+
+## Verweise
+
+- [`deployment-dev.md`](deployment-dev.md) — Dev-Setup ohne Hardening.
+- [`auth.md`](auth.md) — Token-Vertrag, Ticket-Flow, Storage-Optionen.
+- [`security-hardening.md`](security-hardening.md) — Phase 1/2/3 + P1
+  CI-Security-Scans + Slice 3 Redis-Tickets.
+- [`dependency-risk-register.md`](dependency-risk-register.md) — aktive
+  CVE-Baseline und Aufräum-Prozess.
+- [`SECURITY_REVIEW_SUMMARY.md`](SECURITY_REVIEW_SUMMARY.md) — historischer
+  Review-Stand (vor v0.9.0).


### PR DESCRIPTION
## Summary

- Adds [`docu/deployment-dev.md`](docu/deployment-dev.md): bare-metal (`npm run dev`) and Compose-Dev-Stage (`target: dev`) paths, with prerequisites (`uv`, `npm`, Neo4j, Ollama, optional Redis), endpoint table, volume layout, dev pitfalls, and a pointer to `auth.md` for token setup.
- Adds [`docu/deployment-prod-like.md`](docu/deployment-prod-like.md): Gunicorn (`--workers 2`), Traefik/Nginx reverse-proxy examples (incl. SSE `proxy_buffering off`), Tailscale/WireGuard pattern, mandatory CORS/Auth env (no `AGORA_CORS_ALLOW_ALL`, no `AGORA_ALLOW_ANONYMOUS`), Compose-Prod-Override mechanics (Vite port drops via `!override`, Neo4j ports via `!reset []`), update + rollback path, and a pointer to `dependency-risk-register.md` for the CVE baseline.
- README (DE Schnellstart + EN Quick Start) now links both files; Doku-Index sections at the end of `Entwicklung` / `Development checks` list deployment, auth/security, API contracts and architecture explicitly.
- CHANGELOG `[Unreleased]` gains a new `### Docs` block for Slice 7.
- New work log: [`docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md`](docu/2026-05-01-slice-7-deployment-doku-arbeitsprotokoll.md).

Implements Sub-Slice F1 from [`docu/2026-05-01-v0.9.0-review-folge-slices-plan.md`](docu/2026-05-01-v0.9.0-review-folge-slices-plan.md).

## Test plan

- [x] `npm run check` green: 690 backend tests, 40 frontend tests, frontend build ok (1 preexisting `nextTick`-unused warning in `Step4Report.vue`, out of scope).
- [x] README links both deployment docs in DE + EN, in both Schnellstart/Quick-Start headers and the Doku-Index footer.
- [x] Doc cross-references to `auth.md`, `security-hardening.md`, `dependency-risk-register.md` and `SECURITY_REVIEW_SUMMARY.md` resolve.
- [x] Compose / Dockerfile / `.env.example` content matches what the new docs describe (`target: dev`/`prod`, `127.0.0.1` bindings, `!override`/`!reset`, Gunicorn CMD, secret placeholders rejected by `Config.validate()`).