### PR TITLE
fix: show Gemini models for Google provider

### DIFF
--- a/docu/provider-runtime-settings.md
+++ b/docu/provider-runtime-settings.md
@@ -22,6 +22,20 @@ Prepare, Start und Report als Request-Body-Feld `llm_provider.api_key` an den
 lokalen Backend-Prozess gesendet. `localStorage` speichert nur Provider und
 Base-URL.
 
+Wenn ein Runtime-Provider aktiv ist, zeigt die Modellauswahl providerpassende
+Modelle statt lokaler Ollama-Modelle. Für `Google Gemini` sind die textfähigen
+OpenAI-kompatiblen IDs aus der Gemini-Dokumentation hinterlegt:
+
+- `gemini-3-flash-preview`
+- `gemini-3.1-pro-preview`
+- `gemini-3.1-flash-lite`
+- `gemini-2.5-pro`
+- `gemini-2.5-flash`
+- `gemini-2.5-flash-lite`
+
+`Custom` bleibt verfügbar, falls Google neue Modell-IDs veröffentlicht, bevor
+Agora aktualisiert wurde.
+
 ## Backend
 
 `backend/app/services/llm_runtime.py` validiert `llm_provider` zentral. API-Keys

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -33,6 +33,22 @@ const props = defineProps({
 
 const emit = defineEmits(['go-back', 'next-step', 'add-log', 'update-status'])
 
+const useCustomRounds = ref(false)
+const customMaxRounds = ref(40)
+const useCustomDays = ref(false)
+const customSimulationDays = ref(3)
+const selectedProfile = ref(null)
+const showRuntimeOptions = ref(false)
+
+const {
+  runtimeProvider,
+  runtimeApiKey,
+  runtimeBaseUrl,
+  runtimeProviderOptions,
+  runtimeProviderEnabled,
+  runtimePayload,
+} = useRuntimeLlmOptions(t)
+
 // ----- Model + language picker (useEnvForm — Sub-Slice 37, Refs #203) -----
 
 const {
@@ -49,7 +65,7 @@ const {
   modelOptions,
   loadModels,
   effectiveModel,
-} = useEnvForm({ t, onError: (msg) => addLog(msg) })
+} = useEnvForm({ t, onError: (msg) => addLog(msg), runtimeProvider })
 
 // ----- Prepare flow (useSimulationPrepare — Sub-Slice 34, Refs #203) -----
 
@@ -65,22 +81,6 @@ const {
   startPrepare,
   probeAlreadyPrepared,
 } = useSimulationPrepare()
-
-const useCustomRounds = ref(false)
-const customMaxRounds = ref(40)
-const useCustomDays = ref(false)
-const customSimulationDays = ref(3)
-const selectedProfile = ref(null)
-const showRuntimeOptions = ref(false)
-
-const {
-  runtimeProvider,
-  runtimeApiKey,
-  runtimeBaseUrl,
-  runtimeProviderOptions,
-  runtimeProviderEnabled,
-  runtimePayload,
-} = useRuntimeLlmOptions(t)
 
 // Persona review (Slice 2.4): quality badges, approve/reject, inline edit.
 // Extracted to usePersonaActions (Sub-Slice 38, Refs #203).
@@ -263,7 +263,7 @@ onMounted(() => {
               :options="modelOptions"
             />
             <p class="hint" v-if="loadingModels">{{ t('step2.model.loadingModels') }}</p>
-            <p class="hint" v-else-if="!ollamaReachable">{{ t('step2.model.noOllama') }}</p>
+            <p class="hint" v-else-if="!runtimeProviderEnabled && !ollamaReachable">{{ t('step2.model.noOllama') }}</p>
           </div>
 
           <!-- Custom model input (when 'custom' chosen) -->

--- a/frontend/src/composables/__tests__/useEnvForm.spec.ts
+++ b/frontend/src/composables/__tests__/useEnvForm.spec.ts
@@ -11,8 +11,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import { useEnvForm, STORAGE_CUSTOM_MODEL, STORAGE_MODEL, STORAGE_LANG } from '../useEnvForm'
+import type { RuntimeProvider } from '../useRuntimeLlmOptions'
 
 // ---------------------------------------------------------------------------
 // Mock t() — identity function; tests check key suffixes, not translated text
@@ -153,6 +154,22 @@ describe('useEnvForm', () => {
       expect(opts).toHaveLength(2)
       expect(opts[0].value).toBe('default')
       expect(opts[1].value).toBe('custom')
+    })
+
+    it('zeigt bei Google-Runtime-Provider Gemini-Modelle statt Ollama-Modelle', async () => {
+      localStorage.setItem(STORAGE_MODEL, 'gemma3:31b')
+      const runtimeProvider = ref<RuntimeProvider>('google')
+      const f = useEnvForm({ t, runtimeProvider })
+      f.defaultModel.value = 'gemma3:31b'
+      f.ollamaModels.value = [{ name: 'gemma3:31b', label: 'Gemma 3 31B' }]
+
+      await nextTick()
+
+      const opts = f.modelOptions.value
+      expect(opts.map((o) => o.value)).toContain('gemini-3-flash-preview')
+      expect(opts.map((o) => o.value)).toContain('gemini-2.5-flash')
+      expect(opts.map((o) => o.value)).not.toContain('gemma3:31b')
+      expect(f.modelOption.value).toBe('gemini-3-flash-preview')
     })
   })
 

--- a/frontend/src/composables/__tests__/useRuntimeLlmOptions.spec.ts
+++ b/frontend/src/composables/__tests__/useRuntimeLlmOptions.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import {
+  defaultRuntimeModelForProvider,
+  runtimeModelOptionsForProvider,
   runtimeLlmPayloadFromStorage,
   runtimeProviderMissingApiKeyFromStorage,
   SESSION_LLM_API_KEY,
@@ -61,5 +63,14 @@ describe('runtimeLlmPayloadFromStorage', () => {
 
     expect(runtimeLlmPayloadFromStorage()).toBeNull()
     expect(runtimeProviderMissingApiKeyFromStorage()).toBe(true)
+  })
+
+  it('liefert Gemini-Modelloptionen für den Google-Provider', () => {
+    const options = runtimeModelOptionsForProvider('google')
+
+    expect(options.map((option) => option.value)).toContain('gemini-3-flash-preview')
+    expect(options.map((option) => option.value)).toContain('gemini-3.1-pro-preview')
+    expect(options.map((option) => option.value)).toContain('gemini-2.5-flash')
+    expect(defaultRuntimeModelForProvider('google')).toBe('gemini-3-flash-preview')
   })
 })

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -26,6 +26,12 @@
 
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
 import { getAvailableModels } from '../api/simulation'
+import {
+  defaultRuntimeModelForProvider,
+  isRuntimeModelForProvider,
+  runtimeModelOptionsForProvider,
+  type RuntimeProvider,
+} from './useRuntimeLlmOptions'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -70,6 +76,8 @@ export interface UseEnvFormOptions {
   t: (key: string, params?: Record<string, unknown>) => string
   /** Called when loadModels() encounters a network/API error. */
   onError?: (msg: string) => void
+  /** Runtime provider override; when active, model options must match that provider. */
+  runtimeProvider?: Ref<RuntimeProvider>
 }
 
 export interface UseEnvFormReturn {
@@ -120,7 +128,7 @@ function _loadStoredCustomModel(): string {
 // Composable
 // ---------------------------------------------------------------------------
 
-export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn {
+export function useEnvForm({ t, onError, runtimeProvider }: UseEnvFormOptions): UseEnvFormReturn {
   // --- State ---
 
   const ollamaModels = ref<ModelPreset[]>([])
@@ -137,6 +145,13 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
   // --- Computed ---
 
   const modelOptions = computed<ModelOption[]>(() => {
+    if (runtimeProvider?.value && runtimeProvider.value !== 'default') {
+      const providerModels = runtimeModelOptionsForProvider(runtimeProvider.value)
+      return [
+        ...providerModels,
+        { value: 'custom', label: t('step2.model.customGroup') },
+      ]
+    }
     const opts: ModelOption[] = []
     opts.push({
       value: 'default',
@@ -178,6 +193,24 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
       // ignore
     }
   })
+
+  if (runtimeProvider) {
+    watch(runtimeProvider, (provider, previousProvider) => {
+      const providerDefault = defaultRuntimeModelForProvider(provider)
+      if (provider !== 'default') {
+        if (
+          modelOption.value !== 'custom' &&
+          !isRuntimeModelForProvider(provider, modelOption.value)
+        ) {
+          modelOption.value = providerDefault || 'custom'
+        }
+        return
+      }
+      if (previousProvider && isRuntimeModelForProvider(previousProvider, modelOption.value)) {
+        modelOption.value = 'default'
+      }
+    }, { immediate: true })
+  }
 
   // --- Actions ---
 
@@ -221,12 +254,18 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
             return null
           }
         })()
+        const runtimeProviderActive = runtimeProvider?.value && runtimeProvider.value !== 'default'
+        const storedMatchesRuntimeProvider = runtimeProviderActive
+          ? (stored === 'custom' || isRuntimeModelForProvider(runtimeProvider.value, stored || ''))
+          : false
         if (
           stored &&
-          (stored === 'default' ||
-            stored === 'custom' ||
-            presetModels.value.some((p) => p.name === stored) ||
-            ollamaModels.value.some((p) => p.name === stored))
+          (runtimeProviderActive
+            ? storedMatchesRuntimeProvider
+            : (stored === 'default' ||
+              stored === 'custom' ||
+              presetModels.value.some((p) => p.name === stored) ||
+              ollamaModels.value.some((p) => p.name === stored)))
         ) {
           modelOption.value = stored
         }

--- a/frontend/src/composables/useRuntimeLlmOptions.ts
+++ b/frontend/src/composables/useRuntimeLlmOptions.ts
@@ -5,10 +5,15 @@ export const STORAGE_LLM_PROVIDER = 'agora.runtimeLlm.provider'
 export const STORAGE_LLM_BASE_URL = 'agora.runtimeLlm.baseUrl'
 export const SESSION_LLM_API_KEY = 'agora.runtimeLlm.apiKey'
 
-type RuntimeProvider = 'default' | 'google' | 'openai' | 'custom_openai'
+export type RuntimeProvider = 'default' | 'google' | 'openai' | 'custom_openai'
 
 interface Option {
   value: RuntimeProvider
+  label: string
+}
+
+interface RuntimeModelOption {
+  value: string
   label: string
 }
 
@@ -25,6 +30,28 @@ const DEFAULT_BASE_URLS: Record<Exclude<RuntimeProvider, 'default'>, string> = {
   google: 'https://generativelanguage.googleapis.com/v1beta/openai/',
   openai: 'https://api.openai.com/v1',
   custom_openai: '',
+}
+
+export const GOOGLE_GEMINI_MODEL_OPTIONS: RuntimeModelOption[] = [
+  { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview (Google)' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview (Google)' },
+  { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash-Lite (Google)' },
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro (Google)' },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (Google)' },
+  { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash-Lite (Google)' },
+]
+
+export function runtimeModelOptionsForProvider(provider: RuntimeProvider | string): RuntimeModelOption[] {
+  if (provider === 'google') return GOOGLE_GEMINI_MODEL_OPTIONS
+  return []
+}
+
+export function defaultRuntimeModelForProvider(provider: RuntimeProvider | string): string | null {
+  return runtimeModelOptionsForProvider(provider)[0]?.value ?? null
+}
+
+export function isRuntimeModelForProvider(provider: RuntimeProvider | string, model: string): boolean {
+  return runtimeModelOptionsForProvider(provider).some((option) => option.value === model)
 }
 
 function safeLocalGet(key: string, fallback = ''): string {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import HistoryDatabase from '../components/HistoryDatabase.vue'
@@ -12,7 +12,12 @@ import Field from '../components/ui/Field.vue'
 import AgoraGlyph from '../components/ui/AgoraGlyph.vue'
 import { getAvailableModels } from '../api/simulation'
 import { STORAGE_CUSTOM_MODEL, STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
-import { useRuntimeLlmOptions } from '../composables/useRuntimeLlmOptions'
+import {
+  defaultRuntimeModelForProvider,
+  isRuntimeModelForProvider,
+  runtimeModelOptionsForProvider,
+  useRuntimeLlmOptions,
+} from '../composables/useRuntimeLlmOptions'
 import { setPendingUpload } from '../store/pendingUpload'
 
 const { t, tm } = useI18n()
@@ -73,6 +78,12 @@ async function loadStatus() {
 }
 
 const modelOptions = computed(() => {
+  if (runtimeProviderEnabled.value) {
+    return [
+      ...runtimeModelOptionsForProvider(runtimeProvider.value),
+      { value: 'custom', label: t('step2.model.customGroup') },
+    ]
+  }
   const opts = [{ value: 'default', label: `${t('step2.model.default')} — ${defaultModel.value || '?'}` }]
   for (const p of presetModels.value) {
     opts.push({ value: p.name, label: p.label || p.name })
@@ -85,7 +96,10 @@ const modelOptions = computed(() => {
   return opts
 })
 
-const servicesReady = computed(() => neo4jReachable.value && (ollamaReachable.value || modelOption.value === 'custom'))
+const servicesReady = computed(() => (
+  neo4jReachable.value &&
+  (ollamaReachable.value || runtimeProviderEnabled.value || modelOption.value === 'custom')
+))
 
 const canSubmit = computed(() => {
   return (
@@ -146,6 +160,22 @@ onMounted(() => {
   const stored = localStorage.getItem(STORAGE_CUSTOM_MODEL) || localStorage.getItem('agora.customModel')
   if (stored) customModel.value = stored
 })
+
+watch(runtimeProvider, (provider, previousProvider) => {
+  const providerDefault = defaultRuntimeModelForProvider(provider)
+  if (provider !== 'default') {
+    if (
+      modelOption.value !== 'custom' &&
+      !isRuntimeModelForProvider(provider, modelOption.value)
+    ) {
+      modelOption.value = providerDefault || 'custom'
+    }
+    return
+  }
+  if (previousProvider && isRuntimeModelForProvider(previousProvider, modelOption.value)) {
+    modelOption.value = 'default'
+  }
+}, { immediate: true })
 
 function scrollToConsole() {
   document.getElementById('console')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -333,7 +363,7 @@ const differentiators = computed(() => tm('home.differentiators'))
               :label="t('step2.model.label')"
               :options="modelOptions"
             />
-            <p v-if="!ollamaReachable && !loadingModels" class="console-warning" style="margin-top: 4px;">
+            <p v-if="!runtimeProviderEnabled && !ollamaReachable && !loadingModels" class="console-warning" style="margin-top: 4px;">
               {{ t('step2.model.noOllama') }}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- show Google Gemini model IDs in the model select when the Google runtime provider is active
- keep custom model input available for newly released Google model IDs
- let runtime-provider runs proceed without requiring local Ollama and hide the Ollama warning in that mode
- document the currently wired Gemini model IDs

## Verification
- cd frontend && npm test -- --run src/composables/__tests__/useRuntimeLlmOptions.spec.ts src/composables/__tests__/useEnvForm.spec.ts
- cd frontend && npm run typecheck
- cd frontend && npm run lint
- cd frontend && npm run build
- code-review-graph detect-changes --repo /Volumes/T7/Projekte/agora/.worktrees/provider-runtime-settings

## Sources
- Google Gemini API model docs: https://ai.google.dev/gemini-api/docs/models
- Google Gemini OpenAI compatibility docs: https://ai.google.dev/gemini-api/docs/openai