### PR TITLE
fix: wire LLM routing snapshots into runtime paths

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -13,9 +13,11 @@ from flask import Response, request, current_app
 from . import graph_bp
 from ..config import Config
 from ..services.ontology_generator import OntologyGenerator
+from ..services.llm_routing_seed import resolve_route_api_key, seed_run_stage_routing
 from ..services.llm_runtime import parse_runtime_llm_config
 from ..container import get_container
 from ..services.graph_builder import GraphBuilderService  # noqa: F401  (kept for type re-exports)
+from ..services.stage_model_router import StageModelRouter
 from ..services.text_processor import TextProcessor
 from ..storage.ner_extractor import NERExtractor
 from ..utils.file_parser import FileParser
@@ -485,19 +487,17 @@ def _create_build_run_record(project_id: str, project, graph_name: str, task_man
     return run_record, task_id
 
 
-def _make_ner_override(llm_runtime, llm_model_override: str | None) -> NERExtractor | None:
-    """Build a dedicated NERExtractor for the requested LLM model/provider.
-
-    Returns ``None`` when no override is needed (falls back to server default).
-    """
-    if not (llm_runtime.enabled or llm_model_override):
-        return None
-
-    ner_llm_client = LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
+def _make_ner_override_from_route(run_id: str, resolved_route, llm_runtime) -> NERExtractor:
+    """Build a dedicated NERExtractor from the resolved per-run route."""
+    ner_llm_client = LLMClient.from_route(
+        resolved_route,
+        api_key=resolve_route_api_key(resolved_route, llm_runtime),
+        run_id=run_id,
+    )
     logger.info(
-        "Build-Pfad nutzt NER-LLM-Override: model=%s provider=%s",
+        "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s",
         ner_llm_client.model,
-        llm_runtime.provider,
+        resolved_route.provider_id,
     )
     return NERExtractor(llm_client=ner_llm_client)
 
@@ -545,8 +545,21 @@ def build_graph():
 
     task_manager = TaskManager()
     run_record, task_id = _create_build_run_record(project_id, project, graph_name, task_manager)
+    seed_run_stage_routing(
+        run_record["run_id"],
+        "graph_build",
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+    )
+    route_router = StageModelRouter(run_record["run_id"])
+    resolved_route = route_router.resolve("graph_build")
+    route_router.lock_stage("graph_build", resolved_route)
 
-    ner_override: NERExtractor | None = _make_ner_override(llm_runtime, llm_model_override)
+    ner_override: NERExtractor = _make_ner_override_from_route(
+        run_record["run_id"],
+        resolved_route,
+        llm_runtime,
+    )
 
     # Start background task
     def build_task():

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -2,14 +2,19 @@
 LLM Routing API.
 """
 
+import json
+import os
+
 from flask import request
+from pydantic import ValidationError
+
 from . import runs_bp
 from ..services.runtime_run_config import RuntimeRunConfig
 from ..services.run_registry import RunRegistry
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
 from ..utils.api_responses import handle_api_errors, json_success, json_error
+from ..utils.artifact_locator import ArtifactLocator
 from ..utils.logger import get_logger
-from pydantic import ValidationError
 
 logger = get_logger("agora.api.llm_routing")
 run_registry = RunRegistry()
@@ -30,6 +35,30 @@ def _get_run_state(run_id: str):
         return None
     return run.get("status")
 
+
+def _load_invocation_events(run_id: str, limit: int = 200) -> list[dict]:
+    """Read structured LLM call events for a run, newest last."""
+    log_path = os.path.join(ArtifactLocator.run_dir(run_id), "llm_call_events.jsonl")
+    if not os.path.exists(log_path):
+        return []
+
+    events: list[dict] = []
+    with open(log_path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            payload = line.strip()
+            if not payload:
+                continue
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed llm_call_events line for run %s", run_id)
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+    if limit > 0:
+        return events[-limit:]
+    return events
+
 @runs_bp.route("/<run_id>/llm-routing", methods=["GET"])
 @handle_api_errors(logger=logger)
 def get_run_llm_routing(run_id: str):
@@ -46,7 +75,8 @@ def get_run_llm_routing(run_id: str):
 
     return json_success({
         "runtime_config": config.model_dump(mode="json"),
-        "snapshots": snapshots
+        "snapshots": snapshots,
+        "invocation_events": _load_invocation_events(run_id),
     })
 
 @runs_bp.route("/<run_id>/llm-routing", methods=["PUT"])

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -4,6 +4,7 @@ LLM Routing API.
 
 import json
 import os
+from collections import deque
 
 from flask import request
 from pydantic import ValidationError
@@ -42,7 +43,7 @@ def _load_invocation_events(run_id: str, limit: int = 200) -> list[dict]:
     if not os.path.exists(log_path):
         return []
 
-    events: list[dict] = []
+    events = deque(maxlen=limit if limit > 0 else None)
     with open(log_path, "r", encoding="utf-8") as handle:
         for line in handle:
             payload = line.strip()
@@ -55,9 +56,7 @@ def _load_invocation_events(run_id: str, limit: int = 200) -> list[dict]:
                 continue
             if isinstance(parsed, dict):
                 events.append(parsed)
-    if limit > 0:
-        return events[-limit:]
-    return events
+    return list(events)
 
 @runs_bp.route("/<run_id>/llm-routing", methods=["GET"])
 @handle_api_errors(logger=logger)

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -31,7 +31,9 @@ from ..services.simulation_manager import SimulationManager
 from ..models.project import ProjectManager
 from ..models.task import TaskManager, TaskStatus
 from ..services.graph_tools import GraphToolsService
+from ..services.llm_routing_seed import resolve_route_api_key, seed_run_stage_routing
 from ..services.llm_runtime import parse_runtime_llm_config
+from ..services.stage_model_router import StageModelRouter
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.llm_client import LLMClient
 from ..utils.auth import allow_ticket_auth
@@ -188,6 +190,15 @@ def generate_report():
         task_type="report_generate",
         metadata={"simulation_id": simulation_id, "graph_id": graph_id, "report_id": report_id, "run_id": run_record["run_id"]}
     )
+    seed_run_stage_routing(
+        run_record["run_id"],
+        "report_generation",
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+    )
+    route_router = StageModelRouter(run_record["run_id"])
+    resolved_route = route_router.resolve("report_generation")
+    route_router.lock_stage("report_generation", resolved_route)
 
     # Initialize graph_tools in Flask context BEFORE spawning thread
     # (current_app is not available inside background threads)
@@ -199,10 +210,10 @@ def generate_report():
     # teilen, sonst nutzt GraphToolsService.llm beim Lazy-Init ``LLMClient()``
     # mit Config-Default — egal welches Modell der User für den Report gewählt
     # hat. Wir bauen den Client hier einmal und reichen ihn in beide rein.
-    shared_llm_client = (
-        LLMClient(**llm_runtime.client_kwargs(model=llm_model_override))
-        if (llm_runtime.enabled or llm_model_override)
-        else None
+    shared_llm_client = LLMClient.from_route(
+        resolved_route,
+        api_key=resolve_route_api_key(resolved_route, llm_runtime),
+        run_id=run_record["run_id"],
     )
     graph_tools = GraphToolsService(storage=storage, llm_client=shared_llm_client)
 
@@ -215,7 +226,7 @@ def generate_report():
                 simulation_requirement=simulation_requirement,
                 graph_tools=graph_tools,
                 llm_client=shared_llm_client,
-                model_name=llm_model_override,
+                model_name=resolved_route.model,
             )
             def progress_callback(stage, progress, message):
                 task_manager.update_task(task_id, progress=progress, message=f"[{stage}] {message}")

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -14,9 +14,15 @@ from ..config import Config
 from ..contracts import PersonaQuotaPlan
 from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
+from ..services.llm_routing_seed import (
+    build_runtime_llm_config,
+    resolve_route_api_key,
+    seed_run_stage_routing,
+)
 from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.report_agent import MIN_PERSONA_TABLE_ROWS
 from ..services.simulation_manager import SimulationManager, SimulationStatus
+from ..services.stage_model_router import StageModelRouter
 from ..utils.validation import validate_simulation_id, validate_task_id
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_success, json_error
@@ -322,6 +328,8 @@ def prepare_simulation():
             "root_simulation_id": state.root_simulation_id,
             "branch_name": state.branch_name,
             "branch_depth": state.branch_depth,
+            "llm_model": llm_model_override,
+            "llm_provider": llm_runtime.redacted_metadata() or None,
         },
     )
     task_id = task_manager.create_task(
@@ -332,6 +340,17 @@ def prepare_simulation():
             "run_id": run_record["run_id"],
         },
     )
+    seed_run_stage_routing(
+        run_record["run_id"],
+        "persona_generation",
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+    )
+    route_router = StageModelRouter(run_record["run_id"])
+    resolved_route = route_router.resolve("persona_generation")
+    route_router.lock_stage("persona_generation", resolved_route)
+    resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
+    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
 
     manager._set_status(state, SimulationStatus.PREPARING)
 
@@ -411,8 +430,8 @@ def prepare_simulation():
                 progress_callback=progress_callback,
                 parallel_profile_count=parallel_profile_count,
                 storage=storage,
-                llm_model=llm_model_override,
-                llm_runtime=llm_runtime,
+                llm_model=resolved_route.model,
+                llm_runtime=effective_llm_runtime,
                 language=agent_language_override,
                 max_agents=max_agents,
                 quota_plan=quota_plan,

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -10,9 +10,15 @@ from . import simulation_bp
 from ..config import Config
 from ..models.project import ProjectManager
 from ..services.persona_review_service import PersonaReviewService
+from ..services.llm_routing_seed import (
+    build_route_subprocess_env,
+    resolve_route_api_key,
+    seed_run_stage_routing,
+)
 from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
+from ..services.stage_model_router import StageModelRouter
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.artifact_locator import ArtifactLocator
@@ -195,42 +201,12 @@ def start_simulation():
             extra={'simulation_id': simulation_id},
         )
 
-    if simulation_days is not None or llm_model_override or llm_runtime.enabled:
-        store = get_artifact_store()
-        config = store.read_json(simulation_id, "simulation_config", default=None)
-        if not config:
-            return json_error(
-                ApiErrorCode.SIMULATION_NOT_PREPARED,
-                status=404,
-                message="Simulation configuration does not exist. Please call /prepare first",
-            )
-        if simulation_days is not None:
-            time_config = dict(config.get("time_config") or {})
-            time_config["total_simulation_hours"] = simulation_days * 24
-            config["time_config"] = time_config
-        if llm_model_override:
-            config["llm_model"] = llm_model_override
-        if llm_runtime.enabled:
-            config["llm_base_url"] = llm_runtime.base_url
-        store.write_json(simulation_id, "simulation_config", config)
-
-    run_state = SimulationRunner.start_simulation(
-        simulation_id=simulation_id,
-        platform=platform,
-        max_rounds=max_rounds,
-        enable_graph_memory_update=enable_graph_memory_update,
-        graph_id=graph_id,
-        runtime_env=llm_runtime.subprocess_env(model=llm_model_override),
-    )
-
-    manager._set_status(state, SimulationStatus.RUNNING)
-
     run_record = run_registry.create_run(
         run_type="simulation_run",
         entity_id=simulation_id,
-        status="processing",
+        status="pending",
         progress=0,
-        message="Simulation run started",
+        message="Simulation run queued",
         linked_ids={"simulation_id": simulation_id, "project_id": state.project_id},
         artifacts=_simulation_run_artifacts(simulation_id),
         resume_capability=_simulation_resume_capability(simulation_id, state),
@@ -245,6 +221,53 @@ def start_simulation():
             "llm_model": llm_model_override,
             "llm_provider": llm_runtime.redacted_metadata() or None,
         },
+    )
+    seed_run_stage_routing(
+        run_record["run_id"],
+        "simulation_rounds",
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+    )
+    route_router = StageModelRouter(run_record["run_id"])
+    resolved_route = route_router.resolve("simulation_rounds")
+    route_router.lock_stage("simulation_rounds", resolved_route)
+    resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
+
+    if simulation_days is not None or llm_model_override or llm_runtime.enabled:
+        store = get_artifact_store()
+        config = store.read_json(simulation_id, "simulation_config", default=None)
+        if not config:
+            return json_error(
+                ApiErrorCode.SIMULATION_NOT_PREPARED,
+                status=404,
+                message="Simulation configuration does not exist. Please call /prepare first",
+            )
+        if simulation_days is not None:
+            time_config = dict(config.get("time_config") or {})
+            time_config["total_simulation_hours"] = simulation_days * 24
+            config["time_config"] = time_config
+        if llm_model_override:
+            config["llm_model"] = resolved_route.model
+        if llm_runtime.enabled and resolved_route.base_url_sanitized:
+            config["llm_base_url"] = resolved_route.base_url_sanitized
+        store.write_json(simulation_id, "simulation_config", config)
+
+    run_state = SimulationRunner.start_simulation(
+        simulation_id=simulation_id,
+        platform=platform,
+        max_rounds=max_rounds,
+        enable_graph_memory_update=enable_graph_memory_update,
+        graph_id=graph_id,
+        runtime_env=build_route_subprocess_env(resolved_route, resolved_api_key),
+    )
+
+    manager._set_status(state, SimulationStatus.RUNNING)
+    run_registry.update_run(
+        run_record["run_id"],
+        status="processing",
+        progress=0,
+        message="Simulation run started",
+        resume_capability=_simulation_resume_capability(simulation_id, state),
     )
 
     response_data = run_state.to_dict()

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -258,7 +258,11 @@ def start_simulation():
         max_rounds=max_rounds,
         enable_graph_memory_update=enable_graph_memory_update,
         graph_id=graph_id,
-        runtime_env=build_route_subprocess_env(resolved_route, resolved_api_key),
+        runtime_env=build_route_subprocess_env(
+            resolved_route,
+            resolved_api_key,
+            run_record["run_id"],
+        ),
     )
 
     manager._set_status(state, SimulationStatus.RUNNING)

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -98,9 +98,15 @@ def build_runtime_llm_config(route: ResolvedRoute, api_key: Optional[str]) -> Ru
     )
 
 
-def build_route_subprocess_env(route: ResolvedRoute, api_key: Optional[str]) -> dict[str, str]:
+def build_route_subprocess_env(
+    route: ResolvedRoute,
+    api_key: Optional[str],
+    run_id: Optional[str] = None,
+) -> dict[str, str]:
     """Translate a resolved route into the subprocess env contract used by OASIS."""
     env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
+    if run_id:
+        env["AGORA_RUN_ID"] = run_id
     if api_key:
         env["LLM_API_KEY"] = api_key
         env["OPENAI_API_KEY"] = api_key

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -1,0 +1,112 @@
+"""Helpers to seed per-run LLM routing from the legacy request overrides.
+
+Bridges the existing ``llm_model`` / ``llm_provider`` request contract to the
+new ``RuntimeLlmRouting`` persistence model so runtime snapshots and stage locks
+can be used without a flag day across all API surfaces.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from ..contracts.llm_routing_contract import ResolvedRoute, RuntimeLlmRouting, StageId, StageLLMRoute
+from .llm_provider_registry import LlmProviderRegistry
+from .llm_runtime import RuntimeLlmConfig
+from .runtime_run_config import RuntimeRunConfig
+from .secret_resolver import SecretResolver
+
+_PROVIDER_ID_MAP = {
+    "default": None,
+    "openai": "openai",
+    "google": "google",
+    "custom_openai": "openai_compatible",
+}
+
+_ROUTE_TO_RUNTIME_PROVIDER = {
+    "openai": "openai",
+    "google": "google",
+    "openai_compatible": "custom_openai",
+    "ollama_local": "custom_openai",
+}
+
+
+def map_runtime_provider_to_route_provider(provider: str) -> Optional[str]:
+    return _PROVIDER_ID_MAP.get((provider or "default").strip().lower())
+
+
+def seed_run_stage_routing(
+    run_id: str,
+    stage_id: StageId,
+    *,
+    llm_model_override: Optional[str],
+    llm_runtime: Optional[RuntimeLlmConfig],
+) -> RuntimeLlmRouting:
+    """Persist an initial per-run routing config for *stage_id*.
+
+    New runs inherit the server default route. A request-local model/provider
+    override is stored as a stage override so later stage locks and the UI can
+    inspect the effective runtime decision.
+    """
+    config_service = RuntimeRunConfig(run_id)
+    has_existing_config = os.path.exists(config_service.config_path)
+    config = config_service.load_config()
+
+    runtime = llm_runtime or RuntimeLlmConfig()
+    route_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
+
+    if llm_model_override or runtime.enabled:
+        provider_options = {}
+        if runtime.base_url:
+            provider_options["base_url"] = runtime.base_url
+        config.stage_overrides[stage_id] = StageLLMRoute(
+            provider_id=route_provider_id,
+            model=llm_model_override,
+            provider_options=provider_options,
+        )
+        if has_existing_config:
+            config.routing_version += 1
+
+    config_service.save_config(config)
+    return config
+
+
+def resolve_route_api_key(route: ResolvedRoute, llm_runtime: Optional[RuntimeLlmConfig] = None) -> Optional[str]:
+    """Resolve the secret API key for a resolved route.
+
+    Prefers the request-scoped runtime secret when it matches the selected
+    provider. Falls back to the server-side secret resolver otherwise.
+    """
+    runtime = llm_runtime or RuntimeLlmConfig()
+    runtime_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
+    if runtime.enabled and runtime.api_key and runtime_provider_id == route.provider_id:
+        return runtime.api_key
+
+    registry = LlmProviderRegistry()
+    provider = next((p for p in registry.get_providers() if p.id == route.provider_id), None)
+    provider_type = provider.type if provider else "openai_compatible"
+    return SecretResolver().get_api_key(route.provider_id, provider_type)
+
+
+def build_runtime_llm_config(route: ResolvedRoute, api_key: Optional[str]) -> RuntimeLlmConfig:
+    """Bridge a resolved route back into the legacy RuntimeLlmConfig contract."""
+    provider = _ROUTE_TO_RUNTIME_PROVIDER.get(route.provider_id, "custom_openai")
+    return RuntimeLlmConfig(
+        provider=provider,
+        api_key=api_key,
+        base_url=route.base_url_sanitized,
+    )
+
+
+def build_route_subprocess_env(route: ResolvedRoute, api_key: Optional[str]) -> dict[str, str]:
+    """Translate a resolved route into the subprocess env contract used by OASIS."""
+    env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
+    if api_key:
+        env["LLM_API_KEY"] = api_key
+        env["OPENAI_API_KEY"] = api_key
+    if route.base_url_sanitized:
+        env["LLM_BASE_URL"] = route.base_url_sanitized
+        env["OPENAI_BASE_URL"] = route.base_url_sanitized
+        env["OPENAI_API_BASE"] = route.base_url_sanitized
+        env["OPENAI_API_BASE_URL"] = route.base_url_sanitized
+    return env

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -5,6 +5,7 @@ Handle persistence of runtime_llm_routing.json and stage snapshots.
 
 import os
 import json
+from urllib.parse import urlparse
 from typing import Optional, Dict, Any
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
 from ..utils.artifact_locator import ArtifactLocator
@@ -15,14 +16,17 @@ logger = get_logger("agora.runtime_run_config")
 
 def _detect_default_provider_id(base_url: Optional[str], model_name: Optional[str]) -> str:
     """Best-effort mapping from legacy server config to routing provider IDs."""
-    normalized_base = (base_url or "").strip().lower()
+    normalized_base = (base_url or "").strip()
     normalized_model = (model_name or "").strip().lower()
+    parsed = urlparse(normalized_base) if normalized_base else None
+    hostname = (parsed.hostname or "").lower() if parsed else ""
+    port = parsed.port if parsed else None
 
-    if normalized_model.endswith(":cloud") or "11434" in normalized_base:
+    if normalized_model.endswith(":cloud") or port == 11434:
         return "ollama_local"
-    if "generativelanguage.googleapis.com" in normalized_base or "gemini" in normalized_model:
+    if hostname == "generativelanguage.googleapis.com" or "gemini" in normalized_model:
         return "google"
-    if "openai.com" in normalized_base or "api.openai" in normalized_base:
+    if hostname in {"api.openai.com", "openai.com"}:
         return "openai"
     return "openai_compatible"
 

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -12,6 +12,21 @@ from ..utils.logger import get_logger
 
 logger = get_logger("agora.runtime_run_config")
 
+
+def _detect_default_provider_id(base_url: Optional[str], model_name: Optional[str]) -> str:
+    """Best-effort mapping from legacy server config to routing provider IDs."""
+    normalized_base = (base_url or "").strip().lower()
+    normalized_model = (model_name or "").strip().lower()
+
+    if normalized_model.endswith(":cloud") or "11434" in normalized_base:
+        return "ollama_local"
+    if "generativelanguage.googleapis.com" in normalized_base or "gemini" in normalized_model:
+        return "google"
+    if "openai.com" in normalized_base or "api.openai" in normalized_base:
+        return "openai"
+    return "openai_compatible"
+
+
 class RuntimeRunConfig:
     """Manages runtime configuration for a run."""
 
@@ -33,7 +48,7 @@ class RuntimeRunConfig:
         provider_options: Dict[str, Any] = {"base_url": Config.LLM_BASE_URL} if Config.LLM_BASE_URL else {}
 
         global_default = StageLLMRoute(
-            provider_id="ollama_local",
+            provider_id=_detect_default_provider_id(Config.LLM_BASE_URL, Config.LLM_MODEL_NAME),
             model=Config.LLM_MODEL_NAME,
             provider_options=provider_options,
         )
@@ -44,7 +59,7 @@ class RuntimeRunConfig:
         os.makedirs(self.run_dir, exist_ok=True)
         # Monotonicity check for routing_version should happen in service/api layer
         with open(self.config_path, "w") as f:
-            f.write(config.model_dump_json(indent=2))
+            f.write(config.model_dump_json(indent=2, exclude_none=True, exclude_defaults=True))
 
     def load_stage_snapshot(self, stage_id: StageId) -> Optional[Dict[str, Any]]:
         """Load stage-specific LLM route snapshot."""

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -96,7 +96,7 @@ class LLMClient:
         self.model = model or Config.LLM_MODEL_NAME
         self.reasoning_effort = reasoning_effort or "none"
         self.provider_options = provider_options or {}
-        self.run_id = run_id
+        self.run_id = run_id or os.environ.get("AGORA_RUN_ID")
         self.routing_version = routing_version
         self.route_stage = route_stage
         self.route_provider_id = route_provider_id

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -86,12 +86,20 @@ class LLMClient:
         timeout: float = 300.0,
         reasoning_effort: Optional[ReasoningEffort] = None,
         provider_options: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
+        routing_version: Optional[int] = None,
+        route_stage: Optional[str] = None,
+        route_provider_id: Optional[str] = None,
     ):
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
         self.reasoning_effort = reasoning_effort or "none"
         self.provider_options = provider_options or {}
