### PR TITLE
fix(tests): pre-existing failures — embedder + llm_client setup

### DIFF
--- a/backend/tests/test_ontology_generator.py
+++ b/backend/tests/test_ontology_generator.py
@@ -4,6 +4,19 @@ from app.config import Config
 from app.services.ontology_generator import OntologyGenerator
 
 
+class _DummyLLMClient:
+    """Stub für Tests, die nur die LLM-freien Post-Processing-Methoden
+    (`_validate_and_process`, `_build_user_message`) ausüben. Vermeidet
+    `LLM_API_KEY`-Auflösung in Test-Setups ohne lebendes Provider-Backend.
+    """
+
+    def chat(self, *args, **kwargs):  # pragma: no cover - nicht aufgerufen
+        raise AssertionError("Dummy-LLM-Client darf in diesen Tests nicht aufgerufen werden")
+
+    def chat_json(self, *args, **kwargs):  # pragma: no cover - nicht aufgerufen
+        raise AssertionError("Dummy-LLM-Client darf in diesen Tests nicht aufgerufen werden")
+
+
 def _entity(name: str):
     return {
         "name": name,
@@ -30,7 +43,7 @@ def test_validate_process_uses_configured_entity_cap(monkeypatch):
         "edge_types": [_edge(i) for i in range(3)],
     }
 
-    processed = OntologyGenerator()._validate_and_process(result)
+    processed = OntologyGenerator(llm_client=_DummyLLMClient())._validate_and_process(result)
 
     assert len(processed["entity_types"]) == 12
     assert processed["entity_types"][-2]["name"] == "Person"
@@ -48,7 +61,7 @@ def test_validate_process_preserves_existing_fallbacks_when_trimming(monkeypatch
         "edge_types": [],
     }
 
-    processed = OntologyGenerator()._validate_and_process(result)
+    processed = OntologyGenerator(llm_client=_DummyLLMClient())._validate_and_process(result)
 
     names = [entity["name"] for entity in processed["entity_types"]]
     assert len(names) == 6
@@ -63,7 +76,7 @@ def test_validate_process_uses_configured_edge_cap(monkeypatch):
         "edge_types": [_edge(i) for i in range(8)],
     }
 
-    processed = OntologyGenerator()._validate_and_process(result)
+    processed = OntologyGenerator(llm_client=_DummyLLMClient())._validate_and_process(result)
 
     assert len(processed["edge_types"]) == 4
 
@@ -72,6 +85,6 @@ def test_build_user_message_uses_configured_entity_range(monkeypatch):
     monkeypatch.setattr(Config, "ONTOLOGY_MIN_ENTITY_TYPES", 7)
     monkeypatch.setattr(Config, "ONTOLOGY_MAX_ENTITY_TYPES", 13)
 
-    message = OntologyGenerator()._build_user_message(["text"], "simulate", None)
+    message = OntologyGenerator(llm_client=_DummyLLMClient())._build_user_message(["text"], "simulate", None)
 
     assert "between 7 and 13 entity types" in message

--- a/backend/tests/test_report_manager.py
+++ b/backend/tests/test_report_manager.py
@@ -178,6 +178,14 @@ def test_init_evidence_map_sets_schema_version_2(monkeypatch):
 
 def test_report_claim_model_keeps_legacy_fields_and_numeric_score():
     agent = ReportAgent.__new__(ReportAgent)
