### PR TITLE
fix(frontend): restore lint for Step2 modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - Frontend-Vokabular und README synchronisiert: Knoten→Entitäten, Kanten→Beziehungen, Entitätstypen→Attribute (Sub-Slice 43). Tagline auf Hybrid-Wording „lokal oder Cloud" aktualisiert. Tool-Call-USP („Agenten halluzinieren nicht") als Differenzierungsmerkmal in step3.sub und neuem home.differentiators-Block ergänzt.
 
 ### Fixed
+- **Frontend-CI:** Vue-Template-`as`-Casts in `AddPersonaModal.vue` und `PersonaDetailModal.vue` durch typisierte Event-Handler ersetzt; `npm run lint` ist wieder grün.
 - **`useSimulationPrepare`:** `fetchProfilesRealtime` als öffentliche Methode exposen — beseitigt ReferenceError beim Hinzufügen/Löschen von Personas in Step2EnvSetup (Sub-Slice 36, Closes #292, Regression aus Sub-Slice 34)
 
 ### Added

--- a/frontend/src/components/step2/AddPersonaModal.vue
+++ b/frontend/src/components/step2/AddPersonaModal.vue
@@ -45,6 +45,26 @@ function close() {
 function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaForm[K]) {
   emit('update:persona', { ...props.persona, [key]: value })
 }
+
+function inputValue(event: Event): string {
+  return (event.target as HTMLInputElement).value
+}
+
+function textareaValue(event: Event): string {
+  return (event.target as HTMLTextAreaElement).value
+}
+
+function updateAge(event: Event) {
+  const value = inputValue(event)
+  updateField('age', value === '' ? null : Number(value))
+}
+
+function updateGender(event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  if (value === 'other' || value === 'female' || value === 'male') {
+    updateField('gender', value)
+  }
+}
 </script>
 
 <template>
@@ -63,7 +83,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.username') }} *</span>
           <input
             :value="persona.username"
-            @input="updateField('username', ($event.target as HTMLInputElement).value)"
+            @input="updateField('username', inputValue($event))"
             type="text"
             :placeholder="t('step2.addPersona.placeholders.username')"
           />
@@ -72,7 +92,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.name') }}</span>
           <input
             :value="persona.name"
-            @input="updateField('name', ($event.target as HTMLInputElement).value)"
+            @input="updateField('name', inputValue($event))"
             type="text"
             :placeholder="t('step2.addPersona.placeholders.name')"
           />
@@ -81,7 +101,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.bio') }}</span>
           <input
             :value="persona.bio"
-            @input="updateField('bio', ($event.target as HTMLInputElement).value)"
+            @input="updateField('bio', inputValue($event))"
             type="text"
             maxlength="150"
             :placeholder="t('step2.addPersona.placeholders.bio')"
@@ -91,7 +111,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.profession') }}</span>
           <input
             :value="persona.profession"
-            @input="updateField('profession', ($event.target as HTMLInputElement).value)"
+            @input="updateField('profession', inputValue($event))"
             type="text"
             :placeholder="t('step2.addPersona.placeholders.profession')"
           />
@@ -100,7 +120,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.country') }}</span>
           <input
             :value="persona.country"
-            @input="updateField('country', ($event.target as HTMLInputElement).value)"
+            @input="updateField('country', inputValue($event))"
             type="text"
             maxlength="4"
             :placeholder="t('step2.addPersona.placeholders.country')"
@@ -110,7 +130,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.age') }}</span>
           <input
             :value="persona.age ?? ''"
-            @input="updateField('age', ($event.target as HTMLInputElement).value === '' ? null : Number(($event.target as HTMLInputElement).value))"
+            @input="updateAge"
             type="number"
             min="15"
             max="99"
@@ -120,7 +140,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.gender') }}</span>
           <select
             :value="persona.gender"
-            @change="updateField('gender', ($event.target as HTMLSelectElement).value as NewPersonaForm['gender'])"
+            @change="updateGender"
           >
             <option value="other">other</option>
             <option value="female">female</option>
@@ -131,7 +151,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.mbti') }}</span>
           <input
             :value="persona.mbti"
-            @input="updateField('mbti', ($event.target as HTMLInputElement).value)"
+            @input="updateField('mbti', inputValue($event))"
             type="text"
             maxlength="4"
             placeholder="INTJ"
@@ -141,7 +161,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.topics') }}</span>
           <input
             :value="persona.interested_topics"
-            @input="updateField('interested_topics', ($event.target as HTMLInputElement).value)"
+            @input="updateField('interested_topics', inputValue($event))"
             type="text"
             :placeholder="t('step2.addPersona.placeholders.topics')"
           />
@@ -150,7 +170,7 @@ function updateField<K extends keyof NewPersonaForm>(key: K, value: NewPersonaFo
           <span>{{ t('step2.addPersona.fields.persona') }}</span>
           <textarea
             :value="persona.persona"
-            @input="updateField('persona', ($event.target as HTMLTextAreaElement).value)"
+            @input="updateField('persona', textareaValue($event))"
             rows="6"
             :placeholder="t('step2.addPersona.placeholders.persona')"
           />

--- a/frontend/src/components/step2/PersonaDetailModal.vue
+++ b/frontend/src/components/step2/PersonaDetailModal.vue
@@ -69,6 +69,27 @@ function updateEditField<K extends keyof EditableProfile>(key: K, value: Editabl
   if (!props.editingProfile) return
   emit('update:editingProfile', { ...props.editingProfile, [key]: value })
 }
+
+function inputValue(event: Event): string {
+  return (event.target as HTMLInputElement).value
+}
+
+function textareaValue(event: Event): string {
+  return (event.target as HTMLTextAreaElement).value
+}
+
+function updateRegenerateHint(event: Event) {
+  emit('update:regenerateHint', inputValue(event))
+}
+
+function updateEditAge(event: Event) {
+  const value = inputValue(event)
+  updateEditField('age', value === '' ? null : Number(value))
+}
+
+function updateEditGender(event: Event) {
+  updateEditField('gender', (event.target as HTMLSelectElement).value)
+}
 </script>
 
 <template>
@@ -133,7 +154,7 @@ function updateEditField<K extends keyof EditableProfile>(key: K, value: Editabl
       <div v-if="!editingProfile" class="regenerate-hint-row">
         <input
           :value="regenerateHint"
-          @input="emit('update:regenerateHint', ($event.target as HTMLInputElement).value)"
+          @input="updateRegenerateHint"
           type="text"
           class="regenerate-hint-input"
           :placeholder="t('step2.persona.regenerateHint')"
@@ -186,27 +207,27 @@ function updateEditField<K extends keyof EditableProfile>(key: K, value: Editabl
       <div v-else class="form-grid">
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.displayName') }}</span>
-          <input :value="editingProfile.name" @input="updateEditField('name', ($event.target as HTMLInputElement).value)" type="text" />
+          <input :value="editingProfile.name" @input="updateEditField('name', inputValue($event))" type="text" />
         </label>
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.profession') }}</span>
-          <input :value="editingProfile.profession" @input="updateEditField('profession', ($event.target as HTMLInputElement).value)" type="text" />
+          <input :value="editingProfile.profession" @input="updateEditField('profession', inputValue($event))" type="text" />
         </label>
         <label class="form-row form-row--wide">
           <span>{{ t('step2.detailModal.fields.bioShort') }}</span>
-          <input :value="editingProfile.bio" @input="updateEditField('bio', ($event.target as HTMLInputElement).value)" type="text" maxlength="200" />
+          <input :value="editingProfile.bio" @input="updateEditField('bio', inputValue($event))" type="text" maxlength="200" />
         </label>
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.country') }}</span>
-          <input :value="editingProfile.country" @input="updateEditField('country', ($event.target as HTMLInputElement).value)" type="text" maxlength="4" />
+          <input :value="editingProfile.country" @input="updateEditField('country', inputValue($event))" type="text" maxlength="4" />
         </label>
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.age') }}</span>
-          <input :value="editingProfile.age ?? ''" @input="updateEditField('age', Number(($event.target as HTMLInputElement).value) || null)" type="number" min="15" max="99" />
+          <input :value="editingProfile.age ?? ''" @input="updateEditAge" type="number" min="15" max="99" />
         </label>
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.gender') }}</span>
-          <select :value="editingProfile.gender" @change="updateEditField('gender', ($event.target as HTMLSelectElement).value)">
+          <select :value="editingProfile.gender" @change="updateEditGender">
             <option value="other">other</option>
             <option value="female">female</option>
             <option value="male">male</option>
@@ -214,15 +235,15 @@ function updateEditField<K extends keyof EditableProfile>(key: K, value: Editabl
         </label>
         <label class="form-row">
           <span>{{ t('step2.detailModal.fields.mbti') }}</span>
-          <input :value="editingProfile.mbti" @input="updateEditField('mbti', ($event.target as HTMLInputElement).value)" type="text" maxlength="4" />
+          <input :value="editingProfile.mbti" @input="updateEditField('mbti', inputValue($event))" type="text" maxlength="4" />
         </label>
         <label class="form-row form-row--wide">
           <span>{{ t('step2.detailModal.fields.topicsCsv') }}</span>
-          <input :value="editingProfile.interested_topics" @input="updateEditField('interested_topics', ($event.target as HTMLInputElement).value)" type="text" />
+          <input :value="editingProfile.interested_topics" @input="updateEditField('interested_topics', inputValue($event))" type="text" />
         </label>
         <label class="form-row form-row--wide">
           <span>{{ t('step2.detailModal.fields.personaLong') }}</span>
-          <textarea :value="editingProfile.persona" @input="updateEditField('persona', ($event.target as HTMLTextAreaElement).value)" rows="6"></textarea>
+          <textarea :value="editingProfile.persona" @input="updateEditField('persona', textareaValue($event))" rows="6"></textarea>
         </label>
       </div>
     </div>


### PR DESCRIPTION
## Motivation
- Frontend-CI is currently red on `main` and on the open Docker/CI PRs because Vue template expressions in `AddPersonaModal.vue` and `PersonaDetailModal.vue` use TypeScript `as` casts that ESLint reports as `vue/no-parsing-error`.
- This is a small unblocker PR so the Docker/prod-smoke PRs can be evaluated against a green frontend baseline.

## Änderungen
- Moved DOM event target casts out of Vue templates into typed `<script setup lang="ts">` handlers.
- Kept the existing emitted payloads and UI behavior unchanged.
- Updated `CHANGELOG.md` under `[Unreleased]`.

Contract-/Schema-Änderungen: keine.
Frontend-i18n-Änderungen: keine.

## Tests
- `cd frontend && npm run lint` — passed.
- `cd frontend && npm test -- --run src/components/step2/__tests__/AddPersonaModal.spec.ts src/components/step2/__tests__/PersonaDetailModal.spec.ts` — 2 files / 22 tests passed.
- `cd frontend && npm run check` — passed: `vue-tsc --noEmit`, 43 spec files / 449 tests with coverage, production build.

## Risiken / Out of Scope
- Low risk: handler extraction only; no API, contract, schema, or i18n behavior changed.
- Out of scope: Docker/prod-proxy smoke failures in #290/#293/#294.
- Out of scope: stale duplicate branches #293/#294 deleting recent Step2 refactor files.

## Verifikation
- [x] Removes all template `as` casts from the two failing Step2 modal components.
- [x] `npm run lint` no longer reports `vue/no-parsing-error` for these files.
- [x] Existing modal tests still pass.
- [x] Full frontend check passes locally.

## Follow-ups
- Rebase/replace #293/#294 after this lands; their current diffs are stale and include unrelated deletions from recent Step2 refactor work.
- Continue the prod-proxy-smoke fix separately, without `|| true` masking diagnostics.