+        self.run_id = run_id
+        self.routing_version = routing_version
+        self.route_stage = route_stage
+        self.route_provider_id = route_provider_id
 
         if not self.api_key:
             raise ValueError("LLM_API_KEY not configured")
@@ -114,15 +122,25 @@ class LLMClient:
         self._retry_max_delay = float(os.environ.get('LLM_RETRY_MAX_DELAY', '30.0'))
 
     @classmethod
-    def from_route(cls, route: ResolvedRoute, api_key: str, timeout: float = 300.0) -> "LLMClient":
+    def from_route(
+        cls,
+        route: ResolvedRoute,
+        api_key: Optional[str],
+        timeout: float = 300.0,
+        run_id: Optional[str] = None,
+    ) -> "LLMClient":
         """Factory: create LLMClient from a resolved stage route."""
         return cls(
             api_key=api_key,
-            base_url=route.base_url_sanitized, # Caller must provide secret base_url if needed
+            base_url=route.base_url_sanitized,  # Caller must provide secret base_url if needed
             model=route.model,
             timeout=timeout,
             reasoning_effort=route.reasoning_effort,
             provider_options=route.provider_options,
+            run_id=run_id,
+            routing_version=route.routing_version,
+            route_stage=route.stage,
+            route_provider_id=route.provider_id,
         )
 
     def _is_ollama(self) -> bool:
