### PR TITLE
fix(graph): ontology endpoint respects frontend model + provider

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -4,6 +4,7 @@ Uses project context mechanism with server-side state persistence
 """
 
 import io
+import json
 import os
 import time
 import threading
@@ -12,11 +13,13 @@ from flask import Response, request, current_app
 from . import graph_bp
 from ..config import Config
 from ..services.ontology_generator import OntologyGenerator
+from ..services.llm_runtime import parse_runtime_llm_config
 from ..container import get_container
 from ..services.graph_builder import GraphBuilderService  # noqa: F401  (kept for type re-exports)
 from ..services.text_processor import TextProcessor
 from ..utils.file_parser import FileParser
 from ..utils.artifact_locator import ArtifactLocator
+from ..utils.llm_client import LLMClient
 from ..utils.logger import get_logger
 from ..utils.validation import validate_project_id, validate_graph_id, validate_task_id
 from ..models.task import TaskManager, TaskStatus
@@ -201,6 +204,32 @@ def generate_ontology():
             message="Please provide simulation requirement description (simulation_requirement)",
         )
 
+    # LLM-Override aus dem Frontend (Modell + optionaler Runtime-Provider).
+    # `MainView.handleNewProject` hängt `llm_model` und `llm_provider` (als
+    # JSON-String) ans FormData; ohne diese Felder fällt der LLMClient auf
+    # den Server-Default zurück.
+    llm_model_override = (request.form.get('llm_model') or '').strip() or None
+    llm_provider_raw = request.form.get('llm_provider')
+    if llm_provider_raw:
+        try:
+            llm_provider_payload = json.loads(llm_provider_raw)
+        except json.JSONDecodeError:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message="llm_provider must be a valid JSON object",
+            )
+    else:
+        llm_provider_payload = None
+    try:
+        llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
+    except ValueError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
+
     # Get uploaded files
     uploaded_files = request.files.getlist('files')
     if not uploaded_files or all(not f.filename for f in uploaded_files):
@@ -256,8 +285,13 @@ def generate_ontology():
     logger.info(f"Text extraction completed, total {len(all_text)} characters")
 
     # Generate ontology
-    logger.info("Calling LLM to generate ontology definition...")
-    generator = OntologyGenerator()
+    llm_client = LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+    logger.info(
+        "Calling LLM to generate ontology definition (model=%s, runtime_provider=%s)",
+        llm_client.model,
+        llm_runtime.provider,
+    )
+    generator = OntologyGenerator(llm_client=llm_client)
     ontology = generator.generate(
         document_texts=document_texts,
         simulation_requirement=simulation_requirement,
@@ -275,6 +309,11 @@ def generate_ontology():
     }
     project.analysis_summary = ontology.get("analysis_summary", "")
     project.status = ProjectStatus.ONTOLOGY_GENERATED
+    # Modellauswahl pro Projekt persistieren — Folgestufen (Build/Persona/
+    # Report) können sie als Default verwenden, wenn der jeweilige Request
+    # keinen Override mitschickt. Secrets bleiben ausserhalb (redacted_metadata).
+    project.llm_model = llm_model_override
+    project.llm_provider = llm_runtime.redacted_metadata() or None
     ProjectManager.save_project(project)
     logger.info(f"=== Ontology generation completed === Project ID: {project.project_id}")
 

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -49,6 +49,18 @@ class Project:
     chunk_size: int = 500
     chunk_overlap: int = 50
 
+    # LLM-Auswahl, die der Benutzer im Frontend für diesen Projekt-Run
+    # gewählt hat (Sub-Slice „ontology-respects-frontend-model"). Wird beim
+    # Ontology-Generate aus dem Request persistiert und kann von späteren
+    # Stufen (Build/Persona/Report) als Default herangezogen werden, ohne
+    # dass das Frontend bei jedem Folge-Request denselben Wert erneut
+    # mitschicken muss. `llm_provider` enthält **keine** Secrets — der
+    # API-Key bleibt bei der ``llm_runtime``-Konvention session-local; hier
+    # wird nur ``redacted_metadata()`` (Provider + Base-URL + api_key_set)
+    # abgelegt.
+    llm_model: Optional[str] = None
+    llm_provider: Optional[Dict[str, Any]] = None
+
     # Error information
     error: Optional[str] = None
 
@@ -69,6 +81,8 @@ class Project:
             "simulation_requirement": self.simulation_requirement,
             "chunk_size": self.chunk_size,
             "chunk_overlap": self.chunk_overlap,
+            "llm_model": self.llm_model,
+            "llm_provider": self.llm_provider,
             "error": self.error
         }
     
@@ -94,6 +108,8 @@ class Project:
             simulation_requirement=data.get('simulation_requirement'),
             chunk_size=data.get('chunk_size', 500),
             chunk_overlap=data.get('chunk_overlap', 50),
+            llm_model=data.get('llm_model'),
+            llm_provider=data.get('llm_provider'),
             error=data.get('error')
         )
 

--- a/backend/tests/api/test_graph_ontology_respects_frontend_model.py
+++ b/backend/tests/api/test_graph_ontology_respects_frontend_model.py
@@ -1,0 +1,249 @@
+"""POST /api/graph/ontology/generate respektiert die Frontend-Modellauswahl.
+
+Sub-Slice „ontology-respects-frontend-model" — Frontend hängt
+``llm_model`` (String) und ``llm_provider`` (JSON-String) ans FormData;
+Backend muss daraus den ``LLMClient`` parametrieren, statt blind auf
+``Config.LLM_MODEL_NAME`` zu fallen.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.container import AgoraContainer
+
+
+@pytest.fixture
+def app(monkeypatch):
+    storage = MagicMock(name="Neo4jStorage")
+    container = AgoraContainer(neo4j_storage=storage)
+    flask_app = Flask(__name__)
+    flask_app.config["AGORA_UPLOAD_RATE_LIMIT_MAX"] = 1000
+    flask_app.config["AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    flask_app.extensions = {"container": container, "neo4j_storage": storage}
+    flask_app.register_blueprint(graph_bp, url_prefix="/api/graph")
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _txt(payload: bytes = b"Document body for ontology run.") -> tuple:
+    return (io.BytesIO(payload), "doc.txt")
+
+
+def _make_project_mock():
+    """Project-Mock mit ausschließlich JSON-serialisierbaren Attributen,
+    damit ``json_success({...})`` am Endpoint-Ende nicht über MagicMock-Auto-Attrs stolpert.
+
+    Falle: ``MagicMock(name=...)`` setzt den Mock-Repr-Namen, **nicht** das
+    ``.name``-Attribut. Daher alle felder explizit zugewiesen.
+    """
+    mock = MagicMock()
+    mock.project_id = "proj_abcdef012345"
+    mock.name = "Test"
+    mock.files = []
+    mock.total_text_length = 42
+    mock.ontology = None
+    mock.analysis_summary = None
+    mock.llm_model = None
+    mock.llm_provider = None
+    mock.simulation_requirement = None
+    return mock
+
+
+@patch("app.api.graph.LLMClient")
+@patch("app.api.graph.OntologyGenerator")
+@patch("app.api.graph.ProjectManager")
+@patch("app.api.graph.FileParser")
+@patch("app.api.graph.TextProcessor")
+def test_ontology_generate_uses_frontend_llm_model_and_provider(
+    text_processor_cls,
+    file_parser_cls,
+    project_manager_cls,
+    ontology_generator_cls,
+    llm_client_cls,
+    client,
+):
+    # --- Arrange Stubs ---
+    project_manager_cls.create_project.return_value = _make_project_mock()
+    project_manager_cls.save_file_to_project.return_value = {
+        "original_filename": "doc.txt",
+        "path": "/tmp/doc.txt",
+        "size": 42,
+    }
+    file_parser_cls.extract_text.return_value = "extracted text content"
+    text_processor_cls.preprocess_text.return_value = "cleaned text"
+
+    generator = MagicMock()
+    generator.generate.return_value = {
+        "entity_types": [{"name": "Person"}],
+        "edge_types": [{"name": "KNOWS"}],
+        "analysis_summary": "ok",
+    }
+    ontology_generator_cls.return_value = generator
+
+    # --- Act ---
+    response = client.post(
+        "/api/graph/ontology/generate",
+        data={
+            "simulation_requirement": "Discuss climate policy.",
+            "files": _txt(),
+            "llm_model": "gpt-5-mini",
+            "llm_provider": json.dumps(
+                {
+                    "provider": "openai",
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            ),
+        },
+        content_type="multipart/form-data",
+    )
+
+    # --- Assert ---
+    assert response.status_code == 200, response.get_json()
+    assert response.get_json()["success"] is True
+
+    # LLMClient muss mit dem Frontend-Modell + Provider-Override instanziiert sein.
+    llm_client_cls.assert_called_once()
+    kwargs = llm_client_cls.call_args.kwargs
+    assert kwargs.get("model") == "gpt-5-mini"
+    assert kwargs.get("api_key") == "sk-test"
+    assert kwargs.get("base_url") == "https://api.openai.com/v1"
+
+    # OntologyGenerator muss den injizierten Client bekommen.
+    ontology_generator_cls.assert_called_once()
+    assert ontology_generator_cls.call_args.kwargs.get("llm_client") is llm_client_cls.return_value
+
+
+@patch("app.api.graph.LLMClient")
+@patch("app.api.graph.OntologyGenerator")
+@patch("app.api.graph.ProjectManager")
+@patch("app.api.graph.FileParser")
+@patch("app.api.graph.TextProcessor")
+def test_ontology_generate_without_overrides_uses_server_default(
+    text_processor_cls,
+    file_parser_cls,
+    project_manager_cls,
+    ontology_generator_cls,
+    llm_client_cls,
+    client,
+):
+    """Backwards-Kompat: Ohne llm_model/llm_provider bleibt LLMClient(model=None) → Server-Default."""
+    project_manager_cls.create_project.return_value = _make_project_mock()
+    project_manager_cls.save_file_to_project.return_value = {
+        "original_filename": "doc.txt",
+        "path": "/tmp/doc.txt",
+        "size": 42,
+    }
+    file_parser_cls.extract_text.return_value = "x"
+    text_processor_cls.preprocess_text.return_value = "x"
+    ontology_generator_cls.return_value.generate.return_value = {
+        "entity_types": [],
+        "edge_types": [],
+        "analysis_summary": "",
+    }
+
+    response = client.post(
+        "/api/graph/ontology/generate",
+        data={"simulation_requirement": "Need ontology.", "files": _txt()},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200, response.get_json()
+    llm_client_cls.assert_called_once()
+    kwargs = llm_client_cls.call_args.kwargs
+    # Ohne Runtime-Provider liefert client_kwargs nur {"model": None}.
+    assert kwargs == {"model": None}
+
+
+def test_ontology_generate_rejects_invalid_llm_provider_json(client):
+    response = client.post(
+        "/api/graph/ontology/generate",
+        data={
+            "simulation_requirement": "x",
+            "files": _txt(),
+            "llm_provider": "not-json-{{{",
+        },
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "validation_failed"
+    assert "llm_provider" in payload["error"].lower()
+
+
+def test_ontology_generate_rejects_provider_without_api_key(client):
+    response = client.post(
+        "/api/graph/ontology/generate",
+        data={
+            "simulation_requirement": "x",
+            "files": _txt(),
+            "llm_provider": json.dumps({"provider": "openai"}),
+        },
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "validation_failed"
+
+
+@patch("app.api.graph.LLMClient")
+@patch("app.api.graph.OntologyGenerator")
+@patch("app.api.graph.ProjectManager")
+@patch("app.api.graph.FileParser")
+@patch("app.api.graph.TextProcessor")
+def test_ontology_generate_persists_llm_metadata_on_project(
+    text_processor_cls,
+    file_parser_cls,
+    project_manager_cls,
+    ontology_generator_cls,
+    llm_client_cls,
+    client,
+):
+    """Modell + redacted Provider-Metadaten landen am Projekt — Secrets bleiben draußen."""
+    project_mock = _make_project_mock()
+    project_manager_cls.create_project.return_value = project_mock
+    project_manager_cls.save_file_to_project.return_value = {
+        "original_filename": "doc.txt",
+        "path": "/tmp/doc.txt",
+        "size": 42,
+    }
+    file_parser_cls.extract_text.return_value = "x"
+    text_processor_cls.preprocess_text.return_value = "x"
+    ontology_generator_cls.return_value.generate.return_value = {
+        "entity_types": [],
+        "edge_types": [],
+        "analysis_summary": "",
+    }
+
+    client.post(
+        "/api/graph/ontology/generate",
+        data={
+            "simulation_requirement": "x",
+            "files": _txt(),
+            "llm_model": "gpt-4o",
+            "llm_provider": json.dumps(
+                {"provider": "openai", "api_key": "sk-secret", "base_url": "https://api.openai.com/v1"}
+            ),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert project_mock.llm_model == "gpt-4o"
+    # redacted_metadata() liefert provider/base_url/api_key_set — KEIN api_key-Klartext.
+    assert project_mock.llm_provider is not None
+    assert "api_key" not in project_mock.llm_provider
+    assert project_mock.llm_provider.get("provider") == "openai"
+    assert project_mock.llm_provider.get("api_key_set") is True

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -16,6 +16,8 @@ import { getPendingUpload, clearPendingUpload } from '../store/pendingUpload'
 import { usePolling } from '../composables/usePolling'
 import { useSystemLog } from '../composables/useSystemLog'
 import { useWorkspaceMode } from '../composables/useWorkspaceMode'
+import { storedEffectiveModel } from '../composables/useEnvForm'
+import { runtimeLlmPayloadFromStorage } from '../composables/useRuntimeLlmOptions'
 
 const route = useRoute()
 const router = useRouter()
@@ -125,6 +127,14 @@ async function handleNewProject() {
     const formData = new FormData()
     pending.files.forEach((f) => formData.append('files', f))
     formData.append('simulation_requirement', pending.simulationRequirement)
+    // Frontend-Modellauswahl pro Run an Ontology-Endpoint anhängen, damit
+    // alle nachgelagerten LLM-Aufrufe (Ontology, Build, Persona, Report)
+    // dasselbe Modell verwenden. Helper kommen aus Step2/3/4 — gleiche
+    // localStorage-/sessionStorage-Keys wie dort, kein neuer Pinia-Store.
+    const selectedModel = storedEffectiveModel()
+    if (selectedModel) formData.append('llm_model', selectedModel)
+    const runtimeProvider = runtimeLlmPayloadFromStorage()
+    if (runtimeProvider) formData.append('llm_provider', JSON.stringify(runtimeProvider))
     const res = await generateOntology(formData)
     if (res.success) {
       clearPendingUpload()


### PR DESCRIPTION
## Summary
- Frontend (`MainView.handleNewProject`): hängt `llm_model` (aus `storedEffectiveModel()`) und `llm_provider` (JSON aus `runtimeLlmPayloadFromStorage()`) ans FormData — gleiche Helper wie in Step2/3/4
- Backend (`api/graph.generate_ontology`): parst beide via `parse_runtime_llm_config` (Vorbild: `api/report.py:200ff`) und injiziert `LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))` in den `OntologyGenerator`
- Projekt-Modell hat zwei neue optionale Felder `llm_model` + `llm_provider` (nur `redacted_metadata()`, keine Secrets) — Folgestufen Build/Persona/Report können sie als Default verwenden, ohne dass das Frontend bei jedem Request dasselbe erneut mitschickt

## Slice 2 / 3
Aufbauend auf [#370](https://github.com/arn0ld87/agora/pull/370) (max_completion_tokens-Routing). Mit beiden zusammen funktioniert die Frontend-Modellauswahl im Ontology-Pfad inkl. GPT-5/o1/o3/o4 ohne OpenAI-400. Slice 3 (Graph-Build, Persona/Simulation, Report graph_tools sharing) folgt separat.

## Test plan
- [x] `tests/api/test_graph_ontology_respects_frontend_model.py` — 5 neue Cases:
  - `llm_model='gpt-5-mini'` + `llm_provider={openai, sk-test, …}` → `LLMClient(model='gpt-5-mini', api_key='sk-test', base_url='https://api.openai.com/v1')`, `OntologyGenerator(llm_client=...)` verifiziert
  - Backwards-Kompat: ohne Overrides → `LLMClient(model=None)` (Server-Default)
  - 400 bei kaputtem `llm_provider`-JSON
  - 400 bei `llm_provider` ohne `api_key`
  - `project.llm_provider` enthält keinen `api_key`-Klartext, nur `provider/base_url/api_key_set`
- [x] Backend-Regression: 1914 passed, 2 skipped (Redis), 7 deselected
- [x] `ruff check app/ tests/` clean
- [x] `mypy app` Success (138 files)
- [x] `dump_schemas` — kein Schema-Drift
- [x] `frontend/npm run check` — Lint + Build + Tests grün
- [ ] Manueller Smoke nach Merge: Step1 Modell wählen + OpenAI-Key eintragen, Datei hochladen → Backend-Log zeigt korrektes Modell + 200

## Out of scope (Slice 3 später)
- `GraphBuilderService` + `NERExtractor` Konstruktor um `llm_client`-Injektion erweitern (Build-Pfad)
- `OasisProfileGenerator` / `SimulationConfigGenerator` analog
- `GraphToolsService` von `ReportAgent` mit demselben LLMClient versorgen (heute instanziiert es einen eigenen Default)
- Status-Banner im UI für das aktive Modell (Slice 4, optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)