### PR TITLE
fix(test): unblock quote-validation tests after P1.2 persona-floor

### DIFF
--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -45,3 +45,4 @@ app/services/report_agent/agent.py::ReportAgent._build_claims_for_section
 app/services/report_agent/workflow.py::generate_report
 app/services/report_agent/workflow.py::generate_section_react
 app/services/report_agent/manager.py::ReportManager._post_process_report
+app/services/report_agent/manager.py::ReportManager.build_report_v3

--- a/backend/tests/services/test_report_agent_workflow_quote_validation.py
+++ b/backend/tests/services/test_report_agent_workflow_quote_validation.py
@@ -55,7 +55,12 @@ def _make_agent() -> object:
     agent._active_section_evidence = []
     agent._current_section_index = None
     agent._embed_cache = None
-    agent.persona_ids = ["persona_01"]
+    # MIN_PERSONA_TABLE_ROWS = 50 (Slice P1.2). Bei < 50 Personas markiert
+    # generate_report den Run als INCOMPLETE und kehrt früh zurück, bevor
+    # generate_section_react aufgerufen wird. Quote-Validation-Tests brauchen
+    # also einen vollwertigen Persona-Pool, damit der Workflow bis zum
+    # Section-Generation-Loop läuft.
+    agent.persona_ids = [f"persona_{i:02d}" for i in range(1, 51)]
 
     # ReportAgent-Klassen und Methoden-Stubs
     agent.ReportLogger = MagicMock()


### PR DESCRIPTION
## Summary

- Pre-existing main-Failure: `test_report_agent_workflow_quote_validation.py` (2 Tests) ist seit Slice P1.2 (Persona-Mindestanzahl) rot — die Tests haben einen Persona-Stub mit nur einer `persona_id`, der neue `MIN_PERSONA_TABLE_ROWS=50`-Floor lässt `generate_report` früh zurückkehren bevor `generate_section_react` aufgerufen wird.
- Fix: `_make_agent()` baut 50 Persona-IDs (`persona_01` … `persona_50`). `persona_01` (in den Quote-Test-Fixtures referenziert) bleibt im Set, keine funktionale Änderung an den Quote-Anchor-Tests.
- Blockiert aktuell die Merges von PR #354 (P3.3 Quote-Marker) und PR #355 (think-Provider-Fix).

## Diagnose

```python
# workflow.py:488
persona_count = _load_persona_count(agent)  # liefert 1 statt ≥ 50
if persona_count < MIN_PERSONA_TABLE_ROWS:
    report = _mark_incomplete_for_persona_floor(...)
    return report  # ← hier landet der Workflow → mock_gsr.call_count = 0
```

## Test plan

- [x] `uv run pytest tests/services/test_report_agent_workflow_quote_validation.py -v` — 2 passed
- [x] `uv run ruff check tests/services/test_report_agent_workflow_quote_validation.py` — clean
- [x] `bash scripts/sync-status.sh --check` — OK (kein Drift, kein neuer Test, nur Edit)
- [x] `bash scripts/check_complexity.sh` — OK (mit Allowlist-Eintrag für `build_report_v3`)
- [ ] Gemini-Code-Assist-Review
- [ ] CI grün

## Allowlist-Hinweis

`ReportManager.build_report_v3` ist seit Slice P3.1 mit Class-E-Komplexität auf main, ohne Allowlist-Eintrag. Identischer Eintrag in PR #354 und PR #355. Sobald einer dieser PRs gemerged ist, kann der Eintrag in den anderen während des Rebase deduplizieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)