### PR TITLE
Multi-provider LLM registry and stage-routing

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -29,6 +29,8 @@ from . import simulation_compare  # noqa: E402, F401 -- Sub-Slice 24 (#66): Bran
 from . import simulation  # noqa: E402, F401
 from . import report  # noqa: E402, F401
 from . import runs  # noqa: E402, F401
+from . import llm_routing  # noqa: E402, F401
 from . import status  # noqa: E402, F401
 from . import logs  # noqa: E402, F401 -- Issue #132: Backend-Log-Viewer
 from . import llm  # noqa: E402, F401 -- Slice E.1 (#213): model-active SSE stream
+from . import llm_providers  # noqa: E402, F401

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -1,0 +1,79 @@
+"""
+LLM Provider API.
+"""
+
+from flask import request
+from . import llm_bp
+from ..services.llm_provider_registry import LlmProviderRegistry
+from ..services.model_catalog_service import ModelCatalogService
+from ..services.secret_resolver import SecretResolver
+from ..utils.api_responses import handle_api_errors, json_success, json_error
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.api.llm_providers")
+provider_registry = LlmProviderRegistry()
+model_catalog = ModelCatalogService()
+
+@llm_bp.route("/providers", methods=["GET"])
+@handle_api_errors(logger=logger)
+def list_providers():
+    """List available LLM providers and their auth status."""
+    # In a real app, session keys might come from a secure cookie or session store.
+    # For now, we assume no session keys for the public listing.
+    providers = provider_registry.get_providers()
+    return json_success([p.model_dump(mode="json") for p in providers])
+
+@llm_bp.route("/providers/<provider_id>/models", methods=["GET"])
+@handle_api_errors(logger=logger)
+def list_provider_models(provider_id: str):
+    """List models for a specific provider."""
+    providers = provider_registry.get_providers()
+    provider = next((p for p in providers if p.id == provider_id), None)
+    if not provider:
+        return json_error(f"Provider not found: {provider_id}", status=404)
+
+    base_url = request.args.get("base_url") or provider.default_base_url
+    if not base_url:
+        return json_error("base_url is required for this provider", status=400)
+
+    resolver = SecretResolver()
+    api_key = resolver.get_api_key(provider_id, provider.type)
+
+    models = model_catalog.get_models(provider_id, provider.type, base_url, api_key)
+    return json_success([m.model_dump(mode="json") for m in models])
+
+@llm_bp.route("/providers/<provider_id>/test", methods=["POST"])
+@handle_api_errors(logger=logger)
+def test_provider(provider_id: str):
+    """Test connectivity to a provider."""
+    providers = provider_registry.get_providers()
+    provider = next((p for p in providers if p.id == provider_id), None)
+    if not provider:
+        return json_error(f"Provider not found: {provider_id}", status=404)
+
+    data = request.get_json() or {}
+    base_url = data.get("base_url") or provider.default_base_url
+    api_key = data.get("api_key") # Allow explicit key for testing
+
+    if not base_url:
+        return json_error("base_url is required", status=400)
+
+    resolver = SecretResolver()
+    if not api_key:
+        api_key = resolver.get_api_key(provider_id, provider.type)
+
+    try:
+        models = model_catalog.get_models(provider_id, provider.type, base_url, api_key)
+        inference_test = request.args.get("inference") == "1"
+        test_result = {"connectivity": "ok", "models_found": len(models)}
+
+        if inference_test and models:
+            from ..utils.llm_client import LLMClient
+            client = LLMClient(api_key=api_key, base_url=base_url, model=models[0].id)
+            resp = client.chat([{"role": "user", "content": "ping"}], max_tokens=10)
+            test_result["inference"] = "ok"
+            test_result["response_preview"] = resp[:50]
+
+        return json_success(test_result)
+    except Exception as exc:
+        return json_error(f"Test failed: {exc}", status=400)

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -1,0 +1,93 @@
+"""
+LLM Routing API.
+"""
+
+from flask import request
+from . import runs_bp
+from ..services.runtime_run_config import RuntimeRunConfig
+from ..services.stage_model_router import StageModelRouter
+from ..services.run_registry import RunRegistry
+from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
+from ..utils.api_responses import handle_api_errors, json_success, json_error
+from ..utils.logger import get_logger
+from pydantic import ValidationError
+
+logger = get_logger("agora.api.llm_routing")
+run_registry = RunRegistry()
+
+def _get_run_state(run_id: str):
+    run = run_registry.get_run(run_id)
+    if not run:
+        return None
+    return run.get("status")
+
+@runs_bp.route("/<run_id>/llm-routing", methods=["GET"])
+@handle_api_errors(logger=logger)
+def get_run_llm_routing(run_id: str):
+    """Get runtime LLM routing for a run."""
+    config_service = RuntimeRunConfig(run_id)
+    config = config_service.load_config()
+
+    # Also include snapshots for started stages
+    router = StageModelRouter(run_id)
+    snapshots = {}
+    from ..contracts.llm_routing_contract import StageId
+    for stage in ["document_ingest", "ontology_generation", "graph_build", "persona_generation", "simulation_rounds", "report_generation", "evaluation"]:
+        snap = config_service.load_stage_snapshot(stage)
+        if snap:
+            snapshots[stage] = snap
+
+    return json_success({
+        "runtime_config": config.model_dump(mode="json"),
+        "snapshots": snapshots
+    })
+
+@runs_bp.route("/<run_id>/llm-routing", methods=["PUT"])
+@handle_api_errors(logger=logger)
+def update_run_llm_routing(run_id: str):
+    """Replace runtime LLM routing for a run."""
+    status = _get_run_state(run_id)
+    if status in ("completed", "failed", "stopped"):
+        return json_error("Cannot update routing for a finished run", status=409)
+
+    try:
+        data = request.get_json() or {}
+        new_config = RuntimeLlmRouting.model_validate(data)
+
+        config_service = RuntimeRunConfig(run_id)
+        old_config = config_service.load_config()
+
+        # Increment version
+        new_config.routing_version = old_config.routing_version + 1
+        config_service.save_config(new_config)
+
+        return json_success(new_config.model_dump(mode="json"))
+    except ValidationError as exc:
+        return json_error(exc.errors(), status=400)
+
+@runs_bp.route("/<run_id>/llm-routing/stages/<stage_id>", methods=["PATCH"])
+@handle_api_errors(logger=logger)
+def patch_stage_llm_routing(run_id: str, stage_id: str):
+    """Update routing for a specific stage."""
+    # 1. Check if stage already started/locked
+    config_service = RuntimeRunConfig(run_id)
+    if config_service.load_stage_snapshot(stage_id):
+        return json_error(
+            "Stage already started, route is locked",
+            status=409,
+            extra={"code": "stage_already_started"}
+        )
+
+    # 2. Update override in runtime config
+    try:
+        data = request.get_json() or {}
+        route_override = StageLLMRoute.model_validate(data)
+
+        config = config_service.load_config()
+        config.stage_overrides[stage_id] = route_override
+        config.routing_version += 1
+
+        config_service.save_config(config)
+        return json_success(config.model_dump(mode="json"))
+    except ValidationError as exc:
+        return json_error(exc.errors(), status=400)

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -22,6 +22,11 @@ from app.contracts.persona_entity_context import PersonaEntityContext
 from app.contracts.report_contract import EvidenceMapModel, ReportContractModel, ReportModel
 from app.contracts.report_v3 import ReportV3
 from app.contracts.runs_contract import RunDetail, RunsListResponse, RunSummary
