### PR TITLE
refactor(wording): Glossar v1 in Prompt-Layer (Slice B, Refs #175)

### DIFF
--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -168,11 +168,11 @@ class InsightForgeResult:
     def to_text(self) -> str:
         """Convert to detailed text format for LLM understanding"""
         text_parts = [
-            "## Future Prediction Deep Analysis",
+            "## Scenario Evaluation Deep Analysis",
             f"Analysis Query: {self.query}",
-            f"Prediction Scenario: {self.simulation_requirement}",
-            "\n### Prediction Data Statistics",
-            f"- Related Prediction Facts: {self.total_facts}",
+            f"Evaluation Scenario: {self.simulation_requirement}",
+            "\n### Evaluation Data Statistics",
+            f"- Related Simulation Facts: {self.total_facts}",
             f"- Involved Entities: {self.total_entities}",
             f"- Relationship Chains: {self.total_relationships}"
         ]

--- a/backend/app/services/report_prompts.py
+++ b/backend/app/services/report_prompts.py
@@ -21,34 +21,34 @@ re-exportiert die Namen und nutzt sie unverändert in den
 # ── 1. Planning — Outline ───────────────────────────────────────────
 
 PLAN_SYSTEM_PROMPT_TEMPLATE = """\
-You are an expert in writing "future prediction reports" with a "god's eye view" of the simulated world - you can gain insights into the behavior, statements, and interactions of every agent in the simulation.
+You are an expert in writing "scenario evaluation reports" from an analytical observer perspective on the simulated environment - you can review the behavior, statements, and interactions of every agent in the simulation.
 
 [Core Concept]
-We built a simulated world and injected specific "simulation requirements" as variables into it. The evolution result of the simulated world is a prediction of what might happen in the future. What you're observing is not "experimental data" but a "rehearsal of the future".
+We built a reproducible simulation environment and injected specific "simulation requirements" as variables into it. The evolution of the simulated environment is a structured test of our assumptions about how personas might react. What you are observing is not "experimental data" but a controlled persona-reaction simulation.
 
 [Your Task]
-Write a "future prediction report" that answers:
-1. What happened in the future under the conditions we set?
+Write a "scenario evaluation report" that answers:
+1. How did the scenario unfold under the conditions we set?
 2. How do various agents (groups) react and act?
-3. What future trends and risks does this simulation reveal that deserve attention?
+3. What emerging trends and risks does this simulation reveal that deserve attention?
 
 [Report Positioning]
-- ✅ This is a future prediction report based on simulation, revealing "if this happens, how will the future unfold"
-- ✅ Focus on prediction results: event trajectories, group reactions, emergent phenomena, potential risks
-- ✅ Agent statements and behaviors in the simulated world are predictions of future human behavior
+- ✅ This is a scenario evaluation report based on simulation, revealing "if this happens, how the scenario unfolds under those conditions"
+- ✅ Focus on evaluation results: event trajectories, group reactions, emergent phenomena, potential risks
+- ✅ Agent statements and behaviors in the simulated environment are simulated persona reactions
 - ❌ Not an analysis of the current state of the real world
 - ❌ Not a general overview of public sentiment
 
 [Section Number Limit]
 - Minimum 2 sections, maximum 5 sections
 - No subsections needed, each section directly writes complete content
-- Content should be concise, focused on core prediction findings
-- Section structure is designed independently based on prediction results
+- Content should be concise, focused on core evaluation findings
+- Section structure is designed independently based on the evaluation results
 
 Please output the report outline in JSON format as follows:
 {
     "title": "Report Title",
-    "summary": "Report Summary (one sentence summarizing core prediction findings)",
+    "summary": "Report Summary (one sentence summarizing core evaluation findings)",
     "sections": [
         {
             "title": "Section Title",
@@ -61,36 +61,36 @@ Note: sections array must have at least 2 and at most 5 elements!
 IMPORTANT: The entire report outline (title, summary, section titles and descriptions) MUST be written in {language}. Do not switch to any other language."""
 
 PLAN_USER_PROMPT_TEMPLATE = """\
-[Prediction Scenario Settings]
-Variable (simulation requirement) injected into the simulated world: {simulation_requirement}
+[Scenario Evaluation Settings]
+Variable (simulation requirement) injected into the simulated environment: {simulation_requirement}
 
-[Simulated World Scale]
+[Simulated Environment Scale]
 - Number of entities participating in simulation: {total_nodes}
 - Number of relationships generated between entities: {total_edges}
 - Entity type distribution: {entity_types}
 - Number of active agents: {total_entities}
 
-[Sample of Some Future Facts Predicted by Simulation]
+[Sample of Persona Observations Produced by the Simulation]
 {related_facts_json}
 
-Please examine this future rehearsal from a "god's eye view":
-1. What state does the future present under the conditions we set?
+Please examine this scenario evaluation from an analytical observer perspective:
+1. What state does the scenario present under the conditions we set?
 2. How do various groups (agents) react and act?
-3. What future trends does this simulation reveal that deserve attention?
+3. What emerging trends does this simulation reveal that deserve attention?
 
-Based on the prediction results, design the most appropriate report section structure.
+Based on the evaluation results, design the most appropriate report section structure.
 
-[Reminder] Report section count: minimum 2, maximum 5, content should be concise and focused on core prediction findings."""
+[Reminder] Report section count: minimum 2, maximum 5, content should be concise and focused on core evaluation findings."""
 
 
 # ── 2. Sections — Body Generation ───────────────────────────────────
 
 SECTION_SYSTEM_PROMPT_TEMPLATE = """\
-You are an expert in writing "future prediction reports" and are writing a section of the report.
+You are an expert in writing "scenario evaluation reports" and are writing a section of the report.
 
 Report Title: {report_title}
 Report Summary: {report_summary}
-Prediction Scenario (Simulation Requirement): {simulation_requirement}
+Evaluation Scenario (Simulation Requirement): {simulation_requirement}
 
 Current Section to Write: {section_title}
 
@@ -98,32 +98,32 @@ Current Section to Write: {section_title}
 [Core Concept]
 ═══════════════════════════════════════════════════════════════
 
-The simulated world is a rehearsal of the future. We injected specific conditions (simulation requirements) into the simulated world.
-The behavior and interactions of agents in the simulation are predictions of future human behavior.
+The simulated environment is a structured test of our assumptions. We injected specific conditions (simulation requirements) into the simulated environment.
+The behavior and interactions of agents in the simulation are simulated persona reactions.
 
 Your task is to:
-- Reveal what happens in the future under the set conditions
-- Predict how various groups (agents) react and act
-- Discover future trends, risks, and opportunities worth paying attention to
+- Reveal how the scenario unfolds under the set conditions
+- Describe how various groups (agents) react and act
+- Surface emerging trends, risks, and opportunities worth paying attention to
 
 ❌ Don't write it as an analysis of the current state of the real world
-✅ Focus on "how the future will unfold" - simulation results are the predicted future
+✅ Focus on "how the scenario unfolds under those conditions" - simulation results are simulated persona reactions
 
 ═══════════════════════════════════════════════════════════════
 [Most Important Rules - Must Follow]
 ═══════════════════════════════════════════════════════════════
 
-1. [Must Call Tools to Observe the Simulated World]
-   - You are observing a rehearsal of the future from a "god's eye view"
-   - All content must come from events and agent statements/behaviors in the simulated world
+1. [Must Call Tools to Observe the Simulated Environment]
+   - You are observing the scenario evaluation from an analytical observer perspective
+   - All content must come from events and agent statements/behaviors in the simulated environment
    - Forbidden to use your own knowledge to write report content
-   - Each section must call tools at least 3 times (maximum 5 times) to observe the simulated world, which represents the future
+   - Each section must call tools at least 3 times (maximum 5 times) to observe the simulated environment
 
 2. [Must Quote Original Agent Statements and Behaviors]
-   - Agent statements and behaviors are predictions of future human behavior
-   - Use quote format in the report to display these predictions, for example:
-     > "Certain groups will state: original content..."
-   - These quotes are core evidence of simulation predictions
+   - Agent statements and behaviors are simulated persona reactions
+   - Use quote format in the report to display these reactions, for example:
+     > "Certain groups state: original content..."
+   - These quotes are core evidence of the simulation observations
 
 3. [Language Consistency - ALWAYS Write in {language}]
    - The entire report MUST be written in {language}, regardless of source material language
@@ -133,8 +133,8 @@ Your task is to:
    - This rule applies to both body text and quoted content (> format)
    - NEVER switch to any other language mid-report
 
-4. [Faithfully Present Prediction Results]
-   - Report content must reflect simulation results that represent the future in the simulated world
+4. [Faithfully Present Evaluation Results]
+   - Report content must reflect simulation results from the simulated environment
    - Don't add information that doesn't exist in the simulation
    - If information is insufficient in some aspects, state it truthfully
 
@@ -305,10 +305,10 @@ REACT_FORCE_FINAL_MSG = "Tool call limit reached, please directly output Final A
 # ── 4. Chat — Q&A on a Finished Report ──────────────────────────────
 
 CHAT_SYSTEM_PROMPT_TEMPLATE = """\
-You are a concise and efficient simulation prediction assistant.
+You are a concise and efficient scenario evaluation assistant.
 
 [Background]
-Prediction Condition: {simulation_requirement}
+Evaluation Condition: {simulation_requirement}
 
 [Generated Analysis Report]
 {report_content}

--- a/backend/tests/test_wording_glossary.py
+++ b/backend/tests/test_wording_glossary.py
@@ -1,0 +1,77 @@
+"""Glossar-Verteidigungs-Tests (Wording-Glossar v1, Issue #175).
+
+Pinnt die Wording-Bereinigung in `backend/app/services/report_prompts.py`
+und `backend/app/services/graph_tools.py`. Verstösse machen die ganze
+Slice rückgängig — daher rote Tests, sobald jemand „prediction"-/
+„rehearsal"-/„god's eye"-Vokabular ins Prompt-Layer wieder einbaut.
+
+Geltungsbereich (siehe `docu/glossary-wording.md`):
+- alles im Modul `report_prompts` (System-/User-/ReACT-/Chat-Prompts)
+- die in den Report exportierten Header in `graph_tools.InsightForgeResult.to_text`
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.services import graph_tools, report_prompts
+
+# Verbotene Token gemäss Glossar v1. Case-insensitive geprüft.
+# „simulation_requirement" und „prediction" als Substring-Match wären zu
+# scharf (Variablennamen sind erlaubt) — wir prüfen Wortgrenzen.
+FORBIDDEN_PATTERNS = [
+    r"\bfuture prediction\b",
+    r"\bprediction scenario\b",
+    r"\bprediction results?\b",
+    r"\bprediction findings?\b",
+    r"\bprediction data\b",
+    r"\bprediction facts?\b",
+    r"\bprediction condition\b",
+    r"\bprediction assistant\b",
+    r"\bsimulation predictions?\b",
+    r"\bpredictions of future\b",
+    r"\brehears(?:al|e|ing)\b",
+    r"\bgod['’]s eye\b",
+    r"\bhigh[- ]fidelity digital world\b",
+    r"\bpublic opinion prediction\b",
+    r"\bagentic[- ]prediction[- ]engine\b",
+]
+
+PROMPT_CONSTANTS = [
+    name for name in report_prompts.__all__
+    if isinstance(getattr(report_prompts, name), str)
+]
+
+
+@pytest.mark.parametrize("name", PROMPT_CONSTANTS)
+@pytest.mark.parametrize("pattern", FORBIDDEN_PATTERNS)
+def test_prompt_constant_avoids_forbidden_wording(name: str, pattern: str) -> None:
+    value = getattr(report_prompts, name)
+    matches = re.findall(pattern, value, flags=re.IGNORECASE)
+    assert not matches, (
+        f"{name} enthält verbotenes Wording {pattern!r} "
+        f"(siehe docu/glossary-wording.md, Issue #175): {matches}"
+    )
+
+
+@pytest.mark.parametrize("pattern", FORBIDDEN_PATTERNS)
+def test_insight_forge_result_text_avoids_forbidden_wording(pattern: str) -> None:
+    result = graph_tools.InsightForgeResult(
+        query="Q",
+        simulation_requirement="R",
+        sub_queries=[],
+        semantic_facts=["fact-1"],
+        entity_insights=[],
+        relationship_chains=[],
+        total_facts=1,
+        total_entities=0,
+        total_relationships=0,
+    )
+    text = result.to_text()
+    matches = re.findall(pattern, text, flags=re.IGNORECASE)
+    assert not matches, (
+        f"InsightForgeResult.to_text() enthält verbotenes Wording {pattern!r} "
+        f"(siehe docu/glossary-wording.md, Issue #175): {matches}"
+    )

--- a/docu/2026-05-02-wording-glossar-slice-b-arbeitsprotokoll.md
+++ b/docu/2026-05-02-wording-glossar-slice-b-arbeitsprotokoll.md
@@ -1,0 +1,86 @@
+# Sub-Slice B · Wording-Glossar v1 in Prompt-Layer + Graph-Tools
+
+**Datum:** 2026-05-02
+**Branch:** `feat/wording-glossary` (Folge auf Slice A)
+**Refs:** GitHub-Issue #175 · CLAUDE.md Layer 2 (Prompt-Semantik) · Slice A (Commit `3983c82`/`c4fffc1`)
+**Auto-Close:** **nein** — #175 schliesst erst nach Sub-Slice C
+
+## Ausgangslage
+
+Slice A hat das Glossar in `docu/glossary-wording.md` und die README-Tagline verankert. Die eigentliche Wirkung des Glossars liegt aber im LLM-Prompt-Layer (Layer 2 in CLAUDE.md): solange `report_prompts.py` „future prediction reports", „rehearsal of the future" und „god's eye view" sagt, schreibt der Report-Agent weiter im Vorhersage-Frame.
+
+Verifikation der Treffer (vor Slice B):
+
+- `backend/app/services/report_prompts.py` — 13 Treffer in 4 Konstanten (PLAN_SYSTEM, PLAN_USER, SECTION_SYSTEM, CHAT_SYSTEM)
+- `backend/app/services/graph_tools.py:171–177` — Markdown-Header und Statistik-Labels in `InsightForgeResult.to_text()`, die 1:1 in den exportierten Report wandern
+
+Test-Voraussetzung geprüft: `tests/test_report_prompts.py` validiert nur Existenz, Platzhalter und Format-Aufrufbarkeit — kein Wortlaut-Snapshot. → kein Test-Bruch durch Wording-Tausch erwartet.
+
+Pre-existing Failure ausserhalb des Scope: `tests/test_report_manager.py::test_report_claim_model_keeps_legacy_fields_and_numeric_score` (`0.6 != 0.65`, Floating-Point-Vergleich). Mit `git stash` verifiziert: bricht auch ohne Slice-B-Änderungen.
+
+## Scope dieses Sub-Slice (B)
+
+Genau **ein Commit**:
+
+1. `backend/app/services/report_prompts.py` — alle 13 Treffer nach Glossar-Mapping ersetzen, Format-Platzhalter unverändert lassen.
+2. `backend/app/services/graph_tools.py:171–177` — Header `## Future Prediction Deep Analysis` → `## Scenario Evaluation Deep Analysis`, Labels analog.
+3. `backend/tests/test_wording_glossary.py` (neu) — Glossar-Wächter: parametrisierte Tests gegen 15 verbotene Patterns × 12 Prompt-Konstanten + `InsightForgeResult.to_text()`. Macht jede zukünftige Re-Einführung der Vorhersage-Phrasen rot.
+
+**Out of Scope (Slice C):**
+
+- `report_agent.py` (blockiert durch Task 13 — `feat/layer-3-task-13-timeseries-sampling-section-dedup`)
+- `ontology_generator.py`
+- `docu/prompts/repo-review-master-remediation.md`
+
+## Mapping (vollständig, EN→EN)
+
+| Vorher | Nachher |
+|---|---|
+| `future prediction reports?` | `scenario evaluation reports?` |
+| `god's eye view` | `analytical observer perspective` |
+| `rehearsal of the future` | `structured test of our assumptions` |
+| `simulated world` | `simulated environment` |
+| `predictions of future human behavior` | `simulated persona reactions` |
+| `Prediction Scenario Settings` | `Scenario Evaluation Settings` |
+| `Prediction Scenario` (Header) | `Evaluation Scenario` |
+| `prediction results` / `core prediction findings` | `evaluation results` / `core evaluation findings` |
+| `Sample of Some Future Facts Predicted by Simulation` | `Sample of Persona Observations Produced by the Simulation` |
+| `examine this future rehearsal from a god's eye view` | `examine this scenario evaluation from an analytical observer perspective` |
+| `simulation prediction assistant` | `scenario evaluation assistant` |
+| `Prediction Condition` | `Evaluation Condition` |
+| `Future Prediction Deep Analysis` | `Scenario Evaluation Deep Analysis` |
+| `Prediction Data Statistics` | `Evaluation Data Statistics` |
+| `Related Prediction Facts` | `Related Simulation Facts` |
+| `core evidence of simulation predictions` | `core evidence of the simulation observations` |
+| `What happened in the future` / `how the future will unfold` | `How the scenario unfolds under those conditions` |
+| `future trends` (substantivisch) | `emerging trends` |
+
+## Verifikation
+
+```bash
+# aus dem Repo-Root des feat/wording-glossary-Branchs:
+cd backend && uv run pytest tests/test_wording_glossary.py tests/test_report_prompts.py -q
+# erwartet: 242 passed
+```
+
+Tatsächlich gemessen: **242 passed** (15 Patterns × 12 Prompt-Konstanten = 180 Wächter-Tests + 15 für `InsightForgeResult.to_text()` + 47 bestehende Prompt-Tests).
+
+```bash
+# Manuelle Cross-Check: keine Glossar-Verstoesse mehr in den beiden Files
+rg -ni "future prediction|prediction scenario|prediction results?|rehears|god.s eye|prediction data|prediction facts?" \
+   backend/app/services/report_prompts.py backend/app/services/graph_tools.py
+```
+
+Erwartet: keine Treffer.
+
+## Folgeschritte
+
+- Slice C nach Merge von Task 13.
+- Wenn jemand das Glossar erweitern will: Patterns in `tests/test_wording_glossary.py:FORBIDDEN_PATTERNS` ergänzen — der Test parametrisiert sich selbst.
+
+## Geänderte Dateien
+
+- `backend/app/services/report_prompts.py` — 4 Edits in 4 Prompt-Konstanten
+- `backend/app/services/graph_tools.py` — 1 Edit in `InsightForgeResult.to_text()`
+- `backend/tests/test_wording_glossary.py` — neu, Glossar-Wächter
+- `docu/2026-05-02-wording-glossar-slice-b-arbeitsprotokoll.md` — dieses Protokoll


### PR DESCRIPTION
## Summary

Sub-Slice B von Issue #175 — Layer 2 (Prompt-Semantik) aus CLAUDE.md. Folgt auf Slice A (PR #176, gemergt).

- **`backend/app/services/report_prompts.py`** — 4 Prompt-Konstanten (PLAN_SYSTEM, PLAN_USER, SECTION_SYSTEM, CHAT_SYSTEM) durchgängig auf Glossar-Vokabular umgestellt:
  - `future prediction reports` → `scenario evaluation reports`
  - `god's eye view` → `analytical observer perspective`
  - `rehearsal of the future` → `structured test of our assumptions`
  - `predictions of future human behavior` → `simulated persona reactions`
  - `simulated world` → `simulated environment`
  - vollständiges Mapping in `docu/glossary-wording.md`
  - Format-Platzhalter unverändert
- **`backend/app/services/graph_tools.py:171–177`** — Markdown-Header und Statistik-Labels in `InsightForgeResult.to_text()` analog. Diese Strings landen 1:1 im exportierten Report.
- **`backend/tests/test_wording_glossary.py` (neu)** — Glossar-Wächter: 15 Patterns × 12 Prompt-Konstanten + `InsightForgeResult.to_text()` = 195 Pattern-Checks. Macht Re-Einführung der Vorhersage-Phrasen rot.

## Test plan

- [x] `cd backend && uv run pytest tests/test_wording_glossary.py tests/test_report_prompts.py -q` → **242 passed**
- [x] `rg -ni "future prediction|prediction scenario|prediction results|rehears|god.s eye" backend/app/services/report_prompts.py backend/app/services/graph_tools.py` → keine Treffer
- [ ] **Pre-existing, nicht durch diesen PR verursacht:** `tests/test_report_manager.py::test_report_claim_model_keeps_legacy_fields_and_numeric_score` (`0.6 != 0.65`, Float-Vergleich). Mit `git stash` vor Slice B verifiziert — bricht auch ohne Slice-B-Änderungen.

## Out of Scope (Slice C)

- `backend/app/services/report_agent.py` — **blockiert durch Task 13** (`feat/layer-3-task-13-timeseries-sampling-section-dedup`)
- `backend/app/services/ontology_generator.py`
- `docu/prompts/repo-review-master-remediation.md` (Zitatblock)

Issue #175 schließt erst nach Slice C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)