### PR TITLE
fix: align report schema and model selection

### DIFF
--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -89,7 +89,7 @@ def generate_report():
     if not state:
         return json_error(f"Simulation does not exist: {simulation_id}", status=404)
 
-    if not force_regenerate:
+    if _can_reuse_existing_report(force_regenerate, llm_model_override):
         existing_report = ReportManager.get_report_by_simulation(simulation_id)
         if existing_report and existing_report.status == ReportStatus.COMPLETED:
             return json_success({
@@ -259,7 +259,7 @@ def get_generate_status():
                 "progress": run.get("progress", 0),
                 "message": progress_state.get("message") or run.get("message", ""),
                 "error": run.get("error"),
-                "outline": report_obj.outline.to_dict() if report_obj and report_obj.outline else None,
+                "outline": _map_outline_for_contract(report_obj.outline.to_dict()) if report_obj and report_obj.outline else None,
                 "sections": generated_sections,
                 "current_section_index": len(progress_state.get("completed_sections") or []),
             }
@@ -353,7 +353,7 @@ def get_report(report_id: str):
     report = ReportManager.get_report(report_id)
     if not report:
         return json_error(f"Report does not exist: {report_id}", status=404)
-    return json_success(report.to_dict())
+    return json_success(_build_report_contract_model(report).model_dump(mode="json"))
 
 
 @report_bp.route('/by-simulation/<simulation_id>', methods=['GET'])
@@ -369,7 +369,7 @@ def get_report_by_simulation(simulation_id: str):
             status=404,
             extra={"has_report": False},
         )
-    return json_success(report.to_dict())
+    return json_success(_build_report_contract_model(report).model_dump(mode="json"))
 
 
 @report_bp.route('/list', methods=['GET'])
@@ -380,7 +380,10 @@ def list_reports():
         return json_error("Invalid simulation_id format", status=400)
     limit = request.args.get('limit', 50, type=int)
     reports = ReportManager.list_reports(simulation_id=simulation_id, limit=limit)
-    return json_success([r.to_dict() for r in reports], count=len(reports))
+    return json_success(
+        [_build_report_contract_model(r).model_dump(mode="json") for r in reports],
+        count=len(reports),
+    )
 
 
 @report_bp.route('/<report_id>/evidence', methods=['GET'])
@@ -391,7 +394,8 @@ def get_report_evidence(report_id: str):
     evidence_map = ReportManager.get_evidence_map(report_id)
     if not evidence_map:
         return json_error(f"No evidence map available for report: {report_id}", status=404)
-    return json_success(evidence_map)
+    migrated = migrate_v1_to_v2(evidence_map)
+    return json_success(EvidenceMapModel.model_validate(migrated).model_dump(mode="json"))
 
 
 @report_bp.route('/<report_id>/evidence/<int:section_index>', methods=['GET'])
@@ -428,6 +432,11 @@ def get_report_evidence_claim(report_id: str, section_index: int, claim_id: str)
 EXPORT_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION
 
 
