### PR TITLE
fix(graph,report): frontend model reaches NER + GraphTools shares LLMClient

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -17,6 +17,7 @@ from ..services.llm_runtime import parse_runtime_llm_config
 from ..container import get_container
 from ..services.graph_builder import GraphBuilderService  # noqa: F401  (kept for type re-exports)
 from ..services.text_processor import TextProcessor
+from ..storage.ner_extractor import NERExtractor
 from ..utils.file_parser import FileParser
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.llm_client import LLMClient
@@ -361,6 +362,23 @@ def build_graph():
             message=f"Project does not exist: {project_id}",
         )
 
+    # LLM-Override für den Build-Pfad (Sub-Slice „build-respects-frontend-model").
+    # Reihenfolge: explizit im Request > persistiert am Projekt aus dem
+    # Ontology-Schritt > Server-Default. Secrets (api_key) sind im Projekt
+    # nicht persistiert (redacted_metadata) — daher kann der Build den
+    # Provider-Override nur dann rekonstruieren, wenn der Request ihn
+    # erneut mitschickt. Modell-Name allein wird vom Projekt-Default geerbt.
+    llm_model_override = (data.get('llm_model') or '').strip() or project.llm_model or None
+    llm_provider_payload = data.get('llm_provider')
+    try:
+        llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
+    except ValueError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
+
     # Check project status
     force = data.get('force', False)  # Force rebuild
 
@@ -450,6 +468,20 @@ def build_graph():
     project.graph_build_task_id = task_id
     ProjectManager.save_project(project)
 
+    # NER-Override pro Build: wenn der Request (oder das Projekt-Default)
+    # ein Frontend-Modell vorgibt, bauen wir einen dedizierten NERExtractor,
+    # damit Phase-1-Extraktion das gewählte Modell nutzt — ohne den
+    # globalen Storage-Singleton-NER zu mutieren.
+    ner_override: NERExtractor | None = None
+    if llm_runtime.enabled or llm_model_override:
+        ner_llm_client = LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+        ner_override = NERExtractor(llm_client=ner_llm_client)
+        logger.info(
+            "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s",
+            ner_llm_client.model,
+            llm_runtime.provider,
+        )
+
     # Start background task
     def build_task():
         build_logger = get_logger('agora.build')
@@ -527,7 +559,8 @@ def build_graph():
                 graph_id,
                 chunks,
                 batch_size=3,
-                progress_callback=add_progress_callback
+                progress_callback=add_progress_callback,
+                ner_extractor=ner_override,
             )
 
             # Neo4j processing is synchronous, no need to wait

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -194,7 +194,17 @@ def generate_report():
     storage = current_app.extensions.get('neo4j_storage')
     if not storage:
         return json_error("GraphStorage not initialized — check Neo4j connection", status=500)
-    graph_tools = GraphToolsService(storage=storage)
+
+    # Bug-Fix: ReportAgent und GraphToolsService müssen denselben LLMClient
+    # teilen, sonst nutzt GraphToolsService.llm beim Lazy-Init ``LLMClient()``
+    # mit Config-Default — egal welches Modell der User für den Report gewählt
+    # hat. Wir bauen den Client hier einmal und reichen ihn in beide rein.
+    shared_llm_client = (
+        LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+        if (llm_runtime.enabled or llm_model_override)
+        else None
+    )
+    graph_tools = GraphToolsService(storage=storage, llm_client=shared_llm_client)
 
     def run_generate():
         try:
@@ -204,11 +214,7 @@ def generate_report():
                 simulation_id=simulation_id,
                 simulation_requirement=simulation_requirement,
                 graph_tools=graph_tools,
-                llm_client=(
-                    LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
-                    if llm_runtime.enabled
-                    else None
-                ),
+                llm_client=shared_llm_client,
                 model_name=llm_model_override,
             )
             def progress_callback(stage, progress, message):

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -31,6 +31,7 @@ from ..services.run_registry import RunRegistry
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import RunnerStatus, SimulationRunner
 from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.llm_client import LLMClient
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.logger import get_logger
 from ..utils.validation import validate_run_id
@@ -598,7 +599,14 @@ def _resume_report_generate(run: dict):
     storage = current_app.extensions.get("neo4j_storage")
     if not storage:
         raise ValueError("GraphStorage not initialized")