@@ -269,6 +287,39 @@ class LLMClient:
                 "model_event_bus.publish failed (LLM call proceeds): %s", exc
             )
 
+    def _log_invocation_event(
+        self,
+        *,
+        stage: str,
+        latency_ms: float,
+        success: bool,
+        error_type: Optional[str] = None,
+        http_status: Optional[int] = None,
+        remote_request_id: Optional[str] = None,
+    ) -> None:
+        """Persist LLM call telemetry for routed runs without blocking execution."""
+        if not getattr(self, "run_id", None):
+            return
+
+        try:
+            from ..services.llm_invocation_logger import LlmInvocationLogger
+
+            logger_service = LlmInvocationLogger(self.run_id)
+            logger_service.log_event(
+                stage=getattr(self, "route_stage", None) or stage,
+                provider_id=getattr(self, "route_provider_id", None) or self._detect_provider(),
+                model=self.model or "unknown",
+                base_url=self.base_url,
+                routing_version=getattr(self, "routing_version", None) or 0,
+                latency_ms=latency_ms,
+                success=success,
+                error_type=error_type,
+                http_status=http_status,
+                remote_request_id=remote_request_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("llm invocation logging failed (LLM call proceeds): %s", exc)
+
     def chat(
         self,
         messages: List[Dict[str, str]],
@@ -367,36 +418,52 @@ class LLMClient:
                 )
                 return _create(swapped)
 
-        if force_stream:
-            kwargs["stream"] = True
-            stream = _call_with_token_key_fallback(kwargs)
-            chunks: List[str] = []
-            finish_reason = None
-            completion_tokens = None
-            for event in stream:
-                if not event.choices:
-                    continue
-                delta = event.choices[0].delta
-                piece = getattr(delta, "content", None)
-                if piece:
-                    chunks.append(piece)
-                if event.choices[0].finish_reason:
-                    finish_reason = event.choices[0].finish_reason
-                usage = getattr(event, "usage", None)
-                if usage and getattr(usage, "completion_tokens", None) is not None:
-                    completion_tokens = usage.completion_tokens
-            content = "".join(chunks)
-        else:
-            response = _call_with_token_key_fallback(kwargs)
-            choice = response.choices[0]
-            finish_reason = getattr(choice, "finish_reason", None)
-            usage = getattr(response, "usage", None)
-            completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
-            content = choice.message.content or ""
+        try:
+            if force_stream:
+                kwargs["stream"] = True
+                stream = _call_with_token_key_fallback(kwargs)
+                chunks: List[str] = []
+                finish_reason = None
+                completion_tokens = None
+                for event in stream:
+                    if not event.choices:
+                        continue
+                    delta = event.choices[0].delta
+                    piece = getattr(delta, "content", None)
+                    if piece:
+                        chunks.append(piece)
+                    if event.choices[0].finish_reason:
+                        finish_reason = event.choices[0].finish_reason
+                    usage = getattr(event, "usage", None)
+                    if usage and getattr(usage, "completion_tokens", None) is not None:
+                        completion_tokens = usage.completion_tokens
+                content = "".join(chunks)
+            else:
+                response = _call_with_token_key_fallback(kwargs)
+                choice = response.choices[0]
+                finish_reason = getattr(choice, "finish_reason", None)
+                usage = getattr(response, "usage", None)
+                completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
+                content = choice.message.content or ""
+        except Exception as exc:  # noqa: BLE001
+            elapsed = _time.monotonic() - _t0
+            self._log_invocation_event(
+                stage=context,
+                latency_ms=elapsed * 1000,
+                success=False,
+                error_type=exc.__class__.__name__,
+                http_status=getattr(exc, "status_code", None),
+            )
+            raise
         elapsed = _time.monotonic() - _t0
         logger.info(
             "LLM chat returned model=%s finish=%s tokens_out=%s elapsed=%.1fs max_tokens=%s stream=%s",
             self.model, finish_reason, completion_tokens, elapsed, max_tokens, force_stream,
+        )
+        self._log_invocation_event(
+            stage=context,
+            latency_ms=elapsed * 1000,
+            success=True,
         )
         # Some models (like MiniMax M2.5, DeepSeek-R1) include <think>thinking content in response, need to remove
         content = re.sub(r'<think>[\s\S]*?</think>', '', content, flags=re.IGNORECASE).strip()

--- a/backend/tests/api/test_graph_build_routing.py
+++ b/backend/tests/api/test_graph_build_routing.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.models.project import ProjectStatus
+
+
+VALID_PROJECT_ID = "proj_0123456789ab"
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    storage = MagicMock(name="Neo4jStorage")
+    app.extensions = {"neo4j_storage": storage}
+    app.register_blueprint(graph_bp, url_prefix="/api/graph")
+    return app.test_client()
+
+
+def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
+    fake_project = MagicMock()
+    fake_project.status = ProjectStatus.ONTOLOGY_GENERATED
+    fake_project.ontology = {"entity_types": [], "edge_types": []}
+    fake_project.graph_build_task_id = None
+    fake_project.graph_id = None
+    fake_project.name = "Test Project"
+    fake_project.chunk_size = 500
+    fake_project.chunk_overlap = 50
+    fake_project.llm_model = None
+    fake_project.llm_provider = None
+
+    fake_builder = MagicMock()
+    fake_builder.create_graph.return_value = "graph-123"
+    fake_builder.set_ontology.return_value = None
+    fake_builder.add_text_batches.return_value = None
+    fake_builder.get_graph_data.return_value = {"node_count": 2, "edge_count": 1}
+
+    fake_container = MagicMock()
+    fake_container.neo4j_storage = MagicMock()
+    fake_container.graph_builder.return_value = fake_builder
+
+    fake_llm_client = MagicMock(name="ResolvedRouteLLMClient")
+    captured_ner = {}
+
+    class FakeRouter:
+        def __init__(self, run_id: str):
+            self.run_id = run_id
+
+        def resolve(self, _stage_id: str):
+            return ResolvedRoute(
+                stage="graph_build",
+                provider_id="openai",
+                model="gpt-4o-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=4,
+            )
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def run_inline(self):
+        self.run()
+
+    def fake_ner_extractor(*, llm_client):
+        captured_ner["llm_client"] = llm_client
+        return MagicMock(name="NEROverride")
+
+    monkeypatch.setattr("app.api.graph.ProjectManager.get_project", lambda _pid: fake_project)
+    monkeypatch.setattr("app.api.graph.ProjectManager.save_project", lambda _project: None)
+    monkeypatch.setattr("app.api.graph.ProjectManager.get_extracted_text", lambda _pid: "some text")
+    monkeypatch.setattr("app.api.graph.get_container", lambda: fake_container)
+    monkeypatch.setattr("app.api.graph.TextProcessor.split_text", lambda *a, **k: ["chunk1"])
+    monkeypatch.setattr("app.api.graph.ArtifactLocator.existing_paths", lambda *_a, **_k: {})
+    monkeypatch.setattr("app.api.graph.seed_run_stage_routing", lambda *a, **k: None)
+    monkeypatch.setattr("app.api.graph.StageModelRouter", FakeRouter)
+    monkeypatch.setattr("app.api.graph.resolve_route_api_key", lambda *_a, **_k: "sk-route")
+    monkeypatch.setattr("app.api.graph.LLMClient.from_route", lambda *a, **k: fake_llm_client)
+    monkeypatch.setattr("app.api.graph.NERExtractor", fake_ner_extractor)
+    monkeypatch.setattr("app.api.graph.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.api.graph.run_registry.create_run", lambda *a, **k: {"run_id": "run_graph_1"})
+    monkeypatch.setattr("app.api.graph.run_registry.update_run", lambda *a, **k: None)
+
+    response = client.post("/api/graph/build", json={"project_id": VALID_PROJECT_ID})
+
+    assert response.status_code == 200, response.get_json()
+    assert captured_ner["llm_client"] is fake_llm_client

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -29,14 +29,18 @@ def test_list_provider_models(mock_get_models, client):
     assert resp.status_code == 200
 
 def test_get_run_llm_routing(client):
-    with patch("app.services.runtime_run_config.RuntimeRunConfig.load_config") as mock_load:
+    with patch("app.services.runtime_run_config.RuntimeRunConfig.load_config") as mock_load, patch(
+        "app.api.llm_routing._load_invocation_events"
+    ) as mock_events:
         from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
         mock_load.return_value = RuntimeLlmRouting(
             global_default=StageLLMRoute(provider_id="o", model="m")
         )
+        mock_events.return_value = [{"stage": "report_generation", "success": True}]
         resp = client.get("/api/runs/proj_123/llm-routing")
         assert resp.status_code == 200
         assert "runtime_config" in resp.json["data"]
+        assert resp.json["data"]["invocation_events"][0]["stage"] == "report_generation"
 
 def test_patch_stage_llm_routing_locked(client):
     with patch("app.services.runtime_run_config.RuntimeRunConfig.load_stage_snapshot") as mock_snap:

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+from app.contracts.llm_routing_contract import ResolvedRoute
+
+
+VALID_SIM_ID = "sim_0123456789ab"
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 1000
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+def test_prepare_endpoint_uses_resolved_route_for_legacy_service_call(client, monkeypatch):
+    captured: dict = {}
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_123"
+    fake_state.graph_id = "graph_123"
+    fake_state.source_simulation_id = None
+    fake_state.root_simulation_id = None
+    fake_state.branch_name = None
+    fake_state.branch_depth = 0
+    fake_state.entities_count = 1
+    fake_state.entity_types = ["Person"]
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Discuss the project"
+
+    fake_filtered = MagicMock()
+    fake_filtered.filtered_count = 1
+    fake_filtered.entity_types = {"Person"}
+
+    fake_manager = MagicMock()
+    fake_manager.get_simulation.return_value = fake_state
+    fake_manager.prepare_simulation.side_effect = lambda **kwargs: captured.update(kwargs) or MagicMock(
+        to_simple_dict=lambda: {"simulation_id": VALID_SIM_ID, "status": "ready"}
+    )
+
+    class FakeTaskManager:
+        def create_task(self, *args, **kwargs):
+            return "task_prepare_1"
+
+        def update_task(self, *args, **kwargs):
+            return None
+
+        def complete_task(self, *args, **kwargs):
+            return None
+
+        def fail_task(self, *args, **kwargs):
+            return None
+
+    class FakeRouter:
+        def __init__(self, run_id: str):
+            self.run_id = run_id
+
+        def resolve(self, _stage_id: str):
+            return ResolvedRoute(
+                stage="persona_generation",
+                provider_id="openai",
+                model="gpt-4o-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=9,
+            )
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def run_inline(self):
+        self.run()
+
+    monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
+    monkeypatch.setattr("app.api.simulation_prepare.ProjectManager.get_project", lambda _pid: fake_project)
+    monkeypatch.setattr("app.api.simulation_prepare.ProjectManager.get_extracted_text", lambda _pid: "document text")
+    monkeypatch.setattr("app.api.simulation_prepare.get_simulation_storage", lambda: MagicMock())
+    monkeypatch.setattr(
+        "app.api.simulation_prepare.EntityReader",
+        lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=fake_filtered)),
+    )
+    monkeypatch.setattr("app.api.simulation_prepare.seed_run_stage_routing", lambda *a, **k: None)
+    monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
+    monkeypatch.setattr("app.api.simulation_prepare.resolve_route_api_key", lambda *_a, **_k: "sk-route")
+    monkeypatch.setattr(
+        "app.api.simulation_prepare.run_registry.create_run",
+        lambda *a, **k: {"run_id": "run_prepare_1"},
+    )
+    monkeypatch.setattr("app.api.simulation_prepare.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
+
+    response = client.post(
+        "/api/simulation/prepare",
+        json={"simulation_id": VALID_SIM_ID, "llm_model": "ignored-by-route"},
+    )
+
+    assert response.status_code == 200, response.get_json()
+    assert captured["llm_model"] == "gpt-4o-mini"
+    assert captured["llm_runtime"].api_key == "sk-route"
+    assert captured["llm_runtime"].base_url == "https://api.openai.com/v1"

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from app.services.runtime_run_config import RuntimeRunConfig
+from app.services.runtime_run_config import RuntimeRunConfig, _detect_default_provider_id
 from app.services.stage_model_router import StageModelRouter
 from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
 
@@ -70,3 +70,14 @@ def test_stage_model_router_snapshot_isolation(temp_run_dir):
     resolved_other = router.resolve("graph_build")
     assert resolved_other.provider_id == "ollama"
     assert resolved_other.routing_version == 2
+
+
+def test_detect_default_provider_id_matches_hostname_not_substring():
+    assert _detect_default_provider_id("https://api.openai.com/v1", "gpt-4o") == "openai"
+    assert _detect_default_provider_id(
+        "https://generativelanguage.googleapis.com/v1beta/openai/", "gemini-1.5-pro"
+    ) == "google"
+    assert _detect_default_provider_id("https://evil-openai.com/v1", "custom-model") == "openai_compatible"
+    assert _detect_default_provider_id(
+        "https://proxy.example/generativelanguage.googleapis.com", "custom-model"
+    ) == "openai_compatible"

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -93,8 +93,9 @@ def test_build_route_subprocess_env_uses_resolved_route_values():
         provider_options={"num_ctx": 32768},
     )
 