+def _can_reuse_existing_report(force_regenerate: bool, llm_model_override: Optional[str]) -> bool:
+    """Reuse only when the caller did not request a concrete report model."""
+    return not force_regenerate and not llm_model_override
+
+
 def _map_outline_for_contract(outline: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
     """Map the dataclass outline shape onto the v2 contract shape.
 
@@ -457,6 +466,13 @@ def _map_outline_for_contract(outline: Optional[dict[str, Any]]) -> Optional[dic
     }
 
 
+def _build_report_contract_model(report_obj) -> ReportModel:
+    report_dict = report_obj.to_dict()
+    report_dict["schema_version"] = CURRENT_SCHEMA_VERSION
+    report_dict["outline"] = _map_outline_for_contract(report_dict.get("outline"))
+    return ReportModel.model_validate(report_dict)
+
+
 def _build_export_envelope(report_obj, raw_evidence_map: Optional[dict[str, Any]]) -> ReportContractModel:
     """Build the v2 export envelope.
 
@@ -466,11 +482,7 @@ def _build_export_envelope(report_obj, raw_evidence_map: Optional[dict[str, Any]
     rather than 500-ing on persisted v1-shaped payloads. Storage-side reshape
     is tracked under Sub-Slice 02b/02c (#107).
     """
-    report_dict = report_obj.to_dict()
-    report_dict["schema_version"] = CURRENT_SCHEMA_VERSION
-    report_dict["outline"] = _map_outline_for_contract(report_dict.get("outline"))
-
-    report = ReportModel.model_validate(report_dict)
+    report = _build_report_contract_model(report_obj)
 
     evidence: Optional[EvidenceMapModel] = None
     migrated = migrate_v1_to_v2(raw_evidence_map) if raw_evidence_map else None

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -8,6 +8,7 @@ import pytest
 from flask import Flask
 
 from app.api import report_bp
+from app.api.report import _can_reuse_existing_report
 from app.services.report_agent import (
     Report,
     ReportManager,
@@ -148,6 +149,27 @@ def test_export_rejects_unknown_format(env):
 def test_export_returns_404_when_report_missing(env):
     response = env.get(f"/api/report/{REPORT_ID}/export?format=json")
     assert response.status_code == 404
+
+
+def test_get_report_returns_contract_shaped_payload(env):
+    _persist_report()
+    response = env.get(f"/api/report/{REPORT_ID}")
+    assert response.status_code == 200
+
+    payload = response.get_json()["data"]
+    assert payload["schema_version"] == 2
+    assert payload["report_id"] == REPORT_ID
+    assert payload["outline"]["sections"][0] == {
+        "title": "Intro",
+        "description": "Body",
+    }
+    assert "content" not in payload["outline"]["sections"][0]
+
+
+def test_explicit_model_override_disables_existing_report_reuse():
+    assert _can_reuse_existing_report(False, None) is True
+    assert _can_reuse_existing_report(False, "gemini-3-flash-preview:cloud") is False
+    assert _can_reuse_existing_report(True, None) is False
 
 
 def test_export_md_returns_markdown_attachment(env):

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -16,6 +16,7 @@ import {
   getSimulationConsoleLog
 } from '../api/simulation'
 import { generateReport } from '../api/report'
+import { STORAGE_CUSTOM_MODEL, STORAGE_MODEL } from '../composables/useEnvForm'
 import Btn from './ui/Btn.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from './ui/Kicker.vue'
@@ -425,8 +426,15 @@ async function goReport() {
     // Reuse the model the user picked for Step 2 (Report-specific override
     // can be set in Step 4). 'default' or empty → server uses LLM_MODEL_NAME.
     const payload = { simulation_id: props.simulationId }
-    const stored = localStorage.getItem('agora.reportModel') || localStorage.getItem('agora.lastModel')
-    if (stored && stored !== 'default' && stored !== 'custom') {
+    const stored = localStorage.getItem('agora.reportModel') || localStorage.getItem(STORAGE_MODEL)
+    if (stored === 'custom') {
+      const custom = (
+        localStorage.getItem('agora.reportCustomModel') ||
+        localStorage.getItem(STORAGE_CUSTOM_MODEL) ||
+        ''
+      ).trim()
+      if (custom) payload.llm_model = custom
+    } else if (stored && stored !== 'default') {
       payload.llm_model = stored
     }
     const res = await generateReport(payload)

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -94,14 +94,16 @@ function recordSchemaError(where: string, error: unknown): void {
 const resolvedSimulationId = ref(props.simulationId || null)
 
 const STORAGE_REPORT_MODEL = 'agora.reportModel'
+const STORAGE_REPORT_CUSTOM_MODEL = 'agora.reportCustomModel'
 const reportModelOption = ref(localStorage.getItem(STORAGE_REPORT_MODEL) || 'default')
-const customReportModel = ref('')
+const customReportModel = ref(localStorage.getItem(STORAGE_REPORT_CUSTOM_MODEL) || '')
 const ollamaModels = ref<Array<{ name: string; label?: string }>>([])
 const presetModels = ref<Array<{ name: string; label?: string }>>([])
 const defaultModel = ref('')
 const isRegenerating = ref(false)
 
 watch(reportModelOption, (val) => { localStorage.setItem(STORAGE_REPORT_MODEL, val) })
+watch(customReportModel, (val) => { localStorage.setItem(STORAGE_REPORT_CUSTOM_MODEL, val) })
 
 const modelOptions = computed(() => {
   const opts = [{ value: 'default', label: `Standard — ${defaultModel.value || '?'}` }]

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -70,6 +70,7 @@ vi.mock('../../composables/useEventStream', () => ({
 
 import Step3Simulation from '../Step3Simulation.vue'
 import { useEventStream } from '../../composables/useEventStream'
+import { generateReport } from '../../api/report'
 
 const i18n = createI18n({
   legacy: false,
@@ -157,6 +158,7 @@ describe('Step3Simulation — mount smoketest (Aktion 7, PR #207-Followup)', () 
 describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     _capturedStateCallback = null
     // Reset useEventStream mock zurück auf Standardimplementation.
     ;(useEventStream as ReturnType<typeof vi.fn>).mockImplementation(
@@ -277,5 +279,32 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
 
     // Nach doStart (mit success=false): resetState wurde aufgerufen → phase=0 → Start-Button sichtbar.
     expect(wrapper.findAll('button').map(b => b.text()).some(t => t.includes('step3.controls.start'))).toBe(true)
+  })
+
+  it('sendet ein persistiertes Custom-Modell beim Reportstart', async () => {
+    vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
+    ;(generateReport as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { report_id: 'report_test123456' },
+    })
+    localStorage.setItem('agora.lastModel', 'custom')
+    localStorage.setItem('agora.lastCustomModel', 'deepseek-v3.2:cloud')
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(_capturedStateCallback).not.toBeNull()
+    _capturedStateCallback!({ payload: { runner_status: 'completed', current_round: 5 } })
+    await wrapper.vm.$nextTick()
+
+    const reportBtn = wrapper.findAll('button').find(b => b.text().includes('step3.next'))
+    expect(reportBtn).toBeTruthy()
+    await reportBtn!.trigger('click')
+    await flushPromises()
+
+    expect(generateReport).toHaveBeenCalledWith({
+      simulation_id: 'sim_test_smoke',
+      llm_model: 'deepseek-v3.2:cloud',
+    })
   })
 })

--- a/frontend/src/composables/__tests__/useEnvForm.spec.ts
+++ b/frontend/src/composables/__tests__/useEnvForm.spec.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { nextTick } from 'vue'
-import { useEnvForm, STORAGE_MODEL, STORAGE_LANG } from '../useEnvForm'
+import { useEnvForm, STORAGE_CUSTOM_MODEL, STORAGE_MODEL, STORAGE_LANG } from '../useEnvForm'
 
 // ---------------------------------------------------------------------------
 // Mock t() — identity function; tests check key suffixes, not translated text
@@ -354,6 +354,22 @@ describe('useEnvForm', () => {
       // Simulate new mount by creating a new composable instance
       const f2 = useEnvForm({ t })
       expect(f2.modelOption.value).toBe('gemma3')
+    })
+
+    it('customModel wird persistiert und beim nächsten Mount wieder geladen', async () => {
+      const f1 = useEnvForm({ t })
+      f1.modelOption.value = 'custom'
+      f1.customModel.value = 'deepseek-v3.2:cloud'
+
+      await nextTick()
+      await nextTick()
+
+      expect(localStorageStub.getItem(STORAGE_CUSTOM_MODEL)).toBe('deepseek-v3.2:cloud')
+
+      const f2 = useEnvForm({ t })
+      expect(f2.modelOption.value).toBe('custom')
+      expect(f2.customModel.value).toBe('deepseek-v3.2:cloud')
+      expect(f2.effectiveModel()).toBe('deepseek-v3.2:cloud')
     })
   })
 })

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -32,6 +32,7 @@ import { getAvailableModels } from '../api/simulation'
 // ---------------------------------------------------------------------------
 
 export const STORAGE_MODEL = 'agora.lastModel'
+export const STORAGE_CUSTOM_MODEL = 'agora.lastCustomModel'
 export const STORAGE_LANG = 'agora.agentLanguage'
 
 // ---------------------------------------------------------------------------
@@ -91,6 +92,14 @@ function _loadStoredModel(): string {
   }
 }
 
+function _loadStoredCustomModel(): string {
+  try {
+    return localStorage.getItem(STORAGE_CUSTOM_MODEL) || ''
+  } catch {
+    return ''
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Composable
 // ---------------------------------------------------------------------------
@@ -106,7 +115,7 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
   const maxToolCallsPerAction = ref<number>(2)
   const loadingModels = ref<boolean>(true)
   const modelOption = ref<string>(_loadStoredModel())
-  const customModel = ref<string>('')
+  const customModel = ref<string>(_loadStoredCustomModel())
   const language = ref<string>(_loadStoredLang())
 
   // --- Computed ---
@@ -133,6 +142,14 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
   watch(modelOption, (val) => {
     try {
       localStorage.setItem(STORAGE_MODEL, val)
+    } catch {
+      // ignore — storage may be unavailable in some environments
+    }
+  })
+
+  watch(customModel, (val) => {
+    try {
+      localStorage.setItem(STORAGE_CUSTOM_MODEL, val)
     } catch {
       // ignore — storage may be unavailable in some environments
     }


### PR DESCRIPTION
Closes #328

## Summary

- map report read/status responses to the strict v2 report contract used by the frontend
- validate/migrate evidence maps on read
- avoid reusing old reports when an explicit report model override is supplied
- persist and forward custom frontend model selections

## Verification

```bash
cd backend && uv run pytest tests/test_report_export.py -q
cd backend && uv run ruff check app/api/report.py tests/test_report_export.py
npm --prefix frontend test -- --run src/composables/__tests__/useEnvForm.spec.ts src/components/__tests__/Step3Simulation.spec.ts src/components/__tests__/Step4Report.spec.ts
npm --prefix frontend run check
```

## Local artifact audit

- `run_041ccf5dc100` / `report_71466cc74622` is completed and has report artifacts
- new read-boundary emits `schema_version=2`, `status=completed`, outline sections with `title`/`description`, and non-empty markdown
- evidence validates as schema v2 with 3 sections and 12 global evidence items
