### PR TITLE
chore(m11): drei rote CI-Gates auf main entspannen

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -16,4 +16,4 @@ secret:
     - backend/tests/test_settings_validator.py
     - backend/tests/test_settings_api.py
     - backend/tests/test_settings_persistence.py
-    - frontend/src/store/__tests__/settings.spec.js
+    - frontend/src/store/__tests__/settings.spec.ts

--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -2,21 +2,25 @@
 # Neue Einträge nur nach Sub-Slice mit Architektur-Begründung im Arbeitsprotokoll.
 # Format: <rel-path>::<func>  (rel-path relativ zu backend/, func = radon-Ausgabe-Name)
 #
-# Gemessen: 2026-05-10, radon 6.0.1, radon cc -n D app/
-# Anzahl Einträge: 27 (4 x Class E, 1 x Class F, 22 x Class D)
+# Gemessen: 2026-05-11, radon 6.0.1, radon cc -n D app/
+# Anzahl Einträge: 29 (5 x Class E/F, 24 x Class D)
 #
 # Top-5 nach Cyclomatic Complexity:
+#   F (cc=50)  app/services/evidence_migrations.py::migrate_v2_to_v3
 #   F (cc=44)  app/api/report.py::get_generate_status
 #   E (cc=38)  app/services/report_agent/workflow.py::generate_report
 #   E (cc=33)  app/api/simulation_run.py::start_simulation
 #   E (cc=33)  app/services/oasis_profile_generator.py::OasisProfileGenerator.generate_profiles_from_entities
-#   D (cc=30)  app/services/report_agent/workflow.py::generate_section_react
 #
 # Refactor-Kandidaten (eigene Sub-Slices nötig):
 #   - app/api/report.py (F/E): Kandidat für API-Envelope-Refactor (M11.6)
 #   - app/services/report_agent/workflow.py (E/D): Kandidat für Report-Agent-Refactor
 #   - app/api/simulation_run.py (E): Kandidat für Sim-Run-Refactor
 #   - app/services/oasis_profile_generator.py (E): Kandidat für OASIS-Profil-Refactor
+#   - app/services/evidence_migrations.py (F/D): aus P3.1-Followup (Commit 83b7488),
+#     echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation. Eigener
+#     Refactor-Slice nach v1.0 (Aufgabenkatalog: Aggregations-Helper splitten,
+#     Persona-Mapper als eigenes Modul).
 
 app/config.py::Config
 app/config.py::Config.validate
@@ -46,3 +50,5 @@ app/services/report_agent/workflow.py::generate_report
 app/services/report_agent/workflow.py::generate_section_react
 app/services/report_agent/manager.py::ReportManager._post_process_report
 app/services/report_agent/manager.py::ReportManager.build_report_v3
+app/services/evidence_migrations.py::migrate_v2_to_v3
+app/services/evidence_migrations.py::_map_profile_to_persona

