### PR TITLE
chore(design-v3): migrate side surfaces to v3 sans typography

### DIFF
--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -529,7 +529,7 @@ onMounted(loadRuns)
   border-bottom: 1px solid var(--rule);
   padding-bottom: var(--s-4);
 }
-.drawer-head h3 { margin: 4px 0 0; font-family: var(--ff-serif); }
+.drawer-head h3 { margin: 4px 0 0; font-family: var(--ff-sans); font-weight: 600; letter-spacing: -0.01em; }
 .eyebrow { font-family: var(--ff-mono); font-size: 11px; letter-spacing: var(--ls-mono); text-transform: uppercase; color: var(--fg-muted); }
 .linkish, .action {
   border: 1px solid var(--rule-strong);
@@ -568,7 +568,7 @@ onMounted(loadRuns)
 .retry-btn:hover { background: var(--bg-panel-2); }
 .actions, .branch-row { display: flex; gap: var(--s-3); margin-top: var(--s-4); }
 .branch-box, .artifacts, .events, .advanced-box { margin-top: var(--s-6); }
-.branch-box h4, .artifacts h4, .events h4 { margin-bottom: var(--s-3); font-family: var(--ff-serif); }
+.branch-box h4, .artifacts h4, .events h4 { margin-bottom: var(--s-3); font-family: var(--ff-sans); font-weight: 600; }
 .branch-box label { display: block; margin-top: var(--s-2); color: var(--fg-muted); }
 pre {
   max-height: 200px;

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -241,5 +241,5 @@ onUnmounted(stopStream)
 }
 .log-line { padding: 1px 0; }
 .log-line.is-error { color: var(--status-error, #f56565); }
-.meta { color: var(--fg-muted); font-style: italic; }
+.meta { color: var(--fg-muted); }
 </style>

--- a/frontend/src/components/RunsDashboard.vue
+++ b/frontend/src/components/RunsDashboard.vue
@@ -221,7 +221,8 @@ const intervalSeconds = computed(() => Math.round(props.pollIntervalMs / 1000))
 }
 
 .dashboard-title {
-  font-family: var(--ff-serif, serif);
+  font-family: var(--ff-sans);
+  font-weight: 600;
   font-size: 1.5rem;
   letter-spacing: -0.01em;
   margin: 0;

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -731,10 +731,12 @@ onUnmounted(() => {
 .stat:last-child { border-right: 0; }
 .stat-value {
   display: block;
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
+  font-weight: 600;
   font-size: var(--fs-32);
   color: var(--fg);
   line-height: 1;
+  letter-spacing: -0.02em;
 }
 .stat-label {
   display: block;

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -616,7 +616,7 @@ onUnmounted(stopPolling)
 .report-body {
   max-width: 72ch;
   margin: 0 auto;
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   color: var(--fg);
   font-size: var(--fs-18, 17px);
   line-height: 1.75;
@@ -634,12 +634,12 @@ onUnmounted(stopPolling)
 .markdown-body :deep(h2),
 .markdown-body :deep(h3),
 .markdown-body :deep(h4) {
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   color: var(--fg);
   line-height: 1.25;
   margin: 1.8em 0 0.4em;
-  font-weight: 500;
-  letter-spacing: -0.01em;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 .markdown-body :deep(h1) { font-size: 2em; border-bottom: 1px solid var(--rule); padding-bottom: 0.3em; }
 .markdown-body :deep(h2) { font-size: 1.5em; color: var(--accent); }
@@ -655,7 +655,6 @@ onUnmounted(stopPolling)
   margin: 1em 0;
   padding: 0.2em 1em;
   color: var(--fg-muted);
-  font-style: italic;
 }
 .markdown-body :deep(code) {
   background: var(--bg-elevated);
@@ -784,7 +783,7 @@ onUnmounted(stopPolling)
   word-break: break-word;
   padding: 4px 0 0 12px;
   border-left: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   font-size: 12px;
   line-height: 1.6;
 }

--- a/frontend/src/components/step2/AddPersonaModal.vue
+++ b/frontend/src/components/step2/AddPersonaModal.vue
@@ -229,10 +229,10 @@ function updateGender(event: Event) {
   margin-bottom: var(--s-2);
 }
 .modal-head h3 {
-  font-family: var(--ff-serif);
-  font-weight: 400;
-  font-size: clamp(32px, 4vw, 52px);
-  line-height: 1.05;
+  font-family: var(--ff-sans);
+  font-weight: 650;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.1;
   letter-spacing: -0.02em;
   margin: 0;
   color: var(--fg);
@@ -267,7 +267,7 @@ function updateGender(event: Event) {
   letter-spacing: normal;
   outline: none;
 }
-.form-row textarea { resize: vertical; font-family: var(--ff-serif); line-height: 1.4; }
+.form-row textarea { resize: vertical; font-family: var(--ff-sans); line-height: 1.4; }
 .form-row input:focus,
 .form-row select:focus,
 .form-row textarea:focus { border-color: var(--accent); }

--- a/frontend/src/components/step2/PersonaCardGrid.vue
+++ b/frontend/src/components/step2/PersonaCardGrid.vue
@@ -183,9 +183,9 @@ const { t } = useI18n()
   color: var(--fg-muted);
 }
 .persona-bio {
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   font-size: var(--fs-16);
-  line-height: 1.3;
+  line-height: 1.45;
   color: var(--fg);
 }
 .persona-topics {

--- a/frontend/src/components/step2/PersonaDetailModal.vue
+++ b/frontend/src/components/step2/PersonaDetailModal.vue
@@ -289,10 +289,10 @@ function updateEditGender(event: Event) {
   margin-bottom: var(--s-2);
 }
 .modal-head h3 {
-  font-family: var(--ff-serif);
-  font-weight: 400;
-  font-size: clamp(32px, 4vw, 52px);
-  line-height: 1.05;
+  font-family: var(--ff-sans);
+  font-weight: 650;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.1;
   letter-spacing: -0.02em;
   margin: 0;
   color: var(--fg);
@@ -361,11 +361,10 @@ function updateEditGender(event: Event) {
 .regenerate-hint-input::placeholder { color: var(--fg-muted); }
 .regenerate-hint-input:disabled { opacity: 0.5; cursor: not-allowed; }
 .modal-bio {
-  font-family: var(--ff-serif);
-  font-style: italic;
+  font-family: var(--ff-sans);
   font-weight: 400;
-  font-size: var(--fs-24);
-  line-height: 1.35;
+  font-size: var(--fs-18);
+  line-height: 1.5;
   color: var(--fg-body);
   margin: 0;
   border-left: 2px solid var(--accent);
@@ -467,7 +466,7 @@ function updateEditGender(event: Event) {
   letter-spacing: normal;
   outline: none;
 }
-.form-row textarea { resize: vertical; font-family: var(--ff-serif); line-height: 1.4; }
+.form-row textarea { resize: vertical; font-family: var(--ff-sans); line-height: 1.4; }
 .form-row input:focus,
 .form-row select:focus,
 .form-row textarea:focus { border-color: var(--accent); }

--- a/frontend/src/components/step4/ReportEvidencePanel.vue
+++ b/frontend/src/components/step4/ReportEvidencePanel.vue
@@ -304,7 +304,6 @@ function sectionHypotheses(section: ReportSection | null | undefined) {
   margin: 0.5em 0;
   padding: 0.4em 0.8em;
   background: var(--bg-glass);
-  font-style: italic;
   color: var(--fg-meta);
   font-size: 0.92em;
 }

--- a/frontend/src/components/step4/ReportOutlinePanel.vue
+++ b/frontend/src/components/step4/ReportOutlinePanel.vue
@@ -134,16 +134,18 @@ function sectionConfidenceAuditTrail(idx: number): SectionConfidenceResult['audi
   color: var(--fg-muted);
 }
 .outline-title {
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
+  font-weight: 600;
   font-size: var(--fs-20);
   color: var(--fg);
+  letter-spacing: -0.01em;
 }
 .outline-body {
   margin-top: var(--s-3);
   padding-left: 32px;
 }
 .section-content {
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   font-size: var(--fs-16);
   line-height: 1.7;
   color: var(--fg);
@@ -156,11 +158,12 @@ function sectionConfidenceAuditTrail(idx: number): SectionConfidenceResult['audi
 .markdown-body :deep(h2),
 .markdown-body :deep(h3),
 .markdown-body :deep(h4) {
-  font-family: var(--ff-serif);
+  font-family: var(--ff-sans);
   color: var(--fg);
   line-height: 1.25;
   margin: 1.8em 0 0.4em;
-  font-weight: 500;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 .markdown-body :deep(p) {
   margin: 0.9em 0;
@@ -175,7 +178,6 @@ function sectionConfidenceAuditTrail(idx: number): SectionConfidenceResult['audi
   margin: 1em 0;
   padding: 0.2em 1em;
   color: var(--fg-muted);
-  font-style: italic;
 }
 .markdown-body :deep(code) {
   background: var(--bg-elevated);


### PR DESCRIPTION
## Summary

Follow-up to PR #403. Migrates compat-aliased side surfaces from deferred list to v3-native typography.

- 10 files, 22 v2-token references replaced (`--ff-serif` → `--ff-sans` + weight/letter-spacing; productive `italic` removed in favor of accent-border quotes).
- `composables/useReportExports.ts` intentionally untouched: Georgia serif there is correct print/HTML-export typography, not app UI.
- After this slice the only remaining v2 references live in `tokens-v3.css` (compat layer) and `global.css` (next slice).

## Files

`HistoryDatabase.vue`, `LogDrawer.vue`, `RunsDashboard.vue`, `Step3Simulation.vue`, `Step4Report.vue`, `step2/AddPersonaModal.vue`, `step2/PersonaCardGrid.vue`, `step2/PersonaDetailModal.vue`, `step4/ReportOutlinePanel.vue`, `step4/ReportEvidencePanel.vue`.

## Verification

- [x] \`cd frontend && npm run typecheck\` clean
- [x] \`cd frontend && npm test -- --run\` (501 / 501 pass)
- [x] \`cd frontend && npm run build\` clean (24.09 kB gzip CSS)
- [x] \`cd frontend && npm run lint\` clean

## Out of scope (next + final slice)

\`global.css\` v2-Editorial blocks (.persona, .card-work, .serif utility, .btn--plasma, ff-serif headings) — 26 token references, higher regression risk because .persona/.card-work are consumed across components.

## Test plan

- [ ] CI: typecheck, vitest, build, lint
- [ ] Manual smoke (Step2 Persona-Modals, Step4 Report-Render, History-Drawer)