### PR TITLE
refactor(frontend): split Step4 report view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - **Step2EnvSetup:** Simulation-Prepare-Lifecycle nach `useSimulationPrepare`-Composable extrahiert (Sub-Slice 34, Refs #203)
 
 ### Refactored
+- Step4Report.vue unter 800 LOC gebracht (Refs #203): Report-Modellsteuerung, Outline/Sections, Evidence-Inspector, Branch-Controls, Export-/Download-Logik und Agent-Log-Parsing in dedizierte `step4/*`-Komponenten, `useReportExports` und `reportAgentLog` ausgelagert. Aktueller Stand: 795 LOC.
 - Step2EnvSetup.vue unter 800 LOC gebracht (Task 47, Refs #203): tote scoped Styles aus früheren Step2-Subkomponenten-Extraktionen entfernt und verbliebene hartkodierte Setup-/Run-Labels auf i18n umgestellt. Aktueller Stand: 667 LOC.
 - Persona-Library-Section aus Step2EnvSetup.vue in `step2/PersonaLibraryPanel.vue`-Subkomponente extrahiert (Sub-Slice 45, Refs #203). Step2EnvSetup.vue von 1065 LOC → 1044. Existierende `step2.library.*`-i18n-Keys weiterverwendet, keine neuen Keys nötig.
 - Persona-Cards-Loop aus Step2EnvSetup.vue in `step2/PersonaCardGrid.vue`-Subkomponente extrahiert (Sub-Slice 44, Refs #203). Step2EnvSetup.vue von 1099 LOC → 1065. i18n-Keys unter `step2.cardGrid.*` neu mit Pluralisierung für Hinweis-Anzahl (de.json + en.json).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - **Step2EnvSetup:** Simulation-Prepare-Lifecycle nach `useSimulationPrepare`-Composable extrahiert (Sub-Slice 34, Refs #203)
 
 ### Refactored
-- Step4Report.vue unter 800 LOC gebracht (Refs #203): Report-Modellsteuerung, Outline/Sections, Evidence-Inspector, Branch-Controls, Export-/Download-Logik und Agent-Log-Parsing in dedizierte `step4/*`-Komponenten, `useReportExports` und `reportAgentLog` ausgelagert. Aktueller Stand: 795 LOC.
+- Step4Report.vue unter 800 LOC gebracht: Report-Modellsteuerung, Outline/Sections, Evidence-Inspector, Branch-Controls, Export-/Download-Logik und Agent-Log-Parsing in dedizierte `step4/*`-Komponenten, `useReportExports` und `reportAgentLog` ausgelagert. Aktueller Stand: 795 LOC.
 - Step2EnvSetup.vue unter 800 LOC gebracht (Task 47, Refs #203): tote scoped Styles aus früheren Step2-Subkomponenten-Extraktionen entfernt und verbliebene hartkodierte Setup-/Run-Labels auf i18n umgestellt. Aktueller Stand: 667 LOC.
 - Persona-Library-Section aus Step2EnvSetup.vue in `step2/PersonaLibraryPanel.vue`-Subkomponente extrahiert (Sub-Slice 45, Refs #203). Step2EnvSetup.vue von 1065 LOC → 1044. Existierende `step2.library.*`-i18n-Keys weiterverwendet, keine neuen Keys nötig.
 - Persona-Cards-Loop aus Step2EnvSetup.vue in `step2/PersonaCardGrid.vue`-Subkomponente extrahiert (Sub-Slice 44, Refs #203). Step2EnvSetup.vue von 1099 LOC → 1065. i18n-Keys unter `step2.cardGrid.*` neu mit Pluralisierung für Hinweis-Anzahl (de.json + en.json).

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -6,30 +6,28 @@ import { usePolling } from '../composables/usePolling'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { renderMarkdown } from '../utils/markdown'
-import { generateReport, getAgentLog, getConsoleLog, getReport, getReportStatus, getReportEvidence, exportReport } from '../api/report'
+import { generateReport, getAgentLog, getConsoleLog, getReport, getReportStatus, getReportEvidence } from '../api/report'
 import { createSimulationBranch, getAvailableModels } from '../api/simulation'
 import Btn from './ui/Btn.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from './ui/Kicker.vue'
-import Select from './ui/Select.vue'
-import ConfidenceBadge from './ui/ConfidenceBadge.vue'
 import StickyScrollBanner from './ui/StickyScrollBanner.vue'
-import { deriveLabel, aggregateSectionConfidence } from '../utils/confidenceUtils'
-import type { SectionConfidenceResult } from '../utils/confidenceUtils'
+import ReportBranchControls from './step4/ReportBranchControls.vue'
+import ReportModelControls from './step4/ReportModelControls.vue'
+import ReportOutlinePanel from './step4/ReportOutlinePanel.vue'
+import ReportEvidencePanel from './step4/ReportEvidencePanel.vue'
+import { useReportExports } from '../composables/useReportExports'
+import { parseAgentEntry } from '../utils/reportAgentLog'
 import { parseSourceAnchor, entryAnchorId } from '../utils/sourceAnchor'
 import {
   ReportSchema,
   ReportOutlineSchema,
   EvidenceMapSchema,
-  parseReportContract,
   type Report,
   type ReportOutline,
-  type ReportClaim,
-  type EvidenceItem,
   type EvidenceMap,
 } from '../contracts/reportContract'
 
-// Hilfstype für JS-API-Responses (Dateien haben kein TS — kein Refactor-Scope hier)
 interface StatusData {
   message?: string
   outline?: unknown
@@ -74,12 +72,10 @@ const generatedSections = ref<Record<string, unknown>>({})
 const currentSectionIndex = ref<number | null>(null)
 const isComplete = ref(false)
 const fullReport = ref<Report | null>(null)
-const collapsedSections = ref(new Set<number>())
 const evidenceMap = ref<EvidenceMap | null>(null)
 const selectedEvidenceSection = ref<number | null>(null)
 const branchBusy = ref(false)
 
-// --- Schema-Fehler-State ---
 const schemaError = ref<{ where: string; issues: string[] } | null>(null)
 
 function recordSchemaError(where: string, error: unknown): void {
@@ -95,16 +91,8 @@ function recordSchemaError(where: string, error: unknown): void {
   schemaError.value = { where, issues }
   console.error(`[Step4Report] Schema-Mismatch in ${where}:`, issues)
 }
-const branchForm = ref({
-  branch_name: '',
-  llm_model: '',
-  language: '',
-  max_agents: ''
-})
-// Resolved from /generate/status when only reportId was known on mount.
 const resolvedSimulationId = ref(props.simulationId || null)
 
-// ----- Per-report model override (falls back to .env LLM_MODEL_NAME) -----
 const STORAGE_REPORT_MODEL = 'agora.reportModel'
 const reportModelOption = ref(localStorage.getItem(STORAGE_REPORT_MODEL) || 'default')
 const customReportModel = ref('')
@@ -184,25 +172,17 @@ async function regenerateWithModel() {
 
 function addLog(msg: string) { emit('add-log', msg) }
 
-// Sub-Slice J.3 (#221): Polling-Intervalle gebündelt — statusPolling und
-// agentLog teilen sich denselben Wert, damit Drift bei Anpassungen wegfällt.
 const STATUS_POLLING_INTERVAL_MS = 2500
 const AGENT_LOG_POLLING_INTERVAL_MS = STATUS_POLLING_INTERVAL_MS
 const CONSOLE_LOG_POLLING_INTERVAL_MS = 2000
 
 const statusPolling = usePolling(pollStatus, STATUS_POLLING_INTERVAL_MS)
 
-// Issue #141 — Sticky-Scroll für Agent- und Console-Log-Pane.
-// Separate containerRef-Refs werden extern erstellt, an useStickyScroll übergeben
-// und dann im Template gebunden. Der stickyScroll-Parameter ersetzt das blinde
-// scrollTop = scrollHeight im Composable durch markAppended(deltaCount).
 const agentLogRef = ref<HTMLElement | null>(null)
 const consoleLogRef = ref<HTMLElement | null>(null)
 const agentSticky = useStickyScroll(agentLogRef)
 const consoleSticky = useStickyScroll(consoleLogRef)
 
-// Issue #39 — Agent- und Console-Logs laufen über das geteilte Composable.
-// `parseAgentEntry` filtert ungültige Zeilen (return null), Composable überspringt sie.
 const {
   lines: agentLogs,
   polling: agentLogPolling,
@@ -282,80 +262,6 @@ async function pollStatus() {
   } catch { /* swallow */ }
 }
 
-interface AgentLogEntry {
-  ts: string
-  stage: string
-  action: string
-  title: string
-  subtitle: string
-  body: string
-  elapsed: number | undefined
-  [key: string]: unknown
-}
-
-function parseAgentObject(raw: unknown): Record<string, unknown> | null {
-  if (typeof raw === 'string') {
-    try {
-      return JSON.parse(raw) as Record<string, unknown>
-    } catch {
-      return { action: 'raw', message: raw }
-    }
-  }
-  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
-  return null
-}
-
-function parseAgentEntry(raw: unknown): AgentLogEntry | null {
-  // Each backend line is a JSON object (or JSON-encoded string). Parse defensively.
-  const obj = parseAgentObject(raw)
-  if (!obj) return null
-  const ts = obj.timestamp ? String(obj.timestamp).slice(11, 19) : ''
-  const stage = (obj.stage as string) || ''
-  const action = (obj.action as string) || ''
-  const d = (obj.details as Record<string, unknown>) || {}
-  let title = action.replace(/_/g, ' ')
-  let subtitle = ''
-  let body = ''
-
-  if (action === 'tool_call') {
-    title = `TOOL → ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
-    const params = (d.parameters as Record<string, unknown>) || {}
-    subtitle = Object.entries(params).map(([k, v]) => {
-      const str = typeof v === 'string' ? v : JSON.stringify(v)
-      return `${k}=${str.length > 80 ? str.slice(0, 80) + '…' : str}`
-    }).join('  ')
-  } else if (action === 'tool_result') {
-    title = `← ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
-    subtitle = `${(d.result_length as number) || 0} chars`
-  } else if (action === 'llm_response') {
-    title = 'LLM'
-    subtitle = `iter ${d.iteration ?? ''} · tool_calls=${d.has_tool_calls} · final=${d.has_final_answer}`
-    body = (d.response as string) || ''
-  } else if (action === 'section_start') {
-    title = `▶ Section ${obj.section_index ?? ''}: ${(obj.section_title as string) || (d.message as string) || ''}`
-  } else if (action === 'section_complete') {
-    title = `✓ Section ${obj.section_index ?? ''}`
-    subtitle = (d.message as string) || ''
-  } else if (action === 'planning_complete') {
-    title = 'PLAN'
-    const outline = ((d.outline as Record<string, unknown>)?.sections as unknown[]) || []
-    subtitle = `${outline.length} sections`
-    body = (d.summary as string) || ''
-  } else if (action === 'error') {
-    title = '⚠ ERROR'
-    subtitle = (d.message as string) || (d.error as string) || ''
-  }
-  return {
-    ts,
-    stage,
-    action,
-    title,
-    subtitle,
-    body,
-    elapsed: obj.elapsed_seconds as number | undefined,
-  }
-}
-
 function startPolling() {
   void statusPolling.start()
   void agentLogPolling.start()
@@ -365,12 +271,6 @@ function stopPolling() {
   statusPolling.stop()
   agentLogPolling.stop()
   consoleLogPolling.stop()
-}
-
-function toggleSection(i: number) {
-  const next = new Set(collapsedSections.value)
-  next.has(i) ? next.delete(i) : next.add(i)
-  collapsedSections.value = next
 }
 
 const reportMarkdown = computed((): string => {
@@ -393,53 +293,6 @@ const sectionHtml = computed((): Record<string, string> => {
 })
 
 const evidenceSections = computed(() => evidenceMap.value?.sections || [])
-const activeEvidenceSection = computed(() => {
-  return evidenceSections.value.find((section) => section.section_index === selectedEvidenceSection.value) || null
-})
-
-function claimConfidenceScore(claim: ReportClaim | null | undefined): number | null {
-  return claim?.confidence_score ?? null
-}
-
-function claimConfidenceLabel(claim: ReportClaim | null | undefined): string {
-  return claim?.confidence_label ?? 'low'
-}
-
-function claimConfidenceText(claim: ReportClaim | null | undefined): string {
-  const label = claimConfidenceLabel(claim)
-  const score = claimConfidenceScore(claim)
-  return score === null ? label : `${Math.round(score * 100)}% · ${label}`
-}
-
-function claimEvidenceItems(claim: ReportClaim | null | undefined): EvidenceItem[] {
-  return Array.isArray(claim?.evidence) ? claim.evidence : []
-}
-
-function evidenceSnippet(item: EvidenceItem | null | undefined): string {
-  return item?.snippet ?? ''
-}
-
-// Sub-Slice 16a — sectionConfidence-Helper (Refs #173)
-// aggregateSectionConfidence und deriveLabel kommen aus ../utils/confidenceUtils
-function sectionConfidence(idx: number): SectionConfidenceResult | null {
-  const sections = evidenceMap.value?.sections
-  if (!sections || sections.length === 0) return null
-  // section_index ist 1-basiert; idx ist 0-basiert aus reportOutline
-  const section = sections.find(s => s.section_index === idx + 1) ?? null
-  if (!section) return null
-  return aggregateSectionConfidence(section)
-}
-
-// Typsichere Getter fuer Template — vermeide Non-null-Assertions in Vue-Templates
-function sectionConfidenceScore(idx: number): number {
-  return sectionConfidence(idx)?.score ?? 0
-}
-function sectionConfidenceLabel(idx: number): 'low' | 'medium' | 'high' | 'verified' {
-  return sectionConfidence(idx)?.label ?? 'low'
-}
-function sectionConfidenceAuditTrail(idx: number): SectionConfidenceResult['auditTrail'] {
-  return sectionConfidence(idx)?.auditTrail ?? []
-}
 
 function navigateToAnchor(anchor: string | null | undefined) {
   const parsed = parseSourceAnchor(anchor)
@@ -477,134 +330,38 @@ async function loadEvidence() {
   }
 }
 
-function triggerDownload(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  setTimeout(() => URL.revokeObjectURL(url), 500)
-}
+const {
+  copyMarkdown,
+  downloadCombinedJson,
+  downloadEvidence,
+  downloadHtml,
+  downloadMarkdown,
+  printReport,
+} = useReportExports({
+  reportId: () => props.reportId,
+  reportMarkdown,
+  reportHtml,
+  evidenceMap,
+  addLog,
+  recordSchemaError,
+})
 
-function downloadMarkdown() {
-  const md = reportMarkdown.value
-  if (!md) return
-  triggerDownload(
-    new Blob([md], { type: 'text/markdown;charset=utf-8' }),
-    `agora-report-${props.reportId}.md`
-  )
-}
-
-function buildStandaloneHtml(title: string, bodyHtml: string) {
-  return `<!doctype html>
-<html lang="de"><head><meta charset="utf-8" />
-<title>${title}</title>
-<style>
-  body { font-family: Georgia, 'Iowan Old Style', serif; max-width: 740px; margin: 48px auto; padding: 0 24px; color: #111; line-height: 1.6; font-size: 16px; }
-  h1,h2,h3,h4 { font-family: Georgia, serif; line-height: 1.25; margin: 2em 0 0.4em; }
-  h1 { font-size: 2em; border-bottom: 1px solid #ccc; padding-bottom: 0.3em; }
-  h2 { font-size: 1.5em; }
-  h3 { font-size: 1.2em; }
-  p { margin: 0.8em 0; }
-  ul, ol { margin: 0.8em 0 0.8em 1.4em; }
-  li { margin: 0.3em 0; }
-  blockquote { border-left: 3px solid #e2681a; margin: 1em 0; padding: 0.2em 1em; color: #555; font-style: italic; }
-  code { background: #f3f3f3; padding: 2px 4px; border-radius: 3px; font-size: 0.92em; }
-  pre { background: #1a1a1a; color: #eee; padding: 1em; overflow: auto; border-radius: 4px; }
-  pre code { background: transparent; color: inherit; padding: 0; }
-  table { border-collapse: collapse; margin: 1em 0; }
-  th, td { border: 1px solid #ccc; padding: 6px 10px; }
-  hr { border: 0; border-top: 1px solid #ccc; margin: 2em 0; }
-  @media print { body { margin: 0; padding: 24px; } }
-</style>
-</head>
-<body>
-<h1>${title}</h1>
-${bodyHtml}
-</body></html>`
-}
-
-function downloadHtml() {
-  const html = buildStandaloneHtml(
-    `Agora-Report · ${props.reportId || ''}`,
-    reportHtml.value
-  )
-  triggerDownload(
-    new Blob([html], { type: 'text/html;charset=utf-8' }),
-    `agora-report-${props.reportId}.html`
-  )
-}
-
-function printReport() {
-  const html = buildStandaloneHtml(
-    `Agora-Report · ${props.reportId || ''}`,
-    reportHtml.value
-  )
-  const w = window.open('', '_blank')
-  if (!w) {
-    addLog('Popup blockiert — bitte Popups erlauben.')
-    return
-  }
-  w.document.open()
-  w.document.write(html)
-  w.document.close()
-  // Give the browser a tick to render, then trigger print.
-  w.addEventListener('load', () => {
-    setTimeout(() => w.print(), 200)
-  })
-}
-
-async function copyMarkdown() {
-  const md = reportMarkdown.value
-  if (!md) return
-  try {
-    await navigator.clipboard.writeText(md)
-    addLog('Markdown in Zwischenablage kopiert.')
-  } catch (e) {
-    addLog('Kopieren fehlgeschlagen: ' + (e as Error).message)
-  }
-}
-
-function downloadEvidence() {
-  if (!evidenceMap.value) return
-  triggerDownload(
-    new Blob([JSON.stringify(evidenceMap.value, null, 2)], { type: 'application/json;charset=utf-8' }),
-    `agora-report-${props.reportId}-evidence.json`
-  )
-}
-
-async function downloadCombinedJson() {
-  if (!props.reportId) return
-  try {
-    const blob = await exportReport(props.reportId, 'json')
-    const text = await blob.text()
-    const json = JSON.parse(text)
-    const parsed = parseReportContract(json)
-    if (!parsed.ok) {
-      recordSchemaError('export', { issues: parsed.errors })
-      addLog('JSON-Export: Schema-Mismatch — siehe rote Box')
-      return
-    }
-    const validatedBlob = new Blob([JSON.stringify(parsed.data, null, 2)], { type: 'application/json;charset=utf-8' })
-    triggerDownload(validatedBlob, `agora-report-${props.reportId}.json`)
-  } catch (e) {
-    addLog('JSON-Export fehlgeschlagen: ' + ((e as Error)?.message || String(e)))
-  }
-}
-
-async function createBranchFromReport() {
+async function createBranchFromReport(branchForm: {
+  branch_name: string
+  llm_model: string
+  language: string
+  max_agents: string
+}) {
   const simulationId = resolvedSimulationId.value || props.simulationId
-  if (!simulationId || !branchForm.value.branch_name.trim()) return
+  if (!simulationId || !branchForm.branch_name.trim()) return
   branchBusy.value = true
   try {
     const overrides: Record<string, unknown> = {}
-    if (branchForm.value.llm_model.trim()) overrides.llm_model = branchForm.value.llm_model.trim()
-    if (branchForm.value.language.trim()) overrides.language = branchForm.value.language.trim()
-    if (branchForm.value.max_agents !== '') overrides.max_agents = Number(branchForm.value.max_agents)
+    if (branchForm.llm_model.trim()) overrides.llm_model = branchForm.llm_model.trim()
+    if (branchForm.language.trim()) overrides.language = branchForm.language.trim()
+    if (branchForm.max_agents !== '') overrides.max_agents = Number(branchForm.max_agents)
     const res = (await createSimulationBranch(simulationId, {
-      branch_name: branchForm.value.branch_name.trim(),
+      branch_name: branchForm.branch_name.trim(),
       copy_profiles: true,
       copy_report_artifacts: false,
       overrides
@@ -666,69 +423,24 @@ onUnmounted(stopPolling)
         <p class="card-desc">{{ t('step4.sub') }}</p>
         <p v-if="statusMsg" class="meta">{{ statusMsg }}</p>
 
-        <!-- Per-report model override + regenerate -->
-        <div class="model-row" v-if="resolvedSimulationId || simulationId">
-          <div class="model-cell">
-            <Select
-              v-model="reportModelOption"
-              label="Modell für Report"
-              :options="modelOptions"
-            />
-          </div>
-          <div class="model-cell" v-if="reportModelOption === 'custom'">
-            <label class="field-label">Eigenes Modell</label>
-            <input
-              v-model="customReportModel"
-              class="model-input"
-              type="text"
-              placeholder="z. B. deepseek-v3.2:cloud"
-            />
-          </div>
-          <Btn
-            variant="ghost"
-            :loading="isRegenerating"
-            :disabled="isRegenerating"
-            @click="regenerateWithModel"
-          >Neu generieren</Btn>
-        </div>
+        <ReportModelControls
+          v-if="resolvedSimulationId || simulationId"
+          v-model:report-model-option="reportModelOption"
+          v-model:custom-report-model="customReportModel"
+          :model-options="modelOptions"
+          :is-regenerating="isRegenerating"
+          @regenerate="regenerateWithModel"
+        />
       </article>
 
-      <!-- Outline + sections -->
-      <article class="card" v-if="reportOutline?.sections">
-        <header class="card-head">
-          <Kicker num="02">{{ t('step4.view.sections') }}</Kicker>
-          <Badge variant="ghost">{{ Object.keys(generatedSections).length }} / {{ reportOutline.sections.length }}</Badge>
-        </header>
-        <ol class="outline">
-          <li
-            v-for="(sec, i) in reportOutline.sections"
-            :key="i"
-            :class="{ 'is-current': currentSectionIndex === i }"
-          >
-            <header class="outline-head" @click="toggleSection(i)">
-              <span class="outline-num">{{ String(i + 1).padStart(2, '0') }}</span>
-              <span class="outline-title">{{ sec.title }}</span>
-              <span class="outline-badges">
-                <ConfidenceBadge
-                  v-if="sectionConfidence(i)"
-                  :score="sectionConfidenceScore(i)"
-                  :label="sectionConfidenceLabel(i)"
-                  :audit-trail="sectionConfidenceAuditTrail(i)"
-                />
-                <Badge :variant="generatedSections[i + 1] ? 'solid' : 'ghost'">
-                  {{ generatedSections[i + 1] ? '✓' : (currentSectionIndex === i ? '…' : '—') }}
-                </Badge>
-              </span>
-            </header>
-            <div
-              class="outline-body"
-              v-if="generatedSections[i + 1] && !collapsedSections.has(i)"
-            >
-              <div class="section-content markdown-body" v-html="sectionHtml[i + 1] || ''"></div>
-            </div>
-          </li>
-        </ol>
-      </article>
+      <ReportOutlinePanel
+        v-if="reportOutline"
+        :outline="reportOutline"
+        :generated-sections="generatedSections"
+        :section-html="sectionHtml"
+        :current-section-index="currentSectionIndex"
+        :evidence-sections="evidenceSections"
+      />
 
       <!-- Live logs: Agent reasoning (left) + raw console (right) -->
       <article class="card" v-if="agentLogs.length || consoleLogs.length">
@@ -805,53 +517,12 @@ onUnmounted(stopPolling)
         </header>
         <div class="report-layout" :class="{ 'report-layout--stacked': !evidenceSections.length }">
           <div class="report-body markdown-body" v-html="reportHtml"></div>
-          <aside v-if="evidenceSections.length" class="evidence-panel">
-            <div class="evidence-head">
-              <strong>Evidence Inspector</strong>
-              <span>{{ evidenceSections.length }} sections</span>
-            </div>
-            <div class="evidence-sections">
-              <button
-                v-for="section in evidenceSections"
-                :key="section.section_index"
-                class="evidence-tab"
-                :class="{ active: selectedEvidenceSection === section.section_index }"
-                @click="selectedEvidenceSection = section.section_index"
-              >
-                {{ section.section_index }} · {{ section.section_title }}
-              </button>
-            </div>
-            <div v-if="activeEvidenceSection" class="evidence-body">
-              <p class="meta">{{ activeEvidenceSection.section_summary }}</p>
-              <article v-for="claim in activeEvidenceSection.claims" :key="claim.claim_id" class="claim-card">
-                <header>
-                  <strong>{{ claim.claim_id }}</strong>
-                  <Badge :variant="claimConfidenceLabel(claim) === 'low' ? 'ghost' : claimConfidenceLabel(claim) === 'medium' ? 'accent' : 'solid'">
-                    {{ claimConfidenceText(claim) }}
-                  </Badge>
-                </header>
-                <p>{{ claim.claim_text }}</p>
-                <div class="evidence-items">
-                  <div v-for="(item, idx) in claimEvidenceItems(claim)" :key="`${claim.claim_id}-${idx}`" class="evidence-item">
-                    <div class="evidence-item-head">
-                      <Badge variant="ghost">{{ item.type }}</Badge>
-                      <span v-if="item.source">{{ item.source }}</span>
-                    </div>
-                    <blockquote v-if="item.quote" class="evidence-quote">{{ item.quote }}</blockquote>
-                    <span v-else>{{ evidenceSnippet(item) }}</span>
-                    <button
-                      v-if="item.source_id_anchor"
-                      type="button"
-                      class="evidence-anchor-link"
-                      @click="navigateToAnchor(item.source_id_anchor)"
-                    >
-                      {{ t('step4.quote.openSource') }}
-                    </button>
-                  </div>
-                </div>
-              </article>
-            </div>
-          </aside>
+          <ReportEvidencePanel
+            v-if="evidenceSections.length"
+            v-model:selected-section="selectedEvidenceSection"
+            :sections="evidenceSections"
+            @navigate="navigateToAnchor"
+          />
         </div>
       </article>
 
@@ -860,13 +531,11 @@ onUnmounted(stopPolling)
         <header class="card-head">
           <Kicker num="05" accent>{{ t('step4.next') }}</Kicker>
         </header>
-        <div class="branch-controls" v-if="resolvedSimulationId || simulationId">
-          <input v-model="branchForm.branch_name" class="model-input" type="text" placeholder="Branch name" />
-          <input v-model="branchForm.llm_model" class="model-input" type="text" placeholder="LLM model override" />
-          <input v-model="branchForm.language" class="model-input" type="text" placeholder="language" />
-          <input v-model="branchForm.max_agents" class="model-input" type="number" min="1" placeholder="max agents" />
-          <Btn variant="ghost" :loading="branchBusy" :disabled="branchBusy" @click="createBranchFromReport">Create Branch</Btn>
-        </div>
+        <ReportBranchControls
+          v-if="resolvedSimulationId || simulationId"
+          :branch-busy="branchBusy"
+          @create="createBranchFromReport"
+        />
         <div class="actions">
           <Btn variant="primary" arrow @click="goConversation">{{ t('step4.next') }}</Btn>
         </div>
@@ -908,53 +577,6 @@ onUnmounted(stopPolling)
 }
 .card-desc { color: var(--fg-body); margin: 0; }
 
-.outline {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-}
-.outline li {
-  border-top: 1px solid var(--rule);
-  padding: var(--s-3) 0;
-}
-.outline li:last-child { border-bottom: 1px solid var(--rule); }
-.outline-head {
-  display: grid;
-  grid-template-columns: 32px 1fr auto;
-  gap: var(--s-3);
-  align-items: center;
-  cursor: pointer;
-}
-.outline-badges {
-  display: flex;
-  align-items: center;
-  gap: var(--s-2);
-}
-.outline-num {
-  font-family: var(--ff-mono);
-  font-size: var(--fs-12);
-  letter-spacing: var(--ls-mono);
-  color: var(--fg-muted);
-}
-.outline-title {
-  font-family: var(--ff-serif);
-  font-size: var(--fs-20);
-  color: var(--fg);
-}
-.outline-body {
-  margin-top: var(--s-3);
-  padding-left: 32px;
-}
-.section-content {
-  font-family: var(--ff-serif);
-  font-size: var(--fs-16);
-  line-height: 1.7;
-  color: var(--fg);
-  margin: 0;
-}
-
 .report-body {
   max-width: 72ch;
   margin: 0 auto;
@@ -972,70 +594,6 @@ onUnmounted(stopPolling)
 .report-layout--stacked {
   grid-template-columns: 1fr;
 }
-.evidence-panel {
-  border-left: 1px solid var(--rule);
-  padding-left: var(--s-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--s-3);
-}
-.evidence-head {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--s-2);
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  letter-spacing: var(--ls-mono);
-  text-transform: uppercase;
-}
-.evidence-sections {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.evidence-tab {
-  border: 1px solid var(--rule);
-  background: var(--bg);
-  color: var(--fg);
-  text-align: left;
-  padding: 10px 12px;
-  cursor: pointer;
-}
-.evidence-tab.active { border-color: var(--accent); background: var(--bg-elevated); }
-.claim-card {
-  border-top: 1px solid var(--rule);
-  padding-top: var(--s-3);
-}
-.claim-card header {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--s-3);
-  align-items: center;
-}
-.evidence-items {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: var(--s-3);
-}
-.evidence-item {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--rule);
-}
-.evidence-item-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--s-2);
-  color: var(--fg-muted);
-  font-family: var(--ff-mono);
-  font-size: 11px;
-}
-
 .markdown-body :deep(h1),
 .markdown-body :deep(h2),
 .markdown-body :deep(h3),
@@ -1100,46 +658,7 @@ onUnmounted(stopPolling)
   text-underline-offset: 2px;
 }
 .markdown-body :deep(strong) { font-weight: 600; color: var(--fg); }
-.outline li.is-current .outline-title { color: var(--accent); }
-
 .actions { display: flex; gap: var(--s-3); justify-content: flex-end; }
-.branch-controls {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: var(--s-3);
-}
-
-.model-row {
-  display: grid;
-  grid-template-columns: 2fr 2fr auto;
-  gap: var(--s-3);
-  align-items: end;
-  border-top: 1px solid var(--rule);
-  padding-top: var(--s-3);
-}
-.model-cell { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.field-label {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  letter-spacing: var(--ls-mono);
-  text-transform: uppercase;
-  color: var(--fg-muted);
-}
-.model-input {
-  background: var(--bg-elevated);
-  border: 1px solid var(--rule);
-  border-radius: var(--r-1);
-  color: var(--fg);
-  font-family: var(--ff-mono);
-  font-size: var(--fs-14);
-  padding: 8px 10px;
-  outline: none;
-}
-.model-input:focus { border-color: var(--accent); }
-@media (max-width: 720px) {
-  .model-row { grid-template-columns: 1fr; }
-  .branch-controls { grid-template-columns: 1fr; }
-}
 
 .log-meta { display: flex; gap: var(--s-2); }
 
@@ -1243,12 +762,6 @@ onUnmounted(stopPolling)
 @media (max-width: 880px) {
   .logs-grid { grid-template-columns: 1fr; }
   .report-layout { grid-template-columns: 1fr; }
-  .evidence-panel {
-    border-left: 0;
-    border-top: 1px solid var(--rule);
-    padding-left: 0;
-    padding-top: var(--s-4);
-  }
 }
 
 .schema-error {
@@ -1279,28 +792,4 @@ onUnmounted(stopPolling)
   transition: background 0.4s ease-in-out;
 }
 
-.evidence-quote {
-  border-left: 3px solid var(--accent);
-  margin: 0.5em 0;
-  padding: 0.4em 0.8em;
-  background: var(--bg-glass);
-  font-style: italic;
-  color: var(--fg-meta);
-  font-size: 0.92em;
-}
-
-.evidence-anchor-link {
-  appearance: none;
-  background: transparent;
-  border: 1px solid var(--accent);
-  color: var(--accent);
-  padding: 0.2em 0.6em;
-  border-radius: var(--r-pill);
-  font-size: 0.85em;
-  cursor: pointer;
-  margin-left: 0.4em;
-}
-.evidence-anchor-link:hover {
-  background: var(--accent-soft);
-}
 </style>

--- a/frontend/src/components/step4/ReportBranchControls.vue
+++ b/frontend/src/components/step4/ReportBranchControls.vue
@@ -28,7 +28,7 @@ const branchForm = ref({
       variant="ghost"
       :loading="branchBusy"
       :disabled="branchBusy"
-      @click="emit('create', branchForm)"
+      @click="emit('create', { ...branchForm })"
     >
       Create Branch
     </Btn>

--- a/frontend/src/components/step4/ReportBranchControls.vue
+++ b/frontend/src/components/step4/ReportBranchControls.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Btn from '../ui/Btn.vue'
+
+const emit = defineEmits<{
+  create: [form: { branch_name: string; llm_model: string; language: string; max_agents: string }]
+}>()
+
+defineProps<{
+  branchBusy: boolean
+}>()
+
+const branchForm = ref({
+  branch_name: '',
+  llm_model: '',
+  language: '',
+  max_agents: '',
+})
+</script>
+
+<template>
+  <div class="branch-controls">
+    <input v-model="branchForm.branch_name" class="model-input" type="text" placeholder="Branch name" />
+    <input v-model="branchForm.llm_model" class="model-input" type="text" placeholder="LLM model override" />
+    <input v-model="branchForm.language" class="model-input" type="text" placeholder="language" />
+    <input v-model="branchForm.max_agents" class="model-input" type="number" min="1" placeholder="max agents" />
+    <Btn
+      variant="ghost"
+      :loading="branchBusy"
+      :disabled="branchBusy"
+      @click="emit('create', branchForm)"
+    >
+      Create Branch
+    </Btn>
+  </div>
+</template>
+
+<style scoped>
+.branch-controls {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+.model-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  color: var(--fg);
+  font-family: var(--ff-mono);
+  font-size: var(--fs-14);
+  padding: 8px 10px;
+  outline: none;
+}
+.model-input:focus {
+  border-color: var(--accent);
+}
+@media (max-width: 720px) {
+  .branch-controls {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/step4/ReportEvidencePanel.vue
+++ b/frontend/src/components/step4/ReportEvidencePanel.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Badge from '../ui/Badge.vue'
+import type { EvidenceItem, ReportClaim, ReportSection } from '../../contracts/reportContract'
+
+interface Props {
+  sections: ReportSection[]
+  selectedSection: number | null
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:selectedSection': [sectionIndex: number]
+  navigate: [anchor: string]
+}>()
+
+const { t } = useI18n()
+
+const activeEvidenceSection = computed(() => {
+  return props.sections.find((section) => section.section_index === props.selectedSection) || null
+})
+
+function claimConfidenceScore(claim: ReportClaim | null | undefined): number | null {
+  return claim?.confidence_score ?? null
+}
+
+function claimConfidenceLabel(claim: ReportClaim | null | undefined): string {
+  return claim?.confidence_label ?? 'low'
+}
+
+function claimConfidenceText(claim: ReportClaim | null | undefined): string {
+  const label = claimConfidenceLabel(claim)
+  const score = claimConfidenceScore(claim)
+  return score === null ? label : `${Math.round(score * 100)}% · ${label}`
+}
+
+function claimEvidenceItems(claim: ReportClaim | null | undefined): EvidenceItem[] {
+  return Array.isArray(claim?.evidence) ? claim.evidence : []
+}
+
+function evidenceSnippet(item: EvidenceItem | null | undefined): string {
+  return item?.snippet ?? ''
+}
+</script>
+
+<template>
+  <aside class="evidence-panel">
+    <div class="evidence-head">
+      <strong>Evidence Inspector</strong>
+      <span>{{ sections.length }} sections</span>
+    </div>
+    <div class="evidence-sections">
+      <button
+        v-for="section in sections"
+        :key="section.section_index"
+        class="evidence-tab"
+        :class="{ active: selectedSection === section.section_index }"
+        @click="emit('update:selectedSection', section.section_index)"
+      >
+        {{ section.section_index }} · {{ section.section_title }}
+      </button>
+    </div>
+    <div v-if="activeEvidenceSection" class="evidence-body">
+      <p class="meta">{{ activeEvidenceSection.section_summary }}</p>
+      <article
+        v-for="claim in activeEvidenceSection.claims"
+        :key="claim.claim_id"
+        class="claim-card"
+      >
+        <header>
+          <strong>{{ claim.claim_id }}</strong>
+          <Badge :variant="claimConfidenceLabel(claim) === 'low' ? 'ghost' : claimConfidenceLabel(claim) === 'medium' ? 'accent' : 'solid'">
+            {{ claimConfidenceText(claim) }}
+          </Badge>
+        </header>
+        <p>{{ claim.claim_text }}</p>
+        <div class="evidence-items">
+          <div
+            v-for="(item, idx) in claimEvidenceItems(claim)"
+            :key="`${claim.claim_id}-${idx}`"
+            class="evidence-item"
+          >
+            <div class="evidence-item-head">
+              <Badge variant="ghost">{{ item.type }}</Badge>
+              <span v-if="item.source">{{ item.source }}</span>
+            </div>
+            <blockquote v-if="item.quote" class="evidence-quote">{{ item.quote }}</blockquote>
+            <span v-else>{{ evidenceSnippet(item) }}</span>
+            <button
+              v-if="item.source_id_anchor"
+              type="button"
+              class="evidence-anchor-link"
+              @click="emit('navigate', item.source_id_anchor)"
+            >
+              {{ t('step4.quote.openSource') }}
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.evidence-panel {
+  border-left: 1px solid var(--rule);
+  padding-left: var(--s-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+}
+.evidence-head {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--s-2);
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+}
+.evidence-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.evidence-tab {
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  color: var(--fg);
+  text-align: left;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.evidence-tab.active {
+  border-color: var(--accent);
+  background: var(--bg-elevated);
+}
+.claim-card {
+  border-top: 1px solid var(--rule);
+  padding-top: var(--s-3);
+}
+.claim-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--s-3);
+  align-items: center;
+}
+.evidence-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: var(--s-3);
+}
+.evidence-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+}
+.evidence-item-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--s-2);
+  color: var(--fg-muted);
+  font-family: var(--ff-mono);
+  font-size: 11px;
+}
+.evidence-quote {
+  border-left: 3px solid var(--accent);
+  margin: 0.5em 0;
+  padding: 0.4em 0.8em;
+  background: var(--bg-glass);
+  font-style: italic;
+  color: var(--fg-meta);
+  font-size: 0.92em;
+}
+.evidence-anchor-link {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 0.2em 0.6em;
+  border-radius: var(--r-pill);
+  font-size: 0.85em;
+  cursor: pointer;
+  margin-left: 0.4em;
+}
+.evidence-anchor-link:hover {
+  background: var(--accent-soft);
+}
+@media (max-width: 880px) {
+  .evidence-panel {
+    border-left: 0;
+    border-top: 1px solid var(--rule);
+    padding-left: 0;
+    padding-top: var(--s-4);
+  }
+}
+</style>

--- a/frontend/src/components/step4/ReportModelControls.vue
+++ b/frontend/src/components/step4/ReportModelControls.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Btn from '../ui/Btn.vue'
+import Select from '../ui/Select.vue'
+
+interface Option {
+  value: string
+  label: string
+}
+
+interface Props {
+  reportModelOption: string
+  customReportModel: string
+  modelOptions: Option[]
+  isRegenerating: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:reportModelOption': [value: string]
+  'update:customReportModel': [value: string]
+  regenerate: []
+}>()
+
+const selectedModel = computed({
+  get: () => props.reportModelOption,
+  set: (value: string) => emit('update:reportModelOption', value),
+})
+
+const customModel = computed({
+  get: () => props.customReportModel,
+  set: (value: string) => emit('update:customReportModel', value),
+})
+</script>
+
+<template>
+  <div class="model-row">
+    <div class="model-cell">
+      <Select
+        v-model="selectedModel"
+        label="Modell für Report"
+        :options="modelOptions"
+      />
+    </div>
+    <div v-if="reportModelOption === 'custom'" class="model-cell">
+      <label class="field-label">Eigenes Modell</label>
+      <input
+        v-model="customModel"
+        class="model-input"
+        type="text"
+        placeholder="z. B. deepseek-v3.2:cloud"
+      />
+    </div>
+    <Btn
+      variant="ghost"
+      :loading="isRegenerating"
+      :disabled="isRegenerating"
+      @click="emit('regenerate')"
+    >
+      Neu generieren
+    </Btn>
+  </div>
+</template>
+
+<style scoped>
+.model-row {
+  display: grid;
+  grid-template-columns: 2fr 2fr auto;
+  gap: var(--s-3);
+  align-items: end;
+  border-top: 1px solid var(--rule);
+  padding-top: var(--s-3);
+}
+.model-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.field-label {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.model-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  color: var(--fg);
+  font-family: var(--ff-mono);
+  font-size: var(--fs-14);
+  padding: 8px 10px;
+  outline: none;
+}
+.model-input:focus {
+  border-color: var(--accent);
+}
+@media (max-width: 720px) {
+  .model-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/step4/ReportOutlinePanel.vue
+++ b/frontend/src/components/step4/ReportOutlinePanel.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Badge from '../ui/Badge.vue'
+import Kicker from '../ui/Kicker.vue'
+import ConfidenceBadge from '../ui/ConfidenceBadge.vue'
+import { aggregateSectionConfidence } from '../../utils/confidenceUtils'
+import type { SectionConfidenceResult } from '../../utils/confidenceUtils'
+import type { ReportOutline, ReportSection } from '../../contracts/reportContract'
+
+interface Props {
+  outline: ReportOutline
+  generatedSections: Record<string, unknown>
+  sectionHtml: Record<string, string>
+  currentSectionIndex: number | null
+  evidenceSections: ReportSection[]
+}
+
+const props = defineProps<Props>()
+const { t } = useI18n()
+const collapsedSections = ref(new Set<number>())
+
+function toggleSection(i: number) {
+  const next = new Set(collapsedSections.value)
+  next.has(i) ? next.delete(i) : next.add(i)
+  collapsedSections.value = next
+}
+
+function sectionConfidence(idx: number): SectionConfidenceResult | null {
+  if (!props.evidenceSections.length) return null
+  const section = props.evidenceSections.find(s => s.section_index === idx + 1) ?? null
+  if (!section) return null
+  return aggregateSectionConfidence(section)
+}
+
+function sectionConfidenceScore(idx: number): number {
+  return sectionConfidence(idx)?.score ?? 0
+}
+
+function sectionConfidenceLabel(idx: number): 'low' | 'medium' | 'high' | 'verified' {
+  return sectionConfidence(idx)?.label ?? 'low'
+}
+
+function sectionConfidenceAuditTrail(idx: number): SectionConfidenceResult['auditTrail'] {
+  return sectionConfidence(idx)?.auditTrail ?? []
+}
+</script>
+
+<template>
+  <article class="card">
+    <header class="card-head">
+      <Kicker num="02">{{ t('step4.view.sections') }}</Kicker>
+      <Badge variant="ghost">{{ Object.keys(generatedSections).length }} / {{ outline.sections.length }}</Badge>
+    </header>
+    <ol class="outline">
+      <li
+        v-for="(sec, i) in outline.sections"
+        :key="i"
+        :class="{ 'is-current': currentSectionIndex === i }"
+      >
+        <header class="outline-head" @click="toggleSection(i)">
+          <span class="outline-num">{{ String(i + 1).padStart(2, '0') }}</span>
+          <span class="outline-title">{{ sec.title }}</span>
+          <span class="outline-badges">
+            <ConfidenceBadge
+              v-if="sectionConfidence(i)"
+              :score="sectionConfidenceScore(i)"
+              :label="sectionConfidenceLabel(i)"
+              :audit-trail="sectionConfidenceAuditTrail(i)"
+            />
+            <Badge :variant="generatedSections[i + 1] ? 'solid' : 'ghost'">
+              {{ generatedSections[i + 1] ? '✓' : (currentSectionIndex === i ? '…' : '—') }}
+            </Badge>
+          </span>
+        </header>
+        <div
+          v-if="generatedSections[i + 1] && !collapsedSections.has(i)"
+          class="outline-body"
+        >
+          <div class="section-content markdown-body" v-html="sectionHtml[i + 1] || ''"></div>
+        </div>
+      </li>
+    </ol>
+  </article>
+</template>
+
+<style scoped>
+.card {
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  padding: var(--s-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+}
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: var(--s-3);
+}
+.outline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.outline li {
+  border-top: 1px solid var(--rule);
+  padding: var(--s-3) 0;
+}
+.outline li:last-child {
+  border-bottom: 1px solid var(--rule);
+}
+.outline-head {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: var(--s-3);
+  align-items: center;
+  cursor: pointer;
+}
+.outline-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+}
+.outline-num {
+  font-family: var(--ff-mono);
+  font-size: var(--fs-12);
+  letter-spacing: var(--ls-mono);
+  color: var(--fg-muted);
+}
+.outline-title {
+  font-family: var(--ff-serif);
+  font-size: var(--fs-20);
+  color: var(--fg);
+}
+.outline-body {
+  margin-top: var(--s-3);
+  padding-left: 32px;
+}
+.section-content {
+  font-family: var(--ff-serif);
+  font-size: var(--fs-16);
+  line-height: 1.7;
+  color: var(--fg);
+  margin: 0;
+}
+.outline li.is-current .outline-title {
+  color: var(--accent);
+}
+.markdown-body :deep(h1),
+.markdown-body :deep(h2),
+.markdown-body :deep(h3),
+.markdown-body :deep(h4) {
+  font-family: var(--ff-serif);
+  color: var(--fg);
+  line-height: 1.25;
+  margin: 1.8em 0 0.4em;
+  font-weight: 500;
+}
+.markdown-body :deep(p) {
+  margin: 0.9em 0;
+}
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) {
+  margin: 0.9em 0 0.9em 1.4em;
+  padding: 0;
+}
+.markdown-body :deep(blockquote) {
+  border-left: 3px solid var(--accent);
+  margin: 1em 0;
+  padding: 0.2em 1em;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.markdown-body :deep(code) {
+  background: var(--bg-elevated);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: var(--ff-mono);
+  font-size: 0.9em;
+}
+</style>

--- a/frontend/src/composables/useReportExports.ts
+++ b/frontend/src/composables/useReportExports.ts
@@ -1,0 +1,145 @@
+import type { ComputedRef, Ref } from 'vue'
+import { exportReport } from '../api/report'
+import { parseReportContract, type EvidenceMap } from '../contracts/reportContract'
+
+interface UseReportExportsOptions {
+  reportId: () => string | undefined
+  reportMarkdown: ComputedRef<string>
+  reportHtml: ComputedRef<string>
+  evidenceMap: Ref<EvidenceMap | null>
+  addLog: (message: string) => void
+  recordSchemaError: (where: string, error: unknown) => void
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  setTimeout(() => URL.revokeObjectURL(url), 500)
+}
+
+function buildStandaloneHtml(title: string, bodyHtml: string) {
+  return `<!doctype html>
+<html lang="de"><head><meta charset="utf-8" />
+<title>${title}</title>
+<style>
+  body { font-family: Georgia, 'Iowan Old Style', serif; max-width: 740px; margin: 48px auto; padding: 0 24px; color: #111; line-height: 1.6; font-size: 16px; }
+  h1,h2,h3,h4 { font-family: Georgia, serif; line-height: 1.25; margin: 2em 0 0.4em; }
+  h1 { font-size: 2em; border-bottom: 1px solid #ccc; padding-bottom: 0.3em; }
+  h2 { font-size: 1.5em; }
+  h3 { font-size: 1.2em; }
+  p { margin: 0.8em 0; }
+  ul, ol { margin: 0.8em 0 0.8em 1.4em; }
+  li { margin: 0.3em 0; }
+  blockquote { border-left: 3px solid #e2681a; margin: 1em 0; padding: 0.2em 1em; color: #555; font-style: italic; }
+  code { background: #f3f3f3; padding: 2px 4px; border-radius: 3px; font-size: 0.92em; }
+  pre { background: #1a1a1a; color: #eee; padding: 1em; overflow: auto; border-radius: 4px; }
+  pre code { background: transparent; color: inherit; padding: 0; }
+  table { border-collapse: collapse; margin: 1em 0; }
+  th, td { border: 1px solid #ccc; padding: 6px 10px; }
+  hr { border: 0; border-top: 1px solid #ccc; margin: 2em 0; }
+  @media print { body { margin: 0; padding: 24px; } }
+</style>
+</head>
+<body>
+<h1>${title}</h1>
+${bodyHtml}
+</body></html>`
+}
+
+export function useReportExports(options: UseReportExportsOptions) {
+  function downloadMarkdown() {
+    const md = options.reportMarkdown.value
+    const reportId = options.reportId()
+    if (!md || !reportId) return
+    triggerDownload(
+      new Blob([md], { type: 'text/markdown;charset=utf-8' }),
+      `agora-report-${reportId}.md`
+    )
+  }
+
+  function downloadHtml() {
+    const reportId = options.reportId()
+    const html = buildStandaloneHtml(
+      `Agora-Report · ${reportId || ''}`,
+      options.reportHtml.value
+    )
+    triggerDownload(
+      new Blob([html], { type: 'text/html;charset=utf-8' }),
+      `agora-report-${reportId}.html`
+    )
+  }
+
+  function printReport() {
+    const reportId = options.reportId()
+    const html = buildStandaloneHtml(
+      `Agora-Report · ${reportId || ''}`,
+      options.reportHtml.value
+    )
+    const w = window.open('', '_blank')
+    if (!w) {
+      options.addLog('Popup blockiert — bitte Popups erlauben.')
+      return
+    }
+    w.document.open()
+    w.document.write(html)
+    w.document.close()
+    w.addEventListener('load', () => {
+      setTimeout(() => w.print(), 200)
+    })
+  }
+
+  async function copyMarkdown() {
+    const md = options.reportMarkdown.value
+    if (!md) return
+    try {
+      await navigator.clipboard.writeText(md)
+      options.addLog('Markdown in Zwischenablage kopiert.')
+    } catch (e) {
+      options.addLog('Kopieren fehlgeschlagen: ' + (e as Error).message)
+    }
+  }
+
+  function downloadEvidence() {
+    const evidenceMap = options.evidenceMap.value
+    const reportId = options.reportId()
+    if (!evidenceMap || !reportId) return
+    triggerDownload(
+      new Blob([JSON.stringify(evidenceMap, null, 2)], { type: 'application/json;charset=utf-8' }),
+      `agora-report-${reportId}-evidence.json`
+    )
+  }
+
+  async function downloadCombinedJson() {
+    const reportId = options.reportId()
+    if (!reportId) return
+    try {
+      const blob = await exportReport(reportId, 'json')
+      const text = await blob.text()
+      const json = JSON.parse(text)
+      const parsed = parseReportContract(json)
+      if (!parsed.ok) {
+        options.recordSchemaError('export', { issues: parsed.errors })
+        options.addLog('JSON-Export: Schema-Mismatch — siehe rote Box')
+        return
+      }
+      const validatedBlob = new Blob([JSON.stringify(parsed.data, null, 2)], { type: 'application/json;charset=utf-8' })
+      triggerDownload(validatedBlob, `agora-report-${reportId}.json`)
+    } catch (e) {
+      options.addLog('JSON-Export fehlgeschlagen: ' + ((e as Error)?.message || String(e)))
+    }
+  }
+
+  return {
+    copyMarkdown,
+    downloadCombinedJson,
+    downloadEvidence,
+    downloadHtml,
+    downloadMarkdown,
+    printReport,
+  }
+}

--- a/frontend/src/utils/__tests__/reportAgentLog.spec.ts
+++ b/frontend/src/utils/__tests__/reportAgentLog.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { parseAgentEntry } from '../reportAgentLog'
+
+describe('parseAgentEntry', () => {
+  it('preserves visual log markers from the original Step4 renderer', () => {
+    expect(parseAgentEntry({
+      action: 'tool_call',
+      tool_name: 'graph_search',
+      details: { parameters: { query: 'x'.repeat(90) } },
+    })?.title).toBe('TOOL → graph_search')
+    expect(parseAgentEntry({
+      action: 'tool_call',
+      details: { parameters: { query: 'x'.repeat(90) } },
+    })?.subtitle).toContain('…')
+    expect(parseAgentEntry({ action: 'tool_result', tool_name: 'graph_search' })?.title).toBe('← graph_search')
+    expect(parseAgentEntry({ action: 'section_start', section_index: 2, section_title: 'Kontext' })?.title).toBe('▶ Section 2: Kontext')
+    expect(parseAgentEntry({ action: 'section_complete', section_index: 2 })?.title).toBe('✓ Section 2')
+    expect(parseAgentEntry({ action: 'error', details: { message: 'kaputt' } })?.title).toBe('⚠ ERROR')
+  })
+})

--- a/frontend/src/utils/reportAgentLog.ts
+++ b/frontend/src/utils/reportAgentLog.ts
@@ -33,23 +33,23 @@ export function parseAgentEntry(raw: unknown): AgentLogEntry | null {
   let body = ''
 
   if (action === 'tool_call') {
-    title = `TOOL -> ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
+    title = `TOOL → ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
     const params = (d.parameters as Record<string, unknown>) || {}
     subtitle = Object.entries(params).map(([k, v]) => {
       const str = typeof v === 'string' ? v : JSON.stringify(v)
-      return `${k}=${str.length > 80 ? str.slice(0, 80) + '...' : str}`
+      return `${k}=${str.length > 80 ? str.slice(0, 80) + '…' : str}`
     }).join('  ')
   } else if (action === 'tool_result') {
-    title = `<- ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
+    title = `← ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
     subtitle = `${(d.result_length as number) || 0} chars`
   } else if (action === 'llm_response') {
     title = 'LLM'
     subtitle = `iter ${d.iteration ?? ''} · tool_calls=${d.has_tool_calls} · final=${d.has_final_answer}`
     body = (d.response as string) || ''
   } else if (action === 'section_start') {
-    title = `Section ${obj.section_index ?? ''}: ${(obj.section_title as string) || (d.message as string) || ''}`
+    title = `▶ Section ${obj.section_index ?? ''}: ${(obj.section_title as string) || (d.message as string) || ''}`
   } else if (action === 'section_complete') {
-    title = `Section ${obj.section_index ?? ''}`
+    title = `✓ Section ${obj.section_index ?? ''}`
     subtitle = (d.message as string) || ''
   } else if (action === 'planning_complete') {
     title = 'PLAN'
@@ -57,7 +57,7 @@ export function parseAgentEntry(raw: unknown): AgentLogEntry | null {
     subtitle = `${outline.length} sections`
     body = (d.summary as string) || ''
   } else if (action === 'error') {
-    title = 'ERROR'
+    title = '⚠ ERROR'
     subtitle = (d.message as string) || (d.error as string) || ''
   }
   return {

--- a/frontend/src/utils/reportAgentLog.ts
+++ b/frontend/src/utils/reportAgentLog.ts
@@ -1,0 +1,72 @@
+export interface AgentLogEntry {
+  ts: string
+  stage: string
+  action: string
+  title: string
+  subtitle: string
+  body: string
+  elapsed: number | undefined
+  [key: string]: unknown
+}
+
+function parseAgentObject(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      return { action: 'raw', message: raw }
+    }
+  }
+  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
+  return null
+}
+
+export function parseAgentEntry(raw: unknown): AgentLogEntry | null {
+  const obj = parseAgentObject(raw)
+  if (!obj) return null
+  const ts = obj.timestamp ? String(obj.timestamp).slice(11, 19) : ''
+  const stage = (obj.stage as string) || ''
+  const action = (obj.action as string) || ''
+  const d = (obj.details as Record<string, unknown>) || {}
+  let title = action.replace(/_/g, ' ')
+  let subtitle = ''
+  let body = ''
+
+  if (action === 'tool_call') {
+    title = `TOOL -> ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
+    const params = (d.parameters as Record<string, unknown>) || {}
+    subtitle = Object.entries(params).map(([k, v]) => {
+      const str = typeof v === 'string' ? v : JSON.stringify(v)
+      return `${k}=${str.length > 80 ? str.slice(0, 80) + '...' : str}`
+    }).join('  ')
+  } else if (action === 'tool_result') {
+    title = `<- ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
+    subtitle = `${(d.result_length as number) || 0} chars`
+  } else if (action === 'llm_response') {
+    title = 'LLM'
+    subtitle = `iter ${d.iteration ?? ''} · tool_calls=${d.has_tool_calls} · final=${d.has_final_answer}`
+    body = (d.response as string) || ''
+  } else if (action === 'section_start') {
+    title = `Section ${obj.section_index ?? ''}: ${(obj.section_title as string) || (d.message as string) || ''}`
+  } else if (action === 'section_complete') {
+    title = `Section ${obj.section_index ?? ''}`
+    subtitle = (d.message as string) || ''
+  } else if (action === 'planning_complete') {
+    title = 'PLAN'
+    const outline = ((d.outline as Record<string, unknown>)?.sections as unknown[]) || []
+    subtitle = `${outline.length} sections`
+    body = (d.summary as string) || ''
+  } else if (action === 'error') {
+    title = 'ERROR'
+    subtitle = (d.message as string) || (d.error as string) || ''
+  }
+  return {
+    ts,
+    stage,
+    action,
+    title,
+    subtitle,
+    body,
+    elapsed: obj.elapsed_seconds as number | undefined,
+  }
+}


### PR DESCRIPTION
## Summary

- split `Step4Report.vue` into focused Step4 subcomponents
- move report export/download handling into `useReportExports`
- move agent-log parsing into `reportAgentLog`
- document the refactor in `CHANGELOG.md`

## Notes

This intentionally does not close an existing GitHub issue: the currently open issues are CVE/dependency trackers plus unrelated #212/#199, while #203 is already closed and Step2-specific.

## Verification

- `cd frontend && npm run test -- --run src/components/__tests__/Step4Report.spec.ts`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run check`
