### PR TITLE
fix(llm): route max_completion_tokens for GPT-5/o1/o3/o4

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -119,18 +119,29 @@ class LLMClient:
         # sonst 400 "Unsupported parameter: 'max_tokens'". Heuristik gespiegelt
         # aus backend/scripts/_sim_common.py::uses_max_completion_tokens —
         # Single Source of Truth bleibt dort, hier nur die zweite Stelle.
+        # Striktes Prefix-Matching ("gpt-5", "gpt-5-…") verhindert
+        # Mismatches wie hypothetisches "gpt-500".
         lowered = (model or "").strip().lower()
-        if lowered.startswith("gpt-5"):
-            return True
-        for prefix in ("o1", "o3", "o4"):
+        for prefix in ("gpt-5", "o1", "o3", "o4"):
             if lowered == prefix or lowered.startswith(f"{prefix}-"):
                 return True
         return False
 
-    def _completion_token_kwargs(self, max_tokens: int) -> Dict[str, int]:
+    def _completion_token_kwargs(
+        self, max_tokens: int, model: Optional[str] = None
+    ) -> Dict[str, int]:
+        """Wire-Key für das Token-Limit pro Modell.
+
+        Liefert ``{"max_completion_tokens": N}`` für GPT-5/o1/o3/o4 und
+        ``{"max_tokens": N}`` für alle anderen Modelle. ``model`` überschreibt
+        ``self.model`` — nötig im Vision-Pfad, der ein anderes Modell als das
+        Default-Chat-Modell nutzen kann (z. B. ``gemini-3-flash-preview:cloud``
+        bei einer GPT-5-Chat-Session).
+        """
+        target_model = model if model is not None else (self.model or "")
         key = (
             "max_completion_tokens"
-            if self._uses_max_completion_tokens(self.model or "")
+            if self._uses_max_completion_tokens(target_model)
             else "max_tokens"
         )
         return {key: max_tokens}
@@ -337,13 +348,7 @@ class LLMClient:
             "messages": messages,
             "temperature": temperature,
         }
-        # Vision-Pfad nutzt evtl. ein anderes Modell als self.model → eigene Auflösung.
-        token_key = (
-            "max_completion_tokens"
-            if self._uses_max_completion_tokens(vision_model or "")
-            else "max_tokens"
-        )
-        kwargs[token_key] = max_tokens
+        kwargs.update(self._completion_token_kwargs(max_tokens, model=vision_model))
         if self._is_ollama():
             extra_body: Dict[str, Any] = {"options": {"num_ctx": max(self._num_ctx, 8192)}}
             extra_body["think"] = False  # never want reasoning noise in vision output

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -113,6 +113,28 @@ class LLMClient:
         """Check if we're talking to an Ollama server."""
         return '11434' in (self.base_url or '')
 
