### PR TITLE
fix(llm): 400 fallback-retry for max_tokens vs max_completion_tokens

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -127,6 +127,58 @@ class LLMClient:
                 return True
         return False
 
+    @staticmethod
+    def _is_token_key_400(exc: Exception) -> bool:
+        """True wenn ein OpenAI-/Proxy-400 auf eine Token-Limit-Key-Inkompatibilität hindeutet.
+
+        Erkennt beide Richtungen, je nachdem welcher Schlüssel im Request stand:
+        - „'max_tokens' is not supported with this model. Use 'max_completion_tokens'"
+        - „'max_completion_tokens' is not supported …" / Unsupported parameter
+
+        Wird von ``chat()`` als Fallback-Retry-Trigger genutzt — Heuristik
+        kann z. B. bei einem neuen OpenAI-kompatiblen Proxy daneben liegen,
+        und dann reicht der Wortlaut der Antwort als Fallback.
+        """
+        try:
+            from openai import APIStatusError
+        except ImportError:
+            APIStatusError = ()  # type: ignore[assignment]
+
+        if APIStatusError and isinstance(exc, APIStatusError):
+            status = getattr(exc, "status_code", None)
+            if status is None:
+                response = getattr(exc, "response", None)
+                status = getattr(response, "status_code", None)
+            if status != 400:
+                return False
+        msg = str(exc).lower()
+        if "max_tokens" not in msg and "max_completion_tokens" not in msg:
+            return False
+        return (
+            "not supported" in msg
+            or "unsupported parameter" in msg
+            or "use 'max_completion_tokens'" in msg
+            or "use 'max_tokens'" in msg
+            or "use max_completion_tokens" in msg
+            or "use max_tokens" in msg
+        )
+
+    @staticmethod
+    def _swap_token_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Liefert eine Kopie von *kwargs* mit getauschtem Token-Limit-Schlüssel,
+        oder ``None`` wenn keiner der beiden Schlüssel gesetzt ist.
+        """
+        swapped = dict(kwargs)
+        if "max_tokens" in swapped:
+            value = swapped.pop("max_tokens")
+            swapped["max_completion_tokens"] = value
+            return swapped
+        if "max_completion_tokens" in swapped:
+            value = swapped.pop("max_completion_tokens")
+            swapped["max_tokens"] = value
+            return swapped
+        return None
+
     def _completion_token_kwargs(
         self, max_tokens: int, model: Optional[str] = None
     ) -> Dict[str, int]:
@@ -267,15 +319,41 @@ class LLMClient:
 
         import time as _time
         _t0 = _time.monotonic()
-        if force_stream:
-            kwargs["stream"] = True
-            stream = llm_call_with_retry(
+
+        def _create(call_kwargs: Dict[str, Any]):
+            """One-shot call mit transient-retry. KEINE 400-Behandlung — die macht der äußere Wrapper."""
+            return llm_call_with_retry(
                 self.client.chat.completions.create,
                 max_retries=self._max_retries,
                 initial_delay=self._retry_initial_delay,
                 max_delay=self._retry_max_delay,
-                **kwargs,
+                **call_kwargs,
             )
+
+        def _call_with_token_key_fallback(call_kwargs: Dict[str, Any]):
+            """Fallback-Retry: bei 400 wg. max_tokens/max_completion_tokens-Inkompatibilität
+            einmalig den anderen Schlüssel verwenden. Heuristik in
+            ``_uses_max_completion_tokens`` deckt die bekannten Familien ab; der
+            Fallback schützt vor neuen Modellen/Proxies, die wir noch nicht kennen.
+            """
+            try:
+                return _create(call_kwargs)
+            except Exception as exc:  # noqa: BLE001 — wir filtern selbst
+                if not self._is_token_key_400(exc):
+                    raise
+                swapped = self._swap_token_kwargs(call_kwargs)
+                if swapped is None:
+                    raise
+                logger.warning(
+                    "LLM 400 on token-limit key — retrying once with swapped key (model=%s, msg=%s)",
+                    self.model,
+                    str(exc)[:200],
+                )
+                return _create(swapped)
+
+        if force_stream:
+            kwargs["stream"] = True
+            stream = _call_with_token_key_fallback(kwargs)
             chunks: List[str] = []
             finish_reason = None
             completion_tokens = None
@@ -293,13 +371,7 @@ class LLMClient:
                     completion_tokens = usage.completion_tokens
             content = "".join(chunks)
         else:
-            response = llm_call_with_retry(
-                self.client.chat.completions.create,
-                max_retries=self._max_retries,
-                initial_delay=self._retry_initial_delay,
-                max_delay=self._retry_max_delay,
-                **kwargs,
-            )
+            response = _call_with_token_key_fallback(kwargs)
             choice = response.choices[0]
             finish_reason = getattr(choice, "finish_reason", None)
             usage = getattr(response, "usage", None)
@@ -354,13 +426,28 @@ class LLMClient:
             extra_body["think"] = False  # never want reasoning noise in vision output
             kwargs["extra_body"] = extra_body
 
-        response = llm_call_with_retry(
-            self.client.chat.completions.create,
-            max_retries=self._max_retries,
-            initial_delay=self._retry_initial_delay,
-            max_delay=self._retry_max_delay,
-            **kwargs,
-        )
+        def _create_vision(call_kwargs: Dict[str, Any]):
+            return llm_call_with_retry(
+                self.client.chat.completions.create,
+                max_retries=self._max_retries,
+                initial_delay=self._retry_initial_delay,
+                max_delay=self._retry_max_delay,
+                **call_kwargs,
+            )
+
+        try:
+            response = _create_vision(kwargs)
+        except Exception as exc:  # noqa: BLE001
+            if not self._is_token_key_400(exc):
+                raise
+            swapped = self._swap_token_kwargs(kwargs)
+            if swapped is None:
+                raise
+            logger.warning(
+                "Vision LLM 400 on token-limit key — retrying once with swapped key (model=%s)",
+                vision_model,
+            )
+            response = _create_vision(swapped)
         content = response.choices[0].message.content or ""
         content = re.sub(r'<think>[\s\S]*?</think>', '', content, flags=re.IGNORECASE).strip()
         return content

--- a/backend/tests/utils/test_llm_client_token_key_fallback.py
+++ b/backend/tests/utils/test_llm_client_token_key_fallback.py
@@ -1,0 +1,271 @@
+"""Slice 1b: 400-Fallback-Retry für max_tokens ↔ max_completion_tokens.
+
+Die Heuristik in ``_uses_max_completion_tokens`` deckt die heutigen GPT-5/
+o-Modelle ab, aber ein neuer Proxy oder ein neues Modell kann den Trigger
+verschieben. Wenn das Backend einen 400 mit Wortlaut „'max_tokens' is not
+supported … use 'max_completion_tokens'" (oder umgekehrt) bekommt, muss
+``LLMClient.chat()`` **einmalig** mit getauschtem Schlüssel retryen — kein
+Endlos-Retry, kein 4xx-Loop.
+
+Streaming + Non-Streaming + describe_image sind alle abgedeckt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.llm_client import LLMClient
+
+
+# ---------------------------------------------------------------------------
+# Heuristik-Unit-Tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenAIBadRequest(Exception):
+    """Ersatz für openai.BadRequestError, falls openai im Test nicht installiert ist.
+
+    Die Heuristik in ``_is_token_key_400`` greift auf den Wortlaut, nicht
+    auf den Typ — daher reicht eine Exception mit der richtigen Message.
+    """
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Error code: 400 - Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+        "Unsupported parameter: 'max_completion_tokens' is not supported with this model. Use 'max_tokens' instead.",
+        "BadRequest: max_tokens is not supported, use max_completion_tokens",
+        "max_completion_tokens is not supported with this provider, use max_tokens",
+    ],
+)
+def test_is_token_key_400_matches_known_wordings(message: str) -> None:
+    exc = _FakeOpenAIBadRequest(message)
+    assert LLMClient._is_token_key_400(exc) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Connection reset by peer",
+        "Rate limit exceeded (429)",
+        "Invalid API key",
+        "max_tokens parameter is required",  # generic validation, kein 400-Routing-Hint
+        "",
+    ],
+)
+def test_is_token_key_400_ignores_unrelated_errors(message: str) -> None:
+    exc = _FakeOpenAIBadRequest(message)
+    assert LLMClient._is_token_key_400(exc) is False
+
+
+def test_swap_token_kwargs_max_tokens_to_completion() -> None:
+    swapped = LLMClient._swap_token_kwargs({"model": "x", "max_tokens": 4096})
+    assert swapped == {"model": "x", "max_completion_tokens": 4096}
+
+
+def test_swap_token_kwargs_completion_to_max_tokens() -> None:
+    swapped = LLMClient._swap_token_kwargs({"model": "x", "max_completion_tokens": 2048})
+    assert swapped == {"model": "x", "max_tokens": 2048}
+
+
+def test_swap_token_kwargs_no_key_returns_none() -> None:
+    assert LLMClient._swap_token_kwargs({"model": "x", "messages": []}) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: chat() retried einmalig mit getauschtem Key
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    completion_tokens = 42
+
+
+class _FakeMessage:
+    content = '{"ok": true}'
+
+
+class _FakeChoice:
+    finish_reason = "stop"
+    message = _FakeMessage()
+
+
+class _FakeResponse:
+    choices = [_FakeChoice()]
+    usage = _FakeUsage()
+
+
+class _FlakyCompletions:
+    """Wirft beim ersten Call einen 400-Token-Key-Error; beim zweiten gibt sie 200 zurück."""
+
+    def __init__(self, fail_first_with: str) -> None:
+        self.calls: list[dict] = []
+        self._fail_first_with = fail_first_with
+
+    def create(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        if len(self.calls) == 1:
+            raise _FakeOpenAIBadRequest(self._fail_first_with)
+        return _FakeResponse()
+
+
+class _FakeChat:
+    def __init__(self, completions) -> None:
+        self.completions = completions
+
+
+class _FakeOpenAI:
+    def __init__(self, completions) -> None:
+        self.chat = _FakeChat(completions)
+
+
+@pytest.fixture()
+def fake_client(monkeypatch):
+    obj = LLMClient.__new__(LLMClient)
+    obj._max_retries = 0
+    obj._retry_initial_delay = 0.0
+    obj._retry_max_delay = 0.0
+    obj._num_ctx = 8192
+    obj._think = False
+    obj.api_key = "test"
+    obj.base_url = "https://api.openai.com/v1"
+    obj.model = "gpt-4o"  # Heuristik sagt max_tokens
+    monkeypatch.setenv("LLM_FORCE_STREAM", "false")
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    return obj
+
+
+def test_chat_retries_with_swapped_key_on_400(fake_client) -> None:
+    """gpt-4o sendet max_tokens. Wenn der Proxy 400 wirft mit 'use max_completion_tokens',
+    soll der zweite Versuch max_completion_tokens enthalten — kein dritter Versuch.
+    """
+    completions = _FlakyCompletions(
+        fail_first_with=(
+            "Error code: 400 - Unsupported parameter: 'max_tokens' is not "
+            "supported with this model. Use 'max_completion_tokens' instead."
+        )
+    )
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.chat(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
+
+    assert len(completions.calls) == 2, "must retry exactly once"
+    # 1. Versuch: Heuristik → max_tokens
+    assert completions.calls[0].get("max_tokens") == 4096
+    assert "max_completion_tokens" not in completions.calls[0]
+    # 2. Versuch: getauscht
+    assert completions.calls[1].get("max_completion_tokens") == 4096
+    assert "max_tokens" not in completions.calls[1]
+
+
+def test_chat_retries_in_other_direction_too(fake_client) -> None:
+    """gpt-5-mini sendet max_completion_tokens. Wenn ein älterer Proxy 400 wirft mit
+    'use max_tokens', muss der Fallback in die andere Richtung greifen.
+    """
+    fake_client.model = "gpt-5-mini"
+    completions = _FlakyCompletions(
+        fail_first_with=(
+            "Unsupported parameter: 'max_completion_tokens' is not supported "
+            "with this model. Use 'max_tokens' instead."
+        )
+    )
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.chat(messages=[{"role": "user", "content": "hi"}], max_tokens=2048)
+
+    assert len(completions.calls) == 2
+    assert completions.calls[0].get("max_completion_tokens") == 2048
+    assert "max_tokens" not in completions.calls[0]
+    assert completions.calls[1].get("max_tokens") == 2048
+    assert "max_completion_tokens" not in completions.calls[1]
+
+
+def test_chat_does_not_retry_on_unrelated_400(fake_client) -> None:
+    """Ein 400, der nichts mit Token-Limit zu tun hat, propagiert sofort —
+    kein Endlos-Retry, kein Verschleiern echter Validation-Fehler."""
+
+    class _AlwaysFail:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def create(self, **kwargs):
+            self.calls += 1
+            raise _FakeOpenAIBadRequest("Invalid API key")
+
+    completions = _AlwaysFail()
+    fake_client.client = _FakeOpenAI(completions)
+
+    with pytest.raises(_FakeOpenAIBadRequest):
+        fake_client.chat(messages=[{"role": "user", "content": "hi"}], max_tokens=1024)
+    assert completions.calls == 1, "must NOT retry unrelated 400"
+
+
+def test_chat_streaming_path_also_falls_back(monkeypatch) -> None:
+    """Force-Stream (Ollama) muss denselben Fallback nutzen — Streaming-Pfad
+    war historisch der häufigere, weil Ollama Cloud non-stream stalled.
+    """
+    obj = LLMClient.__new__(LLMClient)
+    obj._max_retries = 0
+    obj._retry_initial_delay = 0.0
+    obj._retry_max_delay = 0.0
+    obj._num_ctx = 8192
+    obj._think = False
+    obj.api_key = "test"
+    obj.base_url = "http://localhost:11434/v1"  # Ollama → force_stream
+    obj.model = "qwen2.5:32b"
+    monkeypatch.setenv("LLM_FORCE_STREAM", "true")
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+    # Streaming-Response simulieren: eine einzige fake-chunk-Folge.
+    class _Chunk:
+        def __init__(self, content=None, finish=None):
+            self.choices = [
+                type("Choice", (), {
+                    "delta": type("Delta", (), {"content": content})(),
+                    "finish_reason": finish,
+                })()
+            ]
+            self.usage = None
+
+    def fake_iter():
+        yield _Chunk(content="ok", finish=None)
+        yield _Chunk(content=None, finish="stop")
+
+    class _StreamingFlaky:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def create(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            if len(self.calls) == 1:
+                raise _FakeOpenAIBadRequest(
+                    "'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."
+                )
+            return fake_iter()
+
+    completions = _StreamingFlaky()
+    obj.client = _FakeOpenAI(completions)
+
+    obj.chat(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
+
+    assert len(completions.calls) == 2
+    assert completions.calls[0].get("max_tokens") == 4096
+    assert completions.calls[1].get("max_completion_tokens") == 4096
+
+
+def test_describe_image_falls_back_too(fake_client) -> None:
+    """Vision-Pfad muss denselben Fallback haben — sonst läuft ein neues
+    Vision-Modell beim nächsten Mal wieder auf 400 auf.
+    """
+    completions = _FlakyCompletions(
+        fail_first_with=(
+            "Unsupported parameter: 'max_tokens' is not supported. Use 'max_completion_tokens' instead."
+        )
+    )
+    fake_client.client = _FakeOpenAI(completions)
+    fake_client.describe_image(image_b64="aGVsbG8=", prompt="describe", max_tokens=1024)
+
+    assert len(completions.calls) == 2
+    assert completions.calls[0].get("max_tokens") == 1024
+    assert completions.calls[1].get("max_completion_tokens") == 1024


### PR DESCRIPTION
## Summary
Plan-Review-Punkt 1: Heuristik allein ist nicht robust gegen neue OpenAI-kompatible Proxies oder neue Modellfamilien. Wenn der Backend trotz Heuristik einen 400 mit Wortlaut „'max_tokens' is not supported … use 'max_completion_tokens'" (oder umgekehrt) zurückgibt, retried `LLMClient.chat()` und `describe_image()` jetzt **einmalig** mit getauschtem Schlüssel — kein Endlos-Retry, kein Verschleiern echter 4xx-Validation-Fehler.

## Änderungen
- `LLMClient._is_token_key_400(exc)`: wortlautbasierte Erkennung (string match), zusätzlich Status-Code-Check wenn `openai.APIStatusError` vorliegt — keine False-Positives auf unverwandte 4xx.
- `LLMClient._swap_token_kwargs(kwargs)`: liefert Kopie mit getauschtem Schlüssel oder `None`.
- `chat()` (Streaming + Non-Streaming) wrappt den SDK-Call in `_call_with_token_key_fallback`. `describe_image()` mirror't dieselbe Logik.
- Beobachtung: `_publish_model_active`-Bus-Label bleibt `extra={'max_tokens': N}` — internes Telemetrie, kein API-Wire-Key.

## Slice 1b — folgt auf [#370](https://github.com/arn0ld87/agora/pull/370)
Mit Slice 1 + 1b ist der LLMClient gegen den OpenAI-400 sowohl präventiv (Heuristik) als auch reaktiv (Fallback) abgesichert. Slice 3 (Build-NER-Injection + Report-graph_tools-Sharing) folgt separat.

## Test plan
- [x] `tests/utils/test_llm_client_token_key_fallback.py` — 16 Cases:
  - Wording-Heuristik parametrisiert: 4 echte 400-Varianten (true), 5 unverwandte Fehler inkl. leerer String (false)
  - `_swap_token_kwargs` deckt beide Richtungen + None-Fall
  - `chat()` Integration: gpt-4o → 400 → Retry mit `max_completion_tokens`
  - `chat()` Integration: gpt-5-mini → 400 → Retry mit `max_tokens` (Gegenrichtung)
  - `chat()` Integration: unrelated 400 (z. B. "Invalid API key") propagiert sofort, keine Retry-Schleife
  - Streaming-Pfad (Ollama force_stream) → Retry funktioniert auch über fake-iterator-Streaming-Antwort
  - `describe_image()` retried analog
- [x] Backend-Regression: 1931 passed, 2 skipped (Redis), 7 deselected
- [x] `ruff check app/utils tests/utils` clean
- [x] `mypy app/utils/llm_client.py` Success
- [x] `dump_schemas` — kein Schema-Drift (Layer 0 unangetastet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)