### PR TITLE
fix(auth): /api/logs/stream auf signed-ticket-Auth migrieren (F2.2)

### DIFF
--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -25,6 +25,7 @@ from flask import Response, request, stream_with_context
 
 from . import logs_bp
 from ..utils.api_responses import handle_api_errors, json_success
+from ..utils.auth import allow_ticket_auth
 from ..utils.logger import LOG_DIR, get_logger
 
 logger = get_logger('agora.api.logs')
@@ -164,6 +165,7 @@ def get_logs():
 
 
 @logs_bp.route('/stream', methods=['GET'])
+@allow_ticket_auth(lambda: "logs:stream", single_use=False)
 def stream_logs():
     """SSE-Stream auf neue Zeilen ab dem aktuellen Datei-Offset.
 

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -1,5 +1,5 @@
 // Issue #132 — Backend-Log-Viewer-API.
-import api from './index'
+import api, { getAgoraToken } from './index'
 
 export interface FetchLogsParams {
   tail?: number
@@ -26,22 +26,24 @@ export function fetchLogs({ tail = 200, level = null }: FetchLogsParams = {}): P
   return api.get('/api/logs', { params })
 }
 
-export function logsStreamUrl(
-  token: string | null | undefined,
+export async function buildLogsStreamUrl(
   level: string | null = null,
   offset: number | null = null
-): string {
-  // EventSource kann keine Header setzen → Token via ?token=. SSE-Pfad
-  // entspricht den anderen Stream-Endpoints (vgl. simulation_stream).
-  // ``offset`` wird vom Tail-Endpunkt geliefert und sorgt dafür, dass
-  // der Stream genau dort weiterläuft — ohne ihn gehen Log-Zeilen
-  // verloren, die zwischen Tail-Antwort und Stream-Connect geschrieben
-  // werden (PR #146-Review).
+): Promise<string> {
+  // EventSource kann keine Custom-Header setzen — Auth läuft via signed
+  // ticket (?ticket=…, scope "logs:stream"), analog zu buildSimulationStreamUrl.
+  // Der offset sorgt dafür, dass der Stream genau dort weiterläuft wo
+  // der Tail-Endpunkt aufgehört hat (verhindert Zeilen-Verlust, PR #146).
   const u = new URL('/api/logs/stream', window.location.origin)
-  if (token) u.searchParams.set('token', token)
   if (level) u.searchParams.set('level', level)
   if (Number.isInteger(offset) && offset !== null && offset >= 0) {
     u.searchParams.set('offset', String(offset))
   }
+  if (!getAgoraToken()) return u.toString()
+  try {
+    const res = await api.post('/api/auth/ticket', { scope: 'logs:stream', ttl_seconds: 60 })
+    const ticket = (res as unknown as { data?: { ticket?: string } })?.data?.ticket
+    if (ticket) u.searchParams.set('ticket', ticket)
+  } catch { /* open-mode or ticket-endpoint not reachable — proceed without ticket */ }
   return u.toString()
 }

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -46,8 +46,7 @@
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { fetchLogs, logsStreamUrl } from '../api/logs'
-import { getAgoraToken } from '../api'
+import { fetchLogs, buildLogsStreamUrl } from '../api/logs'
 import { useStickyScroll } from '../composables/useStickyScroll'
 import StickyScrollBanner from './ui/StickyScrollBanner.vue'
 
@@ -110,12 +109,11 @@ function appendLine(line, { bypassPause = false } = {}) {
   nextTick(() => sticky.markAppended(1))
 }
 
-function startStream() {
+async function startStream() {
   stopStream()
   reconnectAttempts = 0
   streamFailed.value = false
-  const token = getAgoraToken?.() || ''
-  const url = logsStreamUrl(token, level.value || null, lastOffset)
+  const url = await buildLogsStreamUrl(level.value || null, lastOffset)
   try {
     _eventSource = new EventSource(url)
     _eventSource.onmessage = (e) => {

--- a/frontend/src/components/__tests__/LogDrawer.spec.ts
+++ b/frontend/src/components/__tests__/LogDrawer.spec.ts
@@ -28,11 +28,11 @@ Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, wri
 // --- Mock API-Abhängigkeiten ---
 vi.mock('../../api/logs', () => ({
   fetchLogs: vi.fn().mockResolvedValue({ data: { success: true, data: { lines: [], offset: 0 } } }),
-  logsStreamUrl: vi.fn().mockReturnValue('http://localhost/api/logs/stream'),
+  buildLogsStreamUrl: vi.fn().mockResolvedValue('http://localhost/api/logs/stream'),
 }))
 
 vi.mock('../../api/index', () => ({
-  default: { get: vi.fn().mockResolvedValue({ data: {} }) },
+  default: { get: vi.fn().mockResolvedValue({ data: {} }), post: vi.fn().mockResolvedValue({ data: { ticket: 'mock-ticket' } }) },
   getAgoraToken: vi.fn().mockReturnValue('test-token'),
 }))
 


### PR DESCRIPTION
## Problem

`/api/logs/stream` wurde in Prod mit `?token=` angesprochen. Seit F2.2 blockiert `utils/auth.py::_extract_token()` genau das im Non-Debug-Modus und loggt:

```
auth: ?token= *** rejected in production on /api/logs/stream — use signed tickets
```

Zusätzlich fehlte `@allow_ticket_auth` am `stream_logs`-View, sodass auch `?ticket=` nicht akzeptiert wurde.

## Fix

- `backend/app/api/logs.py`: `@allow_ticket_auth(lambda: "logs:stream", single_use=False)` hinzugefügt (analog zu `simulation_stream`)
- `frontend/src/api/logs.ts`: `logsStreamUrl(token)` → `buildLogsStreamUrl()` (async, holt Ticket via `POST /api/auth/ticket`)
- `frontend/src/components/LogDrawer.vue`: `startStream()` async, ruft `buildLogsStreamUrl()` auf
- `frontend/src/components/__tests__/LogDrawer.spec.ts`: Mock auf `buildLogsStreamUrl` / `mockResolvedValue` aktualisiert

## Test plan

- [ ] 170 Vitest-Tests grün (`npm test -- --run`)
- [ ] `ruff check app/api/logs.py` clean
- [ ] In Prod kein `?token=`-Fehler mehr in `docker logs agora`
- [ ] LogDrawer öffnet SSE-Verbindung erfolgreich via `?ticket=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)