+from app.contracts.llm_routing_contract import (
+    RuntimeLlmRouting,
+    ProviderDescriptor,
+    ResolvedRoute,
+)
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -39,6 +44,9 @@ CONTRACTS: dict[str, type] = {
     "run-summary.schema.json": RunSummary,
     "runs-list-response.schema.json": RunsListResponse,
     "run-detail.schema.json": RunDetail,
+    "llm-runtime-routing.schema.json": RuntimeLlmRouting,
+    "llm-provider-descriptor.schema.json": ProviderDescriptor,
+    "llm-resolved-route.schema.json": ResolvedRoute,
 }
 
 

--- a/backend/app/contracts/llm_routing_contract.py
+++ b/backend/app/contracts/llm_routing_contract.py
@@ -1,0 +1,71 @@
+"""
+LLM Routing Contracts (Pydantic v2).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Literal, Optional, Any
+from pydantic import BaseModel, ConfigDict, Field
+
+_STRICT = ConfigDict(extra="forbid")
+
+StageId = Literal[
+    "document_ingest",
+    "ontology_generation",
+    "graph_build",
+    "persona_generation",
+    "simulation_rounds",
+    "report_generation",
+    "evaluation",
+]
+
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high"]
+
+
+class StageLLMRoute(BaseModel):
+    """Configuration for a single stage route."""
+
+    model_config = _STRICT
+
+    provider_id: str
+    model: str
+    base_url: Optional[str] = None
+    reasoning_effort: ReasoningEffort = "none"
+    provider_options: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RuntimeLlmRouting(BaseModel):
+    """Runtime LLM routing configuration for a run."""
+
+    model_config = _STRICT
+
+    default_route: StageLLMRoute
+    stage_overrides: Dict[StageId, StageLLMRoute] = Field(default_factory=dict)
+    routing_version: int = 1
+
+
+class ProviderDescriptor(BaseModel):
+    """Metadata about an LLM provider."""
+
+    model_config = _STRICT
+
+    id: str
+    name: str
+    type: Literal["ollama_local", "openai", "google", "openai_compatible"]
+    default_base_url: Optional[str] = None
+    auth_status: Literal["configured", "missing", "session_required"] = "missing"
+
+
+class ResolvedRoute(BaseModel):
+    """The final resolved configuration for an LLM call inside a stage."""
+
+    model_config = _STRICT
+
+    stage: StageId
+    provider_id: str
+    model: str
+    base_url_sanitized: Optional[str] = None
+    reasoning_effort: ReasoningEffort = "none"
+    routing_version: int
+    provider_options: Dict[str, Any] = Field(default_factory=dict)
+    started_at: Optional[str] = None

--- a/backend/app/services/llm_invocation_logger.py
+++ b/backend/app/services/llm_invocation_logger.py
@@ -1,0 +1,54 @@
+"""
+LLM Invocation Logger.
+Structured JSONL logging of LLM calls, ensuring secret hygiene.
+"""
+
+import os
+import json
+import time
+from typing import Optional, Dict, Any
+from ..utils.artifact_locator import ArtifactLocator
+from .secret_resolver import SecretResolver
+
+class LlmInvocationLogger:
+    """Logs LLM invocation events to a structured JSONL file."""
+
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+        self.log_path = os.path.join(ArtifactLocator.run_dir(run_id), "llm_call_events.jsonl")
+        self.resolver = SecretResolver()
+
+    def log_event(
+        self,
+        stage: str,
+        provider_id: str,
+        model: str,
+        base_url: Optional[str],
+        routing_version: int,
+        latency_ms: float,
+        success: bool,
+        error_type: Optional[str] = None,
+        http_status: Optional[int] = None,
+        remote_request_id: Optional[str] = None,
+    ) -> None:
+        """Append a call event to the log file."""
+        event = {
+            "run_id": self.run_id,
+            "stage": stage,
+            "provider_id": provider_id,
+            "model": model,
+            "base_url_sanitized": self.resolver.sanitize_url(base_url),
+            "routing_version": routing_version,
+            "timestamp": time.time(),
+            "latency_ms": latency_ms,
+            "success": success,
+            "error_type": error_type,
+            "http_status": http_status,
+            "remote_request_id": remote_request_id,
+        }
+
+        # Ensure log directory exists
+        os.makedirs(os.path.dirname(self.log_path), exist_ok=True)
+
+        with open(self.log_path, "a") as f:
+            f.write(json.dumps(event) + "\n")

--- a/backend/app/services/llm_provider_registry.py
+++ b/backend/app/services/llm_provider_registry.py
@@ -1,0 +1,72 @@
+"""
+LLM Provider Registry.
+Public provider metadata only — no secrets.
+"""
+
+from typing import List, Optional
+from ..contracts.llm_routing_contract import ProviderDescriptor
+from ..config import Config
+
+class LlmProviderRegistry:
+    """Registry for LLM providers."""
+
+    def __init__(self):
+        # In a real app, this might be dynamic or from config.
+        # For the first cut, we use a static list with auth status check.
+        pass
+
+    def get_providers(self, session_api_keys: Optional[dict] = None) -> List[ProviderDescriptor]:
+        """Return list of available providers and their auth status."""
+        providers = [
+            ProviderDescriptor(
+                id="ollama_local",
+                name="Ollama (Local)",
+                type="ollama_local",
+                default_base_url="http://localhost:11434",
+                auth_status="configured"  # Ollama local usually needs no key
+            ),
+            ProviderDescriptor(
+                id="openai",
+                name="OpenAI",
+                type="openai",
+                default_base_url="https://api.openai.com/v1",
+                auth_status=self._check_auth("openai", session_api_keys)
+            ),
+            ProviderDescriptor(
+                id="google",
+                name="Google Gemini",
+                type="google",
+                default_base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+                auth_status=self._check_auth("google", session_api_keys)
+            ),
+            ProviderDescriptor(
+                id="openai_compatible",
+                name="OpenAI Compatible",
+                type="openai_compatible",
+                auth_status=self._check_auth("openai_compatible", session_api_keys)
+            )
+        ]
+        return providers
+
+    def _check_auth(self, provider_id: str, session_api_keys: Optional[dict] = None) -> str:
+        """Heuristic check for auth status."""
+        # 1. Check session
+        if session_api_keys and session_api_keys.get(provider_id):
+            return "configured"
+
+        # 2. Check environment (via Config)
+        # Mapping provider_id to Config fields
+        if provider_id == "openai":
+            if Config.LLM_API_KEY and "openai" in (Config.LLM_BASE_URL or "").lower():
+                 return "configured"
+            if os.environ.get("OPENAI_API_KEY"):
+                 return "configured"
+
+        if provider_id == "google":
+            if os.environ.get("GOOGLE_API_KEY"):
+                return "configured"
+
+        # Fallback
+        return "missing"
+
+import os

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -1,0 +1,125 @@
+"""
+Model Catalog Service.
+Live /models discovery, normalization, cache, source-badge.
+"""
+
+import time
+import requests
+from typing import List, Optional, Dict, Any, Literal
+from pydantic import BaseModel, ConfigDict
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.model_catalog")
+
+class ModelEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    provider_id: str
+    source: Literal["live", "cached", "fallback", "custom"]
+    refreshed_at: float
+
+from typing import Literal
+
+class ModelCatalogService:
+    """Service for discovering and normalizing models from different providers."""
+
+    _cache: Dict[str, List[ModelEntry]] = {}
+    _cache_ttl = 300 # 5 minutes
+
+    def get_models(self, provider_id: str, provider_type: str, base_url: str, api_key: Optional[str]) -> List[ModelEntry]:
+        """Fetch models from provider, with caching and fallback."""
+        now = time.time()
+
+        # 1. Check cache
+        if provider_id in self._cache:
+            entries = self._cache[provider_id]
+            if entries and (now - entries[0].refreshed_at < self._cache_ttl):
+                return entries
+
+        # 2. Try live discovery
+        try:
+            live_models = self._fetch_live(provider_type, base_url, api_key)
+            if live_models:
+                entries = [
+                    ModelEntry(
+                        id=m,
+                        name=m,
+                        provider_id=provider_id,
+                        source="live",
+                        refreshed_at=now
+                    ) for m in live_models
+                ]
+                self._cache[provider_id] = entries
+                return entries
+        except Exception as exc:
+            logger.warning("Failed to fetch live models from %s: %s", provider_id, exc)
+
+        # 3. Fallback to cached (even if expired)
+        if provider_id in self._cache:
+            entries = self._cache[provider_id]
+            # Update source to cached
+            for e in entries:
+                e.source = "cached"
+            return entries
+
+        # 4. Fallback to hardcoded defaults
+        fallback_models = self._get_fallbacks(provider_type)
+        return [
+            ModelEntry(
+                id=m,
+                name=m,
+                provider_id=provider_id,
+                source="fallback",
+                refreshed_at=now
+            ) for m in fallback_models
+        ]
+
+    def _fetch_live(self, provider_type: str, base_url: str, api_key: Optional[str]) -> List[str]:
+        """Discovery implementation per provider type."""
+        if provider_type == "ollama_local":
+            # Ollama has /api/tags (native) and /v1/models (OpenAI compatible)
+            # We prefer /api/tags for full metadata if available
+            try:
+                # Try OpenAI compatible first as it's the standard Agora uses
+                resp = requests.get(f"{base_url.rstrip('/')}/v1/models", timeout=5)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return [m["id"] for m in data.get("data", [])]
+            except:
+                 pass
+
+            # Try native Ollama /api/tags as fallback
+            # We need to strip /v1 if it was added to base_url for OpenAI compat
+            native_url = base_url.replace("/v1", "").rstrip("/")
+            resp = requests.get(f"{native_url}/api/tags", timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                return [m["name"] for m in data.get("models", [])]
+
+        elif provider_type in ("openai", "google", "openai_compatible"):
+            headers = {}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            resp = requests.get(f"{base_url.rstrip('/')}/models", headers=headers, timeout=5)
+            if resp.status_code != 200:
+                 # Try /v1/models if /models failed
+                 resp = requests.get(f"{base_url.rstrip('/')}/v1/models", headers=headers, timeout=5)
+
+            if resp.status_code == 200:
+                data = resp.json()
+                # OpenAI and Google (OpenAI-shim) both use data[]
+                return [m["id"] for m in data.get("data", [])]
+
+        return []
+
+    def _get_fallbacks(self, provider_type: str) -> List[str]:
+        if provider_type == "ollama_local":
+            return ["qwen2.5:32b", "llama3.1:8b", "phi3"]
+        if provider_type == "openai":
+            return ["gpt-4o", "gpt-4o-mini", "o1-preview"]
+        if provider_type == "google":
+            return ["gemini-1.5-pro", "gemini-1.5-flash"]
+        return []

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -1,0 +1,66 @@
+"""
+Runtime Run Configuration Service.
+Handle persistence of runtime_llm_routing.json and stage snapshots.
+"""
+
+import os
+import json
+from datetime import datetime
+from typing import Optional, Dict, Any
+from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
+from ..utils.artifact_locator import ArtifactLocator
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.runtime_run_config")
+
+class RuntimeRunConfig:
+    """Manages runtime configuration for a run."""
+
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+        self.run_dir = ArtifactLocator.run_dir(run_id)
+        self.config_path = os.path.join(self.run_dir, "runtime_llm_routing.json")
+        self.stages_dir = os.path.join(self.run_dir, "stages")
+
+    def load_config(self) -> RuntimeLlmRouting:
+        """Load runtime configuration, with legacy fallback."""
+        if os.path.exists(self.config_path):
+            with open(self.config_path, "r") as f:
+                data = json.load(f)
+                return RuntimeLlmRouting.model_validate(data)
+
+        # Legacy fallback: synthesize from global Config or existing run metadata
+        from ..config import Config
+        default_route = StageLLMRoute(
+            provider_id="ollama_local",
+            model=Config.LLM_MODEL_NAME,
+            base_url=Config.LLM_BASE_URL
+        )
+        return RuntimeLlmRouting(default_route=default_route)
+
+    def save_config(self, config: RuntimeLlmRouting) -> None:
+        """Persist runtime configuration."""
+        os.makedirs(self.run_dir, exist_ok=True)
+        # Monotonicity check for routing_version should happen in service/api layer
+        with open(self.config_path, "w") as f:
+            f.write(config.model_dump_json(indent=2))
+
+    def load_stage_snapshot(self, stage_id: StageId) -> Optional[Dict[str, Any]]:
+        """Load stage-specific LLM route snapshot."""
+        path = os.path.join(self.stages_dir, f"{stage_id}_llm_route_snapshot.json")
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                return json.load(f)
+        return None
+
+    def save_stage_snapshot(self, stage_id: StageId, snapshot: Dict[str, Any]) -> None:
+        """Persist stage-specific LLM route snapshot."""
+        os.makedirs(self.stages_dir, exist_ok=True)
+        path = os.path.join(self.stages_dir, f"{stage_id}_llm_route_snapshot.json")
+        # Ensure no secrets in snapshot
+        if "api_key" in snapshot:
+            snapshot = dict(snapshot)
+            del snapshot["api_key"]
+
+        with open(path, "w") as f:
+            json.dump(snapshot, f, indent=2)

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -1,0 +1,39 @@
+"""
+Secret Resolver.
+Resolves API keys from environment or session without exposing them in serializable objects.
+"""
+
+import os
+from typing import Optional, Dict
+from ..config import Config
+
+class SecretResolver:
+    """Resolves secrets for LLM providers."""
+
+    def __init__(self, session_api_keys: Optional[Dict[str, str]] = None):
+        self._session_keys = session_api_keys or {}
+
+    def get_api_key(self, provider_id: str, provider_type: str) -> Optional[str]:
+        """Resolve API key for a provider."""
+        # 1. Session-only override
+        if provider_id in self._session_keys:
+            return self._session_keys[provider_id]
+
+        # 2. Provider-specific environment variables
+        if provider_type == "openai":
+            return os.environ.get("OPENAI_API_KEY") or Config.LLM_API_KEY
+        if provider_type == "google":
+            return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+
+        # 3. Global fallback
+        return Config.LLM_API_KEY
+
+    def sanitize_url(self, url: Optional[str]) -> Optional[str]:
+        """Remove secrets from URL (no userinfo, no query string)."""
+        if not url:
+            return url
+        from urllib.parse import urlparse, urlunparse
+        parsed = urlparse(url)
+        # Remove user:pass and query/fragment
+        sanitized = parsed._replace(netloc=parsed.hostname + (f":{parsed.port}" if parsed.port else ""), query="", fragment="")
+        return urlunparse(sanitized)

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -1,0 +1,54 @@
+"""
+Stage Model Router.
+Resolve(run_id, stage_id, runtime_cfg) -> ResolvedRoute.
+"""
+
+from datetime import datetime
+from typing import Optional
+from ..contracts.llm_routing_contract import (
+    RuntimeLlmRouting,
+    ResolvedRoute,
+    StageId,
+    StageLLMRoute
+)
+from .runtime_run_config import RuntimeRunConfig
+from .secret_resolver import SecretResolver
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.stage_model_router")
+
+class StageModelRouter:
+    """Resolves the LLM route for a given stage."""
+
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+        self.config_service = RuntimeRunConfig(run_id)
+
+    def resolve(self, stage_id: StageId, runtime_cfg: Optional[RuntimeLlmRouting] = None) -> ResolvedRoute:
+        """Resolve route for a stage, using snapshot if it exists."""
+        # 1. Check for existing snapshot (locked-for-execution)
+        snapshot = self.config_service.load_stage_snapshot(stage_id)
+        if snapshot:
+            return ResolvedRoute.model_validate(snapshot)
+
+        # 2. Resolve from runtime config
+        cfg = runtime_cfg or self.config_service.load_config()
+        route = cfg.stage_overrides.get(stage_id) or cfg.default_route
+
+        # 3. Create new snapshot (but don't persist yet - caller should do that on stage start)
+        resolver = SecretResolver()
+        resolved = ResolvedRoute(
+            stage=stage_id,
+            provider_id=route.provider_id,
+            model=route.model,
+            base_url_sanitized=resolver.sanitize_url(route.base_url),
+            reasoning_effort=route.reasoning_effort,
+            routing_version=cfg.routing_version,
+            provider_options=route.provider_options,
+            started_at=datetime.now().isoformat()
+        )
+        return resolved
+
+    def lock_stage(self, stage_id: StageId, resolved_route: ResolvedRoute) -> None:
+        """Lock the route for a stage by persisting the snapshot."""
+        self.config_service.save_stage_snapshot(stage_id, resolved_route.model_dump(mode="json"))

--- a/backend/app/utils/artifact_locator.py
+++ b/backend/app/utils/artifact_locator.py
@@ -32,6 +32,18 @@ class ArtifactLocator:
         return os.path.join(cls.reports_dir(), report_id)
 
     @classmethod
+    def runs_dir(cls) -> str:
+        # AGORA_INSTANCE_DIR fallback ensures we don't break logic-first code
+        base = os.environ.get("AGORA_INSTANCE_DIR") or os.path.join(
+            os.path.dirname(__file__), "../../../instance"
+        )
+        return os.path.join(base, "runs")
+
+    @classmethod
+    def run_dir(cls, run_id: str) -> str:
+        return os.path.join(cls.runs_dir(), run_id)
+
+    @classmethod
     def simulation_file(cls, simulation_id: str, filename: str) -> str:
         return os.path.join(cls.simulation_dir(simulation_id), filename)
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -13,6 +13,7 @@ from openai import OpenAI
 from pydantic import BaseModel
 
 from ..config import Config
+from ..contracts.llm_routing_contract import ResolvedRoute, ReasoningEffort
 from .logger import get_logger
 from .retry import llm_call_with_retry
 
@@ -82,11 +83,15 @@ class LLMClient:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         model: Optional[str] = None,
-        timeout: float = 300.0
+        timeout: float = 300.0,
+        reasoning_effort: Optional[ReasoningEffort] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
     ):
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
+        self.reasoning_effort = reasoning_effort or "none"
+        self.provider_options = provider_options or {}
 
         if not self.api_key:
             raise ValueError("LLM_API_KEY not configured")
@@ -98,16 +103,27 @@ class LLMClient:
         )
 
         # Ollama context window size — prevents prompt truncation.
-        # Read from env OLLAMA_NUM_CTX, default 8192 (Ollama default is only 2048).
-        self._num_ctx = int(os.environ.get('OLLAMA_NUM_CTX', '8192'))
-        # Ollama thinking toggle (Gemma 4, Qwen3, DeepSeek-R1, GPT-OSS).
-        # Default false to keep latency low on long prompts.
-        self._think = os.environ.get('OLLAMA_THINKING', 'false').lower() in ('1', 'true', 'yes')
+        # Legacy: read from env OLLAMA_NUM_CTX. New: from provider_options.
+        self._num_ctx = int(self.provider_options.get('num_ctx') or os.environ.get('OLLAMA_NUM_CTX', '8192'))
+        # Ollama thinking toggle (mapped from reasoning_effort).
+        self._think = self.reasoning_effort != "none"
 
         # Transient-failure retry knobs (Ollama Cloud sometimes 5xx-flaps).
         self._max_retries = int(os.environ.get('LLM_MAX_RETRIES', '3'))
         self._retry_initial_delay = float(os.environ.get('LLM_RETRY_INITIAL_DELAY', '1.0'))
         self._retry_max_delay = float(os.environ.get('LLM_RETRY_MAX_DELAY', '30.0'))
+
+    @classmethod
+    def from_route(cls, route: ResolvedRoute, api_key: str, timeout: float = 300.0) -> "LLMClient":
+        """Factory: create LLMClient from a resolved stage route."""
+        return cls(
+            api_key=api_key,
+            base_url=route.base_url_sanitized, # Caller must provide secret base_url if needed
+            model=route.model,
+            timeout=timeout,
+            reasoning_effort=route.reasoning_effort,
+            provider_options=route.provider_options,
+        )
 
     def _is_ollama(self) -> bool:
         """Check if we're talking to an Ollama server."""

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from flask import Flask
+from app.api import llm_bp, runs_bp
+from app.utils.api_responses import handle_api_errors
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(llm_bp, url_prefix="/api/llm")
+    app.register_blueprint(runs_bp, url_prefix="/api/runs")
+    app.config["TESTING"] = True
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_list_providers(client):
+    with patch("app.api.llm_providers.provider_registry.get_providers") as mock_get:
+        mock_get.return_value = []
+        resp = client.get("/api/llm/providers")
+        assert resp.status_code == 200
+        assert resp.json["success"] is True
+
+@patch("app.api.llm_providers.model_catalog.get_models")
+def test_list_provider_models(mock_get_models, client):
+    mock_get_models.return_value = []
+    resp = client.get("/api/llm/providers/ollama_local/models")
+    assert resp.status_code == 200
+
+def test_get_run_llm_routing(client):
+    with patch("app.services.runtime_run_config.RuntimeRunConfig.load_config") as mock_load:
+        from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+        mock_load.return_value = RuntimeLlmRouting(
+            default_route=StageLLMRoute(provider_id="o", model="m")
+        )
+        resp = client.get("/api/runs/proj_123/llm-routing")
+        assert resp.status_code == 200
+        assert "runtime_config" in resp.json["data"]
+
+def test_patch_stage_llm_routing_locked(client):
+    with patch("app.services.runtime_run_config.RuntimeRunConfig.load_stage_snapshot") as mock_snap:
+        mock_snap.return_value = {"locked": True}
+        resp = client.patch("/api/runs/proj_123/llm-routing/stages/graph_build", json={})
+        assert resp.status_code == 409
+        assert resp.json["code"] == "stage_already_started"

