### PR TITLE
fix(auth): Gemini-Followup auf PR #287 — Race Condition + Docstring

### DIFF
--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -169,10 +169,11 @@ def get_logs():
 def stream_logs():
     """SSE-Stream auf neue Zeilen ab dem aktuellen Datei-Offset.
 
-    Auth-Sonderregel: Der Standard-Blueprint-Guard prüft den Header bzw.
-    den ``?token=`` Param schon vor dieser View. Da Browsers bei
-    ``EventSource`` keine Custom-Header setzen können, wird der Token via
-    ``?token=`` mitgegeben (analog zu :mod:`api.simulation_stream`).
+    Auth-Sonderregel: Da ``EventSource`` keine Custom-Header setzen kann,
+    läuft die Auth über ein kurzlebiges signiertes Ticket (``?ticket=``,
+    Scope ``logs:stream``). Der Blueprint-Guard akzeptiert es via
+    ``@allow_ticket_auth`` (``single_use=False``, damit Reconnects
+    innerhalb der TTL ohne neues Ticket funktionieren).
 
     Reconnect-Semantik (RFC 8895 §9.2): Jede Datenzeile trägt ein
     ``id: <byte-offset-nach-zeile>``-Frame. Der Browser sendet bei einem

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -83,6 +83,7 @@ const filteredLines = computed(() => {
 })
 
 let _eventSource = null
+let _streamGeneration = 0
 
 async function reload() {
   try {
@@ -113,7 +114,9 @@ async function startStream() {
   stopStream()
   reconnectAttempts = 0
   streamFailed.value = false
+  const generation = ++_streamGeneration
   const url = await buildLogsStreamUrl(level.value || null, lastOffset)
+  if (generation !== _streamGeneration) return
   try {
     _eventSource = new EventSource(url)
     _eventSource.onmessage = (e) => {


### PR DESCRIPTION
## Gemini HIGH/MEDIUM Findings aus PR #287

### HIGH — Race Condition in `startStream()`

`startStream()` ist async. Bei schnellem Level-Wechsel konnte ein veralteter `await buildLogsStreamUrl(...)` nach einem neueren `startStream()`-Aufruf noch eine `EventSource` öffnen.

**Fix:** `_streamGeneration`-Counter — jeder `startStream()`-Aufruf inkrementiert den Counter. Nach dem `await` wird abgebrochen wenn der Counter weitergeschaltet hat.

### MEDIUM — Docstring `stream_logs()` veraltet

Docstring erwähnte noch `?token=` — auf `?ticket=` / `logs:stream`-Scope aktualisiert.

## Test plan
- [x] 170/170 Vitest-Tests grün
- [ ] In Prod kein `?token=`-Fehler mehr nach Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)