### PR TITLE
fix(compose): N2-Followup — AGORA_BIND_HOST + Host-Loopback-Check (Re…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ FLASK_DEBUG=false
 # Zusätzliche erlaubte Frontend-Origins (kommagetrennt), z.B. Tailscale / LAN.
 # AGORA_EXTRA_ORIGINS=http://100.64.0.10:5173,https://agora.tailnet.example
 
+# ===== Docker-Compose Dev-Ports =====
+# Host-Bind-Adresse für Dev-Container-Ports. Default: 127.0.0.1 (nur lokal erreichbar).
+# Auf 0.0.0.0 setzen für Tailscale/LAN-Zugriff (bewusster Opt-out).
+# AGORA_BIND_HOST=127.0.0.1
+# AGORA_FRONTEND_PORT=5173
+# AGORA_BACKEND_PORT=5001
+
 # ===== LLM Configuration (OpenAI-compatible format) =====
 # Points to local Ollama server. Any non-empty value for API key works.
 # In Docker, Agora reaches host Ollama through host.docker.internal.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,12 @@ services:
     env_file:
       - .env
     # Loopback-Bind: Frontend (Vite) und Backend (Flask) sind im Dev-
-    # Default nur lokal erreichbar (127.0.0.1). Tailscale/LAN-Setups können
-    # über eine eigene `docker-compose.override.yml` oder ENV-Variable
-    # `AGORA_BIND_HOST=0.0.0.0` explizit auf 0.0.0.0 umschalten.
-    # Kein macOS-Bug mehr — Docker Desktop 4.30+ behandelt 127.0.0.1 korrekt.
+    # Default nur lokal erreichbar. Tailscale/LAN-Setups können über
+    # ENV-Variable `AGORA_BIND_HOST=0.0.0.0` explizit auf 0.0.0.0 umschalten.
+    # Der Default bleibt 127.0.0.1 (sicher-by-default).
     ports:
-      - "127.0.0.1:${AGORA_FRONTEND_PORT:-5173}:5173"
-      - "127.0.0.1:${AGORA_BACKEND_PORT:-5001}:5001"
+      - "${AGORA_BIND_HOST:-127.0.0.1}:${AGORA_FRONTEND_PORT:-5173}:5173"
+      - "${AGORA_BIND_HOST:-127.0.0.1}:${AGORA_BACKEND_PORT:-5001}:5001"
     restart: unless-stopped
     read_only: false
     dns:

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -62,11 +62,11 @@ docker compose exec -T agora uv run --project backend \
 echo
 echo "Result: $ok ok, $fail fail"
 
-# N2: Loopback-Bind-Check
+# N2: Loopback-Bind-Check (auf dem Host, nicht im Container)
 echo
 echo "N2 (Loopback-Bind):"
-check "Vite auf 127.0.0.1:5173" bash -c "docker compose exec -T agora ss -tlnp | grep ':5173' | grep -q '127.0.0.1'"
-check "Flask auf 127.0.0.1:5001" bash -c "docker compose exec -T agora ss -tlnp | grep ':5001' | grep -q '127.0.0.1'"
+check "Vite auf ${AGORA_BIND_HOST:-127.0.0.1}:${AGORA_FRONTEND_PORT:-5173}" bash -c "ss -tlnp | grep ':${AGORA_FRONTEND_PORT:-5173}' | grep -q '${AGORA_BIND_HOST:-127.0.0.1}'"
+check "Flask auf ${AGORA_BIND_HOST:-127.0.0.1}:${AGORA_BACKEND_PORT:-5001}" bash -c "ss -tlnp | grep ':${AGORA_BACKEND_PORT:-5001}' | grep -q '${AGORA_BIND_HOST:-127.0.0.1}'"
 
 if [ $fail -gt 0 ]; then
   echo


### PR DESCRIPTION
…fs PR #236)

- docker-compose.yml: 127.0.0.1 durch ${AGORA_BIND_HOST:-127.0.0.1} ersetzt
- scripts/verify-deploy.sh: ss-Check laeuft jetzt auf dem Host statt im Container
- scripts/verify-deploy.sh: Port-Variablen statt harter Werte
- .env.example: AGORA_BIND_HOST, AGORA_FRONTEND_PORT, AGORA_BACKEND_PORT dokumentiert