+    @staticmethod
+    def _uses_max_completion_tokens(model: str) -> bool:
+        # GPT-5 / o1 / o3 / o4 verlangen max_completion_tokens; OpenAI antwortet
+        # sonst 400 "Unsupported parameter: 'max_tokens'". Heuristik gespiegelt
+        # aus backend/scripts/_sim_common.py::uses_max_completion_tokens —
+        # Single Source of Truth bleibt dort, hier nur die zweite Stelle.
+        lowered = (model or "").strip().lower()
+        if lowered.startswith("gpt-5"):
+            return True
+        for prefix in ("o1", "o3", "o4"):
+            if lowered == prefix or lowered.startswith(f"{prefix}-"):
+                return True
+        return False
+
+    def _completion_token_kwargs(self, max_tokens: int) -> Dict[str, int]:
+        key = (
+            "max_completion_tokens"
+            if self._uses_max_completion_tokens(self.model or "")
+            else "max_tokens"
+        )
+        return {key: max_tokens}
+
     def _detect_provider(self) -> Literal["ollama", "cloud", "openai", "unknown"]:
         """Infer the LLM provider from base_url and model name.
 
@@ -203,12 +225,12 @@ class LLMClient:
                 context,
             )
             return e2e_stub_chat_response(messages=messages)
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "temperature": temperature,
-            "max_tokens": max_tokens,
         }
+        kwargs.update(self._completion_token_kwargs(max_tokens))
 
         if response_format:
             kwargs["response_format"] = response_format
@@ -314,8 +336,14 @@ class LLMClient:
             "model": vision_model,
             "messages": messages,
             "temperature": temperature,
-            "max_tokens": max_tokens,
         }
+        # Vision-Pfad nutzt evtl. ein anderes Modell als self.model → eigene Auflösung.
+        token_key = (
+            "max_completion_tokens"
+            if self._uses_max_completion_tokens(vision_model or "")
+            else "max_tokens"
+        )
+        kwargs[token_key] = max_tokens
         if self._is_ollama():
             extra_body: Dict[str, Any] = {"options": {"num_ctx": max(self._num_ctx, 8192)}}
             extra_body["think"] = False  # never want reasoning noise in vision output

--- a/backend/tests/utils/test_llm_client_completion_token_routing.py
+++ b/backend/tests/utils/test_llm_client_completion_token_routing.py
@@ -52,12 +52,32 @@ def test_models_that_require_max_completion_tokens(model: str) -> None:
         "deepseek-v4-flash:cloud",
         "gemini-3-flash-preview",
         "llama3.1:70b",
+        # Strikt-Prefix-Matching: hypothetische Namen, die "gpt-5" nur als
+        # Substring-Anfang ohne Trennzeichen enthalten, sind KEIN GPT-5.
+        "gpt-500",
+        "gpt-50",
+        "o10-experimental",
+        "o42-mini",
         "",          # leerer Modellname → Fallback auf max_tokens
         "   ",
     ],
 )
 def test_models_that_keep_max_tokens(model: str) -> None:
     assert LLMClient._uses_max_completion_tokens(model) is False
+
+
+def test_completion_token_kwargs_override_model() -> None:
+    """Vision-Pfad: explizites `model` überschreibt self.model."""
+    obj = LLMClient.__new__(LLMClient)
+    obj.model = "qwen2.5:32b"
+    assert obj._completion_token_kwargs(1024, model="gpt-5-vision") == {
+        "max_completion_tokens": 1024
+    }
+    # Umgekehrt: self.model GPT-5, override auf gpt-4o → max_tokens.
+    obj.model = "gpt-5-mini"
+    assert obj._completion_token_kwargs(2048, model="gpt-4o") == {
+        "max_tokens": 2048
+    }
 
 
 def test_completion_token_kwargs_gpt5() -> None:

--- a/backend/tests/utils/test_llm_client_completion_token_routing.py
+++ b/backend/tests/utils/test_llm_client_completion_token_routing.py
@@ -1,0 +1,188 @@
+"""
+Regression cover for OpenAI 400: ``Unsupported parameter: 'max_tokens' is not
+supported with this model. Use 'max_completion_tokens' instead.``
+
+GPT-5 / o1 / o3 / o4 müssen den OpenAI-Aufruf mit ``max_completion_tokens=N``
+statt ``max_tokens=N`` bekommen. Alle anderen Modelle (gpt-4o, gpt-3.5,
+qwen2.5:32b, gemini-*) bleiben bei ``max_tokens=N``.
+
+Mock-only — kein Netzwerk.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.llm_client import LLMClient
+
+
+# ---------------------------------------------------------------------------
+# Pure-Heuristik-Unit-Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "GPT-5-Pro",            # case-insensitiv
+        "  gpt-5-thinking  ",   # getrimmt
+        "o1",
+        "o1-preview",
+        "o3",
+        "o3-mini",
+        "o4-mini-2025-01-01",
+    ],
+)
+def test_models_that_require_max_completion_tokens(model: str) -> None:
+    assert LLMClient._uses_max_completion_tokens(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo",
+        "qwen2.5:32b",
+        "qwen3-coder-next:cloud",
+        "deepseek-v4-flash:cloud",
+        "gemini-3-flash-preview",
+        "llama3.1:70b",
+        "",          # leerer Modellname → Fallback auf max_tokens
+        "   ",
+    ],
+)
+def test_models_that_keep_max_tokens(model: str) -> None:
+    assert LLMClient._uses_max_completion_tokens(model) is False
+
+
+def test_completion_token_kwargs_gpt5() -> None:
+    """Instance-Methode liefert das passende Wire-Key-Dict pro self.model."""
+    obj = LLMClient.__new__(LLMClient)
+    obj.model = "gpt-5-mini"
+    assert obj._completion_token_kwargs(4096) == {"max_completion_tokens": 4096}
+
+
+def test_completion_token_kwargs_legacy() -> None:
+    obj = LLMClient.__new__(LLMClient)
+    obj.model = "gpt-4o"
+    assert obj._completion_token_kwargs(2048) == {"max_tokens": 2048}
+
+
+# ---------------------------------------------------------------------------
+# Integration: chat() ruft OpenAI-SDK mit dem richtigen Schlüssel
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    completion_tokens = 42
+
+
+class _FakeMessage:
+    content = '{"ok": true}'
+
+
+class _FakeChoice:
+    finish_reason = "stop"
+    message = _FakeMessage()
+
+
+class _FakeResponse:
+    choices = [_FakeChoice()]
+    usage = _FakeUsage()
+
+
+class _FakeCompletions:
+    def __init__(self) -> None:
+        self.captured_kwargs: dict | None = None
+
+    def create(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return _FakeResponse()
+
+
+class _FakeChat:
+    def __init__(self) -> None:
+        self.completions = _FakeCompletions()
+
+
+class _FakeOpenAI:
+    def __init__(self) -> None:
+        self.chat = _FakeChat()
+
+
+@pytest.fixture()
+def fake_client(monkeypatch):
+    """LLMClient ohne echten OpenAI-Init, mit fake-Client an .client."""
+    obj = LLMClient.__new__(LLMClient)
+    obj._max_retries = 0          # kein Retry-Wrap nötig
+    obj._retry_initial_delay = 0.0
+    obj._retry_max_delay = 0.0
+    obj._num_ctx = 8192
+    obj._think = False
+    obj.api_key = "test"
+    # Non-Ollama base_url → kein force-stream-Pfad.
+    obj.base_url = "https://api.openai.com/v1"
+    obj.client = _FakeOpenAI()
+    # Deaktiviere Streaming-Force-Pfad explizit (für alle Tests in diesem Modul).
+    monkeypatch.setenv("LLM_FORCE_STREAM", "false")
+    # E2E-Stub muss aus sein.
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    return obj
+
+
+def test_chat_sends_max_completion_tokens_for_gpt5(fake_client) -> None:
+    fake_client.model = "gpt-5-mini"
+    fake_client.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=4096,
+    )
+    captured = fake_client.client.chat.completions.captured_kwargs
+    assert captured is not None
+    assert captured.get("max_completion_tokens") == 4096
+    assert "max_tokens" not in captured
+
+
+def test_chat_sends_max_tokens_for_gpt4o(fake_client) -> None:
+    fake_client.model = "gpt-4o"
+    fake_client.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=2048,
+    )
+    captured = fake_client.client.chat.completions.captured_kwargs
+    assert captured is not None
+    assert captured.get("max_tokens") == 2048
+    assert "max_completion_tokens" not in captured
+
+
+def test_chat_sends_max_completion_tokens_for_o1_preview(fake_client) -> None:
+    fake_client.model = "o1-preview"
+    fake_client.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=8192,
+    )
+    captured = fake_client.client.chat.completions.captured_kwargs
+    assert captured is not None
+    assert captured.get("max_completion_tokens") == 8192
+    assert "max_tokens" not in captured
+
+
+def test_describe_image_picks_key_from_vision_model_not_self_model(fake_client) -> None:
+    """describe_image kann ein anderes Modell als self.model nutzen — die
+    Token-Key-Heuristik muss sich am tatsächlich versendeten Modell orientieren.
+    """
+    fake_client.model = "qwen2.5:32b"  # self.model -> max_tokens
+    fake_client.describe_image(
+        image_b64="aGVsbG8=",
+        prompt="describe",
+        model="gpt-5-vision",          # override -> max_completion_tokens
+        max_tokens=1024,
+    )
+    captured = fake_client.client.chat.completions.captured_kwargs
+    assert captured is not None
+    assert captured.get("max_completion_tokens") == 1024
+    assert "max_tokens" not in captured