-    graph_tools = GraphToolsService(storage=storage)
+    # Resume-Pfad teilt denselben LLMClient zwischen Agent und GraphTools
+    # — api_key bleibt redacted (Secrets nicht persistiert), aber das Modell
+    # kommt sauber aus der Run-Metadata durch. Vorher hat GraphTools beim
+    # Lazy-Init Config-Default genommen.
+    shared_llm_client = (
+        LLMClient(model=llm_model_override) if llm_model_override else None
+    )
+    graph_tools = GraphToolsService(storage=storage, llm_client=shared_llm_client)
 
     task_manager = TaskManager()
     task_id = task_manager.create_task(
@@ -614,6 +622,7 @@ def _resume_report_generate(run: dict):
                 simulation_id=simulation_id,
                 simulation_requirement=project.simulation_requirement or "",
                 graph_tools=graph_tools,
+                llm_client=shared_llm_client,
                 model_name=llm_model_override,
             )
 

--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -15,6 +15,13 @@ from ..models.task import TaskManager, TaskStatus
 from ..storage import GraphStorage
 from .text_processor import TextProcessor
 
+# Forward-import nur fürs Type-Hint — der konkrete Extractor wird vom
+# Aufrufer (api/graph.py::build_graph) gebaut und durchgereicht, damit
+# der Storage-Singleton-NER unangetastet bleibt.
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..storage.ner_extractor import NERExtractor
+
 logger = logging.getLogger('agora.graph_builder')
 
 
@@ -52,7 +59,8 @@ class GraphBuilderService:
         graph_name: str = "Agora Graph",
         chunk_size: int = 500,
         chunk_overlap: int = 50,
-        batch_size: int = 3
+        batch_size: int = 3,
+        ner_extractor: Optional["NERExtractor"] = None,
     ) -> str:
         """
         Build graph asynchronously
@@ -64,6 +72,10 @@ class GraphBuilderService:
             chunk_size: Text chunk size
             chunk_overlap: Chunk overlap size
             batch_size: Number of chunks to send per batch
+            ner_extractor: optionaler NER-Override pro Build-Run (Sub-Slice
+                „build-respects-frontend-model"). Wenn gesetzt, wird er an
+                ``storage.add_text`` durchgereicht — der Storage-Singleton-NER
+                bleibt unverändert für andere Pfade.
 
         Returns:
             Task ID
@@ -81,7 +93,7 @@ class GraphBuilderService:
         # Execute build in background thread
         thread = threading.Thread(
             target=self._build_graph_worker,
-            args=(task_id, text, ontology, graph_name, chunk_size, chunk_overlap, batch_size)
+            args=(task_id, text, ontology, graph_name, chunk_size, chunk_overlap, batch_size, ner_extractor)
         )
         thread.daemon = True
         thread.start()
@@ -96,7 +108,8 @@ class GraphBuilderService:
         graph_name: str,
         chunk_size: int,
         chunk_overlap: int,
-        batch_size: int
+        batch_size: int,
+        ner_extractor: Optional["NERExtractor"] = None,
     ):
         """Graph build worker thread"""
         try:
@@ -139,7 +152,8 @@ class GraphBuilderService:
                     task_id,
                     progress=20 + int(prog * 0.6),  # 20-80%
                     message=msg
-                )
+                ),
+                ner_extractor=ner_extractor,
             )
 
             # 5. Wait for processing (no-op for Neo4j — already synchronous)
@@ -188,7 +202,8 @@ class GraphBuilderService:
         graph_id: str,
         chunks: List[str],
         batch_size: int = 3,
-        progress_callback: Optional[Callable[[str, float, int, int], None]] = None
+        progress_callback: Optional[Callable[[str, float, int, int], None]] = None,
+        ner_extractor: Optional["NERExtractor"] = None,
     ) -> List[str]:
         """Add text chunks to graph in parallel, return uuid list of all episodes.
 
@@ -201,6 +216,9 @@ class GraphBuilderService:
           - progress_ratio (float): 0.0–1.0 completion ratio
           - completed (int): number of chunks committed so far (monotonically increasing)
           - total (int): total number of chunks in this build
