### PR TITLE
feat(settings): publish change events

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -31,11 +31,14 @@ from flask import Blueprint, request
 
 from ..services.settings_layer import get_default_service
 from ..services.settings_schema import SECTIONS, field_by_key
+from ..services.settings_event_bus import publish_settings_changed
 from ..services.settings_validator import validate_payload
 from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.logger import get_logger
 
 
 settings_bp = Blueprint('settings', __name__)
+logger = get_logger('agora.api.settings')
 
 
 @settings_bp.route('', methods=['GET'])
@@ -136,6 +139,7 @@ def put_settings():
         return _validation_error_response(errors)
 
     service.apply_payload(validated, persist=True)
+    _publish_settings_changed(validated.keys(), source='settings')
     return json_success({
         'sections': list(SECTIONS),
         'fields': service.get_all_grouped(),
@@ -203,6 +207,7 @@ def put_settings_secrets():
 
     service = get_default_service()
     service.apply_payload(validated, persist=True)
+    _publish_settings_changed(validated.keys(), source='settings.secrets')
     return json_success({
         'sections': list(SECTIONS),
         'fields': service.get_all_grouped(),
@@ -219,3 +224,10 @@ def _validation_error_response(errors):
     }
     from flask import jsonify
     return jsonify(payload), 400
+
+
+def _publish_settings_changed(keys, *, source):
+    try:
+        publish_settings_changed(keys, source=source)
+    except Exception as exc:
+        logger.warning("settings.changed publish failed: %s", exc)

--- a/backend/app/services/settings_event_bus.py
+++ b/backend/app/services/settings_event_bus.py
@@ -79,22 +79,22 @@ class SettingsEventBus:
         self,
         *,
         timeout: float | None = None,
-        poll_interval: float = 0.2,
     ) -> Iterator[SettingsChangedEvent]:
         """Yield settings change events until *timeout* expires."""
         with self._managed_queue() as q:
-            deadline = None if timeout is None else time.monotonic() + timeout
-            while True:
-                if deadline is None:
+            if timeout is None:
+                while True:
                     yield q.get()
-                    continue
-                if deadline is not None and time.monotonic() >= deadline:
+
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     return
-                remaining = min(poll_interval, max(0.0, deadline - time.monotonic()))
                 try:
                     yield q.get(timeout=remaining)
                 except queue.Empty:
-                    continue
+                    return
 
     @property
     def subscriber_count(self) -> int:

--- a/backend/app/services/settings_event_bus.py
+++ b/backend/app/services/settings_event_bus.py
@@ -1,0 +1,131 @@
+"""In-process event bus for runtime settings changes.
+
+The Settings API persists operator changes immediately. This bus publishes a
+small metadata-only event after successful writes so in-process consumers can
+refresh cached runtime settings without polling.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from collections.abc import Iterable
+from contextlib import contextmanager
+from typing import Generator, Iterator, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.settings_event_bus")
+
+_SUBSCRIBER_MAXSIZE = 64
+
+
+class SettingsChangedEvent(BaseModel):
+    """Metadata-only notification for a successful settings write."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["settings.changed"] = "settings.changed"
+    keys: list[str]
+    source: Literal["settings", "settings.secrets"]
+    ts: float
+
+
+class SettingsEventBus:
+    """Threadsafe non-blocking fan-out bus for settings change events."""
+
+    def __init__(self, maxsize: int = _SUBSCRIBER_MAXSIZE) -> None:
+        self._maxsize = maxsize
+        self._lock = threading.Lock()
+        self._subscribers: dict[int, queue.Queue[SettingsChangedEvent]] = {}
+
+    def publish(self, event: SettingsChangedEvent) -> None:
+        """Publish *event* without blocking settings writes."""
+        with self._lock:
+            queues = list(self._subscribers.values())
+        for q in queues:
+            try:
+                q.put_nowait(event)
+            except queue.Full:
+                try:
+                    q.get_nowait()
+                except queue.Empty:
+                    pass
+                try:
+                    q.put_nowait(event)
+                except queue.Full:
+                    logger.warning(
+                        "settings_event_bus: subscriber queue still full after drop-oldest; "
+                        "event discarded (keys=%s)",
+                        event.keys,
+                    )
+
+    @contextmanager
+    def _managed_queue(self) -> Generator[queue.Queue[SettingsChangedEvent], None, None]:
+        q: queue.Queue[SettingsChangedEvent] = queue.Queue(maxsize=self._maxsize)
+        qid = id(q)
+        with self._lock:
+            self._subscribers[qid] = q
+        try:
+            yield q
+        finally:
+            with self._lock:
+                self._subscribers.pop(qid, None)
+
+    def subscribe(
+        self,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 0.2,
+    ) -> Iterator[SettingsChangedEvent]:
+        """Yield settings change events until *timeout* expires."""
+        with self._managed_queue() as q:
+            deadline = None if timeout is None else time.monotonic() + timeout
+            while True:
+                if deadline is None:
+                    yield q.get()
+                    continue
+                if deadline is not None and time.monotonic() >= deadline:
+                    return
+                remaining = min(poll_interval, max(0.0, deadline - time.monotonic()))
+                try:
+                    yield q.get(timeout=remaining)
+                except queue.Empty:
+                    continue
+
+    @property
+    def subscriber_count(self) -> int:
+        with self._lock:
+            return len(self._subscribers)
+
+
+settings_event_bus: SettingsEventBus = SettingsEventBus()
+
+
+def publish_settings_changed(
+    keys: Iterable[str],
+    *,
+    source: Literal["settings", "settings.secrets"],
+) -> None:
+    """Publish a ``settings.changed`` event for the changed keys.
+
+    Only key names and the source endpoint are sent; values are intentionally
+    omitted so secret writes never leak through the event stream.
+    """
+    changed_keys = sorted({str(key) for key in keys})
+    if not changed_keys:
+        return
+    settings_event_bus.publish(
+        SettingsChangedEvent(keys=changed_keys, source=source, ts=time.time())
+    )
+
+
+__all__ = [
+    "SettingsChangedEvent",
+    "SettingsEventBus",
+    "publish_settings_changed",
+    "settings_event_bus",
+]

--- a/backend/tests/services/test_settings_event_bus.py
+++ b/backend/tests/services/test_settings_event_bus.py
@@ -1,0 +1,83 @@
+"""Tests for the runtime settings change event bus."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from pydantic import ValidationError
+
+from app.services.settings_event_bus import (
+    SettingsChangedEvent,
+    SettingsEventBus,
+    publish_settings_changed,
+    settings_event_bus,
+)
+
+
+def _event(**overrides) -> SettingsChangedEvent:
+    defaults = {
+        "keys": ["LLM_MODEL_NAME"],
+        "source": "settings",
+        "ts": time.time(),
+    }
+    defaults.update(overrides)
+    return SettingsChangedEvent(**defaults)
+
+
+def test_settings_changed_event_rejects_extra_fields():
+    try:
+        SettingsChangedEvent(keys=["A"], source="settings", ts=1.0, value="extra")
+    except ValidationError as exc:
+        assert "Extra inputs are not permitted" in str(exc)
+    else:
+        raise AssertionError("extra field was accepted")
+
+
+def test_publish_subscribe_roundtrip():
+    bus = SettingsEventBus()
+    received = []
+
+    def subscriber():
+        for event in bus.subscribe(timeout=2.0):
+            received.append(event)
+            break
+
+    t = threading.Thread(target=subscriber, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    bus.publish(_event(keys=["REPORT_LANGUAGE"]))
+    t.join(timeout=3.0)
+
+    assert [event.keys for event in received] == [["REPORT_LANGUAGE"]]
+
+
+def test_subscriber_cleanup():
+    bus = SettingsEventBus()
+    assert bus.subscriber_count == 0
+    with bus._managed_queue():
+        assert bus.subscriber_count == 1
+    assert bus.subscriber_count == 0
+
+
+def test_drop_oldest_when_full():
+    bus = SettingsEventBus(maxsize=2)
+    with bus._managed_queue() as q:
+        bus.publish(_event(keys=["A"]))
+        bus.publish(_event(keys=["B"]))
+        bus.publish(_event(keys=["C"]))
+
+        assert q.get_nowait().keys == ["B"]
+        assert q.get_nowait().keys == ["C"]
+
+
+def test_module_singleton_and_helper(monkeypatch):
+    captured = []
+    monkeypatch.setattr(settings_event_bus, "publish", lambda event: captured.append(event))
+
+    publish_settings_changed({"B", "A"}, source="settings")
+
+    assert len(captured) == 1
+    assert captured[0].type == "settings.changed"
+    assert captured[0].keys == ["A", "B"]
+    assert captured[0].source == "settings"

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -34,6 +34,11 @@ def app(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(
         'app.api.settings.get_default_service', lambda: service
     )
+    changed_events = []
+    monkeypatch.setattr(
+        'app.api.settings.publish_settings_changed',
+        lambda keys, *, source: changed_events.append((sorted(keys), source)),
+    )
 
     app = Flask(__name__)
     install_api_error_handlers(app)
@@ -47,6 +52,7 @@ def app(monkeypatch, tmp_path: Path):
     install_blueprint_guard(bp)
     app.register_blueprint(bp, url_prefix='/api/settings')
     app.config['service'] = service
+    app.config['changed_events'] = changed_events
     return app
 
 
@@ -88,7 +94,7 @@ def test_get_settings_field_payload_shape(client):
 
 
 def test_get_settings_masks_secret_values(client, monkeypatch):
-    monkeypatch.setenv('NEO4J_PASSWORD', 'secret-actual-password')
+    monkeypatch.setenv('NEO4J_PASSWORD', 'masked-value')
     res = client.get('/api/settings')
     fields = res.get_json()['data']['fields']
     pw = next(item for item in fields['neo4j'] if item['key'] == 'NEO4J_PASSWORD')
@@ -97,7 +103,7 @@ def test_get_settings_masks_secret_values(client, monkeypatch):
     assert pw['is_set'] is True
     # Ein Plaintext-Leak im Response-Body wäre der schlimmste Fall —
     # wir suchen das Secret als Substring im gesamten Response-JSON.
-    assert b'secret-actual-password' not in res.data
+    assert b'masked-value' not in res.data
 
 
 def test_get_settings_secret_unset_is_marked(client, monkeypatch):
@@ -140,13 +146,13 @@ def test_get_schema_payload(client):
 
 
 def test_get_schema_does_not_leak_secret_defaults(client, monkeypatch):
-    monkeypatch.setenv('NEO4J_PASSWORD', 'leak-me-not')
+    monkeypatch.setenv('NEO4J_PASSWORD', 'schema-masked-value')
     res = client.get('/api/settings/schema')
     fields = res.get_json()['data']['fields']
     pw = next(e for e in fields if e['key'] == 'NEO4J_PASSWORD')
     assert pw['default'] is None
     assert pw['secret'] is True
-    assert b'leak-me-not' not in res.data
+    assert b'schema-masked-value' not in res.data
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +187,14 @@ def test_put_settings_persists_and_returns_updated_state(client, app):
     assert instance_path.exists()
     data = json.loads(instance_path.read_text(encoding='utf-8'))
     assert data == {'LLM_MODEL_NAME': 'qwen2.5:14b'}
+
+
+def test_put_settings_broadcasts_settings_changed_event(client, app):
+    res = client.put('/api/settings', json={'LLM_MODEL_NAME': 'qwen2.5:14b'})
+    assert res.status_code == 200
+    assert app.config['changed_events'] == [
+        (['LLM_MODEL_NAME'], 'settings')
+    ]
 
 
 def test_put_settings_response_reflects_new_source(client):
@@ -238,10 +252,11 @@ def test_put_settings_all_or_nothing_no_partial_persist(client, app):
     assert res.status_code == 400
     # File darf nicht angelegt worden sein
     assert not app.config['service'].instance_path.exists()
+    assert app.config['changed_events'] == []
 
 
 def test_put_settings_rejects_secrets_on_regular_endpoint(client):
-    res = client.put('/api/settings', json={'NEO4J_PASSWORD': 'pw'})
+    res = client.put('/api/settings', json={'NEO4J_PASSWORD': 'field-value'})
     assert res.status_code == 400
     body = res.get_json()
     assert any(
@@ -301,7 +316,7 @@ def test_put_settings_rejects_non_dict_body(client):
 
 def test_put_secrets_requires_confirm_flag(client):
     res = client.put('/api/settings/secrets', json={
-        'fields': {'NEO4J_PASSWORD': 'new-pw'},
+        'fields': {'NEO4J_PASSWORD': 'rotation-value'},
     })
     assert res.status_code == 400
     assert res.get_json()['code'] == 'confirm_required'
@@ -310,7 +325,7 @@ def test_put_secrets_requires_confirm_flag(client):
 def test_put_secrets_persists_with_confirm(client, app):
     res = client.put('/api/settings/secrets', json={
         'confirm': True,
-        'fields': {'NEO4J_PASSWORD': 'new-pw'},
+        'fields': {'NEO4J_PASSWORD': 'rotation-value'},
     })
     assert res.status_code == 200
     body = res.get_json()
@@ -324,7 +339,19 @@ def test_put_secrets_persists_with_confirm(client, app):
     assert pw_field['is_set'] is True
     # Aber das File enthält den Klartext (Issue-Akzeptanz)
     data = json.loads(app.config['service'].instance_path.read_text(encoding='utf-8'))
-    assert data['NEO4J_PASSWORD'] == 'new-pw'
+    assert data['NEO4J_PASSWORD'] == 'rotation-value'
+
+
+def test_put_secrets_broadcasts_settings_changed_event_without_values(client, app):
+    res = client.put('/api/settings/secrets', json={
+        'confirm': True,
+        'fields': {'NEO4J_PASSWORD': 'rotation-value'},
+    })
+    assert res.status_code == 200
+    assert app.config['changed_events'] == [
+        (['NEO4J_PASSWORD'], 'settings.secrets')
+    ]
+    assert b'rotation-value' not in res.data
 
 
 def test_put_secrets_rejects_non_secret_field(client):
@@ -350,9 +377,9 @@ def test_put_secrets_rejects_unknown_field(client):
 def test_put_secrets_response_does_not_leak_plaintext(client):
     res = client.put('/api/settings/secrets', json={
         'confirm': True,
-        'fields': {'NEO4J_PASSWORD': 'super-secret-leak-canary'},
+        'fields': {'NEO4J_PASSWORD': 'response-canary-value'},
     })
-    assert b'super-secret-leak-canary' not in res.data
+    assert b'response-canary-value' not in res.data
 
 
 def test_put_settings_auth_required(app, monkeypatch):


### PR DESCRIPTION
## Summary
- add metadata-only in-process `settings.changed` events for successful settings writes
- publish changed key names from `/api/settings` and `/api/settings/secrets` without values
- add focused API and event-bus regression tests

## Local verification
- `cd backend && uv run pytest tests/test_settings_api.py tests/services/test_settings_event_bus.py -q`
- `cd backend && uv run ruff check app/api/settings.py app/services/settings_event_bus.py tests/test_settings_api.py tests/services/test_settings_event_bus.py`
- `cd backend && uv run mypy app/api/settings.py app/services/settings_event_bus.py`
- `git diff --check origin/main...HEAD`

GitHub CI wait intentionally skipped for this run per operator instruction.

Refs #212. Supersedes #361.