### PR TITLE
fix(frontend): Step4Report-Spec auf Report/EvidenceMap-Types typisieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
-- fix(frontend): Step4Report-Spec auf Report/EvidenceMap-Types typisieren (vue-tsc strict, kein Runtime-Effekt)
+- Step4Report-Spec auf Report/EvidenceMap-Types typisiert, um vue-tsc Fehler zu beheben (kein Runtime-Effekt)
 - Fixed: LogDrawer SSE Reconnect ist jetzt nach 5 Fehlversuchen gecappt; UI bietet einen Reload-Button (Slice J.6, Audit-Empfehlung 7).
 - `docker-compose.yml`/`docker-compose.prod.yml` `LLM_BASE_URL` und `EMBEDDING_BASE_URL` auf `${VAR:-default}`-Substitution umgestellt — `.env`-Werte gewinnen jetzt, Default-Fallback bleibt host-Ollama. Vorher wurden die Werte hardcoded überschrieben, sodass OpenAI-Embedding-Switch via `.env` ins Leere lief und der Container in den Reboot-Loop ging (404 von Ollama auf `text-embedding-3-small`). Slice K.2.
 - `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write. Followup: `time.sleep(_STREAM_POLL_SEC)` vor `break` ergänzt, weil `size > offset` wahr bleibt und der reguläre Sleep-Zweig sonst nie erreicht wird (Hot-Loop, 100 % CPU). Gemini MEDIUM #254 + HIGH #255, Slice K.0.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 ### Fixed
+- fix(frontend): Step4Report-Spec auf Report/EvidenceMap-Types typisieren (vue-tsc strict, kein Runtime-Effekt)
 - Fixed: LogDrawer SSE Reconnect ist jetzt nach 5 Fehlversuchen gecappt; UI bietet einen Reload-Button (Slice J.6, Audit-Empfehlung 7).
 - `docker-compose.yml`/`docker-compose.prod.yml` `LLM_BASE_URL` und `EMBEDDING_BASE_URL` auf `${VAR:-default}`-Substitution umgestellt — `.env`-Werte gewinnen jetzt, Default-Fallback bleibt host-Ollama. Vorher wurden die Werte hardcoded überschrieben, sodass OpenAI-Embedding-Switch via `.env` ins Leere lief und der Container in den Reboot-Loop ging (404 von Ollama auf `text-embedding-3-small`). Slice K.2.
 - `/api/logs/stream` verwirft Halb-Zeilen bei EOF und rückt `offset` nicht vor (`readline`-Result endet nicht auf `\n` → Retry im nächsten Poll-Zyklus). Verhindert Datenverlust bei Multi-Byte-UTF-8 mid-write. Followup: `time.sleep(_STREAM_POLL_SEC)` vor `break` ergänzt, weil `size > offset` wahr bleibt und der reguläre Sleep-Zweig sonst nie erreicht wird (Hot-Loop, 100 % CPU). Gemini MEDIUM #254 + HIGH #255, Slice K.0.1.

--- a/docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md
+++ b/docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md
@@ -1,0 +1,102 @@
+# Arbeitsprotokoll: Step4Report-Spec TypeScript-Typing-Fix
+
+**Datum:** 2026-05-04
+**Branch:** fix/spec-step4report-typing
+**Scope:** `frontend/src/components/__tests__/Step4Report.spec.ts`
+
+## Diagnose
+
+`npm run check` (via `vue-tsc --noEmit`) schlug mit zwei Fehlern fehl, während `npm test` (158 Tests) grün blieb. Die Fehler traten nur bei `vi.mocked(...).mockResolvedValue(...)` auf, nicht bei den Cast-basierten `(fn as ReturnType<typeof vi.fn>).mockResolvedValue(...)` Stellen, weil letztere den Return-Type-Constraint umgehen.
+
+### Fehler 1 (Zeile 416)
+
+```
+src/components/__tests__/Step4Report.spec.ts(416,44): error TS2345
+  '{ data: { schema_version: number; ... } }' not assignable to
+  ApiEnvelope<{ schema_version: 2; ... }>
+```
+
+Ursache: `VALID_REPORT` (Zeile 98) war ohne Type-Annotation definiert. TypeScript inferierte `schema_version` als `number`, der `ReportSchema` verlangt aber das Literal `2` (`z.literal(2)`). Damit war `{ success: true, data: VALID_REPORT }` nicht assignierbar zu `ApiEnvelope<Report>`.
+
+### Fehler 2 (Zeile 420)
+
+```
+src/components/__tests__/Step4Report.spec.ts(420,52): error TS2345
+  '{ success: true; data: object }' not assignable to ApiEnvelope<EvidenceMap>
+```
+
+Ursache: `VALID_EVIDENCE` (Zeile 111) war als `object` annotiert. `object` ist strukturell zu schwach und enthält nicht die konkreten Felder, die `EvidenceMap` verlangt.
+
+## Durchgefuehrte Edits
+
+Alle Aenderungen ausschliesslich in `frontend/src/components/__tests__/Step4Report.spec.ts`.
+
+### 1. Import hinzugefuegt (Zeile 14, nach den bestehenden Imports)
+
+```typescript
+import type { Report, EvidenceMap } from '../../contracts/reportContract'
+```
+
+### 2. VALID_REPORT typisiert (Zeile 99)
+
+```typescript
+// vorher:
+const VALID_REPORT = {
+
+// nachher:
+const VALID_REPORT: Report = {
+```
+
+### 3. VALID_EVIDENCE typisiert (Zeile 113)
+
+```typescript
+// vorher:
+const VALID_EVIDENCE: object = {
+
+// nachher:
+const VALID_EVIDENCE: EvidenceMap = {
+```
+
+### Weitere Konstanten (Schritt 4 gemaess Aufgabe)
+
+- `EVIDENCE_WITH_QUOTE` (Zeile 201) und `EVIDENCE_WITHOUT_QUOTE` (Zeile 235): Werden nur an `mountWithEvidence(evidenceData: object)` uebergeben, nie an `vi.mocked(...).mockResolvedValue(...)`. Kein vue-tsc-Fehler dort — unveraendert belassen.
+- `VALID_EVIDENCE_WITH_SECTIONS` (Zeile 453): Wird in `(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue(...)` verwendet (Cast-Stil), nicht in `vi.mocked(...)`. Kein vue-tsc-Fehler dort — unveraendert belassen.
+
+## Akzeptanz-Output
+
+```
+> frontend@0.9.0 check
+> vue-tsc --noEmit && npm run test && npm run build
+
+> frontend@0.9.0 test
+> vitest run
+
+ RUN  v4.1.5 /private/tmp/agora-spec-fix/frontend
+
+ Test Files  21 passed (21)
+      Tests  158 passed (158)
+   Start at  10:41:27
+   Duration  3.87s (transform 2.52s, setup 0ms, import 5.75s, tests 1.68s, environment 14.92s)
+
+> frontend@0.9.0 build
+> vite build
+
+vite v7.3.2 building client environment for production...
+transforming...
+✓ 850 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                        1.50 kB │ gzip:   0.73 kB
+dist/assets/agora-logo-CUo_nDp2.jpg   69.51 kB
+dist/assets/index-B3gBmRwn.css       128.68 kB │ gzip:  20.21 kB
+dist/assets/index-nDINGcy8.js        620.30 kB │ gzip: 205.01 kB
+✓ built in 1.44s
+```
+
+vue-tsc: 0 Fehler. vitest: 158 Tests gruen, 21 Files. vite build: gruen.
+
+## Geaenderte Dateien
+
+- `frontend/src/components/__tests__/Step4Report.spec.ts` — Zeilen 14 (Import), 99 (VALID_REPORT-Annotation), 113 (VALID_EVIDENCE-Annotation)
+- `CHANGELOG.md` — [Unreleased] Fixed-Sektion ergaenzt
+- `docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md` — dieses Protokoll

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { createI18n } from 'vue-i18n'
+import type { Report, EvidenceMap } from '../../contracts/reportContract'
 
 // localStorage muss vor allen Modul-Imports gemockt sein,
 // da i18n/index.js bei Import-Zeit localStorage.getItem aufruft.
@@ -95,7 +96,7 @@ const globalStubs = {
 }
 
 // Valides Report-Payload (ReportSchema-konform)
-const VALID_REPORT = {
+const VALID_REPORT: Report = {
   schema_version: 2,
   report_id: 'report_test01',
   simulation_id: 'sim_test01',
@@ -108,7 +109,7 @@ const VALID_REPORT = {
 }
 
 // Valides EvidenceMap-Payload
-const VALID_EVIDENCE: object = {
+const VALID_EVIDENCE: EvidenceMap = {
   schema_version: 2,
   report_id: 'report_test01',
   simulation_id: 'sim_test01',


### PR DESCRIPTION
## Summary

- `npm run check` war seit dem vue-router 4→5 / vue-i18n 9→11 / TypeScript-6 Major-Bump-Cluster rot — `vue-tsc --noEmit` meldete TS2345 in `Step4Report.spec.ts:416,420` (`vi.mocked(...).mockResolvedValue({...})` enforct den Return-Type-Constraint, im Gegensatz zu den `as ReturnType<typeof vi.fn>`-Casts an anderen Stellen).
- Ursache: `VALID_REPORT` ohne Type-Annotation (schema_version als `number` statt Literal `2` inferred), `VALID_EVIDENCE: object` (zu schwach gegen `EvidenceMap`).
- Fix: `import type { Report, EvidenceMap }` aus `contracts/reportContract` + `VALID_REPORT: Report` / `VALID_EVIDENCE: EvidenceMap`. Drei-Zeilen-Diff in der Spec, keine Runtime-Änderung.

## Test plan

- [x] `cd frontend && npm run check` — vue-tsc 0 Errors, Vitest 158/158 in 21 Files, vite build grün
- [x] `git diff --stat` zeigt nur `Step4Report.spec.ts`, `CHANGELOG.md`, neues Arbeitsprotokoll
- [x] keine `as any`, keine `@ts-ignore`/`@ts-expect-error`

Arbeitsprotokoll: [`docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md`](https://github.com/arn0ld87/agora/blob/fix/spec-step4report-typing/docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md)

Refs: vue-i18n 9→11-Bump-Cluster (#246-#250). Kein `Closes` — chore-Slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)