--- a/backend/tests/contracts/test_llm_routing_contract.py
+++ b/backend/tests/contracts/test_llm_routing_contract.py
@@ -1,0 +1,61 @@
+import pytest
+from pydantic import ValidationError
+from app.contracts.llm_routing_contract import (
+    StageLLMRoute,
+    RuntimeLlmRouting,
+    ProviderDescriptor,
+    ResolvedRoute,
+)
+
+def test_stage_llm_route_valid():
+    route = StageLLMRoute(
+        provider_id="ollama",
+        model="qwen2.5:32b",
+        reasoning_effort="medium"
+    )
+    assert route.provider_id == "ollama"
+    assert route.model == "qwen2.5:32b"
+    assert route.reasoning_effort == "medium"
+    assert route.provider_options == {}
+
+def test_stage_llm_route_extra_forbid():
+    with pytest.raises(ValidationError):
+        StageLLMRoute(
+            provider_id="ollama",
+            model="qwen2.5:32b",
+            unknown_field="error"
+        )
+
+def test_runtime_llm_routing_valid():
+    default_route = StageLLMRoute(provider_id="openai", model="gpt-4o")
+    routing = RuntimeLlmRouting(
+        default_route=default_route,
+        stage_overrides={
+            "graph_build": StageLLMRoute(provider_id="ollama", model="qwen2.5:32b")
+        },
+        routing_version=2
+    )
+    assert routing.default_route.provider_id == "openai"
+    assert routing.stage_overrides["graph_build"].provider_id == "ollama"
+    assert routing.routing_version == 2
+
+def test_provider_descriptor_valid():
+    desc = ProviderDescriptor(
+        id="ollama_local",
+        name="Ollama Local",
+        type="ollama_local",
+        auth_status="configured"
+    )
+    assert desc.id == "ollama_local"
+    assert desc.type == "ollama_local"
+
+def test_resolved_route_valid():
+    route = ResolvedRoute(
+        stage="graph_build",
+        provider_id="ollama",
+        model="qwen2.5:32b",
+        routing_version=5,
+        started_at="2026-05-12T10:00:00Z"
+    )
+    assert route.stage == "graph_build"
+    assert route.routing_version == 5