--- a/docu/2026-05-11-m11-hygiene-arbeitsprotokoll.md
+++ b/docu/2026-05-11-m11-hygiene-arbeitsprotokoll.md
@@ -1,0 +1,58 @@
+# M11-Hygiene — drei rote CI-Gates auf `main` und `feat/issue-212-live-settings` fixen
+
+**Datum:** 2026-05-11
+**Branch:** `feat/m11-hygiene-radon-status`
+**Worktree:** `.claude/worktrees/m11-hygiene`
+**Refs:** #212 (PR #363 verklemmt sich an denselben Gates), PLAN.md M11.5 / Phase 6, CLAUDE.md PR-Workflow
+
+## Befund
+
+`main` ist seit Commit `83b7488` (P3.1-Followup, echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation in `migrate_v2_to_v3`) auf drei CI-Gates rot. PR #363 (Live-Settings #212) erbt die gleichen Failures, weil er von `main` ausgeht.
+
+| Gate | Befund | Ursache |
+|---|---|---|
+| Komplexitäts-Gate (radon) | `migrate_v2_to_v3` Class F (cc=50), `_map_profile_to_persona` Class D (cc=21) — beide nicht in Allowlist | `83b7488` hat die Aggregations-Logik massiv ausgebaut, Allowlist wurde nicht nachgezogen |
+| STATUS.md Drift-Check | Backend-Test-Count 1782 in STATUS.md, real 1855 | Mehrere Slice-Adds seit 2026-05-04 ohne `scripts/sync-status.sh`-Lauf |
+| GitGuardian Security Checks | `frontend/src/store/__tests__/settings.spec.ts:118` — Generic Password `'new-pw'` als Test-Marker | `.gitguardian.yaml` listet noch alte `.spec.js`-Endung von vor der TS-Migration (Sub-Slice 28, #71/#72/#73) |
+
+## Fixes
+
+### 1. GitGuardian-Pfad-Korrektur
+
+`.gitguardian.yaml`: `frontend/src/store/__tests__/settings.spec.js` → `.spec.ts`. Die Test-Strings (`new-pw`, `tok-xyz`, …) sind synthetische Marker, die im bestehenden Block-Kommentar bereits begründet sind. Die Konfig wollte schon vor der TS-Migration nur diese Datei freigeben — sie hat das durch die Endung-Änderung verloren.
+
+### 2. Radon-Allowlist-Erweiterung
+
+`backend/radon-allowlist.txt`: zwei Einträge dazu:
+
+```
+app/services/evidence_migrations.py::migrate_v2_to_v3
+app/services/evidence_migrations.py::_map_profile_to_persona
+```
+
+Top-5-Tabelle und Refactor-Kandidaten-Liste am Kopf der Datei aktualisiert (Stand 2026-05-11): `migrate_v2_to_v3` rückt mit cc=50 an Position 1 vor `get_generate_status` (cc=44). Die Datei `evidence_migrations.py` ist als eigener Refactor-Kandidat „nach v1.0" markiert (Aggregations-Helper splitten, Persona-Mapper ausgliedern).
+
+Begründung für den Allow statt sofortigen Refactor: P3.1-Followup ist auf `main` und durch `tests/` abgedeckt; ein Refactor-Slice mitten in v1.0-Releasekritik (P4.1 echte Verdrahtung steht noch aus) lenkt den Fokus weg.
+
+### 3. STATUS.md-Sync
+
+`bash scripts/sync-status.sh` lief sauber durch: nur die `<!-- BEGIN_AUTOGEN_TESTS -->`-Tabelle wurde upgedated (Backend 1782 → 1855). Frontend-Test-Files bleiben 47 — meine #212-Test-Adds sind dort nicht enthalten, weil dieser Branch von `main` ausgeht und PR #363 noch nicht gemerged ist.
+
+## Verify
+
+- `bash scripts/check_complexity.sh` → `OK: Keine neuen D/E/F-Klassen-Funktionen ausserhalb der Allow-List.`
+- `bash scripts/sync-status.sh --check` → grün (keine weitere Drift)
+- `cd backend && uv run ruff check app/ tests/` → grün
+- Schemas-Drift: nicht angerührt, keine Veränderung in `schemas/`
+
+## Out of Scope
+
+- **P4.1 echt verdrahten** — Code-Audit 2026-05-11 hat aufgedeckt, dass `ReportMode`-Literal/Schema-Feld/Resolver fehlen und `ReportModelControls.vue` nur LLM-Modellwahl ist. Eigener Slice, kein Hygiene-Beifang.
+- **`evidence_migrations.py` refactoren** — eigener Slice nach v1.0 (Allow-Eintrag dokumentiert das).
+- **PR #363 weiterbringen** — die hier gefixten Gates entspannen #363 mit, aber #363 wartet zusätzlich auf User-Go zum Merge (CLAUDE.md: „Live-Settings #212 P2: erst nach M11-Stabilisierung").
+
+## Folgeaktionen
+
+1. Diesen PR mergen → `main` ist auf drei Gates wieder grün.
+2. PR #363 rebase auf neue `main` → übernimmt die Fixes automatisch.
+3. P4.1 als nächsten v1.0-Slice anziehen.

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-10
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1782 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 1855 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 47 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

`main` ist seit Commit `83b7488` (P3.1-Followup, echte Persona/Segment-Aggregation in `migrate_v2_to_v3`) auf drei CI-Gates rot. PR #363 (Live-Settings #212) erbt die gleichen Failures.

Dieser PR entspannt alle drei Gates ohne Code-Refactor.

| Gate | Fix |
|---|---|
| Komplexitäts-Gate (radon) | `migrate_v2_to_v3` (cc=50, F) + `_map_profile_to_persona` (cc=21, D) in `backend/radon-allowlist.txt`; Top-5- und Refactor-Kandidaten-Tabelle aktualisiert |
| STATUS.md Drift-Check | `bash scripts/sync-status.sh` lief — Backend-Test-Count 1782 → 1855 |
| GitGuardian | `.gitguardian.yaml` listete `frontend/src/store/__tests__/settings.spec.js`, die Datei ist seit der TS-Migration (Sub-Slice 28, #71/#72/#73) `.spec.ts` — Endung korrigiert |

Refs: PLAN.md M11.5 / Phase 6, CLAUDE.md PR-Workflow.

## Verify

- [x] `bash scripts/check_complexity.sh` → OK
- [x] `bash scripts/sync-status.sh --check` → OK
- [x] `cd backend && uv run ruff check app/ tests/` → OK
- [x] Schemas-Drift: keine Veränderung in `schemas/`

## Test plan

- [ ] CI grün (alle drei vorgenannten Gates)
- [ ] Nach Merge: PR #363 rebase auf neue `main` → PR #363 wird auf 2/3 Gates grün (3. Gate ist Live-Settings-spezifisch und schon dort grün)

## Out of Scope

- **P4.1 echt verdrahten** — Code-Audit 2026-05-11 hat aufgedeckt, dass `ReportMode`-Literal/Schema-Feld/Resolver fehlen. Eigener Slice.
- **`evidence_migrations.py` refactoren** — eigener Slice nach v1.0 (Allow-Eintrag dokumentiert das).

Arbeitsprotokoll: [`docu/2026-05-11-m11-hygiene-arbeitsprotokoll.md`](docu/2026-05-11-m11-hygiene-arbeitsprotokoll.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)