### PR TITLE
fix(security): Gemini-Followups für Rate-Limits

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -37,6 +37,16 @@ def create_app(config_class=Config):
 
     # Setup logging
     logger = setup_logger('agora')
+    from .utils.proxy import apply_proxy_fix
+    if apply_proxy_fix(app):
+        logger.info(
+            "ProxyFix enabled (x_for=%s, x_proto=%s, x_host=%s, x_port=%s, x_prefix=%s)",
+            app.config["AGORA_PROXY_FIX_X_FOR"],
+            app.config["AGORA_PROXY_FIX_X_PROTO"],
+            app.config["AGORA_PROXY_FIX_X_HOST"],
+            app.config["AGORA_PROXY_FIX_X_PORT"],
+            app.config["AGORA_PROXY_FIX_X_PREFIX"],
+        )
 
     # Werkzeug-Access-Log enthält die volle Request-Line inkl. Query-String
     # (z. B. /api/simulation/<id>/stream?ticket=<signed>); ohne Redaction

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -15,7 +15,7 @@ from flask import Blueprint, current_app, request
 from ..utils import signed_ticket
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import json_error, json_success
-from ..utils.rate_limit import ticket_rate_limiter
+from ..utils.rate_limit import build_rate_limit_key, ticket_rate_limiter
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -38,8 +38,7 @@ def _scope_is_allowed(scope: str) -> bool:
 
 
 def _ticket_rate_limit_key() -> str:
-    remote = request.remote_addr or "unknown"
-    return f"auth-ticket:{remote}"
+    return build_rate_limit_key("auth-ticket")
 
 
 @auth_bp.before_request
@@ -49,10 +48,8 @@ def _limit_ticket_endpoint():
 
     result = ticket_rate_limiter.check(
         _ticket_rate_limit_key(),
-        max_requests=int(current_app.config.get("AGORA_TICKET_RATE_LIMIT_MAX", 60)),
-        window_seconds=int(
-            current_app.config.get("AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS", 60)
-        ),
+        max_requests=current_app.config["AGORA_TICKET_RATE_LIMIT_MAX"],
+        window_seconds=current_app.config["AGORA_TICKET_RATE_LIMIT_WINDOW_SECONDS"],
     )
     if result.allowed:
         return None

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -26,7 +26,7 @@ from ..services.run_registry import RunRegistry
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from ..utils.graph_diff_helpers import build_pydantic_graph_diff
-from ..utils.rate_limit import upload_rate_limiter
+from ..utils.rate_limit import build_rate_limit_key, upload_rate_limiter
 
 # Get logger
 logger = get_logger('agora.api')
@@ -63,8 +63,7 @@ def allowed_file(file_storage) -> bool:
 
 
 def _upload_rate_limit_key() -> str:
-    remote = request.remote_addr or "unknown"
-    return f"graph-ontology-upload:{remote}"
+    return build_rate_limit_key("graph-ontology-upload")
 
 
 @graph_bp.before_request
@@ -74,10 +73,8 @@ def _limit_upload_endpoint():
 
     result = upload_rate_limiter.check(
         _upload_rate_limit_key(),
-        max_requests=int(current_app.config.get("AGORA_UPLOAD_RATE_LIMIT_MAX", 10)),
-        window_seconds=int(
-            current_app.config.get("AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS", 60)
-        ),
+        max_requests=current_app.config["AGORA_UPLOAD_RATE_LIMIT_MAX"],
+        window_seconds=current_app.config["AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS"],
     )
     if result.allowed:
         return None

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -31,7 +31,7 @@ from ..utils.api_errors import ApiErrorCode
 from ..utils.logger import get_logger
 from ..utils.validation import validate_report_id, validate_simulation_id, validate_task_id
 from ..utils.api_responses import handle_api_errors, json_success, json_error
-from ..utils.rate_limit import report_rate_limiter
+from ..utils.rate_limit import build_rate_limit_key, report_rate_limiter
 
 logger = get_logger(__name__)
 run_registry = RunRegistry()
