### PR TITLE
feat: add runtime LLM provider overrides

### DIFF
--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -25,7 +25,9 @@ from ..services.simulation_manager import SimulationManager
 from ..models.project import ProjectManager
 from ..models.task import TaskManager, TaskStatus
 from ..services.graph_tools import GraphToolsService
+from ..services.llm_runtime import parse_runtime_llm_config
 from ..utils.artifact_locator import ArtifactLocator
+from ..utils.llm_client import LLMClient
 from ..utils.auth import allow_ticket_auth
 from ..utils.api_errors import ApiErrorCode
 from ..utils.logger import get_logger
@@ -84,12 +86,16 @@ def generate_report():
 
     force_regenerate = data.get('force_regenerate', False)
     llm_model_override = (data.get('llm_model') or '').strip() or None
+    try:
+        llm_runtime = parse_runtime_llm_config(data)
+    except ValueError as exc:
+        return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
     manager = SimulationManager()
     state = manager.get_simulation(simulation_id)
     if not state:
         return json_error(f"Simulation does not exist: {simulation_id}", status=404)
 
-    if _can_reuse_existing_report(force_regenerate, llm_model_override):
+    if _can_reuse_existing_report(force_regenerate, llm_model_override, llm_runtime.enabled):
         existing_report = ReportManager.get_report_by_simulation(simulation_id)
         if existing_report and existing_report.status == ReportStatus.COMPLETED:
             return json_success({
@@ -141,6 +147,7 @@ def generate_report():
             # Persist the model override so _resume_report_generate in runs.py
             # can reconstruct the same ReportAgent when the run is resumed. (Sub-Slice C)
             "llm_model": llm_model_override,
+            "llm_provider": llm_runtime.redacted_metadata() or None,
         },
     )
     task_id = task_manager.create_task(
@@ -163,6 +170,11 @@ def generate_report():
                 simulation_id=simulation_id,
                 simulation_requirement=simulation_requirement,
                 graph_tools=graph_tools,
+                llm_client=(
+                    LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+                    if llm_runtime.enabled
+                    else None
+                ),
                 model_name=llm_model_override,
             )
             def progress_callback(stage, progress, message):
@@ -432,9 +444,13 @@ def get_report_evidence_claim(report_id: str, section_index: int, claim_id: str)
 EXPORT_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION
 
 
-def _can_reuse_existing_report(force_regenerate: bool, llm_model_override: Optional[str]) -> bool:
-    """Reuse only when the caller did not request a concrete report model."""
-    return not force_regenerate and not llm_model_override
+def _can_reuse_existing_report(
+    force_regenerate: bool,
+    llm_model_override: Optional[str],
+    runtime_provider_override: bool = False,
+) -> bool:
+    """Reuse only when the caller did not request concrete LLM runtime settings."""
+    return not force_regenerate and not llm_model_override and not runtime_provider_override
 
 
 def _map_outline_for_contract(outline: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -14,6 +14,7 @@ from ..config import Config
 from ..contracts import PersonaQuotaPlan
 from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
+from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..utils.validation import validate_simulation_id, validate_task_id
 from ..utils.api_errors import ApiErrorCode
@@ -186,12 +187,21 @@ def prepare_simulation():
         )
 
     force_regenerate = data.get('force_regenerate', False)
+    llm_model_override = (data.get('llm_model') or '').strip() or None
+    try:
+        llm_runtime = parse_runtime_llm_config(data)
+    except ValueError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
     logger.info(
         f"Start processing /prepare Request: simulation_id={simulation_id}, force_regenerate={force_regenerate}",
         extra={'simulation_id': simulation_id},
     )
 
-    if not force_regenerate:
+    if not force_regenerate and not llm_model_override and not llm_runtime.enabled:
         logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
         is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
         logger.debug(f"Check result: is_prepared={is_prepared}, prepare_info={prepare_info}")
@@ -247,7 +257,6 @@ def prepare_simulation():
             message=f"Invalid quota_plan: {exc}",
         )
 
-    llm_model_override = (data.get('llm_model') or '').strip() or None
     agent_language_override = (data.get('language') or '').strip().lower() or None
     if agent_language_override and agent_language_override not in ('de', 'en'):
         agent_language_override = None
@@ -384,6 +393,7 @@ def prepare_simulation():
                 parallel_profile_count=parallel_profile_count,
                 storage=storage,
                 llm_model=llm_model_override,
+                llm_runtime=llm_runtime,
                 language=agent_language_override,
                 max_agents=max_agents,
                 quota_plan=quota_plan,

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -10,6 +10,7 @@ from . import simulation_bp
 from ..config import Config
 from ..models.project import ProjectManager
 from ..services.persona_review_service import PersonaReviewService
+from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
 from ..utils.api_errors import ApiErrorCode
@@ -73,6 +74,15 @@ def start_simulation():
     platform = data.get('platform', 'parallel')
     max_rounds = data.get('max_rounds')
     simulation_days = data.get('simulation_days')
+    llm_model_override = (data.get('llm_model') or '').strip() or None
+    try:
+        llm_runtime = parse_runtime_llm_config(data)
+    except ValueError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
     enable_graph_memory_update = data.get('enable_graph_memory_update', False)
     force = data.get('force', False)
 
@@ -185,7 +195,7 @@ def start_simulation():
             extra={'simulation_id': simulation_id},
         )
 
