### PR TITLE
feat(report): render simulated_quote tags as marked blockquote (Slice P3.3 Backend)

### DIFF
--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -54,17 +54,17 @@ logger = get_logger('agora.report_agent')
 # ohne UI-Render erkennbar, dass es sich um simulierte Persona-O-Töne handelt
 # (Anti-Halluzinations-Disziplin, ADR-0004).
 _SIMULATED_QUOTE_TAG_RE = re.compile(
-    r"<simulated_quote\s+([^>]+?)>(.*?)</simulated_quote>",
+    r"<simulated_quote(?:\s+([^>]*?))?>(.*?)</simulated_quote>",
     re.DOTALL,
 )
-_SIMULATED_QUOTE_ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
+_SIMULATED_QUOTE_ATTR_RE = re.compile(r'(\w+)\s*=\s*["\']([^"\']*)["\']')
 
 
 def _render_simulated_quote_blocks(content: str) -> str:
     """Ersetzt <simulated_quote>-Tags durch Markdown-Blockquotes mit Anker-Header."""
 
     def _replace(match: "re.Match[str]") -> str:
-        attrs = dict(_SIMULATED_QUOTE_ATTR_RE.findall(match.group(1)))
+        attrs = dict(_SIMULATED_QUOTE_ATTR_RE.findall(match.group(1) or ""))
         text = match.group(2).strip()
         persona_id = attrs.get("persona_id", "unbekannt")
         seed_anchor = attrs.get("seed_anchor", "unbekannt")

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
@@ -41,6 +42,41 @@ from .sections import (
 )
 
 logger = get_logger('agora.report_agent')
+
+
+# ---------------------------------------------------------------------------
+# Slice P3.3 — Quote-Marker-Render
+# ---------------------------------------------------------------------------
+#
+# Wandelt rohe `<simulated_quote persona_id="..." seed_anchor="...">…</simulated_quote>`
+# Tags vor der Section-Persistenz in lesbare Markdown-Blockquotes mit explizit
+# sichtbarem Persona- und Seed-Anker-Header. Damit ist im exportierten Markdown
+# ohne UI-Render erkennbar, dass es sich um simulierte Persona-O-Töne handelt
+# (Anti-Halluzinations-Disziplin, ADR-0004).
+_SIMULATED_QUOTE_TAG_RE = re.compile(
+    r"<simulated_quote\s+([^>]+?)>(.*?)</simulated_quote>",
+    re.DOTALL,
+)
+_SIMULATED_QUOTE_ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
+
+
+def _render_simulated_quote_blocks(content: str) -> str:
+    """Ersetzt <simulated_quote>-Tags durch Markdown-Blockquotes mit Anker-Header."""
+
+    def _replace(match: "re.Match[str]") -> str:
+        attrs = dict(_SIMULATED_QUOTE_ATTR_RE.findall(match.group(1)))
+        text = match.group(2).strip()
+        persona_id = attrs.get("persona_id", "unbekannt")
+        seed_anchor = attrs.get("seed_anchor", "unbekannt")
+        header = (
+            f"> **Simulierter Persona-O-Ton** "
+            f"(persona_id: {persona_id}, seed_anchor: {seed_anchor})"
+        )
+        body_lines = [f"> {line}" if line else ">" for line in text.split("\n")]
+        return "\n".join([header, *body_lines])
+
+    return _SIMULATED_QUOTE_TAG_RE.sub(_replace, content)
+
 
 class ReportManager:
     """Persistence and retrieval facade for generated reports."""
@@ -307,22 +343,26 @@ class ReportManager:
     def _clean_section_content(cls, content: str, section_title: str) -> str:
         """
         cleanSectioncontent
-        
-        1. removecontentbeginningandSection TitleduplicateMarkdowntitlerow
-        2. convertall ### and below levelstitleconvert toboldtext
-        
+
+        1. <simulated_quote>-Tags zu lesbaren Persona-O-Ton-Blockquotes rendern
+           (Slice P3.3, ADR-0004 Quote-Marker)
+        2. removecontentbeginningandSection TitleduplicateMarkdowntitlerow
+        3. convertall ### and below levelstitleconvert toboldtext
+
         Args:
             content: originalcontent
             section_title: Section Title
-            
+
         Returns:
             after cleaningcontent
         """
         import re
-        
+
         if not content:
             return content
