### PR TITLE
fix(graph-api): drop build_graph below D-class complexity gate

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -328,60 +328,71 @@ def generate_ontology():
     })
 
 
-# ============== Interface 2: Build Graph ==============
+# ============== Private helpers for build_graph ==============
 
-@graph_bp.route('/build', methods=['POST'])
-@handle_api_errors(log_prefix="Graph build initiation failed")
-def build_graph():
-    """
-    Interface 2: Build graph based on project_id
-    """
-    logger.info("=== Starting graph build ===")
 
-    # Parse request
-    data = request.get_json() or {}
+def _validate_build_request(data: dict):
+    """Validate project_id from request data and look up the project.
+
+    Returns ``(project_id, project, error_response)`` where *error_response*
+    is ``None`` on success.
+    """
     project_id = data.get('project_id')
     logger.debug(f"Request parameters: project_id={project_id}")
 
     if not project_id:
-        return json_error(
+        return None, None, json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=400,
             message="Please provide project_id",
         )
 
     if not validate_project_id(project_id):
-        return json_error(ApiErrorCode.INVALID_ID, status=400)
+        return None, None, json_error(ApiErrorCode.INVALID_ID, status=400)
 
-    # Get project
     project = ProjectManager.get_project(project_id)
     if not project:
-        return json_error(
+        return None, None, json_error(
             ApiErrorCode.NOT_FOUND,
             status=404,
             message=f"Project does not exist: {project_id}",
         )
 
-    # LLM-Override für den Build-Pfad (Sub-Slice „build-respects-frontend-model").
+    return project_id, project, None
+
+
+def _resolve_llm_overrides(data: dict, project):
+    """Parse llm_model / llm_provider from *data* and build RuntimeLlmConfig.
+
+    Returns ``(llm_runtime, llm_model_override, error_response)`` where
+    *error_response* is ``None`` on success.
+    """
     # Reihenfolge: explizit im Request > persistiert am Projekt aus dem
     # Ontology-Schritt > Server-Default. Secrets (api_key) sind im Projekt
     # nicht persistiert (redacted_metadata) — daher kann der Build den
     # Provider-Override nur dann rekonstruieren, wenn der Request ihn
-    # erneut mitschickt. Modell-Name allein wird vom Projekt-Default geerbt.
+    # erneut mitschickt.
     llm_model_override = (data.get('llm_model') or '').strip() or project.llm_model or None
     llm_provider_payload = data.get('llm_provider')
     try:
         llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
     except ValueError as exc:
-        return json_error(
+        return None, None, json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=400,
             message=str(exc),
         )
 
-    # Check project status
-    force = data.get('force', False)  # Force rebuild
+    return llm_runtime, llm_model_override, None
 
+
+def _check_project_state_for_build(project, force: bool):
+    """Check and optionally reset project status before a build.
+
+    Returns ``error_response`` (a tuple ready for Flask return) or ``None``
+    when the project state is acceptable for starting a build.  Mutates
+    *project* in-place when a force-reset is performed.
+    """
     if project.status == ProjectStatus.CREATED:
         return json_error(
             ApiErrorCode.ONTOLOGY_MISSING,
@@ -397,53 +408,57 @@ def build_graph():
             extra={"task_id": project.graph_build_task_id},
         )
 
-    # If force rebuild, reset status
-    if force and project.status in [ProjectStatus.GRAPH_BUILDING, ProjectStatus.FAILED, ProjectStatus.GRAPH_COMPLETED]:
+    if force and project.status in [
+        ProjectStatus.GRAPH_BUILDING,
+        ProjectStatus.FAILED,
+        ProjectStatus.GRAPH_COMPLETED,
+    ]:
         project.status = ProjectStatus.ONTOLOGY_GENERATED
         project.graph_id = None
         project.graph_build_task_id = None
         project.error = None
 
-    # Get configuration
+    return None
+
+
+def _load_build_inputs(project_id: str, project, data: dict):
+    """Read configuration, extracted text and ontology for the build.
+
+    Returns ``(graph_name, text, ontology, chunk_size, chunk_overlap, error_response)``
+    where *error_response* is ``None`` on success.  Also persists chunk
+    params back onto *project*.
+    """
     graph_name = data.get('graph_name', project.name or 'Agora Graph')
     chunk_size = data.get('chunk_size', project.chunk_size or Config.DEFAULT_CHUNK_SIZE)
     chunk_overlap = data.get('chunk_overlap', project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP)
 
-    # Update project configuration
     project.chunk_size = chunk_size
     project.chunk_overlap = chunk_overlap
 
-    # Get extracted text
     text = ProjectManager.get_extracted_text(project_id)
     if not text:
-        return json_error(
+        return None, None, None, None, None, json_error(
             ApiErrorCode.NOT_FOUND,
             status=400,
             message="Extracted text not found",
         )
 
-    # Get ontology
     ontology = project.ontology
     if not ontology:
-        return json_error(
+        return None, None, None, None, None, json_error(
             ApiErrorCode.ONTOLOGY_MISSING,
             status=400,
             message="Ontology definition not found",
         )
 
-    # Get storage in request context (background thread cannot access current_app)
-    # Capture container in the request thread so the background closure
-    # below can resolve services without a live Flask app context.
-    container = get_container()
-    if container.neo4j_storage is None:
-        return json_error(
-            ApiErrorCode.NEO4J_UNAVAILABLE,
-            status=503,
-            message="GraphStorage not initialized",
-        )
+    return graph_name, text, ontology, chunk_size, chunk_overlap, None
 
-    # Create async task
-    task_manager = TaskManager()
+
+def _create_build_run_record(project_id: str, project, graph_name: str, task_manager: TaskManager):
+    """Register run + task records and transition project to GRAPH_BUILDING.
+
+    Returns ``(run_record, task_id)``.
+    """
     run_record = run_registry.create_run(
         run_type="graph_build",
         entity_id=project_id,
@@ -463,24 +478,75 @@ def build_graph():
     )
     logger.info(f"Graph build task created: task_id={task_id}, project_id={project_id}")
 
-    # Update project status
     project.status = ProjectStatus.GRAPH_BUILDING
     project.graph_build_task_id = task_id
     ProjectManager.save_project(project)
 
-    # NER-Override pro Build: wenn der Request (oder das Projekt-Default)
-    # ein Frontend-Modell vorgibt, bauen wir einen dedizierten NERExtractor,
-    # damit Phase-1-Extraktion das gewählte Modell nutzt — ohne den
-    # globalen Storage-Singleton-NER zu mutieren.
-    ner_override: NERExtractor | None = None
-    if llm_runtime.enabled or llm_model_override:
-        ner_llm_client = LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
-        ner_override = NERExtractor(llm_client=ner_llm_client)
-        logger.info(
-            "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s",
-            ner_llm_client.model,
-            llm_runtime.provider,
+    return run_record, task_id
+
+
+def _make_ner_override(llm_runtime, llm_model_override: str | None) -> NERExtractor | None:
+    """Build a dedicated NERExtractor for the requested LLM model/provider.
+
+    Returns ``None`` when no override is needed (falls back to server default).
+    """
+    if not (llm_runtime.enabled or llm_model_override):
+        return None
+
+    ner_llm_client = LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+    logger.info(
+        "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s",
+        ner_llm_client.model,
+        llm_runtime.provider,
+    )
+    return NERExtractor(llm_client=ner_llm_client)
+
+
+# ============== Interface 2: Build Graph ==============
+
+@graph_bp.route('/build', methods=['POST'])
+@handle_api_errors(log_prefix="Graph build initiation failed")
+def build_graph():
+    """
+    Interface 2: Build graph based on project_id
+    """
+    logger.info("=== Starting graph build ===")
+
+    data = request.get_json() or {}
+
+    project_id, project, err = _validate_build_request(data)
+    if err is not None:
+        return err
+
+    llm_runtime, llm_model_override, err = _resolve_llm_overrides(data, project)
+    if err is not None:
+        return err
+
+    force = data.get('force', False)
+    err = _check_project_state_for_build(project, force)
+    if err is not None:
+        return err
+
+    graph_name, text, ontology, chunk_size, chunk_overlap, err = _load_build_inputs(
+        project_id, project, data
+    )
+    if err is not None:
+        return err
+
+    # Capture container in the request thread so the background closure
+    # below can resolve services without a live Flask app context.
+    container = get_container()
+    if container.neo4j_storage is None:
+        return json_error(
+            ApiErrorCode.NEO4J_UNAVAILABLE,
+            status=503,
+            message="GraphStorage not initialized",
         )
+
+    task_manager = TaskManager()
+    run_record, task_id = _create_build_run_record(project_id, project, graph_name, task_manager)
+
+    ner_override: NERExtractor | None = _make_ner_override(llm_runtime, llm_model_override)
 
     # Start background task
     def build_task():

--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -21,10 +21,6 @@
 #     echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation. Eigener
 #     Refactor-Slice nach v1.0 (Aufgabenkatalog: Aggregations-Helper splitten,
 #     Persona-Mapper als eigenes Modul).
-#   - app/api/graph.py::build_graph (D): vorbestehender API-Orchestrator-Hotspot,
-#     im Design-v3-PR nur als finales CI-Gate sichtbar geworden. Eigener
-#     Refactor-Slice nach Design-v3-Merge: Request-Validation, Task-Dispatch und
-#     Response-Mapping extrahieren.
 
 app/config.py::Config
 app/config.py::Config.validate
@@ -56,4 +52,3 @@ app/services/report_agent/manager.py::ReportManager._post_process_report
 app/services/report_agent/manager.py::ReportManager.build_report_v3
 app/services/evidence_migrations.py::migrate_v2_to_v3
 app/services/evidence_migrations.py::_map_profile_to_persona
-app/api/graph.py::build_graph

--- a/docu/2026-05-11-fix-build-graph-complexity.md
+++ b/docu/2026-05-11-fix-build-graph-complexity.md
@@ -1,0 +1,65 @@
+# fix/build-graph-complexity — Arbeitsprotokoll
+
+**Branch:** `fix/build-graph-complexity`
+**Basis:** `0df2fa2` (origin/main, 2026-05-11)
+**Ziel:** `build_graph` in `app/api/graph.py` von cc=22 (Class D) unter das Gate-Limit (cc < 21, Class C) drücken, ohne neuen Allow-List-Eintrag.
+
+## Ausgangslage
+
+```
+app/api/graph.py
+    F 335:0 build_graph - D (22)
+```
+
+`bash scripts/check_complexity.sh` schlug fehl mit:
+
+```
+::error:: Neue High-Complexity-Funktionen (Cyclomatic Class D+) gefunden:
+  D  app/api/graph.py::build_graph
+```
+
+## Refactor-Strategie
+
+Extraktion von sechs privaten Helpern direkt in `app/api/graph.py` (keine neue Datei, kein Import-Impact). Die `build_task`-Closure wurde nicht angefasst (greift auf viele Closure-Locals zu, Extraktion würde mehr Komplexität erzeugen als sie beseitigt).
+
+## Neue Helper + jeweilige cc
+
+| Funktion | cc | Klasse |
+|---|---|---|
+| `_validate_build_request(data)` | 4 | A |
+| `_resolve_llm_overrides(data, project)` | 2 | A |
+| `_check_project_state_for_build(project, force)` | 6 | B |
+| `_load_build_inputs(project_id, project, data)` | 6 | B |
+| `_create_build_run_record(project_id, project, graph_name, task_manager)` | 1 | A |
+| `_make_ner_override(llm_runtime, llm_model_override)` | 2 | A |
+
+Alle Helper sind Class A oder B — kein neuer Allow-List-Eintrag nötig.
+
+## Endwert für `build_graph`
+
+```
+F 509:0 build_graph - B (7)
+```
+
+Reduktion: D (22) → B (7), Δ = -15.
+
+## Test-Counts
+
+- Vorher: 1945 passed (Baseline)
+- Nachher: 1945 passed, 9 skipped, 7 deselected
+
+Keine Tests geändert. Die Monkeypatches in `tests/api/test_graph_endpoints.py` greifen weiterhin auf `app.api.graph.ProjectManager` — bleibt korrekt, da alle Helper in derselben Datei leben.
+
+## check_complexity.sh-Output
+
+```
+OK: Keine neuen D/E/F-Klassen-Funktionen ausserhalb der Allow-List.
+```
+
+## mypy-Hinweis
+
+5 Pre-existing-Fehler in `app/api/llm_routing.py` (Out of Scope, unverändert seit Commit `0df2fa2`). Kein neuer Fehler durch diesen Refactor eingeführt.
+
+## Betroffene Dateien
+
+- `backend/app/api/graph.py` (+~130 LOC durch Helper-Definitionen, -100 LOC aus `build_graph`-Body; netto ~+30 LOC)


### PR DESCRIPTION
## Summary

Drop `app/api/graph.py::build_graph` from D-class (cc=22) below the radon gate by extracting six private helpers. This is the refactor that `b4d5a65` (in #401) explicitly listed in `radon-allowlist.txt`:

> "Eigener Refactor-Slice nach Design-v3-Merge: Request-Validation, Task-Dispatch und Response-Mapping extrahieren."

Rebased onto current main (`a2935b0`) after #401. Also reverts the temporary allow-list entry that `b4d5a65` had added as a stop-gap.

## New helpers

| Helper | cc | Class |
|---|---|---|
| `_validate_build_request` | 4 | A |
| `_resolve_llm_overrides` | 2 | A |
| `_check_project_state_for_build` | 6 | B |
| `_load_build_inputs` | 6 | B |
| `_create_build_run_record` | 1 | A |
| `_make_ner_override` | 2 | A |
| `build_graph` (after) | 7 | B |

The background `build_task` closure stays untouched — it captures many request-thread locals (`project`, `task_id`, `chunks`, `ner_override`, `container`, …) and isn't what tripped the gate.

## Files

- `backend/app/api/graph.py` — six helpers extracted.
- `backend/radon-allowlist.txt` — `build_graph`-entry + its comment block removed (added by `b4d5a65` as a stop-gap; obsolete after this refactor).
- `docu/2026-05-11-fix-build-graph-complexity.md` — Arbeitsprotokoll.

## Test plan

- [x] `bash scripts/check_complexity.sh` — `OK: Keine neuen D/E/F-Klassen-Funktionen ausserhalb der Allow-List.` (and now also without an allow-list entry)
- [x] `LLM_API_KEY=dummy-ci-key uv run pytest -q` — `1945 passed, 9 skipped, 7 deselected`
- [x] `uv run ruff check app/ tests/` — `All checks passed!`
- [x] `uv run mypy app` — `Success: no issues found in 147 source files`
- [x] `bash scripts/sync-status.sh --check` — `OK: docu/STATUS.md in sync`
- [x] `git diff --exit-code schemas/` — clean

## Out of scope

- LLM-routing contracts, stage router, RuntimeRunConfig — not touched.
- `get_generate_status` (F, cc=45) and `report_agent/workflow.py::generate_report` (E, cc=38) — already on `radon-allowlist.txt`, separate slices.

Refs #388, #390, #391, #401. Replaces the closed #392 + #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)