### PR TITLE
fix(llm-routing): clear PR #390 blockers — CI green + Gemini findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,11 @@ PLAN.md.bak
 backend/logs/
 *.log
 
+# Runtime instance dir (pytest writes runtime_llm_routing.json + stage
+# snapshots there via ArtifactLocator.run_dir when AGORA_INSTANCE_DIR is
+# unset). Test artefacts only — never committed.
+/instance/
+
 # Archives / Snapshots (kein Backup im Repo)
 *.zip
 

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -525,28 +525,39 @@ def build_graph():
     project.graph_build_task_id = task_id
     ProjectManager.save_project(project)
 
-    # Stage 3: graph_build
+    # Stage 3: graph_build — resolve and lock the route at the boundary, but
+    # defer the actual ``LLMClient`` construction into the worker thread so a
+    # missing ``LLM_API_KEY`` only fails the background task, not the API
+    # response that just queues the build.
     router = StageModelRouter(run_id)
     build_route = router.resolve("graph_build")
     router.lock_stage("graph_build", build_route)
-
-    # NER-Override pro Build: wenn der Request (oder das Projekt-Default)
-    # ein Frontend-Modell vorgibt, bauen wir einen dedizierten NERExtractor,
-    # damit Phase-1-Extraktion das gewählte Modell nutzt — ohne den
-    # globalen Storage-Singleton-NER zu mutieren.
-    ner_llm_client = LLMClient.from_route(build_route, run_id=run_id)
-    ner_override = NERExtractor(llm_client=ner_llm_client)
-    logger.info(
-        "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s, version=%d",
-        ner_llm_client.model,
-        build_route.provider_id,
-        build_route.routing_version
-    )
 
     # Start background task
     def build_task():
         build_logger = get_logger('agora.build')
         try:
