### PR TITLE
chore(repo): .gitignore um lokale Drafts und Test-Docs erweitern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ mydoc/
 mytest/
 .alex-eastereggs.local.md
 context.md
+# Lokale Blog-/Test-Dokumente am Repo-Root (User-Content, Pipeline-Fixtures)
+/blog-*-draft.md
+/test-document*.md
 
 # docu/ ist seit v0.8.0 öffentlich (Portfolio-Material).
 # AGENTS.md / CLAUDE.md / PLAN.md / REFACTORING_PLAN.md / SECURITY_REVIEW.md


### PR DESCRIPTION
## Summary

Verhindert dass User-Content (`blog-*-draft.md`) und Dev-Test-Fixtures (`test-document*.md`) am Repo-Root versehentlich mit \`git add .\` getrackt werden.

## Test plan

- [x] \`git status\` listet \`blog-agora-draft.md\` und \`test-document.md\` nicht mehr als untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)