+
+        ``ner_extractor`` wird an jedes ``storage.add_text`` durchgereicht
+        (Override pro Run). Ohne Override greift der Storage-Singleton-NER.
         """
         total_chunks = len(chunks)
         if total_chunks == 0:
@@ -224,7 +242,9 @@ class GraphBuilderService:
                 # Issue #10 — initial document ingest stamps round 0 so later
                 # time-travel diffs can distinguish document knowledge from
                 # edges learned during simulation.
-                episode_id = self.storage.add_text(graph_id, chunk, round_num=0)
+                episode_id = self.storage.add_text(
+                    graph_id, chunk, round_num=0, ner_extractor=ner_extractor
+                )
                 elapsed = time.time() - t0
                 logger.info(
                     f"[graph_build] Chunk {idx + 1}/{total_chunks} done in {elapsed:.1f}s"

--- a/backend/app/storage/graph_storage.py
+++ b/backend/app/storage/graph_storage.py
@@ -33,7 +33,13 @@ class GraphStorage(ABC):
     # --- Add data ---
 
     @abstractmethod
-    def add_text(self, graph_id: str, text: str, round_num: Optional[int] = None) -> str:
+    def add_text(
+        self,
+        graph_id: str,
+        text: str,
+        round_num: Optional[int] = None,
+        ner_extractor: Optional[Any] = None,
+    ) -> str:
         """
         Process text: NER/RE → create nodes/edges → return episode_id.
         This is synchronous (unlike Zep Cloud's async episodes).
@@ -42,6 +48,12 @@ class GraphStorage(ABC):
         ``valid_from_round``. Pass ``0`` for the initial document ingest
         and the current OASIS round for live simulation updates; leave
         ``None`` for legacy callers where temporal tracking is not needed.
+
+        ``ner_extractor`` (Sub-Slice „build-respects-frontend-model"):
+        optionaler NER-Override pro Aufruf. Erlaubt dem Build-Pfad, einen
+        frontend-LLM-gesteuerten Extractor durchzureichen, ohne den
+        Storage-Singleton-Default zu mutieren. ``None`` greift den
+        konfigurierten Default-Extractor.
         """
 
     @abstractmethod
@@ -52,8 +64,13 @@ class GraphStorage(ABC):
         batch_size: int = 3,
         progress_callback: Optional[Callable] = None,
         round_num: Optional[int] = None,
+        ner_extractor: Optional[Any] = None,
     ) -> List[str]:
-        """Batch-add text chunks. Returns list of episode_ids."""
+        """Batch-add text chunks. Returns list of episode_ids.
+
+        ``ner_extractor`` wird an jedes ``add_text`` durchgereicht (Override
+        pro Run). Ohne Override greift der Storage-Default-NER.
+        """
 
     @abstractmethod
     def wait_for_processing(

--- a/backend/app/storage/neo4j_write.py
+++ b/backend/app/storage/neo4j_write.py
@@ -23,13 +23,16 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from ..services.ingestion_pipeline import (
     embed_entities_and_relations,
     extract_entities_and_relations,
 )
 from .neo4j_mappings import edge_to_dict, sanitize_label
+
+if TYPE_CHECKING:
+    from .ner_extractor import NERExtractor
 
 logger = logging.getLogger("agora.neo4j_storage")
 
@@ -152,7 +155,13 @@ class Neo4jWriteMixin:
 
     # ── Add data (NER → nodes/edges) ────────────────────────────────
 
-    def add_text(self, graph_id: str, text: str, round_num: Optional[int] = None) -> str:
+    def add_text(
+        self,
+        graph_id: str,
+        text: str,
+        round_num: Optional[int] = None,
+        ner_extractor: Optional["NERExtractor"] = None,
+    ) -> str:
         """Process text in three phases — NER, embed, persist.
 
         Phase 1 (``extract_entities_and_relations``) + Phase 2
@@ -164,13 +173,20 @@ class Neo4jWriteMixin:
         ``valid_from_round``. ``None`` keeps the legacy behaviour (property
         absent); ``0`` means "present since the initial ingest"; any positive
         value means the edge was learned during that OASIS round.
+
+        ``ner_extractor`` (Sub-Slice „build-respects-frontend-model"): wenn
+        gesetzt, wird **dieser** Extractor statt der Storage-Default-Instanz
+        (``self._ner``) für Phase 1 verwendet. Damit kann der Build-Pfad
+        einen pro-Request gebauten Extractor mit Frontend-LLM-Override
+        durchreichen, ohne den Storage-Singleton anzufassen.
         """
         episode_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
 
         # Phase 1 — NER + Relation-Extraction
         ontology = self.get_ontology(graph_id)
-        extraction = extract_entities_and_relations(self._ner, text, ontology)
+        ner = ner_extractor if ner_extractor is not None else self._ner
+        extraction = extract_entities_and_relations(ner, text, ontology)
         entities = extraction.get("entities", [])
         relations = extraction.get("relations", [])
 
@@ -373,15 +389,23 @@ class Neo4jWriteMixin:
         batch_size: int = 3,
         progress_callback: Optional[Callable] = None,
         round_num: Optional[int] = None,
+        ner_extractor: Optional["NERExtractor"] = None,
     ) -> List[str]:
-        """Batch-add text chunks with progress reporting."""
+        """Batch-add text chunks with progress reporting.
+
+        ``ner_extractor`` wird an jedes ``add_text`` durchgereicht — damit
+        kann der Build-Pfad einen LLM-Override-NER pro Run verwenden, ohne
+        die globale ``Neo4jStorage._ner``-Instanz zu mutieren.
+        """
         episode_ids = []
         total = len(chunks)
 
         for i, chunk in enumerate(chunks):
             if not chunk or not chunk.strip():
                 continue
-            episode_id = self.add_text(graph_id, chunk, round_num=round_num)
+            episode_id = self.add_text(
+                graph_id, chunk, round_num=round_num, ner_extractor=ner_extractor
+            )
             episode_ids.append(episode_id)
 
             if progress_callback:

--- a/backend/tests/api/test_graph_endpoints.py
+++ b/backend/tests/api/test_graph_endpoints.py
@@ -265,8 +265,12 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager():
     fake_project.name = "Test Project"
     fake_project.chunk_size = 500
     fake_project.chunk_overlap = 50
+    fake_project.llm_model = None
+    fake_project.llm_provider = None
 
-    def fake_add_text_batches(graph_id, chunks, batch_size=3, progress_callback=None):
+    def fake_add_text_batches(
+        graph_id, chunks, batch_size=3, progress_callback=None, ner_extractor=None
+    ):
         # Simulate two chunks completing
         if progress_callback:
             progress_callback("Processed 1/2 chunks...", 0.5, 1, 2)

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -202,7 +202,15 @@ async function startBuildGraph() {
     currentPhase.value = 1
     buildProgress.value = { progress: 0, message: t('step1.build.running') }
     addLog(t('step1.build.running'))
-    const res = await buildGraph({ project_id: currentProjectId.value })
+    // Frontend-Modell pro Build-Run mitgeben — NER-Extraktion läuft sonst
+    // mit dem Server-Default. Backend fällt auf den am Projekt
+    // persistierten Modellnamen zurück, wenn das Feld hier fehlt.
+    const buildPayload = { project_id: currentProjectId.value }
+    const selectedModel = storedEffectiveModel()
+    if (selectedModel) buildPayload.llm_model = selectedModel
+    const runtimeProvider = runtimeLlmPayloadFromStorage()
+    if (runtimeProvider) buildPayload.llm_provider = runtimeProvider
+    const res = await buildGraph(buildPayload)
     if (res.success) {
       addLog(`Build task: ${res.data.task_id}`)
       startGraphPolling()


### PR DESCRIPTION
## Summary
Plan-Review-Punkte 2 + 3 in einem PR.

### (2) Build-Pfad: NER-Injection via add_text(ner_extractor=...)
Der Storage-Singleton-NER (Neo4jStorage._ner) blieb beim Build aktiv, auch wenn der User im Frontend ein anderes Modell gewählt hatte. Jetzt:

- Neo4jWriteMixin.add_text + add_text_batch um optionalen ner_extractor erweitert (Default None → bestehender Pfad)
- GraphStorage (abstract) analog
- GraphBuilderService.build_graph_async / _build_graph_worker / add_text_batches reichen ner_extractor durch
- api/graph.py::build_graph baut LLMClient + NERExtractor pro Run und reicht ihn an den Builder. Fallback-Reihenfolge: Request-Body > project.llm_model > Server-Default
- Frontend MainView.startBuildGraph hängt llm_model + llm_provider ans Build-Body (storedEffectiveModel / runtimeLlmPayloadFromStorage)

Storage-Singleton-NER bleibt für andere Pfade unangetastet.

### (3) Report-Pfad: ReportAgent + GraphToolsService teilen LLMClient
api/report.py + api/runs.py (resume) bauen LLMClient einmal und reichen ihn in BEIDE Konstruktoren rein. Vorher hat GraphToolsService beim Lazy-Init self.llm den Config-Default genommen — egal welches Modell der User wählte.

## Slice 3/3 — folgt auf #370 (Heuristik) + #371 (Ontology) + #372 (Fallback-Retry)
Mit diesem Slice ist die Frontend-Modellauswahl in allen Layer-1-LLM-Pfaden (Ontology, NER/Build, Report) verdrahtet.

## Known limitations (separater Slice)
- GraphMemoryUpdater._send_batch_activities (Sim-Round-Updates) nutzt weiter Storage-Default-NER — dort existiert kein Request-Kontext für einen LLM-Override

## Test plan
- [x] Backend-Regression: 1931 passed, 2 skipped (Redis), 7 deselected
- [x] ruff/mypy clean
- [x] Bestehender test_graph_endpoints-Stub fake_add_text_batches um ner_extractor=None erweitert
- [x] fake_project.llm_model/llm_provider gesetzt um MagicMock-Truthy-Falle zu vermeiden
- [ ] Manueller Smoke nach Merge: Step1 GPT-5-mini wählen, OpenAI-Key hinterlegen, Ontology+Build+Report → alle drei laufen auf demselben Modell

🤖 Generated with [Claude Code](https://claude.com/claude-code)