### PR TITLE
fix(camel): hoist ScoreBasedContextCreator floor + memory limit per agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,3 +199,5 @@ Signalen direkt Opus ziehen:
 - `git push --no-verify` ohne explizite User-Freigabe
 - Auf `main` mergen ohne Gemini-Findings-Sichtung (siehe PR-Workflow oben)
 - Hartkodierte UI-Strings in `Step*.vue` — immer `vue-i18n` (`t(...)`) + Keys in `de.json`+`en.json`
+- **Neue OASIS/CAMEL-Runner-Skripte ohne `apply_camel_context_floor()` + `enforce_memory_token_limit()`-Aufruf nach `generate_*_agent_graph(...)`.** Sonst kappt CAMELs `ScoreBasedContextCreator` jeden Agent-Memory bei 8192 Tokens — unabhängig vom realen Modell-Context. Floor wird zentral in `backend/scripts/_sim_common.py::apply_camel_context_floor()` gepflegt; Pro-Modell-Heuristik in `backend/scripts/agent_tools.py::_heuristic_context_limit()`. User-Override via `LLM_CONTEXT_LIMIT` und `LLM_MODEL_CONTEXT_LIMITS_JSON` (Vorrang vor Heuristik)
+- Hartkodierte `token_limit`-Defaults in CAMEL-/OASIS-Anbindungen (8192, 4096, 16384) — immer aus `_resolve_memory_token_limit(model_name)` lesen, damit Frontend-gewählte Cloud-Modelle (Gemini 3 ≈ 1 M, Qwen3-Coder 256 k, GPT-OSS 128 k) ihren echten Context-Window nutzen können

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -69,6 +69,49 @@ def install_max_tokens_warning_filter() -> None:
         root_logger.addFilter(MaxTokensWarningFilter())
 
 
+_DEFAULT_CONTEXT_FLOOR = 262_144
+
+
+def apply_camel_context_floor(default_floor: int = _DEFAULT_CONTEXT_FLOOR) -> int:
+    """Hebe CAMELs ScoreBasedContextCreator-Default-Token-Limit auf
+    LLM_CONTEXT_LIMIT (oder ``default_floor``) an.
+
+    Hintergrund: ``camel.memories.context_creators.score_based.ScoreBasedContextCreator``
+    initialisiert ``token_limit`` per Default auf 8192. Sobald CAMEL einen
+    Agent ohne explizit hochgesetztes Limit anlegt, kappt die Memory-Truncation
+    bei 8 k Tokens — unabhaengig davon, ob das Modell 256 k oder 1 M kann.
+    Diese Funktion patcht ``__init__`` so, dass der Floor als Mindestwert wirkt
+    (groessere Werte aus dem Aufrufer werden respektiert).
+
+    Idempotent: mehrfache Aufrufe sind ein No-op. Gibt den effektiven Floor
+    zurueck, damit der Aufrufer ihn loggen kann.
+    """
+    try:
+        floor = int(os.environ.get("LLM_CONTEXT_LIMIT", str(default_floor)))
+    except ValueError:
+        floor = default_floor
+
+    try:
+        from camel.memories.context_creators.score_based import (
+            ScoreBasedContextCreator,
+        )
+    except ImportError:
+        return floor
+
+    if getattr(ScoreBasedContextCreator, "_agora_context_floor_applied", False):
+        return floor
+
+    original_init = ScoreBasedContextCreator.__init__
+
+    def _patched_init(self, token_counter, token_limit=None, *args, **kwargs):
+        effective = floor if (token_limit is None or token_limit < floor) else token_limit
+        return original_init(self, token_counter, effective, *args, **kwargs)
+
+    ScoreBasedContextCreator.__init__ = _patched_init
+    ScoreBasedContextCreator._agora_context_floor_applied = True
+    return floor
+
+
 class UnicodeFormatter(logging.Formatter):
     """Convert unicode escape sequences to readable characters."""
 

--- a/backend/scripts/agent_tools.py
+++ b/backend/scripts/agent_tools.py
@@ -17,7 +17,7 @@ import os
 import re
 import sqlite3
 import sys
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 from dataclasses import dataclass
 
 import requests
