### PR TITLE
fix(backend): logs.py Binärmodus für garantierte Byte-Offsets (Slice K.0, Refs PR #253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
+- `/api/logs/stream` öffnet die Logdatei jetzt im Binärmodus, damit `tell()` garantiert Byte-Offsets liefert (Gemini HIGH-Finding auf #253, Slice K.0).
 - SSE-Reconnect: `/api/logs/stream` sendet jetzt `id:`-Frames pro Datenzeile und wertet `Last-Event-ID`-Header aus (überstimmt `?offset=`), wodurch Duplikate und Datenverlust beim Browser-Reconnect verschwinden. `/api/simulation/<id>/stream` loggt Reconnect-IDs (Bus-Replay folgt) (Slice J.5.1, #233).
 - SimulationRunView: doppelten `/run-status`-Poll entfernt; Step3Simulation propagiert `paused`/`current_round`/`total_rounds` jetzt via `update-progress`-Event (Slice J.2, #220).
 - **Slice J.1 (#219, P1): refreshQuality aus 3-s-Tick herausgelöst.** `Step2EnvSetup.vue` rief bei jedem `fetchProfilesRealtime`-Tick (alle 3 s) `personaReview.refreshQuality()` auf — ein versteckter Doppel-HTTP-Call pro Poll-Runde. Fix: Aufruf aus dem Tick-Pfad entfernt; stattdessen `watch(() => profiles.value.length, (n, prev) => { if (prev === 0 && n > 0) ... })` — Trigger exakt einmal beim Übergang 0 → erste Profile. Sim-Wechsel ohne Unmount wird durch zweiten `watch(() => props.simulationId)` abgedeckt, der den Guard zurücksetzt. Vitest: 5 Ticks → exakt 1 `refreshQuality`-Call. Arbeitsprotokoll: [`docu/2026-05-04-j1-refresh-quality-watch-arbeitsprotokoll.md`](docu/2026-05-04-j1-refresh-quality-watch-arbeitsprotokoll.md). (Gemini-Followup auf PR #245: Sim-Wechsel-Trigger-Lücke + Race-Guard, 1-watch-Variante)

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -183,6 +183,13 @@ def stream_logs():
     Kein ``event:``-Frame: Das Frontend-Konsument (LogDrawer) lauscht auf
     den Default-Event-Namen ``message`` via ``onmessage`` — ein expliziter
     ``event: line``-Frame würde den Konsumenten stumm schalten.
+
+    Die Logdatei wird im Binärmodus (``'rb'``) gelesen, weil ``tell()`` im
+    Textmodus laut CPython-Doku einen opaken Cookie liefert, der nicht
+    garantiert dem Byte-Offset entspricht. Im Binärmodus ist ``tell()``
+    immer ein exakter Byte-Offset, der sicher mit ``st_size`` verglichen
+    werden kann. Jede Zeile wird nach dem Lesen mit
+    ``line.decode('utf-8', errors='replace')`` dekodiert.
     """
     path = _resolve_log_path()
     level = request.args.get('level')
@@ -246,18 +253,18 @@ def stream_logs():
                 offset = 0
             if size > offset:
                 try:
-                    with current_path.open('r', encoding='utf-8', errors='replace') as fh:
+                    with current_path.open('rb') as fh:
                         fh.seek(offset)
-                        # Zeilenweise mit readline() lesen: fh.tell() nach
-                        # jeder Zeile ist direkt der korrekte id:-Wert ohne
-                        # Längen-Rekonstruktion (UTF-8-aware, \r\n-safe).
+                        # Binärmodus: tell() liefert garantiert Byte-Offsets —
+                        # im Textmodus wäre tell() ein opaker Cookie, der nicht
+                        # zwingend mit st_size oder requested_offset vergleichbar ist.
                         while True:
                             line = fh.readline()
                             if not line:
                                 break
-                            line_stripped = line.rstrip('\r\n')
                             line_offset = fh.tell()
                             offset = line_offset
+                            line_stripped = line.decode('utf-8', errors='replace').rstrip('\r\n')
                             if level_pat is not None and not level_pat.search(line_stripped):
                                 continue
                             payload = json.dumps({

--- a/backend/tests/api/test_logs_stream_reconnect.py
+++ b/backend/tests/api/test_logs_stream_reconnect.py
@@ -369,3 +369,64 @@ def test_simulation_stream_logs_last_event_id():
         f"Kein Log-Eintrag mit 'Last-Event-ID' und sim_id={sim_id!r} gefunden. "
         f"Records: {[r.getMessage() for r in captured]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test F — Multi-Byte-UTF-8: id:-Werte entsprechen Byte-Offsets
+# ---------------------------------------------------------------------------
+
+
+def test_id_frames_correct_for_multibyte_utf8_lines(client, tmp_path, monkeypatch):
+    """Bei UTF-8-Multi-Byte-Zeilen muss id == Byte-Offset in der Datei sein.
+
+    Im alten Textmodus war tell() ein opakes Cookie, das beim Reconnect
+    nicht zuverlässig mit st_size verglichen werden konnte. Mit 'rb' ist
+    tell() garantiert ein Byte-Offset.
+
+    Zwei Zeilen mit Umlauten und Emoji — bewusst Multi-Byte pro Zeichen.
+    """
+    line1 = "Müller-Maße: 42 €"
+    line2 = "Test 🚀 läuft"
+    content = (line1 + "\n" + line2 + "\n").encode("utf-8")
+
+    from datetime import datetime as _dt
+    log_name = _dt.now().strftime('%Y-%m-%d') + '.log'
+    log_file = tmp_path / log_name
+    log_file.write_bytes(content)
+
+    # Erwartete Byte-Offsets: jeweils nach dem abschließenden \n jeder Zeile.
+    expected_id_after_line1 = len(line1.encode("utf-8")) + 1  # +1 für \n
+    expected_id_after_line2 = len(content)
+
+    response = client.get('/api/logs/stream?offset=0', buffered=False)
+    assert response.status_code == 200
+    assert response.mimetype == 'text/event-stream'
+
+    chunks = _collect_sse_frames(response, max_data_frames=2)
+    events = _parse_sse_events(chunks)
+    data_events = [e for e in events if 'data' in e]
+
+    assert len(data_events) >= 2, (
+        f"Erwartet mind. 2 data:-Events für Multi-Byte-Zeilen, "
+        f"erhalten: {len(data_events)}. Chunks: {chunks!r}"
+    )
+
+    ids = [int(e['id']) for e in data_events[:2]]
+
+    assert ids[0] == expected_id_after_line1, (
+        f"id nach Zeile 1: erwartet {expected_id_after_line1} (Byte-Offset), "
+        f"erhalten: {ids[0]}. Zeile enthält Multi-Byte-Zeichen."
+    )
+    assert ids[1] == expected_id_after_line2, (
+        f"id nach Zeile 2: erwartet {expected_id_after_line2} (Byte-Offset = Dateigröße), "
+        f"erhalten: {ids[1]}."
+    )
+
+    # Zeileninhalte müssen korrekt dekodiert ankommen.
+    decoded_lines = [json.loads(e['data'])['line'] for e in data_events[:2]]
+    assert decoded_lines[0] == line1, (
+        f"Zeile 1 falsch dekodiert: erwartet {line1!r}, erhalten: {decoded_lines[0]!r}"
+    )
+    assert decoded_lines[1] == line2, (
+        f"Zeile 2 falsch dekodiert: erwartet {line2!r}, erhalten: {decoded_lines[1]!r}"
+    )

--- a/docu/2026-05-04-k0-logs-stream-binary-mode-arbeitsprotokoll.md
+++ b/docu/2026-05-04-k0-logs-stream-binary-mode-arbeitsprotokoll.md
@@ -1,0 +1,49 @@
+# Slice K.0 — Logs-Stream Binärmodus-Followup (Gemini HIGH auf PR #253)
+
+**Datum:** 2026-05-04
+**Branch:** `fix/j5-1-followup-binary-mode`
+**Basis:** `origin/main`, HEAD `0e3758e`
+
+## Problem
+
+Gemini-Code-Assist hat nach dem Merge von PR #253 (Slice J.5.1) ein **HIGH-Finding** auf
+`backend/app/api/logs.py:269` gepostet:
+
+> Das Öffnen der Logdatei im Textmodus (`'r'`) in Kombination mit `fh.tell()` und
+> `fh.seek()` für Byte-Offsets ist problematisch. In Python 3 liefert `tell()` bei
+> Textstreams einen opaken Cookie (Integer), der nicht zwingend dem Byte-Offset entspricht.
+> Zudem ist `seek()` mit einem Byte-Offset in Textstreams laut Dokumentation nicht
+> unterstützt (außer für 0 und das Dateiende) und führt zu undefiniertem Verhalten. Dies
+> kann insbesondere bei Zeilenumbruch-Konvertierungen (CRLF vs LF) oder Multi-Byte-Encodings
+> dazu führen, dass Reconnects an falschen Positionen starten oder die Validierung gegen
+> `file_size` fehlschlägt.
+
+Auf Linux/macOS mit reinem LF/UTF-8 funktioniert es praktisch — die Semantik ist aber laut
+CPython-Doku ungarantiert.
+
+## Lösung
+
+Datei im Binärmodus (`'rb'`) öffnen. `tell()` liefert dann garantiert Byte-Offsets.
+Dekodierung erfolgt pro Zeile mit `line.decode('utf-8', errors='replace')`.
+
+## Geänderte Dateien
+
+| Datei | Art |
+|---|---|
+| `backend/app/api/logs.py` | Open-Mode `'r'` → `'rb'`, per-Zeilen-Dekodierung, Docstring-Ergänzung |
+| `backend/tests/api/test_logs_stream_reconnect.py` | Neuer Test F: Multi-Byte-UTF-8-Byte-Offsets |
+| `CHANGELOG.md` | `[Unreleased] ### Fixed`-Eintrag ergänzt |
+| `docu/2026-05-04-k0-logs-stream-binary-mode-arbeitsprotokoll.md` | diese Datei |
+
+## Tests
+
+- Bestehende 5 Tests (A–E) unverändert, alle grün.
+- Neuer Test F (`test_id_frames_correct_for_multibyte_utf8_lines`): schreibt zwei Zeilen
+  mit Umlauten und Emoji (`Müller-Maße: 42 €`, `Test 🚀 läuft`) als raw bytes in die
+  Logdatei und prüft, dass die `id:`-Werte exakt den Byte-Offsets (nicht Zeichen-Offsets)
+  entsprechen.
+
+## Risiken
+
+Keine. Auf LF-only UTF-8-Dateien (Linux-Prod, macOS-Dev) ist das Verhalten funktional
+identisch. Korrektheit ist jetzt für Multi-Byte-Zeichen und CRLF garantiert.


### PR DESCRIPTION
## Summary

Folgepatch auf den Gemini HIGH-Finding aus PR #253. `/api/logs/stream` öffnet die Logdatei jetzt im Binärmodus (`'rb'`), weil `tell()`/`seek()` im Textmodus laut Python-3-Doku opake Cookies liefern, keine garantierten Byte-Offsets. Auf Linux/macOS mit reinem LF/UTF-8 funktionierte es praktisch — aber:
- Vergleich `last_event_offset <= file_size` (st_size in Bytes) konnte inkonsistent sein
- Multi-Byte-UTF-8-Logs theoretisch verschobene IDs
- CRLF (Windows) wäre kaputt

Fix: `open('rb')` + `line.decode('utf-8', errors='replace')` pro Zeile vor Filter/Payload.

## Test plan

- [x] Neuer Test F (Multi-Byte-UTF-8 mit Umlauten + Emoji) belegt korrekte Byte-Offsets in `id:`-Frames
- [x] Bestehende 5 Tests bleiben grün
- [x] `pytest -q` Volltest: 1371 passed, 9 skipped
- [x] `ruff` + `mypy` clean

## Quelle

Gemini HIGH-Comment auf #253 (`backend/app/api/logs.py:269`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)