### PR TITLE
test(report): Output-Contract-Snapshot pinnt 11 Pflichtabschnitte (M11.8b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - docs(plan): sync M11-Status auf 2026-05-08 — `AGENTS.md`/`CLAUDE.md`/`PLAN.md`/`STATUS.md` an realen Code-Stand angeglichen (M11 Phase 1–5b abgeschlossen, M11.2/M11.3 Coverage-Gates aktiv, ADR-0001 Accepted, Layer 9–10 grün).
 
 ### Added
+- test(report): Output-Contract-Snapshot pinnt DEFAULT_REPORT_SECTIONS gegen `tests/eval/snapshots/output-contract-required-sections.txt` (11 Zeilen, in Reihenfolge). Neue Konstante `MIN_PERSONA_TABLE_ROWS=50` in `report_agent/contract_constants.py` macht das Mengengerüst aus der externen Bewertung (§6.1) maschinenprüfbar. Drift in beiden Werten erfordert bewussten Sub-Slice mit Bewertungs-Begründung. M11.8b.
 - docs(m11): add `graph_tools.py` Phase-5b cut analysis (Refs F7)
 - **M11 Phase 5 Vorbereitung:** Schnittanalyse für `backend/app/services/simulation_runner.py` (1904 LOC) unter [`docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md`](docu/2026-05-07-m11-phase5-simulation-runner-cut-analysis.md). Dokumentiert Verantwortlichkeiten, externe Call-Sites, Test-Coverage und fünf Extraktionskandidaten mit empfohlener PR-Reihenfolge (read-only Doku, kein Code-Edit). Refs F7.
 

--- a/backend/app/services/report_agent/__init__.py
+++ b/backend/app/services/report_agent/__init__.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
+from .contract_constants import MIN_PERSONA_TABLE_ROWS
+
 __all__ = [
+    "MIN_PERSONA_TABLE_ROWS",
     "FORBIDDEN_EVIDENCE_TYPES",
     "VALID_TOOL_NAMES",
     "EvidenceItem",

--- a/backend/app/services/report_agent/contract_constants.py
+++ b/backend/app/services/report_agent/contract_constants.py
@@ -1,0 +1,17 @@
+"""Output-Contract-Konstanten für den Report-Agent (M11.8 Output-Vertrag-Hardening).
+
+Quelle: docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md
+- §3 Hauptbefund: 11 Pflichtabschnitte
+- §6.1 Fehlende vollständige Persona-Tabelle: 50 Zeilen Pflicht
+"""
+
+from __future__ import annotations
+
+# Mindest-Mengengerüst für die Persona-Tabelle eines DACH-Reports.
+# Quelle: docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md §6.1
+# ("Der Prompt fordert explizit 50 Persona-Zeilen.").
+MIN_PERSONA_TABLE_ROWS: int = 50
+
+__all__ = [
+    "MIN_PERSONA_TABLE_ROWS",
+]

--- a/backend/tests/eval/snapshots/output-contract-required-sections.txt
+++ b/backend/tests/eval/snapshots/output-contract-required-sections.txt
@@ -1,0 +1,11 @@
+Executive Summary
+Segment-Tabelle
+Persona-Tabelle
+Multiplikator-Auswertung
+Top 10 Reibungspunkte
+Top 10 Vertrauenssignale
+Top 10 Änderungen
+Projektwirkung
+Positionierung
+Content-Ideen
+Datenlücken

--- a/backend/tests/eval/test_output_contract_snapshot.py
+++ b/backend/tests/eval/test_output_contract_snapshot.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from app.services.report_agent import MIN_PERSONA_TABLE_ROWS
 from app.services.report_prompts import DEFAULT_REPORT_SECTIONS
 

--- a/backend/tests/eval/test_output_contract_snapshot.py
+++ b/backend/tests/eval/test_output_contract_snapshot.py
@@ -1,0 +1,61 @@
+"""M11.8b: Output-Contract-Snapshot-Tests.
+
+Pinnt die DEFAULT_REPORT_SECTIONS aus report_prompts.py gegen einen
+maschinenlesbaren Snapshot (output-contract-required-sections.txt).
+Drift in der Section-Liste schlägt damit sofort als Test-Fail an,
+nicht erst beim externen Bewertungs-Review.
+
+Quelle: docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.report_agent import MIN_PERSONA_TABLE_ROWS
+from app.services.report_prompts import DEFAULT_REPORT_SECTIONS
+
+SNAPSHOT_PATH = (
+    Path(__file__).parent / "snapshots" / "output-contract-required-sections.txt"
+)
+
+
+def test_default_report_sections_matches_snapshot():
+    """DEFAULT_REPORT_SECTIONS-Titles müssen exakt mit Snapshot übereinstimmen.
+
+    Drift erfordert bewussten Snapshot-Update, nicht stillschweigendes
+    Wegrutschen der Pflichtabschnitt-Liste.
+    """
+    expected = SNAPSHOT_PATH.read_text(encoding="utf-8").strip().splitlines()
+    actual = [title for title, _desc in DEFAULT_REPORT_SECTIONS]
+    assert actual == expected, (
+        "DEFAULT_REPORT_SECTIONS-Titles weichen vom Snapshot ab.\n"
+        f"  Snapshot: {expected}\n"
+        f"  Actual:   {actual}\n"
+        "Wenn das Update beabsichtigt ist, passe "
+        f"{SNAPSHOT_PATH} an."
+    )
+
+
+def test_default_report_sections_descriptions_non_empty():
+    """Jede Default-Section muss eine non-empty description haben."""
+    for title, desc in DEFAULT_REPORT_SECTIONS:
+        assert desc and desc.strip(), (
+            f"Section '{title}' hat leere description in DEFAULT_REPORT_SECTIONS"
+        )
+
+
+def test_min_persona_table_rows_pinned_to_fifty():
+    """MIN_PERSONA_TABLE_ROWS pinnt das Mengengerüst aus der externen Bewertung.
+
+    Quelle: docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md §6.1.
+    Eine Änderung verlangt expliziten Sub-Slice + Bewertungs-Begründung.
+    """
+    assert MIN_PERSONA_TABLE_ROWS == 50
+
+
+def test_required_sections_count_is_eleven():
+    """Pflichtabschnitt-Liste muss genau 11 Einträge haben."""
+    assert len(DEFAULT_REPORT_SECTIONS) == 11

--- a/docu/2026-05-09-m11-8b-output-contract-snapshot-arbeitsprotokoll.md
+++ b/docu/2026-05-09-m11-8b-output-contract-snapshot-arbeitsprotokoll.md
@@ -1,0 +1,48 @@
+# Arbeitsprotokoll — M11.8b: Output-Contract-Snapshot (schlank)
+
+**Datum:** 2026-05-09
+**Slice:** M11.8b — Output-Contract-Snapshot (schlank)
+**Branch:** feat/m11-8b-output-contract-snapshot
+
+## Ziel
+
+Den im PR #334 verankerten Output-Vertrag (`docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md`) maschinenprüfbar machen, ohne den vollen Eval-Korpus (seed.md / prompt.md / pdf / evidence.json) zu benötigen — die liegen aktuell nicht im Repo.
+
+Stattdessen: gepinnter Snapshot-Test gegen die bereits eingecheckte `DEFAULT_REPORT_SECTIONS` (PR #335 / `backend/app/services/report_prompts.py`) und eine neue Konstante `MIN_PERSONA_TABLE_ROWS`.
+
+## Begründung für schlanken Cut
+
+Eval-Korpus (seed.md, prompt.md, agora_1.pdf, evidence.json) liegt aktuell nicht im Repo. Schlanker Snapshot gegen DEFAULT_REPORT_SECTIONS deckt das Drift-Risiko ab; voller Eval-Pfad wartet auf separate Korpus-Einchecken-Slice.
+
+## Geänderte Dateien
+
+| Datei | Art | Beschreibung |
+|---|---|---|
+| `backend/app/services/report_agent/contract_constants.py` | NEU | `MIN_PERSONA_TABLE_ROWS=50` — Mengengerüst aus §6.1 des Output-Vertrags |
+| `backend/app/services/report_agent/__init__.py` | geändert | Re-Export `MIN_PERSONA_TABLE_ROWS` aus `contract_constants` |
+| `backend/tests/eval/snapshots/output-contract-required-sections.txt` | NEU | 11-Zeilen-Snapshot der Pflichtabschnitte |
+| `backend/tests/eval/test_output_contract_snapshot.py` | NEU | 4 Snapshot-Tests (Titles, Descriptions, Count, MIN_PERSONA_TABLE_ROWS) |
+| `CHANGELOG.md` | geändert | `[Unreleased] ### Added` Eintrag M11.8b |
+| `docu/STATUS.md` | zu syncen | `sync-status.sh` läuft nach Commit |
+
+## Out-of-Scope
+
+- ReportV3-DTOs (M11.8c)
+- chat_json Strict-Schema (M11.8d)
+- Quote-Markup (M11.8e)
+- Echter Eval-Korpus mit seed/prompt/pdf/json — User checkt separat ein
+- Pydantic-/Layer-0-Änderungen
+
+## Verifikation
+
+Alle Pflicht-Schritte grün:
+
+1. Schema-Drift clean (`git diff --exit-code schemas/`)
+2. Snapshot-Datei 11 Zeilen
+3. Pydantic-Contracts importierbar, `MIN_PERSONA_TABLE_ROWS=50`
+4. Schema-Dump idempotent
+5. Contract-Tests grün
+6. 4 neue Output-Contract-Snapshot-Tests grün
+7. Voice-Lint grün
+8. Volltest grün (1615 → 1619 Tests)
+9. `sync-status.sh --check` Exit 0

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-08
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1615 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1619 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Spec-Files | 44 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

**M11.8b** aus dem Output-Vertrag-Hardening-Block (siehe `docu/2026-05-09-output-vertrag-bewertung-evidence-quality.md`).

Macht den in M11.8a verankerten 11-Pflichtabschnitt-Vertrag und das aus der externen Bewertung übernommene 50-Persona-Mengengerüst maschinenprüfbar.

**Bewusst schlanker Cut:** Eval-Korpus (`seed.md` / `prompt.md` / `agora_1.pdf` / `evidence.json`) liegt aktuell nicht im Repo. Voller Korpus-Einchecken folgt als separater Slice, sobald die externen Files vorliegen.

**Neu:**
- `backend/app/services/report_agent/contract_constants.py` mit `MIN_PERSONA_TABLE_ROWS = 50`
- `backend/tests/eval/snapshots/output-contract-required-sections.txt` mit 11 Zeilen Section-Titles in Reihenfolge
- `backend/tests/eval/test_output_contract_snapshot.py` mit 4 Tests:
  - `test_default_report_sections_matches_snapshot` (Drift-Pin gegen Snapshot-Datei)
  - `test_default_report_sections_descriptions_non_empty`
  - `test_min_persona_table_rows_pinned_to_fifty`
  - `test_required_sections_count_is_eleven`

**Re-Export:** `from app.services.report_agent import MIN_PERSONA_TABLE_ROWS`.

## Test plan

- [x] 1619 collected (vorher 1615, +4 neue Tests)
- [x] 1605 passed, 9 skipped (Redis + Docker-Compose ohne env), 7 deselected
- [x] Snapshot-File: exakt 11 Zeilen LF
- [x] Schema-Drift clean (Layer 0 unangetastet)
- [x] STATUS.md `sync-status.sh --check` Exit 0 (1615 → 1619 mit-synced)
- [x] Voice-Lint clean
- [ ] CI grün
- [ ] Gemini-Findings sichten

## Out-of-Scope (folgen in M11.8c–e)

- ReportV3-Pydantic-DTOs (M11.8c)
- `chat_json` Strict-Schema-Forced-Output (M11.8d)
- Quote+Evidence-Anchors (M11.8e)
- Vollständiger Eval-Korpus mit externen Files

Refs M11.8