### PR TITLE
fix(design-v3): Gemini-Followup auf PR #339 + STATUS-Sync

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,7 +9,10 @@ import './assets/styles/tokens.css'
 if (import.meta.env.VITE_DESIGN_V3 === 'true') {
   // Design Language v3 (Apple Enterprise · Light) — overlays v2 tokens via
   // alias layer in tokens-v3.css. EPIC docu/2026-05-09-design-v3-epic.md.
-  import('./assets/styles/tokens-v3.css')
+  // v3 ist light-only: data-theme aus localStorage könnte 'dark' sein,
+  // hartcodierte Komponenten-Logik darf nicht stillschweigend dunkel bleiben.
+  document.documentElement.setAttribute('data-theme', 'light')
+  await import('./assets/styles/tokens-v3.css')
 }
 import './assets/styles/global.css'
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,9 +9,13 @@ import './assets/styles/tokens.css'
 if (import.meta.env.VITE_DESIGN_V3 === 'true') {
   // Design Language v3 (Apple Enterprise · Light) — overlays v2 tokens via
   // alias layer in tokens-v3.css. EPIC docu/2026-05-09-design-v3-epic.md.
-  // v3 ist light-only: data-theme aus localStorage könnte 'dark' sein,
-  // hartcodierte Komponenten-Logik darf nicht stillschweigend dunkel bleiben.
+  // v3 ist light-only. data-theme aus localStorage könnte 'dark' sein und
+  // würde sonst beim ersten useTheme()-Call (App.vue → ensureWatcher →
+  // applyTheme) das DOM-Attribut wieder überschreiben (Gemini-HIGH #340).
+  // Daher: DOM-Attribut + ref-State + localStorage konsistent auf 'light'.
   document.documentElement.setAttribute('data-theme', 'light')
+  const { useTheme } = await import('./composables/useTheme')
+  useTheme().setTheme('light')
   await import('./assets/styles/tokens-v3.css')
 }
 import './assets/styles/global.css'


### PR DESCRIPTION
## Summary

- `fix(design-v3)`: in `frontend/src/main.ts` — `await import('./assets/tokens-v3.css')` und Force `data-theme=light` (Gemini-HIGH-Followup auf PR #339)
- `chore(status)`: STATUS.md-Sync (Backend 1619→1636, Frontend Specs 44→45) nach Merge von #339

## Test plan

- [x] `frontend/src/main.ts` lädt Tokens deterministisch (kein FOUC mehr)
- [x] STATUS.md spiegelt aktuelle Test-Counts
- [ ] Gemini-Sichtung nach 90 s (PR-Workflow-Pflicht)

Refs #339