-    env = build_route_subprocess_env(route, api_key="server-key")
+    env = build_route_subprocess_env(route, api_key="server-key", run_id="run_telemetry")
 
+    assert env["AGORA_RUN_ID"] == "run_telemetry"
     assert env["LLM_API_KEY"] == "server-key"
     assert env["OPENAI_API_KEY"] == "server-key"
     assert env["LLM_BASE_URL"] == "https://api.openai.com/v1"

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.services.llm_routing_seed import (
+    build_route_subprocess_env,
+    build_runtime_llm_config,
+    resolve_route_api_key,
+    seed_run_stage_routing,
+)
+from app.services.llm_runtime import RuntimeLlmConfig
+from app.services.runtime_run_config import RuntimeRunConfig
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_seed_run_stage_routing_persists_stage_override(mock_run_dir, tmp_path):
+    run_id = "run_seed_123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    config = seed_run_stage_routing(
+        run_id,
+        "report_generation",
+        llm_model_override="gpt-4o-mini",
+        llm_runtime=RuntimeLlmConfig(
+            provider="custom_openai",
+            api_key="session-secret",
+            base_url="https://gateway.example/v1",
+        ),
+    )
+
+    loaded = RuntimeRunConfig(run_id).load_config()
+    override = loaded.stage_overrides["report_generation"]
+    assert config.stage_overrides["report_generation"].provider_id == "openai_compatible"
+    assert override.provider_id == "openai_compatible"
+    assert override.model == "gpt-4o-mini"
+    assert override.provider_options == {"base_url": "https://gateway.example/v1"}
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_seed_run_stage_routing_keeps_server_default_without_override(mock_run_dir, tmp_path):
+    run_id = "run_seed_default"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    with patch("app.config.Config.LLM_BASE_URL", "https://api.openai.com/v1"), patch(
+        "app.config.Config.LLM_MODEL_NAME", "gpt-4o"
+    ):
+        loaded = seed_run_stage_routing(
+            run_id,
+            "graph_build",
+            llm_model_override=None,
+            llm_runtime=RuntimeLlmConfig(),
+        )
+
+    assert loaded.global_default.provider_id == "openai"
+    assert loaded.global_default.model == "gpt-4o"
+    assert loaded.stage_overrides == {}
+
+
+@patch("app.services.secret_resolver.SecretResolver.get_api_key")
+def test_resolve_route_api_key_prefers_runtime_secret_for_matching_provider(mock_get_api_key):
+    route = ResolvedRoute(
+        stage="report_generation",
+        provider_id="google",
+        model="gemini-1.5-pro",
+        routing_version=3,
+    )
+
+    api_key = resolve_route_api_key(
+        route,
+        RuntimeLlmConfig(
+            provider="google",
+            api_key="runtime-google-key",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+        ),
+    )
+
+    assert api_key == "runtime-google-key"
+    mock_get_api_key.assert_not_called()
+
+
+def test_build_route_subprocess_env_uses_resolved_route_values():
+    route = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="openai",
+        model="gpt-4o-mini",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=2,
+        provider_options={"num_ctx": 32768},
+    )
+
+    env = build_route_subprocess_env(route, api_key="server-key")
+
+    assert env["LLM_API_KEY"] == "server-key"
+    assert env["OPENAI_API_KEY"] == "server-key"
+    assert env["LLM_BASE_URL"] == "https://api.openai.com/v1"
+    assert env["LLM_MODEL_NAME"] == "gpt-4o-mini"
+
+
+def test_build_runtime_llm_config_maps_resolved_route_for_legacy_callers():
+    route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="ollama_local",
+        model="qwen2.5:32b",
+        base_url_sanitized="http://localhost:11434/v1",
+        routing_version=4,
+    )
+
+    cfg = build_runtime_llm_config(route, api_key="local-key")
+
+    assert cfg.provider == "custom_openai"
+    assert cfg.api_key == "local-key"
+    assert cfg.base_url == "http://localhost:11434/v1"

