### PR TITLE
fix(prepare): enforce persona floor (MIN_PERSONA_TABLE_ROWS=50) for max_agents

### DIFF
--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -15,6 +15,7 @@ from ..contracts import PersonaQuotaPlan
 from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
 from ..services.llm_runtime import parse_runtime_llm_config
+from ..services.report_agent import MIN_PERSONA_TABLE_ROWS
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..utils.validation import validate_simulation_id, validate_task_id
 from ..utils.api_errors import ApiErrorCode
@@ -49,6 +50,24 @@ def _parse_quota_plan(data: dict) -> Optional[PersonaQuotaPlan]:
     if isinstance(raw, dict) and not raw:
         return None
     return PersonaQuotaPlan.model_validate(raw)
+
+
+def _resolve_max_agents_with_floor(raw_value: object) -> int | None:
+    """Parse optional max_agents and enforce the report persona floor."""
+    try:
+        parsed = int(raw_value) if raw_value not in (None, "", 0) else None
+    except (TypeError, ValueError):
+        return None
+    if parsed is None or parsed <= 0:
+        return None
+    if parsed < MIN_PERSONA_TABLE_ROWS:
+        logger.info(
+            "Applying persona floor for max_agents: requested=%s floor=%s",
+            parsed,
+            MIN_PERSONA_TABLE_ROWS,
+        )
+        return MIN_PERSONA_TABLE_ROWS
+    return parsed
 
 
 def _check_simulation_prepared(simulation_id: str) -> tuple:
@@ -237,11 +256,7 @@ def prepare_simulation():
     use_llm_for_profiles = data.get('use_llm_for_profiles', True)
     parallel_profile_count = data.get('parallel_profile_count') or None
 
-    max_agents_raw = data.get('max_agents')
-    try:
-        max_agents = int(max_agents_raw) if max_agents_raw not in (None, '', 0) else None
-    except (TypeError, ValueError):
-        max_agents = None
+    max_agents = _resolve_max_agents_with_floor(data.get("max_agents"))
 
     # Sub-Slice 20a: optional PersonaQuotaPlan aus Body. ValidationError →
     # HTTP 400 mit Pydantic-Fehlermessage; sonst wird der Plan an den

--- a/backend/tests/api/test_simulation_prepare_quota.py
+++ b/backend/tests/api/test_simulation_prepare_quota.py
@@ -17,7 +17,8 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
-from app.api.simulation_prepare import _parse_quota_plan
+from app.api.simulation_prepare import _parse_quota_plan, _resolve_max_agents_with_floor
+from app.services.report_agent import MIN_PERSONA_TABLE_ROWS
 from app.contracts import PersonaQuotaPlan
 from app.services import prepare_service
 from app.services.simulation_manager import SimulationManager
@@ -79,6 +80,14 @@ def test_parse_quota_plan_rejects_non_dict_payload():
     payload = {"quota_plan": "not-a-dict"}
     with pytest.raises(ValidationError):
         _parse_quota_plan(payload)
+
+
+def test_resolve_max_agents_with_floor_enforces_minimum():
+    assert _resolve_max_agents_with_floor(1) == MIN_PERSONA_TABLE_ROWS
+    assert _resolve_max_agents_with_floor("25") == MIN_PERSONA_TABLE_ROWS
+    assert _resolve_max_agents_with_floor(MIN_PERSONA_TABLE_ROWS + 5) == MIN_PERSONA_TABLE_ROWS + 5
+    assert _resolve_max_agents_with_floor(None) is None
+    assert _resolve_max_agents_with_floor("invalid") is None
 
 
 # ---- SimulationManager.prepare_simulation pass-through ---------------------

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -332,7 +332,7 @@ onMounted(() => {
               <input
                 type="range"
                 v-model.number="maxAgents"
-                min="5"
+                min="50"
                 max="500"
                 step="5"
                 :disabled="isPreparing"
@@ -340,7 +340,7 @@ onMounted(() => {
               <input
                 type="number"
                 v-model.number="maxAgents"
-                min="1"
+                min="50"
                 max="2000"
                 :disabled="isPreparing"
                 class="agent-cap-number"


### PR DESCRIPTION
### Motivation
- The release plan requires enforcing a minimum persona table size so reports always include at least `MIN_PERSONA_TABLE_ROWS` personas (Output-Contract / PLAN.md P1.2). 

### Description
- Added helper `_resolve_max_agents_with_floor` to `backend/app/api/simulation_prepare.py` and use it to parse `max_agents` so values below `MIN_PERSONA_TABLE_ROWS` are raised to the floor; invalid inputs remain `None` for backward compatibility. 
- Imported the shared constant `MIN_PERSONA_TABLE_ROWS` from `app.services.report_agent` and logged when the floor is applied. 
- Updated the Step-2 UI `frontend/src/components/Step2EnvSetup.vue` to set the agent-cap inputs (`range` and `number`) minimum to `50` so the frontend enforces the same floor. 
- Added unit tests in `backend/tests/api/test_simulation_prepare_quota.py` to assert the floor behaviour (`_resolve_max_agents_with_floor`) and that invalid/`None` inputs are handled.

### Testing
- Ran the focused API tests with `cd backend && uv run pytest tests/api/test_simulation_prepare_quota.py -q` and all tests passed (`10 passed`).
- The changes touched the following files: `backend/app/api/simulation_prepare.py`, `backend/tests/api/test_simulation_prepare_quota.py`, and `frontend/src/components/Step2EnvSetup.vue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c113a4e883289f219219df5d726c)