### PR TITLE
docs(plan): sync M11-Status auf 2026-05-08

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Agora ist ein **lokal-first** Multi-Agent-Simulator für DACH-Zielgruppenreaktio
 
 **Stack:** Flask (Python 3.11) + Pydantic v2 + Vue 3 + Vite + Pinia + Neo4j 5.18 CE + OASIS (`camel-oasis`) + Redis (Pub/Sub-IPC) + Ollama. Package-Manager: `uv` fürs Backend, `npm` fürs Frontend.
 
-**Status:** v0.9.0+ post-tag · Layer 0–6 grün · Layer 7–9 teilweise · Layer 10 dokumentiert. Test-Counts und Layer-Status laufen ausschließlich über [`docu/STATUS.md`](docu/STATUS.md) — keine Inline-Zahlen mehr in README/CLAUDE.md/AGENTS.md.
+**Status:** v0.9.0+ post-tag · Layer 0–6 grün · Layer 7–8 teilweise · Layer 9–10 grün · M11 Phase 1–5b durch. Test-Counts und Layer-Status laufen ausschließlich über [`docu/STATUS.md`](docu/STATUS.md) — keine Inline-Zahlen mehr in README/CLAUDE.md/AGENTS.md.
 
 ## Sofort wichtig
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Alle nennenswerten Änderungen an Agora werden hier dokumentiert.
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [SemVer](https://semver.org/lang/de/).
 
 ## [Unreleased]
+### Documentation
+- docs(plan): sync M11-Status auf 2026-05-08 — `AGENTS.md`/`CLAUDE.md`/`PLAN.md`/`STATUS.md` an realen Code-Stand angeglichen (M11 Phase 1–5b abgeschlossen, M11.2/M11.3 Coverage-Gates aktiv, ADR-0001 Accepted, Layer 9–10 grün).
+
 ### Added
 - docs(m11): add `graph_tools.py` Phase-5b cut analysis (Refs F7)
 - **M11 Phase 5 Vorbereitung:** Schnittanalyse für `backend/app/services/simulation_runner.py` (1904 LOC) unter [`docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md`](docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md). Dokumentiert Verantwortlichkeiten, externe Call-Sites, Test-Coverage und fünf Extraktionskandidaten mit empfohlener PR-Reihenfolge (read-only Doku, kein Code-Edit). Refs F7.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ backend/                    Python 3.11, uv, Flask, Pydantic v2, pytest
     api/                    HTTP-Routen (Flask Blueprints)
     services/               Business-Logik
       report_agent/         Package-Split (Sub-Slice M11.13, #202): agent.py, manager.py, planning.py, evidence.py, prompts.py, schemas.py, sections.py, storage.py, tools.py, workflow.py — Layer-0-Boundary in agent.py + planning.py
+      sim/                  M11 Phase 5 Hotspot-Refactor (2026-05-08, 5 PRs): run_state_store, action_log_reader, monitor, interview_client, process_manager extrahiert. `simulation_runner.py` orchestriert nur noch.
+      graph/                M11 Phase 5b Hotspot-Refactor (2026-05-08, 3 PRs): graph_dtos, graph_reader, insight_forge_tool extrahiert. `graph_tools.py` orchestriert.
       evidence_binder.py    Sub-Slice 07: Contradiction-Penalty, kein dekoratives Fallback
       confidence_calculator.py  Sub-Slice 08: Match-Score-Cap + Verified-Quellen-Gate
       oasis_profile_generator.py  voice_register-Pflichtfeld (Sub-Slice 10)
@@ -89,16 +91,23 @@ prompts/                    UI-Prompt-Vorlagen
 | 6 | Frontend-TypeScript-Migration (API, Composables, Pinia) | grün (26, 27, 28 — #71/#72/#73) |
 | 7 | Graph / Runs / Compare | teilweise — done: 29 (#65), 33 (#62), 35 (#64). Offen: 22 #74 (Graph-Diff), 24 #66 (Compare-API), 25 #67 (Compare-UI), 27 #63 (RunsDashboard) |
 | 8 | Persona Review + UX | teilweise — done: 30 (#141 Sticky-Scroll). Offen: 29 #69 (Persona-Diff), 30 #70 (Approve/Reject/Regenerate), 32 #137 (Graph-Build-Batch-Marker) |
-| 9 | Production Deployment | grün mit bewusst pausiertem PR-Smoke — Reverse-Proxy ✅ (`deploy/nginx/`, `deploy/compose/docker-compose.prod-with-proxy.yml`), gevent ✅ (`Dockerfile` `prod`-Stage), Bundle-Token-Gate ✅ (`ALLOW_BUILD_TIME_TOKEN=false` Default), `?token=`-Block in Prod ✅ (`utils/auth.py`), signed-tickets-Frontend ✅ (`frontend/src/api/stream.ts`), Prod-Stack-Smoke auf `main`/Tags/`workflow_dispatch` ✅ (`docker-image.yml::prod-proxy-smoke`). PR-Trigger seit 2026-05-06 wegen ~30 min Laufzeit pausiert und vor Release neu zu bewerten. |
-| 10 | Security Watchlist (CVE-Tracking, pip-audit) | grün — CVE-Monitor wöchentlich (`.github/workflows/cve-monitor.yml`, `pip-audit --strict` ohne `--ignore-vuln`), Hardstop 2026-07-30 verdrahtet (Workflow failt ab dann), Risk-Register mit Eskalationspfad (`docu/dependency-risk-register.md`). Issues #121–#126 bleiben open bis Upstream patcht. |
+| 9 | Production Deployment | grün — M11 Phase 1–4 Hardening (Release-Gating, Static-Analysis-Gates, Multi-Stage `prod`-Image ohne Node/npm/curl + `read_only: true`, Supply Chain) abgeschlossen 2026-05-07. Reverse-Proxy ✅, gevent ✅, Bundle-Token-Gate ✅, `?token=`-Block in Prod ✅, signed-tickets-Frontend ✅, Prod-Stack-Smoke auf `main`/Tags/`workflow_dispatch` ✅ (`docker-image.yml::prod-proxy-smoke`). PR-Trigger seit 2026-05-06 wegen ~30 min Laufzeit pausiert und vor Release neu zu bewerten. |
+| 10 | Security Watchlist (CVE-Tracking, pip-audit) | grün — CVE-Monitor wöchentlich (`.github/workflows/cve-monitor.yml`, `pip-audit --strict` ohne `--ignore-vuln`), Hardstop 2026-07-30 verdrahtet (Workflow failt ab dann), Risk-Register mit Eskalationspfad (`docu/dependency-risk-register.md`). Issues #121–#126 bleiben open bis Upstream patcht. Zusätzlich CVE-Tracker #296/#297/#298 seit 2026-05-07 unter Beobachtung. Phase 4 Supply Chain (`dependency-review.yml`, `codeql.yml`, GHCR Build-Provenance-Attestation, SPDX-JSON-SBOM-Artefakt) zusätzlich aktiv. |
 
 ## Aktive Hot-Spots / offene Hauspflicht
 
-Die ursprünglichen Layer-0–6-Hot-Spots aus dem ChatGPT-Audit sind alle gefixt. Layer-9-Hardening ist überwiegend im Code drin (siehe Layer-Tabelle oben). Aktuelle Baustellen:
+Layer-0–6 + 9–10 sind durch. Aktuelle M11-Baustellen:
 
-- **Coverage-Gates** (M11.2/M11.3): `pytest-cov` + `@vitest/coverage-v8`, Startwerte 70 % Backend / 60 % Frontend.
+- **Coverage-Gate-Anhebung** (M11.2/M11.3): Aktuelle Schwellen Backend 53 % / Frontend 24 %. Ziel Backend 70 % / Frontend 60 % schrittweise. Coverage-Reports als Artifacts `backend-coverage` / `frontend-coverage` (14 Tage Retention) in `ci.yml`.
+- **Phase 6 Contract-Generation + Status-Sync:** Contract-Dump reproduzierbar machen, Frontend-Zod-Spiegel automatisiert gegen Pydantic prüfen, `scripts/sync-status.sh` als CI-Pflichtschritt.
+- **Phase 7 / M11.4 Playwright-Smokes:** Drei stabile E2E-Smokes — Health/Login, Upload+Graph, Minimalreport. Keine 90-Test-Pyramide.
+- **M11.5 Komplexitäts-Gate:** `radon` Backend, ESLint/size-limit Frontend.
+- **M11.6 API-Envelope:** Error-/Success-Envelopes vollständig durchziehen.
+- **Frontend-Hotspots (Issue #203):** `Step2EnvSetup.vue` 1804 LOC, `Step4Report.vue` 1287 LOC — analog zu Backend-Phase 5/5b zerschneiden.
 - **gevent ↔ OASIS-Subprozess Smoke:** `subprocess.Popen` läuft bei aktivem `gevent.monkey.patch_all()` standardmäßig durch den Patch — bei jedem Slice, der den OASIS-Pfad anfasst, per `scripts/verify-deploy.sh` smoken.
-- **Init-Logs doppelt** — gunicorn ohne `--preload`. Kein Bug, aber unschön. Folge-Slice braucht Fork-Safety-Verifikation der Neo4j/Redis-Pools vor `--preload`-Aktivierung.
+- **Init-Logs doppelt:** Folge-Slice braucht Fork-Safety-Verifikation der Neo4j/Redis-Pools vor `--preload`-Aktivierung.
+- **Dependabot-Aufräumen:** Offene PRs #323 (`mistune` 3.1.4 → 3.2.1), #326 (`pygments` 2.19.2 → 2.20.0). PR #315 (`camel-ai`) bleibt blockiert durch `camel-oasis==0.2.5` hard pin.
+- **Live-Settings #212 (P2):** Erst nach M11-Stabilisierung.
 
 ## Kommandos (immer diese)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # Agora — Konsolidierter Findings- & Maßnahmenplan
 
-**Stand:** 2026-05-04 (post-tag, M9-Hardening überwiegend im Code)  
+**Stand:** 2026-05-08 (M9/M10 abgeschlossen, M11 Phase 1–5b durch)  
 **Repo:** [`arn0ld87/agora`](https://github.com/arn0ld87/agora) · v0.9.0 + Layer-9-Slices auf `main`  
 **Quellen:** Code-Verifikation 2026-05-04 (`Dockerfile`, `docker-compose.prod.yml`, `deploy/`, `backend/app/utils/auth.py`, `frontend/src/api/stream.ts`, `.github/workflows/`), Audit-Snapshot [`docu/history/2026-05-04-plan-update-audit-snapshot.md`](docu/history/2026-05-04-plan-update-audit-snapshot.md), interner Backlog.  
 **Ziel:** Findings aus Code-Review und Audit konsolidieren, mit den vorhandenen Slash-Commands (`/agora-next-task`, `/verify-after-subagent`, `/fix-task-*`) und Subagents (`agora-refactor-worker`, `agora-test-worker`, `agora-frontend-worker`, `agora-doc-worker`, `agora-evidence-auditor`) kompatibel halten und in eine umsetzbare Reihenfolge bringen.
@@ -34,9 +34,9 @@
 
 ---
 
-## Status-Sync 2026-05-04
+## Status-Sync 2026-05-08
 
-Konsolidierte Bewertung gegen den realen Code-Stand. Quelle: Audit-Snapshot [`docu/history/2026-05-04-plan-update-audit-snapshot.md`](docu/history/2026-05-04-plan-update-audit-snapshot.md), verifiziert per `grep`/`find` 2026-05-04. Die ursprünglichen F-Detail-Sektionen ab [§ Findings im Detail](#findings-im-detail) bleiben als historische Tiefe stehen — Status-Update hier ist autoritativ.
+Konsolidierte Bewertung gegen den realen Code-Stand. Quellen: `docu/STATUS.md` 2026-05-07-Einträge, Recent commits (M11 Phase 5/5b), offene PRs/Issues #123–#326, verifikation per `ls`/`grep` 2026-05-08. Die ursprünglichen F-Detail-Sektionen ab [§ Findings im Detail](#findings-im-detail) bleiben als historische Tiefe stehen — Status-Update hier ist autoritativ.
 
 ### Erledigt (Code-verifiziert)
 
@@ -58,39 +58,55 @@ Konsolidierte Bewertung gegen den realen Code-Stand. Quelle: Audit-Snapshot [`do
 | R3 / M10.4 | Auth-Zielbild | ADR-0001 Accepted: Agora v1 bleibt Single-User-only mit Shared Token + signed Tickets. |
 | N3 / M10.5 | Rate Limits | App-seitige Fixed-Window-Limits für Ticket-, Upload-, Simulation-LLM- und Report-Trigger-Endpunkte vorhanden (#302, PR #303–#306). |
 | W2 / M11.1 | Evidence-Gate | `contract-gates.yml` führt `evidence-quality` als Hard-Gate aus; Bad-Cases sind Snapshot-gepinnt. |
+| M11.2 | Backend-Coverage | `pytest-cov` mit `--cov-fail-under=53` aktiv, `backend-coverage`-Artifact in `ci.yml` (14 Tage). Startschwelle 53 %, Ziel 70 % schrittweise. |
+| M11.3 | Frontend-Coverage | `@vitest/coverage-v8@4.1.5` mit Threshold 24 % aktiv, `frontend-coverage`-Artifact in `ci.yml` (14 Tage). Ziel 60 % schrittweise. |
+| M11 Phase 1 | Release-Gating | `docker-image.yml` mit SHA-gepinnten Actions, striktem Tag-Smoke, `latest` nur auf Default-Branch, Smoke extrahiert `frontend/dist`, Release-/RC-Smokes für `release/**`/`rc/**`. |
+| M11 Phase 2 | Static-Analysis | `ci.yml::backend` blockiert auf `uv run mypy app` (Contract-Scope strict + Legacy-Baseline), `ci.yml::frontend` blockiert auf `npm run typecheck`. Ruff `E/F/B/I/UP/SIM` mit Phase-2-Baseline. |
+| M11 Phase 3 | Container-Hardening | Multi-Stage-Dockerfile, finaler `prod`-Stage auf `python:3.11-slim` ohne Node/npm/curl, Python-Healthcheck. `docker-compose.prod.yml` mit `read_only: true` + tmpfs. Image 747 MB → 320 MB (-57 %). |
+| M11 Phase 4 | Supply Chain | `dependency-review.yml` (PR-Block bei High), `codeql.yml` (Python + JS/TS, weekly), `docker-image.yml::publish` Build-Provenance-Attestation + SPDX-JSON-SBOM-Artefakt. |
+| M11 Phase 5 | Hotspot `simulation_runner` | 5 PRs durch: run_state_store, action_log_reader, monitor_thread, interview_client, process_manager extrahiert. |
+| M11 Phase 5b | Hotspot `graph_tools` | 3 PRs durch: graph_dtos, graph_reader, insight_forge_tool extrahiert. |
+| #202 / F7 | Hotspot `report_agent` | Closed 2026-05-05 als Package-Split. |
 
 ### Aktiv offen
 
 | ID | Priorität | Bereich | Befund |
 |---|---:|---|---|
-| **M9.7** | 🟡 | Doku | `AGENTS.md`/`CLAUDE.md` enthielten alte Statusangaben (v0.6/gevent-Workaround/SSE-Token). Slice „Doku-Sync 2026-05-04" adressiert das. |
-| **W3 / M11.2-3** | 🟡 | Coverage | Kein `pytest-cov`, kein Frontend-Coverage-Gate. Startwerte: 70 % Backend / 60 % Frontend. |
-| **W4 / M11.4** | 🟡 | E2E | Keine Playwright/Cypress-Smokes für Kernworkflow. |
-| **W5 / F7-F8** | 🟡 | Code-Hotspots | `report_agent.py` 2400 LOC, `simulation_runner.py` 1904, `Step2EnvSetup.vue` 1804, `Step4Report.vue` 1287 — Issues #202/#203 in Milestone v1.0.0. |
-| **W6 / M11.6** | 🟡 | API-Envelope | Error-/Success-Envelopes werden schrittweise eingeführt, nicht vollständig belegbar. |
-| **N1 / F14.2** | 🟢 | SBOM | Kein SBOM/Third-Party-License-Report. |
-| **N2 / F14.1** | 🟢 | AGPL | Kein App-/API-Hinweis auf Source-Code des laufenden Builds (`/api/version` mit Commit-SHA). |
+| **P1-A** | 🟡 | Dependencies | Dependabot-Aufräumen: PR #323 (`mistune` 3.1.4→3.2.1) und PR #326 (`pygments` 2.19.2→2.20.0) prüfen + mergen, falls CI/contract-gates/dependency-review/CodeQL grün. |
+| **M11 Phase 6** | 🟡 | Contract-Sync | Contract-Dump reproduzierbar machen, Frontend-Zod-Spiegel automatisierte Prüfung, `scripts/sync-status.sh` als CI-Pflichtschritt. |
+| **M11.4 / Phase 7** | 🟡 | E2E | Drei stabile Playwright-Smokes: Health/Login, Upload+Graph, Minimalreport. Keine 90-Test-Pyramide. |
+| **W3 / M11.2-3** | 🟢 | Coverage-Anhebung | Startschwellen aktiv (Backend 53 %, Frontend 24 %). Schrittweise Anhebung Richtung 70 %/60 %. |
+| **M11.5** | 🟡 | Komplexitäts-Gate | `radon` Backend, ESLint/size-limit Frontend. |
+| **W6 / M11.6** | 🟡 | API-Envelope | Error-/Success-Envelopes vollständig durchziehen. |
+| **F8 / #203** | 🟡 | Frontend-Hotspots | `Step2EnvSetup.vue` (1804 LOC) und `Step4Report.vue` (1287 LOC) analog zu Backend-Phase 5/5b zerschneiden. |
+| **#199** | 🟡 | Python 3.14 | Docker-Image blockiert von tiktoken-wheel-Lag. |
+| **#296/#297/#298** | 🟡 | CVE-Tracker | Neue Watchlist-Issues seit 2026-05-07 zusätzlich zu #121–#126. |
+| **N1 / F14.2** | 🟢 | SBOM | SBOM-Artefakt seit Phase 4 in `docker-image.yml::publish`. Operationalisierung (Veröffentlichung pro Release) noch offen. |
+| **N2 / F14.1** | 🟢 | AGPL | `/api/version` mit Commit-SHA + Source-URL noch offen. |
+| **#212** | 🟢 | Live-Settings | P2 — nach M11-Stabilisierung. |
 
 ### Priorisierte To-do-Liste (operativ)
 
 🔴 **Kritisch:**
 
-1. **Coverage-Gates Backend/Frontend** — Zielpfad M11.2/M11.3; Startschwellen sind aktiv, Zielwerte werden schrittweise angehoben.
-2. **Playwright-Smokes** — Health/Login, Upload+Graph, Minimalreport.
-3. **Final-Release-Gate** — Docker-Image-Build + Reverse-Proxy-Smoke für PRs oder Release-Kandidaten wieder aktivieren.
+1. **Dependabot-Aufräumen** — PR #323/#326 prüfen + mergen oder begründet schließen.
+2. **Phase 6 Contract-Generation + Status-Sync** — Contract-Dump reproduzierbar, Zod-Spiegel CI-geprüft, `scripts/sync-status.sh` Pflicht.
+3. **Phase 7 / M11.4 Playwright-Smokes** — drei stabile E2E-Tests.
 
-🟡 **Wichtig:** 4. Komplexitäts-Gate (`radon` Backend, ESLint/size-limit Frontend). 5. API-Envelope abschließen. 6. Frontend-/Backend-Hotspot-Splits weiterführen.
+🟡 **Wichtig:** 4. Coverage-Schwellen schrittweise auf 70 %/60 % heben. 5. M11.5 Komplexitäts-Gate. 6. M11.6 API-Envelope abschließen. 7. F8 Frontend-Hotspots `Step2EnvSetup.vue`/`Step4Report.vue` (#203). 8. CVE-Watchlist #296/#297/#298 + Issue #199.
 
-🟢 **Nice-to-have:** 7. SBOM/License-Report. 8. AGPL-Operationalisierung (`/api/version` mit SHA + Source-URL).
+🟢 **Nice-to-have:** 9. N1 SBOM-Operationalisierung pro Release. 10. N2 AGPL `/api/version`-Endpoint mit Commit-SHA. 11. P2 Live-Settings (#212) nach M11-Stabilisierung.
 
 ### Arbeitsreihenfolge (PR-by-PR)
 
-1. **PR 1:** Doku-Sync `AGENTS.md`/`CLAUDE.md`/`PLAN.md`/`STATUS.md`/`docu/plan.heuristic.md` (= dieser Slice). ✅
-2. **PR 2:** Coverage-Zielwerte schrittweise Richtung Backend 70 % / Frontend 60 % anheben.
-3. **PR 3:** Playwright-Smokes.
-4. **PR 4:** Final-Release-Gate für Docker-Image-Build + Reverse-Proxy-Smoke reaktivieren oder ersetzen.
-5. **PR 5:** Komplexitäts-Gate + Hotspot-Backlog.
-6. **PR 6:** SBOM/License-Report + AGPL-Source-Link.
+1. **PR 1:** Doku-Sync `AGENTS.md`/`CLAUDE.md`/`PLAN.md`/`STATUS.md` (= dieser Slice). ✅
+2. **PR 2:** Dependabot-Aufräumen — #323 (`mistune`) und #326 (`pygments`) entscheiden.
+3. **PR 3:** M11 Phase 6 Contract-Generation + Status-Sync.
+4. **PR 4:** M11.4 / Phase 7 Playwright-Smokes (Health/Login, Upload+Graph, Minimalreport).
+5. **PR 5:** Coverage-Schwellen-Anhebung (Backend 53 → 60 → 70 %, Frontend 24 → 40 → 60 %).
+6. **PR 6:** M11.5 Komplexitäts-Gate.
+7. **PR 7:** M11.6 API-Envelope abschließen.
+8. **PR 8:** F8 Frontend-Hotspots (#203).
 
 ### Definition of Done für v1.0
 

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-05-07
+Stand: 2026-05-08
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 
@@ -127,16 +127,28 @@ Detail: [`PLAN.md § Status-Sync 2026-05-04`](../PLAN.md#status-sync-2026-05-04)
 - M10.4 Auth-Zielbild-ADR Single-User-only-v1 (`docu/decisions/0001-auth-model.md` Accepted) + Code-Update `_get_auth_mode()` returnt `"single_user_token"` + README/security-hardening Single-User-Block + Token-Rotation-Prozedur
 - M10.5 Rate-Limits für `/api/auth/ticket`, Uploads (`/api/graph/ontology/generate`), Simulation-LLM-Trigger (`/api/simulation/generate-profiles`, `/api/simulation/prepare`) und Report-Trigger (`/api/report/generate`, `/api/report/chat`) (#302)
 - M11.1 Evidence-Quality-Gate hard (`--soft` raus aus `contract-gates.yml`, Hard-Gate gegen `tests/eval/fixtures/good/`, Bad-Cases gepinnt durch Snapshot-Test)
+- M11 Phase 1 Release-Gating gehärtet (`docker-image.yml` SHA-gepinnt, strikter Tag-Smoke, latest nur Default-Branch)
+- M11 Phase 2 Static-Analysis-Gates (`mypy app` + `npm run typecheck` blockierend)
+- M11 Phase 3 Runtime-Image-Hardening (Multi-Stage, slim ohne Node/npm/curl, `read_only: true`, 747 MB → 320 MB)
+- M11 Phase 4 Supply Chain (`dependency-review.yml`, `codeql.yml`, Build-Provenance-Attestation, SPDX-JSON-SBOM)
+- M11 Phase 5 (`simulation_runner.py`-Refactor, 5 PRs)
+- M11 Phase 5b (`graph_tools.py`-Refactor, 3 PRs)
+- M11.2 Backend-Coverage-Gate (`--cov-fail-under=53`)
+- M11.3 Frontend-Coverage-Gate (Threshold 24 %)
+- ADR-0001 Single-User-only-v1 Accepted (M10.4)
+- M10.5 Rate-Limits (PRs #303–#306, Issue #302)
 
 **Aktiv offen (nächste 3 Slices in Reihenfolge):**
-1. v1.0-Hotspot-Refactors Phase 5 in vier separaten PRs.
-2. Contract-Generation + Status-Sync Phase 6.
-3. M11.4 Playwright-Smokes Phase 7 (3 E2E-Tests: Health/Login, Upload+Graph, Minimalreport) plus Coverage-Gate-Anhebung.
+1. P1-A Dependabot-Aufräumen — PR #323 (`mistune`) + PR #326 (`pygments`).
+2. Phase 6 Contract-Generation + Status-Sync (Contract-Dump reproduzierbar, Zod-Spiegel CI-geprüft, `scripts/sync-status.sh` Pflicht).
+3. Phase 7 / M11.4 Playwright-Smokes (Health/Login, Upload+Graph, Minimalreport).
 
-Mittelfristig: M11.2/M11.3 Coverage-Gates, M11.4 Playwright-Smokes, M11.5 Komplexitäts-Gate, F8 Hotspot-Split Frontend (#203). #202 geschlossen 2026-05-05 (report_agent als Package).
+Mittelfristig: M11.2/M11.3 Coverage-Schwellen-Anhebung (Backend 53 → 70 %, Frontend 24 → 60 %), M11.5 Komplexitäts-Gate, M11.6 API-Envelope, F8 Hotspot-Split Frontend (#203). Phase 5/5b abgeschlossen 2026-05-08, #202 geschlossen 2026-05-05.
 
 ## Aktualisierungs-Protokoll
 
+- 2026-05-08: M11 Phase 5 + Phase 5b — Hotspot-Refactors abgeschlossen. Phase 5 (`simulation_runner.py`): 5 PRs, Helfer `run_state_store`/`action_log_reader`/`monitor_thread`/`interview_client`/`process_manager` extrahiert (Commits ff52643, 2142e0a, b177cd9, ef9f5b6, db2c0f8). Phase 5b (`graph_tools.py`): 3 PRs, Helfer `graph_dtos`/`graph_reader`/`insight_forge_tool` extrahiert (Commits 8ce5ecb, 7abd3df, b8493b8). Verhalten unverändert, Tests grün. Arbeitsprotokolle unter `docu/2026-05-08-m11-phase5*-arbeitsprotokoll.md`.
+- 2026-05-08: Doku-Sync — `AGENTS.md` Status-Zeile (Layer 9–10 grün, M11 Phase 1–5b durch), `CLAUDE.md` „Aktive Hot-Spots" auf realen M11-Stand, `PLAN.md` Status-Sync 2026-05-08 mit aktualisierter Erledigt-/Offen-Tabelle und neuer PR-Reihenfolge, `docu/STATUS.md` aktuelles Milestone auf Phase 6/7/CVE-Aufräumen.
 - 2026-05-03: Sub-Slice 44 — STATUS.md inaugural, Test-Counts und Versionsstände zentralisiert, Inline-Zahlen aus README/CLAUDE.md entfernt, ROADMAP auf v0.9.0+ / 2026-05-03 geheben.
 - 2026-05-04: F5 Doku-Sync (1) — Test-Counts auf 1370 (1330 → 1370 nach Layer-9-Slices), README inline-Zahl entfernt.
 - 2026-05-04: Doku-Sync 2026-05-04 — `AGENTS.md` v0.6.0 → v0.9.0+, `CLAUDE.md` Layer-9-Hot-Spots auf realen Code-Stand, `PLAN.md` Status-Sync-Block, neue `docu/plan.heuristic.md` als Subagent-Routing-SSoT, User-Drop-Audit-Snapshots nach `docu/history/`.


### PR DESCRIPTION
## Summary

Doku-Sync-Slice. AGENTS.md / CLAUDE.md / PLAN.md / STATUS.md / CHANGELOG.md auf realen Code-Stand 2026-05-08 angeglichen. Kein Code-Change.

**Erledigt (seit Stand 2026-05-04 in der Doku):**
- M11.2 Backend-Coverage-Gate (`--cov-fail-under=53`)
- M11.3 Frontend-Coverage-Gate (Threshold 24 %)
- M11 Phase 1 Release-Gating gehärtet (SHA-pinned Actions, strikter Tag-Smoke)
- M11 Phase 2 Static-Analysis-Gates blockierend (`mypy app`, `npm run typecheck`)
- M11 Phase 3 Multi-Stage `prod`-Image (slim, ohne Node/npm/curl, `read_only: true`, 747 → 320 MB)
- M11 Phase 4 Supply Chain (CodeQL, Build-Provenance-Attestation, SPDX-JSON-SBOM)
- M11 Phase 5: `simulation_runner.py` → `sim/`-Subpackage (5 PRs durch)
- M11 Phase 5b: `graph_tools.py` → `graph/`-Subpackage (3 PRs durch)
- ADR-0001 Single-User-only-v1 Accepted (M10.4)
- M10.5 Rate-Limits (PRs #303–#306, Issue #302)
- #202 closed als `report_agent`-Package-Split

**Aktiv offen (nächste Slices):**
1. P1-A Dependabot-Aufräumen (PR #323 `mistune`, PR #326 `pygments`)
2. M11 Phase 6 Contract-Generation + Status-Sync
3. M11.4 / Phase 7 Playwright-Smokes (Health/Login, Upload+Graph, Minimalreport)

**Layer-Tabelle:** Layer 7–8 weiterhin teilweise, Layer 9–10 grün (vorher „Layer 10 dokumentiert"). CVE-Tracker #296/#297/#298 zusätzlich zu #121–#126 unter Beobachtung.

**Stack-Map korrigiert:** `sim/` und `graph/` sind echte Subpackages (vorher in einem Zwischenstand fälschlich als Module beschrieben).

## Test plan

- [x] `git diff --exit-code schemas/` → clean (kein Code/Pydantic angefasst)
- [x] Markdown-Header-Sanity in PLAN.md / AGENTS.md / STATUS.md geprüft
- [x] Stack-Map gegen reale Verzeichnis-Struktur (`backend/app/services/`) verifiziert
- [x] Nur 5 Files modifiziert (AGENTS.md, CHANGELOG.md, CLAUDE.md, PLAN.md, docu/STATUS.md)
- [ ] Gemini-Code-Assist-Findings sichten und ggf. nachpatchen vor Merge

Refs M11