### PR TITLE
🔒 [security] Sanitize dynamic index name in DROP INDEX query

### DIFF
--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -7,6 +7,7 @@ Includes: CRUD, NER/RE-based text ingestion, hybrid search, retry logic.
 
 import logging
 import os
+import re
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -182,6 +183,11 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
             stored_dim,
             expected_dim,
         )
+        # Strict validation: alphanumeric and underscores only, max 50 chars.
+        # This prevents Cypher injection in the dynamic DROP INDEX query.
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]{0,49}$", index_name):
+            raise ValueError(f"Invalid index name for DROP INDEX: {index_name}")
+
         session.run(f"DROP INDEX {index_name}")
 
     _VECTOR_INDEX_NAMES = ("entity_embedding", "fact_embedding")

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -185,8 +185,8 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
         )
         # Strict validation: alphanumeric and underscores only, max 50 chars.
         # This prevents Cypher injection in the dynamic DROP INDEX query.
-        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]{0,49}$", index_name):
-            raise ValueError(f"Invalid index name for DROP INDEX: {index_name}")
+        if not re.fullmatch(r"^[A-Za-z_][A-Za-z0-9_]{0,49}$", index_name):
+            raise ValueError(f"Invalid index name: {index_name}")
 
         session.run(f"DROP INDEX {index_name}")
 

--- a/backend/tests/test_neo4j_index_security.py
+++ b/backend/tests/test_neo4j_index_security.py
@@ -1,0 +1,43 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from app.storage.neo4j_storage import Neo4jStorage
+
+def test_ensure_vector_index_dim_sanitization():
+    # Mocking dependencies for Neo4jStorage init
+    mock_embedding = MagicMock()
+    mock_ner = MagicMock()
+
+    # We use patch to avoid real connection attempts during init
+    with patch.object(Neo4jStorage, '_verify_connectivity', return_value=None):
+        # Initialize storage with mocks
+        storage = Neo4jStorage(
+            uri="bolt://localhost:7687",
+            user="neo4j",
+            password="password",
+            embedding_service=mock_embedding,
+            ner_extractor=mock_ner
+        )
+        storage._driver = MagicMock()
+
+    mock_session = MagicMock()
+
+    # Case 1: Valid index name should pass
+    # Mock session.run to return a row with different dimension
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"dim": 128}
+    mock_session.run.return_value = mock_result
+
+    storage._ensure_vector_index_dim(mock_session, "valid_index", 256)
+
+    # Verify DROP INDEX was called with valid name
+    mock_session.run.assert_any_call("DROP INDEX valid_index")
+
+    # Case 2: Invalid index name (Cypher injection attempt) should raise ValueError
+    hostile_name = "idx`; DROP DATABASE neo4j; //"
+    with pytest.raises(ValueError, match="Invalid index name for DROP INDEX"):
+        storage._ensure_vector_index_dim(mock_session, hostile_name, 256)
+
+    # Case 3: Another invalid name
+    with pytest.raises(ValueError, match="Invalid index name for DROP INDEX"):
+        storage._ensure_vector_index_dim(mock_session, "invalid-name-with-dashes", 256)


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The `_ensure_vector_index_dim` method in `Neo4jStorage` used an f-string to construct a `DROP INDEX` query using the `index_name` parameter without sanitization. This created a potential Cypher injection vulnerability if `index_name` were ever to be controlled by an external or untrusted source.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could potentially provide a specially crafted `index_name` (e.g., `idx`; DROP DATABASE neo4j; //`) to execute arbitrary Cypher commands, leading to data loss, unauthorized access, or complete database compromise.

### 🛡️ Solution: How the fix addresses the vulnerability
I implemented a strict validation check using a regular expression (`r"^[A-Za-z_][A-Za-z0-9_]{0,49}$"`) that only allows alphanumeric characters and underscores, starting with a letter or underscore, and capped at 50 characters. This follows Neo4j's rules for unquoted identifiers and effectively neutralizes any injection attempt. If an invalid name is detected, a `ValueError` is raised before the query is executed. I also added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [1664902526318729168](https://jules.google.com/task/1664902526318729168) started by @arn0ld87*