### PR TITLE
fix(report): restore agent tools runtime

### DIFF
--- a/backend/app/services/event_bus.py
+++ b/backend/app/services/event_bus.py
@@ -264,6 +264,8 @@ class FilePollingEventBus:
         payload = {
             **event.to_dict(),
             "command_id": event.correlation_id,  # legacy field for IPC consumers
+            "command_type": event.type,
+            "args": event.payload,
         }
         self._store.write_json(
             event.simulation_id,

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -99,48 +99,28 @@ class SectionMetadata(BaseModel):
 # Section-type → DTO mapper (M11.8d)
 # ---------------------------------------------------------------------------
 
-_SECTION_KEYWORD_MAP: dict[str, type[BaseModel]] = {
+_SECTION_TITLE_MAP: dict[str, type[BaseModel]] = {
     # ReportV3 Pflichtabschnitt-DTOs
-    "persona": Persona,
-    "personas": Persona,
-    "zielgrupp": Persona,
-    "segment": Segment,
-    "segments": Segment,
-    "claim": Claim,
-    "claims": Claim,
-    "befund": Claim,
-    "multipli": Multiplier,
-    "multiplier": Multiplier,
-    "hebel": Multiplier,
-    "friction": FrictionPoint,
-    "reibung": FrictionPoint,
-    "hindernis": FrictionPoint,
-    "trust": TrustSignal,
-    "vertrauen": TrustSignal,
-    "empfehlung": ChangeRecommendation,
-    "recommendation": ChangeRecommendation,
-    "handlung": ChangeRecommendation,
-    "impact": ProjectImpact,
-    "auswirkung": ProjectImpact,
-    "wirkung": ProjectImpact,
-    "position": PositioningVariant,
+    "segment-tabelle": Segment,
+    "persona-tabelle": Persona,
+    "multiplikator-auswertung": Multiplier,
+    "top 10 reibungspunkte": FrictionPoint,
+    "top 10 vertrauenssignale": TrustSignal,
+    "top 10 änderungen": ChangeRecommendation,
+    "projektwirkung": ProjectImpact,
     "positionierung": PositioningVariant,
-    "content": ContentIdea,
-    "inhalt": ContentIdea,
-    "datenlücke": DataGap,
+    "content-ideen": ContentIdea,
     "datenlücken": DataGap,
-    "data gap": DataGap,
-    "data_gap": DataGap,
-    "datagap": DataGap,
-    "lücke": DataGap,
 }
 
 
 def _section_schema_for(section_title: str) -> type[BaseModel]:
     """Liefert das passende Pydantic-DTO für einen Abschnittstitel.
 
-    Sucht case-insensitiv nach Schlüsselwörtern im Titel.
-    Fallback: :class:`SectionMetadata` (allgemeine Metadaten).
+    Mappt nur bekannte Pflichtabschnitt-Titel auf ReportV3-DTOs. Freie
+    Abschnittstitel wie ``Persona Reaction Analysis`` bekommen bewusst das
+    generische :class:`SectionMetadata`, statt ein vollständiges Persona-Objekt
+    zu erzwingen.
 
     Args:
         section_title: Titel des generierten Abschnitts.
@@ -149,9 +129,9 @@ def _section_schema_for(section_title: str) -> type[BaseModel]:
         Pydantic-Modell-Klasse, die als ``schema=`` an ``chat_json`` übergeben
         werden kann.
     """
-    lower = section_title.lower()
-    for keyword, schema_cls in _SECTION_KEYWORD_MAP.items():
-        if keyword in lower:
+    lower = section_title.strip().lower()
+    for title, schema_cls in _SECTION_TITLE_MAP.items():
+        if lower == title:
             return schema_cls
     return SectionMetadata
 

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -130,10 +130,7 @@ def _section_schema_for(section_title: str) -> type[BaseModel]:
         werden kann.
     """
     lower = section_title.strip().lower()
-    for title, schema_cls in _SECTION_TITLE_MAP.items():
-        if lower == title:
-            return schema_cls
-    return SectionMetadata
+    return _SECTION_TITLE_MAP.get(lower, SectionMetadata)
 
 
 __all__ = [

--- a/backend/app/services/settings_layer.py
+++ b/backend/app/services/settings_layer.py
@@ -208,6 +208,23 @@ class SettingsService:
                     snapshot[spec.key] = value
             return snapshot
 
+    def effective_value(self, key: str, *, include_secret: bool = False) -> Any:
+        """Return the effective runtime value for a single settings key.
+
+        Secrets are withheld unless ``include_secret=True`` is passed by a
+        trusted in-process caller. API routes must continue to use
+        :meth:`get_field_state`, which masks secret values.
+        """
+        spec = field_by_key(key)
+        if spec is None:
+            return None
+        if spec.secret and not include_secret:
+            return None
+        with self._lock:
+            file_layer = self._read_file_layer()
+            value, _, _ = self._resolve_field(spec, file_layer)
+            return value
+
     def get_schema(self) -> list[dict[str, Any]]:
         """Liefert nur Meta-Daten (kein Wert, keine Source) — für das
         Frontend-Form-Render. Defaults sind dabei bewusst enthalten,

--- a/backend/app/services/web_tools.py
+++ b/backend/app/services/web_tools.py
@@ -41,7 +41,7 @@ def _setting_value(key: str, *, include_secret: bool = False) -> Any:
 def _bool_enabled(value: Any) -> bool:
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() not in ("0", "false", "no", "off", "")
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
 
 
 def _is_public_url(url: str) -> tuple[bool, str]:

--- a/backend/app/services/web_tools.py
+++ b/backend/app/services/web_tools.py
@@ -12,7 +12,6 @@ the service reports itself as disabled and the tools are simply not registered.
 from __future__ import annotations
 
 import ipaddress
-import os
 import socket
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -26,6 +25,23 @@ logger = get_logger('agora.web_tools')
 TAVILY_SEARCH_URL = "https://api.tavily.com/search"
 TAVILY_EXTRACT_URL = "https://api.tavily.com/extract"
 DEFAULT_TIMEOUT = 25.0
+
+
+def _setting_value(key: str, *, include_secret: bool = False) -> Any:
+    """Best-effort runtime settings lookup without making startup depend on it."""
+    try:
+        from .settings_layer import get_default_service
+
+        return get_default_service().effective_value(key, include_secret=include_secret)
+    except Exception as exc:
+        logger.debug("Settings lookup failed for %s: %s", key, exc)
+        return None
+
+
+def _bool_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in ("0", "false", "no", "off", "")
 
 
 def _is_public_url(url: str) -> tuple[bool, str]:
@@ -76,9 +92,13 @@ class WebToolsService:
     """Thin wrapper around the Tavily REST API."""
 
     def __init__(self, api_key: Optional[str] = None, enabled: Optional[bool] = None):
-        self.api_key = api_key or os.environ.get("TAVILY_API_KEY", "").strip() or None
-        env_enabled = os.environ.get("ENABLE_WEB_TOOLS", "true").strip().lower() not in ("0", "false", "no", "off")
-        self.enabled = bool(self.api_key) and (env_enabled if enabled is None else enabled)
+        settings_api_key = _setting_value("TAVILY_API_KEY", include_secret=True)
+        self.api_key = (api_key or settings_api_key or "").strip() or None
+        settings_enabled = _setting_value("ENABLE_WEB_TOOLS")
+        configured_enabled = _bool_enabled(settings_enabled)
+        self.enabled = bool(self.api_key) and (
+            configured_enabled if enabled is None else bool(enabled)
+        )
 
     def is_available(self) -> bool:
         return self.enabled

--- a/backend/tests/services/test_report_agent_strict_schema.py
+++ b/backend/tests/services/test_report_agent_strict_schema.py
@@ -21,7 +21,6 @@ from app.services.report_agent.schemas import (
     _section_schema_for,
 )
 from app.contracts.report_v3 import (
-    Claim,
     ContentIdea,
     DataGap,
     FrictionPoint,
@@ -185,25 +184,16 @@ class TestPlanOutlineStrictSchema:
 
 class TestSectionSchemaFor:
     @pytest.mark.parametrize("title,expected_cls", [
-        ("Zielgruppen-Personas", Persona),
-        ("Persona-Übersicht", Persona),
-        ("Marktsegmente", Segment),
-        ("Segment-Analyse", Segment),
-        ("Zentrale Claims", Claim),
-        ("Befunde aus der Simulation", Claim),
-        ("Wachstumshebel und Multiplikatoren", Multiplier),
-        ("Reibungspunkte und Hindernisse", FrictionPoint),
-        ("Friction-Analyse", FrictionPoint),
-        ("Vertrauenssignale nach Cialdini", TrustSignal),
-        ("Trust-Building-Massnahmen", TrustSignal),
-        ("Handlungsempfehlungen", ChangeRecommendation),
-        ("Change Recommendations", ChangeRecommendation),
-        ("Projektwirkung und Impact", ProjectImpact),
-        ("Auswirkungen auf die Markteinführung", ProjectImpact),
-        ("Positionierungsvarianten", PositioningVariant),
-        ("Content-Ideen für Social Media", ContentIdea),
-        ("Datenlücken und Limitierungen", DataGap),
-        ("Data Gaps", DataGap),
+        ("Persona-Tabelle", Persona),
+        ("Segment-Tabelle", Segment),
+        ("Multiplikator-Auswertung", Multiplier),
+        ("Top 10 Reibungspunkte", FrictionPoint),
+        ("Top 10 Vertrauenssignale", TrustSignal),
+        ("Top 10 Änderungen", ChangeRecommendation),
+        ("Projektwirkung", ProjectImpact),
+        ("Positionierung", PositioningVariant),
+        ("Content-Ideen", ContentIdea),
+        ("Datenlücken", DataGap),
     ])
     def test_schema_mapping(self, title: str, expected_cls: type):
         result = _section_schema_for(title)
@@ -219,8 +209,12 @@ class TestSectionSchemaFor:
 
     def test_case_insensitive_matching(self):
         """Matching ist case-insensitiv."""
-        assert _section_schema_for("PERSONA-Analyse") is Persona
-        assert _section_schema_for("trust signals") is TrustSignal
+        assert _section_schema_for("PERSONA-TABELLE") is Persona
+        assert _section_schema_for("top 10 vertrauenssignale") is TrustSignal
+
+    def test_free_persona_analysis_title_uses_generic_metadata(self):
+        """Freie 3-Section-Fallback-Titel dürfen kein volles Persona-DTO erzwingen."""
+        assert _section_schema_for("Persona Reaction Analysis") is SectionMetadata
 
 
 # ---------------------------------------------------------------------------
@@ -253,8 +247,8 @@ class TestGenerateSectionMetadata:
         assert call_kwargs.get("schema") is SectionMetadata
         assert "section_metadata" in call_kwargs.get("schema_name", "")
 
-    def test_passes_persona_schema_for_persona_section(self):
-        """generate_section_metadata() wählt Persona-DTO für Persona-Abschnitt."""
+    def test_passes_persona_schema_for_required_persona_table(self):
+        """generate_section_metadata() wählt Persona-DTO für den Pflichtabschnitt."""
         from app.services.report_agent.workflow import generate_section_metadata
 
         agent = _make_agent()
@@ -265,7 +259,7 @@ class TestGenerateSectionMetadata:
 
         result = generate_section_metadata(
             agent,
-            section_title="Zielgruppen-Personas",
+            section_title="Persona-Tabelle",
             section_content="Persona Alpha ist 35-50 Jahre alt.",
             section_index=2,
         )

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -277,6 +277,29 @@ def test_request_response_correlation(bus):
     assert response.payload["result"]["echo"]["agent_id"] == 7
 
 
+def test_file_adapter_writes_legacy_rpc_command_fields(tmp_path):
+    """File IPC consumers still read command_type/args directly."""
+    store = LocalFilesystemArtifactStore(simulations_root=str(tmp_path))
+    bus = FilePollingEventBus(store=store)
+
+    bus.publish(
+        CHANNEL_RPC_COMMAND,
+        SimulationEvent(
+            type="batch_interview",
+            simulation_id=SIM_ID,
+            payload={"interviews": [{"agent_id": 7, "prompt": "hello"}]},
+            correlation_id="cmd-123",
+        ),
+    )
+
+    raw = store.read_json(SIM_ID, "ipc_command/cmd-123", default={})
+    assert raw["type"] == "batch_interview"
+    assert raw["payload"]["interviews"][0]["agent_id"] == 7
+    assert raw["command_id"] == "cmd-123"
+    assert raw["command_type"] == "batch_interview"
+    assert raw["args"]["interviews"][0]["prompt"] == "hello"
+
+
 def test_request_response_times_out(bus):
     """No responder → request_response raises TimeoutError within the window."""
     start = time.monotonic()

--- a/backend/tests/test_evidence_gating_prompt.py
+++ b/backend/tests/test_evidence_gating_prompt.py
@@ -96,19 +96,6 @@ def test_source_kind_field_naming():
     Source-Kind-Feld ist mit korrekten Enum-Werten referenziert.
     (Zukunfts-Sicherung für Slice B: forward-compatible naming)
     """
-    required_source_kinds = [
-        "seed_corpus",
-        "agent_quote",
-        "graph_relation",
-        "inferred"
-    ]
-    prompt_lower = SECTION_SYSTEM_PROMPT_TEMPLATE.lower()
-    for source_kind in required_source_kinds:
-        # Prüfe, dass mindestens zwei dieser Werte erwähnt sind
-        # (Slice B wird alle vier einführen, aber dieser Slice muss
-        # mindestens die ersten zwei korrekt referenzieren)
-        pass
-
     # Aktuelle Assertion: mindestens "seed_corpus" und "agent_quote" sind genannt
     assert "seed_corpus" in SECTION_SYSTEM_PROMPT_TEMPLATE
     assert "agent_quote" in SECTION_SYSTEM_PROMPT_TEMPLATE

--- a/backend/tests/test_web_tools.py
+++ b/backend/tests/test_web_tools.py
@@ -1,0 +1,47 @@
+"""Tests for optional ReportAgent web tools."""
+
+from __future__ import annotations
+
+import json
+
+from app.services.settings_layer import SettingsService
+from app.services.web_tools import WebToolsService
+
+
+def test_web_tools_read_tavily_secret_from_settings_file(tmp_path, monkeypatch):
+    service = SettingsService(instance_path=tmp_path / "settings.json")
+    service.instance_path.parent.mkdir(parents=True, exist_ok=True)
+    service.instance_path.write_text(
+        json.dumps({
+            "ENABLE_WEB_TOOLS": True,
+            "TAVILY_API_KEY": "tvly-test-key",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "app.services.settings_layer.get_default_service",
+        lambda: service,
+    )
+
+    tools = WebToolsService()
+
+    assert tools.api_key == "tvly-test-key"
+    assert tools.is_available() is True
+
+
+def test_web_tools_disabled_when_flag_false_even_with_key(tmp_path, monkeypatch):
+    service = SettingsService(instance_path=tmp_path / "settings.json")
+    service.instance_path.parent.mkdir(parents=True, exist_ok=True)
+    service.instance_path.write_text(
+        json.dumps({
+            "ENABLE_WEB_TOOLS": False,
+            "TAVILY_API_KEY": "tvly-test-key",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "app.services.settings_layer.get_default_service",
+        lambda: service,
+    )
+
+    assert WebToolsService().is_available() is False

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-08
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1712 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1707 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Spec-Files | 45 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Zusammenfassung
- stellt File-IPC-Legacy-Felder fuer OASIS-Interview-Kommandos wieder her
- liest WebTools-Konfiguration ueber den Settings-Layer inklusive Tavily-Secret
- verhindert falsche Persona-DTO-Metadatenextraktion fuer freie Report-Titel

## Testplan
- [x] cd backend && uv run pytest tests/test_event_bus.py tests/test_web_tools.py tests/services/test_report_agent_strict_schema.py -q
- [x] cd backend && uv run ruff check app/services/event_bus.py app/services/settings_layer.py app/services/web_tools.py app/services/report_agent/schemas.py tests/test_event_bus.py tests/test_web_tools.py tests/services/test_report_agent_strict_schema.py

## Diagnose
- report_5aae24ec3675 zeigte `Unknown command type: None`, weil der OASIS-File-IPC nur `command_type`/`args` liest.
- `web_search`/`fetch_url` waren in den Report-Agent-Logs nicht registriert; WebTools haengen an `ENABLE_WEB_TOOLS` und `TAVILY_API_KEY`.
