### PR TITLE
feat(ai): multi-provider backend (openai/gemini/ollama) mit Live-Discovery

### DIFF
--- a/backend/services/ai/__init__.py
+++ b/backend/services/ai/__init__.py
@@ -1,0 +1,17 @@
+"""Multi-Provider AI Service Layer (openai / gemini / ollama).
+
+API-Keys ausschließlich aus Umgebungsvariablen — kein Logging, keine Exceptions
+mit Secret-Leak. Live-Model-Discovery, kein hardcoded Catalog.
+"""
+
+from .model_discovery import ModelInfo, discover_models
+from .session import AISession, SwitchEvent
+from .unified_client import UnifiedLLMClient
+
+__all__ = [
+    "AISession",
+    "ModelInfo",
+    "SwitchEvent",
+    "UnifiedLLMClient",
+    "discover_models",
+]

--- a/backend/services/ai/errors.py
+++ b/backend/services/ai/errors.py
@@ -1,0 +1,45 @@
+"""Fehlerklassen für den Multi-Provider-AI-Layer.
+
+Alle Exception-Strings sind sekret-frei: Wir nehmen ENV-Variablen-Namen,
+HTTP-Status, Provider-Namen — nie Key-Werte.
+"""
+
+from __future__ import annotations
+
+
+class AIProviderError(Exception):
+    """Basisfehler für alle Provider-Operationen."""
+
+
+class MissingCredentialError(AIProviderError):
+    """Pflicht-ENV fehlt. Meldung verweist auf .env.example, nie auf den Key-Inhalt."""
+
+    def __init__(self, env_var: str, hint: str | None = None) -> None:
+        msg = f"{env_var} nicht in .env gesetzt — siehe .env.example"
+        if hint:
+            msg = f"{msg} ({hint})"
+        super().__init__(msg)
+        self.env_var = env_var
+
+
+class ProviderHTTPError(AIProviderError):
+    """Upstream-HTTP-Fehler. Bewusst ohne Request-/Response-Body, da diese
+    Auth-Header oder Echo-Keys enthalten könnten."""
+
+    def __init__(self, provider: str, status_code: int, detail: str | None = None) -> None:
+        msg = f"{provider}: HTTP {status_code}"
+        if detail:
+            msg = f"{msg} — {detail}"
+        super().__init__(msg)
+        self.provider = provider
+        self.status_code = status_code
+
+
+class UnknownProviderError(AIProviderError):
+    """Provider-Slug ist nicht openai/gemini/ollama."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(
+            f"Unbekannter Provider '{provider}'. Erlaubt: openai, gemini, ollama"
+        )
+        self.provider = provider

--- a/backend/services/ai/model_discovery.py
+++ b/backend/services/ai/model_discovery.py
@@ -1,0 +1,245 @@
+"""Live-Discovery verfügbarer Modelle pro Provider.
+
+Keine hardcodierten Modell-Listen. API-Keys werden ausschließlich aus
+``os.environ`` gelesen und nie geloggt oder in Exceptions weitergereicht.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+import httpx
+
+from .errors import (
+    MissingCredentialError,
+    ProviderHTTPError,
+    UnknownProviderError,
+)
+
+DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+
+# OpenAI-Modelle, die für Chat-Completions relevant sind. Wir matchen
+# Familien (gpt-*, o1*, o3*, o4*) statt einer festen Liste, damit neue
+# Modelle ohne Code-Change auftauchen.
+_OPENAI_MODEL_RE = re.compile(r"^(gpt-|o1|o3|o4)", re.IGNORECASE)
+
+# Reasoning- bzw. Audio-/Bild-/Embedding-Varianten, die nicht zur Chat-Auswahl
+# gehören. Bewusst konservativ — nur klare Negative.
+_OPENAI_BLOCK_SUBSTR: tuple[str, ...] = (
+    "embedding",
+    "tts",
+    "whisper",
+    "audio",
+    "moderation",
+    "image",
+    "dall-e",
+    "realtime",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelInfo:
+    """Provider-agnostisches Modell-Tupel."""
+
+    provider: str
+    id: str
+    label: str | None = None
+    context_window: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def display(self) -> str:
+        return self.label or self.id
+
+
+async def discover_models(
+    provider: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout: httpx.Timeout | float | None = None,
+) -> list[ModelInfo]:
+    """Liefert die aktuell vom Provider angebotenen Modelle.
+
+    Args:
+        provider: ``"openai"`` | ``"gemini"`` | ``"ollama"``.
+        client: Optionaler vorhandener ``httpx.AsyncClient``.
+            Sinnvoll für Tests oder zum Pooling.
+        timeout: Override für den Default-Timeout.
+
+    Raises:
+        MissingCredentialError: Pflicht-ENV fehlt (openai/gemini).
+        ProviderHTTPError: Upstream antwortet mit Fehlerstatus.
+        UnknownProviderError: Unbekannter Provider-Slug.
+    """
+
+    slug = provider.strip().lower()
+    if slug == "openai":
+        fetcher = _fetch_openai
+    elif slug == "gemini":
+        fetcher = _fetch_gemini
+    elif slug == "ollama":
+        fetcher = _fetch_ollama
+    else:
+        raise UnknownProviderError(provider)
+
+    own_client = client is None
+    http = client or httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT)
+    try:
+        return await fetcher(http)
+    finally:
+        if own_client:
+            await http.aclose()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_openai(http: httpx.AsyncClient) -> list[ModelInfo]:
+    api_key = _require_env("OPENAI_API_KEY")
+    base = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com").rstrip("/")
+    url = f"{base}/v1/models"
+    resp = await http.get(url, headers={"Authorization": f"Bearer {api_key}"})
+    _raise_for_status("openai", resp)
+    payload = resp.json()
+    raw = payload.get("data") or []
+    return sorted(
+        (model for model in (_map_openai(item) for item in raw) if model is not None),
+        key=lambda m: m.id,
+    )
+
+
+def _map_openai(item: dict[str, Any]) -> ModelInfo | None:
+    model_id = str(item.get("id") or "").strip()
+    if not model_id:
+        return None
+    if not _OPENAI_MODEL_RE.match(model_id):
+        return None
+    lower = model_id.lower()
+    if any(sub in lower for sub in _OPENAI_BLOCK_SUBSTR):
+        return None
+    return ModelInfo(
+        provider="openai",
+        id=model_id,
+        extra={"owned_by": item.get("owned_by")} if item.get("owned_by") else {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_gemini(http: httpx.AsyncClient) -> list[ModelInfo]:
+    api_key = _require_env("GEMINI_API_KEY")
+    base = os.environ.get("GEMINI_BASE_URL", "https://generativelanguage.googleapis.com").rstrip("/")
+    url = f"{base}/v1beta/models"
+    resp = await http.get(url, params={"key": api_key})
+    _raise_for_status("gemini", resp, suppress_key=api_key)
+    payload = resp.json()
+    raw = payload.get("models") or []
+    out: list[ModelInfo] = []
+    for item in raw:
+        info = _map_gemini(item)
+        if info is not None:
+            out.append(info)
+    out.sort(key=lambda m: m.id)
+    return out
+
+
+def _map_gemini(item: dict[str, Any]) -> ModelInfo | None:
+    methods = item.get("supportedGenerationMethods") or []
+    if "generateContent" not in methods:
+        return None
+    name = str(item.get("name") or "").strip()
+    if not name:
+        return None
+    # Format: "models/gemini-1.5-pro" → strip prefix für stabilen ID-Slug.
+    model_id = name.split("/", 1)[1] if name.startswith("models/") else name
+    return ModelInfo(
+        provider="gemini",
+        id=model_id,
+        label=item.get("displayName") or None,
+        context_window=item.get("inputTokenLimit"),
+        extra={
+            "output_token_limit": item.get("outputTokenLimit"),
+            "version": item.get("version"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_ollama(http: httpx.AsyncClient) -> list[ModelInfo]:
+    base = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+    url = f"{base}/api/tags"
+    try:
+        resp = await http.get(url)
+    except httpx.HTTPError as exc:
+        # Verbindung verweigert ist hier der Normalfall (Server aus).
+        raise ProviderHTTPError(
+            "ollama",
+            0,
+            detail=f"nicht erreichbar unter {base} ({type(exc).__name__})",
+        ) from None
+    _raise_for_status("ollama", resp)
+    payload = resp.json()
+    raw: Iterable[dict[str, Any]] = payload.get("models") or []
+    out: list[ModelInfo] = []
+    for item in raw:
+        info = _map_ollama(item)
+        if info is not None:
+            out.append(info)
+    out.sort(key=lambda m: m.id)
+    return out
+
+
+def _map_ollama(item: dict[str, Any]) -> ModelInfo | None:
+    name = str(item.get("name") or item.get("model") or "").strip()
+    if not name:
+        return None
+    details = item.get("details") or {}
+    return ModelInfo(
+        provider="ollama",
+        id=name,
+        label=name,
+        extra={
+            "size": item.get("size"),
+            "parameter_size": details.get("parameter_size"),
+            "quantization_level": details.get("quantization_level"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise MissingCredentialError(name)
+    return value
+
+
+def _raise_for_status(
+    provider: str,
+    resp: httpx.Response,
+    *,
+    suppress_key: str | None = None,
+) -> None:
+    if resp.is_success:
+        return
+    # Kein Body in den Fehlertext — Body kann Echo-Keys enthalten.
+    detail = resp.reason_phrase or None
+    if suppress_key and detail and suppress_key in detail:
+        detail = "<redacted>"
+    raise ProviderHTTPError(provider, resp.status_code, detail=detail)

--- a/backend/services/ai/model_discovery.py
+++ b/backend/services/ai/model_discovery.py
@@ -178,6 +178,10 @@ def _map_gemini(item: dict[str, Any]) -> ModelInfo | None:
 
 
 async def _fetch_ollama(http: httpx.AsyncClient) -> list[ModelInfo]:
+    # Default ``localhost`` ist Repo-Konvention (vgl. ``LLM_BASE_URL`` und
+    # ``EMBEDDING_BASE_URL``). Docker-User setzen
+    # ``OLLAMA_BASE_URL=http://host.docker.internal:11434`` — siehe
+    # ``.env.example`` „Docker-mode overrides".
     base = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
     url = f"{base}/api/tags"
     try:

--- a/backend/services/ai/providers/__init__.py
+++ b/backend/services/ai/providers/__init__.py
@@ -1,0 +1,12 @@
+"""Schlanke Provider-Wrapper für OpenAI, Gemini, Ollama.
+
+Jeder Wrapper bietet ``async complete(prompt, model, **opts) -> str``
+und ist auf das Nötigste reduziert. Komplexere Logik (Routing, Retry,
+Streaming) gehört in ``unified_client.UnifiedLLMClient``.
+"""
+
+from .gemini import GeminiClient
+from .ollama import OllamaClient
+from .openai import OpenAIClient
+
+__all__ = ["GeminiClient", "OllamaClient", "OpenAIClient"]

--- a/backend/services/ai/providers/gemini.py
+++ b/backend/services/ai/providers/gemini.py
@@ -1,0 +1,91 @@
+"""Google Gemini generateContent-Wrapper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..errors import MissingCredentialError, ProviderHTTPError
+
+DEFAULT_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+
+
+class GeminiClient:
+    """Minimaler Wrapper für ``v1beta/models/{model}:generateContent``.
+
+    Der API-Key wird ausschließlich aus ``GEMINI_API_KEY`` gelesen und nie
+    in Exceptions ausgegeben.
+    """
+
+    name = "gemini"
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        base_url: str | None = None,
+        timeout: httpx.Timeout | float | None = None,
+    ) -> None:
+        self._own_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT)
+        self._base_url = (
+            base_url
+            or os.environ.get(
+                "GEMINI_BASE_URL", "https://generativelanguage.googleapis.com"
+            )
+        ).rstrip("/")
+
+    async def aclose(self) -> None:
+        if self._own_client:
+            await self._client.aclose()
+
+    async def complete(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+        if not api_key:
+            raise MissingCredentialError("GEMINI_API_KEY")
+
+        body: dict[str, Any] = {
+            "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+        }
+        if system:
+            body["systemInstruction"] = {"parts": [{"text": system}]}
+
+        gen_config: dict[str, Any] = {}
+        if temperature is not None:
+            gen_config["temperature"] = temperature
+        if max_tokens is not None:
+            gen_config["maxOutputTokens"] = max_tokens
+        if gen_config:
+            body["generationConfig"] = gen_config
+
+        model_id = model.split("/", 1)[1] if model.startswith("models/") else model
+        url = f"{self._base_url}/v1beta/models/{model_id}:generateContent"
+
+        resp = await self._client.post(
+            url,
+            params={"key": api_key},
+            headers={"Content-Type": "application/json"},
+            json=body,
+        )
+        if not resp.is_success:
+            detail = resp.reason_phrase or None
+            if detail and api_key in detail:
+                detail = "<redacted>"
+            raise ProviderHTTPError(self.name, resp.status_code, detail=detail)
+
+        data = resp.json()
+        try:
+            parts = data["candidates"][0]["content"]["parts"]
+        except (KeyError, IndexError, TypeError):
+            return ""
+        return "".join(part.get("text", "") for part in parts if isinstance(part, dict))

--- a/backend/services/ai/providers/ollama.py
+++ b/backend/services/ai/providers/ollama.py
@@ -1,0 +1,92 @@
+"""Ollama Chat-Wrapper (lokal, kein API-Key)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..errors import ProviderHTTPError
+
+DEFAULT_TIMEOUT = httpx.Timeout(120.0, connect=5.0)
+
+
+class OllamaClient:
+    """Spricht ``/api/chat`` auf einem lokalen oder LAN-Ollama-Daemon.
+
+    ``OLLAMA_BASE_URL`` darf gesetzt sein; Default ist
+    ``http://localhost:11434``. Es gibt keinen API-Key — wer den Endpunkt
+    nicht erreicht, bekommt eine sprechende Fehlermeldung mit Basis-URL.
+    """
+
+    name = "ollama"
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        base_url: str | None = None,
+        timeout: httpx.Timeout | float | None = None,
+    ) -> None:
+        self._own_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT)
+        self._base_url = (
+            base_url or os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        ).rstrip("/")
+
+    async def aclose(self) -> None:
+        if self._own_client:
+            await self._client.aclose()
+
+    async def complete(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        messages: list[dict[str, Any]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        options: dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if max_tokens is not None:
+            options["num_predict"] = max_tokens
+
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+        }
+        if options:
+            body["options"] = options
+
+        try:
+            resp = await self._client.post(
+                f"{self._base_url}/api/chat",
+                headers={"Content-Type": "application/json"},
+                json=body,
+            )
+        except httpx.HTTPError as exc:
+            raise ProviderHTTPError(
+                self.name,
+                0,
+                detail=f"nicht erreichbar unter {self._base_url} ({type(exc).__name__})",
+            ) from None
+
+        if not resp.is_success:
+            raise ProviderHTTPError(
+                self.name,
+                resp.status_code,
+                detail=resp.reason_phrase or None,
+            )
+
+        data = resp.json()
+        message = data.get("message") or {}
+        return message.get("content", "") or data.get("response", "") or ""

--- a/backend/services/ai/providers/ollama.py
+++ b/backend/services/ai/providers/ollama.py
@@ -16,8 +16,13 @@ class OllamaClient:
     """Spricht ``/api/chat`` auf einem lokalen oder LAN-Ollama-Daemon.
 
     ``OLLAMA_BASE_URL`` darf gesetzt sein; Default ist
-    ``http://localhost:11434``. Es gibt keinen API-Key — wer den Endpunkt
-    nicht erreicht, bekommt eine sprechende Fehlermeldung mit Basis-URL.
+    ``http://localhost:11434`` (Repo-Konvention, identisch zu
+    ``LLM_BASE_URL``/``EMBEDDING_BASE_URL``). **In Docker-Setups muss
+    ``OLLAMA_BASE_URL=http://host.docker.internal:11434`` gesetzt werden**,
+    sonst löst ``localhost`` auf den Container selbst auf — siehe
+    ``.env.example``-Sektion „Docker-mode overrides".
+    Es gibt keinen API-Key; wer den Endpunkt nicht erreicht, bekommt eine
+    sprechende Fehlermeldung mit Basis-URL.
     """
 
     name = "ollama"

--- a/backend/services/ai/providers/openai.py
+++ b/backend/services/ai/providers/openai.py
@@ -1,0 +1,88 @@
+"""OpenAI Chat-Completions-Wrapper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..errors import MissingCredentialError, ProviderHTTPError
+
+DEFAULT_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+
+
+class OpenAIClient:
+    """Minimaler OpenAI-Client für Chat-Completions.
+
+    API-Key wird zur Laufzeit aus ``OPENAI_API_KEY`` gelesen, niemals
+    geloggt oder in Exceptions weitergereicht.
+    """
+
+    name = "openai"
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        base_url: str | None = None,
+        timeout: httpx.Timeout | float | None = None,
+    ) -> None:
+        self._own_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT)
+        self._base_url = (
+            base_url
+            or os.environ.get("OPENAI_BASE_URL", "https://api.openai.com")
+        ).rstrip("/")
+
+    async def aclose(self) -> None:
+        if self._own_client:
+            await self._client.aclose()
+
+    async def complete(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if not api_key:
+            raise MissingCredentialError("OPENAI_API_KEY")
+
+        messages: list[dict[str, Any]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        body: dict[str, Any] = {"model": model, "messages": messages}
+        if temperature is not None:
+            body["temperature"] = temperature
+        if max_tokens is not None:
+            # o-Modelle erwarten ``max_completion_tokens`` — Auto-Fallback
+            # behandeln wir im UnifiedClient/Retry, hier bleibt es schlank.
+            body["max_tokens"] = max_tokens
+
+        resp = await self._client.post(
+            f"{self._base_url}/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+        if not resp.is_success:
+            raise ProviderHTTPError(
+                self.name,
+                resp.status_code,
+                detail=resp.reason_phrase or None,
+            )
+        data = resp.json()
+        try:
+            return data["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ProviderHTTPError(
+                self.name, 200, detail=f"unerwartetes Response-Format ({type(exc).__name__})"
+            ) from None

--- a/backend/services/ai/providers/openai.py
+++ b/backend/services/ai/providers/openai.py
@@ -11,6 +11,13 @@ from ..errors import MissingCredentialError, ProviderHTTPError
 
 DEFAULT_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
 
+# Reasoning-Familien lehnen ``max_tokens`` ab. Stand 2026-05: o1/o3/o4-Slugs.
+_REASONING_PREFIXES: tuple[str, ...] = ("o1", "o3", "o4")
+
+
+def _is_reasoning_model(model: str) -> bool:
+    return model.lower().startswith(_REASONING_PREFIXES)
+
 
 class OpenAIClient:
     """Minimaler OpenAI-Client für Chat-Completions.
@@ -61,9 +68,13 @@ class OpenAIClient:
         if temperature is not None:
             body["temperature"] = temperature
         if max_tokens is not None:
-            # o-Modelle erwarten ``max_completion_tokens`` — Auto-Fallback
-            # behandeln wir im UnifiedClient/Retry, hier bleibt es schlank.
-            body["max_tokens"] = max_tokens
+            # o-Familien (o1/o3/o4) lehnen ``max_tokens`` mit HTTP 400 ab und
+            # verlangen ``max_completion_tokens``. Wir setzen den passenden
+            # Key direkt — kein Retry-Loop nötig.
+            if _is_reasoning_model(model):
+                body["max_completion_tokens"] = max_tokens
+            else:
+                body["max_tokens"] = max_tokens
 
         resp = await self._client.post(
             f"{self._base_url}/v1/chat/completions",

--- a/backend/services/ai/session.py
+++ b/backend/services/ai/session.py
@@ -8,7 +8,7 @@ auf der API-Ebene (Flask-Route oder Frontend-Store).
 from __future__ import annotations
 
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any
 

--- a/backend/services/ai/session.py
+++ b/backend/services/ai/session.py
@@ -1,0 +1,274 @@
+"""Session-State für den Multi-Provider-AI-Layer.
+
+Hält den aktuell gewählten Provider/Modell, die User-Chat-Historie sowie ein
+Audit-Log aller Switch-Ereignisse. Bewusst In-Memory — Persistierung passiert
+auf der API-Ebene (Flask-Route oder Frontend-Store).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .errors import UnknownProviderError
+from .model_discovery import ModelInfo, discover_models
+from .unified_client import ALLOWED_PROVIDERS, UnifiedLLMClient
+
+
+@dataclass(frozen=True, slots=True)
+class SwitchEvent:
+    """Ein protokollierter Provider-/Modell-Wechsel."""
+
+    timestamp: str
+    step: int
+    from_provider: str | None
+    from_model: str | None
+    to_provider: str
+    to_model: str
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ChatTurn:
+    """Ein User-Prompt + LLM-Antwort, inkl. genutztem Setup."""
+
+    step: int
+    timestamp: str
+    provider: str
+    model: str
+    prompt: str
+    response: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class AISession:
+    """Stateful Multi-Provider-Chat-Session.
+
+    Beispiel::
+
+        sess = AISession()                 # liest AI_DEFAULT_PROVIDER
+        await sess.bootstrap()             # nimmt Default-Modell für Provider
+        reply = await sess.chat("Hallo")
+        sess.switch(provider="openai", model="gpt-4o", reason="bessere Quali")
+        reply = await sess.chat("Und nun?")
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        client: UnifiedLLMClient | None = None,
+    ) -> None:
+        initial_provider = (
+            provider or os.environ.get("AI_DEFAULT_PROVIDER", "ollama")
+        ).strip().lower()
+        if initial_provider not in ALLOWED_PROVIDERS:
+            raise UnknownProviderError(initial_provider)
+        self._client = client or UnifiedLLMClient(provider=initial_provider)
+        self._client.set_provider(initial_provider)
+        self._provider: str = initial_provider
+        self._model: str | None = model
+        self._history: list[ChatTurn] = []
+        self._switch_history: list[SwitchEvent] = []
+        # Initialer Zustand wird als Switch #0 protokolliert, damit das
+        # spätere Audit nahtlos ist.
+        self._record_switch(
+            from_provider=None,
+            from_model=None,
+            to_provider=initial_provider,
+            to_model=model or self._client.default_model(initial_provider),
+            reason="session-start",
+        )
+        if self._model is None:
+            self._model = self._client.default_model(initial_provider)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def model(self) -> str:
+        return self._model or ""
+
+    @property
+    def step(self) -> int:
+        return len(self._history)
+
+    @property
+    def history(self) -> list[ChatTurn]:
+        return list(self._history)
+
+    @property
+    def switch_history(self) -> list[SwitchEvent]:
+        return list(self._switch_history)
+
+    # ------------------------------------------------------------------
+    # Setup / Discovery
+    # ------------------------------------------------------------------
+
+    async def bootstrap(self) -> list[ModelInfo]:
+        """Lädt die verfügbaren Modelle für den aktuellen Provider und
+        setzt das aktive Modell auf das ENV-Default, falls noch keins
+        gewählt wurde."""
+
+        models = await discover_models(self._provider)
+        if not self._model:
+            preferred = self._client.default_model(self._provider)
+            if preferred and any(m.id == preferred for m in models):
+                self._model = preferred
+            elif models:
+                self._model = models[0].id
+        return models
+
+    async def list_models(self, provider: str | None = None) -> list[ModelInfo]:
+        return await discover_models((provider or self._provider).lower())
+
+    # ------------------------------------------------------------------
+    # Switching
+    # ------------------------------------------------------------------
+
+    def switch(
+        self,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        reason: str | None = None,
+    ) -> SwitchEvent:
+        """Wechselt Provider und/oder Modell und protokolliert das Event."""
+
+        if provider is None and model is None:
+            raise ValueError("switch() braucht mindestens 'provider' oder 'model'")
+
+        new_provider = (provider or self._provider).strip().lower()
+        if new_provider not in ALLOWED_PROVIDERS:
+            raise UnknownProviderError(new_provider)
+
+        # Default-Modell ziehen, wenn Provider wechselt und kein neues Modell angegeben ist.
+        if provider and not model:
+            new_model = self._client.default_model(new_provider)
+        else:
+            new_model = model or self._model or self._client.default_model(new_provider)
+
+        from_provider = self._provider
+        from_model = self._model
+
+        if new_provider == from_provider and new_model == from_model:
+            # No-Op explizit als „bestätigt" loggen, hilft beim Audit.
+            return self._record_switch(
+                from_provider, from_model, new_provider, new_model,
+                reason=reason or "no-change",
+            )
+
+        self._provider = new_provider
+        self._model = new_model
+        self._client.set_provider(new_provider)
+        return self._record_switch(
+            from_provider, from_model, new_provider, new_model, reason=reason
+        )
+
+    # ------------------------------------------------------------------
+    # Chat
+    # ------------------------------------------------------------------
+
+    async def chat(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        if not self._model:
+            await self.bootstrap()
+        if not self._model:
+            raise RuntimeError(
+                f"Kein Modell für Provider '{self._provider}' verfügbar — "
+                "ENV *_DEFAULT_MODEL setzen oder 'switch(model=...)' nutzen."
+            )
+        response = await self._client.complete(
+            prompt,
+            model=self._model,
+            provider=self._provider,
+            system=system,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        turn = ChatTurn(
+            step=self.step + 1,
+            timestamp=_now(),
+            provider=self._provider,
+            model=self._model,
+            prompt=prompt,
+            response=response,
+        )
+        self._history.append(turn)
+        return response
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AISession":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    # ------------------------------------------------------------------
+    # Serialisierung
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        """Komplett-Dump für UI/Persistenz (keine Secrets enthalten)."""
+
+        return {
+            "provider": self._provider,
+            "model": self._model,
+            "step": self.step,
+            "history": [turn.to_dict() for turn in self._history],
+            "switchHistory": [event.to_dict() for event in self._switch_history],
+        }
+
+    # ------------------------------------------------------------------
+    # Intern
+    # ------------------------------------------------------------------
+
+    def _record_switch(
+        self,
+        from_provider: str | None,
+        from_model: str | None,
+        to_provider: str,
+        to_model: str,
+        *,
+        reason: str | None = None,
+    ) -> SwitchEvent:
+        event = SwitchEvent(
+            timestamp=_now(),
+            step=self.step,
+            from_provider=from_provider,
+            from_model=from_model,
+            to_provider=to_provider,
+            to_model=to_model,
+            reason=reason,
+        )
+        self._switch_history.append(event)
+        return event
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/backend/services/ai/unified_client.py
+++ b/backend/services/ai/unified_client.py
@@ -1,0 +1,126 @@
+"""Provider-agnostischer Chat-Client.
+
+Hält je Provider eine Wrapper-Instanz und routet ``complete(...)`` an den
+passenden Backend-Client. Provider/Modell kann zur Laufzeit gewechselt
+werden, ohne dass Caller die HTTP-Details kennen muss.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from .errors import UnknownProviderError
+from .model_discovery import ModelInfo, discover_models
+from .providers import GeminiClient, OllamaClient, OpenAIClient
+
+ProviderClient = OpenAIClient | GeminiClient | OllamaClient
+
+_DEFAULT_MODEL_ENV: dict[str, str] = {
+    "openai": "OPENAI_DEFAULT_MODEL",
+    "gemini": "GEMINI_DEFAULT_MODEL",
+    "ollama": "OLLAMA_DEFAULT_MODEL",
+}
+
+_HARDCODED_DEFAULT: dict[str, str] = {
+    "openai": "gpt-4o",
+    "gemini": "gemini-1.5-pro",
+    "ollama": "llama3",
+}
+
+ALLOWED_PROVIDERS: tuple[str, ...] = ("openai", "gemini", "ollama")
+
+
+class UnifiedLLMClient:
+    """Einheitliche Fassade über alle drei Provider.
+
+    Beispiel::
+
+        client = UnifiedLLMClient(provider="ollama")
+        text = await client.complete("Hallo", model="llama3")
+        await client.aclose()
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        slug = (provider or os.environ.get("AI_DEFAULT_PROVIDER", "ollama")).strip().lower()
+        if slug not in ALLOWED_PROVIDERS:
+            raise UnknownProviderError(slug)
+        self._provider = slug
+        self._http = http_client
+        self._clients: dict[str, ProviderClient] = {}
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    def set_provider(self, provider: str) -> None:
+        slug = provider.strip().lower()
+        if slug not in ALLOWED_PROVIDERS:
+            raise UnknownProviderError(slug)
+        self._provider = slug
+
+    def default_model(self, provider: str | None = None) -> str:
+        slug = (provider or self._provider).lower()
+        env_key = _DEFAULT_MODEL_ENV.get(slug)
+        if env_key:
+            value = os.environ.get(env_key, "").strip()
+            if value:
+                return value
+        return _HARDCODED_DEFAULT.get(slug, "")
+
+    async def list_models(self, provider: str | None = None) -> list[ModelInfo]:
+        slug = (provider or self._provider).strip().lower()
+        return await discover_models(slug, client=self._http)
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        slug = (provider or self._provider).strip().lower()
+        chosen_model = model or self.default_model(slug)
+        backend = self._get_or_create(slug)
+        return await backend.complete(
+            prompt,
+            chosen_model,
+            system=system,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    async def aclose(self) -> None:
+        for backend in self._clients.values():
+            await backend.aclose()
+        self._clients.clear()
+
+    async def __aenter__(self) -> "UnifiedLLMClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    def _get_or_create(self, slug: str) -> ProviderClient:
+        if slug in self._clients:
+            return self._clients[slug]
+        if slug == "openai":
+            client: ProviderClient = OpenAIClient(client=self._http)
+        elif slug == "gemini":
+            client = GeminiClient(client=self._http)
+        elif slug == "ollama":
+            client = OllamaClient(client=self._http)
+        else:
+            raise UnknownProviderError(slug)
+        self._clients[slug] = client
+        return client


### PR DESCRIPTION
## Summary

- `backend/services/ai/` führt OpenAI, Google Gemini und Ollama hinter einer einheitlichen Fassade (`UnifiedLLMClient`) und einem Session-State (`AISession`) zusammen.
- Modelle werden ausschließlich per Live-Call gegen die Provider-APIs ermittelt (`/v1/models`, `v1beta/models`, `/api/tags`) — keine hardcodierten Listen.
- API-Keys werden bei jedem Call frisch aus `os.environ` gelesen, niemals geloggt, niemals in Exceptions weitergereicht. Sprechende `MissingCredentialError` verweist auf `.env.example`, nie auf den Key-Inhalt.

## Architektur

| Modul | Aufgabe |
|---|---|
| `model_discovery.py` | async `discover_models(provider)` mit Provider-spezifischen Filtern (gpt-*/o1*/o3*/o4*, generateContent-Support, /api/tags) |
| `providers/{openai,gemini,ollama}.py` | schlanke httpx-Wrapper, identische `complete()`-Signatur |
| `unified_client.py` | provider-/modell-agnostische `complete()`, lazy Provider-Instanziierung, async-Context-Manager |
| `session.py` | `AISession` mit `provider`, `model`, `history` (`ChatTurn`), `switchHistory` (`SwitchEvent` mit Timestamp + Step-Nr.), `snapshot()` ohne Secrets |
| `errors.py` | `MissingCredentialError`, `ProviderHTTPError` (ohne Response-Body, um Echo-Keys zu vermeiden), `UnknownProviderError` |

Gegen Context7-Docs validiert: httpx-Patterns, OpenAI Chat-Completions-Shape, Ollama `/api/chat`-Shape.

## Test plan

- [ ] `cd backend && uv run python -c "from services.ai import AISession; print(AISession().snapshot())"` — Smoke-Test ohne externe Calls
- [ ] Mit lokalem Ollama: `await AISession().bootstrap()` listet Modelle, `chat("Hallo")` antwortet
- [ ] Mit `OPENAI_API_KEY`: `await discover_models("openai")` filtert auf gpt-/o-Familien
- [ ] Mit `GEMINI_API_KEY`: `await discover_models("gemini")` listet nur Modelle mit `generateContent`-Support
- [ ] Fehlender Key → `MissingCredentialError` mit `<ENV_VAR> nicht in .env gesetzt — siehe .env.example`
- [ ] pytest-Suite folgt in eigenem Slice (`backend/tests/services/ai/`)

## Out of Scope (Folgeslices)

- `.env.example`-Block + `CLAUDE.md`-Sektion (manuell zu patchen, Block liegt in PR-Description / Chat-Verlauf)
- Flask-Route `backend/app/api/ai_session.py`, die die Slash-Commands (`/ai-init`, `/switch`, `/list-models`, `/status`) an `AISession` bindet
- Auflösung der `OPENAI_API_KEY`-Slot-Kollision mit CAMEL-AI (CAMEL nutzt aktuell `OPENAI_API_KEY=ollama` als Dummy für die lokale Ollama-Bridge)