@@ -963,6 +963,46 @@ def _install_empty_assistant_memory_sanitizer(agent_id: Any, memory: Any) -> Non
     memory._agora_empty_assistant_sanitizer = True
 
 
+# Heuristische Default-Mappings fuer haeufige Cloud-/lokale Modellfamilien.
+# Greift NUR, wenn weder Config.LLM_MODEL_CONTEXT_LIMITS noch
+# LLM_MODEL_CONTEXT_LIMITS_JSON einen exakten Match liefern. Modelle werden
+# inzwischen ueber das Frontend gewaehlt und stehen nicht mehr in der .env,
+# deshalb braucht der Resolver einen sinnvollen Fallback statt blind auf den
+# globalen LLM_CONTEXT_LIMIT zu fallen — sonst kappt CAMEL z. B. einen
+# Gemini-3-Pro-Run mit 1 M Context-Window faelschlich auf 256 k.
+_MODEL_CONTEXT_HEURISTICS: Tuple[Tuple[str, int], ...] = (
+    ("gemini-3", 1_048_576),       # Gemini 3 Pro / Flash: ~1M Tokens
+    ("gemini-2.5", 1_048_576),
+    ("gemini-2", 1_048_576),
+    ("deepseek-v3", 131_072),      # DeepSeek-V3 / V3.1 / V3.2: 128k
+    ("deepseek-v4", 1_048_576),    # DeepSeek-V4 (laut Vendor-Stand 2026)
+    ("deepseek-r1", 131_072),
+    ("qwen3-coder", 262_144),      # Qwen3-Coder / -Coder-Next: 256k
+    ("qwen3", 131_072),
+    ("qwen2.5", 131_072),
+    ("llama-3.3", 131_072),
+    ("llama3.3", 131_072),
+    ("llama-3.1", 131_072),
+    ("gpt-oss", 131_072),          # gpt-oss-Cloud-Familie: 128k
+    ("gpt-4.1", 1_048_576),
+    ("gpt-4o", 131_072),
+    ("claude-opus-4", 200_000),
+    ("claude-sonnet-4", 200_000),
+    ("claude-haiku-4", 200_000),
+)
+
+
+def _heuristic_context_limit(model_name: str) -> Optional[int]:
+    """Best-effort Substring-Match fuer bekannte Modellfamilien."""
+    if not model_name:
+        return None
+    needle = model_name.lower()
+    for prefix, limit in _MODEL_CONTEXT_HEURISTICS:
+        if prefix in needle:
+            return limit
+    return None
+
+
 def _resolve_memory_token_limit(model_name: Optional[str] = None) -> int:
     from app.config import Config
 
@@ -978,10 +1018,64 @@ def _resolve_memory_token_limit(model_name: Optional[str] = None) -> int:
                 overrides.update(parsed)
     default_limit = int(os.environ.get("LLM_CONTEXT_LIMIT", str(Config.LLM_CONTEXT_LIMIT)))
     override = overrides.get(model_name or "")
+    if override is not None:
+        try:
+            return int(override)
+        except (TypeError, ValueError):
+            pass
+    heuristic = _heuristic_context_limit(model_name or "")
+    if heuristic is not None:
+        return max(heuristic, default_limit)
+    return default_limit
+
+
+def enforce_memory_token_limit(agent_graph) -> int:
+    """Hebe creator._token_limit jedes Agents auf das resolved Memory-Budget.
+
+    Komplementaer zur globalen ``apply_camel_context_floor()``-Patch in
+    ``_sim_common.py``: dort wirkt der Floor nur fuer NEU instanzierte
+    ScoreBasedContextCreators. OASIS legt seine SocialAgents jedoch ueber
+    ``generate_*_agent_graph`` an, und CAMEL kann den Creator dabei mit dem
+    *altem* Limit cachen, sobald die Memory-Instanz bereits den Default 8192
+    geerbt hat. Diese Funktion zieht das Live-Limit pro Agent nach — auch
+    wenn KEIN ``attach_tools_to_agents``-Pfad benutzt wird.
+
+    Gibt die Anzahl gepatchter Creator-Instanzen zurueck (fuer Logging).
+    """
+    if agent_graph is None:
+        return 0
     try:
-        return int(override) if override is not None else default_limit
-    except (TypeError, ValueError):
-        return default_limit
+        agents_iter = agent_graph.get_agents()
+    except Exception as exc:  # pragma: no cover — Defensive Hook
+        print(f"[enforce_memory_token_limit] get_agents failed: {exc}", flush=True)
+        return 0
+
+    patched = 0
+    for agent_id, agent in agents_iter:
+        try:
+            model_name = str(getattr(getattr(agent, "model_backend", None), "model_type", "") or "")
+            ctx_limit = _resolve_memory_token_limit(model_name)
+            memory = getattr(agent, "memory", None)
+            if memory is None or not hasattr(memory, "get_context_creator"):
+                continue
+            creator = memory.get_context_creator()
+            if creator is None or not hasattr(creator, "_token_limit"):
+                continue
+            old_limit = getattr(creator, "token_limit", None)
+            if old_limit is None or old_limit < ctx_limit:
+                creator._token_limit = ctx_limit
+                patched += 1
+                print(
+                    f"[enforce_memory_token_limit] agent {agent_id}: "
+                    f"{old_limit} -> {ctx_limit} (model={model_name or '?'})",
+                    flush=True,
+                )
+        except Exception as exc:
+            print(
+                f"[enforce_memory_token_limit] agent {agent_id} patch failed: {exc}",
+                flush=True,
+            )
+    return patched
 
 
 def attach_tools_to_agents(agent_graph, tools: List[Any]) -> int:

--- a/backend/scripts/agent_tools.py
+++ b/backend/scripts/agent_tools.py
@@ -1053,7 +1053,8 @@ def enforce_memory_token_limit(agent_graph) -> int:
     patched = 0
     for agent_id, agent in agents_iter:
         try:
-            model_name = str(getattr(getattr(agent, "model_backend", None), "model_type", "") or "")
+            model_backend = getattr(agent, "model_backend", None)
+            model_name = str(getattr(model_backend, "model_type", "") or "")
             ctx_limit = _resolve_memory_token_limit(model_name)
             memory = getattr(agent, "memory", None)
             if memory is None or not hasattr(memory, "get_context_creator"):

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -83,6 +83,7 @@ _cleanup_done = False
 # Script is fixed in backend/scripts/ directory
 try:
     from ._sim_common import (
+        apply_camel_context_floor,
         build_parallel_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -91,6 +92,7 @@ try:
     )
 except ImportError:  # direct script execution
     from _sim_common import (
+        apply_camel_context_floor,
         build_parallel_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -102,6 +104,8 @@ _runtime_paths = resolve_runtime_paths(__file__)
 install_script_paths(_runtime_paths)
 load_project_env(__file__, verbose=True)
 install_max_tokens_warning_filter()
+_camel_context_floor = apply_camel_context_floor()
+print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_parallel_parser().parse_args()
@@ -1068,7 +1072,21 @@ def resolve_model_runtime_settings(model_name: str) -> Dict[str, Any]:
     )
     context_overrides = dict(getattr(Config, "LLM_MODEL_CONTEXT_LIMITS", {}) or {})
     context_overrides.update(_parse_model_context_limits())