--- a/backend/tests/services/test_llm_core_services.py
+++ b/backend/tests/services/test_llm_core_services.py
@@ -1,0 +1,59 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+from app.services.llm_provider_registry import LlmProviderRegistry
+from app.services.secret_resolver import SecretResolver
+from app.services.model_catalog_service import ModelCatalogService
+
+def test_provider_registry_auth_status():
+    registry = LlmProviderRegistry()
+
+    # Mock Config.LLM_API_KEY
+    with patch("app.services.llm_provider_registry.Config") as mock_config:
+        mock_config.LLM_API_KEY = "sk-test"
+        mock_config.LLM_BASE_URL = "https://api.openai.com/v1"
+
+        providers = registry.get_providers()
+        openai = next(p for p in providers if p.id == "openai")
+        assert openai.auth_status == "configured"
+
+        google = next(p for p in providers if p.id == "google")
+        assert google.auth_status == "missing"
+
+def test_secret_resolver():
+    resolver = SecretResolver(session_api_keys={"openai": "session-key"})
+    assert resolver.get_api_key("openai", "openai") == "session-key"
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+        resolver_no_session = SecretResolver()
+        assert resolver_no_session.get_api_key("openai", "openai") == "env-key"
+
+def test_secret_resolver_sanitize_url():
+    resolver = SecretResolver()
+    assert resolver.sanitize_url("http://user:pass@localhost:11434/v1?query=1") == "http://localhost:11434/v1"
+    assert resolver.sanitize_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
+
+@patch("requests.get")
+def test_model_catalog_ollama_discovery(mock_get):
+    # Mock /v1/models response
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"data": [{"id": "model1"}, {"id": "model2"}]}
+    mock_get.return_value = mock_resp
+
+    service = ModelCatalogService()
+    models = service.get_models("ollama", "ollama_local", "http://localhost:11434/v1", None)
+
+    assert len(models) == 2
+    assert models[0].id == "model1"
+    assert models[0].source == "live"
+
+def test_model_catalog_fallback():
+    service = ModelCatalogService()
+    # Clear cache to force fallback
+    service._cache = {}
+
+    with patch("requests.get", side_effect=Exception("Connection error")):
+        models = service.get_models("openai", "openai", "https://api.openai.com/v1", "key")
+        assert len(models) > 0
+        assert models[0].source == "fallback"

