### PR TITLE
fix(storage): Vector-Index Dimension-Drift Drop+Recreate (#263, P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - Incident-Bericht zum Vector-Index Dimension-Drift vom 2026-05-04 angelegt: alte 2560-dim Indexe (qwen3-embedding) blieben nach OpenAI-Switch (1536-dim) bestehen, weil `CREATE VECTOR INDEX … IF NOT EXISTS` nur über den Namen matcht. Manueller Cleanup (Index-Drop + 316 Entity-Delete + 14 Graph-Delete + Container-Restart) ist dokumentiert; Code-Hardening folgt in Issue [#263](https://github.com/arn0ld87/agora/issues/263). Siehe [`docu/2026-05-04-vector-index-dimension-drift-incident.md`](docu/2026-05-04-vector-index-dimension-drift-incident.md).
 
 ### Fixed
+- Vector-Index Dimension-Drift: `_ensure_schema()` droppt+recreated Indexe bei Dimension-Mismatch (#263, P1).
 - Persona-Default-Branchenverteilung folgt Destatis-WZ-2008; IT-Anteil ≤ 12 %, ≥ 7 Branchen (#215).
 - bug(report): `plan_outline()` baut `ReportOutlineModel` mit `description`-Feld; Frontend-Zod-Validation wieder grün (Closes #274)
 - `test_add_progress_callback_sets_progress_detail_on_task_manager` (Slice 137-Followup): Wartet jetzt via `threading.Event` statt 50×0.05 s `time.sleep`-Loop auf den Background-Thread. Verhindert intermittente Failures unter CI-Last und gibt sofort frei, sobald `progress_detail`-Call durch ist. Gemini-MEDIUM auf #265.

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -109,14 +109,69 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
                 pass
             raise
 
+    # ----------------------------------------------------------------
+    # Vector-index dimension guard  (Issue #263)
+    # ----------------------------------------------------------------
+
+    _SHOW_INDEX_DIM_QUERY = (
+        "SHOW INDEXES YIELD name, options "
+        "WHERE name = $name "
+        "RETURN options.indexConfig.`vector.dimensions` AS dim"
+    )
+
+    def _ensure_vector_index_dim(self, session, index_name: str, expected_dim: int) -> None:
+        """Drop a vector index whose stored dimension differs from *expected_dim*.
+
+        Three cases:
+        - Index absent          → no-op (caller's CREATE will handle it).
+        - Index dim == expected → no-op.
+        - Index dim != expected → DROP + log warning; caller will re-CREATE.
+        """
+        result = session.run(self._SHOW_INDEX_DIM_QUERY, name=index_name)
+        row = result.single()
+        if row is None:
+            # Index does not exist yet.
+            return
+        stored_dim = row["dim"]
+        if stored_dim == expected_dim:
+            return
+        logger.warning(
+            "Vector index '%s' has dim=%s, expected_dim=%s -> dropping for recreation",
+            index_name,
+            stored_dim,
+            expected_dim,
+        )
+        session.run(f"DROP INDEX {index_name}")
+
+    _VECTOR_INDEX_NAMES = ("entity_embedding", "fact_embedding")
+
     def _ensure_schema(self):
-        """Create indexes and constraints if they don't exist."""
+        """Create indexes and constraints if they don't exist.
+
+        Vector indexes are checked for dimension-drift before the CREATE
+        statement runs.  If an index already exists with the wrong dimension
+        it is dropped first so the subsequent CREATE builds it correctly.
+        """
         with self._driver.session() as session:
             for query in neo4j_schema.ALL_SCHEMA_QUERIES:
+                # Before each vector-index CREATE, validate stored dimension.
+                for idx_name in self._VECTOR_INDEX_NAMES:
+                    if f"CREATE VECTOR INDEX {idx_name}" in query:
+                        try:
+                            self._ensure_vector_index_dim(
+                                session, idx_name, Config.VECTOR_DIM
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Vector index dimension check for '%s' failed: %s",
+                                idx_name,
+                                e,
+                            )
+                        break
                 try:
                     session.run(query)
                 except Exception as e:
-                    logger.warning(f"Schema query warning: {e}")
+                    logger.warning("Schema query warning: %s", e)
 
     # ----------------------------------------------------------------
     # Health-status properties

--- a/backend/tests/storage/test_vector_index_dim_drift.py
+++ b/backend/tests/storage/test_vector_index_dim_drift.py
@@ -1,0 +1,213 @@
+"""
+Tests for Vector-Index Dimension-Drift guard (Issue #263).
+
+Strategy: instantiate Neo4jStorage via ``object.__new__`` (same pattern as
+test_neo4j_resilience.py) to bypass the real driver and connectivity check,
+then inject a mock session and call ``_ensure_vector_index_dim`` /
+``_ensure_schema`` directly.
+
+Scenarios:
+  1. No index exists         → CREATE runs, no DROP.
+  2. Index dim mismatch      → DROP + CREATE runs.
+  3. Index dim matches       → no DROP, CREATE still runs (IF NOT EXISTS no-op).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.storage.neo4j_storage import Neo4jStorage
+from app.config import Config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_storage() -> Neo4jStorage:
+    """Return a Neo4jStorage shell with no real driver."""
+    inst = object.__new__(Neo4jStorage)
+    inst._is_connected = True
+    inst._last_error = None
+    inst._last_success_ts = None
+    inst._driver = MagicMock()
+    return inst
+
+
+def _mock_session_for_dim(existing_dim: int | None) -> MagicMock:
+    """Return a mock session whose SHOW INDEXES query returns *existing_dim*.
+
+    Pass ``None`` to simulate an absent index (``result.single()`` returns
+    ``None``).
+    """
+    session = MagicMock()
+    show_result = MagicMock()
+    if existing_dim is None:
+        show_result.single.return_value = None
+    else:
+        show_result.single.return_value = {"dim": existing_dim}
+    session.run.return_value = show_result
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _ensure_vector_index_dim
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureVectorIndexDim:
+    """Low-level tests for the private helper method."""
+
+    def test_no_index_no_drop(self):
+        """Szenario 1: Index existiert nicht → kein DROP."""
+        storage = _make_storage()
+        session = _mock_session_for_dim(None)
+
+        storage._ensure_vector_index_dim(session, "entity_embedding", 1536)
+
+        # session.run was called exactly once (the SHOW INDEXES query).
+        # No DROP should have been issued.
+        assert session.run.call_count == 1
+        for c in session.run.call_args_list:
+            assert "DROP" not in str(c).upper()
+
+    def test_dim_mismatch_triggers_drop(self):
+        """Szenario 2: Gespeicherte Dim ≠ Config.VECTOR_DIM → DROP INDEX."""
+        storage = _make_storage()
+        session = _mock_session_for_dim(2560)
+
+        storage._ensure_vector_index_dim(session, "entity_embedding", 1536)
+
+        # Two calls: SHOW INDEXES + DROP INDEX
+        assert session.run.call_count == 2
+        drop_call = session.run.call_args_list[1]
+        assert "DROP INDEX entity_embedding" in drop_call[0][0]
+
+    def test_dim_match_no_drop(self):
+        """Szenario 3: Gespeicherte Dim == Config.VECTOR_DIM → no-op."""
+        storage = _make_storage()
+        session = _mock_session_for_dim(1536)
+
+        storage._ensure_vector_index_dim(session, "entity_embedding", 1536)
+
+        # Only the SHOW INDEXES query, no DROP.
+        assert session.run.call_count == 1
+        for c in session.run.call_args_list:
+            assert "DROP" not in str(c).upper()
+
+    def test_warning_logged_on_mismatch(self):
+        """Bei Dimension-Mismatch muss ein Warning-Log erscheinen.
+
+        Die agora-Logger-Hierarchie hat ``propagate=False``, daher wird
+        ``logger.warning`` direkt gemockt statt ``caplog`` zu nutzen.
+        """
+        storage = _make_storage()
+        session = _mock_session_for_dim(2560)
+
+        with patch("app.storage.neo4j_storage.logger") as mock_logger:
+            storage._ensure_vector_index_dim(session, "fact_embedding", 1536)
+
+        mock_logger.warning.assert_called_once()
+        args = mock_logger.warning.call_args[0]
+        formatted = args[0] % args[1:]
+        assert "fact_embedding" in formatted
+        assert "2560" in formatted
+
+    def test_fact_embedding_drop(self):
+        """Szenario 2 gilt auch für fact_embedding."""
+        storage = _make_storage()
+        session = _mock_session_for_dim(768)
+
+        storage._ensure_vector_index_dim(session, "fact_embedding", 1536)
+
+        assert session.run.call_count == 2
+        drop_call = session.run.call_args_list[1]
+        assert "DROP INDEX fact_embedding" in drop_call[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Integration-level tests for _ensure_schema (mock driver)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureSchemaVectorIndexGuard:
+    """_ensure_schema muss die Dim-Guard-Methode vor jedem CREATE VECTOR INDEX
+    aufrufen und bei Mismatch den Drop durchführen."""
+
+    def _make_storage_with_session(self, session: MagicMock) -> Neo4jStorage:
+        storage = _make_storage()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=session)
+        ctx.__exit__ = MagicMock(return_value=False)
+        storage._driver.session.return_value = ctx
+        return storage
+
+    def test_schema_no_drop_when_no_index(self):
+        """Szenario 1 via _ensure_schema: kein Index vorhanden → normaler CREATE."""
+        # session.run: first two calls for SHOW INDEXES return "no row",
+        # remaining calls are the actual schema CREATE/fulltext queries.
+        session = MagicMock()
+        no_index_result = MagicMock()
+        no_index_result.single.return_value = None
+        # Make all session.run calls return the "no index" result by default
+        session.run.return_value = no_index_result
+
+        storage = self._make_storage_with_session(session)
+
+        with patch.object(Config, "VECTOR_DIM", 1536):
+            storage._ensure_schema()
+
+        call_args = [str(c) for c in session.run.call_args_list]
+        drop_calls = [a for a in call_args if "DROP" in a.upper()]
+        assert drop_calls == [], "Kein DROP erwartet wenn kein Index existiert"
+
+    def test_schema_drops_mismatched_entity_index(self):
+        """Szenario 2: entity_embedding hat dim=2560, Config.VECTOR_DIM=1536 → DROP."""
+        session = MagicMock()
+
+        def run_side_effect(query, **kwargs):
+            result = MagicMock()
+            # First SHOW INDEXES (entity_embedding) → dim=2560
+            if "SHOW INDEXES" in query and kwargs.get("name") == "entity_embedding":
+                result.single.return_value = {"dim": 2560}
+            # Second SHOW INDEXES (fact_embedding) → absent
+            elif "SHOW INDEXES" in query and kwargs.get("name") == "fact_embedding":
+                result.single.return_value = None
+            else:
+                result.single.return_value = None
+            return result
+
+        session.run.side_effect = run_side_effect
+
+        storage = self._make_storage_with_session(session)
+
+        with patch.object(Config, "VECTOR_DIM", 1536):
+            storage._ensure_schema()
+
+        call_args = [str(c) for c in session.run.call_args_list]
+        drop_calls = [a for a in call_args if "DROP INDEX entity_embedding" in a]
+        assert len(drop_calls) == 1, "Genau ein DROP INDEX entity_embedding erwartet"
+        # fact_embedding must not be dropped (it was absent)
+        fact_drop_calls = [a for a in call_args if "DROP INDEX fact_embedding" in a]
+        assert fact_drop_calls == []
+
+    def test_schema_no_drop_when_dim_matches(self):
+        """Szenario 3: entity_embedding + fact_embedding dim=1536, Config=1536 → no DROP."""
+        session = MagicMock()
+
+        def run_side_effect(query, **kwargs):
+            result = MagicMock()
+            if "SHOW INDEXES" in query:
+                result.single.return_value = {"dim": 1536}
+            else:
+                result.single.return_value = None
+            return result
+
+        session.run.side_effect = run_side_effect
+
+        storage = self._make_storage_with_session(session)
+
+        with patch.object(Config, "VECTOR_DIM", 1536):
+            storage._ensure_schema()
+
+        call_args = [str(c) for c in session.run.call_args_list]
+        drop_calls = [a for a in call_args if "DROP" in a.upper()]
+        assert drop_calls == [], "Kein DROP erwartet wenn Dim übereinstimmt"

--- a/docu/2026-05-04-263-vector-index-dim-drift-arbeitsprotokoll.md
+++ b/docu/2026-05-04-263-vector-index-dim-drift-arbeitsprotokoll.md
@@ -1,0 +1,140 @@
+# Arbeitsprotokoll: Vector-Index Dimension-Drift Fix (Issue #263)
+
+**Datum:** 2026-05-04
+**Branch:** feat/task-263-vector-index-dim-drift
+**Sub-Slice:** A (Backend-Fix, kein Frontend, kein Admin-Endpoint)
+**Priorität:** P1
+
+---
+
+## Problem-Kurzbeschreibung
+
+`backend/app/storage/neo4j_schema.py` legt die Vector-Indexe mit
+`CREATE VECTOR INDEX … IF NOT EXISTS` an. Wenn ein Index bereits existiert —
+auch mit falscher Dimension — wird die `CREATE`-Anweisung von Neo4j still
+ignoriert. Beim Switch von `qwen3-embedding:4b` (2560 dim) auf
+`text-embedding-3-small` (1536 dim) am 2026-05-04 führte das zu einem
+Dimension-Mismatch: der Neo4j-Index hatte weiterhin 2560 Dimensionen, aber
+die Embeddings waren 1536-dimensional. Das erzwang einen manuellen Cleanup
+per Cypher-Shell.
+
+Die Falle ist dokumentiert in `docu/2026-05-04-vector-index-dimension-drift-incident.md`.
+
+---
+
+## Gelöster Ansatz
+
+### Private Methode `_ensure_vector_index_dim`
+
+In `Neo4jStorage` wurde eine private Hilfsmethode eingeführt:
+
+```python
+def _ensure_vector_index_dim(self, session, index_name: str, expected_dim: int) -> None
+```
+
+Sie führt folgende Cypher-Query aus:
+
+```cypher
+SHOW INDEXES YIELD name, options
+WHERE name = $name
+RETURN options.indexConfig.`vector.dimensions` AS dim
+```
+
+Drei Fälle:
+- Index existiert nicht → no-op (nachfolgende `CREATE … IF NOT EXISTS` übernimmt).
+- Gespeicherte Dim == `expected_dim` → no-op.
+- Gespeicherte Dim != `expected_dim` → `DROP INDEX <name>` + Warning-Log;
+  die nachfolgende `CREATE`-Anweisung legt den Index mit korrekter Dimension neu an.
+
+### Geänderte `_ensure_schema`
+
+`_ensure_schema` ruft `_ensure_vector_index_dim` vor den beiden
+`CREATE VECTOR INDEX`-Queries auf:
+
+- vor `CREATE VECTOR INDEX entity_embedding`
+- vor `CREATE VECTOR INDEX fact_embedding`
+
+Der Check ist in `try/except` gekapselt, damit ein Fehler im Check-Schritt
+(z. B. Neo4j-Version ohne SHOW INDEXES Yield) den normalen Schema-Aufbau
+nicht blockiert.
+
+---
+
+## Geänderte Dateien
+
+| Datei | Typ | Beschreibung |
+|---|---|---|
+| `backend/app/storage/neo4j_storage.py` | Geändert | `_ensure_vector_index_dim` + angepasste `_ensure_schema` |
+| `backend/tests/storage/__init__.py` | Neu | Package-Marker für Subdirectory |
+| `backend/tests/storage/test_vector_index_dim_drift.py` | Neu | 8 Tests (Unit + Schema-Level) |
+| `docu/2026-05-04-263-vector-index-dim-drift-arbeitsprotokoll.md` | Neu | Dieses Dokument |
+| `CHANGELOG.md` | Geändert | `### Fixed`-Eintrag unter `[Unreleased]` |
+
+---
+
+## Neue / geänderte Tests
+
+**Datei:** `backend/tests/storage/test_vector_index_dim_drift.py`
+
+### Klasse `TestEnsureVectorIndexDim` (Unit-Tests für die Helper-Methode)
+
+| Test | Szenario |
+|---|---|
+| `test_no_index_no_drop` | Szenario 1: kein Index → kein DROP |
+| `test_dim_mismatch_triggers_drop` | Szenario 2: dim=2560, Config=1536 → DROP |
+| `test_dim_match_no_drop` | Szenario 3: dim=1536, Config=1536 → kein DROP |
+| `test_warning_logged_on_mismatch` | Bei Mismatch wird `logger.warning` aufgerufen |
+| `test_fact_embedding_drop` | Szenario 2 für `fact_embedding` |
+
+### Klasse `TestEnsureSchemaVectorIndexGuard` (via `_ensure_schema`)
+
+| Test | Szenario |
+|---|---|
+| `test_schema_no_drop_when_no_index` | Kein Index vorhanden → normaler CREATE, kein DROP |
+| `test_schema_drops_mismatched_entity_index` | entity_embedding dim=2560 → DROP |
+| `test_schema_no_drop_when_dim_matches` | Beide Indexe dim=1536 → kein DROP |
+
+Alle 8 Tests laufen ohne echten Neo4j (Mock-Driver via `object.__new__`).
+
+---
+
+## Manuelle Verifikation
+
+Die folgende Cypher-Query entspricht dem, was `_ensure_vector_index_dim` ausführt
+und kann gegen eine laufende Neo4j-Instanz geprüft werden:
+
+```cypher
+SHOW INDEXES YIELD name, options
+WHERE name = 'entity_embedding'
+RETURN options.indexConfig.`vector.dimensions` AS dim
+```
+
+Im Mismatch-Fall wird ausgeführt:
+
+```cypher
+DROP INDEX entity_embedding
+```
+
+Danach erzeugt `_ensure_schema` durch die `CREATE VECTOR INDEX entity_embedding IF NOT EXISTS`-Query
+den Index mit der in `Config.VECTOR_DIM` konfigurierten Dimension neu.
+
+---
+
+## Verbleibendes Risiko
+
+- **Index-Drop blockiert bei aktiven Queries:** Ein `DROP INDEX` während einer
+  laufenden Vektorsimilarität-Suche kann in Neo4j 5.x zu einem kurzen
+  Blockierungszustand führen. Der Drop passiert beim Anwendungsstart
+  (`_ensure_schema` wird im Konstruktor aufgerufen), bevor der Flask-Server
+  Anfragen annimmt, was das Risiko in der Praxis minimiert. Im Cluster- oder
+  Hot-Reload-Szenario (gevent) sollte geprüft werden, ob mehrere Prozesse
+  gleichzeitig `_ensure_schema` aufrufen.
+- **Knoten mit alter Embedding-Dim:** Bestehende `Entity`- und `RELATION`-Knoten,
+  die mit der alten Dimension eingebettet wurden, bleiben im Graph. Der
+  Similarity-Search liefert für diese Knoten keine sinnvollen Ergebnisse.
+  Ein Re-Embed-Schritt (Admin-Endpoint `POST /api/admin/embeddings/reindex`)
+  ist als Folge-Slice vorgesehen und ist explizit **nicht** Teil dieses Fix.
+- **Neo4j Community Edition ohne SHOW INDEXES YIELD-Support:** Ältere Neo4j-
+  Versionen (< 4.4) kennen `SHOW INDEXES YIELD` nicht. Der Check ist in
+  `try/except` gekapselt, so dass er im Fehlerfall übersprungen wird und der
+  bisherige Verhalten erhalten bleibt.


### PR DESCRIPTION
## Summary

- **P1 Backend-Bug-Fix:** `_ensure_schema()` prüft pro Vector-Index die tatsächliche `vector.dimensions` per `SHOW INDEXES YIELD options` und droppt+recreates bei Mismatch.
- Helper `_ensure_vector_index_dim()` für `entity_embedding` und `fact_embedding` wiederverwendbar.
- Neo4j < 4.4 (ohne `SHOW INDEXES YIELD`) per `try/except` gekapselt — Fallback auf bisheriges Verhalten.
- 8 neue Pytest-Cases (Mock-Driver) decken kein-Index, Mismatch-Drop, Match-noop, Warning-Log, `fact_embedding`-Drop.

## Closes

Closes #263

## Test plan

- [x] `uv run pytest tests/storage/test_vector_index_dim_drift.py -x -v` → 8 passed
- [x] `uv run pytest tests/contracts/ -x -v` → 62 passed
- [x] `uv run pytest -x -q` → 1437 passed, 9 skipped
- [x] `uv run ruff check app/ tests/` → clean
- [x] `uv run mypy app/storage/neo4j_storage.py` → clean
- [x] `git diff --exit-code schemas/` → no drift
- [ ] Gemini-Code-Assist Findings sichten + adressieren

## Risiken (im Commit dokumentiert)

- Index-Drop blockiert kurz bei aktiven Vektor-Queries.
- Bei zukünftiger gevent `--preload`-Aktivierung: parallele `_ensure_schema`-Aufrufe könnten konkurrieren — Pool-Fork-Safety vorher prüfen (CLAUDE.md Hot-Spots).
- Bestehende Knoten mit alter Embedding-Dim bleiben im Graph; Daten-Cleanup als Folge-Slice (Admin-Endpoint `/api/admin/embeddings/reindex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)