-    if simulation_days is not None:
+    if simulation_days is not None or llm_model_override or llm_runtime.enabled:
         store = get_artifact_store()
         config = store.read_json(simulation_id, "simulation_config", default=None)
         if not config:
@@ -194,9 +204,14 @@ def start_simulation():
                 status=404,
                 message="Simulation configuration does not exist. Please call /prepare first",
             )
-        time_config = dict(config.get("time_config") or {})
-        time_config["total_simulation_hours"] = simulation_days * 24
-        config["time_config"] = time_config
+        if simulation_days is not None:
+            time_config = dict(config.get("time_config") or {})
+            time_config["total_simulation_hours"] = simulation_days * 24
+            config["time_config"] = time_config
+        if llm_model_override:
+            config["llm_model"] = llm_model_override
+        if llm_runtime.enabled:
+            config["llm_base_url"] = llm_runtime.base_url
         store.write_json(simulation_id, "simulation_config", config)
 
     run_state = SimulationRunner.start_simulation(
@@ -205,6 +220,7 @@ def start_simulation():
         max_rounds=max_rounds,
         enable_graph_memory_update=enable_graph_memory_update,
         graph_id=graph_id,
+        runtime_env=llm_runtime.subprocess_env(model=llm_model_override),
     )
 
     manager._set_status(state, SimulationStatus.RUNNING)
@@ -226,6 +242,8 @@ def start_simulation():
             "root_simulation_id": state.root_simulation_id,
             "branch_name": state.branch_name,
             "branch_depth": state.branch_depth,
+            "llm_model": llm_model_override,
+            "llm_provider": llm_runtime.redacted_metadata() or None,
         },
     )
 

--- a/backend/app/services/llm_runtime.py
+++ b/backend/app/services/llm_runtime.py
@@ -1,0 +1,107 @@
+"""Per-request LLM runtime settings.
+
+The UI may pass provider credentials for one run. API keys are intentionally
+kept out of run metadata and simulation artifacts; only non-secret provider
+data such as the OpenAI-compatible base URL may be persisted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+
+PROVIDER_DEFAULT_BASE_URLS = {
+    "google": "https://generativelanguage.googleapis.com/v1beta/openai/",
+    "openai": "https://api.openai.com/v1",
+}
+
+_PROVIDER_ALIASES = {
+    "default": "default",
+    "server": "default",
+    "google": "google",
+    "gemini": "google",
+    "openai": "openai",
+    "custom": "custom_openai",
+    "custom_openai": "custom_openai",
+    "openai_compatible": "custom_openai",
+}
+
+
+@dataclass(frozen=True)
+class RuntimeLlmConfig:
+    """Validated runtime provider override for one request."""
+
+    provider: str = "default"
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+
+    @property
+    def enabled(self) -> bool:
+        return self.provider != "default"
+
+    def redacted_metadata(self) -> dict[str, Any]:
+        if not self.enabled:
+            return {}
+        return {
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_key_set": bool(self.api_key),
+        }
+
+    def client_kwargs(self, *, model: Optional[str] = None) -> dict[str, Optional[str]]:
+        if not self.enabled:
+            return {"model": model}
+        return {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "model": model,
+        }
+
+    def subprocess_env(self, *, model: Optional[str] = None) -> dict[str, str]:
+        if not self.enabled:
+            return {}
+        env = {
+            "LLM_API_KEY": self.api_key or "",
+            "OPENAI_API_KEY": self.api_key or "",
+        }
+        if self.base_url:
+            env["LLM_BASE_URL"] = self.base_url
+            env["OPENAI_API_BASE_URL"] = self.base_url
+        if model:
+            env["LLM_MODEL_NAME"] = model
+        return env
+
+
+def parse_runtime_llm_config(data: Mapping[str, Any]) -> RuntimeLlmConfig:
+    raw = data.get("llm_provider") or data.get("llm_runtime") or None
+    if not raw:
+        return RuntimeLlmConfig()
+    if not isinstance(raw, Mapping):
+        raise ValueError("llm_provider must be an object")
+
+    provider_raw = str(raw.get("provider") or "default").strip().lower()
+    provider = _PROVIDER_ALIASES.get(provider_raw)
+    if provider is None:
+        raise ValueError(
+            "llm_provider.provider must be one of: default, google, openai, custom_openai"
+        )
+    if provider == "default":
+        return RuntimeLlmConfig()
+
+    api_key = str(raw.get("api_key") or "").strip()
+    if not api_key:
+        raise ValueError("llm_provider.api_key is required for non-default providers")
+
+    base_url = str(raw.get("base_url") or "").strip()
+    if not base_url:
+        base_url = PROVIDER_DEFAULT_BASE_URLS.get(provider, "")
+    if not base_url:
+        raise ValueError("llm_provider.base_url is required for custom_openai")
+
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("llm_provider.base_url must be an absolute http(s) URL")
+
+    return RuntimeLlmConfig(provider=provider, api_key=api_key, base_url=base_url)

--- a/backend/app/services/prepare_service.py
+++ b/backend/app/services/prepare_service.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from ..contracts import PersonaQuotaActual, PersonaQuotaPlan
 from ..utils.logger import get_logger
 from .entity_reader import EntityReader
+from .llm_runtime import RuntimeLlmConfig
 from .oasis_profile_generator import OasisAgentProfile, OasisProfileGenerator
 from .persona_quota_defaults import default_dach_industry_quota
 from .simulation_config_generator import SimulationConfigGenerator
@@ -103,6 +104,7 @@ def _phase_generate_profiles(
     sim_dir: str,
     *,
     llm_model: Optional[str],
+    llm_runtime: Optional[RuntimeLlmConfig] = None,
     language: Optional[str],
     use_llm_for_profiles: bool,
     parallel_profile_count: int,
@@ -137,6 +139,8 @@ def _phase_generate_profiles(
     # (IT-Cap ≤ 12 %). total_entities als Pool-Größe für proportionale Verteilung.
     industry_plan = default_dach_industry_quota(max(total_entities, 1))
     generator = OasisProfileGenerator(
+        api_key=llm_runtime.api_key if llm_runtime and llm_runtime.enabled else None,
+        base_url=llm_runtime.base_url if llm_runtime and llm_runtime.enabled else None,
         storage=storage,
         graph_id=state.graph_id,
         model_name=llm_model,
@@ -222,6 +226,7 @@ def _phase_generate_config(
     filtered,
     *,
     llm_model: Optional[str],
+    llm_runtime: Optional[RuntimeLlmConfig] = None,
     language: Optional[str],
     progress_callback: Optional[Callable] = None,
     quota_plan: Optional[PersonaQuotaPlan] = None,
@@ -246,6 +251,8 @@ def _phase_generate_config(
         )
 
     config_generator = SimulationConfigGenerator(
+        api_key=llm_runtime.api_key if llm_runtime and llm_runtime.enabled else None,
+        base_url=llm_runtime.base_url if llm_runtime and llm_runtime.enabled else None,
         model_name=llm_model,
         language=language,
     )
@@ -382,6 +389,7 @@ def prepare_simulation(
     parallel_profile_count: Optional[int] = None,
     storage: Any = None,
     llm_model: Optional[str] = None,
+    llm_runtime: Optional[RuntimeLlmConfig] = None,
     language: Optional[str] = None,
     max_agents: Optional[int] = None,
     quota_plan: Optional[PersonaQuotaPlan] = None,
@@ -435,6 +443,7 @@ def prepare_simulation(
             filtered,
             sim_dir,
             llm_model=llm_model,
+            llm_runtime=llm_runtime,
             language=language,
             use_llm_for_profiles=use_llm_for_profiles,
             parallel_profile_count=parallel_profile_count,
@@ -455,6 +464,7 @@ def prepare_simulation(
             document_text,
             filtered,
             llm_model=llm_model,
+            llm_runtime=llm_runtime,
             language=language,
             progress_callback=progress_callback,
             quota_plan=quota_plan,

--- a/backend/app/services/sim/process_manager.py
+++ b/backend/app/services/sim/process_manager.py
@@ -149,6 +149,7 @@ def start_simulation(
     config_exists: Callable[[str], bool],
     setup_graph_memory: Callable[[str], None],
     max_rounds: Optional[int] = None,
+    runtime_env: Optional[Dict[str, str]] = None,
 ) -> SimulationRunState:
     """Start an OASIS simulation: validate, init state, launch subprocess, start monitor.
 
