### PR TITLE
docs: Gemini-Followup auf #260 — Zeilennummern im Arbeitsprotokoll

### DIFF
--- a/docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md
+++ b/docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md
@@ -31,7 +31,7 @@ Ursache: `VALID_EVIDENCE` (Zeile 111) war als `object` annotiert. `object` ist s
 
 Alle Aenderungen ausschliesslich in `frontend/src/components/__tests__/Step4Report.spec.ts`.
 
-### 1. Import hinzugefuegt (Zeile 14, nach den bestehenden Imports)
+### 1. Import hinzugefuegt (Zeile 13, nach den bestehenden Imports)
 
 ```typescript
 import type { Report, EvidenceMap } from '../../contracts/reportContract'
@@ -47,7 +47,7 @@ const VALID_REPORT = {
 const VALID_REPORT: Report = {
 ```
 
-### 3. VALID_EVIDENCE typisiert (Zeile 113)
+### 3. VALID_EVIDENCE typisiert (Zeile 112)
 
 ```typescript
 // vorher:
@@ -97,6 +97,6 @@ vue-tsc: 0 Fehler. vitest: 158 Tests gruen, 21 Files. vite build: gruen.
 
 ## Geaenderte Dateien
 
-- `frontend/src/components/__tests__/Step4Report.spec.ts` — Zeilen 14 (Import), 99 (VALID_REPORT-Annotation), 113 (VALID_EVIDENCE-Annotation)
+- `frontend/src/components/__tests__/Step4Report.spec.ts` — Zeilen 13 (Import), 99 (VALID_REPORT-Annotation), 112 (VALID_EVIDENCE-Annotation)
 - `CHANGELOG.md` — [Unreleased] Fixed-Sektion ergaenzt
 - `docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md` — dieses Protokoll


### PR DESCRIPTION
## Summary

- Gemini-MEDIUM-Finding 2 auf [PR #260](https://github.com/arn0ld87/agora/pull/260): Zeilennummern im Arbeitsprotokoll wichen off-by-one von der tatsächlichen Datei ab.
- Korrektur: Import 14→13, VALID_EVIDENCE-Annotation 113→112 (drei Stellen im Protokoll).
- Gemini-MEDIUM-Finding 1 (CHANGELOG-Stil) wurde beim Squash-Merge von #260 bereits automatisch adressiert (Suggestion akzeptiert) — kein weiterer Bedarf.

## Test plan

- [x] `git diff --stat`: nur ein File geändert (`docu/2026-05-04-spec-step4report-typing-arbeitsprotokoll.md`), 3 Zeilen
- [x] Kein Code-Effekt — reine Doku-Korrektur

🤖 Generated with [Claude Code](https://claude.com/claude-code)