### PR TITLE
fix: show provider options on home

### DIFF
--- a/backend/app/services/llm_runtime.py
+++ b/backend/app/services/llm_runtime.py
@@ -68,6 +68,8 @@ class RuntimeLlmConfig:
         }
         if self.base_url:
             env["LLM_BASE_URL"] = self.base_url
+            env["OPENAI_BASE_URL"] = self.base_url
+            env["OPENAI_API_BASE"] = self.base_url
             env["OPENAI_API_BASE_URL"] = self.base_url
         if model:
             env["LLM_MODEL_NAME"] = model

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1149,6 +1149,8 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
         raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
     
     if llm_base_url:
+        os.environ["OPENAI_BASE_URL"] = llm_base_url
+        os.environ["OPENAI_API_BASE"] = llm_base_url
         os.environ["OPENAI_API_BASE_URL"] = llm_base_url
     
     runtime_settings = resolve_model_runtime_settings(llm_model)

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -476,6 +476,8 @@ class RedditSimulationRunner:
             raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
         
         if llm_base_url:
+            os.environ["OPENAI_BASE_URL"] = llm_base_url
+            os.environ["OPENAI_API_BASE"] = llm_base_url
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url
         
         print(f"LLM configuration: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
@@ -860,4 +862,3 @@ if __name__ == "__main__":
         pass
     finally:
         print("Simulation process exited")
-

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -463,6 +463,8 @@ class TwitterSimulationRunner:
             raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
         
         if llm_base_url:
+            os.environ["OPENAI_BASE_URL"] = llm_base_url
+            os.environ["OPENAI_API_BASE"] = llm_base_url
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url
         
         print(f"LLM configuration: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")

--- a/backend/tests/services/test_llm_runtime.py
+++ b/backend/tests/services/test_llm_runtime.py
@@ -13,6 +13,8 @@ def test_google_runtime_uses_openai_compatible_base_url():
         "LLM_API_KEY": "gemini-key",
         "OPENAI_API_KEY": "gemini-key",
         "LLM_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "OPENAI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "OPENAI_API_BASE": "https://generativelanguage.googleapis.com/v1beta/openai/",
         "OPENAI_API_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
         "LLM_MODEL_NAME": "gemini-2.5-flash",
     }

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-08
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1718 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Spec-Files | 45 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
+| Backend Tests (collected) | 1722 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Spec-Files | 46 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -20,11 +20,11 @@ Stand: 2026-05-08
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 1722 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Spec-Files | 46 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' \)` |
+| Frontend Test-Files | 46 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._
-_Die Frontend-Zeile zählt Dateien, nicht einzelne Test-Cases. Pro Spec-File laufen mehrere `it`-Blöcke; die exakte Test-Case-Anzahl liefert `cd frontend && npx vitest list`._
+_Die Frontend-Zeile zählt Dateien, nicht einzelne Test-Cases. Gezählt werden Vitest-Pattern `*.spec.{js,ts}` und `*.test.{js,ts}`; pro Test-File laufen mehrere `it`-Blöcke. Die exakte Test-Case-Anzahl liefert `cd frontend && npx vitest list`._
 
 ## Backend-Coverage (M11.2)
 

--- a/docu/provider-runtime-settings.md
+++ b/docu/provider-runtime-settings.md
@@ -34,4 +34,7 @@ werden nur nicht-geheime Werte:
 
 Für den OASIS-Subprozess injiziert `/api/simulation/start` die Runtime-Werte als
 Environment (`LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_BASE_URL`,
-`OPENAI_API_BASE_URL`) nur für diesen Prozess.
+`OPENAI_BASE_URL`, `OPENAI_API_BASE`, `OPENAI_API_BASE_URL`) nur für diesen
+Prozess. Die drei OpenAI-Base-URL-Aliase werden parallel gesetzt, damit
+CAMEL/OASIS-Skripte und OpenAI-kompatible Clients mit unterschiedlichen
+Konventionen dieselbe Runtime-Auswahl nutzen.

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -11,6 +11,8 @@ import Select from '../components/ui/Select.vue'
 import Field from '../components/ui/Field.vue'
 import AgoraGlyph from '../components/ui/AgoraGlyph.vue'
 import { getAvailableModels } from '../api/simulation'