-        
+
+        content = _render_simulated_quote_blocks(content)
+
         content = content.strip()
         lines = content.split('\n')
         cleaned_lines = []

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -73,7 +73,7 @@ def _render_simulated_quote_blocks(content: str) -> str:
             f"(persona_id: {persona_id}, seed_anchor: {seed_anchor})"
         )
         body_lines = [f"> {line}" if line else ">" for line in text.split("\n")]
-        return "\n".join([header, *body_lines])
+        return "\n\n" + "\n".join([header, *body_lines]) + "\n\n"
 
     return _SIMULATED_QUOTE_TAG_RE.sub(_replace, content)
 

--- a/backend/tests/test_report_manager.py
+++ b/backend/tests/test_report_manager.py
@@ -346,3 +346,20 @@ def test_assemble_full_report_renders_confidence_markers(tmp_path, monkeypatch):
     assert "score=0.15" in markdown
     assert "medium-confidence" in markdown
     assert "score=0.55" in markdown
+
+
+def test_clean_section_content_renders_simulated_quote_marker() -> None:
+    content = (
+        '<simulated_quote persona_id="persona_10" '
+        'seed_anchor="seed_doc:robert_krasniqi_statement">'
+        'Meine Generation will keine 5-Tage-Woche mehr.'
+        '</simulated_quote>'
+    )
+
+    cleaned = ReportManager._clean_section_content(content, "Persona-O-Ton")
+
+    assert "**Simulierter Persona-O-Ton**" in cleaned
+    assert "persona_id: persona_10" in cleaned
+    assert "seed_anchor: seed_doc:robert_krasniqi_statement" in cleaned
+    assert "Meine Generation will keine 5-Tage-Woche mehr." in cleaned
+    assert "<simulated_quote" not in cleaned

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-10
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1741 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1742 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 47 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

- Wandelt rohe `<simulated_quote persona_id="..." seed_anchor="...">…</simulated_quote>` Tags beim Schreiben jeder Section in ein lesbares Markdown-Blockquote mit explizit sichtbarem Persona- und Seed-Anker-Header.
- Damit ist im exportierten Markdown (und Print-PDF) ohne UI-Render erkennbar, dass es sich um simulierte Persona-O-Töne handelt — Anti-Halluzinations-Disziplin nach ADR-0004 / PLAN.md §4.3.

## Render-Format

```markdown
> **Simulierter Persona-O-Ton** (persona_id: persona_10, seed_anchor: seed_doc:robert_krasniqi_statement)
> Meine Generation will keine 5-Tage-Woche mehr.
```

## Implementierung

- `_render_simulated_quote_blocks()` als Modul-Helper in `backend/app/services/report_agent/manager.py` (separater Renderer, nutzt `re`-Pattern analog zu `evidence.py`-Validator, aber ohne Validator-Logik).
- Hook in `ReportManager._clean_section_content()` als allererster Schritt — vor der bestehenden Heading-Normalisierung, damit Quote-Tags transformiert sind, bevor andere Markdown-Regeln greifen.
- TDD: RED-Test `test_clean_section_content_renders_simulated_quote_marker` zuerst geschrieben (war auf dem Branch bereits da), dann GREEN-Implementation.

## Scope-Begrenzung

**Nicht in diesem PR:** Frontend-Render von `markdown.js` (PLAN.md §4.3 Schritt 2). Der Backend-Marker reicht für den DoD von §4.3 Schritt 1 (sichtbarer Quote-Marker im exportierten MD/Print-PDF). Frontend folgt als separater Sub-Slice P3.3b.

**Ebenfalls nicht hier:** Quote-Anchor-Validator-Strict-Modus (PLAN.md §4.3 Schritt 3) — der ist Phase-4-Voraussetzung, nicht Phase-3.

## Test plan

- [x] `uv run pytest tests/test_report_manager.py` — 14 passed
- [x] `uv run pytest tests/services/test_report_agent_quote_anchors.py tests/services/test_report_agent_workflow_quote_validation.py tests/eval/` — keine neuen Failures (2 vorhandene workflow-quote-validation-Failures sind pre-existing auf main, nicht durch diesen PR ausgelöst)
- [x] `uv run ruff check app/services/report_agent/manager.py tests/test_report_manager.py` — clean
- [x] `uv run mypy app/services/report_agent/manager.py` — clean
- [x] `uv run python scripts/check_voice.py` — OK
- [x] `uv run python -m app.contracts.dump_schemas --check` — OK (kein Schema-Drift)
- [ ] Gemini-Code-Assist-Review (innerhalb 60–120 s nach PR-Open)
- [ ] CI inkl. Contract-Gates und CodeQL grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)