@@ -267,6 +268,8 @@ def start_simulation(
         env = os.environ.copy()
         env["PYTHONUTF8"] = "1"
         env["PYTHONIOENCODING"] = "utf-8"
+        if runtime_env:
+            env.update({k: v for k, v in runtime_env.items() if v})
         # Sub-Slice 21: OASIS-DB pro Sim ins schreibbare uploads/-Volume
         _inject_oasis_db_env(env, sim_dir)
 

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -18,6 +18,7 @@ from . import branching_service, prepare_service
 
 if TYPE_CHECKING:
     from ..contracts import PersonaQuotaPlan
+    from .llm_runtime import RuntimeLlmConfig
 # simulation_state_machine importiert ``SimulationStatus`` aus diesem Modul,
 # daher Lazy-Import in ``_set_status`` (vermeidet Zirkularität).
 
@@ -296,6 +297,7 @@ class SimulationManager:
         parallel_profile_count: Optional[int] = None,
         storage: Any = None,
         llm_model: Optional[str] = None,
+        llm_runtime: Optional["RuntimeLlmConfig"] = None,
         language: Optional[str] = None,
         max_agents: Optional[int] = None,
         quota_plan: Optional["PersonaQuotaPlan"] = None,
@@ -311,6 +313,7 @@ class SimulationManager:
             parallel_profile_count=parallel_profile_count,
             storage=storage,
             llm_model=llm_model,
+            llm_runtime=llm_runtime,
             language=language,
             max_agents=max_agents,
             quota_plan=quota_plan,

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -208,6 +208,7 @@ class SimulationRunner:
         enable_graph_memory_update: bool = False,
         graph_id: str = None,
         storage: Any = None,
+        runtime_env: Optional[Dict[str, str]] = None,
     ) -> SimulationRunState:
         """Start simulation.
 
@@ -246,6 +247,7 @@ class SimulationRunner:
                 s, enable_graph_memory_update, graph_id, storage
             ),
             max_rounds=max_rounds,
+            runtime_env=runtime_env,
         )
 
     @classmethod

--- a/backend/tests/services/test_llm_runtime.py
+++ b/backend/tests/services/test_llm_runtime.py
@@ -1,0 +1,46 @@
+from app.services.llm_runtime import parse_runtime_llm_config
+
+
+def test_google_runtime_uses_openai_compatible_base_url():
+    cfg = parse_runtime_llm_config(
+        {"llm_provider": {"provider": "google", "api_key": "gemini-key"}}
+    )
+
+    assert cfg.enabled
+    assert cfg.provider == "google"
+    assert cfg.base_url == "https://generativelanguage.googleapis.com/v1beta/openai/"
+    assert cfg.subprocess_env(model="gemini-2.5-flash") == {
+        "LLM_API_KEY": "gemini-key",
+        "OPENAI_API_KEY": "gemini-key",
+        "LLM_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "OPENAI_API_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "LLM_MODEL_NAME": "gemini-2.5-flash",
+    }
+
+
+def test_runtime_metadata_redacts_api_key():
+    cfg = parse_runtime_llm_config(
+        {
+            "llm_provider": {
+                "provider": "custom_openai",
+                "api_key": "secret-value",
+                "base_url": "https://example.test/v1",
+            }
+        }
+    )
+
+    assert cfg.redacted_metadata() == {
+        "provider": "custom_openai",
+        "base_url": "https://example.test/v1",
+        "api_key_set": True,
+    }
+    assert "secret-value" not in str(cfg.redacted_metadata())
+
+
+def test_non_default_provider_requires_api_key():
+    try:
+        parse_runtime_llm_config({"llm_provider": {"provider": "google"}})
+    except ValueError as exc:
+        assert "api_key" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing api_key")

--- a/backend/tests/services/test_process_manager_runtime_env.py
+++ b/backend/tests/services/test_process_manager_runtime_env.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.services.sim import process_manager
+
+
+def test_process_manager_applies_runtime_env_without_persisting_secret(tmp_path, monkeypatch):
+    script_path = tmp_path / "run_parallel_simulation.py"
+    script_path.write_text("print('ok')\n", encoding="utf-8")
+    sim_dir = tmp_path / "sim_runtime"
+    sim_dir.mkdir()
+    (sim_dir / "simulation_config.json").write_text("{}", encoding="utf-8")
+
+    captured_env = {}
+
+    class FakeProcess:
+        pid = 12345
+
+    def fake_popen(*args, **kwargs):
+        captured_env.update(kwargs["env"])
+        return FakeProcess()
+
+    monkeypatch.setattr(process_manager.subprocess, "Popen", fake_popen)
+
+    state = process_manager.start_simulation(
+        "sim_runtime",
+        "parallel",
+        run_state_dir=str(tmp_path),
+        scripts_dir=str(tmp_path),
+        processes={},
+        action_queues={},
+        monitor_threads={},
+        stdout_files={},
+        stderr_files={},
+        graph_memory_enabled={},
+        get_run_state=lambda _: None,
+        save_state=MagicMock(),
+        on_monitor_start=MagicMock(),
+        write_control_state=MagicMock(),
+        get_config=lambda _: {
+            "time_config": {
+                "total_simulation_hours": 1,
+                "minutes_per_round": 60,
+            }
+        },
+        config_exists=lambda _: True,
+        setup_graph_memory=MagicMock(),
+        runtime_env={
+            "LLM_API_KEY": "runtime-secret",
+            "OPENAI_API_KEY": "runtime-secret",
+            "LLM_BASE_URL": "https://example.test/v1",
+        },
+    )
+
+    assert state.process_pid == 12345
+    assert captured_env["LLM_API_KEY"] == "runtime-secret"
+    assert captured_env["OPENAI_API_KEY"] == "runtime-secret"
+    assert captured_env["LLM_BASE_URL"] == "https://example.test/v1"
+    assert "runtime-secret" not in (sim_dir / "simulation_config.json").read_text(encoding="utf-8")

--- a/docu/provider-runtime-settings.md
+++ b/docu/provider-runtime-settings.md
@@ -1,0 +1,37 @@
+# Provider-Runtime-Optionen
+
+Stand: 2026-05-10
+
+Agora kann pro Simulation einen OpenAI-kompatiblen LLM-Provider aus der UI
+nutzen. Die Modellauswahl aus Schritt 2 wird an Prepare, Start und Report
+weitergereicht; ein späterer Start aktualisiert `simulation_config.json` bei
+gesetztem `llm_model`.
+
+## UI
+
+In Schritt 2 öffnet `Provider-Optionen` ein Menü für:
+
+- `Server-Standard` — nutzt `.env` / `instance/settings.json`.
+- `Google Gemini` — setzt die OpenAI-kompatible Base-URL
+  `https://generativelanguage.googleapis.com/v1beta/openai/`.
+- `OpenAI` — setzt `https://api.openai.com/v1`.
+- `OpenAI-kompatibel` — erwartet eine eigene Base-URL.
+
+Der API-Key wird nur in `sessionStorage` des Browsers gehalten und bei
+Prepare, Start und Report als Request-Body-Feld `llm_provider.api_key` an den
+lokalen Backend-Prozess gesendet. `localStorage` speichert nur Provider und
+Base-URL.
+
+## Backend
+
+`backend/app/services/llm_runtime.py` validiert `llm_provider` zentral. API-Keys
+werden nicht in Run-Metadata oder Simulation-Artefakte geschrieben. Persistiert
+werden nur nicht-geheime Werte:
+
+- `simulation_config.json::llm_model`
+- `simulation_config.json::llm_base_url`
+- Run-Metadata `llm_provider.api_key_set=true`
+
+Für den OASIS-Subprozess injiziert `/api/simulation/start` die Runtime-Werte als
+Environment (`LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_BASE_URL`,
+`OPENAI_API_BASE_URL`) nur für diesen Prozess.

--- a/frontend/src/api/llmRuntime.ts
+++ b/frontend/src/api/llmRuntime.ts
@@ -1,0 +1,5 @@
+export interface LlmRuntimePayload {
+  provider: 'google' | 'openai' | 'custom_openai'
+  api_key: string
+  base_url?: string
+}

--- a/frontend/src/api/report.ts
+++ b/frontend/src/api/report.ts
@@ -1,5 +1,6 @@
 import service, { requestWithRetry } from './index'
 import type { ApiEnvelope } from './envelope'
+import type { LlmRuntimePayload } from './llmRuntime'
 import type { Report, EvidenceMap, ReportSection, EvidenceItem } from '../contracts/reportContract'
 
 // --- Local payload/data types -------------------------------------------
@@ -9,6 +10,7 @@ export interface GenerateReportData {
   simulation_id: string
   force_regenerate?: boolean
   llm_model?: string
+  llm_provider?: LlmRuntimePayload
   [key: string]: unknown
 }
 

--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -1,4 +1,5 @@
 import service, { requestWithRetry } from './index'
+import type { LlmRuntimePayload } from './llmRuntime'
 import type { PersonaQuotaPlan } from '../contracts/personaQuotaContract'
 
 // --- Local types --------------------------------------------------------
@@ -19,6 +20,10 @@ export interface PrepareSimulationData {
   parallel_profile_count?: number
   force_regenerate?: boolean
   quota_plan?: PersonaQuotaPlan
+  llm_model?: string
+  llm_provider?: LlmRuntimePayload
+  language?: string
+  max_agents?: number
 }
 
 export interface TaskStatusData {
@@ -36,6 +41,9 @@ export interface StartSimulationData {
   max_rounds?: number
   simulation_days?: number
   enable_graph_memory_update?: boolean
+  llm_model?: string
+  llm_provider?: LlmRuntimePayload
+  force?: boolean
 }
 
 export interface StopSimulationData {

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -7,6 +7,7 @@ import { useSimulationPrepare } from '../composables/useSimulationPrepare'
 import { usePersonaQuota } from '../composables/usePersonaQuota'
 import { useI18n } from 'vue-i18n'
 import { useEnvForm } from '../composables/useEnvForm'
+import { useRuntimeLlmOptions } from '../composables/useRuntimeLlmOptions'
 import Btn from './ui/Btn.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from './ui/Kicker.vue'
@@ -70,6 +71,16 @@ const customMaxRounds = ref(40)
 const useCustomDays = ref(false)
 const customSimulationDays = ref(3)
 const selectedProfile = ref(null)
+const showRuntimeOptions = ref(false)
+
+const {
+  runtimeProvider,
+  runtimeApiKey,
+  runtimeBaseUrl,
+  runtimeProviderOptions,
+  runtimeProviderEnabled,
+  runtimePayload,
+} = useRuntimeLlmOptions(t)
 
 // Persona review (Slice 2.4): quality badges, approve/reject, inline edit.
 // Extracted to usePersonaActions (Sub-Slice 38, Refs #203).
@@ -182,6 +193,13 @@ async function triggerPrepare() {
   }
   const m = effectiveModel()
   if (m) payload.llm_model = m
+  if (runtimeProviderEnabled.value && !runtimeApiKey.value.trim()) {
+    addLog(t('step2.runtimeProvider.missingKey'))
+    emit('update-status', 'error')
+    return
+  }
+  const provider = runtimePayload()
+  if (provider) payload.llm_provider = provider
   if (useAgentCap.value && maxAgents.value > 0) {
     payload.max_agents = maxAgents.value
   }
@@ -255,6 +273,40 @@ onMounted(() => {
               :label="t('step2.model.customLabel')"
               :placeholder="t('step2.model.customPlaceholder')"
             />
+          </div>
+
+          <div class="setup-cell setup-cell--wide">
+            <button
+              type="button"
+              class="runtime-toggle"
+              :aria-expanded="showRuntimeOptions"
+              @click="showRuntimeOptions = !showRuntimeOptions"
+            >
+              <span>{{ t('step2.runtimeProvider.toggle') }}</span>
+              <span class="meta">
+                {{ runtimeProviderEnabled ? t('step2.runtimeProvider.active') : t('step2.runtimeProvider.default') }}
+              </span>
+            </button>
+            <div v-if="showRuntimeOptions" class="runtime-panel">
+              <Select
+                v-model="runtimeProvider"
+                :label="t('step2.runtimeProvider.label')"
+                :options="runtimeProviderOptions"
+              />
+              <Field
+                v-if="runtimeProviderEnabled"
+                v-model="runtimeApiKey"
+                type="password"
+                :label="t('step2.runtimeProvider.apiKey')"
+                :placeholder="t('step2.runtimeProvider.apiKeyPlaceholder')"
+              />
+              <Field
+                v-if="runtimeProviderEnabled"
+                v-model="runtimeBaseUrl"
+                :label="t('step2.runtimeProvider.baseUrl')"
+                :placeholder="t('step2.runtimeProvider.baseUrlPlaceholder')"
+              />
+            </div>
           </div>
 
           <!-- Agent language -->
@@ -536,6 +588,35 @@ onMounted(() => {
 .setup-cell { display: flex; flex-direction: column; gap: var(--s-2); }
 .setup-cell--wide { grid-column: 1 / -1; }
 
+.runtime-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  width: 100%;
+  min-height: var(--ctl-h-md);
+  padding: 0 var(--ctl-pad-x);
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--r-1);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  cursor: pointer;
+  font-family: var(--ff-mono);
+  font-size: 12px;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+}
+.runtime-toggle:hover { border-color: color-mix(in oklch, var(--fg) 30%, transparent); }
+.runtime-panel {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--s-4);
+  padding: var(--s-4);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  background: var(--bg-subtle);
+}
+
 .agent-cap {
   display: flex;
   align-items: center;
@@ -659,6 +740,7 @@ onMounted(() => {
 
 @media (max-width: 720px) {
   .setup-grid { grid-template-columns: 1fr; }
+  .runtime-panel { grid-template-columns: 1fr; }
 }
 
 .hint--warn {

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -16,7 +16,11 @@ import {
   getSimulationConsoleLog
 } from '../api/simulation'
 import { generateReport } from '../api/report'
-import { STORAGE_CUSTOM_MODEL, STORAGE_MODEL } from '../composables/useEnvForm'
+import { storedEffectiveModel, STORAGE_CUSTOM_MODEL, STORAGE_MODEL } from '../composables/useEnvForm'
+import {
+  runtimeLlmPayloadFromStorage,
+  runtimeProviderMissingApiKeyFromStorage,
+} from '../composables/useRuntimeLlmOptions'
 import Btn from './ui/Btn.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from './ui/Kicker.vue'
@@ -232,6 +236,15 @@ async function doStart() {
     }
     if (props.maxRounds) params.max_rounds = props.maxRounds
     if (props.simulationDays) params.simulation_days = props.simulationDays
+    const model = storedEffectiveModel()
+    if (model) params.llm_model = model
+    if (runtimeProviderMissingApiKeyFromStorage()) {
+      addLog(t('step2.runtimeProvider.missingKey'))
+      emit('update-status', 'error')
+      return
+    }
+    const runtimeProvider = runtimeLlmPayloadFromStorage()
+    if (runtimeProvider) params.llm_provider = runtimeProvider
     addLog(t('step3.controls.starting'))
     const res = await startSimulation(params)
     if (res?.success) {
@@ -426,17 +439,15 @@ async function goReport() {
     // Reuse the model the user picked for Step 2 (Report-specific override
     // can be set in Step 4). 'default' or empty → server uses LLM_MODEL_NAME.
     const payload = { simulation_id: props.simulationId }
-    const stored = localStorage.getItem('agora.reportModel') || localStorage.getItem(STORAGE_MODEL)
-    if (stored === 'custom') {
-      const custom = (
-        localStorage.getItem('agora.reportCustomModel') ||
-        localStorage.getItem(STORAGE_CUSTOM_MODEL) ||
-        ''
-      ).trim()
-      if (custom) payload.llm_model = custom
-    } else if (stored && stored !== 'default') {
-      payload.llm_model = stored
+    const model = storedEffectiveModel('agora.reportModel', 'agora.reportCustomModel')
+      || storedEffectiveModel(STORAGE_MODEL, STORAGE_CUSTOM_MODEL)
+    if (model) payload.llm_model = model
+    if (runtimeProviderMissingApiKeyFromStorage()) {
+      addLog(t('step2.runtimeProvider.missingKey'))
+      return
     }
+    const runtimeProvider = runtimeLlmPayloadFromStorage()
+    if (runtimeProvider) payload.llm_provider = runtimeProvider
     const res = await generateReport(payload)
     if (res?.success && res.data?.report_id) {
       router.push({ name: 'Report', params: { reportId: res.data.report_id } })

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -17,6 +17,10 @@ import ReportModelControls from './step4/ReportModelControls.vue'
 import ReportOutlinePanel from './step4/ReportOutlinePanel.vue'
 import ReportEvidencePanel from './step4/ReportEvidencePanel.vue'
 import { useReportExports } from '../composables/useReportExports'
+import {
+  runtimeLlmPayloadFromStorage,
+  runtimeProviderMissingApiKeyFromStorage,
+} from '../composables/useRuntimeLlmOptions'
 import { parseAgentEntry } from '../utils/reportAgentLog'
 import { parseSourceAnchor, entryAnchorId } from '../utils/sourceAnchor'
 import {
@@ -147,6 +151,12 @@ async function regenerateWithModel() {
     }
     const m = effectiveReportModel()
     if (m) payload.llm_model = m
+    if (runtimeProviderMissingApiKeyFromStorage()) {
+      addLog(t('step2.runtimeProvider.missingKey'))
+      return
+    }
+    const runtimeProvider = runtimeLlmPayloadFromStorage()
+    if (runtimeProvider) payload.llm_provider = runtimeProvider
     addLog(`Report neu generieren${m ? ` mit ${m}` : ''}…`)
     const res = (await generateReport(payload)) as ApiResult
     if (res?.success && res.data?.report_id) {

--- a/frontend/src/composables/__tests__/useRuntimeLlmOptions.spec.ts
+++ b/frontend/src/composables/__tests__/useRuntimeLlmOptions.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import {
+  runtimeLlmPayloadFromStorage,
+  runtimeProviderMissingApiKeyFromStorage,
+  SESSION_LLM_API_KEY,
+  STORAGE_LLM_BASE_URL,
+  STORAGE_LLM_PROVIDER,
+} from '../useRuntimeLlmOptions'
+
+describe('runtimeLlmPayloadFromStorage', () => {
+  function makeStorageStub(): Storage {
+    const store: Record<string, string> = {}
+    return {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k])
+      },
+      get length() {
+        return Object.keys(store).length
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    }
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', makeStorageStub())
+    vi.stubGlobal('sessionStorage', makeStorageStub())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('liefert null für Server-Default', () => {
+    localStorage.setItem(STORAGE_LLM_PROVIDER, 'default')
+
+    expect(runtimeLlmPayloadFromStorage()).toBeNull()
+  })
+
+  it('baut Google-Gemini Runtime-Payload mit Default-Base-URL', () => {
+    localStorage.setItem(STORAGE_LLM_PROVIDER, 'google')
+    sessionStorage.setItem(SESSION_LLM_API_KEY, 'gemini-key')
+
+    expect(runtimeLlmPayloadFromStorage()).toEqual({
+      provider: 'google',
+      api_key: 'gemini-key',
+      base_url: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+    })
+  })
+
+  it('liest API-Key nur aus sessionStorage', () => {
+    localStorage.setItem(STORAGE_LLM_PROVIDER, 'custom_openai')
+    localStorage.setItem(STORAGE_LLM_BASE_URL, 'https://example.test/v1')
+    localStorage.setItem(SESSION_LLM_API_KEY, 'wrong-place')
+
+    expect(runtimeLlmPayloadFromStorage()).toBeNull()
+    expect(runtimeProviderMissingApiKeyFromStorage()).toBe(true)
+  })
+})

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -35,6 +35,22 @@ export const STORAGE_MODEL = 'agora.lastModel'
 export const STORAGE_CUSTOM_MODEL = 'agora.lastCustomModel'
 export const STORAGE_LANG = 'agora.agentLanguage'
 
+export function storedEffectiveModel(
+  modelKey = STORAGE_MODEL,
+  customModelKey = STORAGE_CUSTOM_MODEL,
+): string | null {
+  try {
+    const stored = localStorage.getItem(modelKey)
+    if (!stored || stored === 'default') return null
+    if (stored === 'custom') {
+      return (localStorage.getItem(customModelKey) || '').trim() || null
+    }
+    return stored
+  } catch {
+    return null
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/frontend/src/composables/useRuntimeLlmOptions.ts
+++ b/frontend/src/composables/useRuntimeLlmOptions.ts
@@ -1,0 +1,142 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
+import type { LlmRuntimePayload } from '../api/llmRuntime'
+
+export const STORAGE_LLM_PROVIDER = 'agora.runtimeLlm.provider'
+export const STORAGE_LLM_BASE_URL = 'agora.runtimeLlm.baseUrl'
+export const SESSION_LLM_API_KEY = 'agora.runtimeLlm.apiKey'
+
+type RuntimeProvider = 'default' | 'google' | 'openai' | 'custom_openai'
+
+interface Option {
+  value: RuntimeProvider
+  label: string
+}
+
+export interface UseRuntimeLlmOptionsReturn {
+  runtimeProvider: Ref<RuntimeProvider>
+  runtimeApiKey: Ref<string>
+  runtimeBaseUrl: Ref<string>
+  runtimeProviderOptions: ComputedRef<Option[]>
+  runtimeProviderEnabled: ComputedRef<boolean>
+  runtimePayload: () => LlmRuntimePayload | null
+}
+
+const DEFAULT_BASE_URLS: Record<Exclude<RuntimeProvider, 'default'>, string> = {
+  google: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+  openai: 'https://api.openai.com/v1',
+  custom_openai: '',
+}
+
+function safeLocalGet(key: string, fallback = ''): string {
+  try {
+    return localStorage.getItem(key) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function safeLocalSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // ignore
+  }
+}
+
+function safeSessionGet(key: string, fallback = ''): string {
+  try {
+    return sessionStorage.getItem(key) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function safeSessionSet(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value)
+  } catch {
+    // ignore
+  }
+}
+
+function normalizeProvider(value: string): RuntimeProvider {
+  if (value === 'google' || value === 'openai' || value === 'custom_openai') return value
+  return 'default'
+}
+
+function defaultBaseUrl(provider: RuntimeProvider): string {
+  if (provider === 'default') return ''
+  return DEFAULT_BASE_URLS[provider]
+}
+
+export function runtimeLlmPayloadFromStorage(): LlmRuntimePayload | null {
+  const provider = normalizeProvider(safeLocalGet(STORAGE_LLM_PROVIDER, 'default'))
+  if (provider === 'default') return null
+  const apiKey = safeSessionGet(SESSION_LLM_API_KEY).trim()
+  if (!apiKey) return null
+  const storedBaseUrl = safeLocalGet(STORAGE_LLM_BASE_URL).trim()
+  const baseUrl = storedBaseUrl || defaultBaseUrl(provider)
+  return { provider, api_key: apiKey, ...(baseUrl ? { base_url: baseUrl } : {}) }
+}
+
+export function runtimeProviderMissingApiKeyFromStorage(): boolean {
+  const provider = normalizeProvider(safeLocalGet(STORAGE_LLM_PROVIDER, 'default'))
+  return provider !== 'default' && !safeSessionGet(SESSION_LLM_API_KEY).trim()
+}
+
+export function useRuntimeLlmOptions(
+  t: (key: string) => string,
+): UseRuntimeLlmOptionsReturn {
+  const runtimeProvider = ref<RuntimeProvider>(
+    normalizeProvider(safeLocalGet(STORAGE_LLM_PROVIDER, 'default')),
+  )
+  const runtimeApiKey = ref(safeSessionGet(SESSION_LLM_API_KEY))
+  const runtimeBaseUrl = ref(safeLocalGet(STORAGE_LLM_BASE_URL))
+
+  const runtimeProviderOptions = computed<Option[]>(() => [
+    { value: 'default', label: t('step2.runtimeProvider.default') },
+    { value: 'google', label: t('step2.runtimeProvider.google') },
+    { value: 'openai', label: t('step2.runtimeProvider.openai') },
+    { value: 'custom_openai', label: t('step2.runtimeProvider.customOpenAi') },
+  ])
+
+  const runtimeProviderEnabled = computed(() => runtimeProvider.value !== 'default')
+
+  watch(runtimeProvider, (provider) => {
+    safeLocalSet(STORAGE_LLM_PROVIDER, provider)
+    if (provider === 'google' || provider === 'openai') {
+      runtimeBaseUrl.value = defaultBaseUrl(provider)
+    } else if (provider === 'custom_openai' && Object.values(DEFAULT_BASE_URLS).includes(runtimeBaseUrl.value)) {
+      runtimeBaseUrl.value = ''
+    }
+  })
+
+  watch(runtimeApiKey, (value) => {
+    safeSessionSet(SESSION_LLM_API_KEY, value)
+  })
+
+  watch(runtimeBaseUrl, (value) => {
+    safeLocalSet(STORAGE_LLM_BASE_URL, value)
+  })
+
+  function runtimePayload(): LlmRuntimePayload | null {
+    if (runtimeProvider.value === 'default') return null
+    const apiKey = runtimeApiKey.value.trim()
+    if (!apiKey) return null
+    const baseUrl = runtimeBaseUrl.value.trim() || defaultBaseUrl(runtimeProvider.value)
+    return {
+      provider: runtimeProvider.value,
+      api_key: apiKey,
+      ...(baseUrl ? { base_url: baseUrl } : {}),
+    }
+  }
+
+  return {
+    runtimeProvider,
+    runtimeApiKey,
+    runtimeBaseUrl,
+    runtimeProviderOptions,
+    runtimeProviderEnabled,
+    runtimePayload,
+  }
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -225,6 +225,20 @@
       "noOllama": "Keine Verbindung zu Ollama. Custom-Eingabe nutzen oder Ollama starten.",
       "default": "Standard aus .env"
     },
+    "runtimeProvider": {
+      "toggle": "Provider-Optionen",
+      "label": "Provider",
+      "default": "Server-Standard",
+      "active": "Override aktiv",
+      "google": "Google Gemini",
+      "openai": "OpenAI",
+      "customOpenAi": "OpenAI-kompatibel",
+      "apiKey": "API-Key",
+      "apiKeyPlaceholder": "Nur für diese Browser-Sitzung",
+      "baseUrl": "Base-URL",
+      "baseUrlPlaceholder": "https://generativelanguage.googleapis.com/v1beta/openai/",
+      "missingKey": "Provider-Override ist aktiv, aber der API-Key fehlt."
+    },
     "personas": {
       "title": "Personas generieren",
       "count": "Anzahl Agenten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -214,6 +214,20 @@
       "noOllama": "No connection to Ollama. Use custom input or start Ollama.",
       "default": "Default from .env"
     },
+    "runtimeProvider": {
+      "toggle": "Provider options",
+      "label": "Provider",
+      "default": "Server default",
+      "active": "Override active",
+      "google": "Google Gemini",
+      "openai": "OpenAI",
+      "customOpenAi": "OpenAI-compatible",
+      "apiKey": "API key",
+      "apiKeyPlaceholder": "Only for this browser session",
+      "baseUrl": "Base URL",
+      "baseUrlPlaceholder": "https://generativelanguage.googleapis.com/v1beta/openai/",
+      "missingKey": "Provider override is active, but the API key is missing."
+    },
     "personas": {
       "title": "Generate personas",
       "count": "Number of agents",


### PR DESCRIPTION
## Zusammenfassung
- verdrahtet die Frontend-Modellauswahl bis in Prepare, Simulation-Start und Report-Generation
- ergänzt ein Step-2-Provider-Menü für Google Gemini, OpenAI und OpenAI-kompatible Endpunkte
- validiert Runtime-Provider zentral im Backend und hält API-Keys aus Artefakten/Run-Metadata heraus

## Testplan
- [x] cd backend && uv run pytest tests/services/test_llm_runtime.py tests/services/test_process_manager_runtime_env.py tests/test_quota_persistence.py tests/api/test_simulation_prepare_quota.py -q
- [x] cd backend && uv run pytest tests/api/test_simulation_uses_request_model.py tests/services/test_llm_runtime.py tests/services/test_process_manager_runtime_env.py -q
- [x] cd backend && uv run ruff check app tests/services/test_llm_runtime.py tests/services/test_process_manager_runtime_env.py
- [x] cd backend && uv run mypy app
- [x] cd frontend && npm test -- --run src/composables/__tests__/useRuntimeLlmOptions.spec.ts src/composables/__tests__/useEnvForm.spec.ts src/components/__tests__/Step3Simulation.spec.ts
- [x] cd frontend && npm run typecheck
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run build