--- a/backend/tests/services/test_llm_observability.py
+++ b/backend/tests/services/test_llm_observability.py
@@ -1,0 +1,33 @@
+import pytest
+import os
+import json
+from app.services.llm_invocation_logger import LlmInvocationLogger
+from unittest.mock import patch
+
+def test_llm_invocation_logger_hygiene(tmp_path):
+    run_id = "proj_hygiene"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+
+    with patch("app.utils.artifact_locator.ArtifactLocator.run_dir", return_value=str(run_dir)):
+        logger = LlmInvocationLogger(run_id)
+        logger.log_event(
+            stage="graph_build",
+            provider_id="openai",
+            model="gpt-4",
+            base_url="https://user:pass@api.openai.com/v1?key=secret",
+            routing_version=1,
+            latency_ms=150.5,
+            success=True
+        )
+
+        log_file = run_dir / "llm_call_events.jsonl"
+        assert log_file.exists()
+
+        with open(log_file, "r") as f:
+            event = json.loads(f.readline())
+
+        assert event["run_id"] == run_id
+        assert "pass" not in event["base_url_sanitized"]
+        assert "key=secret" not in event["base_url_sanitized"]
+        assert event["base_url_sanitized"] == "https://api.openai.com/v1"

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -1,0 +1,76 @@
+import pytest
+import os
+import shutil
+from app.services.runtime_run_config import RuntimeRunConfig
+from app.services.stage_model_router import StageModelRouter
+from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, ResolvedRoute
+from app.utils.artifact_locator import ArtifactLocator
+
+@pytest.fixture
+def temp_run_dir(tmp_path):
+    run_id = "proj_testrun123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+
+    with patch("app.utils.artifact_locator.ArtifactLocator.run_dir", return_value=str(run_dir)):
+        yield run_id
+
+from unittest.mock import patch
+
+def test_runtime_run_config_persistence(temp_run_dir):
+    service = RuntimeRunConfig(temp_run_dir)
+    default_route = StageLLMRoute(provider_id="ollama", model="qwen")
+    config = RuntimeLlmRouting(default_route=default_route, routing_version=1)
+
+    service.save_config(config)
+    loaded = service.load_config()
+    assert loaded.routing_version == 1
+    assert loaded.default_route.provider_id == "ollama"
+
+def test_stage_model_router_resolution(temp_run_dir):
+    service = RuntimeRunConfig(temp_run_dir)
+    default_route = StageLLMRoute(provider_id="openai", model="gpt-4o")
+    override_route = StageLLMRoute(provider_id="ollama", model="qwen")
+    config = RuntimeLlmRouting(
+        default_route=default_route,
+        stage_overrides={"graph_build": override_route},
+        routing_version=1
+    )
+    service.save_config(config)
+
+    router = StageModelRouter(temp_run_dir)
+
+    # Resolve default
+    resolved_ingest = router.resolve("document_ingest")
+    assert resolved_ingest.provider_id == "openai"
+
+    # Resolve override
+    resolved_graph = router.resolve("graph_build")
+    assert resolved_graph.provider_id == "ollama"
+
+def test_stage_model_router_snapshot_isolation(temp_run_dir):
+    service = RuntimeRunConfig(temp_run_dir)
+    router = StageModelRouter(temp_run_dir)
+
+    default_route = StageLLMRoute(provider_id="openai", model="gpt-4o")
+    config = RuntimeLlmRouting(default_route=default_route, routing_version=1)
+    service.save_config(config)
+
+    # 1. Resolve and lock stage
+    resolved = router.resolve("document_ingest")
+    router.lock_stage("document_ingest", resolved)
+
+    # 2. Update runtime config
+    new_default = StageLLMRoute(provider_id="ollama", model="qwen")
+    new_config = RuntimeLlmRouting(default_route=new_default, routing_version=2)
+    service.save_config(new_config)
+
+    # 3. Resolve again - should still return the locked version
+    resolved_after = router.resolve("document_ingest")
+    assert resolved_after.provider_id == "openai"
+    assert resolved_after.routing_version == 1
+
+    # 4. Resolve another stage - should return the new version
+    resolved_other = router.resolve("graph_build")
+    assert resolved_other.provider_id == "ollama"
+    assert resolved_other.routing_version == 2

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.9.1-dev",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.9.1-dev",
+      "version": "1.0.0",
       "dependencies": {
         "@pinia/testing": "^1.0.3",
         "axios": "^1.16.0",

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -1,0 +1,40 @@
+import service from "./index";
+import {
+  ProviderDescriptor,
+  RuntimeLlmRouting,
+  ResolvedRoute,
+  StageLLMRoute
+} from "../contracts/llmRoutingContract";
+import { SuccessEnvelope } from "./envelope";
+
+export async function listLlmProviders(): Promise<ProviderDescriptor[]> {
+  const resp = await service.get<SuccessEnvelope<ProviderDescriptor[]>>("/llm/providers");
+  return (resp as any).data;
+}
+
+export async function listProviderModels(providerId: string, baseUrl?: string): Promise<any[]> {
+  const query = baseUrl ? `?base_url=${encodeURIComponent(baseUrl)}` : "";
+  const resp = await service.get<SuccessEnvelope<any[]>>(`/llm/providers/${providerId}/models${query}`);
+  return (resp as any).data;
+}
+
+export async function getRunLlmRouting(runId: string): Promise<{
+  runtime_config: RuntimeLlmRouting,
+  snapshots: Record<string, ResolvedRoute>
+}> {
+  const resp = await service.get<SuccessEnvelope<{
+    runtime_config: RuntimeLlmRouting,
+    snapshots: Record<string, ResolvedRoute>
+  }>>(`/runs/${runId}/llm-routing`);
+  return (resp as any).data;
+}
+
+export async function updateRunLlmRouting(runId: string, config: RuntimeLlmRouting): Promise<RuntimeLlmRouting> {
+  const resp = await service.put<SuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing`, config);
+  return (resp as any).data;
+}
+
+export async function patchStageLlmRouting(runId: string, stageId: string, route: StageLLMRoute): Promise<RuntimeLlmRouting> {
+  const resp = await service.patch<SuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing/stages/${stageId}`, route);
+  return (resp as any).data;
+}

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import {
+  listLlmProviders,
+  getRunLlmRouting,
+  updateRunLlmRouting,
+  patchStageLlmRouting,
+  listProviderModels
+} from '../../api/llmRouting';
+import {
+  ProviderDescriptor,
+  RuntimeLlmRouting,
+  StageLLMRoute,
+  StageId,
+  ReasoningEffort
+} from '../../contracts/llmRoutingContract';
+
+const props = defineProps<{
+  runId: string;
+}>();
+
+const { t } = useI18n();
+
+const providers = ref<ProviderDescriptor[]>([]);
+const routing = ref<RuntimeLlmRouting | null>(null);
+const snapshots = ref<Record<string, any>>({});
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const STAGES: StageId[] = [
+  "document_ingest",
+  "ontology_generation",
+  "graph_build",
+  "persona_generation",
+  "simulation_rounds",
+  "report_generation",
+  "evaluation",
+];
+
+const REASONING_EFFORTS: ReasoningEffort[] = ["none", "minimal", "low", "medium", "high"];
+
+async function load() {
+  loading.ref = true;
+  try {
+    const [p, r] = await Promise.all([
+      listLlmProviders(),
+      getRunLlmRouting(props.runId)
+    ]);
+    providers.value = p;
+    routing.value = r.runtime_config;
+    snapshots.value = r.snapshots;
+  } catch (e: any) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+
+async function saveGlobal() {
+  if (!routing.value) return;
+  try {
+    loading.value = true;
+    routing.value = await updateRunLlmRouting(props.runId, routing.value);
+  } catch (e: any) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function saveStage(stageId: StageId, route: StageLLMRoute) {
+  try {
+    loading.value = true;
+    routing.value = await patchStageLlmRouting(props.runId, stageId, route);
+  } catch (e: any) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function getProvider(id: string) {
+  return providers.value.find(p => p.id === id);
+}
+
+const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
+
+</script>
+
+<template>
+  <div class="llm-routing-view">
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <div v-if="routing" class="content-grid">
+      <!-- Left: Global Config -->
+      <div class="config-pane">
+        <h3>{{ t('llm.routing.global_default') }}</h3>
+        <div class="card">
+          <label>{{ t('llm.provider') }}</label>
+          <select v-model="routing.default_route.provider_id">
+            <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</option>
+          </select>
+
+          <label>{{ t('llm.model') }}</label>
+          <input v-model="routing.default_route.model" />
+
+          <label>{{ t('llm.reasoning_effort') }}</label>
+          <select v-model="routing.default_route.reasoning_effort">
+            <option v-for="e in REASONING_EFFORTS" :key="e" :value="e">{{ e }}</option>
+          </select>
+
+          <button @click="saveGlobal" :disabled="loading">{{ t('common.save') }}</button>
+        </div>
+
+        <h3>{{ t('llm.routing.stage_overrides') }}</h3>
+        <div v-for="stage in STAGES" :key="stage" class="stage-row card" :class="{ locked: isStageLocked(stage) }">
+          <h4>{{ t(`llm.stages.${stage}`) }}</h4>
+          <div v-if="isStageLocked(stage)" class="locked-badge">
+             <span class="icon">🔒</span> {{ t('llm.routing.locked') }}
+          </div>
+
+          <div class="stage-controls">
+            <label>{{ t('llm.provider') }}</label>
+            <select
+              :value="routing.stage_overrides[stage]?.provider_id || routing.default_route.provider_id"
+              @change="(e: any) => {
+                if (!routing) return;
+                if (!routing.stage_overrides[stage]) {
+                  routing.stage_overrides[stage] = { ...routing.default_route };
+                }
+                routing.stage_overrides[stage].provider_id = e.target.value;
+              }"
+              :disabled="isStageLocked(stage)"
+            >
+              <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</option>
+            </select>
+
+            <button
+              v-if="routing.stage_overrides[stage]"
+              @click="saveStage(stage, routing.stage_overrides[stage])"
+              :disabled="loading || isStageLocked(stage)"
+            >
+              {{ t('common.apply') }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right: Runtime Transparency -->
+      <div class="status-pane">
+        <h3>{{ t('llm.routing.active_snapshots') }}</h3>
+        <div v-if="Object.keys(snapshots).length === 0" class="empty-hint">
+          {{ t('llm.routing.no_snapshots_yet') }}
+        </div>
+        <div v-for="(snap, stageId) in snapshots" :key="stageId" class="snapshot-card card">
+          <div class="snap-header">
+            <strong>{{ t(`llm.stages.${stageId}`) }}</strong>
+            <span class="version">v{{ snap.routing_version }}</span>
+          </div>
+          <div class="snap-body">
+            <p><strong>{{ t('llm.model') }}:</strong> {{ snap.model }}</p>
+            <p><strong>{{ t('llm.provider') }}:</strong> {{ snap.provider_id }}</p>
+            <p class="timestamp">{{ snap.started_at }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.content-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+.card {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+}
+.locked {
+  background-color: #f5f5f5;
+  opacity: 0.8;
+}
+.locked-badge {
+  color: #666;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+.snapshot-card .snap-header {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.version {
+  background: #eee;
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+}
+.timestamp {
+  font-size: 0.7rem;
+  color: #999;
+}
+</style>

--- a/frontend/src/contracts/llmRoutingContract.ts
+++ b/frontend/src/contracts/llmRoutingContract.ts
@@ -1,0 +1,56 @@
+/**
+ * LLM Routing Contracts — Zod-Spiegel.
+ * Spiegelt backend/app/contracts/llm_routing_contract.py.
+ */
+import { z } from "zod";
+
+export const StageIdSchema = z.enum([
+  "document_ingest",
+  "ontology_generation",
+  "graph_build",
+  "persona_generation",
+  "simulation_rounds",
+  "report_generation",
+  "evaluation",
+]);
+export type StageId = z.infer<typeof StageIdSchema>;
+
+export const ReasoningEffortSchema = z.enum(["none", "minimal", "low", "medium", "high"]);
+export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
+
+export const StageLLMRouteSchema = z.object({
+  provider_id: z.string(),
+  model: z.string(),
+  base_url: z.string().url().optional().nullable(),
+  reasoning_effort: ReasoningEffortSchema.default("none"),
+  provider_options: z.record(z.any()).default({}),
+}).strict();
+export type StageLLMRoute = z.infer<typeof StageLLMRouteSchema>;
+
+export const RuntimeLlmRoutingSchema = z.object({
+  default_route: StageLLMRouteSchema,
+  stage_overrides: z.record(StageIdSchema, StageLLMRouteSchema).default({}),
+  routing_version: z.number().int().min(1).default(1),
+}).strict();
+export type RuntimeLlmRouting = z.infer<typeof RuntimeLlmRoutingSchema>;
+
+export const ProviderDescriptorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["ollama_local", "openai", "google", "openai_compatible"]),
+  default_base_url: z.string().url().optional().nullable(),
+  auth_status: z.enum(["configured", "missing", "session_required"]).default("missing"),
+}).strict();
+export type ProviderDescriptor = z.infer<typeof ProviderDescriptorSchema>;
+
+export const ResolvedRouteSchema = z.object({
+  stage: StageIdSchema,
+  provider_id: z.string(),
+  model: z.string(),
+  base_url_sanitized: z.string().optional().nullable(),
+  reasoning_effort: ReasoningEffortSchema.default("none"),
+  routing_version: z.number().int(),
+  provider_options: z.record(z.any()).default({}),
+  started_at: z.string().optional().nullable(),
+}).strict();
+export type ResolvedRoute = z.infer<typeof ResolvedRouteSchema>;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -346,6 +346,27 @@
     },
     "next": "Weiter zur Simulation →"
   },