--- a/backend/tests/utils/test_llm_client_publishes_model_active.py
+++ b/backend/tests/utils/test_llm_client_publishes_model_active.py
@@ -6,6 +6,7 @@ All tests are mock-only — no live LLM call is made.
 from __future__ import annotations
 
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -67,6 +68,19 @@ class TestDetectProvider:
         client.base_url = "http://some-other-host:8080/v1"
         client.model = "some-model"
         assert client._detect_provider() == "unknown"
+
+
+class TestRunIdInitialization:
+    def test_init_reads_run_id_from_env_when_not_passed(self, monkeypatch):
+        monkeypatch.setenv("AGORA_RUN_ID", "run_env_123")
+        monkeypatch.setattr("app.utils.llm_client.OpenAI", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("app.utils.llm_client.Config.LLM_API_KEY", "env-key")
+        monkeypatch.setattr("app.utils.llm_client.Config.LLM_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.setattr("app.utils.llm_client.Config.LLM_MODEL_NAME", "gpt-4o-mini")
+
+        client = LLMClient()
+
+        assert client.run_id == "run_env_123"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -3,7 +3,8 @@ import {
   ProviderDescriptor,
   RuntimeLlmRouting,
   ResolvedRoute,
-  StageLLMRoute
+  StageLLMRoute,
+  LlmInvocationEvent,
 } from "../contracts/llmRoutingContract";
 import { ApiSuccessEnvelope } from "./envelope";
 
@@ -20,11 +21,13 @@ export async function listProviderModels(providerId: string, baseUrl?: string): 
 
 export async function getRunLlmRouting(runId: string): Promise<{
   runtime_config: RuntimeLlmRouting,
-  snapshots: Record<string, ResolvedRoute>
+  snapshots: Record<string, ResolvedRoute>,
+  invocation_events: LlmInvocationEvent[],
 }> {
   const resp = await service.get<ApiSuccessEnvelope<{
     runtime_config: RuntimeLlmRouting,
-    snapshots: Record<string, ResolvedRoute>
+    snapshots: Record<string, ResolvedRoute>,
+    invocation_events: LlmInvocationEvent[],
   }>>(`/runs/${runId}/llm-routing`);
   return (resp as any).data;
 }

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   listLlmProviders,
+  listProviderModels,
   getRunLlmRouting,
   updateRunLlmRouting,
   patchStageLlmRouting
@@ -12,7 +13,8 @@ import {
   RuntimeLlmRouting,
   StageLLMRoute,
   StageId,
-  ReasoningEffort
+  ReasoningEffort,
+  LlmInvocationEvent,
 } from '../../contracts/llmRoutingContract';
 
 const props = defineProps<{
@@ -24,6 +26,8 @@ const { t } = useI18n();
 const providers = ref<ProviderDescriptor[]>([]);
 const routing = ref<RuntimeLlmRouting | null>(null);
 const snapshots = ref<Record<string, any>>({});
+const invocationEvents = ref<LlmInvocationEvent[]>([]);
+const modelOptions = ref<Record<string, Array<{ id: string; name: string }>>>({});
 const loading = ref(false);
 const error = ref<string | null>(null);
 
@@ -49,6 +53,23 @@ async function load() {
     providers.value = p;
     routing.value = r.runtime_config;
     snapshots.value = r.snapshots;
+    invocationEvents.value = [...(r.invocation_events || [])].reverse();
+
+    const discoveries = await Promise.allSettled(
+      p
+        .filter((provider) => !!provider.base_url)
+        .map(async (provider) => ({
+          providerId: provider.id,
+          models: await listProviderModels(provider.id, provider.base_url || undefined),
+        })),
+    );
+
+    const nextOptions: Record<string, Array<{ id: string; name: string }>> = {};
+    for (const result of discoveries) {
+      if (result.status !== 'fulfilled') continue;
+      nextOptions[result.value.providerId] = result.value.models || [];
+    }
+    modelOptions.value = nextOptions;
   } catch (e: any) {
     error.value = e.message;
   } finally {
@@ -82,6 +103,12 @@ async function saveStage(stageId: StageId, route: StageLLMRoute) {
 }
 
 const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
+const formatLatency = (latencyMs: number) => `${Math.round(latencyMs)} ms`;
+const formatTimestamp = (timestamp: number) => new Date(timestamp * 1000).toLocaleString();
+const modelsFor = (providerId?: string | null) => {
+  if (!providerId) return [];
+  return modelOptions.value[providerId] || [];
+};
 
 </script>
 
@@ -101,7 +128,12 @@ const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
           </select>
 
           <label>{{ t('llm.model') }}</label>
-          <input v-model="routing.global_default.model" />
+          <select v-if="modelsFor(routing.global_default.provider_id).length > 0" v-model="routing.global_default.model">
+            <option v-for="model in modelsFor(routing.global_default.provider_id)" :key="model.id" :value="model.id">
+              {{ model.name }}
+            </option>
+          </select>
+          <input v-else v-model="routing.global_default.model" />
 
           <label>{{ t('llm.reasoning_effort') }}</label>
           <select v-model="routing.global_default.reasoning_effort">
@@ -134,6 +166,40 @@ const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
               <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.label }}</option>
             </select>
 
+            <label>{{ t('llm.model') }}</label>
+            <select
+              v-if="modelsFor(routing.stage_overrides[stage]?.provider_id || routing.global_default.provider_id).length > 0"
+              :value="routing.stage_overrides[stage]?.model || routing.global_default.model"
+              @change="(e: any) => {
+                if (!routing) return;
+                if (!routing.stage_overrides[stage]) {
+                  routing.stage_overrides[stage] = { ...routing.global_default };
+                }
+                routing.stage_overrides[stage].model = e.target.value;
+              }"
+              :disabled="isStageLocked(stage)"
+            >
+              <option
+                v-for="model in modelsFor(routing.stage_overrides[stage]?.provider_id || routing.global_default.provider_id)"
+                :key="model.id"
+                :value="model.id"
+              >
+                {{ model.name }}
+              </option>
+            </select>
+            <input
+              v-else
+              :value="routing.stage_overrides[stage]?.model || routing.global_default.model"
+              @input="(e: any) => {
+                if (!routing) return;
+                if (!routing.stage_overrides[stage]) {
+                  routing.stage_overrides[stage] = { ...routing.global_default };
+                }
+                routing.stage_overrides[stage].model = e.target.value;
+              }"
+              :disabled="isStageLocked(stage)"
+            />
+
             <button
               v-if="routing.stage_overrides[stage]"
               @click="saveStage(stage, routing.stage_overrides[stage])"
