### PR TITLE
ci(status): sync-status.sh Marker-basiert + CI-Gate (M11 Phase 6)

### DIFF
--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -30,6 +30,22 @@ jobs:
             exit 1
           fi
 
+  status-sync-drift:
+    name: STATUS.md Drift-Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+      - name: Sync backend deps (für pytest --collect-only)
+        working-directory: backend
+        run: uv sync --group dev
+      - name: Run sync-status.sh --check
+        run: bash scripts/sync-status.sh --check
+
   contract-tests:
     name: Pydantic-Contract-Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Alle nennenswerten Änderungen an Agora werden hier dokumentiert.
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [SemVer](https://semver.org/lang/de/).
 
 ## [Unreleased]
+### Tooling
+- ci(status): `scripts/sync-status.sh` Marker-basiert (HTML-Comment-Marker `BEGIN_AUTOGEN_VERSIONS`/`BEGIN_AUTOGEN_TESTS`); ersetzt nur dynamische Versions- und Test-Count-Tabellen, lässt Layer-Status, Coverage-Sektion, Aktualisierungs-Protokoll und Aktuelles Milestone unangetastet. Neuer CI-Job `contract-gates.yml::status-sync-drift` blockiert auf `--check`.
+
 ### Documentation
 - docs(plan): sync M11-Status auf 2026-05-08 — `AGENTS.md`/`CLAUDE.md`/`PLAN.md`/`STATUS.md` an realen Code-Stand angeglichen (M11 Phase 1–5b abgeschlossen, M11.2/M11.3 Coverage-Gates aktiv, ADR-0001 Accepted, Layer 9–10 grün).
 

--- a/docu/2026-05-09-m11-phase6-status-sync-arbeitsprotokoll.md
+++ b/docu/2026-05-09-m11-phase6-status-sync-arbeitsprotokoll.md
@@ -1,0 +1,86 @@
+# Arbeitsprotokoll — M11 Phase 6: sync-status.sh Marker-basiert + CI-Gate
+
+**Datum:** 2026-05-09
+**Slice:** M11 Phase 6
+**Branch:** `feat/m11-phase6-status-sync`
+
+## Ziel
+
+`scripts/sync-status.sh` darf `docu/STATUS.md` nicht mehr komplett überschreiben.
+Stattdessen ersetzt es nur die dynamischen Bereiche (Versions- und Test-Count-Tabellen)
+über HTML-Comment-Marker. Alle manuell gepflegten Sektionen (Layer-Status,
+Coverage-Sektion, Static-Analysis-Gates, Aktuelles Milestone, Aktualisierungs-Protokoll)
+bleiben unangetastet.
+
+## Architektur-Entscheidung
+
+**Marker-Sektionen statt Datei-Overwrite.**
+
+Begründung: `docu/STATUS.md` enthält reichhaltigen manuellen Inhalt (Layer-Status,
+Backend-/Frontend-Coverage-Roadmaps, Static-Analysis-Gates, ausführliches
+Aktualisierungs-Protokoll), der beim alten Full-Overwrite-Ansatz bei jedem
+`sync-status.sh`-Lauf auf den M9-Stand zurückgesetzt worden wäre.
+
+Das Skript definiert genau zwei dynamische Blöcke:
+- `<!-- BEGIN_AUTOGEN_VERSIONS -->` ... `<!-- END_AUTOGEN_VERSIONS -->` — Versionstabelle
+- `<!-- BEGIN_AUTOGEN_TESTS -->` ... `<!-- END_AUTOGEN_TESTS -->` — Test-Count-Tabelle
+
+Der Stand-Datum-Header (`Stand: YYYY-MM-DD`) bleibt absichtlich manuell, weil ein
+automatisches Datum in CI bei jedem Tageswechsel drift erzeugen würde.
+
+## Geänderte Dateien
+
+| Datei | Art |
+|---|---|
+| `docu/STATUS.md` | Marker eingefügt (BEGIN/END_AUTOGEN_VERSIONS + TESTS) |
+| `scripts/sync-status.sh` | Kompletter Neubau: Marker-basierte Ersetzung, `--check`-Modus |
+| `.github/workflows/contract-gates.yml` | Neuer Job `status-sync-drift` |
+| `CHANGELOG.md` | `[Unreleased]` Tooling-Eintrag |
+| `docu/2026-05-09-m11-phase6-status-sync-arbeitsprotokoll.md` | dieses Protokoll |
+
+## Implementierungs-Details
+
+### scripts/sync-status.sh
+
+- Liest `docu/STATUS.md` und ersetzt **nur** den Inhalt zwischen den Markern via
+  eingebettetem Python3-Einzeiler (`re.sub` mit `re.DOTALL`).
+- Marker-Tags selbst bleiben erhalten; nur der Inhalt dazwischen wird überschrieben.
+- Fehlt ein Marker → `exit 1` mit klarer Fehlermeldung an stderr.
+- `--check`-Modus: kopiert STATUS.md in ein Tempfile, wendet die Ersetzungen an,
+  vergleicht mit `diff -q`. Keine Schreiboperation auf die echte Datei.
+  Exit 0 bei Sync, Exit 1 bei Drift (mit Diff in stderr).
+- Idempotent: Doppellauf auf einer bereits aktualisierten Datei erzeugt keinen Diff.
+- Backend-Tests via `pytest --collect-only -q` mit 180 s Timeout, Fallback `unknown`.
+- Frontend-Spec-Files via `find` — stabil, kein `npm install` nötig.
+
+### contract-gates.yml
+
+Neuer Job `status-sync-drift` nach `schema-drift`:
+- `actions/checkout@v6`, `actions/setup-python@v6` (gleiche Version wie Rest der Datei)
+- `uv sync --group dev` für `pytest --collect-only`
+- `bash scripts/sync-status.sh --check` → Exit 1 bei Drift
+
+## Test-Schritte (lokal verifiziert)
+
+1. `chmod +x scripts/sync-status.sh` — ausführbar
+2. Erster Lauf: `bash scripts/sync-status.sh` — Marker-Bereiche werden befüllt
+3. `git diff docu/STATUS.md` — nur die neuen Marker-Zeilen betroffen (keine anderen Sektionen)
+4. Doppellauf: `bash scripts/sync-status.sh` — kein neuer diff
+5. `--check` bei sync: Exit 0
+6. `--check` bei manuell korrumpiertem Inhalt: Exit 1
+7. `git diff --exit-code schemas/` — kein Schema-Drift (kein Backend-Code geändert)
+8. `cd backend && uv run pytest tests/contracts/ -x -v` — alle Contract-Tests grün
+
+## Marker-Sanity
+
+```
+grep -c "BEGIN_AUTOGEN_VERSIONS" docu/STATUS.md  # 1
+grep -c "BEGIN_AUTOGEN_TESTS"    docu/STATUS.md  # 1
+grep -c "BEGIN_AUTOGEN_HEADER"   docu/STATUS.md  # 0
+```
+
+## Out-of-Scope (absichtlich nicht erledigt)
+
+- AGENTS.md / CLAUDE.md Sync (separater Doku-Slice)
+- `sync-status.sh` als Pre-Commit-Hook verdrahten (Folge-Slice)
+- HEADER-Marker in STATUS.md (würde CI-Tageswechsel-Drift erzeugen → bewusst manuell)

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -6,18 +6,22 @@ Stand: 2026-05-08
 
 ## Versionen
 
+<!-- BEGIN_AUTOGEN_VERSIONS -->
 | Komponente | Pfad | Version |
 |---|---|---|
 | Backend | `backend/pyproject.toml` | 0.9.1-dev |
 | Frontend | `frontend/package.json` | 0.9.1-dev |
 | Root | `package.json` | 0.9.1-dev |
+<!-- END_AUTOGEN_VERSIONS -->
 
 ## Tests
 
+<!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1567 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Spec-Files | 43 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
+| Backend Tests (collected) | 1612 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Spec-Files | 44 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
+<!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._
 _Die Frontend-Zeile zählt Dateien, nicht einzelne Test-Cases. Pro Spec-File laufen mehrere `it`-Blöcke; die exakte Test-Case-Anzahl liefert `cd frontend && npx vitest list`._

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -1,140 +1,148 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# sync-status.sh — Regenerates docu/STATUS.md with current test counts and versions
-# Usage: bash scripts/sync-status.sh [--check]
-# --check: dry-run mode, compare with existing docu/STATUS.md, exit 1 if drift detected
+# sync-status.sh — Updates marker-delimited sections in docu/STATUS.md
+# Replaces only the content between HTML-comment markers:
+#   <!-- BEGIN_AUTOGEN_VERSIONS --> ... <!-- END_AUTOGEN_VERSIONS -->
+#   <!-- BEGIN_AUTOGEN_TESTS -->    ... <!-- END_AUTOGEN_TESTS -->
+# All manually maintained sections (Layer-Status, Coverage, Milestone,
+# Aktualisierungs-Protokoll) are left untouched.
+#
+# Usage:
+#   bash scripts/sync-status.sh           # update STATUS.md in-place
+#   bash scripts/sync-status.sh --check   # drift-check only (exit 1 on drift)
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+STATUS_FILE="$REPO_ROOT/docu/STATUS.md"
 
-# Parse arguments
 CHECK_MODE=false
 if [[ "${1:-}" == "--check" ]]; then
   CHECK_MODE=true
 fi
 
-# Helper: Extract version from pyproject.toml / package.json
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 get_version_from_pyproject() {
-  local file=$1
-  grep '^version' "$file" | head -1 | sed 's/^version = "\([^"]*\)".*/\1/'
+  grep '^version' "$1" | head -1 | sed 's/^version = "\([^"]*\)".*/\1/'
 }
 
 get_version_from_json() {
-  local file=$1
-  jq -r .version "$file" 2>/dev/null || echo "unknown"
+  jq -r .version "$1" 2>/dev/null || echo "unknown"
 }
 
-# Extract versions
+# ---------------------------------------------------------------------------
+# Collect values
+# ---------------------------------------------------------------------------
 BACKEND_VERSION=$(get_version_from_pyproject "$REPO_ROOT/backend/pyproject.toml")
 FRONTEND_VERSION=$(get_version_from_json "$REPO_ROOT/frontend/package.json")
 ROOT_VERSION=$(get_version_from_json "$REPO_ROOT/package.json")
 
-# Get test counts
-# Backend: use pytest --collect-only with timeout
 BACKEND_TESTS="unknown"
 if command -v uv &>/dev/null; then
-  if timeout 180 bash -c "cd '$REPO_ROOT/backend' && uv run pytest --collect-only -q 2>/dev/null | tail -3" > /tmp/pytest_collect.tmp 2>&1; then
-    BACKEND_TESTS_MATCH=$(grep -oE '[0-9]+ tests collected' /tmp/pytest_collect.tmp | grep -oE '[0-9]+' | head -1 || echo "")
-    if [[ -n "$BACKEND_TESTS_MATCH" ]]; then
-      BACKEND_TESTS="$BACKEND_TESTS_MATCH"
+  # Optional timeout: GNU coreutils auf Linux/CI, gtimeout auf macOS, sonst kein Wrapper.
+  if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD=(timeout 180)
+  elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD=(gtimeout 180)
+  else
+    TIMEOUT_CMD=()
+  fi
+  COLLECT_TMP=$(mktemp)
+  if ${TIMEOUT_CMD[@]+"${TIMEOUT_CMD[@]}"} bash -c "cd '$REPO_ROOT/backend' && uv run pytest --collect-only -q 2>/dev/null | tail -3" > "$COLLECT_TMP" 2>&1; then
+    MATCH=$(grep -oE '[0-9]+ tests collected' "$COLLECT_TMP" | grep -oE '[0-9]+' | head -1 || true)
+    if [[ -n "$MATCH" ]]; then
+      BACKEND_TESTS="$MATCH"
     else
       echo "WARNING: pytest --collect-only ran but no count found" >&2
     fi
   else
-    echo "WARNING: pytest --collect-only timed out or failed — using unknown" >&2
+    echo "WARNING: pytest --collect-only timed out or failed — keeping 'unknown'" >&2
   fi
-  rm -f /tmp/pytest_collect.tmp
+  rm -f "$COLLECT_TMP"
 fi
 
-# Frontend: count spec files (deterministic, no vitest dependency).
-# Note: Each spec file contains multiple `describe`/`it` cases. The actual
-# test-case count is roughly an order of magnitude higher (run `npx vitest list`
-# in `frontend/` to materialize it). We report spec-files because it is
-# stable, deterministic, and does not require `npm install`.
-FRONTEND_SPEC_FILES=$(find "$REPO_ROOT/frontend/src" \( -name '*.spec.ts' -o -name '*.spec.js' \) 2>/dev/null | wc -l)
+FRONTEND_SPEC_FILES=$(find "$REPO_ROOT/frontend/src" \( -name '*.spec.ts' -o -name '*.spec.js' \) 2>/dev/null | wc -l | tr -d ' ')
 
-# Get status date
-STATUS_DATE=$(date +%Y-%m-%d)
-
-# Build the STATUS.md content
-STATUS_CONTENT=$(cat <<EOF
-# Agora — Status (Single Source of Truth)
-
-Stand: $STATUS_DATE
-
-**Aktualisiert via \`scripts/sync-status.sh\`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
-
-## Versionen
-
-| Komponente | Pfad | Version |
+# ---------------------------------------------------------------------------
+# Build replacement blocks (content between markers, without the marker lines)
+# ---------------------------------------------------------------------------
+VERSIONS_BLOCK="| Komponente | Pfad | Version |
 |---|---|---|
 | Backend | \`backend/pyproject.toml\` | $BACKEND_VERSION |
 | Frontend | \`frontend/package.json\` | $FRONTEND_VERSION |
-| Root | \`package.json\` | $ROOT_VERSION |
+| Root | \`package.json\` | $ROOT_VERSION |"
 
-## Tests
-
-| Kategorie | Anzahl | Methode |
+TESTS_BLOCK="| Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | $BACKEND_TESTS | \`cd backend && uv run pytest --collect-only -q\` |
-| Frontend Spec-Files | $FRONTEND_SPEC_FILES | \`find frontend/src \\( -name '*.spec.ts' -o -name '*.spec.js' \\)\` |
+| Frontend Spec-Files | $FRONTEND_SPEC_FILES | \`find frontend/src \\( -name '*.spec.ts' -o -name '*.spec.js' \\)\` |"
 
-_Hinweise: 2 Redis-Integrationstests skippen sauber ohne \`TEST_REDIS_URL\` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._
-_Die Frontend-Zeile zählt Dateien, nicht einzelne Test-Cases. Pro Spec-File laufen mehrere \`it\`-Blöcke; die exakte Test-Case-Anzahl liefert \`cd frontend && npx vitest list\`._
+# ---------------------------------------------------------------------------
+# replace_block: replaces content between BEGIN/END markers using Python3.
+# Args: MARKER_NAME NEW_CONTENT FILE
+# Exits with error if marker is missing.
+# ---------------------------------------------------------------------------
+replace_block() {
+  local marker_name="$1"
+  local new_content="$2"
+  local file="$3"
 
-## Layer-Status (Übersicht)
+  python3 - "$marker_name" "$new_content" "$file" <<'PYEOF'
+import sys
+import re
+import pathlib
 
-Verbindliche Detailtabelle und Layer-Semantik: [\`CLAUDE.md\` § Architektur-Layer](../CLAUDE.md#architektur-layer-status).
+marker_name = sys.argv[1]
+new_content = sys.argv[2]
+file_path   = sys.argv[3]
 
-| Layer | Inhalt | Status |
-|---|---|---|
-| 0 | Pydantic-Contracts + Zod-Spiegel | grün |
-| 1 | Backend-Hardening | grün |
-| 2 | DACH-Voice + Glossar v1 | grün |
-| 3 | Reader-Honesty | grün |
-| 4 | Frontend strict-Zod | grün |
-| 5 | Eval/Baseline-Suite | grün |
-| 6 | Frontend-TypeScript-Migration | grün |
-| 7–8 | Graph/Runs/Persona-Review | teilweise |
-| 9 | Prod-Deployment (Reverse-Proxy, gevent, SSE-Auth) | offen |
-| 10 | Security Watchlist | dokumentiert |
+text  = pathlib.Path(file_path).read_text(encoding="utf-8")
+begin = f"<!-- BEGIN_AUTOGEN_{marker_name} -->"
+end   = f"<!-- END_AUTOGEN_{marker_name} -->"
 
-## Aktuelles Milestone
+pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+if not pattern.search(text):
+    sys.stderr.write(
+        f"::error::Marker {begin} oder {end} fehlt in {file_path}\n"
+    )
+    sys.exit(1)
 
-**M9 — Prod-Hardening (Mai 2026, 23 Wochen).**
+new_block = f"{begin}\n{new_content}\n{end}"
+new_text  = pattern.sub(new_block, text)
+pathlib.Path(file_path).write_text(new_text, encoding="utf-8")
+PYEOF
+}
 
-Detail: [\`PLAN.md\` § Milestone M9](../PLAN.md).
-
-Aktive Slices: F5 Doku-Sync, F1 Reverse-Proxy, F2 Auth-Hardening, F3 Gunicorn-Gevent.
-
-## Aktualisierungs-Protokoll
-
-- $STATUS_DATE: Sub-Slice 44 — STATUS.md inaugural, Test-Counts und Versionsstände zentralisiert, Inline-Zahlen aus README/CLAUDE.md entfernt, ROADMAP auf v0.9.0+ / 2026-05-03 geheben.
-EOF
-)
-
-# Write to temp location for --check mode
-OUTPUT_FILE="$REPO_ROOT/docu/STATUS.md"
+# ---------------------------------------------------------------------------
+# Apply to target (real file or tempfile for --check)
+# ---------------------------------------------------------------------------
+TARGET_FILE="$STATUS_FILE"
 if [[ "$CHECK_MODE" == true ]]; then
-  OUTPUT_FILE="/tmp/STATUS.md.tmp"
+  TARGET_FILE=$(mktemp)
+  cp "$STATUS_FILE" "$TARGET_FILE"
 fi
 
-echo "$STATUS_CONTENT" > "$OUTPUT_FILE"
+replace_block "VERSIONS" "$VERSIONS_BLOCK" "$TARGET_FILE"
+replace_block "TESTS"    "$TESTS_BLOCK"    "$TARGET_FILE"
 
-# Verify idempotency in check mode
+# ---------------------------------------------------------------------------
+# --check: compare and report
+# ---------------------------------------------------------------------------
 if [[ "$CHECK_MODE" == true ]]; then
-  if diff -q "$REPO_ROOT/docu/STATUS.md" /tmp/STATUS.md.tmp > /dev/null 2>&1; then
+  if diff -q "$STATUS_FILE" "$TARGET_FILE" >/dev/null 2>&1; then
     echo "OK: docu/STATUS.md in sync" >&2
-    rm -f /tmp/STATUS.md.tmp
+    rm -f "$TARGET_FILE"
     exit 0
   else
-    echo "DRIFT: docu/STATUS.md differs from generated content" >&2
-    echo "Run again without --check to regenerate." >&2
-    rm -f /tmp/STATUS.md.tmp
+    echo "DRIFT: docu/STATUS.md weicht von autogenerated Inhalt ab" >&2
+    echo "Diff (STATUS.md vs. generated):" >&2
+    diff "$STATUS_FILE" "$TARGET_FILE" >&2 || true
+    rm -f "$TARGET_FILE"
     exit 1
   fi
 else
-  echo "OK: $OUTPUT_FILE written" >&2
-  echo "Run again with --check to verify no drift" >&2
+  echo "OK: $STATUS_FILE aktualisiert" >&2
+  echo "Tipp: bash scripts/sync-status.sh --check zur Drift-Verifikation" >&2
 fi

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -50,7 +50,7 @@ if command -v uv &>/dev/null; then
     TIMEOUT_CMD=()
   fi
   COLLECT_TMP=$(mktemp)
-  if ${TIMEOUT_CMD[@]+"${TIMEOUT_CMD[@]}"} bash -c "cd '$REPO_ROOT/backend' && uv run pytest --collect-only -q 2>/dev/null | tail -3" > "$COLLECT_TMP" 2>&1; then
+  if ${TIMEOUT_CMD[@]+${TIMEOUT_CMD[@]}} bash -c "cd '$REPO_ROOT/backend' && uv run pytest --collect-only -q | tail -3" > "$COLLECT_TMP" 2>&1; then
     MATCH=$(grep -oE '[0-9]+ tests collected' "$COLLECT_TMP" | grep -oE '[0-9]+' | head -1 || true)
     if [[ -n "$MATCH" ]]; then
       BACKEND_TESTS="$MATCH"

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -110,7 +110,7 @@ if not pattern.search(text):
     sys.exit(1)
 
 new_block = f"{begin}\n{new_content}\n{end}"
-new_text  = pattern.sub(new_block, text)
+new_text  = pattern.sub(lambda m: new_block, text)
 pathlib.Path(file_path).write_text(new_text, encoding="utf-8")
 PYEOF
 }


### PR DESCRIPTION
## Summary

M11 Phase 6 — `scripts/sync-status.sh` Marker-basiert + neuer CI-Job. Verhindert versehentliches Plattmachen der manuell gepflegten STATUS.md-Sektionen (Layer-Status, Coverage, Aktualisierungs-Protokoll) und blockiert PRs/main-Push bei STATUS.md-Drift.

**Architektur:**
- HTML-Comment-Marker `BEGIN_AUTOGEN_VERSIONS` / `BEGIN_AUTOGEN_TESTS` annotieren die dynamischen Tabellen
- Skript ersetzt **nur** Inhalt zwischen Markern — Marker selbst und alle anderen Sektionen bleiben unangetastet
- Header (`Stand: …`) bleibt bewusst manuell, sonst Tageswechsel-Drift in CI

**Skript-Hardening:**
- `timeout`/`gtimeout` optional (macOS-Fallback)
- `${TIMEOUT_CMD[@]:-}` mit `set -u` kompatibel (bash 3.2 macOS)
- `--check`-Modus mit klarem Diff im stderr, Exit 1 bei Drift

**Neuer CI-Job:** `contract-gates.yml::status-sync-drift` läuft `bash scripts/sync-status.sh --check` und blockiert bei Drift.

## Test plan

- [x] Doppellauf-Idempotenz: bestätigt (zweiter Skript-Lauf produziert keinen neuen Diff)
- [x] `--check` bei sync: exit 0
- [x] `--check` bei künstlichem Drift: exit 1 mit klarem Diff
- [x] Schema-Drift-Check (`git diff --exit-code schemas/`): clean
- [x] 71 Contract-Tests passed
- [x] Marker-Sanity: genau 1× `BEGIN_AUTOGEN_VERSIONS`, 1× `BEGIN_AUTOGEN_TESTS`, 0× `BEGIN_AUTOGEN_HEADER`
- [ ] CI-Job `status-sync-drift` grün auf diesem PR
- [ ] Gemini-Findings sichten

Refs M11 Phase 6