### PR TITLE
fix(backend): logs.py Partial-Line-Schutz bei EOF (Slice K.0.1, Refs PR #254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
+- `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write (Gemini MEDIUM auf #254, Slice K.0.1).
 - `/api/logs/stream` öffnet die Logdatei jetzt im Binärmodus, damit `tell()` garantiert Byte-Offsets liefert (Gemini HIGH-Finding auf #253, Slice K.0).
 - SSE-Reconnect: `/api/logs/stream` sendet jetzt `id:`-Frames pro Datenzeile und wertet `Last-Event-ID`-Header aus (überstimmt `?offset=`), wodurch Duplikate und Datenverlust beim Browser-Reconnect verschwinden. `/api/simulation/<id>/stream` loggt Reconnect-IDs (Bus-Replay folgt) (Slice J.5.1, #233).
 - SimulationRunView: doppelten `/run-status`-Poll entfernt; Step3Simulation propagiert `paused`/`current_round`/`total_rounds` jetzt via `update-progress`-Event (Slice J.2, #220).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
-- `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write (Gemini MEDIUM auf #254, Slice K.0.1).
+- `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write. Followup: `time.sleep(_STREAM_POLL_SEC)` vor `break` ergänzt, weil `size > offset` wahr bleibt und der reguläre Sleep-Zweig sonst nie erreicht wird (Hot-Loop, 100 % CPU). Gemini MEDIUM #254 + HIGH #255, Slice K.0.1.
 - `/api/logs/stream` öffnet die Logdatei jetzt im Binärmodus, damit `tell()` garantiert Byte-Offsets liefert (Gemini HIGH-Finding auf #253, Slice K.0).
 - SSE-Reconnect: `/api/logs/stream` sendet jetzt `id:`-Frames pro Datenzeile und wertet `Last-Event-ID`-Header aus (überstimmt `?offset=`), wodurch Duplikate und Datenverlust beim Browser-Reconnect verschwinden. `/api/simulation/<id>/stream` loggt Reconnect-IDs (Bus-Replay folgt) (Slice J.5.1, #233).
 - SimulationRunView: doppelten `/run-status`-Poll entfernt; Step3Simulation propagiert `paused`/`current_round`/`total_rounds` jetzt via `update-progress`-Event (Slice J.2, #220).

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -262,6 +262,13 @@ def stream_logs():
                             line = fh.readline()
                             if not line:
                                 break
+                            if not line.endswith(b'\n'):
+                                # Partial line at EOF (Logger schreibt gerade): offset
+                                # bewusst NICHT vorruecken, nächster Poll-Zyklus
+                                # liest die Zeile vollständig. Andernfalls würden
+                                # wir Multi-Byte-UTF-8-Sequenzen mid-write zer-
+                                # decoden und Daten verlieren.
+                                break
                             line_offset = fh.tell()
                             offset = line_offset
                             line_stripped = line.decode('utf-8', errors='replace').rstrip('\r\n')

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -263,11 +263,15 @@ def stream_logs():
                             if not line:
                                 break
                             if not line.endswith(b'\n'):
-                                # Partial line at EOF (Logger schreibt gerade): offset
-                                # bewusst NICHT vorruecken, nächster Poll-Zyklus
-                                # liest die Zeile vollständig. Andernfalls würden
-                                # wir Multi-Byte-UTF-8-Sequenzen mid-write zer-
-                                # decoden und Daten verlieren.
+                                # Partial line at EOF (Logger schreibt gerade):
+                                # offset bewusst NICHT vorruecken — naechster
+                                # Poll-Zyklus liest die Zeile vollstaendig,
+                                # andernfalls wuerden wir Multi-Byte-UTF-8-
+                                # Sequenzen mid-write zer-decoden.
+                                # Sleep vor break, sonst Hot-Loop: size > offset
+                                # bleibt wahr, der else-Zweig (mit time.sleep)
+                                # wird nie erreicht.
+                                time.sleep(_STREAM_POLL_SEC)
                                 break
                             line_offset = fh.tell()
                             offset = line_offset

--- a/backend/tests/api/test_logs_stream_reconnect.py
+++ b/backend/tests/api/test_logs_stream_reconnect.py
@@ -474,3 +474,54 @@ def test_partial_line_at_eof_does_not_advance_offset(client, tmp_path, monkeypat
         f"id muss nach Zeile 1 stehen ({expected_id_after_line1}), nicht am Datei-Ende — "
         f"sonst wuerde der naechste Poll die jetzt vollstaendige Zeile ueberspringen."
     )
+
+
+# ---------------------------------------------------------------------------
+# Test H — Partial-Line-Handling triggert Sleep statt Hot-Loop (Slice K.0.1.1)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_line_yields_sleep_to_avoid_hot_loop(app, tmp_path, monkeypatch):
+    """Bei Partial-Line muss time.sleep(_STREAM_POLL_SEC) gerufen werden.
+
+    Sonst: size > offset bleibt wahr, der else-Zweig (mit dem regulaeren
+    Poll-Sleep) wird nie erreicht — die outer while-True dreht in
+    Endlosschleife mit 100 % CPU, Datei wird unzaehlige Male geoeffnet.
+    """
+    sleep_calls: list[float] = []
+
+    def _spy_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        # Nach 3 Sleeps künstlich abbrechen, damit der Generator endet.
+        if len(sleep_calls) >= 3:
+            raise RuntimeError("test-stop")
+
+    monkeypatch.setattr('app.api.logs.LOG_DIR', str(tmp_path))
+    monkeypatch.delenv('AGORA_AUTH_TOKEN', raising=False)
+    monkeypatch.setattr('app.api.logs.time.sleep', _spy_sleep)
+
+    from datetime import datetime as _dt
+    log_name = _dt.now().strftime('%Y-%m-%d') + '.log'
+    log_file = tmp_path / log_name
+    # Nur eine Halb-Zeile (kein \n) — exakt der Hot-Loop-Auslöser.
+    log_file.write_bytes(b"halbe Zeile ohne newline")
+
+    client = app.test_client()
+    response = client.get('/api/logs/stream?offset=0', buffered=False)
+    assert response.status_code == 200
+
+    try:
+        for raw in response.response:
+            _ = raw  # SSE-Inhalt egal — wir messen nur die Sleep-Aufrufe.
+    except RuntimeError:
+        pass
+    finally:
+        response.close()
+
+    # Mind. ein Sleep aus dem Partial-Line-Pfad (vor dem Fix waren es 0).
+    from app.api.logs import _STREAM_POLL_SEC
+    assert _STREAM_POLL_SEC in sleep_calls, (
+        f"Erwartet mind. ein time.sleep({_STREAM_POLL_SEC}) aus dem Partial-Line-Pfad. "
+        f"Erhaltene sleep-calls: {sleep_calls!r}. Ohne diesen Sleep liefe der Stream "
+        f"in eine Hot-Loop, weil size > offset wahr bleibt und der else-Zweig nie greift."
+    )

--- a/backend/tests/api/test_logs_stream_reconnect.py
+++ b/backend/tests/api/test_logs_stream_reconnect.py
@@ -430,3 +430,47 @@ def test_id_frames_correct_for_multibyte_utf8_lines(client, tmp_path, monkeypatc
     assert decoded_lines[1] == line2, (
         f"Zeile 2 falsch dekodiert: erwartet {line2!r}, erhalten: {decoded_lines[1]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test G — Partial-Line bei EOF: offset wird NICHT vorgerueckt (Slice K.0.1)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_line_at_eof_does_not_advance_offset(client, tmp_path, monkeypatch):
+    """Bei einer noch nicht abgeschlossenen Zeile (Logger schreibt gerade)
+    darf der Stream weder die Halb-Zeile ausliefern noch ``offset`` vorruecken.
+
+    Sonst wuerden Multi-Byte-UTF-8-Sequenzen mid-write zer-decoded und der
+    Anfang der vollstaendigen Zeile beim naechsten Poll-Zyklus verloren gehen.
+    """
+    line1 = "vollständige Zeile mit Umlaut"
+    partial = "halbe Zeile ohne newline"
+    content = (line1 + "\n" + partial).encode("utf-8")  # bewusst KEIN \n am Ende
+
+    from datetime import datetime as _dt
+    log_name = _dt.now().strftime('%Y-%m-%d') + '.log'
+    log_file = tmp_path / log_name
+    log_file.write_bytes(content)
+
+    expected_id_after_line1 = len(line1.encode("utf-8")) + 1
+
+    response = client.get('/api/logs/stream?offset=0', buffered=False)
+    assert response.status_code == 200
+
+    # Wir erwarten EXAKT 1 data:-Frame (line1), die Halb-Zeile darf nicht raus.
+    chunks = _collect_sse_frames(response, max_data_frames=1, timeout_sec=1.0)
+    events = _parse_sse_events(chunks)
+    data_events = [e for e in events if 'data' in e]
+
+    assert len(data_events) == 1, (
+        f"Erwartet genau 1 data:-Frame (vollständige Zeile), erhalten {len(data_events)}. "
+        f"Halb-Zeile darf nicht ausgeliefert werden. Chunks: {chunks!r}"
+    )
+
+    decoded = json.loads(data_events[0]['data'])['line']
+    assert decoded == line1
+    assert int(data_events[0]['id']) == expected_id_after_line1, (
+        f"id muss nach Zeile 1 stehen ({expected_id_after_line1}), nicht am Datei-Ende — "
+        f"sonst wuerde der naechste Poll die jetzt vollstaendige Zeile ueberspringen."
+    )

--- a/docu/2026-05-04-k01-logs-stream-partial-line-arbeitsprotokoll.md
+++ b/docu/2026-05-04-k01-logs-stream-partial-line-arbeitsprotokoll.md
@@ -1,0 +1,70 @@
+# Slice K.0.1 — `/api/logs/stream` Partial-Line-Schutz
+
+**Datum:** 2026-05-04
+**Followup auf:** PR #254 (Slice K.0)
+**Quelle:** Gemini-Code-Assist MEDIUM-Comment auf PR #254 (`backend/app/api/logs.py:266`)
+
+## Problem
+
+Nach dem K.0-Switch auf Binärmodus (`open('rb')`) konnte `fh.readline()` bei
+EOF mitten in einer noch nicht ganz geschriebenen Zeile zurückkehren. Wir
+haben die Halb-Zeile dann trotzdem dekodiert und `offset` ans Datei-Ende
+verschoben. Konsequenzen:
+
+1. Bei Multi-Byte-UTF-8 mid-write → `decode(errors='replace')` produziert
+   ein Replacement-Char in der Zeile.
+2. Der Anfang der echten vollständigen Zeile geht verloren, weil der
+   Stream beim nächsten Poll-Zyklus erst nach dem alten EOF weiterliest.
+
+Der Bug war latent — auf produktiv-langsamen Logwritern statistisch
+unwahrscheinlich, bei hoher Last aber real.
+
+## Lösung
+
+Im `while True`-Read-Loop: wenn die zurückgelesene Zeile nicht auf `\n`
+endet, **break** ohne `offset` vorzurücken. Im nächsten Poll-Zyklus
+(`time.sleep(_STREAM_POLL_SEC)` → erneuter `current_path.stat()` →
+`fh.seek(offset)`) wird die jetzt vollständige Zeile sauber gelesen.
+
+```python
+while True:
+    line = fh.readline()
+    if not line:
+        break
+    if not line.endswith(b'\n'):
+        # Partial line at EOF — offset bleibt, retry im naechsten Poll
+        break
+    line_offset = fh.tell()
+    offset = line_offset
+    ...
+```
+
+Geminis Snippet 1:1 übernommen.
+
+## Edge-Cases
+
+- **Letzte Zeile ohne `\n` (abruptes Programmende):** wird nie gestreamt.
+  Akzeptabel — Logger flushen ohnehin zeilenweise mit `\n`.
+- **Leere Datei:** `readline()` gibt `b''`, erste `if not line: break` greift.
+- **Datei-Rotation:** `if size < offset: offset = 0` außerhalb des
+  Read-Loops — unverändert.
+
+## Files geändert
+
+- `backend/app/api/logs.py` — 6 Zeilen Patch im Read-Loop + Kommentar
+- `backend/tests/api/test_logs_stream_reconnect.py` — neuer Test G
+- `CHANGELOG.md` — `[Unreleased] ### Fixed`-Eintrag
+
+## Tests
+
+- **Test G** (`test_partial_line_at_eof_does_not_advance_offset`): schreibt
+  `"vollständige Zeile mit Umlaut\nhalbe Zeile ohne newline"` (bewusst
+  ohne abschließendes `\n`), erwartet exakt 1 data-Frame mit `id` nach
+  Zeile 1 (nicht am Datei-Ende).
+- **Bestehende 6 Tests** unverändert grün.
+- **Volltest:** 1372 passed (1 mehr als nach K.0), 9 skipped.
+
+## Risiken
+
+Keine. Funktional identisch für log-Files mit ordentlichem `\n`-Abschluss
+pro Zeile (Standard für Python `logging`-Handler, `journalctl`, `tail -f`).

--- a/docu/2026-05-04-k01-logs-stream-partial-line-arbeitsprotokoll.md
+++ b/docu/2026-05-04-k01-logs-stream-partial-line-arbeitsprotokoll.md
@@ -41,6 +41,16 @@ while True:
 
 Geminis Snippet 1:1 übernommen.
 
+### Followup im selben PR (Gemini HIGH auf #255)
+
+Erste Version dieses Patches hatte einen Hot-Loop-Bug: bei Partial-Line
+ist `size > offset` weiterhin wahr → der `else`-Zweig (mit dem regulären
+`time.sleep(_STREAM_POLL_SEC)`) wird nie erreicht → outer `while True`
+dreht in Endlosschleife mit 100 % CPU, Datei wird unzählige Male
+geöffnet. Fix: `time.sleep(_STREAM_POLL_SEC)` direkt vor dem `break`.
+Test H (`test_partial_line_yields_sleep_to_avoid_hot_loop`) belegt mit
+einem Sleep-Spy, dass der Sleep aus dem Partial-Line-Pfad gerufen wird.
+
 ## Edge-Cases
 
 - **Letzte Zeile ohne `\n` (abruptes Programmende):** wird nie gestreamt.


### PR DESCRIPTION
## Summary

Followup auf den Gemini MEDIUM-Comment aus PR #254. `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor — die unvollständige Zeile wird im nächsten Poll-Zyklus vollständig gelesen.

Bug nach K.0 (Binärmodus-Switch): Wenn der Logwriter mitten in einer Zeile war und `readline()` bei EOF eine Halb-Zeile zurückgab, dekodierte `decode(errors='replace')` Multi-Byte-UTF-8-Sequenzen kaputt und `offset` sprang ans Datei-Ende — der Anfang der echten vollständigen Zeile ging verloren.

Fix (Geminis Snippet 1:1): `if not line.endswith(b'\n'): break` im Read-Loop vor jedem Vorrücken von `offset`.

## Test plan

- [x] Neuer Test G (`test_partial_line_at_eof_does_not_advance_offset`): vollständige Zeile + Halb-Zeile, exakt 1 data-Frame mit id nach Zeile 1
- [x] Bestehende 6 Tests bleiben grün (5 J.5.1 + 1 K.0)
- [x] `pytest -q` Volltest: 1372 passed, 9 skipped
- [x] `ruff` clean

## Quelle

Gemini MEDIUM auf #254 (`backend/app/api/logs.py:266`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)