@@ -160,6 +226,26 @@ const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
             <p><strong>{{ t('llm.model') }}:</strong> {{ snap.model }}</p>
             <p><strong>{{ t('llm.provider') }}:</strong> {{ snap.provider_id }}</p>
             <p class="timestamp">{{ snap.started_at }}</p>
+          </div>
+        </div>
+
+        <h3>{{ t('llm.routing.call_events') }}</h3>
+        <div v-if="invocationEvents.length === 0" class="empty-hint">
+          {{ t('llm.routing.no_call_events_yet') }}
+        </div>
+        <div v-for="(event, index) in invocationEvents" :key="`${event.timestamp}-${index}`" class="snapshot-card card">
+          <div class="snap-header">
+            <strong>{{ event.stage }}</strong>
+            <span class="version" :class="event.success ? 'version--ok' : 'version--error'">
+              {{ event.success ? t('llm.routing.success') : t('llm.routing.failed') }}
+            </span>
+          </div>
+          <div class="snap-body">
+            <p><strong>{{ t('llm.model') }}:</strong> {{ event.model }}</p>
+            <p><strong>{{ t('llm.provider') }}:</strong> {{ event.provider_id }}</p>
+            <p><strong>{{ t('llm.routing.latency') }}:</strong> {{ formatLatency(event.latency_ms) }}</p>
+            <p v-if="event.error_type"><strong>{{ t('llm.routing.error_type') }}:</strong> {{ event.error_type }}</p>
+            <p class="timestamp">{{ formatTimestamp(event.timestamp) }}</p>
           </div>
         </div>
       </div>
