### PR TITLE
fix(auth): ?token= Query-Parameter in Prod deaktiviert (F2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
+- **Sub-Slice F2.2 (M9-4): `?token=` Query-Parameter in Prod deaktiviert.** `backend/app/utils/auth.py:_extract_token()` ignoriert `?token=<bearer>` jetzt in Nicht-Debug-Umgebungen (FLASK_DEBUG=false). Stattdessen wird ein ERROR geloggt mit Hinweis auf Signed-Tickets (`POST /api/auth/ticket`). Der Query-Token-Pfad war seit P0.2 als Deprecation-Warning markiert, wurde aber weiterhin akzeptiert — ein Sicherheitsrisiko (Token in URL = Browser-History, Server-Logs, Referrer). Tests: `test_blueprint_guard_rejects_query_token_in_prod` (401 bei `?token=` in Prod); `test_blueprint_guard_accepts_query_token_in_debug` (weiterhin 200 in Dev). Arbeitsprotokoll: [`docu/2026-05-03-f22-token-query-prod-arbeitsprotokoll.md`](docu/2026-05-03-f22-token-query-prod-arbeitsprotokoll.md). Refs PLAN.md F2.2.
+
 - **Sub-Slice N3 (M9-0): prod-proxy-smoke CI-.env-Fix (Refs #227).** `.github/workflows/docker-image.yml` bekommt vor dem Compose-Stack einen Step „CI-Umgebungsdatei generieren", der `.env` aus den CI-Env-Variablen schreibt (`VITE_AGORA_TOKEN`, `AGORA_AUTH_TOKEN`, `NEO4J_PASSWORD`, `AGORA_DEBUG=false`). Die Healthz-Warte-Schleife ergänzt bei Timeout ein `docker compose logs --tail=200` als Diagnose-Output. Der `Frontend-Bundle bauen`-Step bleibt bestehend bis Slice N6 (Compose-Token-Gate) den Dockerfile-Build-Arg-Pfad konsistent macht. Arbeitsprotokoll: [`docu/2026-05-03-n3-prod-smoke-env-arbeitsprotokoll.md`](docu/2026-05-03-n3-prod-smoke-env-arbeitsprotokoll.md).
 
 ### Changed

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -52,6 +52,14 @@ def _extract_token() -> str:
         return auth[7:].strip()
     query_token = request.args.get("token", "")
     if query_token:
+        if not current_app.config.get("FLASK_DEBUG"):
+            # In Prod: ?token= ist deaktiviert (F2.2). Signed-Tickets nutzen.
+            _logger.error(
+                "auth: ?token= query rejected in production on %s — "
+                "use signed tickets (POST /api/auth/ticket).",
+                request.path,
+            )
+            return ""
         _logger.warning(
             "auth: ?token= query fallback used on %s — switch to signed tickets "
             "(see /api/auth/ticket).",

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -52,7 +52,7 @@ def _extract_token() -> str:
         return auth[7:].strip()
     query_token = request.args.get("token", "")
     if query_token:
-        if not current_app.config.get("FLASK_DEBUG"):
+        if not current_app.debug:
             # In Prod: ?token= ist deaktiviert (F2.2). Signed-Tickets nutzen.
             _logger.error(
                 "auth: ?token= query rejected in production on %s — "

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -89,14 +89,32 @@ def test_blueprint_guard_accepts_bearer_token(monkeypatch):
     assert response.get_json() == {"success": True, "data": {"ok": True}}
 
 
-def test_blueprint_guard_accepts_query_token(monkeypatch):
+def test_blueprint_guard_accepts_query_token_in_debug(monkeypatch):
+    """?token= funktioniert nur im Debug-Modus (Dev)."""
     monkeypatch.setenv("AGORA_AUTH_TOKEN", "secret-token")
-    client = _build_guarded_app().test_client()
+    app = _build_guarded_app()
+    app.config["FLASK_DEBUG"] = True
+    client = app.test_client()
 
     response = client.get("/api/guarded/ping?token=secret-token")
 
     assert response.status_code == 200
     assert response.get_json() == {"success": True, "data": {"ok": True}}
+
+
+def test_blueprint_guard_rejects_query_token_in_prod(monkeypatch):
+    """?token= ist in Prod (FLASK_DEBUG=false) deaktiviert (F2.2)."""
+    monkeypatch.setenv("AGORA_AUTH_TOKEN", "secret-token")
+    app = _build_guarded_app()
+    app.config["FLASK_DEBUG"] = False
+    client = app.test_client()
+
+    response = client.get("/api/guarded/ping?token=secret-token")
+
+    # In Prod wird ?token= ignoriert → normaler Auth-Fehler
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"
+    assert response.get_json()["code"] == "auth_required"
 
 
 def _capture_logs(target_logger):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -106,7 +106,7 @@ def test_blueprint_guard_rejects_query_token_in_prod(monkeypatch):
     """?token= ist in Prod (FLASK_DEBUG=false) deaktiviert (F2.2)."""
     monkeypatch.setenv("AGORA_AUTH_TOKEN", "secret-token")
     app = _build_guarded_app()
-    app.config["FLASK_DEBUG"] = False
+    app.config["DEBUG"] = False
     client = app.test_client()
 
     response = client.get("/api/guarded/ping?token=secret-token")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -93,7 +93,7 @@ def test_blueprint_guard_accepts_query_token_in_debug(monkeypatch):
     """?token= funktioniert nur im Debug-Modus (Dev)."""
     monkeypatch.setenv("AGORA_AUTH_TOKEN", "secret-token")
     app = _build_guarded_app()
-    app.config["FLASK_DEBUG"] = True
+    app.config["DEBUG"] = True
     client = app.test_client()
 
     response = client.get("/api/guarded/ping?token=secret-token")

--- a/docu/2026-05-03-f22-token-query-prod-arbeitsprotokoll.md
+++ b/docu/2026-05-03-f22-token-query-prod-arbeitsprotokoll.md
@@ -1,0 +1,47 @@
+# Arbeitsprotokoll F2.2 — ?token= Query-Parameter in Prod deaktiviert
+
+**Datum:** 2026-05-03  
+**Slice:** M9-4 / F2.2  
+**Subagent:** agora-refactor-worker (Sonnet)  
+**Branch:** fix/f22-token-query-prod  
+**Refs:** PLAN.md F2.2
+
+## Problem
+
+`?token=<bearer>` als Query-Parameter war seit P0.2 als Deprecation-Warning markiert, wurde aber in Prod-Umgebungen weiterhin akzeptiert. Das ist ein Sicherheitsrisiko (Token in URL = Browser-History, Server-Logs, Referrer).
+
+## Aenderungen
+
+### 1. `backend/app/utils/auth.py` — `_extract_token()`
+
+```python
+query_token = request.args.get("token", "")
+if query_token:
+    if not current_app.config.get("FLASK_DEBUG"):
+        # In Prod: ?token= ist deaktiviert (F2.2). Signed-Tickets nutzen.
+        _logger.error(...)
+        return ""
+    _logger.warning(...)
+return query_token
+```
+
+In Prod (FLASK_DEBUG=false) wird `?token=` ignoriert und mit ERROR geloggt. Der normale Auth-Fehler-Mechanismus (401/403) greift dann.
+
+### 2. `backend/tests/test_auth.py`
+
+- `test_blueprint_guard_accepts_query_token` → umbenannt in `test_blueprint_guard_accepts_query_token_in_debug`
+- Neu: `test_blueprint_guard_rejects_query_token_in_prod` — prüft 401 bei `?token=` wenn FLASK_DEBUG=false
+
+## Akzeptanz
+
+```bash
+cd backend && uv run pytest tests/test_auth.py::test_blueprint_guard_rejects_query_token_in_prod -v
+# → PASSED
+cd backend && uv run pytest tests/test_auth.py -v
+# → alle grün
+```
+
+## Offen
+
+- Merge auf `main` nach 90s + CI-Prüfung.
+- Nächster Slice: F3 (Gunicorn-Gevent-Migration).


### PR DESCRIPTION
Sichert den Deprecation-Pfad ab: ?token= funktioniert nur noch im Dev-Modus.

**Vorher:**
- ?token= wurde in Prod weiterhin akzeptiert (Deprecation-Warning seit P0.2)
- Sicherheitsrisiko: Token in URL = Browser-History, Server-Logs, Referrer

**Nachher:**
- _extract_token() ignoriert ?token= wenn FLASK_DEBUG=false
- ERROR-Log mit Hinweis auf Signed-Tickets (POST /api/auth/ticket)
- Dev-Modus (FLASK_DEBUG=true) lässt ?token= weiter zu

**Tests:**
- test_blueprint_guard_rejects_query_token_in_prod → 401
- test_blueprint_guard_accepts_query_token_in_debug → 200

Refs: PLAN.md F2.2
Arbeitsprotokoll: docu/2026-05-03-f22-token-query-prod-arbeitsprotokoll.md