+import { STORAGE_CUSTOM_MODEL, STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
+import { useRuntimeLlmOptions } from '../composables/useRuntimeLlmOptions'
 import { setPendingUpload } from '../store/pendingUpload'
 
 const { t, tm } = useI18n()
@@ -26,9 +28,6 @@ const errorMsg = ref('')
 const ALLOWED = ['.pdf', '.md', '.txt', '.markdown']
 
 // ---- Model + language selection (persisted) ----
-const STORAGE_MODEL = 'agora.lastModel'
-const STORAGE_LANG = 'agora.agentLanguage'
-
 const ollamaModels = ref([])
 const presetModels = ref([])
 const defaultModel = ref('')
@@ -40,6 +39,14 @@ const loadingModels = ref(true)
 const modelOption = ref(localStorage.getItem(STORAGE_MODEL) || 'default')
 const customModel = ref('')
 const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
+const showRuntimeOptions = ref(false)
+const {
+  runtimeProvider,
+  runtimeApiKey,
+  runtimeBaseUrl,
+  runtimeProviderOptions,
+  runtimeProviderEnabled,
+} = useRuntimeLlmOptions(t)
 
 async function loadStatus() {
   loadingModels.value = true
@@ -85,7 +92,8 @@ const canSubmit = computed(() => {
     simulationPrompt.value.trim() !== '' &&
     files.value.length > 0 &&
     servicesReady.value &&
-    (modelOption.value !== 'custom' || customModel.value.trim() !== '')
+    (modelOption.value !== 'custom' || customModel.value.trim() !== '') &&
+    (!runtimeProviderEnabled.value || runtimeApiKey.value.trim() !== '')
   )
 })
 
@@ -120,7 +128,7 @@ async function startSimulation() {
     // Persist selection so Step2 picks it up.
     localStorage.setItem(STORAGE_MODEL, modelOption.value)
     if (modelOption.value === 'custom') {
-      localStorage.setItem('agora.customModel', customModel.value.trim())
+      localStorage.setItem(STORAGE_CUSTOM_MODEL, customModel.value.trim())
     }
     localStorage.setItem(STORAGE_LANG, language.value)
 
@@ -135,7 +143,7 @@ async function startSimulation() {
 
 onMounted(() => {
   loadStatus()
-  const stored = localStorage.getItem('agora.customModel')
+  const stored = localStorage.getItem(STORAGE_CUSTOM_MODEL) || localStorage.getItem('agora.customModel')
   if (stored) customModel.value = stored
 })
 
@@ -350,6 +358,38 @@ const differentiators = computed(() => tm('home.differentiators'))
           :placeholder="t('step2.model.customPlaceholder')"
         />
 
+        <button
+          type="button"
+          class="runtime-toggle"
+          :aria-expanded="showRuntimeOptions"
+          @click="showRuntimeOptions = !showRuntimeOptions"
+        >
+          <span>{{ t('step2.runtimeProvider.toggle') }}</span>
+          <span class="console-meta">
+            {{ runtimeProviderEnabled ? t('step2.runtimeProvider.active') : t('step2.runtimeProvider.default') }}
+          </span>
+        </button>
+        <div v-if="showRuntimeOptions" class="runtime-panel">
+          <Select
+            v-model="runtimeProvider"
+            :label="t('step2.runtimeProvider.label')"
+            :options="runtimeProviderOptions"
+          />
+          <Field
+            v-if="runtimeProviderEnabled"
+            v-model="runtimeApiKey"
+            type="password"
+            :label="t('step2.runtimeProvider.apiKey')"
+            :placeholder="t('step2.runtimeProvider.apiKeyPlaceholder')"
+          />
+          <Field
+            v-if="runtimeProviderEnabled"
+            v-model="runtimeBaseUrl"
+            :label="t('step2.runtimeProvider.baseUrl')"
+            :placeholder="t('step2.runtimeProvider.baseUrlPlaceholder')"
+          />
+        </div>
+
         <!-- Prompt -->
         <div class="console-head">
           <Kicker num="06" accent>{{ t('home.console.promptKicker') }}</Kicker>
@@ -382,6 +422,9 @@ const differentiators = computed(() => tm('home.differentiators'))
           </span>
           <span v-else-if="!servicesReady" class="console-warning">
             Dienste nicht bereit (Neo4j/Ollama). {{ neo4jError || ollamaError || '' }}
+          </span>
+          <span v-else-if="runtimeProviderEnabled && !runtimeApiKey.trim()" class="console-warning">
+            {{ t('step2.runtimeProvider.missingKey') }}
           </span>
         </div>
         <p v-if="errorMsg" class="error-line">{{ errorMsg }}</p>
@@ -791,8 +834,37 @@ const differentiators = computed(() => tm('home.differentiators'))
   grid-template-columns: 1fr 1fr;
   gap: var(--s-5) var(--s-7);
 }
+.runtime-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  width: 100%;
+  min-height: var(--ctl-h-md);
+  padding: 0 var(--ctl-pad-x);
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--r-1);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  cursor: pointer;
+  font-family: var(--ff-mono);
+  font-size: 12px;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+}
+.runtime-toggle:hover { border-color: color-mix(in oklch, var(--fg) 30%, transparent); }
+.runtime-panel {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--s-4);
+  padding: var(--s-4);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  background: var(--bg-subtle);
+}
 @media (max-width: 720px) {
   .model-grid { grid-template-columns: 1fr; }
+  .runtime-panel { grid-template-columns: 1fr; }
 }
 
 /* Responsive */

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -63,7 +63,7 @@ if command -v uv &>/dev/null; then
   rm -f "$COLLECT_TMP"
 fi
 
-FRONTEND_SPEC_FILES=$(find "$REPO_ROOT/frontend/src" \( -name '*.spec.ts' -o -name '*.spec.js' \) 2>/dev/null | wc -l | tr -d ' ')
+FRONTEND_TEST_FILES=$(find "$REPO_ROOT/frontend/src" \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \) 2>/dev/null | wc -l | tr -d ' ')
 
 # ---------------------------------------------------------------------------
 # Build replacement blocks (content between markers, without the marker lines)
@@ -77,7 +77,7 @@ VERSIONS_BLOCK="| Komponente | Pfad | Version |
 TESTS_BLOCK="| Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | $BACKEND_TESTS | \`cd backend && uv run pytest --collect-only -q\` |
-| Frontend Spec-Files | $FRONTEND_SPEC_FILES | \`find frontend/src \\( -name '*.spec.ts' -o -name '*.spec.js' \\)\` |"
+| Frontend Test-Files | $FRONTEND_TEST_FILES | \`find frontend/src \\( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \\)\` |"
 
 # ---------------------------------------------------------------------------
 # replace_block: replaces content between BEGIN/END markers using Python3.


### PR DESCRIPTION
## Zusammenfassung
- zeigt die Runtime-Provider-Auswahl auch auf dem Home-/Startscreen an
- vereinheitlicht den Custom-Model-Storage-Key mit Step 2, damit die Frontend-Modellauswahl durchgereicht wird
- synchronisiert docu/STATUS.md nach PR #345

## Testplan
- [x] bash scripts/sync-status.sh --check
- [x] cd frontend && npm run typecheck
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run build