### PR DESCRIPTION
## Summary
- `LLMClient.chat()` und `describe_image()` schicken jetzt je nach Modell entweder `max_tokens` oder `max_completion_tokens` — vorher immer `max_tokens`, was OpenAI für GPT-5 und die o1/o3/o4-Familie mit **400 Unsupported parameter** abgelehnt hat
- Heuristik gespiegelt aus `backend/scripts/_sim_common.py::uses_max_completion_tokens` (Single Source of Truth bleibt dort); Kommentar im neuen Helper verlinkt das
- Vision-Pfad nutzt das tatsächlich versendete Modell für die Key-Wahl, nicht `self.model`
- Observability-Label im `ModelActiveEvent` bleibt unverändert (`extra={'max_tokens': N}`) — das ist intern und nicht der OpenAI-Wire-Key

## Slice 1 / 3 — siehe Plan
Erster Schritt aus dem Bugfix-Plan zu „Frontend-Modellauswahl + GPT-5 400-Fix". Slice 2 (Ontology-Endpoint respektiert `llm_model`/`llm_provider`) und Slice 3 (Graph-Build + Persona) folgen in separaten PRs, damit Gemini Review-Findings sauber pro Konzern lesbar bleiben.

## Test plan
- [x] `tests/utils/test_llm_client_completion_token_routing.py` — neue Suite, 27 Cases:
  - Heuristik-Unit-Tests parametrisiert für GPT-5/o1/o3/o4 (true) und gpt-4o/qwen/gemini/leer (false)
  - Integration: `chat()` mit gpt-5-mini → `max_completion_tokens=4096` im OpenAI-SDK-Call, **kein** `max_tokens`
  - Integration: `chat()` mit gpt-4o → `max_tokens=2048`, **kein** `max_completion_tokens`
  - Integration: `chat()` mit o1-preview → `max_completion_tokens`
  - Integration: `describe_image(model='gpt-5-vision')` ignoriert `self.model='qwen2.5:32b'` und routet korrekt
- [x] Backend-Regression: 1904 passed, 2 skipped (Redis-Integration), 7 deselected
- [x] `ruff check app/ tests/` — clean
- [x] `mypy app` — Success
- [x] `dump_schemas` — kein Schema-Drift

## Out of scope (in dieser PR bewusst)
- Frontend-Persistenz der Modellauswahl auf den Ontology-Endpoint (Slice 2)
- NER-Extractor / Persona / GraphTools-LLM-Sharing (Slice 3)
- Konsolidierung der Heuristik zwischen `_sim_common.py` und `LLMClient` (Refactor-Slice später)

🤖 Generated with [Claude Code](https://claude.com/claude-code)