@@ -44,9 +44,7 @@ _REPORT_RATE_LIMIT_ENDPOINTS = {
 
 
 def _report_rate_limit_key() -> str:
-    remote = request.remote_addr or "unknown"
-    endpoint = request.endpoint or "unknown"
-    return f"report-llm-trigger:{endpoint}:{remote}"
+    return build_rate_limit_key("report-llm-trigger", include_endpoint=True)
 
 
 @report_bp.before_request
@@ -56,10 +54,8 @@ def _limit_report_llm_endpoints():
 
     result = report_rate_limiter.check(
         _report_rate_limit_key(),
-        max_requests=int(current_app.config.get("AGORA_REPORT_RATE_LIMIT_MAX", 10)),
-        window_seconds=int(
-            current_app.config.get("AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS", 60)
-        ),
+        max_requests=current_app.config["AGORA_REPORT_RATE_LIMIT_MAX"],
+        window_seconds=current_app.config["AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS"],
     )
     if result.allowed:
         return None

--- a/backend/app/api/simulation_common.py
+++ b/backend/app/api/simulation_common.py
@@ -13,7 +13,7 @@ from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import json_error
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.logger import get_logger
-from ..utils.rate_limit import llm_trigger_rate_limiter
+from ..utils.rate_limit import build_rate_limit_key, llm_trigger_rate_limiter
 
 logger = get_logger('agora.api.simulation')
 run_registry = RunRegistry()
@@ -31,9 +31,7 @@ _LLM_TRIGGER_ENDPOINTS = {
 
 
 def _llm_trigger_rate_limit_key() -> str:
-    remote = request.remote_addr or "unknown"
-    endpoint = request.endpoint or "unknown"
-    return f"simulation-llm-trigger:{endpoint}:{remote}"
+    return build_rate_limit_key("simulation-llm-trigger", include_endpoint=True)
 
 
 @simulation_bp.before_request
@@ -43,10 +41,8 @@ def _limit_llm_trigger_endpoints():
 
     result = llm_trigger_rate_limiter.check(
         _llm_trigger_rate_limit_key(),
-        max_requests=int(current_app.config.get("AGORA_LLM_TRIGGER_RATE_LIMIT_MAX", 20)),
-        window_seconds=int(
-            current_app.config.get("AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS", 60)
-        ),
+        max_requests=current_app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"],
+        window_seconds=current_app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"],
     )
     if result.allowed:
         return None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -202,6 +202,11 @@ class Config:
     AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS = int(
         os.environ.get('AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS', '60')
     )
+    AGORA_PROXY_FIX_X_FOR = int(os.environ.get('AGORA_PROXY_FIX_X_FOR', '0'))
+    AGORA_PROXY_FIX_X_PROTO = int(os.environ.get('AGORA_PROXY_FIX_X_PROTO', '0'))
+    AGORA_PROXY_FIX_X_HOST = int(os.environ.get('AGORA_PROXY_FIX_X_HOST', '0'))
+    AGORA_PROXY_FIX_X_PORT = int(os.environ.get('AGORA_PROXY_FIX_X_PORT', '0'))
+    AGORA_PROXY_FIX_X_PREFIX = int(os.environ.get('AGORA_PROXY_FIX_X_PREFIX', '0'))
 
     # Ontology mutation (Issue #11) — how to handle novel entity types that
     # the NER pipeline flags during simulation:

--- a/backend/app/utils/proxy.py
+++ b/backend/app/utils/proxy.py
@@ -1,0 +1,28 @@
+"""Trusted reverse-proxy helpers."""
+
+from __future__ import annotations
+
+from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+
+def apply_proxy_fix(app: Flask) -> bool:
+    """Apply Werkzeug ProxyFix when explicitly configured.
+
+    X-Forwarded-* headers are client-controlled unless a trusted reverse proxy
+    strips and rewrites them. Keep this opt-in and configure the exact proxy
+    count for the deployment topology.
+    """
+
+    counts = {
+        "x_for": app.config["AGORA_PROXY_FIX_X_FOR"],
+        "x_proto": app.config["AGORA_PROXY_FIX_X_PROTO"],
+        "x_host": app.config["AGORA_PROXY_FIX_X_HOST"],
+        "x_port": app.config["AGORA_PROXY_FIX_X_PORT"],
+        "x_prefix": app.config["AGORA_PROXY_FIX_X_PREFIX"],
+    }
+    if not any(counts.values()):
+        return False
+
+    app.wsgi_app = ProxyFix(app.wsgi_app, **counts)
+    return True

--- a/backend/app/utils/rate_limit.py
+++ b/backend/app/utils/rate_limit.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import math
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
+
+from flask import request
 
 
 @dataclass
@@ -28,9 +31,17 @@ class FixedWindowRateLimiter:
     expands beyond that.
     """
 
-    def __init__(self) -> None:
-        self._buckets: dict[str, _Bucket] = {}
+    def __init__(
+        self,
+        *,
+        max_buckets: int = 4096,
+        sweep_interval_seconds: int = 60,
+    ) -> None:
+        self._buckets: OrderedDict[str, _Bucket] = OrderedDict()
         self._lock = threading.Lock()
+        self._max_buckets = max(1, max_buckets)
+        self._sweep_interval_seconds = max(1, sweep_interval_seconds)
+        self._next_sweep_at = 0.0
 
     def check(
         self,
@@ -49,10 +60,15 @@ class FixedWindowRateLimiter:
         with self._lock:
             bucket = self._buckets.get(key)
             if bucket is None or current >= bucket.reset_at:
+                if current >= self._next_sweep_at:
+                    self._sweep(current)
+                    self._next_sweep_at = current + self._sweep_interval_seconds
+                if key not in self._buckets and len(self._buckets) >= self._max_buckets:
+                    self._buckets.popitem(last=False)
                 self._buckets[key] = _Bucket(count=1, reset_at=reset_at)
-                self._sweep(current)
                 return RateLimitResult(True)
 
+            self._buckets.move_to_end(key)
             if bucket.count >= max_requests:
                 retry_after = max(1, math.ceil(bucket.reset_at - current))
                 return RateLimitResult(False, retry_after)
@@ -63,11 +79,22 @@ class FixedWindowRateLimiter:
     def reset_for_tests(self) -> None:
         with self._lock:
             self._buckets.clear()
+            self._next_sweep_at = 0.0
 
     def _sweep(self, now: float) -> None:
         stale = [key for key, bucket in self._buckets.items() if now >= bucket.reset_at]
         for key in stale:
             self._buckets.pop(key, None)
+
+
+def build_rate_limit_key(prefix: str, *, include_endpoint: bool = False) -> str:
+    """Build a stable limiter key from the trusted Flask client address."""
+
+    parts = [prefix]
+    if include_endpoint:
+        parts.append(request.endpoint or "unknown")
+    parts.append(request.remote_addr or "unknown")
+    return ":".join(parts)
 
 
 ticket_rate_limiter = FixedWindowRateLimiter()
@@ -79,6 +106,7 @@ report_rate_limiter = FixedWindowRateLimiter()
 __all__ = [
     "FixedWindowRateLimiter",
     "RateLimitResult",
+    "build_rate_limit_key",
     "llm_trigger_rate_limiter",
     "report_rate_limiter",
     "ticket_rate_limiter",

--- a/backend/tests/api/test_simulation_uses_request_model.py
+++ b/backend/tests/api/test_simulation_uses_request_model.py
@@ -36,6 +36,8 @@ VALID_GRAPH_ID = "abcdef0123456789abcdef0123456789"
 def sim_history_client(monkeypatch):
     """Flask test client with simulation blueprint + mocked neo4j storage."""
     app = Flask(__name__)
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 20
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
     storage = MagicMock(name="Neo4jStorage")
     app.extensions = {"neo4j_storage": storage}
     app.register_blueprint(simulation_bp, url_prefix="/api/simulation")

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -12,6 +12,8 @@ def _reset_llm_trigger_limiter():
 def _build_test_app(*, artifact_store=None):
     _reset_llm_trigger_limiter()
     app = Flask(__name__)
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 20
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
     app.extensions = {}
     if artifact_store is not None:
         app.extensions["artifact_store"] = artifact_store

--- a/backend/tests/utils/test_proxy.py
+++ b/backend/tests/utils/test_proxy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from flask import Flask, request
+
+from app.utils.rate_limit import build_rate_limit_key
+from app.utils.proxy import apply_proxy_fix
+
+
+def _client_ip_app(*, x_for: int = 0, x_proto: int = 0) -> Flask:
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_PROXY_FIX_X_FOR=x_for,
+        AGORA_PROXY_FIX_X_PROTO=x_proto,
+        AGORA_PROXY_FIX_X_HOST=0,
+        AGORA_PROXY_FIX_X_PORT=0,
+        AGORA_PROXY_FIX_X_PREFIX=0,
+    )
+    apply_proxy_fix(app)
+
+    @app.get("/")
+    def index():
+        return {
+            "key": build_rate_limit_key("auth-ticket"),
+            "remote_addr": request.remote_addr,
+            "scheme": request.scheme,
+        }
+
+    return app
+
+
+def test_proxy_fix_is_opt_in_and_ignores_spoofed_forwarded_for_by_default():
+    client = _client_ip_app().test_client()
+
+    response = client.get(
+        "/",
+        environ_base={"REMOTE_ADDR": "172.18.0.5"},
+        headers={"X-Forwarded-For": "198.51.100.23", "X-Forwarded-Proto": "https"},
+    )
+
+    assert response.get_json() == {
+        "key": "auth-ticket:172.18.0.5",
+        "remote_addr": "172.18.0.5",
+        "scheme": "http",
+    }
+
+
+def test_proxy_fix_uses_forwarded_client_when_one_proxy_is_trusted():
+    client = _client_ip_app(x_for=1, x_proto=1).test_client()
+
+    response = client.get(
+        "/",
+        environ_base={"REMOTE_ADDR": "172.18.0.5"},
+        headers={"X-Forwarded-For": "198.51.100.23", "X-Forwarded-Proto": "https"},
+    )
+
+    assert response.get_json() == {
+        "key": "auth-ticket:198.51.100.23",
+        "remote_addr": "198.51.100.23",
+        "scheme": "https",
+    }

--- a/backend/tests/utils/test_rate_limit.py
+++ b/backend/tests/utils/test_rate_limit.py
@@ -33,3 +33,14 @@ def test_fixed_window_can_be_disabled():
     for _ in range(3):
         result = limiter.check("client", max_requests=0, window_seconds=60, now=100.0)
         assert result.allowed
+
+
+def test_fixed_window_caps_bucket_count():
+    limiter = FixedWindowRateLimiter(max_buckets=2, sweep_interval_seconds=999)
+
+    assert limiter.check("client-1", max_requests=10, window_seconds=60, now=100.0).allowed
+    assert limiter.check("client-2", max_requests=10, window_seconds=60, now=100.0).allowed
+    assert limiter.check("client-3", max_requests=10, window_seconds=60, now=100.0).allowed
+
+    assert len(limiter._buckets) == 2
+    assert "client-1" not in limiter._buckets

--- a/deploy/compose/docker-compose.prod-with-proxy.yml
+++ b/deploy/compose/docker-compose.prod-with-proxy.yml
@@ -20,6 +20,11 @@ services:
     # Backend-Port wird nicht mehr auf den Host veroeffentlicht.
     # Der Sidecar erreicht agora ueber das Compose-interne Netzwerk (agora:5001).
     ports: !reset []
+    environment:
+      # Der Sidecar-nginx ist genau ein vertrauenswuerdiger Proxy vor Flask.
+      # Nur in dieser Topologie darf Flask X-Forwarded-For/-Proto auswerten.
+      - AGORA_PROXY_FIX_X_FOR=1
+      - AGORA_PROXY_FIX_X_PROTO=1
 
   nginx:
     image: nginx:alpine

--- a/docu/security-hardening.md
+++ b/docu/security-hardening.md
@@ -160,6 +160,9 @@ Einzelne Vektoren schließen, die auch nach Auth+CORS noch Missbrauchspotenzial 
 | `AGORA_AUTH_TOKEN` | empfohlen | leer | API-Bearer-Token. |
 | `AGORA_EXTRA_ORIGINS` | nein | leer | Zusätzliche CORS-Origins. |
 | `AGORA_CORS_ALLOW_ALL` | nein | `false` | Wildcard-CORS; löst Warning aus. |
+| `AGORA_PROXY_FIX_X_FOR` | nein | `0` | Anzahl vertrauenswürdiger Proxies, deren `X-Forwarded-For` Flask für `request.remote_addr` auswertet. Im Repo-Sidecar-Proxy-Compose auf `1` gesetzt. |
+| `AGORA_PROXY_FIX_X_PROTO` | nein | `0` | Anzahl vertrauenswürdiger Proxies, deren `X-Forwarded-Proto` Flask für das Request-Schema auswertet. Im Repo-Sidecar-Proxy-Compose auf `1` gesetzt. |
+| `AGORA_PROXY_FIX_X_HOST` / `AGORA_PROXY_FIX_X_PORT` / `AGORA_PROXY_FIX_X_PREFIX` | nein | `0` | Weitere Werkzeug-`ProxyFix`-Zähler. Nur setzen, wenn ein vertrauenswürdiger Proxy diese Header kontrolliert. |
 | `VISION_MAX_CALLS_PER_UPLOAD` | nein | `40` | Hartes Cap für Vision-LLM-Calls pro PDF-Upload. |
 
 ---


### PR DESCRIPTION
## Kontext

Dieser Follow-up-PR adressiert die live geprüften Gemini-Findings aus #303, #304, #305 und #306. #307 bleibt der separate Doku-Sync-PR.

## Änderungen

1. Zentrale Rate-Limit-Key-Erzeugung über `build_rate_limit_key(...)` statt vier lokaler `request.remote_addr`-Implementierungen.
2. Trusted-Proxy-Handling via opt-in `ProxyFix`: Default bleibt aus, der Repo-nginx-Sidecar setzt genau `AGORA_PROXY_FIX_X_FOR=1` und `AGORA_PROXY_FIX_X_PROTO=1`.
3. Direkte Config-Zugriffe auf die bereits typisierten Rate-Limit-Werte per `current_app.config[...]`.
4. `FixedWindowRateLimiter` gegen den #303-HIGH-Fund gehärtet: Bucket-Cap plus periodischer Sweep statt O(N)-Sweep bei jedem neuen Key.
5. Tests für ProxyFix opt-in / Forwarded-Header-Spoofing und Bucket-Cap ergänzt; Minimal-Test-Apps setzen die erforderlichen Config-Defaults explizit.
6. Security-Doku um die ProxyFix-Env-Variablen ergänzt.

## Verifikation

- `uv run pytest tests/utils/test_rate_limit.py tests/utils/test_proxy.py tests/test_auth_ticket.py tests/test_upload_limits.py tests/test_simulation_api_routes.py::test_prepare_simulation_rate_limits_llm_trigger tests/test_simulation_api_routes.py::test_generate_profiles_rate_limits_llm_trigger tests/test_report_export.py::test_report_generate_endpoint_rate_limits_requests tests/test_report_export.py::test_report_chat_endpoint_rate_limits_requests -q` → 31 passed
- `uv run pytest tests/api/test_simulation_uses_request_model.py tests/test_simulation_api_routes.py::test_prepare_simulation_requires_simulation_id tests/test_simulation_api_routes.py::test_generate_profiles_requires_graph_id -q` → 5 passed
- `uv run pytest -q` → 1560 passed, 2 skipped, 7 deselected
- `uv run ruff check app tests/api/test_simulation_uses_request_model.py tests/test_simulation_api_routes.py tests/utils/test_rate_limit.py tests/utils/test_proxy.py tests/test_auth_ticket.py tests/test_upload_limits.py tests/test_report_export.py` → passed
- `git diff --check` → passed
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml -f deploy/compose/docker-compose.prod-with-proxy.yml config --format json | jq ...` → ProxyFix-Env wird ergänzt, bestehende Agora-Env-Schlüssel bleiben vorhanden
- `code-review-graph update --repo /Volumes/T7/Projekte/agora --base main` → incremental build erfolgreich
- `code-review-graph` Review-Kontext vor PR: 14 changed files, high risk, 500 impacted nodes / 72 files

## Hinweise

- `errors/` ist lokal untracked und wurde nicht angefasst.
- Ein breites `uv run ruff check .` zeigt bestehende Script-Lint-Altlasten in `backend/scripts/run_*` und `backend/scripts/security_verify.py`; diese Dateien sind nicht Teil dieses PRs.