+            # NER-Override pro Build: wenn der Request (oder das Projekt-Default)
+            # ein Frontend-Modell vorgibt, bauen wir einen dedizierten NERExtractor,
+            # damit Phase-1-Extraktion das gewählte Modell nutzt — ohne den
+            # globalen Storage-Singleton-NER zu mutieren. Fehlt die LLM-
+            # Konfiguration (z.B. in Test-/Air-Gap-Setups), fällt der Builder
+            # auf den Storage-Default-NER zurück, statt den Build abzubrechen.
+            ner_override: NERExtractor | None = None
+            try:
+                ner_llm_client = LLMClient.from_route(build_route, run_id=run_id)
+                ner_override = NERExtractor(llm_client=ner_llm_client)
+                build_logger.info(
+                    "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s, version=%d",
+                    ner_llm_client.model,
+                    build_route.provider_id,
+                    build_route.routing_version,
+                )
+            except ValueError as exc:
+                build_logger.warning(
+                    "NER-LLM-Override not available, using storage default: %s",
+                    exc,
+                )
             build_logger.info(f"[{task_id}] Starting graph build...")
             task_manager.update_task(
                 task_id,

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -2,10 +2,11 @@
 LLM Routing API.
 """
 
+import typing
+
 from flask import request
 from . import runs_bp
 from ..services.runtime_run_config import RuntimeRunConfig
-from ..services.stage_model_router import StageModelRouter
 from ..services.run_registry import RunRegistry
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
 from ..utils.api_responses import handle_api_errors, json_success, json_error
@@ -14,6 +15,8 @@ from pydantic import ValidationError
 
 logger = get_logger("agora.api.llm_routing")
 run_registry = RunRegistry()
+
+_VALID_STAGE_IDS = typing.get_args(StageId)
 
 def _get_run_state(run_id: str):
     run = run_registry.get_run(run_id)
@@ -29,11 +32,8 @@ def get_run_llm_routing(run_id: str):
     config = config_service.load_config()
 
     # Also include snapshots for started stages
-    router = StageModelRouter(run_id)
     snapshots = {}
-    from ..contracts.llm_routing_contract import StageId
-    import typing
-    for stage in typing.get_args(StageId):
+    for stage in _VALID_STAGE_IDS:
         snap = config_service.load_stage_snapshot(stage)
         if snap:
             snapshots[stage] = snap
@@ -70,10 +70,7 @@ def update_run_llm_routing(run_id: str):
 @handle_api_errors(logger=logger)
 def patch_stage_llm_routing(run_id: str, stage_id: str):
     """Update routing for a specific stage."""
-    # Validate stage_id
-    from ..contracts.llm_routing_contract import StageId
-    import typing
-    if stage_id not in typing.get_args(StageId):
+    if stage_id not in _VALID_STAGE_IDS:
         return json_error(f"Invalid stage_id: {stage_id}", status=400)
 
     typed_stage_id = typing.cast(StageId, stage_id)

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -16,6 +16,7 @@ from flask import Response, request, send_file, current_app
 from pydantic import ValidationError
 
 from . import report_bp
+from ..config import Config
 from ..contracts import (
     DEFAULT_REPORT_MODE,
     EvidenceMapModel,

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -284,34 +284,37 @@ def prepare_simulation():
     run_id = f"sim_{simulation_id}"
     config_service = RuntimeRunConfig(run_id)
 
-    # Initialize or update runtime config
+    # Initialize or update runtime config — load existing if persisted, otherwise
+    # synthesize from the current request. ``ValidationError``/``json`` failures
+    # on a legacy file fall back to fresh construction (same as the legacy path),
+    # but ``SystemExit``/``KeyboardInterrupt`` must propagate.
+    if llm_runtime.enabled:
+        default_route = StageLLMRoute(
+            provider_id=llm_runtime.provider,
+            model=llm_model_override or Config.LLM_MODEL_NAME,
+            base_url=llm_runtime.base_url,
+        )
+    else:
+        default_route = StageLLMRoute(
+            provider_id="ollama_local",
+            model=llm_model_override or Config.LLM_MODEL_NAME,
+            base_url=Config.LLM_BASE_URL,
+        )
+
     try:
         runtime_routing = config_service.load_config()
-        # If it was a legacy fallback, we might want to update it with current request info
         if llm_runtime.enabled:
-             runtime_routing.default_route = StageLLMRoute(
-                 provider_id=llm_runtime.provider,
-                 model=llm_model_override or Config.LLM_MODEL_NAME,
-                 base_url=llm_runtime.base_url
-             )
-             runtime_routing.routing_version += 1
+            runtime_routing.default_route = default_route
+            runtime_routing.routing_version += 1
         elif llm_model_override:
-             runtime_routing.default_route.model = llm_model_override
-             runtime_routing.routing_version += 1
-    except:
-        # Create new config
-        if llm_runtime.enabled:
-            default_route = StageLLMRoute(
-                provider_id=llm_runtime.provider,
-                model=llm_model_override or Config.LLM_MODEL_NAME,
-                base_url=llm_runtime.base_url
-            )
-        else:
-            default_route = StageLLMRoute(
-                provider_id="ollama_local",
-                model=llm_model_override or Config.LLM_MODEL_NAME,
-                base_url=Config.LLM_BASE_URL
-            )
+            runtime_routing.default_route.model = llm_model_override
+            runtime_routing.routing_version += 1
+    except (OSError, ValueError, ValidationError) as exc:
+        logger.warning(
+            "Failed to load runtime routing config for %s, recreating: %s",
+            run_id,
+            exc,
+        )
         runtime_routing = RuntimeLlmRouting(default_route=default_route)
 
     config_service.save_config(runtime_routing)
@@ -457,12 +460,11 @@ def prepare_simulation():
                 parallel_profile_count=parallel_profile_count,
                 storage=storage,
                 llm_model=persona_route.model,
-                llm_runtime=persona_route, # manager handles ResolvedRoute or RuntimeLlmConfig?
-                # Need to check SimulationManager.prepare_simulation signature
+                llm_runtime=persona_route,
                 language=agent_language_override,
                 max_agents=max_agents,
                 quota_plan=quota_plan,
-                run_id=run_id, # Pass run_id for LLMClient creation inside manager
+                run_id=run_id,
             )
 
             task_manager.complete_task(task_id, result=result_state.to_simple_dict())

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -5,6 +5,7 @@ Run-control and live-status routes split from the main simulation API module.
 import os
 
 from flask import jsonify, request
+from pydantic import ValidationError
 
 from . import simulation_bp
 from ..config import Config
@@ -198,26 +199,31 @@ def start_simulation():
     run_id = f"sim_{simulation_id}"
     from ..services.stage_model_router import StageModelRouter
     from ..services.runtime_run_config import RuntimeRunConfig
-    from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+    from ..contracts.llm_routing_contract import StageLLMRoute
 
-    # 0. Initialise or update runtime routing
+    # 0. Initialise or update runtime routing. ``load_config`` already provides a
+    # legacy fallback; recoverable load/parse errors are logged and we skip
+    # mutating the persisted config rather than aborting the run.
     config_service = RuntimeRunConfig(run_id)
     try:
         runtime_routing = config_service.load_config()
         if llm_runtime.enabled:
-             runtime_routing.default_route = StageLLMRoute(
-                 provider_id=llm_runtime.provider,
-                 model=llm_model_override or Config.LLM_MODEL_NAME,
-                 base_url=llm_runtime.base_url
-             )
-             runtime_routing.routing_version += 1
+            runtime_routing.default_route = StageLLMRoute(
+                provider_id=llm_runtime.provider,
+                model=llm_model_override or Config.LLM_MODEL_NAME,
+                base_url=llm_runtime.base_url,
+            )
+            runtime_routing.routing_version += 1
         elif llm_model_override:
-             runtime_routing.default_route.model = llm_model_override
-             runtime_routing.routing_version += 1
+            runtime_routing.default_route.model = llm_model_override
+            runtime_routing.routing_version += 1
         config_service.save_config(runtime_routing)
-    except:
-        # Synthesis happens in load_config fallback
-        pass
+    except (OSError, ValueError, ValidationError) as exc:
+        logger.warning(
+            "Failed to update runtime routing config for %s, leaving fallback in place: %s",
+            run_id,
+            exc,
+        )
 
     router = StageModelRouter(run_id)
     rounds_route = router.resolve("simulation_rounds")

--- a/backend/app/contracts/llm_routing_contract.py
+++ b/backend/app/contracts/llm_routing_contract.py
@@ -57,14 +57,20 @@ class ProviderDescriptor(BaseModel):
 
 
 class ResolvedRoute(BaseModel):
-    """The final resolved configuration for an LLM call inside a stage."""
+    """The final resolved configuration for an LLM call inside a stage.
+
+    ``base_url`` is the runtime URL used for the actual LLM call. Callers must
+    never embed secrets (userinfo, query-string keys) into provider URLs; the
+    invocation logger and snapshot writer apply defensive sanitization when
+    emitting URLs to logs/disk via ``SecretResolver.sanitize_url``.
+    """
 
     model_config = _STRICT
 
     stage: StageId
     provider_id: str
     model: str
-    base_url_sanitized: Optional[str] = None
+    base_url: Optional[str] = None
     reasoning_effort: ReasoningEffort = "none"
     routing_version: int
     provider_options: Dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/services/llm_invocation_logger.py
+++ b/backend/app/services/llm_invocation_logger.py
@@ -6,7 +6,7 @@ Structured JSONL logging of LLM calls, ensuring secret hygiene.
 import os
 import json
 import time
-from typing import Optional, Dict, Any
+from typing import Optional
 from ..utils.artifact_locator import ArtifactLocator
 from .secret_resolver import SecretResolver
 

--- a/backend/app/services/llm_provider_registry.py
+++ b/backend/app/services/llm_provider_registry.py
@@ -3,6 +3,7 @@ LLM Provider Registry.
 Public provider metadata only — no secrets.
 """
 
+import os
 from typing import List, Optional
 from ..contracts.llm_routing_contract import ProviderDescriptor
 from ..config import Config
@@ -68,5 +69,3 @@ class LlmProviderRegistry:
 
         # Fallback
         return "missing"
-
-import os

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -5,7 +5,7 @@ Live /models discovery, normalization, cache, source-badge.
 
 import time
 import requests
-from typing import List, Optional, Dict, Any, Literal
+from typing import List, Optional, Dict, Literal
 from pydantic import BaseModel, ConfigDict
 from ..utils.logger import get_logger
 
@@ -20,7 +20,6 @@ class ModelEntry(BaseModel):
     source: Literal["live", "cached", "fallback", "custom"]
     refreshed_at: float
 
-from typing import Literal
 
 class ModelCatalogService:
     """Service for discovering and normalizing models from different providers."""

--- a/backend/app/services/prepare_service.py
+++ b/backend/app/services/prepare_service.py
@@ -23,9 +23,10 @@ from __future__ import annotations
 import json
 import os
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from ..contracts import PersonaQuotaActual, PersonaQuotaPlan
+from ..contracts.llm_routing_contract import ResolvedRoute
 from ..utils.logger import get_logger
 from .entity_reader import EntityReader
 from .settings_layer import get_default_service as _get_settings
@@ -38,7 +39,31 @@ from .simulation_config_generator import SimulationConfigGenerator
 if TYPE_CHECKING:
     from .simulation_manager import SimulationManager, SimulationState
 
+LlmRuntimeLike = Union[RuntimeLlmConfig, ResolvedRoute]
+
 logger = get_logger("agora.prepare")
+
+
+def _resolve_runtime_secrets(
+    llm_runtime: Optional[LlmRuntimeLike],
+    run_id: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(api_key, base_url)`` regardless of which runtime shape is passed.
+
+    ``ResolvedRoute`` goes through ``LLMClient.from_route`` so the same secret
+    resolution rules apply. Legacy ``RuntimeLlmConfig`` instances expose the
+    fields directly when ``enabled`` is true.
+    """
+    if isinstance(llm_runtime, ResolvedRoute):
+        from ..utils.llm_client import LLMClient
+        client = LLMClient.from_route(llm_runtime, run_id=run_id)
+        return client.api_key, client.base_url
+    if llm_runtime and getattr(llm_runtime, "enabled", False):
+        return (
+            getattr(llm_runtime, "api_key", None),
+            getattr(llm_runtime, "base_url", None),
+        )
+    return None, None
 
 
 def _phase_read_entities(
@@ -106,7 +131,7 @@ def _phase_generate_profiles(
     sim_dir: str,
     *,
     llm_model: Optional[str],
-    llm_runtime: Optional[Any] = None,
+    llm_runtime: Optional[LlmRuntimeLike] = None,
     language: Optional[str],
     run_id: Optional[str] = None,
     use_llm_for_profiles: bool,
@@ -144,18 +169,7 @@ def _phase_generate_profiles(
     # (IT-Cap ≤ 12 %). total_entities als Pool-Größe für proportionale Verteilung.
     industry_plan = default_dach_industry_quota(max(total_entities, 1))
 
-    # Resolve secrets if llm_runtime is a ResolvedRoute
-    from ..contracts.llm_routing_contract import ResolvedRoute
-    from ..utils.llm_client import LLMClient
-    api_key = None
-    base_url = None
-    if isinstance(llm_runtime, ResolvedRoute):
-        client = LLMClient.from_route(llm_runtime, run_id=run_id)
-        api_key = client.api_key
-        base_url = client.base_url
-    elif llm_runtime and getattr(llm_runtime, "enabled", False):
-        api_key = getattr(llm_runtime, "api_key", None)
-        base_url = getattr(llm_runtime, "base_url", None)
+    api_key, base_url = _resolve_runtime_secrets(llm_runtime, run_id)
 
     generator = OasisProfileGenerator(
         api_key=api_key,
@@ -245,7 +259,7 @@ def _phase_generate_config(
     filtered,
     *,
     llm_model: Optional[str],
-    llm_runtime: Optional[Any] = None,
+    llm_runtime: Optional[LlmRuntimeLike] = None,
     language: Optional[str],
     run_id: Optional[str] = None,
     progress_callback: Optional[Callable] = None,
@@ -270,18 +284,7 @@ def _phase_generate_config(
             total=3,
         )
 
-    # Resolve secrets if llm_runtime is a ResolvedRoute
-    from ..contracts.llm_routing_contract import ResolvedRoute
-    from ..utils.llm_client import LLMClient
-    api_key = None
-    base_url = None
-    if isinstance(llm_runtime, ResolvedRoute):
-        client = LLMClient.from_route(llm_runtime, run_id=run_id)
-        api_key = client.api_key
-        base_url = client.base_url
-    elif llm_runtime and getattr(llm_runtime, "enabled", False):
-        api_key = getattr(llm_runtime, "api_key", None)
-        base_url = getattr(llm_runtime, "base_url", None)
+    api_key, base_url = _resolve_runtime_secrets(llm_runtime, run_id)
 
     config_generator = SimulationConfigGenerator(
         api_key=api_key,
@@ -490,7 +493,7 @@ def prepare_simulation(
     parallel_profile_count: Optional[int] = None,
     storage: Any = None,
     llm_model: Optional[str] = None,
-    llm_runtime: Optional[Any] = None,
+    llm_runtime: Optional[LlmRuntimeLike] = None,
     language: Optional[str] = None,
     max_agents: Optional[int] = None,
     quota_plan: Optional[PersonaQuotaPlan] = None,

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -5,7 +5,6 @@ Handle persistence of runtime_llm_routing.json and stage snapshots.
 
 import os
 import json
-from datetime import datetime
 from typing import Optional, Dict, Any
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
 from ..utils.artifact_locator import ArtifactLocator
@@ -38,13 +37,6 @@ class RuntimeRunConfig:
         )
         return RuntimeLlmRouting(default_route=default_route)
 
-    def save_config(self, config: RuntimeLlmRouting) -> None:
-        """Persist runtime configuration."""
-        os.makedirs(self.run_dir, exist_ok=True)
-        # Monotonicity check for routing_version should happen in service/api layer
-        with open(self.config_path, "w") as f:
-            f.write(config.model_dump_json(indent=2))
-
     def load_stage_snapshot(self, stage_id: StageId) -> Optional[Dict[str, Any]]:
         """Load stage-specific LLM route snapshot."""
         path = os.path.join(self.stages_dir, f"{stage_id}_llm_route_snapshot.json")
@@ -54,34 +46,37 @@ class RuntimeRunConfig:
         return None
 
     def save_stage_snapshot(self, stage_id: StageId, snapshot: Dict[str, Any]) -> None:
-        """Persist stage-specific LLM route snapshot."""
+        """Persist stage-specific LLM route snapshot with defensive sanitization."""
         os.makedirs(self.stages_dir, exist_ok=True)
         path = os.path.join(self.stages_dir, f"{stage_id}_llm_route_snapshot.json")
 
-        # Ensure no secrets in snapshot
         snapshot = self._sanitize_deep(snapshot)
 
         with open(path, "w") as f:
             json.dump(snapshot, f, indent=2)
 
     def _sanitize_deep(self, data: Any) -> Any:
-        """Recursively remove keys that might contain secrets."""
+        """Recursively strip secret-bearing keys and sanitize URLs in snapshots."""
+        from .secret_resolver import SecretResolver
+
         if isinstance(data, dict):
-            return {
-                k: self._sanitize_deep(v)
-                for k, v in data.items()
-                if k.lower() not in ("api_key", "apikey", "secret", "password", "token")
-            }
+            cleaned: Dict[str, Any] = {}
+            for k, v in data.items():
+                if k.lower() in ("api_key", "apikey", "secret", "password", "token"):
+                    continue
+                if k == "base_url" and isinstance(v, str):
+                    cleaned[k] = SecretResolver().sanitize_url(v)
+                    continue
+                cleaned[k] = self._sanitize_deep(v)
+            return cleaned
         if isinstance(data, list):
             return [self._sanitize_deep(v) for v in data]
         return data
 
     def save_config(self, config: RuntimeLlmRouting) -> None:
-        """Persist runtime configuration."""
+        """Persist runtime configuration with defensive sanitization."""
         os.makedirs(self.run_dir, exist_ok=True)
-        # Monotonicity check for routing_version should happen in service/api layer
 
-        # Sanitize deep before saving
         data = self._sanitize_deep(config.model_dump(mode="json"))
 
         with open(self.config_path, "w") as f:

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -9,10 +9,8 @@ from ..contracts.llm_routing_contract import (
     RuntimeLlmRouting,
     ResolvedRoute,
     StageId,
-    StageLLMRoute
 )
 from .runtime_run_config import RuntimeRunConfig
-from .secret_resolver import SecretResolver
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.stage_model_router")
@@ -35,13 +33,14 @@ class StageModelRouter:
         cfg = runtime_cfg or self.config_service.load_config()
         route = cfg.stage_overrides.get(stage_id) or cfg.default_route
 
-        # 3. Create new snapshot (but don't persist yet - caller should do that on stage start)
-        resolver = SecretResolver()
+        # 3. Create new snapshot (but don't persist yet - caller should do that on stage start).
+        # ``base_url`` carries the runtime URL untouched; sanitization happens when the
+        # snapshot is written to disk or emitted via the observability logger.
         resolved = ResolvedRoute(
             stage=stage_id,
             provider_id=route.provider_id,
             model=route.model,
-            base_url_sanitized=resolver.sanitize_url(route.base_url),
+            base_url=route.base_url,
             reasoning_effort=route.reasoning_effort,
             routing_version=cfg.routing_version,
             provider_options=route.provider_options,

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -132,6 +132,18 @@ class LLMClient:
         self._retry_initial_delay = float(os.environ.get('LLM_RETRY_INITIAL_DELAY', '1.0'))
         self._retry_max_delay = float(os.environ.get('LLM_RETRY_MAX_DELAY', '30.0'))
 
+    _PROVIDER_TYPE_BY_ID: Dict[str, str] = {
+        "openai": "openai",
+        "google": "google",
+        "ollama_local": "ollama_local",
+    }
+
+    _DEFAULT_BASE_URLS: Dict[str, str] = {
+        "openai": "https://api.openai.com/v1",
+        "google": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "ollama_local": "http://localhost:11434/v1",
+    }
+
     @classmethod
     def from_route(
         cls,
@@ -140,41 +152,19 @@ class LLMClient:
         run_id: Optional[str] = None,
         timeout: float = 300.0
     ) -> "LLMClient":
-        """Factory: create LLMClient from a resolved stage route and secret resolver."""
+        """Factory: create LLMClient from a resolved stage route and secret resolver.
+
+        ``route.base_url`` is the runtime URL — used verbatim for the actual API
+        call. Callers must keep secrets out of URLs; the observability logger and
+        snapshot writer sanitize defensively when emitting to logs/disk.
+        """
         from ..services.secret_resolver import SecretResolver
         resolver = secret_resolver or SecretResolver()
 
-        # 1. Resolve provider type (needed for api key resolution)
-        # We need to know the type, but ResolvedRoute only has provider_id.
-        # For now, we try to infer it or use a default.
-        # In a more robust implementation, ResolvedRoute might carry provider_type.
-        provider_type = "openai_compatible"
-        if route.provider_id == "openai":
-            provider_type = "openai"
-        elif route.provider_id == "google":
-            provider_type = "google"
-        elif route.provider_id == "ollama_local":
-            provider_type = "ollama_local"
-
-        # 2. Resolve secrets
+        provider_type = cls._PROVIDER_TYPE_BY_ID.get(route.provider_id, "openai_compatible")
         api_key = resolver.get_api_key(route.provider_id, provider_type)
 
-        # For base_url, we need the ORIGINAL URL if it was overridden,
-        # but ResolvedRoute only has base_url_sanitized.
-        # This is a gap in the contract: if we use a custom base_url,
-        # where do we get the non-sanitized one?
-        # Requirement 5 says: "do not use base_url_sanitized as the actual invocation URL if the original route URL is needed for execution"
-        # However, secrets are not allowed in URLs anyway by our sanitization logic (userinfo, query).
-        # If the original base_url was in Config, we can get it.
-        # If it was a per-stage override, we might need to recover it.
-
-        base_url = route.base_url_sanitized
-        if route.provider_id == "openai" and not route.base_url_sanitized:
-             base_url = "https://api.openai.com/v1"
-        elif route.provider_id == "google" and not route.base_url_sanitized:
-             base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
-        elif route.provider_id == "ollama_local" and not route.base_url_sanitized:
-             base_url = "http://localhost:11434/v1"
+        base_url = route.base_url or cls._DEFAULT_BASE_URLS.get(route.provider_id)
 
         return cls(
             api_key=api_key,
@@ -397,8 +387,7 @@ class LLMClient:
             and os.environ.get("LLM_FORCE_STREAM", "true").lower() in ("1", "true", "yes")
         )
 
-        import time as _time
-        _t0 = _time.monotonic()
+        _t0 = _time_mod.monotonic()
 
         def _create(call_kwargs: Dict[str, Any]):
             """One-shot call mit transient-retry. KEINE 400-Behandlung — die macht der äußere Wrapper."""
@@ -413,8 +402,7 @@ class LLMClient:
             except Exception as exc:
                 if self._invocation_logger:
                     # Log failure before re-raising
-                    import time as _t
-                    latency = (_t.monotonic() - _t0) * 1000
+                    latency = (_time_mod.monotonic() - _t0) * 1000
                     status_code = getattr(exc, "status_code", None)
                     if status_code is None:
                         response = getattr(exc, "response", None)
@@ -480,7 +468,7 @@ class LLMClient:
             usage = getattr(response, "usage", None)
             completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
             content = choice.message.content or ""
-        elapsed = _time.monotonic() - _t0
+        elapsed = _time_mod.monotonic() - _t0
         logger.info(
             "LLM chat returned model=%s finish=%s tokens_out=%s elapsed=%.1fs max_tokens=%s stream=%s",
             self.model, finish_reason, completion_tokens, elapsed, max_tokens, force_stream,

--- a/backend/tests/api/test_graph_ontology_respects_frontend_model.py
+++ b/backend/tests/api/test_graph_ontology_respects_frontend_model.py
@@ -20,7 +20,11 @@ from app.container import AgoraContainer
 
 
 @pytest.fixture
-def app(monkeypatch):
+def app(monkeypatch, tmp_path):
+    # Isolate per-run routing artifacts (runtime_llm_routing.json + stage
+    # snapshots) so tests don't read previous-test state from the shared
+    # instance dir. Each test gets its own ``AGORA_INSTANCE_DIR``.
+    monkeypatch.setenv("AGORA_INSTANCE_DIR", str(tmp_path))
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)
     flask_app = Flask(__name__)
@@ -113,16 +117,20 @@ def test_ontology_generate_uses_frontend_llm_model_and_provider(
     assert response.status_code == 200, response.get_json()
     assert response.get_json()["success"] is True
 
-    # LLMClient muss mit dem Frontend-Modell + Provider-Override instanziiert sein.
-    llm_client_cls.assert_called_once()
-    kwargs = llm_client_cls.call_args.kwargs
-    assert kwargs.get("model") == "gpt-5-mini"
-    assert kwargs.get("api_key") == "sk-test"
-    assert kwargs.get("base_url") == "https://api.openai.com/v1"
+    # LLMClient.from_route muss mit dem Frontend-Modell + Provider-Override
+    # aus der gelockten ``ResolvedRoute`` aufgerufen worden sein.
+    llm_client_cls.from_route.assert_called_once()
+    resolved_route = llm_client_cls.from_route.call_args.args[0]
+    assert resolved_route.model == "gpt-5-mini"
+    assert resolved_route.provider_id == "openai"
+    assert resolved_route.base_url == "https://api.openai.com/v1"
 
     # OntologyGenerator muss den injizierten Client bekommen.
     ontology_generator_cls.assert_called_once()
-    assert ontology_generator_cls.call_args.kwargs.get("llm_client") is llm_client_cls.return_value
+    assert (
+        ontology_generator_cls.call_args.kwargs.get("llm_client")
+        is llm_client_cls.from_route.return_value
+    )
 
 
 @patch("app.api.graph.LLMClient")
@@ -160,10 +168,11 @@ def test_ontology_generate_without_overrides_uses_server_default(
     )
 
     assert response.status_code == 200, response.get_json()
-    llm_client_cls.assert_called_once()
-    kwargs = llm_client_cls.call_args.kwargs
-    # Ohne Runtime-Provider liefert client_kwargs nur {"model": None}.
-    assert kwargs == {"model": None}
+    # Ohne Runtime-Provider routet der Endpoint auf den ``ollama_local``-Default
+    # und reicht die resolved Route an ``LLMClient.from_route`` weiter.
+    llm_client_cls.from_route.assert_called_once()
+    resolved_route = llm_client_cls.from_route.call_args.args[0]
+    assert resolved_route.provider_id == "ollama_local"
 
 
 def test_ontology_generate_rejects_invalid_llm_provider_json(client):

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -1,8 +1,7 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from flask import Flask
 from app.api import llm_bp, runs_bp
-from app.utils.api_responses import handle_api_errors
 
 @pytest.fixture
 def app():

--- a/backend/tests/api/test_report_modes.py
+++ b/backend/tests/api/test_report_modes.py
@@ -98,6 +98,10 @@ def _make_mock_project():
     project = MagicMock()
     project.graph_id = VALID_GRAPH_ID
     project.simulation_requirement = "Test requirement"
+    # Routing pulls a real string from these via ``or Config.LLM_MODEL_NAME``;
+    # explicit None prevents MagicMock leaking into Pydantic validation.
+    project.llm_model = None
+    project.llm_provider = None
     return project
 
 

--- a/backend/tests/services/test_llm_core_services.py
+++ b/backend/tests/services/test_llm_core_services.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 from unittest.mock import patch, MagicMock
 from app.services.llm_provider_registry import LlmProviderRegistry

--- a/backend/tests/services/test_llm_observability.py
+++ b/backend/tests/services/test_llm_observability.py
@@ -1,5 +1,3 @@
-import pytest
-import os
 import json
 from app.services.llm_invocation_logger import LlmInvocationLogger
 from unittest.mock import patch

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -1,10 +1,10 @@
+from unittest.mock import patch
+
 import pytest
-import os
-import shutil
 from app.services.runtime_run_config import RuntimeRunConfig
 from app.services.stage_model_router import StageModelRouter
-from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, ResolvedRoute
-from app.utils.artifact_locator import ArtifactLocator
+from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+
 
 @pytest.fixture
 def temp_run_dir(tmp_path):
@@ -15,7 +15,6 @@ def temp_run_dir(tmp_path):
     with patch("app.utils.artifact_locator.ArtifactLocator.run_dir", return_value=str(run_dir)):
         yield run_id
 
-from unittest.mock import patch
 
 def test_runtime_run_config_persistence(temp_run_dir):
     service = RuntimeRunConfig(temp_run_dir)

--- a/backend/tests/services/test_secret_hygiene.py
+++ b/backend/tests/services/test_secret_hygiene.py
@@ -1,8 +1,7 @@
 import pytest
-import os
 import json
 from app.services.runtime_run_config import RuntimeRunConfig
-from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, ResolvedRoute
+from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
 from unittest.mock import patch
 
 @pytest.fixture

--- a/backend/tests/utils/test_llm_client_completion_token_routing.py
+++ b/backend/tests/utils/test_llm_client_completion_token_routing.py
@@ -148,6 +148,14 @@ def fake_client(monkeypatch):
     # Non-Ollama base_url → kein force-stream-Pfad.
     obj.base_url = "https://api.openai.com/v1"
     obj.client = _FakeOpenAI()
+    # Routing/observability attributes — normally set in __init__, but tests
+    # bypass it via __new__. chat() references them unconditionally.
+    obj.stage = None
+    obj.provider_id = None
+    obj.routing_version = 0
+    obj.reasoning_effort = "none"
+    obj.provider_options = {}
+    obj._invocation_logger = None
     # Deaktiviere Streaming-Force-Pfad explizit (für alle Tests in diesem Modul).
     monkeypatch.setenv("LLM_FORCE_STREAM", "false")
     # E2E-Stub muss aus sein.

--- a/backend/tests/utils/test_llm_client_token_key_fallback.py
+++ b/backend/tests/utils/test_llm_client_token_key_fallback.py
@@ -131,6 +131,14 @@ def fake_client(monkeypatch):
     obj.api_key = "test"
     obj.base_url = "https://api.openai.com/v1"
     obj.model = "gpt-4o"  # Heuristik sagt max_tokens
+    # Routing/observability attributes are normally set in __init__ but we
+    # bypass it here; the chat() call paths reference them unconditionally.
+    obj.stage = None
+    obj.provider_id = None
+    obj.routing_version = 0
+    obj.reasoning_effort = "none"
+    obj.provider_options = {}
+    obj._invocation_logger = None
     monkeypatch.setenv("LLM_FORCE_STREAM", "false")
     monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
     return obj
@@ -214,6 +222,12 @@ def test_chat_streaming_path_also_falls_back(monkeypatch) -> None:
     obj.api_key = "test"
     obj.base_url = "http://localhost:11434/v1"  # Ollama → force_stream
     obj.model = "qwen2.5:32b"
+    obj.stage = None
+    obj.provider_id = None
+    obj.routing_version = 0
+    obj.reasoning_effort = "none"
+    obj.provider_options = {}
+    obj._invocation_logger = None
     monkeypatch.setenv("LLM_FORCE_STREAM", "true")
     monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
 

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -5,16 +5,16 @@ import {
   ResolvedRoute,
   StageLLMRoute
 } from "../contracts/llmRoutingContract";
-import { SuccessEnvelope } from "./envelope";
+import { ApiSuccessEnvelope } from "./envelope";
 
 export async function listLlmProviders(): Promise<ProviderDescriptor[]> {
-  const resp = await service.get<SuccessEnvelope<ProviderDescriptor[]>>("/llm/providers");
+  const resp = await service.get<ApiSuccessEnvelope<ProviderDescriptor[]>>("/llm/providers");
   return (resp as any).data;
 }
 
 export async function listProviderModels(providerId: string, baseUrl?: string): Promise<any[]> {
   const query = baseUrl ? `?base_url=${encodeURIComponent(baseUrl)}` : "";
-  const resp = await service.get<SuccessEnvelope<any[]>>(`/llm/providers/${providerId}/models${query}`);
+  const resp = await service.get<ApiSuccessEnvelope<any[]>>(`/llm/providers/${providerId}/models${query}`);
   return (resp as any).data;
 }
 
@@ -22,7 +22,7 @@ export async function getRunLlmRouting(runId: string): Promise<{
   runtime_config: RuntimeLlmRouting,
   snapshots: Record<string, ResolvedRoute>
 }> {
-  const resp = await service.get<SuccessEnvelope<{
+  const resp = await service.get<ApiSuccessEnvelope<{
     runtime_config: RuntimeLlmRouting,
     snapshots: Record<string, ResolvedRoute>
   }>>(`/runs/${runId}/llm-routing`);
@@ -30,11 +30,11 @@ export async function getRunLlmRouting(runId: string): Promise<{
 }
 
 export async function updateRunLlmRouting(runId: string, config: RuntimeLlmRouting): Promise<RuntimeLlmRouting> {
-  const resp = await service.put<SuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing`, config);
+  const resp = await service.put<ApiSuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing`, config);
   return (resp as any).data;
 }
 
 export async function patchStageLlmRouting(runId: string, stageId: string, route: StageLLMRoute): Promise<RuntimeLlmRouting> {
-  const resp = await service.patch<SuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing/stages/${stageId}`, route);
+  const resp = await service.patch<ApiSuccessEnvelope<RuntimeLlmRouting>>(`/runs/${runId}/llm-routing/stages/${stageId}`, route);
   return (resp as any).data;
 }

--- a/frontend/src/contracts/llmRoutingContract.ts
+++ b/frontend/src/contracts/llmRoutingContract.ts
@@ -23,13 +23,13 @@ export const StageLLMRouteSchema = z.object({
   model: z.string(),
   base_url: z.string().url().optional().nullable(),
   reasoning_effort: ReasoningEffortSchema.default("none"),
-  provider_options: z.record(z.any()).default({}),
+  provider_options: z.record(z.string(), z.any()).default(() => ({})),
 }).strict();
 export type StageLLMRoute = z.infer<typeof StageLLMRouteSchema>;
 
 export const RuntimeLlmRoutingSchema = z.object({
   default_route: StageLLMRouteSchema,
-  stage_overrides: z.record(StageIdSchema, StageLLMRouteSchema).default({}),
+  stage_overrides: z.record(StageIdSchema, StageLLMRouteSchema).default(() => ({}) as Record<StageId, StageLLMRoute>),
   routing_version: z.number().int().min(1).default(1),
 }).strict();
 export type RuntimeLlmRouting = z.infer<typeof RuntimeLlmRoutingSchema>;
@@ -47,10 +47,10 @@ export const ResolvedRouteSchema = z.object({
   stage: StageIdSchema,
   provider_id: z.string(),
   model: z.string(),
-  base_url_sanitized: z.string().optional().nullable(),
+  base_url: z.string().optional().nullable(),
   reasoning_effort: ReasoningEffortSchema.default("none"),
   routing_version: z.number().int(),
-  provider_options: z.record(z.any()).default({}),
+  provider_options: z.record(z.string(), z.any()).default(() => ({})),
   started_at: z.string().optional().nullable(),
 }).strict();
 export type ResolvedRoute = z.infer<typeof ResolvedRouteSchema>;

--- a/schemas/llm-resolved-route.schema.json
+++ b/schemas/llm-resolved-route.schema.json
@@ -2,9 +2,9 @@
   "$id": "https://alexle135.de/schemas/llm-resolved-route.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "The final resolved configuration for an LLM call inside a stage.",
+  "description": "The final resolved configuration for an LLM call inside a stage.\n\n``base_url`` is the runtime URL used for the actual LLM call. Callers must\nnever embed secrets (userinfo, query-string keys) into provider URLs; the\ninvocation logger and snapshot writer apply defensive sanitization when\nemitting URLs to logs/disk via ``SecretResolver.sanitize_url``.",
   "properties": {
-    "base_url_sanitized": {
+    "base_url": {
       "anyOf": [
         {
           "type": "string"
@@ -14,7 +14,7 @@
         }
       ],
       "default": null,
-      "title": "Base Url Sanitized"
+      "title": "Base Url"
     },
     "model": {
       "title": "Model",


### PR DESCRIPTION
## Summary

Stack-PR auf `feat/llm-stage-routing-completion-14277178618577281990` (#390). Räumt die in der Issue-Beschreibung gelisteten Blocker ab, damit `CI`, `contract-gates` und `e2e-smokes` grün werden können und Gemini-Findings adressiert sind.

### Blocker-Adressierung

- **RuntimeRunConfig.save_config doppelt definiert** (Gemini HIGH): die erste Definition entfernt, die zweite (mit `_sanitize_deep`) bleibt. `_sanitize_deep` zieht jetzt auch die `base_url`-Werte durch `SecretResolver.sanitize_url`, sodass die Snapshot-/Config-Files auf Platte secret-frei bleiben.
- **LLMClient.from_route nutzte `base_url_sanitized` als Runtime-URL**: `ResolvedRoute` führt jetzt `base_url` (unverändert) für den Runtime-Pfad; Sanitization passiert nur noch am Log-/Snapshot-Boundary. Schema + Zod-Mirror regeneriert.
- **`simulation_prepare.py` bare `except:` + TODO/internal notes**: durch `(OSError, ValueError, ValidationError)` ersetzt; TODO-Kommentar vor dem Manager-Call entfernt.
- **`simulation_run.py` bare `except:`**: gleich behandelt; `pydantic.ValidationError` importiert.
- **Frontend-Typecheck (`SuccessEnvelope` + Zod-Defaults)**: Import zu `ApiSuccessEnvelope` korrigiert, `z.record(z.string(), z.any())` und `.default(() => …)`-Factories für Zod 4.x.
- **Gemini Mediums**:
  - `prepare_service.py` Z. 109/248/493 — `Optional[Any]` → `Optional[LlmRuntimeLike]` (Union aus `RuntimeLlmConfig | ResolvedRoute`), zentraler `_resolve_runtime_secrets`-Helper.
  - `utils/llm_client.py` redundante `import time as _t` / `import time as _time` entfernt — Modul-Alias `_time_mod` einheitlich.

### Tests / CI

- `LLM_API_KEY=dummy-ci-key uv run pytest` — **1944 passed, 9 skipped** (vorher 9 Failures).
- `uv run ruff check . && uv run mypy app` — clean.
- `npm run check` (typecheck + tests + build) — clean.
- Schema-Drift: `python -m app.contracts.dump_schemas` liefert exakt das, was in der PR liegt.

## Test plan

- [x] Backend pytest grün
- [x] ruff + mypy grün
- [x] Frontend typecheck + 501 Tests + Vite build grün
- [ ] Gemini-Review nach Merge erneut prüfen
- [ ] `STATUS.md`/`Komplexitaets-Gate`/`Playwright Minimalreport-Smoke` in CI verifizieren

Refs #388. PR #390 bleibt **nicht mergebar bis CI grün und alle Acceptance Criteria erfüllt sind** — Issue #388 bleibt offen.

https://claude.ai/code/session_01RqTeoL1KqvhpLJd32Uu5yK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqTeoL1KqvhpLJd32Uu5yK)_