### PR TITLE
refactor(scripts): extract shared sim-runner helpers

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    scripts_dir: Path
+    backend_dir: Path
+    project_root: Path
+
+
+def resolve_runtime_paths(script_file: str | Path) -> RuntimePaths:
+    script_path = Path(script_file).resolve()
+    scripts_dir = script_path.parent
+    backend_dir = scripts_dir.parent
+    project_root = backend_dir.parent
+    return RuntimePaths(
+        scripts_dir=scripts_dir,
+        backend_dir=backend_dir,
+        project_root=project_root,
+    )
+
+
+def install_script_paths(paths: RuntimePaths) -> None:
+    for path in (str(paths.scripts_dir), str(paths.backend_dir)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def load_project_env(script_file: str | Path, *, verbose: bool = False) -> Path | None:
+    paths = resolve_runtime_paths(script_file)
+    candidates: Iterable[Path] = (
+        paths.project_root / ".env",
+        paths.backend_dir / ".env",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            load_dotenv(candidate)
+            if verbose:
+                print(f"Loaded environment configuration: {candidate}")
+            return candidate
+    return None
+
+
+def should_filter_max_tokens_warning(message: str) -> bool:
+    return "max_tokens" in message and "Invalid or missing" in message
+
+
+class MaxTokensWarningFilter(logging.Filter):
+    """Filter out camel-ai max_tokens warnings."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not should_filter_max_tokens_warning(record.getMessage())
+
+
+def install_max_tokens_warning_filter() -> None:
+    root_logger = logging.getLogger()
+    if not any(isinstance(f, MaxTokensWarningFilter) for f in root_logger.filters):
+        root_logger.addFilter(MaxTokensWarningFilter())
+
+
+class UnicodeFormatter(logging.Formatter):
+    """Convert unicode escape sequences to readable characters."""
+
+    UNICODE_ESCAPE_PATTERN = re.compile(r"\\u([0-9a-fA-F]{4})")
+
+    def format(self, record: logging.LogRecord) -> str:
+        result = super().format(record)
+
+        def replace_unicode(match: re.Match[str]) -> str:
+            try:
+                return chr(int(match.group(1), 16))
+            except (ValueError, OverflowError):
+                return match.group(0)
+
+        return self.UNICODE_ESCAPE_PATTERN.sub(replace_unicode, result)
+
+
+def setup_oasis_logging(log_dir: str | Path) -> None:
+    log_dir_path = Path(log_dir)
+    log_dir_path.mkdir(parents=True, exist_ok=True)
+
+    for entry in log_dir_path.iterdir():
+        if entry.is_file() and entry.suffix == ".log":
+            try:
+                entry.unlink()
+            except OSError:
+                pass
+
+    formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
+    loggers_config = {
+        "social.agent": log_dir_path / "social.agent.log",
+        "social.twitter": log_dir_path / "social.twitter.log",
+        "social.rec": log_dir_path / "social.rec.log",
+        "oasis.env": log_dir_path / "oasis.env.log",
+        "table": log_dir_path / "table.log",
+    }
+
+    for logger_name, log_file in loggers_config.items():
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(logging.DEBUG)
+        logger.handlers.clear()
+        file_handler = logging.FileHandler(log_file, encoding="utf-8", mode="w")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+        logger.propagate = False
+
+
+def _add_shared_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Configuration file path (simulation_config.json)",
+    )
+    parser.add_argument(
+        "--max-rounds",
+        type=int,
+        default=None,
+        help="Maximum simulation rounds (optional, used to truncate long simulations)",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        default=False,
+        help="Close environment immediately after simulation completes, do not enter wait mode",
+    )
+    return parser
+
+
+def build_single_platform_parser(description: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=description)
+    return _add_shared_arguments(parser)
+
+
+def build_parallel_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="OASIS Dual-Platform Parallel Simulation")
+    parser.add_argument("--twitter-only", action="store_true", help="Only run Twitter simulation")
+    parser.add_argument("--reddit-only", action="store_true", help="Only run Reddit simulation")
+    return _add_shared_arguments(parser)

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -81,40 +81,36 @@ _cleanup_done = False
 
 # Add backend directory to path
 # Script is fixed in backend/scripts/ directory
-_scripts_dir = os.path.dirname(os.path.abspath(__file__))
-_backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
-_project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
-sys.path.insert(0, _scripts_dir)
-sys.path.insert(0, _backend_dir)
+try:
+    from ._sim_common import (
+        build_parallel_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+    )
+except ImportError:  # direct script execution
+    from _sim_common import (
+        build_parallel_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+    )
 
-# Load .env file from project root (contains LLM_API_KEY and other configurations)
-from dotenv import load_dotenv
-_env_file = os.path.join(_project_root, '.env')
-if os.path.exists(_env_file):
-    load_dotenv(_env_file)
-    print(f"Loaded environment configuration: {_env_file}")
-else:
-    # Try to load backend/.env
-    _backend_env = os.path.join(_backend_dir, '.env')
-    if os.path.exists(_backend_env):
-        load_dotenv(_backend_env)
-        print(f"Loaded environment configuration: {_backend_env}")
+_runtime_paths = resolve_runtime_paths(__file__)
+_scripts_dir = str(_runtime_paths.scripts_dir)
+_backend_dir = str(_runtime_paths.backend_dir)
+_project_root = str(_runtime_paths.project_root)
+install_script_paths(_runtime_paths)
+load_project_env(__file__, verbose=True)
+install_max_tokens_warning_filter()
+
+if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
+    build_parallel_parser().parse_args()
+    sys.exit(0)
 
 from app.config import Config
-
-
-class MaxTokensWarningFilter(logging.Filter):
-    """Filter out camel-ai max_tokens warnings (we intentionally don't set max_tokens to let the model decide)"""
-
-    def filter(self, record):
-        # Filter out logs containing max_tokens warnings
-        if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
-            return False
-        return True
-
-
-# Add filter immediately when module loads, ensure it takes effect before camel code executes
-logging.getLogger().addFilter(MaxTokensWarningFilter())
 
 
 def disable_oasis_logging():
@@ -1717,36 +1713,7 @@ async def run_reddit_simulation(
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS Dual-Platform Parallel Simulation')
-    parser.add_argument(
-        '--config', 
-        type=str, 
-        required=True,
-        help='Configuration file path (simulation_config.json)'
-    )
-    parser.add_argument(
-        '--twitter-only',
-        action='store_true',
-        help='Only run Twitter simulation'
-    )
-    parser.add_argument(
-        '--reddit-only',
-        action='store_true',
-        help='Only run Reddit simulation'
-    )
-    parser.add_argument(
-        '--max-rounds',
-        type=int,
-        default=None,
-        help='Maximum simulation rounds (optional, used to truncate long simulations)'
-    )
-    parser.add_argument(
-        '--no-wait',
-        action='store_true',
-        default=False,
-        help='Close environment immediately after simulation completes, do not enter wait mode'
-    )
-    
+    parser = build_parallel_parser()
     args = parser.parse_args()
     
     # Create shutdown event at the start of main function to ensure the whole program can respond to exit signal

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -30,89 +30,36 @@ _shutdown_event = None
 _cleanup_done = False
 
 # Add project paths
-_scripts_dir = os.path.dirname(os.path.abspath(__file__))
-_backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
-_project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
-sys.path.insert(0, _scripts_dir)
-sys.path.insert(0, _backend_dir)
+try:
+    from ._sim_common import (
+        build_single_platform_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+        setup_oasis_logging,
+    )
+except ImportError:  # direct script execution
+    from _sim_common import (
+        build_single_platform_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+        setup_oasis_logging,
+    )
 
-# Load .env file from project root (contains LLM_API_KEY and other configurations)
-from dotenv import load_dotenv
-_env_file = os.path.join(_project_root, '.env')
-if os.path.exists(_env_file):
-    load_dotenv(_env_file)
-else:
-    _backend_env = os.path.join(_backend_dir, '.env')
-    if os.path.exists(_backend_env):
-        load_dotenv(_backend_env)
+_runtime_paths = resolve_runtime_paths(__file__)
+_scripts_dir = str(_runtime_paths.scripts_dir)
+_backend_dir = str(_runtime_paths.backend_dir)
+_project_root = str(_runtime_paths.project_root)
+install_script_paths(_runtime_paths)
+load_project_env(__file__)
+install_max_tokens_warning_filter()
 
-
-import re
-
-
-class UnicodeFormatter(logging.Formatter):
-    """Custom formatter to convert Unicode escape sequences to readable characters"""
-    
-    UNICODE_ESCAPE_PATTERN = re.compile(r'\\u([0-9a-fA-F]{4})')
-    
-    def format(self, record):
-        result = super().format(record)
-        
-        def replace_unicode(match):
-            try:
-                return chr(int(match.group(1), 16))
-            except (ValueError, OverflowError):
-                return match.group(0)
-        
-        return self.UNICODE_ESCAPE_PATTERN.sub(replace_unicode, result)
-
-
-class MaxTokensWarningFilter(logging.Filter):
-    """Filter out camel-ai max_tokens warnings (we intentionally don't set max_tokens to let the model decide)"""
-    
-    def filter(self, record):
-        # Filter out logs containing max_tokens warnings
-        if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
-            return False
-        return True
-
-
-# Add filter immediately when module loads, ensure it takes effect before camel code executes
-logging.getLogger().addFilter(MaxTokensWarningFilter())
-
-
-def setup_oasis_logging(log_dir: str):
-    """Configure OASIS logging, use fixed-name log files"""
-    os.makedirs(log_dir, exist_ok=True)
-    
-    # Clean up old log files
-    for f in os.listdir(log_dir):
-        old_log = os.path.join(log_dir, f)
-        if os.path.isfile(old_log) and f.endswith('.log'):
-            try:
-                os.remove(old_log)
-            except OSError:
-                pass
-    
-    formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
-    
-    loggers_config = {
-        "social.agent": os.path.join(log_dir, "social.agent.log"),
-        "social.twitter": os.path.join(log_dir, "social.twitter.log"),
-        "social.rec": os.path.join(log_dir, "social.rec.log"),
-        "oasis.env": os.path.join(log_dir, "oasis.env.log"),
-        "table": os.path.join(log_dir, "table.log"),
-    }
-    
-    for logger_name, log_file in loggers_config.items():
-        logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.DEBUG)
-        logger.handlers.clear()
-        file_handler = logging.FileHandler(log_file, encoding='utf-8', mode='w')
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-        logger.propagate = False
+if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
+    build_single_platform_parser('OASIS Reddit Simulation').parse_args()
+    sys.exit(0)
 
 
 try:
@@ -857,26 +804,7 @@ class RedditSimulationRunner:
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS Reddit Simulation')
-    parser.add_argument(
-        '--config', 
-        type=str, 
-        required=True,
-        help='Configuration file path (simulation_config.json)'
-    )
-    parser.add_argument(
-        '--max-rounds',
-        type=int,
-        default=None,
-        help='Maximum simulation rounds (optional, used to truncate long simulations)'
-    )
-    parser.add_argument(
-        '--no-wait',
-        action='store_true',
-        default=False,
-        help='Close environment immediately after simulation completes, do not enter wait mode'
-    )
-    
+    parser = build_single_platform_parser('OASIS Reddit Simulation')
     args = parser.parse_args()
     
     # Create shutdown event at the start of main function

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -30,89 +30,36 @@ _shutdown_event = None
 _cleanup_done = False
 
 # Add project paths
-_scripts_dir = os.path.dirname(os.path.abspath(__file__))
-_backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
-_project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
-sys.path.insert(0, _scripts_dir)
-sys.path.insert(0, _backend_dir)
+try:
+    from ._sim_common import (
+        build_single_platform_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+        setup_oasis_logging,
+    )
+except ImportError:  # direct script execution
+    from _sim_common import (
+        build_single_platform_parser,
+        install_max_tokens_warning_filter,
+        install_script_paths,
+        load_project_env,
+        resolve_runtime_paths,
+        setup_oasis_logging,
+    )
 
-# Load .env file from project root (contains LLM_API_KEY and other configurations)
-from dotenv import load_dotenv
-_env_file = os.path.join(_project_root, '.env')
-if os.path.exists(_env_file):
-    load_dotenv(_env_file)
-else:
-    _backend_env = os.path.join(_backend_dir, '.env')
-    if os.path.exists(_backend_env):
-        load_dotenv(_backend_env)
+_runtime_paths = resolve_runtime_paths(__file__)
+_scripts_dir = str(_runtime_paths.scripts_dir)
+_backend_dir = str(_runtime_paths.backend_dir)
+_project_root = str(_runtime_paths.project_root)
+install_script_paths(_runtime_paths)
+load_project_env(__file__)
+install_max_tokens_warning_filter()
 
-
-import re
-
-
-class UnicodeFormatter(logging.Formatter):
-    """Custom formatter to convert Unicode escape sequences to readable characters"""
-    
-    UNICODE_ESCAPE_PATTERN = re.compile(r'\\u([0-9a-fA-F]{4})')
-    
-    def format(self, record):
-        result = super().format(record)
-        
-        def replace_unicode(match):
-            try:
-                return chr(int(match.group(1), 16))
-            except (ValueError, OverflowError):
-                return match.group(0)
-        
-        return self.UNICODE_ESCAPE_PATTERN.sub(replace_unicode, result)
-
-
-class MaxTokensWarningFilter(logging.Filter):
-    """Filter out camel-ai max_tokens warnings (we intentionally don't set max_tokens to let the model decide)"""
-    
-    def filter(self, record):
-        # Filter out logs containing max_tokens warnings
-        if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
-            return False
-        return True
-
-
-# Add filter immediately when module loads, ensure it takes effect before camel code executes
-logging.getLogger().addFilter(MaxTokensWarningFilter())
-
-
-def setup_oasis_logging(log_dir: str):
-    """Configure OASIS logging, use fixed-name log files"""
-    os.makedirs(log_dir, exist_ok=True)
-    
-    # Clean up old log files
-    for f in os.listdir(log_dir):
-        old_log = os.path.join(log_dir, f)
-        if os.path.isfile(old_log) and f.endswith('.log'):
-            try:
-                os.remove(old_log)
-            except OSError:
-                pass
-    
-    formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
-    
-    loggers_config = {
-        "social.agent": os.path.join(log_dir, "social.agent.log"),
-        "social.twitter": os.path.join(log_dir, "social.twitter.log"),
-        "social.rec": os.path.join(log_dir, "social.rec.log"),
-        "oasis.env": os.path.join(log_dir, "oasis.env.log"),
-        "table": os.path.join(log_dir, "table.log"),
-    }
-    
-    for logger_name, log_file in loggers_config.items():
-        logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.DEBUG)
-        logger.handlers.clear()
-        file_handler = logging.FileHandler(log_file, encoding='utf-8', mode='w')
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-        logger.propagate = False
+if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
+    build_single_platform_parser('OASIS Twitter Simulation').parse_args()
+    sys.exit(0)
 
 
 try:
@@ -868,26 +815,7 @@ class TwitterSimulationRunner:
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS Twitter Simulation')
-    parser.add_argument(
-        '--config', 
-        type=str, 
-        required=True,
-        help='Configuration file path (simulation_config.json)'
-    )
-    parser.add_argument(
-        '--max-rounds',
-        type=int,
-        default=None,
-        help='Maximum simulation rounds (optional, used to truncate long simulations)'
-    )
-    parser.add_argument(
-        '--no-wait',
-        action='store_true',
-        default=False,
-        help='immediately after simulation completionClose environment，do not enterWait mode'
-    )
-    
+    parser = build_single_platform_parser('OASIS Twitter Simulation')
     args = parser.parse_args()
     
     # Create shutdown event at the start of main function

--- a/backend/tests/scripts/test_sim_runner_help.py
+++ b/backend/tests/scripts/test_sim_runner_help.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+MODULE_PATH = SCRIPTS_DIR / "_sim_common.py"
+spec = importlib.util.spec_from_file_location("_sim_common", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise ImportError(f"Could not create module spec for {MODULE_PATH}")
+_sim_common = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = _sim_common
+spec.loader.exec_module(_sim_common)
+
+
+def test_resolve_runtime_paths_returns_expected_layout():
+    script_path = Path("/tmp/agora/backend/scripts/run_twitter_simulation.py")
+    resolved_script = script_path.resolve()
+    paths = _sim_common.resolve_runtime_paths(script_path)
+
+    assert paths.scripts_dir == resolved_script.parent
+    assert paths.backend_dir == resolved_script.parent.parent
+    assert paths.project_root == resolved_script.parent.parent.parent
+
+
+@pytest.mark.parametrize("description", ["OASIS Twitter Simulation", "OASIS Reddit Simulation"])
+def test_build_single_platform_parser_supports_shared_args(description: str):
+    parser = _sim_common.build_single_platform_parser(description)
+    args = parser.parse_args(["--config", "simulation_config.json", "--max-rounds", "12", "--no-wait"])
+
+    assert args.config == "simulation_config.json"
+    assert args.max_rounds == 12
+    assert args.no_wait is True
+
+
+def test_build_parallel_parser_supports_platform_switches():
+    parser = _sim_common.build_parallel_parser()
+    args = parser.parse_args([
+        "--config", "simulation_config.json",
+        "--twitter-only",
+        "--max-rounds", "7",
+        "--no-wait",
+    ])
+
+    assert args.config == "simulation_config.json"
+    assert args.twitter_only is True
+    assert args.reddit_only is False
+    assert args.max_rounds == 7
+    assert args.no_wait is True
+
+
+def test_max_tokens_warning_filter_matches_only_target_warning():
+    warning = "Invalid or missing max_tokens value in request"
+    other = "totally different warning"
+
+    assert _sim_common.should_filter_max_tokens_warning(warning) is True
+    assert _sim_common.should_filter_max_tokens_warning(other) is False
+
+
+def _run_help(script_name: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / script_name), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+        timeout=20,
+    )
+
+
+@pytest.mark.parametrize(
+    ("script_name", "expected_text"),
+    [
+        ("run_twitter_simulation.py", "OASIS Twitter Simulation"),
+        ("run_reddit_simulation.py", "OASIS Reddit Simulation"),
+        ("run_parallel_simulation.py", "OASIS Dual-Platform Parallel Simulation"),
+    ],
+)
+def test_runner_help_smoke_exits_zero(script_name: str, expected_text: str):
+    result = _run_help(script_name)
+    assert result.returncode == 0
+    assert expected_text in result.stdout
+    assert "--config" in result.stdout

--- a/docu/2026-05-04-task-45-sim-common-arbeitsprotokoll.md
+++ b/docu/2026-05-04-task-45-sim-common-arbeitsprotokoll.md
@@ -1,0 +1,101 @@
+# Arbeitsprotokoll — Task 45 / Issue #201: `_sim_common.py` extrahieren
+
+**Datum:** 2026-05-04  
+**Issue:** #201  
+**Milestone:** v1.0.0 — Stable Release
+
+## Ausgangslage
+
+Gemessene LOC vor dem Slice:
+
+```text
+1954  backend/scripts/run_parallel_simulation.py
+ 943  backend/scripts/run_twitter_simulation.py
+ 933  backend/scripts/run_reddit_simulation.py
+3830  total
+```
+
+Auffällige Duplikate in allen drei Runnern:
+- Pfadberechnung (`_scripts_dir`, `_backend_dir`, `_project_root`)
+- `.env`-Ladelogik
+- `MaxTokensWarningFilter`
+- OASIS-Log-Setup
+- CLI-Parser für `--config`, `--max-rounds`, `--no-wait`
+
+## Umsetzung
+
+Neu extrahiert nach `backend/scripts/_sim_common.py`:
+- `RuntimePaths`
+- `resolve_runtime_paths()`
+- `install_script_paths()`
+- `load_project_env()`
+- `should_filter_max_tokens_warning()`
+- `MaxTokensWarningFilter`
+- `install_max_tokens_warning_filter()`
+- `UnicodeFormatter`
+- `setup_oasis_logging()`
+- `build_single_platform_parser()`
+- `build_parallel_parser()`
+
+Integriert in:
+- `backend/scripts/run_twitter_simulation.py`
+- `backend/scripts/run_reddit_simulation.py`
+- `backend/scripts/run_parallel_simulation.py`
+
+Zusätzlicher kleiner Härtungsschritt:
+- `--help` wird jetzt in allen drei Runnern **vor** den schweren OASIS/CAMEL-Imports beantwortet, damit CLI-Smoke und Tooling nicht an Laufzeit-Dependencies hängen.
+- `_sim_common` wird package-safe importiert (`from ._sim_common ...` mit Fallback für direkte Script-Ausführung).
+
+## Testabdeckung
+
+Neu: `backend/tests/scripts/test_sim_runner_help.py`
+
+Abgedeckt:
+- Pfadauflösung
+- gemeinsamer Single-Platform-Parser
+- Parallel-Parser inkl. Plattform-Switches
+- Warning-Filter-Prädikat
+- echte Subprocess-Smoke-Tests für
+  - `run_twitter_simulation.py --help`
+  - `run_reddit_simulation.py --help`
+  - `run_parallel_simulation.py --help`
+
+## Verifikation
+
+Ausgeführt:
+
+```bash
+cd backend && uv run pytest tests/scripts/test_sim_runner_help.py -v
+cd backend && uv run python -m compileall scripts/_sim_common.py scripts/run_twitter_simulation.py scripts/run_reddit_simulation.py scripts/run_parallel_simulation.py
+python backend/scripts/run_twitter_simulation.py --help
+python backend/scripts/run_reddit_simulation.py --help
+python backend/scripts/run_parallel_simulation.py --help
+```
+
+Ergebnis:
+- `pytest`: **8 passed**
+- `compileall`: erfolgreich
+- alle drei `--help`-Kommandos: Exit `0`
+
+## LOC nach dem Slice
+
+```text
+ 151  backend/scripts/_sim_common.py
+1921  backend/scripts/run_parallel_simulation.py
+ 871  backend/scripts/run_twitter_simulation.py
+ 861  backend/scripts/run_reddit_simulation.py
+3804  total
+```
+
+## Bewertung gegen Issue #201
+
+Erfüllt:
+- gemeinsamer Hilfsmodul-Schnitt vorhanden
+- drei Runner kleiner als vorher
+- CLI-Smoke vorhanden und grün
+- keine offensichtliche Verhaltensänderung im Simulationspfad beabsichtigt
+- Arbeitsprotokoll vorhanden
+
+Offen / bewusst nicht in diesem Slice:
+- keine aggressive Extraktion plattformspezifischer Simulationslogik
+- `run_parallel_simulation.py` bleibt klar >1500 LOC und ist eher Kandidat für weiterführenden Schnitt als für diesen ersten DRY-Schritt


### PR DESCRIPTION
## Summary
- extract shared sim-runner setup into `backend/scripts/_sim_common.py`
- reduce duplication across the Twitter/Reddit/parallel OASIS runner scripts
- add subprocess smoke tests for all three `--help` entrypoints plus a worklog

## Verification
- [x] `cd backend && uv run pytest tests/scripts/test_sim_runner_help.py -v`
- [x] `cd backend && uv run python -m compileall scripts/_sim_common.py scripts/run_twitter_simulation.py scripts/run_reddit_simulation.py scripts/run_parallel_simulation.py`
- [x] `python backend/scripts/run_twitter_simulation.py --help`
- [x] `python backend/scripts/run_reddit_simulation.py --help`
- [x] `python backend/scripts/run_parallel_simulation.py --help`

## Issue
Closes #201