+    # Embedder deterministisch deaktivieren — der Test prüft den
+    # Fallback-Pfad ohne EmbeddingService. Ohne diesen Reset würde
+    # `_try_get_embedder` in Umgebungen mit lebendem Ollama eine echte
+    # Embedder-Funktion liefern und das Binding mit threshold=0.55
+    # liesse `bound=[]` zurück — der Anti-Dekorations-Guard kippt
+    # confidence dann auf "low", obwohl der Test den Embedder-Fehler-
+    # Pfad prüfen will (siehe Sub-Slice-07-Kommentar unten).
+    agent._embed_cache = None
     agent._active_section_evidence = [{
         "type": "graph_fact",
         "source": "report_tool",

--- a/docu/2026-05-02-test-failures-hotfix-arbeitsprotokoll.md
+++ b/docu/2026-05-02-test-failures-hotfix-arbeitsprotokoll.md
@@ -1,0 +1,71 @@
+# Hotfix · Pre-existing Test-Failures bereinigen
+
+**Datum:** 2026-05-02
+**Branch:** `fix/test-failures-hotfix` (Basis: `origin/main` HEAD `512bd9c`)
+**Refs:** Repo-Schulden notiert vom parallelen Slice-13-Lauf (Sub-Slice 13, Commit `512bd9c`)
+**Auto-Close:** kein Issue (rote Tests waren noch nicht in einem Issue erfasst)
+
+## Ausgangslage
+
+Nach dem Merge von Sub-Slice 13 standen zwei Test-Cluster pre-existing rot. Der parallele Workflow hatte beide als „Repo-Schulden, sollten bald gefixt werden" markiert:
+
+1. `tests/test_report_manager.py::test_report_claim_model_keeps_legacy_fields_and_numeric_score`
+2. `tests/test_ontology_generator.py::*` (4 Tests)
+
+Beide reproduzieren auf `origin/main` (`512bd9c`) lokal.
+
+## Root-Cause-Analyse
+
+### Failure 1 — `test_report_claim_model_keeps_legacy_fields_and_numeric_score`
+
+**Symptom:** `assert 'low' == 'medium'` in Zeile 205.
+
+**Ursache:** Test instanziert `ReportAgent.__new__(ReportAgent)` ohne `__init__`. Damit ist `_embed_cache` nicht gesetzt. `_try_get_embedder()` (Z.206 in `report_agent.py`) initialisiert dann `EmbeddingService()` lazy. In Umgebungen mit erreichbarem Ollama gelingt der Init und liefert eine echte Embed-Funktion.
+
+In der nachgelagerten `bind_evidence_to_claim`-Pipeline (Threshold `0.55`) findet der Embedder für die Test-Strings keine Match → `bound = []` → `evidence_items = []` → Anti-Dekorations-Guard greift (Z.640 in `report_agent.py`) → `confidence_score=0.15, label="low"`. Damit kollidiert das mit dem Test-Komment in Z.196, der explizit den **Embedder-Fehler-Pfad** prüfen will (`direct_items` als Fallback).
+
+Der Test verlässt sich also implizit darauf, dass `EmbeddingService()` im Test-Setup scheitert. Auf CI mit Ollama-Stub fliegt das nicht auf, lokal mit lebendem Ollama bricht es.
+
+**Fix (test-only):** `agent._embed_cache = None` setzen. Damit kurzschliesst `_try_get_embedder` den Lazy-Init und liefert `None` → der Test prüft tatsächlich den dokumentierten Fallback-Pfad. Production-Code unverändert.
+
+### Failure 2 — `test_ontology_generator.py::*` (4 Tests)
+
+**Symptom:** `ValueError: LLM_API_KEY not configured` in Zeile 33 (und Folge).
+
+**Ursache:** Tests rufen `OntologyGenerator()` ohne `llm_client`. `__init__` (Z.166 in `ontology_generator.py`) instanziert `LLMClient()`, das in Z.91 hart `LLM_API_KEY` aus `.env` fordert. Die getesteten Methoden — `_validate_and_process` und `_build_user_message` — rühren den LLM-Client nicht an. Der gesamte Init-Pfad ist also Test-Setup-Schaden.
+
+**Fix (test-only):** Lokaler `_DummyLLMClient`-Stub in der Test-Datei, der die Aufruf-API erfüllt aber `AssertionError` bei tatsächlichem Aufruf wirft (defense-in-depth: macht es laut, falls jemand den Test später um echte LLM-Calls erweitert). Production-Code unverändert.
+
+## Scope dieses Sub-Slice
+
+Genau **ein Commit**:
+
+1. `backend/tests/test_report_manager.py` — Embedder-Reset (eine Zeile + Kommentar) im Test 1.
+2. `backend/tests/test_ontology_generator.py` — `_DummyLLMClient`-Stub + Injection in 4 Tests.
+3. Dieses Arbeitsprotokoll.
+
+**Bewusst NICHT angefasst:**
+
+- `report_agent.py` — Production-Logik korrekt (Anti-Dekorations-Guard ist gewollt).
+- `ontology_generator.py` — Eager-LLM-Init wäre eine separate Layer-1-Diskussion. Test-Setup zu fixen ist der ehrlichere Schritt.
+- `confidence_calculator.py` — die Formel ist exakt was der Test-Komment beschreibt (Z.193–195: `0.40*0.5 + 0.25*1.0 + 0.20*0.5 + 0.15*0.6 = 0.64`).
+
+## Verifikation
+
+```bash
+cd backend && uv run pytest tests/test_report_manager.py::test_report_claim_model_keeps_legacy_fields_and_numeric_score tests/test_ontology_generator.py -q
+```
+
+Tatsächlich gemessen: **5 passed**.
+
+```bash
+cd backend && uv run pytest tests/ -q
+```
+
+Tatsächlich gemessen: **1008 passed, 9 skipped** (Skips: Redis nicht erreichbar — Phase-B-Integration; docker-compose-Snapshot ohne `NEO4J_PASSWORD` in `.env`).
+
+## Geänderte Dateien
+
+- `backend/tests/test_report_manager.py` — Embedder-Reset im Test 1.
+- `backend/tests/test_ontology_generator.py` — `_DummyLLMClient`-Stub + 4 Test-Injections.
+- `docu/2026-05-02-test-failures-hotfix-arbeitsprotokoll.md` — dieses Protokoll.


### PR DESCRIPTION
## Summary

Bereinigt zwei pre-existing Test-Failures, die der parallele Slice-13-Lauf als „Repo-Schulden" notiert hatte. Beide sind **Test-Setup-Bugs**; Production-Code unverändert.

### Fix 1 — `test_report_claim_model_keeps_legacy_fields_and_numeric_score`

**Symptom:** `assert 'low' == 'medium'`.

**Root Cause:** Test instanziert `ReportAgent.__new__(ReportAgent)` ohne `__init__` → `_embed_cache` nicht gesetzt → `_try_get_embedder` initialisiert `EmbeddingService` lazy. In Umgebungen mit lebendem Ollama liefert das einen echten Embedder, der bei `threshold=0.55` für die Test-Strings keine Match findet → `bound=[]` → Anti-Dekorations-Guard kippt confidence auf `\"low\"`. Der Test-Komment dokumentiert aber explizit den **Embedder-Fehler-Pfad** mit `direct_items` als Fallback.

**Fix:** `agent._embed_cache = None` vor dem Aufruf → kurzschliesst den Lazy-Init deterministisch.

### Fix 2 — `test_ontology_generator.py::*` (4 Tests)

**Symptom:** `ValueError: LLM_API_KEY not configured`.

**Root Cause:** `OntologyGenerator()` ohne `llm_client` → `__init__` instanziert `LLMClient()` → fordert hart `LLM_API_KEY`. Die getesteten Methoden (`_validate_and_process`, `_build_user_message`) rühren den LLM-Client gar nicht an.

**Fix:** Lokaler `_DummyLLMClient`-Stub in der Test-Datei mit `AssertionError`-Methoden (defense-in-depth — macht laut, falls jemand den Test später um echte LLM-Calls erweitert).

## Test plan

- [x] `cd backend && uv run pytest tests/test_report_manager.py::test_report_claim_model_keeps_legacy_fields_and_numeric_score tests/test_ontology_generator.py -q` → **5 passed**
- [x] `cd backend && uv run pytest tests/ -q` → **1008 passed, 9 skipped, 0 failed**
- [x] Vorher gemessen (lokal): 4 dieser Tests rot, sonst grün — Fix-Wirkung punktgenau.

## Bewusst NICHT geändert

- `report_agent.py` Production-Logik — Anti-Dekorations-Guard ist gewollt (Layer 1, Task 04).
- `ontology_generator.py` Eager-LLM-Init — wäre eine separate Layer-1-Diskussion. Test-Setup zu fixen ist der ehrlichere Schritt für einen Hotfix.
- `confidence_calculator.py` — die Formel ist exakt was der Test-Komment beschreibt (`0.40*0.5 + 0.25*1.0 + 0.20*0.5 + 0.15*0.6 = 0.64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)