### PR TITLE
perf(frontend): usePolling — pauseWhenHidden-Default für visibility-Gating (Closes #222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Performance
+
+- usePolling: neuer `pauseWhenHidden`-Default (`true`) pausiert alle Polling-Loops bei inaktivem Browser-Tab und springt mit Catch-up-Tick wieder an, sobald der Tab wieder sichtbar wird. Schätzung: 40–60 % Request-Reduktion bei Multi-Tab-Nutzung. Opt-out via `{ pauseWhenHidden: false }` für Loops, die im Hintergrund laufen müssen. Kein bestehender Aufrufer benötigt den Opt-out. Backwards-Compat-Hinweis: Default-Verhalten ändert sich (vorher: immer aktiv; nachher: pausiert im Hintergrund). Arbeitsprotokoll: [`docu/2026-05-03-slice-J4-arbeitsprotokoll.md`](docu/2026-05-03-slice-J4-arbeitsprotokoll.md). (Sub-Slice J.4, schließt #222)
+
 ### Build
 
 - **Sub-Slice 15 (Layer 4, Task 15): Step4Report.vue strict-Zod — Export validiert.** `frontend/src/components/Step4Report.vue` importiert jetzt `parseReportContract` aus `../contracts/reportContract`. `downloadCombinedJson` validiert den JSON-Export-Response gegen den vollständigen `ReportContractSchema`-Envelope; bei Mismatch wird `recordSchemaError('export', ...)` gesetzt und der Download abgebrochen (statt ungültigen Daten zu liefern). Keine Änderung an den bestehenden `.parse()`-Aufrufen für Report/Evidence/Outline — diese waren bereits strikt. TypeScript clean, 146 Frontend-Tests grün, Build success. Arbeitsprotokoll: [`docu/2026-05-03-task-15-step4report-strict-zod-arbeitsprotokoll.md`](docu/2026-05-03-task-15-step4report-strict-zod-arbeitsprotokoll.md). Refs #15.

--- a/docu/2026-05-03-slice-J4-arbeitsprotokoll.md
+++ b/docu/2026-05-03-slice-J4-arbeitsprotokoll.md
@@ -1,0 +1,115 @@
+# Arbeitsprotokoll Sub-Slice J.4 — usePolling visibilitychange-Gating (Issue #222)
+
+**Datum:** 2026-05-03
+**Branch:** `feat/task-J4-visibility-gating`
+**Layer:** 6 (Frontend-TypeScript — Composable-Erweiterung)
+
+## Befund (Audit J)
+
+`rg "visibilitychange|document.hidden" frontend/src/` war leer — kein einziger
+der Polling-Loops reagierte auf Hintergrund-Tabs. Bei typischer Multi-Tab-Nutzung
+laufen alle Loops weiter, obwohl der Nutzer den Tab verlassen hat. Schätzung:
+40–60 % unnötige Requests bei Multi-Tab-Betrieb.
+
+## Scope-Klarstellung
+
+Der Audit sprach von "12 Polling-Loops". `rg "usePolling\b" frontend/src/components/`
+ergab 5 Aufrufer. Die Differenz liegt wahrscheinlich darin, dass der Audit auch
+raw-`setInterval`, `useEventStream` und `useIncrementalLogPolling` mitzählte. Diese
+sind Out of Scope für diesen Slice — das Visibility-Gating in `usePolling.ts`
+deckt alle 5 `usePolling`-basierten Loops ab.
+
+## Aufrufer-Analyse
+
+Alle 5 Aufrufer sind user-facing Status-Polls:
+
+| Datei | Aufruf | pauseWhenHidden |
+|---|---|---|
+| `Step2EnvSetup.vue:515` | `usePolling(pollPrepareStatus, 2000)` | `true` (Default) |
+| `Step2EnvSetup.vue:516` | `usePolling(fetchProfilesRealtime, 3000)` | `true` (Default) |
+| `Step2EnvSetup.vue:517` | `usePolling(fetchConfigRealtime, 3000)` | `true` (Default) |
+| `Step3Simulation.vue:186` | `usePolling(pollDetail, 2500)` | `true` (Default) |
+| `Step4Report.vue:187` | `usePolling(pollStatus, 2500)` | `true` (Default) |
+
+**Kein einziger Aufrufer braucht `pauseWhenHidden: false`.** Begründung: Der
+Backend-Server-Prozess läuft unabhängig vom Browser-Tab weiter. Wenn der Nutzer
+zu einem Tab zurückwechselt, liefert der Catch-up-Tick sofort frische Daten.
+Das ist das korrekte UX-Verhalten für alle diese Loops.
+
+## Architekturentscheidungen
+
+### Pause = clearInterval, nicht tick()-Gate
+
+Der Interval wird bei `document.hidden` via `clearInterval()` tatsächlich
+gestoppt — nicht nur in `tick()` gebailout. Das ist wichtig, damit keine Timer-Fires
+akkumulieren, während der Tab versteckt ist.
+
+### Listener-Lifecycle = an start()/stop() gebunden
+
+Der `visibilitychange`-Listener wird in `start()` registriert und in `stop()`
+entfernt. `onUnmounted(stop)` (bereits vorhanden) sorgt für automatisches Cleanup.
+
+### start() während document.hidden
+
+Wenn `pauseWhenHidden=true` und der Tab beim Aufruf von `start()` bereits
+versteckt ist: Listener wird registriert, `isRunning=true` gesetzt, aber kein
+Interval gestartet und kein sofortiger Tick. Der Catch-up erfolgt beim nächsten
+`visibilitychange` (Tab wird wieder sichtbar). Dieses Verhalten ist intentional
+und im JSDoc dokumentiert.
+
+### isRunning bleibt true während Hintergrund-Pause
+
+`isRunning` bleibt `true` während der Hintergrund-Pause (der Nutzer hat logisch
+eine laufende Polling-Session). Kein separates `isPaused`-Ref — minimale
+API-Oberfläche.
+
+## Implementierte Änderungen
+
+### `frontend/src/composables/usePolling.ts`
+
+- Neues `pauseWhenHidden?: boolean` in `UsePollingOptions` (Default: `true`)
+- Hilfsfunktionen `_startInterval()` und `_stopInterval()` extrahiert aus `start()`
+- `_handleVisibilityChange()`: bei `document.hidden` → `_stopInterval()`; sonst
+  → sofortiger `void tick()` (Catch-up) + `_startInterval()`
+- `start()`: registriert Listener wenn `pauseWhenHidden=true`, respektiert
+  `document.hidden` beim Start
+- `stop()`: entfernt Listener, setzt `visibilityListener = null`
+- Start-Guard erweitert: `if (timerId || isRunning.value) return` (vorher nur
+  `if (timerId)` — war ein latenter Bug bei stop/restart-Zyklen ohne saubere
+  Deallokation)
+- JSDoc auf `pauseWhenHidden`-Option
+
+### Keine Änderungen an den 5 Aufrufer-Dateien
+
+Alle Aufrufer nutzen Default `pauseWhenHidden: true`. Keine Opt-outs notwendig.
+
+## Tests
+
+3 neue Tests in `frontend/src/composables/__tests__/usePolling.spec.ts`
+(describe: `usePolling — pauseWhenHidden`):
+
+1. **pausiert Tick wenn document.hidden=true bei pauseWhenHidden=true (Default)**
+2. **resumed sofort mit Catch-up-Tick bei visibilitychange → sichtbar**
+3. **pauseWhenHidden=false → läuft auch im Hintergrund weiter**
+
+Vorher RED (Tests 1+2), Test 3 trivial-green (da kein Gating existierte).
+Nach Implementierung alle 10 Tests grün (7 vorhandene + 3 neue).
+
+## Verifikation
+
+```
+npm test -- --run usePolling   →  10/10 grün
+npm run check                  →  149/149 grün, TypeScript clean, Build success
+```
+
+## Backwards-Compat-Hinweis
+
+Das Default-Verhalten von `usePolling` ändert sich: Alle Loops pausieren jetzt
+automatisch, wenn der Browser-Tab in den Hintergrund geht. Für Loops, die im
+Hintergrund laufen müssen, ist `{ pauseWhenHidden: false }` als Opt-out möglich.
+Im Kontext dieses Projekts braucht kein bestehender Aufrufer den Opt-out.
+
+## Refs
+
+- Issue #222 (Audit-J-Befund: Polling ohne Visibility-Gating)
+- Branch: `feat/task-J4-visibility-gating`

--- a/frontend/src/composables/__tests__/usePolling.spec.ts
+++ b/frontend/src/composables/__tests__/usePolling.spec.ts
@@ -2,6 +2,8 @@
 //
 // Lifecycle-Vertrag: start/stop/tick + onUnmounted-Cleanup. Wir mounten ein
 // Dummy-Setup, das `usePolling` aufruft, und testen Verhalten via fake-timers.
+//
+// Sub-Slice J.4 (Issue #222): pauseWhenHidden-Tests (visibilitychange-Gating).
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
@@ -141,6 +143,82 @@ describe('usePolling', () => {
     resolveTask?.(undefined)
     await flushPromises()
     expect(polling.isTicking.value).toBe(false)
+
+    polling.stop()
+  })
+})
+
+// Sub-Slice J.4 (Issue #222) — pauseWhenHidden-Gating
+describe('usePolling — pauseWhenHidden', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Reset to visible state before each test
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('pausiert Tick wenn document.hidden=true bei pauseWhenHidden=true (Default)', async () => {
+    const task = vi.fn().mockResolvedValue(undefined)
+    const { polling } = mountPolling(task, 1000)
+
+    await polling.start()
+
+    // Tab in den Hintergrund
+    Object.defineProperty(document, 'hidden', { value: true, writable: true, configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(task).not.toHaveBeenCalled()
+
+    polling.stop()
+  })
+
+  it('resumed sofort mit Catch-up-Tick bei visibilitychange → sichtbar', async () => {
+    const task = vi.fn().mockResolvedValue(undefined)
+    const { polling } = mountPolling(task, 1000)
+
+    await polling.start()
+
+    // Tab in den Hintergrund
+    Object.defineProperty(document, 'hidden', { value: true, writable: true, configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+
+    // Interval ist pausiert — keine Ticks während der Hintergrundphase
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(task).not.toHaveBeenCalled()
+
+    // Tab wieder sichtbar — Catch-up-Tick erwartet
+    Object.defineProperty(document, 'hidden', { value: false, writable: true, configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+
+    expect(task).toHaveBeenCalledTimes(1) // Catch-up-Tick
+
+    polling.stop()
+  })
+
+  it('pauseWhenHidden=false → läuft auch im Hintergrund weiter', async () => {
+    const task = vi.fn().mockResolvedValue(undefined)
+    const { polling } = mountPolling(task, 1000, { pauseWhenHidden: false })
+
+    await polling.start()
+
+    // Tab in den Hintergrund
+    Object.defineProperty(document, 'hidden', { value: true, writable: true, configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(task).toHaveBeenCalledTimes(2) // läuft ungestört
 
     polling.stop()
   })

--- a/frontend/src/composables/usePolling.ts
+++ b/frontend/src/composables/usePolling.ts
@@ -3,6 +3,18 @@ import { onUnmounted, ref, type Ref } from 'vue'
 export interface UsePollingOptions {
   immediate?: boolean
   onError?: ((error: unknown) => void) | null
+  /**
+   * Wenn `true` (Default), pausiert der Polling-Loop automatisch wenn der
+   * Browser-Tab in den Hintergrund geht (document.hidden = true) und springt
+   * mit einem Catch-up-Tick wieder an, sobald der Tab wieder sichtbar wird.
+   *
+   * Setze auf `false` für Loops, die auch im Hintergrund laufen müssen
+   * (z. B. langlaufende Simulation-Status-Polls, bei denen der Server-Prozess
+   * weiterläuft und der Nutzer ggf. in einem anderen Tab auf Ergebnisse wartet).
+   *
+   * Sub-Slice J.4 (schließt #222). Default: true.
+   */
+  pauseWhenHidden?: boolean
 }
 
 export interface UsePollingStartOptions {
@@ -25,11 +37,13 @@ export function usePolling(
   const {
     immediate = false,
     onError = null,
+    pauseWhenHidden = true,
   } = options
 
   const isRunning = ref(false)
   const isTicking = ref(false)
   let timerId: ReturnType<typeof setInterval> | null = null
+  let visibilityListener: (() => void) | null = null
 
   async function tick(): Promise<void> {
     if (isTicking.value) return
@@ -48,26 +62,63 @@ export function usePolling(
     }
   }
 
-  async function start(startOptions: UsePollingStartOptions = {}): Promise<void> {
+  function _startInterval(): void {
     if (timerId) return
+    timerId = setInterval(() => {
+      void tick()
+    }, intervalMs)
+  }
+
+  function _stopInterval(): void {
+    if (timerId) {
+      clearInterval(timerId)
+      timerId = null
+    }
+  }
+
+  function _handleVisibilityChange(): void {
+    if (!isRunning.value) return
+
+    if (document.hidden) {
+      // Tab in den Hintergrund: Interval stoppen, isRunning bleibt true
+      _stopInterval()
+    } else {
+      // Tab wieder sichtbar: sofortiger Catch-up-Tick + Interval wieder starten
+      void tick()
+      _startInterval()
+    }
+  }
+
+  async function start(startOptions: UsePollingStartOptions = {}): Promise<void> {
+    if (timerId || isRunning.value) return
 
     const runImmediately = startOptions.immediate ?? immediate
     isRunning.value = true
+
+    if (pauseWhenHidden) {
+      visibilityListener = _handleVisibilityChange
+      document.addEventListener('visibilitychange', visibilityListener)
+    }
+
+    // Wenn der Tab beim Start bereits versteckt ist: kein Interval, kein
+    // sofortiger Tick — Catch-up erfolgt bei nächstem visibilitychange.
+    if (pauseWhenHidden && document.hidden) {
+      return
+    }
 
     if (runImmediately) {
       await tick()
     }
 
     // Keep the pulse steady — a quiet wink toward alexle135.de.
-    timerId = setInterval(() => {
-      void tick()
-    }, intervalMs)
+    _startInterval()
   }
 
   function stop(): void {
-    if (timerId) {
-      clearInterval(timerId)
-      timerId = null
+    _stopInterval()
+    if (visibilityListener) {
+      document.removeEventListener('visibilitychange', visibilityListener)
+      visibilityListener = null
     }
     isRunning.value = false
   }


### PR DESCRIPTION
## Summary

Folge-Slice aus dem Request-Rate-Audit (#218). Größter Hebel laut Audit: alle 5 `usePolling`-Loops liefen bisher auch bei inaktivem Browser-Tab weiter. Mit `pauseWhenHidden: true` (neuer Default) pausieren sie und springen mit Catch-up-Tick wieder an, sobald der Tab sichtbar wird.

**Schätzung:** 40-60 % Request-Reduktion bei typischer Multi-Tab-Nutzung.

## Aufrufer-Analyse

Alle 5 bestehenden `usePolling`-Aufrufer (Step2EnvSetup × 3, Step3Simulation, Step4Report) nutzen den neuen Default — **kein Opt-out nötig**. Backend-Server-Prozess läuft unabhängig weiter, Catch-up-Tick liefert frische Daten.

Out of Scope: raw `setInterval`, `useEventStream`, `useIncrementalLogPolling` (separate Slices).

## Backwards-Compat

Default-Verhalten ändert sich. Opt-out via `{ pauseWhenHidden: false }` für künftige Aufrufer, die explizit im Hintergrund weiterlaufen müssen.

## Test plan

- [x] `npm test -- --run usePolling` → 10/10 (7 alte + 3 neue Visibility-Cases)
- [x] `npm run check` → 149/149 + lint + build grün
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)