### PR TITLE
feat(ci): add actionlint workflow for GitHub-Actions YAML validation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,45 @@
+# Statische Workflow-Validierung via actionlint.
+#
+# Fängt typische GitHub-Actions-Fallen vor dem Merge ab:
+#   - Shell-Injection-Pattern in `run:`-Blöcken (${{ ... }} unquoted)
+#   - Deprecated/falsche `uses:`-Versionen, ungültige Syntax
+#   - Unbekannte `${{ ... }}`-Kontexte, Tippfehler in Secrets/Vars
+#
+# Phase 10 Supply-Chain-Hardening: ergänzt CodeQL/dependency-review/gitleaks
+# um eine Workflow-Layer-Statik-Analyse, bevor Workflow-Bugs in main landen.
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions:
+  contents: read
+  # reviewdog veröffentlicht Findings als PR-Review-Kommentare.
+  pull-requests: write
+
+jobs:
+  actionlint:
+    name: Lint GitHub-Actions-Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          # Findings als PR-Review-Kommentare (auf push: branches main keine
+          # Kommentare, da kein PR-Kontext — der Step failt aber weiterhin).
+          reporter: github-pr-review
+          # Findings sind harte Fehler. Workflow-YAML-Bugs sollen nicht in
+          # main landen.
+          fail_on_error: true
+          level: error


### PR DESCRIPTION
## Summary

- Neuer Workflow `.github/workflows/actionlint.yml`: statischer Linter für GitHub-Actions-YAML.
- Triggert auf PRs und main-Pushes, wenn `.github/workflows/**` oder `.github/actions/**` geändert werden.
- Findet typische Actions-Fallen vor dem Merge: Shell-Injection-Pattern, deprecated `uses:`-Versionen, ungültige `${{ ... }}`-Kontexte, Secret/Var-Tippfehler.

## Kontext

Phase 10 Supply-Chain-Hardening (Tier 1 aus dem Marketplace-Audit 2026-05-10). Ergänzt die bestehende Statik-Layer (CodeQL, dependency-review, gitleaks) um Workflow-spezifische Validierung. Verhindert, dass YAML-Bugs erst beim CI-Lauf auffallen.

## Implementierung

- `reviewdog/action-actionlint@6fb7acc...` (v1.72.0, SHA-gepinnt nach Repo-Konvention).
- `reporter: github-pr-review` + `fail_on_error: true` — Findings als PR-Review-Comments, harter Block beim Merge.
- Permissions: `contents: read` + `pull-requests: write` (für Review-Comments).
- `paths`-Filter — Workflow läuft nur wenn relevant.

## Test plan

- [x] Workflow-YAML selbst valide (kein actionlint-self-run nötig — Workflow lintet sich beim ersten Run gegen sich selbst).
- [ ] CI-Run auf diesem PR muss grün durchlaufen — actionlint findet keine Issues an den bestehenden Workflows.
- [ ] Falls Findings auftauchen: in separatem Slice adressieren oder hier inline fixen.

## Phase-10-Tracker

Tier 1 Slice 1/4 (CI-Hardening Marketplace-Audit). Folge-Slices: harden-runner, scorecard, trivy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)