@@ -200,6 +286,14 @@ const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
   padding: 2px 6px;
   border-radius: 10px;
   font-size: 0.7rem;
+}
+.version--ok {
+  background: #dcfce7;
+  color: #166534;
+}
+.version--error {
+  background: #fee2e2;
+  color: #991b1b;
 }
 .timestamp {
   font-size: 0.7rem;

--- a/frontend/src/contracts/llmRoutingContract.ts
+++ b/frontend/src/contracts/llmRoutingContract.ts
@@ -58,3 +58,19 @@ export const ResolvedRouteSchema = z.object({
   started_at: z.string().optional().nullable(),
 }).strict();
 export type ResolvedRoute = z.infer<typeof ResolvedRouteSchema>;
+
+export const LlmInvocationEventSchema = z.object({
+  run_id: z.string(),
+  stage: z.string(),
+  provider_id: z.string(),
+  model: z.string(),
+  base_url_sanitized: z.string().optional().nullable(),
+  routing_version: z.number().int(),
+  timestamp: z.number(),
+  latency_ms: z.number(),
+  success: z.boolean(),
+  error_type: z.string().optional().nullable(),
+  http_status: z.number().int().optional().nullable(),
+  remote_request_id: z.string().optional().nullable(),
+}).strict();
+export type LlmInvocationEvent = z.infer<typeof LlmInvocationEventSchema>;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -364,7 +364,13 @@
       "stage_overrides": "Stage-Overrides",
       "locked": "Gesperrt",
       "active_snapshots": "Aktive Snapshots",
-      "no_snapshots_yet": "Noch keine Snapshots vorhanden."
+      "no_snapshots_yet": "Noch keine Snapshots vorhanden.",
+      "call_events": "LLM-Aufrufe",
+      "no_call_events_yet": "Noch keine LLM-Aufrufe protokolliert.",
+      "success": "OK",
+      "failed": "Fehlgeschlagen",
+      "latency": "Latenz",
+      "error_type": "Fehlertyp"
     }
   },
   "step3": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -353,7 +353,13 @@
       "stage_overrides": "Stage Overrides",
       "locked": "Locked",
       "active_snapshots": "Active Snapshots",
