### PR TITLE
fix(frontend): LogDrawer SSE Reconnect-Cap + Reload-Button (Slice J.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
+- Fixed: LogDrawer SSE Reconnect ist jetzt nach 5 Fehlversuchen gecappt; UI bietet einen Reload-Button (Slice J.6, Audit-Empfehlung 7).
 - `docker-compose.yml`/`docker-compose.prod.yml` `LLM_BASE_URL` und `EMBEDDING_BASE_URL` auf `${VAR:-default}`-Substitution umgestellt — `.env`-Werte gewinnen jetzt, Default-Fallback bleibt host-Ollama. Vorher wurden die Werte hardcoded überschrieben, sodass OpenAI-Embedding-Switch via `.env` ins Leere lief und der Container in den Reboot-Loop ging (404 von Ollama auf `text-embedding-3-small`). Slice K.2.
 - `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write. Followup: `time.sleep(_STREAM_POLL_SEC)` vor `break` ergänzt, weil `size > offset` wahr bleibt und der reguläre Sleep-Zweig sonst nie erreicht wird (Hot-Loop, 100 % CPU). Gemini MEDIUM #254 + HIGH #255, Slice K.0.1.
 - `/api/logs/stream` öffnet die Logdatei jetzt im Binärmodus, damit `tell()` garantiert Byte-Offsets liefert (Gemini HIGH-Finding auf #253, Slice K.0).

--- a/docu/2026-05-04-J6-logdrawer-reconnect-cap-arbeitsprotokoll.md
+++ b/docu/2026-05-04-J6-logdrawer-reconnect-cap-arbeitsprotokoll.md
@@ -1,0 +1,111 @@
+# Sub-Slice J.6 — LogDrawer SSE Reconnect-Cap
+
+**Datum:** 2026-05-04
+**Branch:** fix/j6-logdrawer-reconnect-cap
+**Referenz:** Audit-Empfehlung 7 (docu/2026-04-22-refactoring-produkt-audit.md)
+
+## Ausgangslage
+
+`LogDrawer.vue` nutzte `EventSource.onerror` ohne jeglichen Reconnect-Cap. Der Browser
+versucht nach einem SSE-Fehler automatisch alle ~3 s neu zu verbinden. Bei dauerhaftem
+Backend-Ausfall hammerte die Verbindung unbegrenzt weiter — ohne UI-Feedback und ohne
+Abbruchbedingung. Das Gegenstück `useEventStream.ts` löst dieses Problem seit PR #9
+mit `MAX_RECONNECT_ATTEMPTS = 5`; LogDrawer hatte diese Absicherung nie erhalten.
+
+## Geänderte Dateien
+
+### `frontend/src/components/LogDrawer.vue`
+
+- **Konstante** `MAX_RECONNECT_ATTEMPTS = 5` neben `RING_BUFFER_MAX` eingefügt.
+- **Reaktiver State** `streamFailed = ref(false)` für Template-Binding hinzugefügt.
+- **Nicht-reaktiver Counter** `let reconnectAttempts = 0` analog zu `lastOffset` als
+  modul-lokale Variable (kein `ref` — reaktive Änderungen des Counters selbst sind
+  nicht nötig; nur `streamFailed` steuert das Template).
+- **`startStream()`** setzt `streamFailed.value = false` am Anfang (bewusster Start
+  zählt nicht als Fehler).
+- **`onerror`-Handler** erhöht `reconnectAttempts`. Bei `>= MAX_RECONNECT_ATTEMPTS`:
+  `stopStream()` → `streamFailed.value = true` → exhausted-Message → `return`.
+  Darunter: bisheriges Verhalten (warn + connectionError-Statuszeile).
+- **`onmessage`-Handler** resettet `reconnectAttempts = 0` bei jeder validen Nachricht,
+  setzt `streamFailed.value = false` zurück (kurze Hiccups akkumulieren nicht).
+- **`manualReconnect()`** neue Funktion: Counter und State zurücksetzen, `startStream()`.
+- **Template** — neuer `v-if="streamFailed"` Reload-Button mit CSS-Klassen
+  `close-btn reconnect-btn` (identischer Stil wie bestehende Drawer-Buttons, nur
+  `width: auto` und Error-Farbe für Erkennbarkeit), Label aus i18n.
+- **Style** — `.reconnect-btn` Differenzierung: `width: auto; padding: 0 10px;
+  color: var(--status-error)`.
+
+### `frontend/src/i18n/locales/de.json`
+
+Zwei neue Keys in der `logs.drawer`-Sektion:
+- `reconnectExhausted`: "Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen."
+- `reconnect`: "Erneut verbinden"
+
+### `frontend/src/i18n/locales/en.json`
+
+Gespiegelt:
+- `reconnectExhausted`: "Log stream connection lost after multiple attempts."
+- `reconnect`: "Reconnect"
+
+### `frontend/src/components/__tests__/LogDrawer.spec.ts` (neu)
+
+Neu angelegt (kein pre-existierender Spec vorhanden).
+
+## Tests
+
+### Befund
+
+`npx vitest run src/components/__tests__/LogDrawer.spec.ts` → 2/2 PASS.
+Gesamt-Suite `npx vitest run` → 158/158 PASS (vorher: 156, d. h. +2 neue Cases).
+
+### Test-Case 1: Reconnect-Cap greift
+
+Mock-`EventSource` wird 5× mit `onerror` gefeuert. Erwartung:
+- `close()` wurde aufgerufen (stopStream)
+- `.reconnect-btn` ist im DOM sichtbar
+
+### Test-Case 2: Counter-Reset bei message
+
+3 Errors → valide Message → Counter reset → 4 weitere Errors (kein Cap) →
+1 weiterer Error (5. nach Reset → Cap). Erwartung:
+- Nach 3 Errors + Message: kein `.reconnect-btn`
+- Nach 4 weiteren Errors (Gesamt 3+4=7, aber Counter nach Reset bei 4): kein Cap
+- Nach dem 5. Post-Reset-Error: `.reconnect-btn` sichtbar, `close()` aufgerufen
+
+### Mock-Pattern
+
+`EventSource` als globale Klasse durch `MockEventSource` ersetzt (vor dem Import
+des SUT). Die `FakeSourceHandle`-Schnittstelle stellt `fireMessage()` und
+`fireError()` für Test-Kontrolle bereit. Pattern analog zu `useEventStream.spec.ts`
+(dort wird `openSimulationStream` gemockt, hier die Klasse selbst — weil LogDrawer
+`new EventSource()` direkt aufruft).
+
+## Edge-Cases
+
+**Counter-Reset-Fenster:** Der Counter wird per `onmessage` auf 0 zurückgesetzt —
+nicht per Timer. Das ist bewusst: Ein kurzer Hiccup (1–2 Fehler, dann Message-Erfolg)
+gibt dem Drawer einen frischen 5er-Cap. Akkumulation über lange Zeit ohne Messages
+wird damit korrekt behandelt.
+
+**`startStream()` resettet `streamFailed`:** Wenn der User auf "Erneut verbinden"
+klickt, setzt `manualReconnect()` erst Counter und Flag zurück, ruft dann
+`startStream()` — das setzt Flag nochmals auf `false` (idempotent, kein Problem).
+
+**Pre-existing TS-Fehler:** `vue-tsc --noEmit` zeigt 2 Fehler in
+`Step4Report.spec.ts` (Zeilen 416, 420). Diese Fehler existieren auch vor meinen
+Änderungen (per `git stash`-Verifikation bestätigt). Meine Änderungen führen keine
+neuen TS-Fehler ein. Tests und Build sind grün.
+
+## Akzeptanz-Checkliste
+
+- [x] `MAX_RECONNECT_ATTEMPTS = 5` Konstante in LogDrawer.vue
+- [x] `onerror` cappt nach 5 Versuchen: `stopStream()` + `streamFailed=true`
+- [x] `onmessage` resettet `reconnectAttempts` auf 0
+- [x] Reload-Button bei `streamFailed === true` (i18n-Label, Drawer-Button-Stil)
+- [x] `manualReconnect()` setzt Counter + State zurück
+- [x] i18n-Keys `reconnectExhausted` + `reconnect` in de.json und en.json
+- [x] Vitest-Cases: Cap-Test + Counter-Reset-Test (2 Cases, alle grün)
+- [x] Lint sauber (eslint .)
+- [x] Build erfolgreich (vite build)
+- [x] CHANGELOG-Eintrag
+- [x] Dieses Arbeitsprotokoll

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -112,6 +112,7 @@ function appendLine(line, { bypassPause = false } = {}) {
 
 function startStream() {
   stopStream()
+  reconnectAttempts = 0
   streamFailed.value = false
   const token = getAgoraToken?.() || ''
   const url = logsStreamUrl(token, level.value || null, lastOffset)
@@ -142,8 +143,6 @@ function startStream() {
 }
 
 function manualReconnect() {
-  reconnectAttempts = 0
-  streamFailed.value = false
   startStream()
 }
 

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -19,6 +19,12 @@
         <label class="pause-toggle">
           <input type="checkbox" v-model="paused" /> {{ t('logs.drawer.pause') }}
         </label>
+        <button
+          v-if="streamFailed"
+          class="close-btn reconnect-btn"
+          @click="manualReconnect"
+          :title="t('logs.drawer.reconnect')"
+        >&#x21bb; {{ t('logs.drawer.reconnect') }}</button>
         <button class="close-btn" @click="$emit('close')" :title="t('common.close')">✕</button>
       </div>
     </header>
@@ -55,14 +61,17 @@ const lines = ref([])
 const level = ref('')
 const search = ref('')
 const paused = ref(false)
+const streamFailed = ref(false)
 const scrollEl = ref(null)
 const sticky = useStickyScroll(scrollEl)
 // Letzter Datei-Offset aus dem Tail-Response — geben wir dem Stream als
 // Wiederaufsetzpunkt mit, damit zwischen Tail und Connect geschriebene
 // Lines nicht verloren gehen (PR #146-Review).
 let lastOffset = null
+let reconnectAttempts = 0
 
 const RING_BUFFER_MAX = 5000
+const MAX_RECONNECT_ATTEMPTS = 5
 const ERROR_PATTERN = /(error|exception|traceback|fatal)/i
 function isErrorLine(line) {
   return typeof line === 'string' && ERROR_PATTERN.test(line)
@@ -103,23 +112,39 @@ function appendLine(line, { bypassPause = false } = {}) {
 
 function startStream() {
   stopStream()
+  streamFailed.value = false
   const token = getAgoraToken?.() || ''
   const url = logsStreamUrl(token, level.value || null, lastOffset)
   try {
     _eventSource = new EventSource(url)
     _eventSource.onmessage = (e) => {
+      reconnectAttempts = 0
+      if (streamFailed.value) streamFailed.value = false
       try {
         const payload = JSON.parse(e.data)
         if (payload?.line != null) appendLine(payload.line)
       } catch { /* ignore non-JSON */ }
     }
     _eventSource.onerror = (err) => {
+      reconnectAttempts++
+      if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+        stopStream()
+        streamFailed.value = true
+        appendLine(t('logs.drawer.reconnectExhausted'), { bypassPause: true })
+        return
+      }
       console.warn('LogDrawer SSE error', err)
       // Connection-Diagnose muss auch bei pausiertem Auto-Scroll sichtbar
       // sein — bypassPause: true.
       appendLine(t('logs.drawer.connectionError'), { bypassPause: true })
     }
   } catch { /* ignore */ }
+}
+
+function manualReconnect() {
+  reconnectAttempts = 0
+  streamFailed.value = false
+  startStream()
 }
 
 function stopStream() {
@@ -195,6 +220,8 @@ onUnmounted(stopStream)
   cursor: pointer;
 }
 .close-btn:hover { color: var(--fg); border-color: var(--accent); }
+.reconnect-btn { width: auto; padding: 0 10px; color: var(--status-error, #f56565); border-color: var(--status-error, #f56565); }
+.reconnect-btn:hover { color: var(--fg); border-color: var(--accent); }
 
 .drawer-body-wrap {
   position: relative;

--- a/frontend/src/components/__tests__/LogDrawer.spec.ts
+++ b/frontend/src/components/__tests__/LogDrawer.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * LogDrawer — SSE Reconnect-Cap Tests (Sub-Slice J.6, Audit-Empfehlung 7).
+ *
+ * Testet:
+ *   1. Nach 5 onerror-Events wird der Stream gestoppt und streamFailed=true gesetzt.
+ *      Der Reload-Button erscheint im DOM.
+ *   2. Eine valide onmessage nach 3 Errors resettet den Counter. Weitere Errors
+ *      akkumulieren erst ab diesem Reset — der Cap greift erst nach 5 neuen Fehlern.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { nextTick } from 'vue'
+
+// localStorage muss vor allen Modul-Imports gemockt sein,
+// da i18n/index.js bei Import-Zeit localStorage.getItem aufruft.
+const localStorageMock = (() => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// --- Mock API-Abhängigkeiten ---
+vi.mock('../../api/logs', () => ({
+  fetchLogs: vi.fn().mockResolvedValue({ data: { success: true, data: { lines: [], offset: 0 } } }),
+  logsStreamUrl: vi.fn().mockReturnValue('http://localhost/api/logs/stream'),
+}))
+
+vi.mock('../../api/index', () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: {} }) },
+  getAgoraToken: vi.fn().mockReturnValue('test-token'),
+}))
+
+vi.mock('../../composables/useStickyScroll', () => ({
+  useStickyScroll: vi.fn().mockReturnValue({
+    unreadCount: { value: 0 },
+    scrollToBottom: vi.fn(),
+    markAppended: vi.fn(),
+  }),
+}))
+
+// --- Kontrollierbarer EventSource-Mock ---
+// _capturedSource gibt Tests Zugriff auf Handler und close().
+interface FakeSourceHandle {
+  close: ReturnType<typeof vi.fn>
+  fireMessage: (data: unknown) => void
+  fireError: () => void
+}
+
+let _capturedSource: FakeSourceHandle | null = null
+
+class MockEventSource {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  close = vi.fn()
+
+  constructor(_url: string) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this
+    _capturedSource = {
+      close: self.close,
+      fireMessage(data: unknown) {
+        if (self.onmessage) {
+          self.onmessage(new MessageEvent('message', { data: JSON.stringify(data) }))
+        }
+      },
+      fireError() {
+        if (self.onerror) {
+          self.onerror(new Event('error'))
+        }
+      },
+    }
+  }
+}
+
+// @ts-expect-error – globales EventSource durch Mock ersetzen
+globalThis.EventSource = MockEventSource
+
+import LogDrawer from '../LogDrawer.vue'
+
+// --- i18n-Minimalkonfiguration ---
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    de: {
+      logs: {
+        drawer: {
+          title: 'Backend-Logs',
+          allLevels: 'Alle Level',
+          search: 'Suchen…',
+          pause: 'Auto-Scroll pausieren',
+          empty: 'Noch keine Log-Zeilen.',
+          connectionError: 'SSE-Verbindung unterbrochen, Browser versucht Reconnect…',
+          reconnectExhausted: 'Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.',
+          reconnect: 'Erneut verbinden',
+        },
+      },
+      common: { close: 'Schließen' },
+    },
+    en: {},
+  },
+})
+
+const globalConfig = {
+  plugins: [i18n],
+  stubs: { StickyScrollBanner: { template: '<div />' } },
+}
+
+beforeEach(() => {
+  _capturedSource = null
+  vi.clearAllMocks()
+})
+
+describe('LogDrawer — SSE Reconnect-Cap (J.6, Audit-Empfehlung 7)', () => {
+  it('stoppt den Stream und zeigt Reload-Button nach 5 onerror-Events', async () => {
+    const wrapper = mount(LogDrawer, {
+      props: { open: true },
+      global: globalConfig,
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    // EventSource muss nach dem Mount erzeugt worden sein.
+    expect(_capturedSource).not.toBeNull()
+    const src = _capturedSource!
+
+    // Reload-Button noch nicht sichtbar.
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(false)
+
+    // 5 onerror-Events feuern.
+    for (let i = 0; i < 5; i++) {
+      src.fireError()
+      await nextTick()
+    }
+
+    await flushPromises()
+    await nextTick()
+
+    // close() muss aufgerufen worden sein (stopStream).
+    expect(src.close).toHaveBeenCalled()
+
+    // Reload-Button ist jetzt sichtbar.
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('resettet den Counter bei onmessage — Cap greift erst nach 5 neuen Fehlern', async () => {
+    const wrapper = mount(LogDrawer, {
+      props: { open: true },
+      global: globalConfig,
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    expect(_capturedSource).not.toBeNull()
+    const src = _capturedSource!
+
+    // 3 Errors — unter dem Cap.
+    for (let i = 0; i < 3; i++) {
+      src.fireError()
+      await nextTick()
+    }
+
+    // close noch nicht aufgerufen, Reload-Button nicht sichtbar.
+    expect(src.close).not.toHaveBeenCalled()
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(false)
+
+    // Valide Message — Counter wird auf 0 zurückgesetzt.
+    src.fireMessage({ line: 'INFO — alles gut' })
+    await nextTick()
+
+    // Reload-Button darf nach Reset nicht erscheinen.
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(false)
+
+    // 4 weitere Errors nach dem Reset — immer noch unter Cap.
+    for (let i = 0; i < 4; i++) {
+      src.fireError()
+      await nextTick()
+    }
+
+    expect(src.close).not.toHaveBeenCalled()
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(false)
+
+    // 5. Error nach Reset — jetzt ist der Cap erreicht (0→5 neue Fehler).
+    src.fireError()
+    await nextTick()
+    await flushPromises()
+
+    expect(src.close).toHaveBeenCalled()
+    expect(wrapper.find('.reconnect-btn').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -495,7 +495,9 @@
       "search": "Suchen…",
       "pause": "Auto-Scroll pausieren",
       "empty": "Noch keine Log-Zeilen.",
-      "connectionError": "SSE-Verbindung unterbrochen, Browser versucht Reconnect…"
+      "connectionError": "SSE-Verbindung unterbrochen, Browser versucht Reconnect…",
+      "reconnectExhausted": "Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.",
+      "reconnect": "Erneut verbinden"
     }
   },
   "settings": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -484,7 +484,9 @@
       "search": "Search…",
       "pause": "Pause auto-scroll",
       "empty": "No log lines yet.",
-      "connectionError": "SSE connection interrupted, browser will attempt reconnect…"
+      "connectionError": "SSE connection interrupted, browser will attempt reconnect…",
+      "reconnectExhausted": "Log stream connection lost after multiple attempts.",
+      "reconnect": "Reconnect"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary

LogDrawer.vue cappt Reconnect-Versuche jetzt nach 5 Fehlern (analog `useEventStream.ts:15` `MAX_RECONNECT_ATTEMPTS = 5`). Vorher liess der `onerror`-Handler den browser-internen EventSource-Reconnect unbegrenzt laufen — bei Backend-Down ~3 s Hammering ohne Limit.

- `MAX_RECONNECT_ATTEMPTS = 5` + `reconnectAttempts`-Counter, `streamFailed`-Ref
- `onerror` cappt → `stopStream()`, `streamFailed=true`, i18n-Statuszeile (`logs.drawer.reconnectExhausted`)
- `onmessage` resettet Counter (kurze Hiccups akkumulieren nicht)
- Neuer Reload-Button im Drawer-Header bei `streamFailed` → `manualReconnect()` resettet Counter und startet Stream neu
- i18n: `reconnect` + `reconnectExhausted` in `de.json` + `en.json`

## Test plan

- [x] `vitest run`: 158/158 PASS, neuer Spec mit 2 Cases (Cap-Trigger + Counter-Reset)
- [x] `eslint`: clean
- [x] `vue-tsc --noEmit`: keine neuen TS-Fehler (2 pre-existing in `Step4Report.spec.ts` bestehen auf `origin/main` — out-of-scope)
- [ ] Manuell: Drawer offen, Backend stoppen → nach 5 Reconnect-Fehlern erscheint Reload-Button + i18n-Statuszeile, Click stellt Verbindung wieder her

Refs: `docu/2026-05-03-request-rate-audit.md` Empfehlung 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)