### PR TITLE
feat(report): Pflichtabschnitt-Liste + Section-Cap raus (M11.8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - **M11 Phase 5 Vorbereitung:** Schnittanalyse für `backend/app/services/simulation_runner.py` (1904 LOC) unter [`docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md`](docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md). Dokumentiert Verantwortlichkeiten, externe Call-Sites, Test-Coverage und fünf Extraktionskandidaten mit empfohlener PR-Reihenfolge (read-only Doku, kein Code-Edit). Refs F7.
 
 ### Changed
+- feat(report): Pflichtabschnitt-Liste über `{required_sections}`-Variable im PLAN-Prompt; harter Section-Cap (Min 2 / Max 5) raus aus `report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE`. Default `DEFAULT_REPORT_SECTIONS` enthält die 11 DACH-Report-Standardabschnitte (Executive Summary bis Datenlücken). Adressiert externen Bewertungs-Befund 5,8/10 zur Prompt-Erfüllung. M11.8a Quick-Win.
 - refactor(graph): extract `insight_forge_tool` (LLM-gestuetzte Retrieval-Pipeline) from `graph_tools.py` to `app.services.graph.insight_forge_tool` (Refs F7, M11 Phase 5b PR 3)
 - refactor(graph): extract `graph_reader` (10 Storage-Reader-Methoden) from `graph_tools.py` to `app.services.graph.graph_reader` (Refs F7, M11 Phase 5b PR 2)
 - refactor(graph): extract `graph_dtos` (7 Dataclasses) from `graph_tools.py` to `app.services.graph.graph_dtos` — Wording-Audit auf neuen Pfad erweitert (Refs F7, M11 Phase 5b PR 1)

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -561,9 +561,14 @@ class ReportAgent:
 
     def plan_outline(
         self,
-        progress_callback: Optional[Callable] = None
+        progress_callback: Optional[Callable] = None,
+        required_sections: Optional[list[tuple[str, str]]] = None,
     ) -> ReportOutline:
-        return plan_outline_impl(self, progress_callback=progress_callback)
+        return plan_outline_impl(
+            self,
+            progress_callback=progress_callback,
+            required_sections=required_sections,
+        )
 
     def _generate_section_react(
         self,

--- a/backend/app/services/report_agent/planning.py
+++ b/backend/app/services/report_agent/planning.py
@@ -78,6 +78,17 @@ def plan_outline(
             )
             for s in pydantic_outline.sections
         ]
+
+        # M11.8a-Followup auf Gemini-MEDIUM (PR #335): Section-Cap (Min 2 / Max 5)
+        # ist entfernt, aber ein leeres Outline-Array darf nicht durchgehen — ein
+        # Report ohne Sections ist trivial invalid. Harter Vertrag (len ==
+        # len(required_sections)) folgt erst in M11.8d (Strict-Schema-Forced-Output).
+        if not result_sections:
+            raise ValueError(
+                "plan_outline() received empty sections from LLM; refusing to "
+                "build an outline with zero entries (M11.8a)."
+            )
+
         outline = ReportOutline(
             title=pydantic_outline.title,
             summary=pydantic_outline.summary,

--- a/backend/app/services/report_agent/planning.py
+++ b/backend/app/services/report_agent/planning.py
@@ -7,12 +7,17 @@ from ...config import Config
 from ...contracts.report_contract import ReportOutlineModel, ReportOutlineSectionModel
 from ...models.report import ReportOutline, ReportSection
 from ...utils.logger import get_logger
+from ..report_prompts import DEFAULT_REPORT_SECTIONS, format_required_sections
 from .prompts import PLAN_SYSTEM_PROMPT_TEMPLATE, PLAN_USER_PROMPT_TEMPLATE
 
 logger = get_logger('agora.report_agent')
 
 
-def plan_outline(agent: Any, progress_callback: Optional[Callable] = None) -> ReportOutline:
+def plan_outline(
+    agent: Any,
+    progress_callback: Optional[Callable] = None,
+    required_sections: Optional[list[tuple[str, str]]] = None,
+) -> ReportOutline:
     logger.info("Starting to plan report outline...")
 
     if progress_callback:
@@ -26,6 +31,7 @@ def plan_outline(agent: Any, progress_callback: Optional[Callable] = None) -> Re
     if progress_callback:
         progress_callback("planning", 30, "Generating report outline...")
 
+    sections = required_sections if required_sections is not None else DEFAULT_REPORT_SECTIONS
     system_prompt = PLAN_SYSTEM_PROMPT_TEMPLATE.replace("{language}", Config.REPORT_LANGUAGE)
     user_prompt = PLAN_USER_PROMPT_TEMPLATE.format(
         simulation_requirement=agent.simulation_requirement,
@@ -34,6 +40,7 @@ def plan_outline(agent: Any, progress_callback: Optional[Callable] = None) -> Re
         entity_types=list(context.get('graph_statistics', {}).get('entity_types', {}).keys()),
         total_entities=context.get('total_entities', 0),
         related_facts_json=json.dumps(context.get('related_facts', [])[:10], ensure_ascii=False, indent=2),
+        required_sections=format_required_sections(sections),
     )
 
     try:
@@ -64,12 +71,7 @@ def plan_outline(agent: Any, progress_callback: Optional[Callable] = None) -> Re
             sections=pydantic_sections,
         )
 
-        if not (2 <= len(pydantic_outline.sections) <= 5):
-            raise ValueError(
-                f"invalid outline response: sections={len(pydantic_outline.sections)}"
-            )
-
-        sections = [
+        result_sections = [
             ReportSection(
                 title=s.title,
                 description=s.description,
@@ -79,13 +81,13 @@ def plan_outline(agent: Any, progress_callback: Optional[Callable] = None) -> Re
         outline = ReportOutline(
             title=pydantic_outline.title,
             summary=pydantic_outline.summary,
-            sections=sections,
+            sections=result_sections,
         )
 
         if progress_callback:
             progress_callback("planning", 100, "Outline planning completed")
 
-        logger.info(f"Outline planning completed: {len(sections)} sections")
+        logger.info(f"Outline planning completed: {len(result_sections)} sections")
         return outline
 
     except Exception as e:

--- a/backend/app/services/report_prompts.py
+++ b/backend/app/services/report_prompts.py
@@ -18,6 +18,33 @@ re-exportiert die Namen und nutzt sie unverändert in den
 `chat_with_report`-Pfaden.
 """
 
+# ── Default-Pflichtabschnitte für DACH-Reports ──────────────────────
+# Quelle: agora_bewertung_komplett.md / docu/2026-05-09-output-vertrag-...
+# Wenn das User-Prompt-Frontend keine eigene required_sections-Liste
+# durchreicht, wird diese 11-Abschnitt-Default-Struktur verwendet.
+DEFAULT_REPORT_SECTIONS: list[tuple[str, str]] = [
+    ("Executive Summary", "Maximal 12 Sätze, was die Simulation gezeigt hat."),
+    ("Segment-Tabelle", "Persona-Segmente mit Größe, Goal, Trust-Score-Aggregat."),
+    ("Persona-Tabelle", "Vollständige Liste der simulierten Personas mit Reaktionen, Drop-off, Decision."),
+    ("Multiplikator-Auswertung", "Multiplikator-Profile mit Reichweite, Wirkung, Reaktion."),
+    ("Top 10 Reibungspunkte", "Stärkste negative Auslöser mit Persona-Refs."),
+    ("Top 10 Vertrauenssignale", "Stärkste positive Auslöser mit Persona-Refs."),
+    ("Top 10 Änderungen", "Konkrete Empfehlungen, priorisiert."),
+    ("Projektwirkung", "Pro Projekt: Wirkung, Glaubwürdigkeit, Risiken."),
+    ("Positionierung", "Drei Positionierungsvarianten mit Trade-offs."),
+    ("Content-Ideen", "Konkrete Themen-/Format-Vorschläge."),
+    ("Datenlücken", "Was die Simulation nicht beantworten kann."),
+]
+
+
+def format_required_sections(sections: list[tuple[str, str]]) -> str:
+    """Rendert eine Section-Liste als nummerierte Markdown-Liste für PLAN_USER_PROMPT_TEMPLATE."""
+    return "\n".join(
+        f"{idx}. **{title}** — {desc}"
+        for idx, (title, desc) in enumerate(sections, start=1)
+    )
+
+
 # ── 1. Planning — Outline ───────────────────────────────────────────
 
 PLAN_SYSTEM_PROMPT_TEMPLATE = """\
@@ -39,11 +66,12 @@ Write a "scenario evaluation report" that answers:
 - ❌ Not an analysis of the current state of the real world
 - ❌ Not a general overview of public sentiment
 
-[Section Number Limit]
-- Minimum 2 sections, maximum 5 sections
-- No subsections needed, each section directly writes complete content
-- Content should be concise, focused on core evaluation findings
-- Section structure is designed independently based on the evaluation results
+[Section Requirements]
+- The exact section list is provided in `required_sections` (variable injected from the user prompt context).
+- All listed sections are mandatory: do not omit, merge, or rename them.
+- Output JSON must contain one outline entry per required section, in the listed order.
+- No subsections needed; each section directly writes complete content.
+- Section descriptions should be concise and reflect what data the section will contain.
 
 Please output the report outline in JSON format as follows:
 {
@@ -57,7 +85,7 @@ Please output the report outline in JSON format as follows:
     ]
 }
 
-Note: sections array must have at least 2 and at most 5 elements!
+Note: sections array must contain exactly the entries listed in `required_sections`, in order.
 IMPORTANT: The entire report outline (title, summary, section titles and descriptions) MUST be written in {language}. Do not switch to any other language."""
 
 PLAN_USER_PROMPT_TEMPLATE = """\
@@ -73,14 +101,16 @@ Variable (simulation requirement) injected into the simulated environment: {simu
 [Sample of Persona Observations Produced by the Simulation]
 {related_facts_json}
 
+[Required Sections]
+The outline must contain exactly these sections, in order:
+{required_sections}
+
 Please examine this scenario evaluation from an analytical observer perspective:
 1. What state does the scenario present under the conditions we set?
 2. How do various groups (agents) react and act?
 3. What emerging trends does this simulation reveal that deserve attention?
 
-Based on the evaluation results, design the most appropriate report section structure.
-
-[Reminder] Report section count: minimum 2, maximum 5, content should be concise and focused on core evaluation findings."""
+Based on the evaluation results, write a description for each required section that reflects what simulation data it will contain."""
 
 
 # ── 2. Sections — Body Generation ───────────────────────────────────
@@ -340,6 +370,9 @@ __all__ = [
     # Planning
     "PLAN_SYSTEM_PROMPT_TEMPLATE",
     "PLAN_USER_PROMPT_TEMPLATE",
+    # Planning helpers
+    "DEFAULT_REPORT_SECTIONS",
+    "format_required_sections",
     # Sections
     "SECTION_SYSTEM_PROMPT_TEMPLATE",
     "SECTION_USER_PROMPT_TEMPLATE",

--- a/backend/tests/services/test_report_agent_outline.py
+++ b/backend/tests/services/test_report_agent_outline.py
@@ -174,6 +174,33 @@ def test_plan_outline_fallback_on_llm_exception():
 
 
 # ---------------------------------------------------------------------------
+# Test 3b: M11.8a-Followup — leeres LLM-Outline triggert Fallback
+# ---------------------------------------------------------------------------
+
+def test_plan_outline_empty_sections_triggers_fallback():
+    """M11.8a-Followup auf Gemini-MEDIUM (PR #335).
+
+    Section-Cap (Min 2 / Max 5) wurde in M11.8a entfernt. Ein leeres
+    sections-Array vom LLM darf dadurch NICHT als valide Outline
+    durchgehen. plan_outline() muss in den Default-Fallback wechseln,
+    statt eine kaputte Zero-Section-Outline zurückzugeben.
+    """
+    agent = _make_agent()
+    agent.llm.chat_json.return_value = {
+        "title": "Empty",
+        "summary": "Empty",
+        "sections": [],
+    }
+
+    outline = agent.plan_outline()
+
+    assert len(outline.sections) >= 2, (
+        "Empty-Sections-Response muss Fallback-Outline triggern, nicht "
+        "leer durchgehen (M11.8a-Followup)."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 4: Rauch-Test — to_dict() emittiert 'description' fuer jede Section
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_report_prompts.py
+++ b/backend/tests/test_report_prompts.py
@@ -22,6 +22,7 @@ PROMPT_SPECS = [
         "{entity_types}",
         "{total_entities}",
         "{related_facts_json}",
+        "{required_sections}",
     ]),
     # Sections
     ("SECTION_SYSTEM_PROMPT_TEMPLATE", [
@@ -90,7 +91,11 @@ def test_prompt_carries_expected_placeholders(name, placeholders):
 
 
 def test_all_prompt_names_in_dunder_all():
-    expected = {spec[0] for spec in PROMPT_SPECS}
+    # Template constants from PROMPT_SPECS plus planning helpers (M11.8a)
+    expected = {spec[0] for spec in PROMPT_SPECS} | {
+        "DEFAULT_REPORT_SECTIONS",
+        "format_required_sections",
+    }
     assert set(report_prompts.__all__) == expected
 
 
@@ -207,8 +212,11 @@ class TestPromptSemantics:
     def test_plan_system_demands_json_outline(self):
         assert "JSON" in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE
         assert "sections" in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE
-        assert "minimum 2" in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE.lower() or \
-               "at least 2" in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE.lower()
+        # M11.8a: Section-Cap (Min 2 / Max 5) entfernt; Pflichtabschnitte kommen
+        # über required_sections-Variable aus dem User-Prompt.
+        assert "required_sections" in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE.lower()
+        assert "minimum 2" not in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE.lower()
+        assert "maximum 5 sections" not in report_prompts.PLAN_SYSTEM_PROMPT_TEMPLATE.lower()
 
     def test_section_system_forbids_markdown_headers(self):
         # Kern-Constraint: keine ## innerhalb der Section
@@ -248,6 +256,7 @@ class TestFormatCallability:
             entity_types=["a"],
             total_entities=3,
             related_facts_json="[]",
+            required_sections="1. **Test** — desc",
         )
         assert "x" in out
 
@@ -292,3 +301,25 @@ class TestFormatCallability:
         )
         assert '{"name": "Tool Name"' in out
         assert "rc" in out
+
+
+def test_default_report_sections_has_eleven_entries():
+    """M11.8a: Default-Pflichtabschnitt-Liste muss 11 DACH-Report-Standardabschnitte enthalten."""
+    sections = report_prompts.DEFAULT_REPORT_SECTIONS
+    assert len(sections) == 11
+    titles = [t for t, _ in sections]
+    assert "Executive Summary" in titles
+    assert "Persona-Tabelle" in titles
+    assert "Datenlücken" in titles
+    # Jede Entry muss Tuple[str, str] mit non-empty desc sein
+    for title, desc in sections:
+        assert isinstance(title, str) and len(title) > 0
+        assert isinstance(desc, str) and len(desc) > 0
+
+
+def test_format_required_sections_renders_numbered_markdown():
+    """M11.8a: format_required_sections() muss nummerierte Markdown-Liste produzieren."""
+    sections = [("A", "alpha"), ("B", "beta")]
+    out = report_prompts.format_required_sections(sections)
+    assert "1. **A** — alpha" in out
+    assert "2. **B** — beta" in out

--- a/docu/2026-05-09-m11-8a-prompt-section-cap-arbeitsprotokoll.md
+++ b/docu/2026-05-09-m11-8a-prompt-section-cap-arbeitsprotokoll.md
@@ -1,0 +1,61 @@
+# Arbeitsprotokoll: M11.8a — Section-Cap raus + required_sections-Variable
+
+**Datum:** 2026-05-09
+**Branch:** feat/m11-8a-prompt-section-cap
+**Worktree:** /Volumes/T7/Projekte/.agora-m11-8a
+
+---
+
+## Slice
+
+M11.8a — Section-Cap raus + required_sections-Variable
+
+## Ziel + Root-Cause
+
+Externe Agora-Output-Bewertung (5,8/10, `docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md`) zeigt: Das Report-LLM liefert nur 2–5 Sections statt der vom User-Prompt geforderten 11 Pflichtabschnitte.
+
+Root-Cause: `backend/app/services/report_prompts.py` Zeilen 42–46 (vor dem Fix) enthielten einen harten `[Section Number Limit]`-Block:
+```
+- Minimum 2 sections, maximum 5 sections
+```
+Dieser Cap überstimmte strukturell jeden User-Prompt. Zusätzlich hatte das `PLAN_USER_PROMPT_TEMPLATE` keine `{required_sections}`-Variable, sodass die gewünschten 11 DACH-Abschnitte dem LLM nie kommuniziert wurden.
+
+## Geänderte Dateien
+
+| Datei | Änderungen |
+|---|---|
+| `backend/app/services/report_prompts.py` | `[Section Number Limit]` → `[Section Requirements]`; Note-Satz aktualisiert; `{required_sections}` in `PLAN_USER_PROMPT_TEMPLATE`; `DEFAULT_REPORT_SECTIONS` (11-Einträge) + `format_required_sections()` neu; `__all__` ergänzt |
+| `backend/app/services/report_agent/planning.py` | Import der neuen Symbole; `required_sections: Optional[list[tuple[str, str]]] = None` Parameter; harter `2 <= len <= 5`-Check entfernt; `required_sections` an `.format(...)` durchgereicht |
+| `backend/app/services/report_agent/agent.py` | `plan_outline()`-Wrapper: `required_sections` als optionaler Parameter ergänzt |
+| `backend/tests/test_report_prompts.py` | `{required_sections}` in PROMPT_SPECS; `__all__`-Test angepasst; Section-Cap-Test umgeschrieben; `.format()`-Call ergänzt; 2 neue Tests (`test_default_report_sections_has_eleven_entries`, `test_format_required_sections_renders_numbered_markdown`) |
+| `CHANGELOG.md` | `[Unreleased] ### Changed`-Eintrag für M11.8a |
+
+## Architektur-Entscheidung
+
+`required_sections` als optionaler Parameter mit `DEFAULT_REPORT_SECTIONS`-Fallback:
+- Backward-Compat: Alle bestehenden Aufrufer (Workflow, Tests) übergeben `required_sections=None` → Default-Pfad, kein Verhaltens-Diff für Legacy-Calls.
+- Erweiterungspunkt: Frontend kann in einem Folge-Slice eine eigene `required_sections`-Liste durchreichen (z. B. projektspezifische Abschnitte).
+- `DEFAULT_REPORT_SECTIONS` als `list[tuple[str, str]]` — kein Pydantic-Modell, da reine Prompt-Konstruktions-Hilfsdaten ohne Serialisierungs-Anforderung.
+
+## Out-of-Scope (explizit nicht angefasst)
+
+- **M11.8c:** ReportV3-Pydantic-DTOs — kein neues DTO.
+- **M11.8d:** JSON-Schema-Forced-Output — kein Strict-Mode-Umbau.
+- **M11.8e:** Quote-Markup — keine Änderungen an Section-Generierung.
+- **Frontend:** `required_sections` aus User-Prompt-Frontend ist Zukunfts-Slice. Keine `*.vue`-Dateien angefasst.
+- **Layer 0:** Keine Pydantic-Contract-Änderungen. Schema-Dump idempotent.
+
+## Verifikation
+
+```
+ruff check app/ tests/   → All checks passed!
+mypy app                 → Success: no issues found in 129 source files
+pytest tests/test_report_prompts.py -x -v  → 53 passed
+pytest tests/services/test_report_agent_outline.py -x -v  → 4 passed
+pytest -x -q             → 1600 passed, 9 skipped
+python scripts/check_voice.py  → Voice-Lint: OK
+git diff --exit-code schemas/  → Schemas clean (kein Drift)
+grep -c "minimum 2 sections|maximum 5 sections" report_prompts.py  → 0 (Cap weg)
+grep -c "required_sections" report_prompts.py  → 6 (>= 2 erwartet)
+grep -c "DEFAULT_REPORT_SECTIONS" report_prompts.py planning.py  → 2 (def + import)
+```

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-08
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1614 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1615 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Spec-Files | 44 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-08
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1612 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1614 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Spec-Files | 44 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

**M11.8a Quick-Win** aus dem Output-Vertrag-Hardening-Block (siehe `docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md`).

Externe Bewertung 5,8/10 hat `backend/app/services/report_prompts.py:53-57` als Root-Cause identifiziert: harter Section-Cap (Minimum 2 / Maximum 5 sections) deckelt das LLM strukturell und blockt jeden User-Prompt mit mehr als 5 Pflichtabschnitten.

**Fix:**
- Cap raus, durch `{required_sections}`-Variable ersetzt
- Default `DEFAULT_REPORT_SECTIONS` mit den 11 DACH-Report-Standardabschnitten
- `format_required_sections()` rendert nummerierte Markdown-Liste
- `plan_outline()` akzeptiert optional eine eigene Section-Liste; Default-Pfad bleibt rückwärtskompatibel
- Frontend kann später eine custom `required_sections`-Liste durchreichen (separater Slice)

## Test plan

- [x] 1600 passed, 9 skipped (Redis + docker-compose ohne env)
- [x] ruff clean
- [x] mypy clean (129 source files)
- [x] voice-lint clean (Wording-Glossar v1 — keine `prediction`/`rehearsal`-Wörter im neuen Prompt-Text)
- [x] schema-drift clean (Layer 0 unangetastet)
- [x] 2 neue Tests für `DEFAULT_REPORT_SECTIONS` + `format_required_sections`
- [ ] CI grün
- [ ] Gemini-Findings sichten

## Out-of-Scope (folgen in M11.8b–e)

- ReportV3-Pydantic-DTOs (M11.8c)
- `chat_json` Strict-Schema-Forced-Output (M11.8d)
- Quote+Evidence-Anchors (M11.8e)
- Frontend-`required_sections`-Durchreichung

Refs M11.8