-      "no_snapshots_yet": "No snapshots yet."
+      "no_snapshots_yet": "No snapshots yet.",
+      "call_events": "LLM Calls",
+      "no_call_events_yet": "No LLM calls recorded yet.",
+      "success": "OK",
+      "failed": "Failed",
+      "latency": "Latency",
+      "error_type": "Error Type"
     }
   },
   "step3": {


### PR DESCRIPTION
## Zusammenfassung
- verdrahtet das neue LLM-Routing in die echten Runtime-Pfade fuer `graph_build`, `simulation_prepare`, `simulation_run` und `report_generation`
- persistiert und lockt Stage-Snapshots pro Run und fuegt Seed-/Bridge-Helfer fuer Legacy-`llm_model`/`llm_provider` Requests hinzu
- protokolliert LLM-Invocation-Events und zeigt sie inkl. Snapshot-Transparenz und Model-Discovery in der Run-Detail-UI an

## Testplan
- [x] `cd backend && uv run pytest tests/services/test_llm_routing_seed.py tests/utils/test_llm_client_publishes_model_active.py tests/utils/test_llm_client_token_key_fallback.py tests/api/test_simulation_prepare_routing.py tests/api/test_graph_build_routing.py tests/api/test_graph_endpoints.py tests/api/test_graph_ontology_respects_frontend_model.py tests/api/test_simulation_prepare_quota.py tests/api/test_simulation_endpoints.py tests/api/test_simulation_uses_request_model.py tests/api/test_runs_resume_stop.py tests/api/test_report_modes.py tests/api/test_report_export_csv.py tests/api/test_report_export_zip.py tests/api/test_llm_routing_api.py -q`
- [x] `cd frontend && npm run build`