+  "llm": {
+    "provider": "Provider",
+    "model": "Modell",
+    "reasoning_effort": "Denkleistung",
+    "stages": {
+      "document_ingest": "Dokument-Ingest",
+      "ontology_generation": "Ontologie-Generierung",
+      "graph_build": "Graph-Aufbau",
+      "persona_generation": "Persona-Generierung",
+      "simulation_rounds": "Simulations-Runden",
+      "report_generation": "Bericht-Erstellung",
+      "evaluation": "Evaluierung"
+    },
+    "routing": {
+      "global_default": "Globaler Standard",
+      "stage_overrides": "Stage-Overrides",
+      "locked": "Gesperrt",
+      "active_snapshots": "Aktive Snapshots",
+      "no_snapshots_yet": "Noch keine Snapshots vorhanden."
+    }
+  },
   "step3": {
     "kicker": "№ 03 — SIMULATION",
     "title": "Lass die Welt laufen.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -335,6 +335,27 @@
     },
     "next": "Next: simulation →"
   },
+  "llm": {
+    "provider": "Provider",
+    "model": "Model",
+    "reasoning_effort": "Reasoning Effort",
+    "stages": {
+      "document_ingest": "Document Ingest",
+      "ontology_generation": "Ontology Generation",
+      "graph_build": "Graph Build",
+      "persona_generation": "Persona Generation",
+      "simulation_rounds": "Simulation Rounds",
+      "report_generation": "Report Generation",
+      "evaluation": "Evaluation"
+    },
+    "routing": {
+      "global_default": "Global Default",
+      "stage_overrides": "Stage Overrides",
+      "locked": "Locked",
+      "active_snapshots": "Active Snapshots",
+      "no_snapshots_yet": "No snapshots yet."
+    }
+  },
   "step3": {
     "kicker": "№ 03 — SIMULATION",
     "title": "Run the world.",

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -6,6 +6,7 @@ import { getRun } from '../api/runs'
 import { ApiError } from '../api/envelope'
 import { RunDetailSchema } from '../contracts/runsContract'
 import type { RunDetail } from '../contracts/runsContract'
+import LlmRoutingView from '../components/LlmRouting/LlmRoutingView.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -123,6 +124,12 @@ onMounted(() => void loadRun())
             <dd>{{ String(val) }}</dd>
           </template>
         </dl>
+      </section>
+
+      <!-- LLM Routing -->
+      <section class="detail-section">
+        <h2 class="section-title">LLM Routing</h2>
+        <LlmRoutingView :run-id="runId" />
       </section>
 
       <!-- Artifacts -->

--- a/schemas/llm-provider-descriptor.schema.json
+++ b/schemas/llm-provider-descriptor.schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-provider-descriptor.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Metadata about an LLM provider.",
+  "properties": {
+    "auth_status": {
+      "default": "missing",
+      "enum": [
+        "configured",
+        "missing",
+        "session_required"
+      ],
+      "title": "Auth Status",
+      "type": "string"
+    },
+    "default_base_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Default Base Url"
+    },
+    "id": {
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "type": {
+      "enum": [
+        "ollama_local",
+        "openai",
+        "google",
+        "openai_compatible"
+      ],
+      "title": "Type",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "type"
+  ],
+  "title": "ProviderDescriptor",
+  "type": "object"
+}

--- a/schemas/llm-resolved-route.schema.json
+++ b/schemas/llm-resolved-route.schema.json
@@ -1,0 +1,82 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-resolved-route.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "The final resolved configuration for an LLM call inside a stage.",
+  "properties": {
+    "base_url_sanitized": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Base Url Sanitized"
+    },
+    "model": {
+      "title": "Model",
+      "type": "string"
+    },
+    "provider_id": {
+      "title": "Provider Id",
+      "type": "string"
+    },
+    "provider_options": {
+      "additionalProperties": true,
+      "title": "Provider Options",
+      "type": "object"
+    },
+    "reasoning_effort": {
+      "default": "none",
+      "enum": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "title": "Reasoning Effort",
+      "type": "string"
+    },
+    "routing_version": {
+      "title": "Routing Version",
+      "type": "integer"
+    },
+    "stage": {
+      "enum": [
+        "document_ingest",
+        "ontology_generation",
+        "graph_build",
+        "persona_generation",
+        "simulation_rounds",
+        "report_generation",
+        "evaluation"
+      ],
+      "title": "Stage",
+      "type": "string"
+    },
+    "started_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Started At"
+    }
+  },
+  "required": [
+    "stage",
+    "provider_id",
+    "model",
+    "routing_version"
+  ],
+  "title": "ResolvedRoute",
+  "type": "object"
+}

