### PR TITLE
fix(auth): rate limit ticket issuance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ FLASK_DEBUG=false
 # Token mit `python -c "import secrets; print(secrets.token_urlsafe(32))"` erzeugen.
 # AGORA_AUTH_TOKEN=
 
+# App-seitiges Fixed-Window-Limit fuer Signed-Ticket-Issuance.
+# Defaults: 60 Requests pro 60 Sekunden und Remote-Adresse.
+AGORA_TICKET_RATE_LIMIT_MAX=60
+AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS=60
+
 # Opt-out für offene Lab-Setups. Nur setzen, wenn der Endpunkt bewusst
 # unauthentifiziert sein soll (z.B. lokales Klassenraum-Demo). Niemals in Prod.
 # AGORA_ALLOW_ANONYMOUS=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - **`useSimulationPrepare`:** `fetchProfilesRealtime` als öffentliche Methode exposen — beseitigt ReferenceError beim Hinzufügen/Löschen von Personas in Step2EnvSetup (Sub-Slice 36, Closes #292, Regression aus Sub-Slice 34)
 
 ### Added
+- **M10.5 Security:** `POST /api/auth/ticket` bekommt ein app-seitiges Fixed-Window-Rate-Limit (Default 60 Requests / 60 s pro Remote-Adresse) mit `429`-JSON-Envelope und `Retry-After`-Header. Konfiguration via `AGORA_TICKET_RATE_LIMIT_MAX` und `AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS`; Werte `<= 0` deaktivieren den Limiter fuer lokale Experimente. Refs #302.
 - **Persona-Regenerate UI:** Button + State-Pill `regenerating` + Start-Gate-Block in `Step2EnvSetup.vue`, `regenerate()`-Methode in `usePersonaReview`-Composable, `regenerateSimulationProfile()` in API-Client, 4 i18n-Keys (`step2.persona.regenerate/regenerateHint/regeneratingPill/regeneratingBlock`) in de.json + en.json (Sub-Slice 33, Closes #70)
 
 ### Changed

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 from flask import Blueprint, current_app, request
 
 from ..utils import signed_ticket
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import json_error, json_success
+from ..utils.rate_limit import ticket_rate_limiter
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -33,6 +35,35 @@ def _scope_is_allowed(scope: str) -> bool:
     if not scope or "." in scope:
         return False
     return any(scope.startswith(prefix) for prefix in _ALLOWED_SCOPE_PREFIXES)
+
+
+def _ticket_rate_limit_key() -> str:
+    remote = request.remote_addr or "unknown"
+    return f"auth-ticket:{remote}"
+
+
+@auth_bp.before_request
+def _limit_ticket_endpoint():
+    if request.endpoint != "auth.issue_ticket" or request.method != "POST":
+        return None
+
+    result = ticket_rate_limiter.check(
+        _ticket_rate_limit_key(),
+        max_requests=int(current_app.config.get("AGORA_TICKET_RATE_LIMIT_MAX", 60)),
+        window_seconds=int(
+            current_app.config.get("AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS", 60)
+        ),
+    )
+    if result.allowed:
+        return None
+
+    response, status = json_error(
+        ApiErrorCode.RATE_LIMITED,
+        status=429,
+        extra={"retry_after_seconds": result.retry_after_seconds},
+    )
+    response.headers["Retry-After"] = str(result.retry_after_seconds)
+    return response, status
 
 
 @auth_bp.route("/ticket", methods=["POST"])

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -182,6 +182,13 @@ class Config:
     # Mirrors the AGORA_LOG_FORMAT env var read directly in utils/logger.py at import time.
     AGORA_LOG_FORMAT = os.environ.get('AGORA_LOG_FORMAT', 'text').lower()
 
+    # App-level abuse guard for short-lived signed ticket issuance.
+    # Values <= 0 disable the limiter for local experiments/tests.
+    AGORA_TICKET_RATE_LIMIT_MAX = int(os.environ.get('AGORA_TICKET_RATE_LIMIT_MAX', '60'))
+    AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS = int(
+        os.environ.get('AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS', '60')
+    )
+
     # Ontology mutation (Issue #11) — how to handle novel entity types that
     # the NER pipeline flags during simulation:
     #   disabled (default) → drop the signal, ontology never changes

--- a/backend/app/utils/rate_limit.py
+++ b/backend/app/utils/rate_limit.py
@@ -1,0 +1,76 @@
+"""Small in-process fixed-window rate limiter for app-level abuse guards."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class RateLimitResult:
+    allowed: bool
+    retry_after_seconds: int = 0
+
+
+@dataclass
+class _Bucket:
+    count: int
+    reset_at: float
+
+
+class FixedWindowRateLimiter:
+    """Thread-safe fixed-window limiter keyed by caller and endpoint.
+
+    This is intentionally process-local. Agora v1.0 is single-user/local-first;
+    Redis-backed distributed throttling can follow if the deployment model
+    expands beyond that.
+    """
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = threading.Lock()
+
+    def check(
+        self,
+        key: str,
+        *,
+        max_requests: int,
+        window_seconds: int,
+        now: float | None = None,
+    ) -> RateLimitResult:
+        if max_requests <= 0 or window_seconds <= 0:
+            return RateLimitResult(True)
+
+        current = time.monotonic() if now is None else now
+        reset_at = current + window_seconds
+
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None or current >= bucket.reset_at:
+                self._buckets[key] = _Bucket(count=1, reset_at=reset_at)
+                self._sweep(current)
+                return RateLimitResult(True)
+
+            if bucket.count >= max_requests:
+                retry_after = max(1, math.ceil(bucket.reset_at - current))
+                return RateLimitResult(False, retry_after)
+
+            bucket.count += 1
+            return RateLimitResult(True)
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            self._buckets.clear()
+
+    def _sweep(self, now: float) -> None:
+        stale = [key for key, bucket in self._buckets.items() if now >= bucket.reset_at]
+        for key in stale:
+            self._buckets.pop(key, None)
+
+
+ticket_rate_limiter = FixedWindowRateLimiter()
+
+
+__all__ = ["FixedWindowRateLimiter", "RateLimitResult", "ticket_rate_limiter"]

--- a/backend/tests/test_auth_ticket.py
+++ b/backend/tests/test_auth_ticket.py
@@ -12,6 +12,7 @@ from app.utils.api_responses import (
     json_success,
 )
 from app.utils.auth import allow_ticket_auth, install_blueprint_guard
+from app.utils.rate_limit import ticket_rate_limiter
 
 
 SECRET = "test-secret-do-not-use"
@@ -21,8 +22,10 @@ TOKEN = "deploy-token"
 @pytest.fixture(autouse=True)
 def _reset_consumed_set():
     signed_ticket._reset_seen_for_tests()
+    ticket_rate_limiter.reset_for_tests()
     yield
     signed_ticket._reset_seen_for_tests()
+    ticket_rate_limiter.reset_for_tests()
 
 
 @pytest.fixture(scope="module")
@@ -32,6 +35,8 @@ def app():
     out of per-test fixtures."""
     flask_app = Flask(__name__)
     flask_app.config["SECRET_KEY"] = SECRET
+    flask_app.config["AGORA_TICKET_RATE_LIMIT_MAX"] = 2
+    flask_app.config["AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS"] = 60
     install_api_error_handlers(flask_app)
 
     bp = Blueprint("guarded", __name__)
@@ -67,6 +72,20 @@ def test_ticket_endpoint_requires_token(client):
     response = client.post("/api/auth/ticket", json={"scope": "sse:sim_abc"})
 
     assert response.status_code == 401
+
+
+def test_ticket_endpoint_rate_limits_before_auth_guard(client):
+    for _ in range(2):
+        response = client.post("/api/auth/ticket", json={"scope": "sse:sim_abc"})
+        assert response.status_code == 401
+
+    response = client.post("/api/auth/ticket", json={"scope": "sse:sim_abc"})
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
+    body = response.get_json()
+    assert body["code"] == "rate_limited"
+    assert body["retry_after_seconds"] == 60
 
 
 def test_ticket_endpoint_returns_ticket_for_valid_scope(client):

--- a/backend/tests/utils/test_rate_limit.py
+++ b/backend/tests/utils/test_rate_limit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from app.utils.rate_limit import FixedWindowRateLimiter
+
+
+def test_fixed_window_blocks_after_limit():
+    limiter = FixedWindowRateLimiter()
+
+    first = limiter.check("client", max_requests=2, window_seconds=60, now=100.0)
+    second = limiter.check("client", max_requests=2, window_seconds=60, now=101.0)
+    third = limiter.check("client", max_requests=2, window_seconds=60, now=102.0)
+
+    assert first.allowed
+    assert second.allowed
+    assert not third.allowed
+    assert third.retry_after_seconds == 58
+
+
+def test_fixed_window_resets_after_window():
+    limiter = FixedWindowRateLimiter()
+
+    assert limiter.check("client", max_requests=1, window_seconds=60, now=100.0).allowed
+    blocked = limiter.check("client", max_requests=1, window_seconds=60, now=120.0)
+    reset = limiter.check("client", max_requests=1, window_seconds=60, now=160.0)
+
+    assert not blocked.allowed
+    assert reset.allowed
+
+
+def test_fixed_window_can_be_disabled():
+    limiter = FixedWindowRateLimiter()
+
+    for _ in range(3):
+        result = limiter.check("client", max_requests=0, window_seconds=60, now=100.0)
+        assert result.allowed

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -115,7 +115,7 @@ Detail: [`PLAN.md § Status-Sync 2026-05-04`](../PLAN.md#status-sync-2026-05-04)
 - M11.1 Evidence-Quality-Gate hard (`--soft` raus aus `contract-gates.yml`, Hard-Gate gegen `tests/eval/fixtures/good/`, Bad-Cases gepinnt durch Snapshot-Test)
 
 **Aktiv offen (nächste 3 Slices in Reihenfolge):**
-1. M10.5 Rate-Limit-Konzept — `/api/auth/ticket`, Uploads, LLM-Trigger, Report-Gen.
+1. M10.5 Rate-Limit-Konzept — `/api/auth/ticket` im ersten Slice rate-limited (#302); offen bleiben Uploads, LLM-Trigger, Report-Gen.
 2. M11.2/M11.3 Coverage-Gates Backend (70 %) / Frontend (60 %).
 3. M11.4 Playwright-Smokes (3 E2E-Tests: Health/Login, Upload+Graph, Minimalreport).
 4. Final-Release-Gate: Docker-Image-Build + Reverse-Proxy-Smoke für PRs oder Release-Kandidaten wieder aktivieren.

--- a/docu/security-hardening.md
+++ b/docu/security-hardening.md
@@ -371,7 +371,7 @@ Agora v1.0 ist **Single-User-only**. Ein einziger gemeinsamer Bearer-Token (`AGO
 
 **Schützt nicht:**
 
-- Brute-Force auf den Token. **Es gibt aktuell keine Rate-Limits** (M10.5 in Planung). Bis dahin: niemals direkt im Internet exponieren.
+- Brute-Force auf den Token außerhalb von `POST /api/auth/ticket`. M10.5 hat mit einem app-seitigen Fixed-Window-Limit für Signed-Ticket-Issuance begonnen; Uploads, LLM-Trigger und Report-Generierung bleiben bis zu ihren Folgeslices ohne Rate-Limit. Bis dahin: niemals direkt im Internet exponieren.
 - Mehrbenutzer-Konflikte: bei zwei Personen mit demselben Token gibt's keine Sitzungstrennung.
 - Audit-Compliance (DSGVO, SOC2, ISO 27001 für Multi-User): nicht erfüllbar in v1.0.
 - Session-Hijacking nach Token-Leak: ohne Logout-Endpunkt muss der Token rotiert werden (Prozedur unten).


### PR DESCRIPTION
## Motivation
- Refs #302 / M10.5.
- `POST /api/auth/ticket` konnte bisher ohne Drosselung signierte Tickets ausstellen. Damit war der URL-bound-Auth-Helfer trotz `AGORA_AUTH_TOKEN` anfällig für Brute-Force- und Flooding-Muster.

## Änderungen
- Kleinen prozesslokalen Fixed-Window-Limiter in `backend/app/utils/rate_limit.py` ergänzt.
- Limiter als `auth_bp.before_request` für `POST /api/auth/ticket` verdrahtet, damit auch ungültige oder fehlende Token-Versuche gezählt werden, bevor der normale Auth-Guard mit 401 abbricht.
- 429-Antwort nutzt den bestehenden JSON-Envelope mit `code: rate_limited`, `retry_after_seconds` und `Retry-After`-Header.
- Konfigurierbare Defaults ergänzt: `AGORA_TICKET_RATE_LIMIT_MAX=60`, `AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS=60`; Werte `<= 0` deaktivieren den Limiter für lokale Experimente.
- Doku/Status aktualisiert: M10.5 ist gestartet; Uploads, LLM-Trigger und Report-Generierung bleiben Folge-Slices.

Contract-/Schema-Änderungen: keine.
Frontend-i18n-Änderungen: keine.

## Tests
- `cd backend && uv run pytest -x -q tests/test_auth_ticket.py` → 10 passed.
- `cd backend && uv run pytest -x -q tests/utils/test_rate_limit.py tests/test_auth_ticket.py tests/test_auth.py tests/test_config_validate.py tests/test_config_security.py tests/api/test_llm_model_stream.py::TestLLMStreamTicketIssuance tests/test_signed_ticket.py tests/test_signed_ticket_redis.py` → 59 passed.
- `cd backend && uv run ruff check app tests/test_auth_ticket.py tests/utils/test_rate_limit.py tests/api/test_llm_model_stream.py tests/test_signed_ticket.py tests/test_signed_ticket_redis.py` → passed.
- `git diff --check` → vor dem Commit grün.
- `code-review-graph` Incremental-Build + Minimal-Kontext vor PR → Risiko 0.55, 0 betroffene Flows.
- `cd backend && uv run ruff check .` → aktueller Repo-Baseline-Fehler außerhalb dieses Slices: bestehende Lint-Befunde in `backend/scripts/run_*_simulation.py` und `backend/scripts/security_verify.py`; diese Dateien wurden nicht angefasst.

## Risiken / Out of Scope
- Der Limiter ist bewusst prozesslokal. Multi-Worker- oder verteiltes Redis-Rate-Limiting ist nicht Teil dieses ersten v1.0-Local-first-Slices.
- Der Client-Schlüssel ist `request.remote_addr`; hinter dem gebündelten Reverse Proxy kann das auf Proxy-/Container-Ebene aggregieren. Für den ersten Single-User-Schutz akzeptabel, bei Bedarf später über Trusted-Proxy-Handling verfeinern.
- Uploads, LLM-Trigger-Endpunkte und Report-Generierung werden hier noch nicht geändert.
- Der Docker-PR-Smoke bleibt gemäß Maintainer-Wunsch pausiert.

## Verifikation
- [x] `/api/auth/ticket` hat ein app-seitiges Rate-Limit.
- [x] Block-Pfad liefert 429 im JSON-Envelope.
- [x] `Retry-After`-Header wird gesetzt.
- [x] Ungültige/fehlende Token-Versuche werden vor dem 401 gezählt.
- [x] Limits sind per Env konfigurierbar und dokumentiert.
- [x] Unit- und Integrationstests decken Allow-, Block-, Reset- und Disable-Pfade ab.

## Follow-ups
- #302 mit Rate-Limits für Upload-Endpunkte fortsetzen.
- #302 mit Rate-Limits für LLM-Trigger und Report-Generierung fortsetzen.
- Redis-/Distributed-Rate-Limiting erst erneut bewerten, wenn das Deployment über das aktuelle Single-User-/Local-first-v1.0-Modell hinausgeht.