-    memory_token_limit = int(context_overrides.get(model_name, default_memory_limit))
+    if model_name in context_overrides:
+        memory_token_limit = int(context_overrides[model_name])
+    else:
+        # Frontend-Modellauswahl: Modell-String steht oft nicht in der env-Map.
+        # Fallback ueber dieselbe Substring-Heuristik wie agent_tools, damit
+        # z. B. ein vom UI gewaehltes "gemini-3-pro:cloud" nicht auf 256 k
+        # gekappt wird, obwohl das Modell 1 M kann.
+        try:
+            from agent_tools import _heuristic_context_limit
+            heuristic = _heuristic_context_limit(str(model_name))
+        except Exception:
+            heuristic = None
+        memory_token_limit = (
+            max(int(heuristic), default_memory_limit) if heuristic else default_memory_limit
+        )
     is_cloud_model = str(model_name).endswith(":cloud")
 
     return {
@@ -1274,6 +1292,16 @@ async def run_twitter_simulation(
         model=model,
         available_actions=TWITTER_ACTIONS,
     )
+
+    # Memory-Token-Limit auch dann anheben, wenn keine Tools attached werden:
+    # CAMELs ScoreBasedContextCreator-Default (8192) wuerde sonst zuschlagen,
+    # bevor attach_tools_to_agents() greift.
+    if AGENT_TOOLS_AVAILABLE:
+        try:
+            from agent_tools import enforce_memory_token_limit
+            enforce_memory_token_limit(result.agent_graph)
+        except Exception as e:
+            log_info(f"enforce_memory_token_limit (twitter) failed: {e}")
 
     # Native CAMEL function-calling: attach web_search / web_fetch / search_graph
     # to every SocialAgent. OASIS triggers these through its normal LLMAction()
@@ -1514,6 +1542,14 @@ async def run_reddit_simulation(
         model=model,
         available_actions=REDDIT_ACTIONS,
     )
+
+    # Memory-Token-Limit auch ohne Tools auf das resolvte Modell-Budget heben.
+    if AGENT_TOOLS_AVAILABLE:
+        try:
+            from agent_tools import enforce_memory_token_limit
+            enforce_memory_token_limit(result.agent_graph)
+        except Exception as e:
+            log_info(f"enforce_memory_token_limit (reddit) failed: {e}")
 
     # Native CAMEL function-calling for Reddit agents (see Twitter branch).
     if enable_tools and AGENT_TOOLS_AVAILABLE:

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -32,6 +32,7 @@ _cleanup_done = False
 # Add project paths
 try:
     from ._sim_common import (
+        apply_camel_context_floor,
         build_single_platform_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -41,6 +42,7 @@ try:
     )
 except ImportError:  # direct script execution
     from _sim_common import (
+        apply_camel_context_floor,
         build_single_platform_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -53,6 +55,8 @@ _runtime_paths = resolve_runtime_paths(__file__)
 install_script_paths(_runtime_paths)
 load_project_env(__file__)
 install_max_tokens_warning_filter()
+_camel_context_floor = apply_camel_context_floor()
+print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Reddit Simulation').parse_args()
@@ -62,16 +66,9 @@ if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
 try:
     from camel.models import ModelFactory
     from camel.types import ModelPlatformType
-    # Monkey-Patch (analog zu run_parallel_simulation.py): heb CAMEL's
-    # ScoreBasedContextCreator-Default von 8192 auf LLM_CONTEXT_LIMIT hoch.
-    from camel.memories.context_creators.score_based import ScoreBasedContextCreator as _SBCC
-    _SBCC_ORIG_INIT = _SBCC.__init__
-    _CTX_LIMIT_OVERRIDE = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-    def _sbcc_patched_init(self, token_counter, token_limit=None, *args, **kwargs):
-        effective = _CTX_LIMIT_OVERRIDE if (token_limit is None or token_limit < _CTX_LIMIT_OVERRIDE) else token_limit
-        return _SBCC_ORIG_INIT(self, token_counter, effective, *args, **kwargs)
-    _SBCC.__init__ = _sbcc_patched_init
-    print(f"[context-patch] token_limit floor = {_CTX_LIMIT_OVERRIDE}", flush=True)
+    # ScoreBasedContextCreator-Floor wird in apply_camel_context_floor() oben
+    # gesetzt. CAMELs Default-token_limit (8192) wuerde sonst bei 8 k Tokens
+    # truncen, unabhaengig von OLLAMA_NUM_CTX und vom realen Modell-Context.
     import oasis
     from oasis import (
         ActionType,
@@ -596,7 +593,15 @@ class RedditSimulationRunner:
             model=model,
             available_actions=self.AVAILABLE_ACTIONS,
         )
-        
+
+        # Memory-Token-Limit auch ohne Tool-Attach hochziehen — sonst kappt
+        # CAMELs ScoreBasedContextCreator-Default bei 8192.
+        try:
+            from agent_tools import enforce_memory_token_limit
+            enforce_memory_token_limit(self.agent_graph)
+        except Exception as e:
+            print(f"enforce_memory_token_limit (reddit-single) failed: {e}", flush=True)
+
         db_path = self._get_db_path()
         if os.path.exists(db_path):
             os.remove(db_path)

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -32,6 +32,7 @@ _cleanup_done = False
 # Add project paths
 try:
     from ._sim_common import (
+        apply_camel_context_floor,
         build_single_platform_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -41,6 +42,7 @@ try:
     )
 except ImportError:  # direct script execution
     from _sim_common import (
+        apply_camel_context_floor,
         build_single_platform_parser,
         install_max_tokens_warning_filter,
         install_script_paths,
@@ -53,6 +55,8 @@ _runtime_paths = resolve_runtime_paths(__file__)
 install_script_paths(_runtime_paths)
 load_project_env(__file__)
 install_max_tokens_warning_filter()
+_camel_context_floor = apply_camel_context_floor()
+print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Twitter Simulation').parse_args()
@@ -62,16 +66,9 @@ if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
 try:
     from camel.models import ModelFactory
     from camel.types import ModelPlatformType
-    # Monkey-Patch (analog zu run_parallel_simulation.py): heb CAMEL's
-    # ScoreBasedContextCreator-Default von 8192 auf LLM_CONTEXT_LIMIT hoch.
-    from camel.memories.context_creators.score_based import ScoreBasedContextCreator as _SBCC
-    _SBCC_ORIG_INIT = _SBCC.__init__
-    _CTX_LIMIT_OVERRIDE = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-    def _sbcc_patched_init(self, token_counter, token_limit=None, *args, **kwargs):
-        effective = _CTX_LIMIT_OVERRIDE if (token_limit is None or token_limit < _CTX_LIMIT_OVERRIDE) else token_limit
-        return _SBCC_ORIG_INIT(self, token_counter, effective, *args, **kwargs)
-    _SBCC.__init__ = _sbcc_patched_init
-    print(f"[context-patch] token_limit floor = {_CTX_LIMIT_OVERRIDE}", flush=True)
+    # ScoreBasedContextCreator-Floor wird in apply_camel_context_floor() oben
+    # gesetzt. CAMELs Default-token_limit (8192) wuerde sonst bei 8 k Tokens
+    # truncen, unabhaengig von OLLAMA_NUM_CTX und vom realen Modell-Context.
     import oasis
     from oasis import (
         ActionType,
@@ -605,7 +602,15 @@ class TwitterSimulationRunner:
             model=model,
             available_actions=self.AVAILABLE_ACTIONS,
         )
-        
+
+        # Memory-Token-Limit auch ohne Tool-Attach hochziehen — sonst kappt
+        # CAMELs ScoreBasedContextCreator-Default bei 8192.
+        try:
+            from agent_tools import enforce_memory_token_limit
+            enforce_memory_token_limit(self.agent_graph)
+        except Exception as e:
+            print(f"enforce_memory_token_limit (twitter-single) failed: {e}", flush=True)
+
         # Databasepath
         db_path = self._get_db_path()
         if os.path.exists(db_path):

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -1,17 +1,34 @@
 import importlib.util
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+RUNNER_SCRIPTS = (
+    "backend/scripts/run_parallel_simulation.py",
+    "backend/scripts/run_twitter_simulation.py",
+    "backend/scripts/run_reddit_simulation.py",
+)
+
+
 def _load_module(module_name: str, relative_path: str):
     module_path = REPO_ROOT / relative_path
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
+    parent_dir = str(module_path.parent.resolve())
+    sys_path_added = False
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+        sys_path_added = True
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if sys_path_added and parent_dir in sys.path:
+            sys.path.remove(parent_dir)
 
 
 def test_resolve_model_runtime_settings_cloud(monkeypatch):
@@ -224,3 +241,82 @@ def test_attach_tools_to_agents_wraps_memory_write_records(monkeypatch):
     graph.agent.memory.write_records([DummyRecord()])
 
     assert graph.agent.memory.records == []
+
+
+def test_enforce_memory_token_limit_without_tools(monkeypatch):
+    """enforce_memory_token_limit muss creator._token_limit auch dann
+    anheben, wenn KEIN attach_tools-Pfad benutzt wird. Ohne diese Garantie
+    bleibt CAMELs ScoreBasedContextCreator-Default 8192 stehen, sobald
+    Persona-Workflows ohne Tool-Registry laufen."""
+    module = _load_module("agent_tools_enforce_test", "backend/scripts/agent_tools.py")
+
+    monkeypatch.setenv("LLM_CONTEXT_LIMIT", "262144")
+    monkeypatch.setenv(
+        "LLM_MODEL_CONTEXT_LIMITS_JSON",
+        '{"qwen3-coder-next:cloud": 262144}',
+    )
+
+    class DummyCreator:
+        def __init__(self):
+            self._token_limit = 8192
+
+        @property
+        def token_limit(self):
+            return self._token_limit
+
+    class DummyMemory:
+        def __init__(self):
+            self.creator = DummyCreator()
+
+        def get_context_creator(self):
+            return self.creator
+
+    class DummyModelBackend:
+        def __init__(self):
+            self.model_type = "qwen3-coder-next:cloud"
+
+    class DummyAgent:
+        def __init__(self):
+            self.memory = DummyMemory()
+            self.model_backend = DummyModelBackend()
+
+    class DummyGraph:
+        def __init__(self):
+            self.agent = DummyAgent()
+
+        def get_agents(self):
+            return [(0, self.agent)]
+
+    graph = DummyGraph()
+    patched = module.enforce_memory_token_limit(graph)
+    assert patched == 1
+    assert graph.agent.memory.get_context_creator().token_limit == 262144
+
+
+def test_all_runners_apply_camel_context_floor():
+    """Alle drei OASIS-Runner-Scripts (twitter/reddit/parallel) muessen
+    CAMELs ScoreBasedContextCreator-Default-Floor (8192) auf
+    LLM_CONTEXT_LIMIT hochziehen. Regression-Schutz dafuer, dass der
+    Patch nicht erneut nur in einem Subset der Runner laeuft."""
+    for relative_path in RUNNER_SCRIPTS:
+        text = (REPO_ROOT / relative_path).read_text()
+        assert (
+            "apply_camel_context_floor" in text
+        ), f"{relative_path}: apply_camel_context_floor() not invoked"
+
+
+def test_resolve_memory_token_limit_uses_substring_heuristic_for_unknown_models(monkeypatch):
+    """Bei Frontend-gewaehlten Modell-Strings, die nicht in
+    LLM_MODEL_CONTEXT_LIMITS stehen, soll _resolve_memory_token_limit
+    eine konservative Substring-Heuristik nutzen statt blind auf 262144
+    zu fallen. Gemini-3-Familien koennen 1M Tokens, gpt-oss/llama nur 128k."""
+    module = _load_module("agent_tools_heuristic_test", "backend/scripts/agent_tools.py")
+    monkeypatch.setenv("LLM_CONTEXT_LIMIT", "262144")
+    monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+
+    assert module._resolve_memory_token_limit("gemini-3-pro:cloud") >= 1_000_000
+    assert module._resolve_memory_token_limit("gemini-3-flash:cloud") >= 1_000_000
+    assert module._resolve_memory_token_limit("deepseek-v3.1:cloud") >= 131_072
+    assert module._resolve_memory_token_limit("qwen3-coder-next:cloud") >= 262_144
+    assert module._resolve_memory_token_limit("gpt-oss:120b-cloud") >= 131_072
+    assert module._resolve_memory_token_limit("some-unknown-model") == 262_144


### PR DESCRIPTION
## Symptom

```
WARNING - Context truncation performed: before=249603, after=8187, limit=8192
```

Trotz Modellen mit 256 k–1 M Context-Window (Gemini 3, DeepSeek, Qwen3-Coder, Claude 4 etc.) kappte CAMELs interner `ScoreBasedContextCreator` jeden Agent-Memory bei 8192 Tokens.

## Ursachen (drei Stellen)

1. **`run_parallel_simulation.py`** fehlte der SBCC-`__init__`-Floor-Patch, den `run_twitter_simulation.py` / `run_reddit_simulation.py` bereits hatten — Refactor-Lücke aus #266 / #269.
2. **`agent_tools.attach_tools_to_agents()`** patchte `creator._token_limit` nur, wenn Tools attached wurden. Tool-lose Persona-Workflows blieben bei 8192.
3. **`_resolve_memory_token_limit()`** fiel bei Frontend-gewählten Modell-Strings ohne env-Override blind auf `LLM_CONTEXT_LIMIT`, statt bekannte Modell-Familien zu erkennen.

## Fix

- **Zentraler Floor-Patch** in `backend/scripts/_sim_common.py::apply_camel_context_floor()` (idempotent). Alle drei Runner rufen ihn nach `install_max_tokens_warning_filter()` auf — Inline-Monkey-Patches in twitter/reddit ersetzt (DRY).
- **`enforce_memory_token_limit(agent_graph)`** in `agent_tools.py` zieht `creator._token_limit` pro Agent **unabhängig von attach_tools** nach. Wird von allen drei Runnern direkt nach `generate_*_agent_graph(...)` aufgerufen.
- **`_heuristic_context_limit()`**: Substring-Map für Modellfamilien (Gemini 3 → 1 M, Qwen3-Coder → 256 k, GPT-OSS / Llama 3.3 → 128 k, Claude 4 → 200 k usw.). Greift nur, wenn weder `Config.LLM_MODEL_CONTEXT_LIMITS` noch `LLM_MODEL_CONTEXT_LIMITS_JSON` einen exakten Match liefern.
- **`resolve_model_runtime_settings()`** in `run_parallel_simulation.py` nutzt dieselbe Heuristik.

## User-Override-Vorrang (unverändert)

1. `LLM_MODEL_CONTEXT_LIMITS_JSON` (env, höchste Priorität)
2. `Config.LLM_MODEL_CONTEXT_LIMITS`
3. Heuristik (`_heuristic_context_limit`)
4. `LLM_CONTEXT_LIMIT` (Default 262_144)

Cloud-Modelle (`*:cloud`) bekommen weiterhin **keinen** client-seitigen `num_ctx`-Override (Ollama-Cloud kapselt das serverseitig).

## Tests

- **Drive-by-Fix**: `_load_module()` in `tests/test_simulation_runtime.py` reparierte sys.path für relative Imports (war auf main schon rot seit #266).
- Neuer Test `test_enforce_memory_token_limit_without_tools` — Tool-unabhängiger Pfad.
- Neuer Test `test_all_runners_apply_camel_context_floor` — Regression-Schutz.
- Neuer Test `test_resolve_memory_token_limit_uses_substring_heuristic_for_unknown_models` — Modell-Familien-Heuristik.

```
tests/test_simulation_runtime.py + tests/services/ → 135 passed, 3 deselected
```

## Doku

`CLAUDE.md` "Verboten"-Liste erweitert: neue OASIS-/CAMEL-Runner-Skripte müssen `apply_camel_context_floor()` + `enforce_memory_token_limit()` aufrufen; hartkodierte `token_limit`-Defaults sind verboten — alles über `_resolve_memory_token_limit(model_name)`.

## Test plan

- [x] `pytest tests/test_simulation_runtime.py` grün
- [x] `pytest tests/services/` grün (keine Regression)
- [x] Keine neuen `ruff`-Errors (14 Errors auf main → 14 auf Branch)
- [ ] **Manuell zu prüfen**: Lokal eine Simulation mit `gemini-3-pro:cloud` o.ä. starten und Logs prüfen — der Linker `[context-patch] token_limit floor = 262144` sollte beim Start erscheinen, gefolgt von `[enforce_memory_token_limit] agent X: 8192 -> <limit> (model=...)` für jeden Agent, **und** die `Context truncation performed` Warning sollte nicht mehr bei 8192 kappen
- [ ] Gemini-Code-Assist-Findings sichten, HIGH/MEDIUM adressieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)