### PR TITLE
fix(graph): rate limit ontology uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ FLASK_DEBUG=false
 # Defaults: 60 Requests pro 60 Sekunden und Remote-Adresse.
 AGORA_TICKET_RATE_LIMIT_MAX=60
 AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS=60
+# Upload-Limit fuer POST /api/graph/ontology/generate.
+# Defaults: 10 Requests pro 60 Sekunden und Remote-Adresse.
+AGORA_UPLOAD_RATE_LIMIT_MAX=10
+AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60
 
 # Opt-out für offene Lab-Setups. Nur setzen, wenn der Endpunkt bewusst
 # unauthentifiziert sein soll (z.B. lokales Klassenraum-Demo). Niemals in Prod.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ### Added
 - **M10.5 Security:** `POST /api/auth/ticket` bekommt ein app-seitiges Fixed-Window-Rate-Limit (Default 60 Requests / 60 s pro Remote-Adresse) mit `429`-JSON-Envelope und `Retry-After`-Header. Konfiguration via `AGORA_TICKET_RATE_LIMIT_MAX` und `AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS`; Werte `<= 0` deaktivieren den Limiter fuer lokale Experimente. Refs #302.
+- **M10.5 Security:** Der Upload-Pfad `POST /api/graph/ontology/generate` bekommt ebenfalls ein app-seitiges Fixed-Window-Rate-Limit (Default 10 Requests / 60 s pro Remote-Adresse) mit `429`-JSON-Envelope und `Retry-After`-Header. Konfiguration via `AGORA_UPLOAD_RATE_LIMIT_MAX` und `AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS`; Werte `<= 0` deaktivieren den Limiter fuer lokale Experimente. Refs #302.
 - **Persona-Regenerate UI:** Button + State-Pill `regenerating` + Start-Gate-Block in `Step2EnvSetup.vue`, `regenerate()`-Methode in `usePersonaReview`-Composable, `regenerateSimulationProfile()` in API-Client, 4 i18n-Keys (`step2.persona.regenerate/regenerateHint/regeneratingPill/regeneratingBlock`) in de.json + en.json (Sub-Slice 33, Closes #70)
 
 ### Changed

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -26,6 +26,7 @@ from ..services.run_registry import RunRegistry
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from ..utils.graph_diff_helpers import build_pydantic_graph_diff
+from ..utils.rate_limit import upload_rate_limiter
 
 # Get logger
 logger = get_logger('agora.api')
@@ -59,6 +60,35 @@ def allowed_file(file_storage) -> bool:
             return False
 
     return True
+
+
+def _upload_rate_limit_key() -> str:
+    remote = request.remote_addr or "unknown"
+    return f"graph-ontology-upload:{remote}"
+
+
+@graph_bp.before_request
+def _limit_upload_endpoint():
+    if request.endpoint != "graph.generate_ontology" or request.method != "POST":
+        return None
+
+    result = upload_rate_limiter.check(
+        _upload_rate_limit_key(),
+        max_requests=int(current_app.config.get("AGORA_UPLOAD_RATE_LIMIT_MAX", 10)),
+        window_seconds=int(
+            current_app.config.get("AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS", 60)
+        ),
+    )
+    if result.allowed:
+        return None
+
+    response, status = json_error(
+        ApiErrorCode.RATE_LIMITED,
+        status=429,
+        extra={"retry_after_seconds": result.retry_after_seconds},
+    )
+    response.headers["Retry-After"] = str(result.retry_after_seconds)
+    return response, status
 
 
 # ============== Project Management Interface ==============

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -188,6 +188,10 @@ class Config:
     AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS = int(
         os.environ.get('AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS', '60')
     )
+    AGORA_UPLOAD_RATE_LIMIT_MAX = int(os.environ.get('AGORA_UPLOAD_RATE_LIMIT_MAX', '10'))
+    AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS = int(
+        os.environ.get('AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS', '60')
+    )
 
     # Ontology mutation (Issue #11) — how to handle novel entity types that
     # the NER pipeline flags during simulation:

--- a/backend/app/utils/rate_limit.py
+++ b/backend/app/utils/rate_limit.py
@@ -71,6 +71,12 @@ class FixedWindowRateLimiter:
 
 
 ticket_rate_limiter = FixedWindowRateLimiter()
+upload_rate_limiter = FixedWindowRateLimiter()
 
 
-__all__ = ["FixedWindowRateLimiter", "RateLimitResult", "ticket_rate_limiter"]
+__all__ = [
+    "FixedWindowRateLimiter",
+    "RateLimitResult",
+    "ticket_rate_limiter",
+    "upload_rate_limiter",
+]

--- a/backend/tests/test_upload_limits.py
+++ b/backend/tests/test_upload_limits.py
@@ -20,15 +20,25 @@ import io
 from pathlib import Path
 
 import pytest
+from flask import Flask
 from werkzeug.datastructures import FileStorage
 
+from app.api import graph_bp
 from app.api.graph import allowed_file
 from app.config import Config
 from app.models.project import ProjectManager
+from app.utils.rate_limit import upload_rate_limiter
 
 
 def _file_storage(filename: str, body: bytes) -> FileStorage:
     return FileStorage(stream=io.BytesIO(body), filename=filename)
+
+
+@pytest.fixture(autouse=True)
+def _reset_upload_limiter():
+    upload_rate_limiter.reset_for_tests()
+    yield
+    upload_rate_limiter.reset_for_tests()
 
 
 # ── Extension / magic-byte gate ─────────────────────────────────────────────
@@ -82,6 +92,32 @@ def test_rejects_filename_without_extension():
 def test_max_content_length_is_50_mb():
     """``Config.MAX_CONTENT_LENGTH`` matches the 50 MB the docs promise."""
     assert Config.MAX_CONTENT_LENGTH == 50 * 1024 * 1024
+
+
+def test_ontology_upload_endpoint_rate_limits_requests():
+    flask_app = Flask(__name__)
+    flask_app.config["AGORA_UPLOAD_RATE_LIMIT_MAX"] = 2
+    flask_app.config["AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    flask_app.register_blueprint(graph_bp, url_prefix="/api/graph")
+
+    with flask_app.test_client() as client:
+        for _ in range(2):
+            response = client.post(
+                "/api/graph/ontology/generate",
+                data={"simulation_requirement": "DACH reaction analysis"},
+            )
+            assert response.status_code == 400
+
+        response = client.post(
+            "/api/graph/ontology/generate",
+            data={"simulation_requirement": "DACH reaction analysis"},
+        )
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
+    body = response.get_json()
+    assert body["code"] == "rate_limited"
+    assert body["retry_after_seconds"] == 60
 
 
 # ── Path-traversal hardening ────────────────────────────────────────────────

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -115,7 +115,7 @@ Detail: [`PLAN.md § Status-Sync 2026-05-04`](../PLAN.md#status-sync-2026-05-04)
 - M11.1 Evidence-Quality-Gate hard (`--soft` raus aus `contract-gates.yml`, Hard-Gate gegen `tests/eval/fixtures/good/`, Bad-Cases gepinnt durch Snapshot-Test)
 
 **Aktiv offen (nächste 3 Slices in Reihenfolge):**
-1. M10.5 Rate-Limit-Konzept — `/api/auth/ticket` im ersten Slice rate-limited (#302); offen bleiben Uploads, LLM-Trigger, Report-Gen.
+1. M10.5 Rate-Limit-Konzept — `/api/auth/ticket` und Upload-Pfad `/api/graph/ontology/generate` rate-limited (#302); offen bleiben LLM-Trigger und Report-Gen.
 2. M11.2/M11.3 Coverage-Gates Backend (70 %) / Frontend (60 %).
 3. M11.4 Playwright-Smokes (3 E2E-Tests: Health/Login, Upload+Graph, Minimalreport).
 4. Final-Release-Gate: Docker-Image-Build + Reverse-Proxy-Smoke für PRs oder Release-Kandidaten wieder aktivieren.

--- a/docu/security-hardening.md
+++ b/docu/security-hardening.md
@@ -371,7 +371,7 @@ Agora v1.0 ist **Single-User-only**. Ein einziger gemeinsamer Bearer-Token (`AGO
 
 **Schützt nicht:**
 
-- Brute-Force auf den Token außerhalb von `POST /api/auth/ticket`. M10.5 hat mit einem app-seitigen Fixed-Window-Limit für Signed-Ticket-Issuance begonnen; Uploads, LLM-Trigger und Report-Generierung bleiben bis zu ihren Folgeslices ohne Rate-Limit. Bis dahin: niemals direkt im Internet exponieren.
+- Brute-Force auf den Token außerhalb von `POST /api/auth/ticket`. M10.5 hat mit app-seitigen Fixed-Window-Limits für Signed-Ticket-Issuance und den Upload-Pfad `POST /api/graph/ontology/generate` begonnen; LLM-Trigger und Report-Generierung bleiben bis zu ihren Folgeslices ohne Rate-Limit. Bis dahin: niemals direkt im Internet exponieren.
 - Mehrbenutzer-Konflikte: bei zwei Personen mit demselben Token gibt's keine Sitzungstrennung.
 - Audit-Compliance (DSGVO, SOC2, ISO 27001 für Multi-User): nicht erfüllbar in v1.0.
 - Session-Hijacking nach Token-Leak: ohne Logout-Endpunkt muss der Token rotiert werden (Prozedur unten).


### PR DESCRIPTION
## Motivation
- Refs #302 / M10.5.
- Nach PR #303 war `/api/auth/ticket` geschützt; der Datei-Upload-Pfad `POST /api/graph/ontology/generate` hatte noch kein Request-Rate-Limit.

## Änderungen
- `POST /api/graph/ontology/generate` bekommt ein app-seitiges Fixed-Window-Rate-Limit.
- Der bestehende `FixedWindowRateLimiter` wird wiederverwendet; neu ist nur ein eigener `upload_rate_limiter`.
- 429-Antworten nutzen den bestehenden JSON-Envelope mit `code: rate_limited`, `retry_after_seconds` und `Retry-After`-Header.
- Konfigurierbare Defaults ergänzt: `AGORA_UPLOAD_RATE_LIMIT_MAX=10`, `AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60`; Werte `<= 0` deaktivieren den Limiter für lokale Experimente.
- `.env.example`, `CHANGELOG.md`, `docu/STATUS.md` und `docu/security-hardening.md` auf den neuen Stand gezogen.

Contract-/Schema-Änderungen: keine.
Frontend-i18n-Änderungen: keine.

## Tests
- `cd backend && uv run pytest -x -q tests/test_upload_limits.py tests/utils/test_rate_limit.py tests/test_auth_ticket.py` → 24 passed.
- `cd backend && uv run pytest -x -q tests/api/test_graph_endpoints.py tests/test_graph_diff_api.py tests/test_graph_export.py tests/test_upload_limits.py` → 39 passed.
- `cd backend && uv run pytest -x -q tests/test_config_validate.py tests/test_config_security.py tests/test_status.py` → 25 passed.
- `cd backend && uv run ruff check app/api/graph.py app/config.py app/utils/rate_limit.py tests/test_upload_limits.py tests/utils/test_rate_limit.py tests/test_auth_ticket.py` → passed.
- `git diff --check` → passed.
- `code-review-graph` Incremental-Build + Minimal-Review-Kontext → Risiko 0.55, 0 betroffene Flows.

## Risiken / Out of Scope
- Der Limiter bleibt prozesslokal wie im ersten M10.5-Sub-Slice. Verteiltes Redis-Rate-Limiting bleibt Follow-up, falls v1.0 über Single-User/local-first hinausgeht.
- Dieser PR schützt nur den Upload-Pfad `/api/graph/ontology/generate`. LLM-Trigger und Report-Generierung bleiben offen.
- Der Docker-PR-Smoke bleibt gemäß Maintainer-Wunsch pausiert.

## Verifikation
- [x] Upload-Endpunkt hat ein app-seitiges Rate-Limit.
- [x] Block-Pfad liefert 429 im JSON-Envelope.
- [x] `Retry-After`-Header wird gesetzt.
- [x] Limits sind per Env konfigurierbar und dokumentiert.
- [x] Bestehende Upload-Hardening-Tests bleiben grün.

## Follow-ups
- #302 mit Rate-Limits für LLM-Trigger fortsetzen.
- #302 mit Rate-Limits für Report-Generierung fortsetzen.
- Redis-/Distributed-Rate-Limiting erst erneut bewerten, wenn das Deployment-Modell es verlangt.