### PR TITLE
security: track ignored CVE-2024-46455 until upstream fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ backend/logs/
 # Persistent caches mounted into the agora container
 backend/.cache/
 
+# Runtime artifacts and local instances
+instance/
+backend/instance/
+
 # Upload folder
 backend/uploads/
 

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -43,7 +43,7 @@ def _load_invocation_events(run_id: str, limit: int = 200) -> list[dict]:
     if not os.path.exists(log_path):
         return []
 
-    events = deque(maxlen=limit if limit > 0 else None)
+    events: deque[dict] = deque(maxlen=limit if limit > 0 else None)
     with open(log_path, "r", encoding="utf-8") as handle:
         for line in handle:
             payload = line.strip()

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from flask import Flask

--- a/docu/2026-05-11-cve-2024-46455-tracking-arbeitsprotokoll.md
+++ b/docu/2026-05-11-cve-2024-46455-tracking-arbeitsprotokoll.md
@@ -1,0 +1,29 @@
+# Work Log: security: track ignored CVE-2024-46455 until upstream fix
+
+**Date:** 2026-05-11
+**Status:** In Progress (Tracking active)
+**CVE:** CVE-2024-46455
+**Package:** `unstructured==0.13.7`
+**Issue:** #125
+
+## Summary
+CVE-2024-46455 in `unstructured==0.13.7` is being deliberately ignored as an upgrade is currently blocked by upstream pins in `camel-oasis`. This log documents the formal inclusion into the Security Watchlist and the Dependency Risk Register.
+
+## Details
+- **Risk:** Medium — Document parsing library. Agora uses `unstructured` for text extraction from PDF/DOCX during the onboarding path (reading knowledge sources).
+- **Blocked by:** `camel-oasis==0.2.5` (pins `unstructured==0.13.7`).
+- **Target Version:** Upgrade to `unstructured>=0.14.3` (fix version according to pip-audit) once `camel-oasis` relaxes the pin.
+- **Deadline:** 2026-07-30 (+90 days baseline hardstop).
+- **Action:** Monitor `camel-oasis` releases for relaxation of the `unstructured` pin. Re-run `pip-audit` after each dependency update.
+
+## Verification (2026-05-11)
+- [x] CVE confirmed in `pip-audit --strict` output.
+- [x] Blocker verified in `backend/uv.lock` (`camel-oasis==0.2.5` requires `unstructured==0.13.7`).
+- [x] Entry present in `docu/dependency-risk-register.md`.
+- [x] Entry present in `docu/2026-05-03-task-34-security-watchlist.md`.
+- [x] `--ignore-vuln CVE-2024-46455` present in `.github/workflows/ci.yml`.
+
+## Next Steps
+- Weekly review via `.github/workflows/cve-monitor.yml`.
+- Start immediate re-audit and upgrade attempt upon release of `camel-oasis > 0.2.5`.
+- If hardstop (2026-07-30) is reached without an upstream fix: Escalate according to ADR-0002 (Vendoring/Fork/Replacement).

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1959 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 49 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 1968 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 72 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._


### PR DESCRIPTION
This change formalizes the tracking of CVE-2024-46455 for the 'unstructured' package. An upgrade is currently blocked by an upstream pin in 'camel-oasis==0.2.5'. The tracking includes a detailed work log in English, verification against existing security registers and CI workflows, and a clean 'pip-audit' baseline with the appropriate ignore flags. Additionally, the '.gitignore' file was updated to prevent committing runtime artifacts from the 'instance/' directory.

Fixes #125

---
*PR created automatically by Jules for task [4911402598254694481](https://jules.google.com/task/4911402598254694481) started by @arn0ld87*