### PR TITLE
fix(ci): stabilize prod-proxy smoke for PR #290 Docker failures

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -147,9 +147,11 @@ jobs:
         # erhalten, daher braucht der Smoke-Test hier eine explizit beschreibbare
         # uploads-Registry auf dem Runner.
         run: |
-          mkdir -p backend/uploads/run_registry
+          mkdir -p backend/uploads/{run_registry,simulations,reports,projects}
           command -v setfacl >/dev/null 2>&1 || { echo "::error::setfacl fehlt auf dem Runner"; exit 1; }
-          setfacl -m u:1000:rwx backend/uploads backend/uploads/run_registry
+          # Zugriff auf bestehende Verzeichnisse und Vererbung für neu erzeugte Unterordner
+          setfacl -Rm  u:1000:rwx backend/uploads
+          setfacl -Rdm u:1000:rwx backend/uploads
 
       - name: Compose-Stack starten
         # Kein --build: das Image ist bereits geladen (docker load oben).

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -82,7 +82,7 @@ check "name->id Lookup im Service" \
 echo
 echo "Diagnose-Run (3 letzte Sims):"
 docker compose exec -T agora uv run --project backend \
-  python backend/scripts/diagnose_metric_snapshot.py --limit 3 --no-write 2>&1 | tail -10
+  python backend/scripts/diagnose_metric_snapshot.py --limit 3 --no-write 2>&1 | tail -10 || true
 
 echo
 echo "Result: $ok ok, $fail fail"


### PR DESCRIPTION
### Motivation
- CI smoke was intermittently failing with a `PermissionError` because the runner-owned bind-mounts under `backend/uploads` were not fully prepared for the in-container UID (1000) and runtime-created subfolders could become unwritable. 
- The deploy verifier could abort a successful smoke in fresh environments when `diagnose_metric_snapshot.py` returned non-zero due to no simulation runs.

### Description
- `.github/workflows/docker-image.yml`: create all known upload subdirectories (`run_registry`, `simulations`, `reports`, `projects`) on the runner and apply recursive access and default ACLs (`setfacl -Rm u:1000:rwx backend/uploads` and `setfacl -Rdm u:1000:rwx backend/uploads`) so newly created nested dirs inherit write permission for container UID 1000. 
- `scripts/verify-deploy.sh`: make the diagnostic pipeline tolerant of empty simulation stores by adding `|| true` to the `diagnose_metric_snapshot.py` call so a diagnostic non-zero exit does not abort the overall verification script.

### Testing
- Local syntax check `bash -n scripts/verify-deploy.sh` was run and succeeded. 
- Diff and changes were reviewed locally (`git diff`) before committing; the CI smoke job previously reported `Smoke-Test Reverse-Proxy-Stack` failure and this PR targets that failure (CI run not re-triggered here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab66bf69c8328a4618c261c4f7d38)