--- a/schemas/llm-runtime-routing.schema.json
+++ b/schemas/llm-runtime-routing.schema.json
@@ -1,0 +1,90 @@
+{
+  "$defs": {
+    "StageLLMRoute": {
+      "additionalProperties": false,
+      "description": "Configuration for a single stage route.",
+      "properties": {
+        "base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Url"
+        },
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "provider_id": {
+          "title": "Provider Id",
+          "type": "string"
+        },
+        "provider_options": {
+          "additionalProperties": true,
+          "title": "Provider Options",
+          "type": "object"
+        },
+        "reasoning_effort": {
+          "default": "none",
+          "enum": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Reasoning Effort",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider_id",
+        "model"
+      ],
+      "title": "StageLLMRoute",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/llm-runtime-routing.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Runtime LLM routing configuration for a run.",
+  "properties": {
+    "default_route": {
+      "$ref": "#/$defs/StageLLMRoute"
+    },
+    "routing_version": {
+      "default": 1,
+      "title": "Routing Version",
+      "type": "integer"
+    },
+    "stage_overrides": {
+      "additionalProperties": {
+        "$ref": "#/$defs/StageLLMRoute"
+      },
+      "propertyNames": {
+        "enum": [
+          "document_ingest",
+          "ontology_generation",
+          "graph_build",
+          "persona_generation",
+          "simulation_rounds",
+          "report_generation",
+          "evaluation"
+        ]
+      },
+      "title": "Stage Overrides",
+      "type": "object"
+    }
+  },
+  "required": [
+    "default_route"
+  ],
+  "title": "RuntimeLlmRouting",
+  "type": "object"
+}


### PR DESCRIPTION
Implement multi-provider LLM registry, stage-routing and runtime snapshots for running simulations. This includes backend contracts, discovery services, persistent run-specific configuration, LLM client refactoring, new API endpoints, and a frontend management view.

Fixes #376

---
*PR created automatically by Jules for task [14188179195694693379](https://jules.google.com/task/14188179195694693379) started by @arn0ld87*