### PR TITLE
fix(scripts): address PR 266 review follow-ups

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -90,13 +90,6 @@ def setup_oasis_logging(log_dir: str | Path) -> None:
     log_dir_path = Path(log_dir)
     log_dir_path.mkdir(parents=True, exist_ok=True)
 
-    for entry in log_dir_path.iterdir():
-        if entry.is_file() and entry.suffix == ".log":
-            try:
-                entry.unlink()
-            except OSError:
-                pass
-
     formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
     loggers_config = {
         "social.agent": log_dir_path / "social.agent.log",

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -99,9 +99,6 @@ except ImportError:  # direct script execution
     )
 
 _runtime_paths = resolve_runtime_paths(__file__)
-_scripts_dir = str(_runtime_paths.scripts_dir)
-_backend_dir = str(_runtime_paths.backend_dir)
-_project_root = str(_runtime_paths.project_root)
 install_script_paths(_runtime_paths)
 load_project_env(__file__, verbose=True)
 install_max_tokens_warning_filter()

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -50,9 +50,6 @@ except ImportError:  # direct script execution
     )
 
 _runtime_paths = resolve_runtime_paths(__file__)
-_scripts_dir = str(_runtime_paths.scripts_dir)
-_backend_dir = str(_runtime_paths.backend_dir)
-_project_root = str(_runtime_paths.project_root)
 install_script_paths(_runtime_paths)
 load_project_env(__file__)
 install_max_tokens_warning_filter()

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -50,9 +50,6 @@ except ImportError:  # direct script execution
     )
 
 _runtime_paths = resolve_runtime_paths(__file__)
-_scripts_dir = str(_runtime_paths.scripts_dir)
-_backend_dir = str(_runtime_paths.backend_dir)
-_project_root = str(_runtime_paths.project_root)
 install_script_paths(_runtime_paths)
 load_project_env(__file__)
 install_max_tokens_warning_filter()

--- a/backend/tests/scripts/test_sim_runner_help.py
+++ b/backend/tests/scripts/test_sim_runner_help.py
@@ -19,7 +19,7 @@ spec.loader.exec_module(_sim_common)
 
 
 def test_resolve_runtime_paths_returns_expected_layout():
-    script_path = Path("/tmp/agora/backend/scripts/run_twitter_simulation.py")
+    script_path = SCRIPTS_DIR / "run_twitter_simulation.py"
     resolved_script = script_path.resolve()
     paths = _sim_common.resolve_runtime_paths(script_path)
 


### PR DESCRIPTION
## Summary
- remove the overly aggressive `*.log` cleanup from `_sim_common.py`
- drop unused runtime path variables from the three simulation runners
- make `test_sim_runner_help.py` use a repo-local script path instead of a hardcoded `/tmp/...` path

## Verification
- [x] `cd backend && uv run pytest tests/scripts/test_sim_runner_help.py -v`
- [x] `cd backend && uv run python -m compileall scripts/_sim_common.py scripts/run_twitter_simulation.py scripts/run_reddit_simulation.py scripts/run_parallel_simulation.py`
- [x] `python backend/scripts/run_twitter_simulation.py --help`
- [x] `python backend/scripts/run_reddit_simulation.py --help`
- [x] `python backend/scripts/run_parallel_simulation.py --help`

## Context
Follow-up for Gemini comments on merged PR #266.
