### PR TITLE
feat(design-v4): rebuild dashboard als Operator-Workbench

### DIFF
--- a/docu/2026-05-14-design-v4-dashboard-worklog.md
+++ b/docu/2026-05-14-design-v4-dashboard-worklog.md
@@ -1,0 +1,114 @@
+# Design-v4 Dashboard — Workbench-Rebuild
+
+- **Datum:** 2026-05-14
+- **Branch:** `feat/design-v4-dashboard` (Worktree `/tmp/agora-design-v4-dashboard`)
+- **Base:** `origin/main` @ `b981a54`
+- **Slice-Kontext:** Folgeslice zu Design-v4 Slice F (Stub-Ersetzung), spielt zugleich Teile der für Slice H geplanten Home.vue-Migration früher ein.
+
+## Discovery
+
+Aktueller Stand vor dem Slice war ein 40-LOC-Stub mit einer einzigen Placeholder-Card. Ziel: vollständig überarbeitetes Dashboard als operative Workbench mit Live-Daten.
+
+Discovery-Antworten (per AskUserQuestion):
+
+- **Scope:** Full Rebuild mit Live-Daten.
+- **Visuelle These:** Workbench — ruhig, dichte Information, Mono für IDs/Counts, ein Accent pro Region.
+- **Primäraktion:** Neuer Run aus Quelle (Hero oben).
+- **Worktree:** `/tmp/agora-design-v4-dashboard`.
+
+## Visuelle Richtung
+
+> "Operator-Workbench" — wenig Farbe, dichte aber gestaffelte Information, ID-Pillen monospace, exakt eine Accent-Aktion pro Region.
+
+Prinzipien:
+
+1. Accent nur auf Primäraktion (Start-CTA im Hero) — sonst Hairlines + Tone-Sätze.
+2. Mono für Run-IDs, Project-Slugs, Counts; Sans für Headlines/Prosa.
+3. Status zeigt sich durch Token-Tones (`status-green/orange/red/...`), nie durch Glow.
+4. Hero dominiert above-the-fold; Stats, Grid, Reports, Quick-Actions staffeln sich darunter.
+5. Empty/Loading/Error sind first-class pro Widget.
+
+## Architektur
+
+```
+DashboardView
+├─ PageHeader
+├─ HeroNewRun                (Drop · Modell+Sprache · Start)
+├─ StatsRow                  (4 Mikro-Kennzahlen)
+├─ Grid 2/3 · 1/3
+│  ├─ ActiveRunsCard
+│  └─ SystemHealthCard
+├─ RecentReportsCard
+└─ QuickActionsRow           (Compare · History · Settings)
+```
+
+Datenfluss:
+
+- `useRunsPolling(5000)` → Active Runs + Stats-Aggregation.
+- `useSystemStatus(15000)` → Ollama / Neo4j / Disk-Telemetrie aus `/api/status`.
+- `RecentReportsCard` pollt `listRuns({run_type:'report_generate', status:'completed', limit:8})` alle 30 s.
+- `HeroNewRun` greift auf bestehenden `setPendingUpload()`-Pfad zu und routet zu `/process/new`.
+
+## Geänderte / neue Dateien
+
+### Neu (Code)
+
+| Datei | LOC | Tests |
+|---|---:|---:|
+| `frontend/src/contracts/systemStatusContract.ts` | 72 | über Composable-Spec |
+| `frontend/src/api/status.ts` | 22 | (Wrapper, gemockt) |
+| `frontend/src/composables/useSystemStatus.ts` | 82 | 3 |
+| `frontend/src/components/v4/dashboard/HeroNewRun.vue` | 469 | 2 |
+| `frontend/src/components/v4/dashboard/StatsRow.vue` | 85 | 2 |
+| `frontend/src/components/v4/dashboard/ActiveRunsCard.vue` | 224 | 4 |
+| `frontend/src/components/v4/dashboard/SystemHealthCard.vue` | 226 | 4 |
+| `frontend/src/components/v4/dashboard/RecentReportsCard.vue` | 230 | 2 |
+| `frontend/src/components/v4/dashboard/QuickActionsRow.vue` | 96 | 2 |
+| `frontend/src/components/v4/dashboard/__tests__/dashTestHelpers.ts` | 41 | — |
+
+### Geändert
+
+- `frontend/src/views/v4/DashboardView.vue` — Stub durch Orchestrator ersetzt.
+- `frontend/src/i18n/locales/de.json` + `en.json` — neuer `dashboard.*`-Namespace + `common.tryAgain`.
+- `frontend/src/views/__tests__/AppShellWrappers.spec.ts` — Dashboard-Block entfernt (durch eigenen Spec ersetzt).
+- `frontend/src/views/v4/__tests__/DashboardView.spec.ts` — Orchestrator-Smoke mit gestubbten Sub-Components.
+
+## Gates (lokal)
+
+| Gate | Status |
+|---|---|
+| `npm run typecheck` | ✓ grün |
+| `npm test -- --run` | ✓ 674/674 Tests, 80/80 Files |
+| `npm run lint` | ✓ grün |
+| `npm run build` | ✓ grün |
+
+Test-Delta: 19 neue Tests in 8 neuen Spec-Dateien.
+
+## Bundle-Delta gegen main
+
+| Asset | main | neu | Δ |
+|---|---:|---:|---:|
+| `DashboardView` JS | 0.91 kB | 22.61 kB | +21.70 kB |
+| `DashboardView` CSS | 0.10 kB | 12.58 kB | +12.48 kB |
+| `index` JS | 677.46 kB | 681.19 kB | +3.73 kB |
+| `index` CSS | 154.87 kB | 154.87 kB | 0 |
+
+Im Lazy-Chunk steht der echte Dashboard-Inhalt — der monolithische `index`-Bundle wächst nur um 3.7 kB (gz +1.1 kB). Akzeptabel.
+
+## Bekannte Gaps
+
+- **OASIS-Health hat keinen Backend-Endpoint.** Die Zeile rendert als gedimmter `idle`-Pill mit Hinweis "Wird beim Start eines Runs aktiv". Sobald ein OASIS-Status verfügbar ist, einfach in `SystemHealthCard.rows.computed` ergänzen.
+- **`metadata.confidence_score` ist nicht garantiert befüllt.** Wenn fehlt: `avgConfidence` bleibt `null`, RecentReportsCard zeigt em-dash.
+- **Hero schreibt nur `STORAGE_MODEL` + `STORAGE_LANG`.** Custom-Model-Pfad (`STORAGE_CUSTOM_MODEL`) bleibt der Settings-Seite vorbehalten — bewusste Reduktion gegenüber Home.vue, um die Hero-UX schmal zu halten.
+
+## Designentscheidungen (Stichpunkte)
+
+- **Mono-IDs durch `shortId(id)` auf 12 Zeichen begrenzt** — verhindert das Aufquellen der Tabellenzeilen bei UUIDs.
+- **Stats-Row als Grid mit `gap: 1px` + Hairline-Hintergrund** — erzeugt klare Trennlinien ohne dekorative Borders.
+- **Drop-Zone als `role="button"` + Enter/Space-Handler** — Tastaturbedienbarkeit ohne zusätzliche Schaltfläche.
+- **Stats berechnen sich aus dem ungefilterten `useRunsPolling`-Stream** — kein zweiter API-Call nötig, kein Drift-Risiko zwischen Stats und Active-Liste.
+- **`prefers-reduced-motion` respektiert** — alle Transitions im Hero werden bei reduce-motion gestoppt.
+
+## Visueller Akzeptanztest
+
+Lokal `npm run dev` → `/dashboard`. Erwartet: Hero oben, dann StatsRow, dann ActiveRuns+SystemHealth nebeneinander, dann Recent Reports, dann Quick-Actions. Sidebar-Active-State `dashboard` bleibt korrekt (durch bestehendes AppShell-Mapping).

--- a/frontend/src/api/status.ts
+++ b/frontend/src/api/status.ts
@@ -1,0 +1,20 @@
+import service from './index'
+import type { SystemStatusResponse } from '../contracts/systemStatusContract'
+
+export interface SystemStatusEnvelope {
+  success: boolean
+  data?: SystemStatusResponse
+  // /api/status nutzt json_success(**extra), wodurch das Envelope flach ist:
+  // { success: true, backend: {...}, neo4j: {...}, ... }
+  // Wir akzeptieren beide Formen und entpacken im Composable.
+  backend?: unknown
+  neo4j?: unknown
+  ollama?: unknown
+  disk?: unknown
+  gpu?: unknown
+  timestamp?: string
+  [key: string]: unknown
+}
+
+export const getSystemStatus = (): Promise<SystemStatusEnvelope> =>
+  service.get('/api/status')

--- a/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
+++ b/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+/**
+ * ActiveRunsCard — Active-Runs-Liste über useRunsPolling.
+ *
+ * Workbench-These: kompakte Tabelle, Mono für IDs/Project-Slugs, Phase als
+ * Tone-Pill (graph_build=teal, simulation_prepare=purple, simulation_run=blue,
+ * report_generate=orange).
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import Card from '../forms/Card.vue'
+import Badge from '../forms/Badge.vue'
+import DataTable, { type DataTableColumn } from '../data/DataTable.vue'
+import EmptyState from '../data/EmptyState.vue'
+import type { RunDetail } from '../../../contracts/runsContract'
+
+const props = defineProps<{
+  runs: RunDetail[]
+  loading: boolean
+  error: string
+}>()
+
+const emit = defineEmits<{
+  refresh: []
+}>()
+
+const { t } = useI18n()
+const router = useRouter()
+
+const ACTIVE_STATUSES = ['pending', 'processing', 'paused'] as const
+
+const activeRuns = computed<RunDetail[]>(() =>
+  props.runs.filter(r => (ACTIVE_STATUSES as readonly string[]).includes(r.status))
+    .slice(0, 8),
+)
+
+const columns: DataTableColumn[] = [
+  { key: 'run_id', label: t('dashboard.active.columns.runId'), mono: true, width: '180px' },
+  { key: 'project', label: t('dashboard.active.columns.project'), secondary: true },
+  { key: 'phase', label: t('dashboard.active.columns.phase'), width: '180px' },
+  { key: 'progress', label: t('dashboard.active.columns.progress'), align: 'right', width: '90px' },
+  { key: 'started', label: t('dashboard.active.columns.started'), secondary: true, align: 'right', width: '120px' },
+]
+
+const PHASE_TONE: Record<string, 'teal' | 'purple' | 'blue' | 'orange' | 'gray'> = {
+  graph_build: 'teal',
+  simulation_prepare: 'purple',
+  simulation_run: 'blue',
+  report_generate: 'orange',
+}
+
+function phaseLabel(runType: string): string {
+  const key = `dashboard.active.phase.${runType}`
+  const fallback = runType
+  const translated = t(key)
+  return translated === key ? fallback : translated
+}
+
+function phaseTone(runType: string) {
+  return PHASE_TONE[runType] ?? 'gray'
+}
+
+function shortId(id: string): string {
+  if (id.length <= 12) return id
+  return `${id.slice(0, 8)}…${id.slice(-3)}`
+}
+
+function relTime(iso: string): string {
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return '—'
+  const diff = Date.now() - ts
+  const secs = Math.round(diff / 1000)
+  if (secs < 60) return t('dashboard.time.secondsAgo', { n: secs })
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return t('dashboard.time.minutesAgo', { n: mins })
+  const hrs = Math.round(mins / 60)
+  if (hrs < 24) return t('dashboard.time.hoursAgo', { n: hrs })
+  return new Date(ts).toLocaleDateString()
+}
+
+interface Row extends Record<string, unknown> {
+  id: string
+  run_id: string
+  run_id_display: string
+  project: string
+  phase: string
+  phase_tone: 'teal' | 'purple' | 'blue' | 'orange' | 'gray'
+  progress: number
+  started: string
+  raw: RunDetail
+}
+
+const rows = computed<Row[]>(() =>
+  activeRuns.value.map(r => ({
+    id: r.run_id,
+    run_id: r.run_id,
+    run_id_display: shortId(r.run_id),
+    project: r.summary?.document_name ?? r.linked_ids?.project_id as string ?? r.entity_id,
+    phase: phaseLabel(r.run_type),
+    phase_tone: phaseTone(r.run_type),
+    progress: r.progress ?? 0,
+    started: relTime(r.started_at),
+    raw: r,
+  })),
+)
+
+function openRun(row: Row) {
+  router.push({ name: 'RunDetail', params: { id: row.run_id } })
+}
+</script>
+
+<template>
+  <Card :title="$t('dashboard.active.title')">
+    <template #right>
+      <span v-if="loading && rows.length === 0" class="ar-loading">{{ $t('common.loading') }}</span>
+      <Badge v-else-if="rows.length > 0" tone="blue" :dot="false">{{ rows.length }}</Badge>
+    </template>
+
+    <div v-if="error" class="ar-error">
+      <Badge tone="red">{{ $t('dashboard.active.errorLabel') }}</Badge>
+      <span class="ar-error__msg">{{ error }}</span>
+      <button class="ar-retry" type="button" @click="emit('refresh')">
+        {{ $t('common.tryAgain') }}
+      </button>
+    </div>
+
+    <template v-else-if="rows.length === 0">
+      <EmptyState
+        :title="$t('dashboard.active.emptyTitle')"
+        :subtitle="$t('dashboard.active.emptyHint')"
+      />
+    </template>
+
+    <DataTable
+      v-else
+      :columns="columns"
+      :rows="rows"
+      :row-click="openRun"
+      compact
+    >
+      <template #cell-run_id="{ row }">
+        <span class="ar-id">{{ (row as Row).run_id_display }}</span>
+      </template>
+      <template #cell-phase="{ row }">
+        <Badge :tone="(row as Row).phase_tone">{{ (row as Row).phase }}</Badge>
+      </template>
+      <template #cell-progress="{ row }">
+        <span class="ar-progress">{{ (row as Row).progress }}<span class="ar-progress__unit">%</span></span>
+      </template>
+    </DataTable>
+  </Card>
+</template>
+
+<style scoped>
+.ar-loading {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.ar-error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ar-error__msg {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+}
+
+.ar-retry {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--accent);
+  background: transparent;
+  border: 0;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: var(--r-3, 6px);
+}
+
+.ar-retry:hover {
+  background: var(--accent-tint-bg);
+}
+
+.ar-retry:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.ar-id {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-primary);
+}
+
+.ar-progress {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.ar-progress__unit {
+  color: var(--text-tertiary);
+}
+</style>

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -1,0 +1,532 @@
+<script setup lang="ts">
+/**
+ * HeroNewRun — primärer Aktions-Block des Dashboards.
+ *
+ * Workbench-These: ruhige Card, drei Zonen (Quelle | Modell+Sprache | Aktion),
+ * Akzent-Aktion rechts. Keine Glows, keine Marketing-Kicker.
+ *
+ * Spiegelt den bestehenden Home.vue-Flow (setPendingUpload → /process/new),
+ * aber ohne Hero-Headline-Cluster und ohne LandingPage-Layout.
+ */
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import Card from '../forms/Card.vue'
+import Badge from '../forms/Badge.vue'
+import IconPlus from '../shell/icons/IconPlus.vue'
+import { getAvailableModels } from '../../../api/simulation'
+import { setPendingUpload } from '../../../store/pendingUpload'
+import { STORAGE_CUSTOM_MODEL, STORAGE_LANG, STORAGE_MODEL } from '../../../composables/useEnvForm'
+
+interface ModelOption {
+  value: string
+  label: string
+}
+
+const { t } = useI18n()
+const router = useRouter()
+
+const ALLOWED = ['.pdf', '.md', '.txt', '.markdown']
+
+const files = ref<File[]>([])
+const isDragOver = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+const errorMsg = ref('')
+
+const presetModels = ref<ModelOption[]>([])
+const ollamaModels = ref<ModelOption[]>([])
+const defaultModel = ref('')
+const ollamaReachable = ref(false)
+const loadingStatus = ref(true)
+
+function readLocal(key: string): string | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const ls = window.localStorage
+    if (!ls || typeof ls.getItem !== 'function') return null
+    return ls.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeLocal(key: string, value: string): void {
+  try {
+    if (typeof window === 'undefined') return
+    const ls = window.localStorage
+    if (!ls || typeof ls.setItem !== 'function') return
+    ls.setItem(key, value)
+  } catch { /* swallow */ }
+}
+
+function removeLocal(key: string): void {
+  try {
+    if (typeof window === 'undefined') return
+    const ls = window.localStorage
+    if (!ls || typeof ls.removeItem !== 'function') return
+    ls.removeItem(key)
+  } catch { /* swallow */ }
+}
+
+const modelOption = ref<string>(readLocal(STORAGE_MODEL) || 'default')
+const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
+
+const modelOptions = computed<ModelOption[]>(() => {
+  const opts: ModelOption[] = [
+    { value: 'default', label: `${t('dashboard.hero.modelDefault')} — ${defaultModel.value || '?'}` },
+  ]
+  for (const p of presetModels.value) opts.push(p)
+  for (const m of ollamaModels.value) {
+    if (presetModels.value.some(p => p.value === m.value)) continue
+    opts.push({ value: m.value, label: `${m.label} (Ollama)` })
+  }
+  return opts
+})
+
+const canSubmit = computed(() => files.value.length > 0 && !loadingStatus.value)
+
+async function loadStatus() {
+  loadingStatus.value = true
+  try {
+    const res = await getAvailableModels()
+    const data = (res as { data?: Record<string, unknown>; success?: boolean })?.data ?? null
+    if (data) {
+      const presets = (data['presets'] as Array<Record<string, unknown>>) ?? []
+      const ollama = (data['ollama'] as Array<Record<string, unknown>>) ?? []
+      presetModels.value = presets.map(p => ({
+        value: String(p['name'] ?? ''),
+        label: String(p['label'] ?? p['name'] ?? ''),
+      })).filter(o => !!o.value)
+      ollamaModels.value = ollama.map(p => ({
+        value: String(p['name'] ?? ''),
+        label: String(p['label'] ?? p['name'] ?? ''),
+      })).filter(o => !!o.value)
+      defaultModel.value = String(data['current_default'] ?? '')
+      ollamaReachable.value = !!data['ollama_reachable']
+    }
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loadingStatus.value = false
+  }
+}
+
+function filterAllowed(list: FileList | File[]): File[] {
+  return Array.from(list).filter(f => {
+    const lower = f.name.toLowerCase()
+    return ALLOWED.some(ext => lower.endsWith(ext))
+  })
+}
+
+function onPickClick() {
+  fileInput.value?.click()
+}
+
+function onPickKey(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onPickClick()
+  }
+}
+
+function onFiles(e: Event) {
+  const t = e.target as HTMLInputElement
+  if (!t.files) return
+  const accepted = filterAllowed(t.files)
+  files.value = accepted
+  if (accepted.length === 0 && t.files.length > 0) {
+    errorMsg.value = t.value
+      ? ''
+      : ''
+    errorMsg.value = ''
+  }
+  t.value = ''
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = false
+  if (!e.dataTransfer?.files) return
+  files.value = filterAllowed(e.dataTransfer.files)
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+function removeFile(i: number) {
+  files.value.splice(i, 1)
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+async function startSimulation() {
+  if (!canSubmit.value) return
+  try {
+    writeLocal(STORAGE_MODEL, modelOption.value)
+    writeLocal(STORAGE_LANG, language.value)
+    removeLocal(STORAGE_CUSTOM_MODEL)
+    setPendingUpload(files.value, '')
+    router.push({ name: 'Process', params: { projectId: 'new' } })
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+onMounted(() => void loadStatus())
+</script>
+
+<template>
+  <Card :title="$t('dashboard.hero.title')" :subtitle="$t('dashboard.hero.subtitle')">
+    <template #right>
+      <Badge
+        v-if="!loadingStatus"
+        :tone="ollamaReachable ? 'green' : 'gray'"
+      >
+        {{ ollamaReachable ? $t('dashboard.system.statusReachable') : $t('dashboard.system.statusIdle') }}
+      </Badge>
+    </template>
+
+    <div class="hero-grid">
+      <!-- Zone 1: Quelle (Drop / Picker) -->
+      <div class="hero-zone hero-source">
+        <label class="hero-label">{{ $t('dashboard.hero.sourceLabel') }}</label>
+        <div
+          class="hero-drop"
+          :class="{ 'hero-drop--over': isDragOver, 'hero-drop--filled': files.length > 0 }"
+          role="button"
+          tabindex="0"
+          @click="onPickClick"
+          @keydown="onPickKey"
+          @drop="onDrop"
+          @dragover="onDragOver"
+          @dragleave="onDragLeave"
+        >
+          <template v-if="files.length === 0">
+            <IconPlus :size="18" :stroke="1.6" class="hero-drop__icon" />
+            <span class="hero-drop__title">{{ $t('dashboard.hero.dropHint') }}</span>
+            <span class="hero-drop__formats">{{ ALLOWED.join('  ·  ') }}</span>
+          </template>
+          <template v-else>
+            <ul class="hero-files">
+              <li v-for="(f, i) in files" :key="`${f.name}-${i}`" class="hero-file">
+                <span class="hero-file__name">{{ f.name }}</span>
+                <span class="hero-file__size">{{ formatBytes(f.size) }}</span>
+                <button
+                  type="button"
+                  class="hero-file__remove"
+                  :aria-label="$t('common.delete')"
+                  @click.stop="removeFile(i)"
+                >
+                  ✕
+                </button>
+              </li>
+            </ul>
+          </template>
+        </div>
+        <input
+          ref="fileInput"
+          type="file"
+          class="hero-input-hidden"
+          :accept="ALLOWED.join(',')"
+          multiple
+          @change="onFiles"
+        />
+      </div>
+
+      <!-- Zone 2: Model + Sprache -->
+      <div class="hero-zone hero-config">
+        <div class="hero-field">
+          <label class="hero-label" for="hero-model">{{ $t('dashboard.hero.modelLabel') }}</label>
+          <select id="hero-model" v-model="modelOption" class="hero-select">
+            <option v-for="opt in modelOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
+        <div class="hero-field">
+          <label class="hero-label" for="hero-lang">{{ $t('dashboard.hero.languageLabel') }}</label>
+          <select id="hero-lang" v-model="language" class="hero-select">
+            <option value="de">Deutsch</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Zone 3: Aktion -->
+      <div class="hero-zone hero-action">
+        <button
+          type="button"
+          class="hero-cta"
+          :disabled="!canSubmit"
+          :aria-disabled="!canSubmit"
+          @click="startSimulation"
+        >
+          {{ $t('dashboard.hero.startCta') }}
+        </button>
+        <p v-if="!canSubmit && !loadingStatus" class="hero-hint">
+          {{ $t('dashboard.hero.disabledHint') }}
+        </p>
+        <p v-if="errorMsg" class="hero-error">{{ errorMsg }}</p>
+      </div>
+    </div>
+  </Card>
+</template>
+
+<style scoped>
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr) minmax(0, 0.9fr);
+  gap: 24px;
+  align-items: stretch;
+}
+
+.hero-zone {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.hero-label {
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+/* Drop-Zone */
+.hero-drop {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px dashed var(--hairline-strong);
+  border-radius: var(--r-5, 10px);
+  padding: 22px;
+  background: var(--surface-inset, #f2f2f7);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+  min-height: 132px;
+}
+
+.hero-drop:hover {
+  background: var(--surface-hover);
+}
+
+.hero-drop:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.hero-drop--over {
+  background: var(--accent-tint-bg);
+  border-color: var(--accent);
+  color: var(--accent-tint-text);
+}
+
+.hero-drop--filled {
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 12px;
+  background: var(--surface-elevated);
+  border-style: solid;
+  border-color: var(--hairline);
+}
+
+.hero-drop__icon {
+  color: var(--text-tertiary);
+}
+
+.hero-drop__title {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.hero-drop__formats {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.hero-files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hero-file {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: var(--r-4, 8px);
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+.hero-file:hover {
+  background: var(--surface-hover);
+}
+
+.hero-file__name {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hero-file__size {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+}
+
+.hero-file__remove {
+  background: transparent;
+  border: 0;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: var(--r-3, 6px);
+}
+
+.hero-file__remove:hover {
+  background: var(--surface-pressed);
+  color: var(--text-secondary);
+}
+
+.hero-input-hidden {
+  display: none;
+}
+
+/* Config */
+.hero-config {
+  justify-content: center;
+}
+
+.hero-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hero-select {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-primary);
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-tertiary) 50%),
+                    linear-gradient(135deg, var(--text-tertiary) 50%, transparent 50%);
+  background-position: calc(100% - 14px) 50%, calc(100% - 9px) 50%;
+  background-size: 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 28px;
+}
+
+.hero-select:hover {
+  border-color: var(--hairline-strong);
+}
+
+.hero-select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Aktion */
+.hero-action {
+  justify-content: center;
+  align-items: stretch;
+}
+
+.hero-cta {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border: 0;
+  border-radius: var(--r-5, 10px);
+  padding: 12px 18px;
+  cursor: pointer;
+  transition: background 80ms ease;
+}
+
+.hero-cta:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.hero-cta:active:not(:disabled) {
+  background: var(--accent-pressed);
+}
+
+.hero-cta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.hero-cta:disabled {
+  background: var(--gray-4, #d1d1d6);
+  color: var(--text-quaternary);
+  cursor: not-allowed;
+}
+
+.hero-hint {
+  margin: 8px 0 0;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.hero-error {
+  margin: 8px 0 0;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--status-red);
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-drop,
+  .hero-cta,
+  .hero-select,
+  .hero-file__remove {
+    transition: none;
+  }
+}
+</style>

--- a/frontend/src/components/v4/dashboard/QuickActionsRow.vue
+++ b/frontend/src/components/v4/dashboard/QuickActionsRow.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+/**
+ * QuickActionsRow — drei RouterLink-Tiles für Compare / History / Settings.
+ * Workbench-These: ruhige Kacheln, Mono-Label, kein Akzent (Hero hat den Akzent).
+ */
+import { RouterLink } from 'vue-router'
+
+interface Tile {
+  to: string
+  labelKey: string
+  hintKey: string
+}
+
+const TILES: Tile[] = [
+  { to: '/v4/compare/last', labelKey: 'dashboard.quick.compare', hintKey: 'dashboard.quick.compareHint' },
+  { to: '/v4/history', labelKey: 'dashboard.quick.history', hintKey: 'dashboard.quick.historyHint' },
+  { to: '/settings/general', labelKey: 'dashboard.quick.settings', hintKey: 'dashboard.quick.settingsHint' },
+]
+</script>
+
+<template>
+  <div class="qa-row">
+    <RouterLink
+      v-for="tile in TILES"
+      :key="tile.to"
+      :to="tile.to"
+      class="qa-tile"
+    >
+      <span class="qa-tile__label">{{ $t(tile.labelKey) }}</span>
+      <span class="qa-tile__hint">{{ $t(tile.hintKey) }}</span>
+      <span class="qa-tile__arrow" aria-hidden="true">→</span>
+    </RouterLink>
+  </div>
+</template>
+
+<style scoped>
+.qa-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.qa-tile {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  column-gap: 12px;
+  padding: 16px 18px;
+  background: var(--surface-elevated, #fff);
+  border-radius: var(--r-6, 12px);
+  box-shadow: 0 0 0 1px var(--hairline);
+  text-decoration: none;
+  color: var(--text-primary);
+  transition: background 80ms ease, box-shadow 80ms ease;
+  min-width: 0;
+}
+
+.qa-tile:hover {
+  background: var(--surface-hover);
+}
+
+.qa-tile:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--hairline), 0 0 0 3px var(--focus-ring);
+}
+
+.qa-tile__label {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.qa-tile__hint {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  grid-row: 2;
+  grid-column: 1;
+  margin-top: 2px;
+}
+
+.qa-tile__arrow {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 16px;
+}
+
+@media (max-width: 720px) {
+  .qa-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/v4/dashboard/RecentReportsCard.vue
+++ b/frontend/src/components/v4/dashboard/RecentReportsCard.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+/**
+ * RecentReportsCard — letzte abgeschlossene Reports.
+ *
+ * Datenquelle: listRuns({ run_type:'report_generate', status:'completed', limit:8 })
+ * eigenständig gepollt (alle 30 s — weniger volatil als ActiveRuns).
+ */
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import Card from '../forms/Card.vue'
+import Badge from '../forms/Badge.vue'
+import DataTable, { type DataTableColumn } from '../data/DataTable.vue'
+import EmptyState from '../data/EmptyState.vue'
+import { listRuns } from '../../../api/runs'
+import { ApiError } from '../../../api/envelope'
+import { RunDetailSchema, type RunDetail } from '../../../contracts/runsContract'
+import { usePolling } from '../../../composables/usePolling'
+
+const { t } = useI18n()
+const router = useRouter()
+
+const reports = ref<RunDetail[]>([])
+const loading = ref(false)
+const error = ref('')
+
+async function tick(): Promise<void> {
+  loading.value = true
+  try {
+    const envelope = await listRuns({
+      run_type: 'report_generate',
+      status: 'completed',
+      limit: 8,
+    })
+    const payload = (envelope as { data?: { runs?: unknown[] } }).data
+    const rawRuns = payload?.runs ?? []
+    const parsed: RunDetail[] = []
+    for (const item of rawRuns) {
+      const ok = RunDetailSchema.safeParse(item)
+      if (ok.success) parsed.push(ok.data)
+    }
+    reports.value = parsed
+    error.value = ''
+  } catch (e) {
+    if (e instanceof ApiError) error.value = e.message
+    else error.value = e instanceof Error ? e.message : 'Netzwerkfehler'
+  } finally {
+    loading.value = false
+  }
+}
+
+const polling = usePolling(tick, 30000, { pauseWhenHidden: true })
+
+onMounted(() => void polling.start({ immediate: true }))
+onUnmounted(() => polling.stop())
+
+const columns: DataTableColumn[] = [
+  { key: 'report_id', label: t('dashboard.reports.columns.reportId'), mono: true, width: '180px' },
+  { key: 'project', label: t('dashboard.reports.columns.project'), secondary: true },
+  { key: 'personas', label: t('dashboard.reports.columns.personas'), mono: true, align: 'right', width: '100px' },
+  { key: 'confidence', label: t('dashboard.reports.columns.confidence'), align: 'right', width: '120px' },
+  { key: 'date', label: t('dashboard.reports.columns.date'), secondary: true, align: 'right', width: '120px' },
+]
+
+interface ReportRow extends Record<string, unknown> {
+  id: string
+  report_id_display: string
+  report_id_full: string | null
+  project: string
+  personas: number | null
+  confidence: number | null
+  date: string
+  raw: RunDetail
+}
+
+function shortId(id: string | null | undefined): string {
+  if (!id) return '—'
+  if (id.length <= 12) return id
+  return `${id.slice(0, 8)}…${id.slice(-3)}`
+}
+
+function fmtDate(iso?: string | null): string {
+  if (!iso) return '—'
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return '—'
+  return new Date(ts).toLocaleDateString()
+}
+
+function pickConfidence(r: RunDetail): number | null {
+  const meta = r.metadata as Record<string, unknown>
+  const cand = meta?.['confidence_score'] ?? meta?.['confidence']
+  if (typeof cand === 'number' && Number.isFinite(cand)) return cand
+  return null
+}
+
+const rows = computed<ReportRow[]>(() =>
+  reports.value.map(r => {
+    const linked = r.linked_ids as Record<string, unknown>
+    const reportId = typeof linked?.['report_id'] === 'string' ? (linked['report_id'] as string) : null
+    return {
+      id: r.run_id,
+      report_id_display: shortId(reportId ?? r.run_id),
+      report_id_full: reportId,
+      project: r.summary?.document_name ?? r.entity_id,
+      personas: r.summary?.persona_count ?? null,
+      confidence: pickConfidence(r),
+      date: fmtDate(r.completed_at ?? r.updated_at),
+      raw: r,
+    }
+  }),
+)
+
+function openReport(row: ReportRow) {
+  if (row.report_id_full) {
+    router.push({ name: 'Report', params: { reportId: row.report_id_full } })
+  } else {
+    router.push({ name: 'RunDetail', params: { id: row.raw.run_id } })
+  }
+}
+
+function confidenceTone(c: number | null): 'green' | 'orange' | 'red' | 'gray' {
+  if (c === null) return 'gray'
+  if (c >= 0.7) return 'green'
+  if (c >= 0.45) return 'orange'
+  return 'red'
+}
+</script>
+
+<template>
+  <Card :title="$t('dashboard.reports.title')">
+    <template #right>
+      <span v-if="loading && rows.length === 0" class="rr-loading">{{ $t('common.loading') }}</span>
+      <Badge v-else-if="rows.length > 0" tone="blue" :dot="false">{{ rows.length }}</Badge>
+    </template>
+
+    <div v-if="error" class="rr-error">
+      <Badge tone="red">{{ $t('dashboard.active.errorLabel') }}</Badge>
+      <span class="rr-error__msg">{{ error }}</span>
+      <button class="rr-retry" type="button" @click="() => void polling.tick()">
+        {{ $t('common.tryAgain') }}
+      </button>
+    </div>
+
+    <template v-else-if="rows.length === 0">
+      <EmptyState
+        :title="$t('dashboard.reports.emptyTitle')"
+        :subtitle="$t('dashboard.reports.emptyHint')"
+      />
+    </template>
+
+    <DataTable
+      v-else
+      :columns="columns"
+      :rows="rows"
+      :row-click="openReport"
+      compact
+    >
+      <template #cell-report_id="{ row }">
+        <span class="rr-id">{{ (row as ReportRow).report_id_display }}</span>
+      </template>
+      <template #cell-personas="{ row }">
+        <template v-if="(row as ReportRow).personas !== null">{{ (row as ReportRow).personas }}</template>
+        <span v-else class="rr-dim">—</span>
+      </template>
+      <template #cell-confidence="{ row }">
+        <template v-if="(row as ReportRow).confidence !== null">
+          <Badge :tone="confidenceTone((row as ReportRow).confidence)">
+            {{ Math.round(((row as ReportRow).confidence as number) * 100) }}%
+          </Badge>
+        </template>
+        <span v-else class="rr-dim">—</span>
+      </template>
+    </DataTable>
+  </Card>
+</template>
+
+<style scoped>
+.rr-loading {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.rr-error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.rr-error__msg {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+}
+
+.rr-retry {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--accent);
+  background: transparent;
+  border: 0;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: var(--r-3, 6px);
+}
+
+.rr-retry:hover {
+  background: var(--accent-tint-bg);
+}
+
+.rr-retry:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.rr-dim {
+  color: var(--text-quaternary);
+}
+
+.rr-id {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-primary);
+}
+</style>

--- a/frontend/src/components/v4/dashboard/StatsRow.vue
+++ b/frontend/src/components/v4/dashboard/StatsRow.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+/**
+ * StatsRow — vier Mikro-Kennzahlen für das Dashboard.
+ * Workbench-These: dichte Information, ruhig, mono-Zahlen, dünne Hairlines.
+ */
+defineProps<{
+  activeRuns: number
+  completedToday: number
+  avgConfidence: number | null
+  personas: number
+}>()
+</script>
+
+<template>
+  <div class="stats-row" role="list">
+    <div class="stats-cell" role="listitem">
+      <div class="stats-cell__value">{{ activeRuns }}</div>
+      <div class="stats-cell__label">{{ $t('dashboard.stats.activeRuns') }}</div>
+    </div>
+    <div class="stats-cell" role="listitem">
+      <div class="stats-cell__value">{{ completedToday }}</div>
+      <div class="stats-cell__label">{{ $t('dashboard.stats.completedToday') }}</div>
+    </div>
+    <div class="stats-cell" role="listitem">
+      <div class="stats-cell__value">
+        <template v-if="avgConfidence === null"><span class="stats-cell__dim">—</span></template>
+        <template v-else>{{ Math.round(avgConfidence * 100) }}<span class="stats-cell__unit">%</span></template>
+      </div>
+      <div class="stats-cell__label">{{ $t('dashboard.stats.avgConfidence') }}</div>
+    </div>
+    <div class="stats-cell" role="listitem">
+      <div class="stats-cell__value">{{ personas }}</div>
+      <div class="stats-cell__label">{{ $t('dashboard.stats.personas') }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--hairline);
+  border-radius: var(--r-6, 12px);
+  overflow: hidden;
+  box-shadow: 0 0 0 1px var(--hairline);
+}
+
+.stats-cell {
+  background: var(--surface-elevated, #fff);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.stats-cell__value {
+  font-family: var(--font-mono);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.stats-cell__unit {
+  font-size: 15px;
+  color: var(--text-secondary);
+  margin-left: 1px;
+}
+
+.stats-cell__dim {
+  color: var(--text-quaternary);
+}
+
+.stats-cell__label {
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+@media (max-width: 720px) {
+  .stats-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>

--- a/frontend/src/components/v4/dashboard/SystemHealthCard.vue
+++ b/frontend/src/components/v4/dashboard/SystemHealthCard.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+/**
+ * SystemHealthCard — Health-Row für Ollama / Neo4j / OASIS + Disk-Subtext.
+ *
+ * Workbench-These: Status nur über Token-Tones, kein Glow. Dot links, Pill rechts,
+ * Subtext gedimmt darunter.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Card from '../forms/Card.vue'
+import Badge from '../forms/Badge.vue'
+import type { SystemStatusResponse } from '../../../contracts/systemStatusContract'
+
+const props = defineProps<{
+  status: SystemStatusResponse | null
+  loading: boolean
+  error: string
+}>()
+
+const emit = defineEmits<{
+  refresh: []
+}>()
+
+const { t } = useI18n()
+
+interface HealthRow {
+  key: 'ollama' | 'neo4j' | 'oasis'
+  label: string
+  tone: 'green' | 'orange' | 'red' | 'gray'
+  state: 'reachable' | 'unreachable' | 'idle'
+  hint: string
+}
+
+function fmtBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined) return '—'
+  if (bytes >= 1e12) return `${(bytes / 1e12).toFixed(1)} TB`
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`
+  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(0)} MB`
+  return `${bytes} B`
+}
+
+const rows = computed<HealthRow[]>(() => {
+  const s = props.status
+  if (!s) {
+    return [
+      { key: 'ollama', label: t('dashboard.system.ollama'), tone: 'gray', state: 'idle', hint: '' },
+      { key: 'neo4j', label: t('dashboard.system.neo4j'), tone: 'gray', state: 'idle', hint: '' },
+      { key: 'oasis', label: t('dashboard.system.oasis'), tone: 'gray', state: 'idle', hint: t('dashboard.system.oasisHint') },
+    ]
+  }
+  const ollamaModels = s.ollama.models_available?.length ?? 0
+  return [
+    {
+      key: 'ollama',
+      label: t('dashboard.system.ollama'),
+      tone: s.ollama.reachable ? 'green' : 'red',
+      state: s.ollama.reachable ? 'reachable' : 'unreachable',
+      hint: s.ollama.reachable
+        ? t('dashboard.system.ollamaHint', { n: ollamaModels })
+        : (s.ollama.error ?? s.ollama.base_url ?? ''),
+    },
+    {
+      key: 'neo4j',
+      label: t('dashboard.system.neo4j'),
+      tone: s.neo4j.reachable ? 'green' : 'red',
+      state: s.neo4j.reachable ? 'reachable' : 'unreachable',
+      hint: s.neo4j.reachable ? (s.neo4j.uri ?? '') : (s.neo4j.error ?? ''),
+    },
+    {
+      key: 'oasis',
+      label: t('dashboard.system.oasis'),
+      tone: 'gray',
+      state: 'idle',
+      hint: t('dashboard.system.oasisHint'),
+    },
+  ]
+})
+
+const diskRow = computed(() => {
+  const d = props.status?.disk.uploads
+  if (!d) return null
+  const used = d.used_pct ?? null
+  const free = d.free_bytes ?? null
+  return { used, free }
+})
+
+const stateLabel = (state: HealthRow['state']) => {
+  if (state === 'reachable') return t('dashboard.system.statusReachable')
+  if (state === 'unreachable') return t('dashboard.system.statusUnreachable')
+  return t('dashboard.system.statusIdle')
+}
+</script>
+
+<template>
+  <Card :title="$t('dashboard.system.title')">
+    <template #right>
+      <span v-if="loading" class="sh-loading">{{ $t('common.loading') }}</span>
+    </template>
+
+    <div v-if="error" class="sh-error">
+      <Badge tone="red">{{ $t('dashboard.active.errorLabel') }}</Badge>
+      <span class="sh-error__msg">{{ error }}</span>
+      <button class="sh-retry" type="button" @click="emit('refresh')">
+        {{ $t('common.tryAgain') }}
+      </button>
+    </div>
+
+    <ul v-else class="sh-list">
+      <li v-for="row in rows" :key="row.key" class="sh-row">
+        <div class="sh-row__head">
+          <span class="sh-row__label">{{ row.label }}</span>
+          <Badge :tone="row.tone">{{ stateLabel(row.state) }}</Badge>
+        </div>
+        <p v-if="row.hint" class="sh-row__hint">{{ row.hint }}</p>
+      </li>
+    </ul>
+
+    <template v-if="!error && diskRow" #footer>
+      <div class="sh-disk">
+        <span class="sh-disk__label">{{ $t('dashboard.system.disk') }}</span>
+        <span class="sh-disk__bar" aria-hidden="true">
+          <span class="sh-disk__bar-fill" :style="{ width: `${diskRow.used ?? 0}%` }" />
+        </span>
+        <span class="sh-disk__value">
+          {{ diskRow.used !== null ? `${diskRow.used}%` : '—' }}
+          <span class="sh-disk__free">· {{ fmtBytes(diskRow.free) }} {{ $t('dashboard.system.diskFree') }}</span>
+        </span>
+      </div>
+    </template>
+  </Card>
+</template>
+
+<style scoped>
+.sh-loading {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.sh-error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.sh-error__msg {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+}
+
+.sh-retry {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--accent);
+  background: transparent;
+  border: 0;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: var(--r-3, 6px);
+}
+
+.sh-retry:hover {
+  background: var(--accent-tint-bg);
+}
+
+.sh-retry:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.sh-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.sh-row {
+  padding: 12px 0;
+  border-top: 1px solid var(--separator);
+}
+
+.sh-row:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.sh-row__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sh-row__label {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.sh-row__hint {
+  margin: 4px 0 0;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+.sh-disk {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+}
+
+.sh-disk__label {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.sh-disk__bar {
+  height: 4px;
+  border-radius: var(--r-pill, 999px);
+  background: var(--gray-5, #e5e5ea);
+  overflow: hidden;
+  display: block;
+}
+
+.sh-disk__bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--text-tertiary);
+  transition: width 240ms ease;
+}
+
+.sh-disk__value {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.sh-disk__free {
+  color: var(--text-tertiary);
+}
+</style>

--- a/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ActiveRunsCard from '../ActiveRunsCard.vue'
+import { makeI18n, makeRouter } from './dashTestHelpers'
+import type { RunDetail } from '../../../../contracts/runsContract'
+
+function run(over: Partial<RunDetail>): RunDetail {
+  return {
+    run_id: 'r-1234567890',
+    run_type: 'graph_build',
+    entity_id: 'project-a',
+    parent_run_id: null,
+    status: 'processing',
+    progress: 45,
+    message: '',
+    error: null,
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    completed_at: null,
+    branch_label: null,
+    metadata: {},
+    linked_ids: { project_id: 'project-a' },
+    artifacts: {},
+    resume_capability: {},
+    summary: {
+      model: 'qwen2.5:32b',
+      document_name: 'Briefing.pdf',
+      persona_count: 12,
+      graph_id: null,
+      graph_name: null,
+      branch_name: null,
+    },
+    ...over,
+  } as RunDetail
+}
+
+describe('ActiveRunsCard', () => {
+  it('rendert aktive Run-Zeilen mit ID und Progress', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(ActiveRunsCard, {
+      props: {
+        runs: [run({ run_id: 'aaaaaaaa-bbbb-cccc', status: 'processing', progress: 33 })],
+        loading: false,
+        error: '',
+      },
+      global: { plugins: [makeI18n(), router] },
+    })
+    expect(w.find('.dt-table').exists()).toBe(true)
+    expect(w.text()).toContain('aaaaaaaa')
+    expect(w.text()).toContain('33')
+  })
+
+  it('rendert EmptyState ohne aktive Runs', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(ActiveRunsCard, {
+      props: { runs: [], loading: false, error: '' },
+      global: { plugins: [makeI18n(), router] },
+    })
+    expect(w.find('.es-root').exists()).toBe(true)
+  })
+
+  it('rendert Error-State + Retry', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(ActiveRunsCard, {
+      props: { runs: [], loading: false, error: 'Schema-Drift: bad field' },
+      global: { plugins: [makeI18n(), router] },
+    })
+    expect(w.find('.ar-error').exists()).toBe(true)
+    await w.find('.ar-retry').trigger('click')
+    expect(w.emitted('refresh')).toBeTruthy()
+  })
+
+  it('filtert nicht-aktive Status raus', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(ActiveRunsCard, {
+      props: {
+        runs: [
+          run({ run_id: 'completed-1', status: 'completed' }),
+          run({ run_id: 'failed-1', status: 'failed' }),
+        ],
+        loading: false,
+        error: '',
+      },
+      global: { plugins: [makeI18n(), router] },
+    })
+    expect(w.find('.es-root').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { makeI18n, makeRouter } from './dashTestHelpers'
+
+vi.mock('../../../../api/simulation', () => ({
+  getAvailableModels: vi.fn().mockResolvedValue({
+    success: true,
+    data: {
+      ollama: [{ name: 'qwen2.5:32b', label: 'Qwen 2.5 32B' }],
+      presets: [{ name: 'preset-a', label: 'Preset A' }],
+      current_default: 'qwen2.5:32b',
+      default_provider: 'ollama',
+      ollama_reachable: true,
+      ollama_error: null,
+      neo4j_reachable: true,
+      neo4j_error: null,
+    },
+  }),
+}))
+
+vi.mock('../../../../store/pendingUpload', () => ({
+  setPendingUpload: vi.fn(),
+}))
+
+import { setPendingUpload } from '../../../../store/pendingUpload'
+import HeroNewRun from '../HeroNewRun.vue'
+
+describe('HeroNewRun', () => {
+  beforeEach(() => {
+    vi.mocked(setPendingUpload).mockReset()
+  })
+
+  it('rendert Drop-Zone, zwei Selects, deaktivierte CTA ohne Datei', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(HeroNewRun, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+    expect(w.find('.hero-drop').exists()).toBe(true)
+    expect(w.findAll('select')).toHaveLength(2)
+    const btn = w.find('.hero-cta')
+    expect(btn.exists()).toBe(true)
+    expect(btn.attributes('disabled')).toBeDefined()
+  })
+
+  it('aktiviert CTA nach Datei-Upload und navigiert zu /process/new', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const pushSpy = vi.spyOn(router, 'push')
+    const w = mount(HeroNewRun, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    const btn = w.find('.hero-cta')
+    expect(btn.attributes('disabled')).toBeUndefined()
+    await btn.trigger('click')
+    await flushPromises()
+
+    expect(setPendingUpload).toHaveBeenCalledTimes(1)
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/QuickActionsRow.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/QuickActionsRow.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import QuickActionsRow from '../QuickActionsRow.vue'
+import { makeI18n, makeRouter } from './dashTestHelpers'
+
+describe('QuickActionsRow', () => {
+  it('rendert drei RouterLink-Tiles', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(QuickActionsRow, {
+      global: { plugins: [makeI18n(), router] },
+    })
+    const tiles = w.findAll('.qa-tile')
+    expect(tiles).toHaveLength(3)
+    const labels = tiles.map(t => t.find('.qa-tile__label').text())
+    expect(labels).toEqual(['Vergleichen', 'Historie', 'Einstellungen'])
+  })
+
+  it('hat Hinweise unter jedem Label', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(QuickActionsRow, {
+      global: { plugins: [makeI18n(), router] },
+    })
+    const hints = w.findAll('.qa-tile__hint')
+    expect(hints).toHaveLength(3)
+    expect(hints[2].text()).toContain('LLM')
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/RecentReportsCard.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/RecentReportsCard.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { makeI18n, makeRouter } from './dashTestHelpers'
+
+vi.mock('../../../../api/runs', () => ({
+  listRuns: vi.fn(),
+}))
+
+import { listRuns } from '../../../../api/runs'
+import RecentReportsCard from '../RecentReportsCard.vue'
+
+describe('RecentReportsCard', () => {
+  beforeEach(() => {
+    vi.mocked(listRuns).mockReset()
+  })
+
+  it('rendert abgeschlossene Reports im Ready-State', async () => {
+    vi.mocked(listRuns).mockResolvedValue({
+      success: true,
+      data: {
+        runs: [{
+          run_id: 'report-run-1234567890',
+          run_type: 'report_generate',
+          entity_id: 'sim-1',
+          parent_run_id: null,
+          status: 'completed',
+          progress: 100,
+          message: '',
+          error: null,
+          started_at: '2026-05-14T09:00:00Z',
+          updated_at: '2026-05-14T10:00:00Z',
+          completed_at: '2026-05-14T10:00:00Z',
+          branch_label: null,
+          metadata: { confidence_score: 0.74 },
+          linked_ids: { report_id: 'rep-abcdef1234' },
+          artifacts: {},
+          resume_capability: {},
+          summary: { persona_count: 12, document_name: 'Test.pdf' },
+        }],
+        total: 1,
+      },
+    } as never)
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(RecentReportsCard, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+    expect(w.text()).toContain('rep-abcd')
+    expect(w.text()).toContain('74%')
+    expect(w.text()).toContain('12')
+  })
+
+  it('rendert EmptyState ohne Reports', async () => {
+    vi.mocked(listRuns).mockResolvedValue({
+      success: true,
+      data: { runs: [], total: 0 },
+    } as never)
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(RecentReportsCard, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+    expect(w.find('.es-root').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/StatsRow.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/StatsRow.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatsRow from '../StatsRow.vue'
+import { makeI18n } from './dashTestHelpers'
+
+describe('StatsRow', () => {
+  it('rendert vier Mikro-Kennzahlen mit Werten', () => {
+    const w = mount(StatsRow, {
+      props: { activeRuns: 3, completedToday: 7, avgConfidence: 0.62, personas: 24 },
+      global: { plugins: [makeI18n()] },
+    })
+    const cells = w.findAll('.stats-cell__value')
+    expect(cells).toHaveLength(4)
+    expect(cells[0].text()).toBe('3')
+    expect(cells[1].text()).toBe('7')
+    expect(cells[2].text()).toBe('62%')
+    expect(cells[3].text()).toBe('24')
+  })
+
+  it('dimmt avgConfidence wenn null', () => {
+    const w = mount(StatsRow, {
+      props: { activeRuns: 0, completedToday: 0, avgConfidence: null, personas: 0 },
+      global: { plugins: [makeI18n()] },
+    })
+    expect(w.find('.stats-cell__dim').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/SystemHealthCard.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/SystemHealthCard.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SystemHealthCard from '../SystemHealthCard.vue'
+import type { SystemStatusResponse } from '../../../../contracts/systemStatusContract'
+import { makeI18n } from './dashTestHelpers'
+
+function buildStatus(over: Partial<SystemStatusResponse> = {}): SystemStatusResponse {
+  return {
+    backend: { ok: true, version: '1.0.0', auth_mode: 'single_user_token' },
+    neo4j: { reachable: true, uri: 'bolt://neo4j:7687', error: null },
+    ollama: {
+      reachable: true,
+      base_url: 'http://localhost:11434',
+      models_available: ['qwen2.5:32b', 'llama3.1:8b'],
+      default_model: 'qwen2.5:32b',
+      error: null,
+    },
+    disk: { uploads: { path: '/uploads', used_pct: 42, free_bytes: 12_000_000_000, total_bytes: 24_000_000_000 } },
+    gpu: { nvidia_smi_available: true, ollama_uses_gpu: true, hints: [] },
+    timestamp: '2026-05-14T12:00:00Z',
+    ...over,
+  } as SystemStatusResponse
+}
+
+describe('SystemHealthCard', () => {
+  it('rendert drei Health-Rows im Ready-State', () => {
+    const w = mount(SystemHealthCard, {
+      props: { status: buildStatus(), loading: false, error: '' },
+      global: { plugins: [makeI18n()] },
+    })
+    const rows = w.findAll('.sh-row')
+    expect(rows).toHaveLength(3)
+    expect(w.text()).toContain('Ollama')
+    expect(w.text()).toContain('Neo4j')
+    expect(w.text()).toContain('OASIS')
+  })
+
+  it('rendert Disk-Footer mit used_pct', () => {
+    const w = mount(SystemHealthCard, {
+      props: { status: buildStatus(), loading: false, error: '' },
+      global: { plugins: [makeI18n()] },
+    })
+    expect(w.find('.sh-disk').exists()).toBe(true)
+    expect(w.find('.sh-disk__value').text()).toContain('42%')
+  })
+
+  it('rendert Error-State mit Retry-Button', () => {
+    const w = mount(SystemHealthCard, {
+      props: { status: null, loading: false, error: 'Backend offline' },
+      global: { plugins: [makeI18n()] },
+    })
+    expect(w.find('.sh-error').exists()).toBe(true)
+    expect(w.find('.sh-retry').exists()).toBe(true)
+    expect(w.text()).toContain('Backend offline')
+  })
+
+  it('emit refresh bei Retry-Klick', async () => {
+    const w = mount(SystemHealthCard, {
+      props: { status: null, loading: false, error: 'down' },
+      global: { plugins: [makeI18n()] },
+    })
+    await w.find('.sh-retry').trigger('click')
+    expect(w.emitted('refresh')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/v4/dashboard/__tests__/dashTestHelpers.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/dashTestHelpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Test-Helper für Dashboard-Specs — i18n + Router-Setup an einer Stelle.
+ */
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import type { RouteRecordRaw } from 'vue-router'
+
+import de from '../../../../i18n/locales/de.json'
+import en from '../../../../i18n/locales/en.json'
+
+export function makeI18n(locale: 'de' | 'en' = 'de') {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: { de, en },
+  })
+}
+
+const stub = { template: '<div/>' }
+
+const BASE_ROUTES: RouteRecordRaw[] = [
+  { path: '/', name: 'Home', component: stub },
+  { path: '/dashboard', name: 'Dashboard', component: stub },
+  { path: '/process/:projectId', name: 'Process', component: stub },
+  { path: '/runs', name: 'Runs', component: stub },
+  { path: '/runs/:id', name: 'RunDetail', component: stub },
+  { path: '/report/:reportId', name: 'Report', component: stub },
+  { path: '/v4/compare/:simulationId', name: 'CompareV4', component: stub },
+  { path: '/v4/compare/last', name: 'CompareV4Last', component: stub },
+  { path: '/v4/history', name: 'HistoryV4', component: stub },
+  { path: '/settings/general', name: 'SettingsGeneral', component: stub },
+]
+
+export function makeRouter(extra: RouteRecordRaw[] = []) {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [...BASE_ROUTES, ...extra],
+  })
+}

--- a/frontend/src/composables/__tests__/useSystemStatus.spec.ts
+++ b/frontend/src/composables/__tests__/useSystemStatus.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+vi.mock('../../api/status', () => ({
+  getSystemStatus: vi.fn(),
+}))
+
+import { getSystemStatus } from '../../api/status'
+import { useSystemStatus, type UseSystemStatusReturn } from '../useSystemStatus'
+
+const statusPayload = {
+  backend: { ok: true, version: '0.9.1-dev', auth_mode: 'single_user_token' },
+  neo4j: { reachable: true, error: null, uri: 'bolt://neo4j:7687' },
+  ollama: {
+    reachable: true,
+    base_url: 'http://localhost:11434',
+    models_available: ['qwen2.5:32b'],
+    default_model: 'qwen2.5:32b',
+    error: null,
+  },
+  disk: { uploads: { used_pct: 23.5, free_bytes: 1000, total_bytes: 4000 } },
+  gpu: { nvidia_smi_available: false, ollama_uses_gpu: null, hints: [] },
+  timestamp: '2026-05-14T10:00:00Z',
+}
+
+function mountComposable(): UseSystemStatusReturn {
+  let exposed: UseSystemStatusReturn | undefined
+  const Comp = defineComponent({
+    setup() {
+      exposed = useSystemStatus(15000)
+      return () => h('div')
+    },
+  })
+  mount(Comp)
+  return exposed as UseSystemStatusReturn
+}
+
+describe('useSystemStatus', () => {
+  beforeEach(() => {
+    vi.mocked(getSystemStatus).mockReset()
+  })
+
+  it('validiert erfolgreiche Status-Antworten via Zod', async () => {
+    vi.mocked(getSystemStatus).mockResolvedValue({ success: true, data: statusPayload } as never)
+    const s = mountComposable()
+
+    await s.refresh()
+
+    expect(s.error.value).toBe('')
+    expect(s.status.value?.backend.version).toBe('0.9.1-dev')
+    expect(s.status.value?.disk.uploads.used_pct).toBe(23.5)
+    expect(s.status.value?.ollama.models_available).toEqual(['qwen2.5:32b'])
+  })
+
+  it('akzeptiert auch flaches Envelope ohne data-Wrapper', async () => {
+    vi.mocked(getSystemStatus).mockResolvedValue({
+      success: true,
+      ...statusPayload,
+    } as never)
+    const s = mountComposable()
+
+    await s.refresh()
+
+    expect(s.error.value).toBe('')
+    expect(s.status.value?.timestamp).toBe('2026-05-14T10:00:00Z')
+  })
+
+  it('behaelt last-known-good bei Schema-Mismatch', async () => {
+    vi.mocked(getSystemStatus)
+      .mockResolvedValueOnce({ success: true, data: statusPayload } as never)
+      .mockResolvedValueOnce({ success: true, data: { backend: {} } } as never)
+    const s = mountComposable()
+
+    await s.refresh()
+    await s.refresh()
+
+    expect(s.error.value).toContain('Schema-Drift')
+    expect(s.status.value?.timestamp).toBe('2026-05-14T10:00:00Z')
+  })
+})

--- a/frontend/src/composables/useSystemStatus.ts
+++ b/frontend/src/composables/useSystemStatus.ts
@@ -1,0 +1,79 @@
+/**
+ * useSystemStatus — Polling-Wrapper um GET /api/status.
+ *
+ * Zod-validiert. Bei Schema-Drift bleibt `status` last-known-good erhalten.
+ * Backend liefert ein flaches Envelope (json_success(**extra)), wir akzeptieren
+ * beide Formen (data.* und top-level).
+ */
+import { ref, type Ref } from 'vue'
+import { getSystemStatus } from '../api/status'
+import { ApiError } from '../api/envelope'
+import {
+  SystemStatusResponseSchema,
+  type SystemStatusResponse,
+} from '../contracts/systemStatusContract'
+import { usePolling } from './usePolling'
+
+export interface UseSystemStatusReturn {
+  status: Ref<SystemStatusResponse | null>
+  loading: Ref<boolean>
+  error: Ref<string>
+  isRunning: Ref<boolean>
+  start: () => Promise<void>
+  stop: () => void
+  refresh: () => Promise<void>
+}
+
+function extractCandidate(envelope: unknown): unknown {
+  if (envelope == null || typeof envelope !== 'object') return null
+  const env = envelope as Record<string, unknown>
+  if (env['data'] && typeof env['data'] === 'object') {
+    return env['data']
+  }
+  // Flat-Envelope: backend/neo4j/ollama/disk/timestamp leben direkt am Root.
+  const { success: _success, ...rest } = env
+  return rest
+}
+
+export function useSystemStatus(
+  intervalMs: number | Ref<number> = 15000,
+): UseSystemStatusReturn {
+  const status = ref<SystemStatusResponse | null>(null)
+  const loading = ref(false)
+  const error = ref('')
+
+  async function tick(): Promise<void> {
+    loading.value = true
+    try {
+      const envelope = await getSystemStatus()
+      const candidate = extractCandidate(envelope)
+      const parsed = SystemStatusResponseSchema.safeParse(candidate)
+      if (!parsed.success) {
+        error.value = `Schema-Drift: ${parsed.error.issues[0]?.message ?? 'unbekannt'}`
+        return
+      }
+      status.value = parsed.data
+      error.value = ''
+    } catch (e) {
+      if (e instanceof ApiError) {
+        error.value = e.message
+      } else {
+        error.value = e instanceof Error ? e.message : 'Netzwerkfehler'
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const polling = usePolling(tick, intervalMs, { pauseWhenHidden: true })
+
+  return {
+    status,
+    loading,
+    error,
+    isRunning: polling.isRunning,
+    start: () => polling.start({ immediate: true }),
+    stop: polling.stop,
+    refresh: polling.tick,
+  }
+}

--- a/frontend/src/contracts/systemStatusContract.ts
+++ b/frontend/src/contracts/systemStatusContract.ts
@@ -1,0 +1,71 @@
+/**
+ * System-Status-Contract — Zod-Spiegel zu /api/status.
+ *
+ * Backend: backend/app/api/status.py::get_status
+ * passthrough() auf allen Unterobjekten, damit Backend additive Felder
+ * (z. B. neue gpu/disk-Subkeys) liefern darf ohne Frontend-Drift-Alarm.
+ */
+import { z } from 'zod'
+
+export const SystemStatusBackendSchema = z
+  .object({
+    ok: z.boolean(),
+    version: z.string().optional(),
+    auth_mode: z.string().optional(),
+  })
+  .passthrough()
+
+export const SystemStatusNeo4jSchema = z
+  .object({
+    reachable: z.boolean(),
+    error: z.string().nullable().optional(),
+    uri: z.string().optional(),
+    is_connected: z.boolean().optional(),
+    last_success_ts: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+export const SystemStatusOllamaSchema = z
+  .object({
+    reachable: z.boolean(),
+    base_url: z.string().optional(),
+    models_available: z.array(z.string()).default(() => []),
+    default_model: z.string().nullable().optional(),
+    error: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+export const SystemStatusDiskSchema = z
+  .object({
+    uploads: z
+      .object({
+        path: z.string().optional(),
+        total_bytes: z.number().nullable().optional(),
+        free_bytes: z.number().nullable().optional(),
+        used_pct: z.number().nullable().optional(),
+        error: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
+export const SystemStatusGpuSchema = z
+  .object({
+    nvidia_smi_available: z.boolean().optional(),
+    ollama_uses_gpu: z.boolean().nullable().optional(),
+    hints: z.array(z.string()).optional(),
+  })
+  .passthrough()
+
+export const SystemStatusResponseSchema = z
+  .object({
+    backend: SystemStatusBackendSchema,
+    neo4j: SystemStatusNeo4jSchema,
+    ollama: SystemStatusOllamaSchema,
+    disk: SystemStatusDiskSchema,
+    gpu: SystemStatusGpuSchema.optional(),
+    timestamp: z.string(),
+  })
+  .passthrough()
+
+export type SystemStatusResponse = z.infer<typeof SystemStatusResponseSchema>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -71,7 +71,8 @@
     "and": "und",
     "or": "oder",
     "all": "Alle",
-    "none": "Keine"
+    "none": "Keine",
+    "tryAgain": "Erneut versuchen"
   },
   "home": {
     "kicker": "STUDIO · LOKAL",
@@ -123,11 +124,31 @@
       "needPrompt": "Beschreibung der Simulation fehlt."
     },
     "steps": [
-      { "num": "01", "title": "Graph aufbauen", "desc": "Entitäten und Beziehungen aus deinem Dokument extrahieren — Wissensgraph in Neo4j." },
-      { "num": "02", "title": "Umgebung", "desc": "Hunderte Agenten-Personas mit Persönlichkeit, Bias und Reaktionsverhalten erzeugen." },
-      { "num": "03", "title": "Simulation", "desc": "Agenten posten, antworten, streiten — runden­basiert, beobachtbar in Echtzeit." },
-      { "num": "04", "title": "Report", "desc": "ReportAgent durchsucht das Ergebnis, befragt eine Fokusgruppe und schreibt den Bericht." },
-      { "num": "05", "title": "Gespräch", "desc": "Sprich direkt mit den Agenten der simulierten Welt — oder mit dem ReportAgent." }
+      {
+        "num": "01",
+        "title": "Graph aufbauen",
+        "desc": "Entitäten und Beziehungen aus deinem Dokument extrahieren — Wissensgraph in Neo4j."
+      },
+      {
+        "num": "02",
+        "title": "Umgebung",
+        "desc": "Hunderte Agenten-Personas mit Persönlichkeit, Bias und Reaktionsverhalten erzeugen."
+      },
+      {
+        "num": "03",
+        "title": "Simulation",
+        "desc": "Agenten posten, antworten, streiten — runden­basiert, beobachtbar in Echtzeit."
+      },
+      {
+        "num": "04",
+        "title": "Report",
+        "desc": "ReportAgent durchsucht das Ergebnis, befragt eine Fokusgruppe und schreibt den Bericht."
+      },
+      {
+        "num": "05",
+        "title": "Gespräch",
+        "desc": "Sprich direkt mit den Agenten der simulierten Welt — oder mit dem ReportAgent."
+      }
     ],
     "differentiators": [
       {
@@ -667,7 +688,10 @@
       "set": "•••••••• (gesetzt)",
       "empty": "leer"
     },
-    "bool": { "on": "an", "off": "aus" },
+    "bool": {
+      "on": "an",
+      "off": "aus"
+    },
     "modal": {
       "title": "Secrets bestätigen",
       "body": "Du speicherst Änderungen an Secret-Feldern (z. B. {neoPw} oder {authToken}). Tippfehler hier können dich aus dem Backend aussperren — bitte nochmal sicher prüfen.",
@@ -681,14 +705,14 @@
       "ontology": "Ontology",
       "hybrid_search": "Hybrid Search",
       "agent_tools": "Agent Tools",
-        "event_bus": "Event Bus",
-        "logging": "Logging",
-        "locale": "Locale",
-        "ui": "UI",
-        "webtools": "Webtools",
-        "oasis": "OASIS",
-        "security": "Secrets"
-      }
+      "event_bus": "Event Bus",
+      "logging": "Logging",
+      "locale": "Locale",
+      "ui": "UI",
+      "webtools": "Webtools",
+      "oasis": "OASIS",
+      "security": "Secrets"
+    }
   },
   "activeModel": {
     "label": "Aktives Modell",
@@ -822,5 +846,85 @@
     "simulationFailed": "Simulation fehlgeschlagen.",
     "reportFailed": "Bericht fehlgeschlagen.",
     "unknown": "Unbekannter Fehler."
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Aktive Runs, Reports, Systemzustand auf einen Blick.",
+    "hero": {
+      "title": "Neuer Run",
+      "subtitle": "Quelle ablegen, Modell wählen, starten.",
+      "sourceLabel": "Quelle",
+      "dropHint": "Datei hierher ziehen oder klicken",
+      "modelLabel": "Modell",
+      "modelDefault": "Standard",
+      "languageLabel": "Sprache",
+      "startCta": "Starten",
+      "disabledHint": "Erst Datei wählen, dann starten."
+    },
+    "stats": {
+      "activeRuns": "Aktive Runs",
+      "completedToday": "Heute fertig",
+      "avgConfidence": "Ø Confidence",
+      "personas": "Personas aktiv"
+    },
+    "active": {
+      "title": "Aktive Runs",
+      "emptyTitle": "Keine aktiven Runs",
+      "emptyHint": "Starte oben einen neuen Run aus einer Quelle.",
+      "errorLabel": "Fehler",
+      "columns": {
+        "runId": "Run-ID",
+        "project": "Projekt",
+        "phase": "Phase",
+        "progress": "Fortschritt",
+        "started": "Gestartet",
+        "actions": ""
+      },
+      "phase": {
+        "graph_build": "Graph-Build",
+        "simulation_prepare": "Personas",
+        "simulation_run": "Simulation",
+        "report_generate": "Report"
+      }
+    },
+    "system": {
+      "title": "System",
+      "ollama": "Ollama",
+      "neo4j": "Neo4j",
+      "oasis": "OASIS",
+      "disk": "Disk",
+      "diskFree": "frei",
+      "statusReachable": "erreichbar",
+      "statusUnreachable": "offline",
+      "statusIdle": "idle",
+      "oasisHint": "Wird beim Start eines Runs aktiv.",
+      "ollamaHint": "{n} Modelle verfügbar"
+    },
+    "reports": {
+      "title": "Letzte Reports",
+      "emptyTitle": "Noch keine Reports",
+      "emptyHint": "Sobald ein Run durchläuft, erscheint hier das Ergebnis.",
+      "columns": {
+        "reportId": "Report-ID",
+        "project": "Projekt",
+        "personas": "Personas",
+        "confidence": "Confidence",
+        "date": "Datum",
+        "actions": ""
+      }
+    },
+    "quick": {
+      "compare": "Vergleichen",
+      "compareHint": "Branches & Runs gegenüberstellen",
+      "history": "Historie",
+      "historyHint": "Alle Runs durchsuchen",
+      "settings": "Einstellungen",
+      "settingsHint": "LLM-Routing, API-Keys, Audit"
+    },
+    "time": {
+      "secondsAgo": "vor {n}s",
+      "minutesAgo": "vor {n}m",
+      "hoursAgo": "vor {n}h"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -71,7 +71,8 @@
     "and": "and",
     "or": "or",
     "all": "All",
-    "none": "None"
+    "none": "None",
+    "tryAgain": "Try again"
   },
   "home": {
     "kicker": "STUDIO · LOCAL",
@@ -93,11 +94,22 @@
       "desc": "The engine runs on your hardware. No account, no signup. Drop a document, write the question — the simulation does the rest."
     },
     "metrics": {
-      "free": { "value": "Free", "label": "Runs on your hardware" },
-      "private": { "value": "Private", "label": "Nothing leaves this machine" },
-      "openSource": { "value": "Open", "label": "AGPL-3.0 licensed" }
+      "free": {
+        "value": "Free",
+        "label": "Runs on your hardware"
+      },
+      "private": {
+        "value": "Private",
+        "label": "Nothing leaves this machine"
+      },
+      "openSource": {
+        "value": "Open",
+        "label": "AGPL-3.0 licensed"
+      }
     },
-    "workflow": { "kicker": "№ 03 — WORKFLOW" },
+    "workflow": {
+      "kicker": "№ 03 — WORKFLOW"
+    },
     "console": {
       "uploadKicker": "01 / DOCUMENT",
       "uploadTitle": "Drop your documents here.",
@@ -112,11 +124,31 @@
       "needPrompt": "Add a simulation description."
     },
     "steps": [
-      { "num": "01", "title": "Build graph", "desc": "Extract entities and relations from your document — knowledge graph in Neo4j." },
-      { "num": "02", "title": "Environment", "desc": "Generate hundreds of agent personas with personality, bias and reaction profile." },
-      { "num": "03", "title": "Simulation", "desc": "Agents post, reply, argue — round-based, observable in real time." },
-      { "num": "04", "title": "Report", "desc": "ReportAgent searches the result, interviews a focus group and writes the report." },
-      { "num": "05", "title": "Conversation", "desc": "Talk directly to the agents in the simulated world — or to the ReportAgent." }
+      {
+        "num": "01",
+        "title": "Build graph",
+        "desc": "Extract entities and relations from your document — knowledge graph in Neo4j."
+      },
+      {
+        "num": "02",
+        "title": "Environment",
+        "desc": "Generate hundreds of agent personas with personality, bias and reaction profile."
+      },
+      {
+        "num": "03",
+        "title": "Simulation",
+        "desc": "Agents post, reply, argue — round-based, observable in real time."
+      },
+      {
+        "num": "04",
+        "title": "Report",
+        "desc": "ReportAgent searches the result, interviews a focus group and writes the report."
+      },
+      {
+        "num": "05",
+        "title": "Conversation",
+        "desc": "Talk directly to the agents in the simulated world — or to the ReportAgent."
+      }
     ],
     "differentiators": [
       {
@@ -656,7 +688,10 @@
       "set": "•••••••• (set)",
       "empty": "empty"
     },
-    "bool": { "on": "on", "off": "off" },
+    "bool": {
+      "on": "on",
+      "off": "off"
+    },
     "modal": {
       "title": "Confirm secrets",
       "body": "You're about to save changes to secret fields (e.g. {neoPw} or {authToken}). A typo here can lock you out of the backend — please double-check.",
@@ -670,14 +705,14 @@
       "ontology": "Ontology",
       "hybrid_search": "Hybrid Search",
       "agent_tools": "Agent Tools",
-        "event_bus": "Event Bus",
-        "logging": "Logging",
-        "locale": "Locale",
-        "ui": "UI",
-        "webtools": "Webtools",
-        "oasis": "OASIS",
-        "security": "Secrets"
-      }
+      "event_bus": "Event Bus",
+      "logging": "Logging",
+      "locale": "Locale",
+      "ui": "UI",
+      "webtools": "Webtools",
+      "oasis": "OASIS",
+      "security": "Secrets"
+    }
   },
   "activeModel": {
     "label": "Active model",
@@ -811,5 +846,85 @@
     "simulationFailed": "Simulation failed.",
     "reportFailed": "Report failed.",
     "unknown": "Unknown error."
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Active runs, reports, system state at a glance.",
+    "hero": {
+      "title": "New run",
+      "subtitle": "Drop source, pick model, start.",
+      "sourceLabel": "Source",
+      "dropHint": "Drop file here or click",
+      "modelLabel": "Model",
+      "modelDefault": "Default",
+      "languageLabel": "Language",
+      "startCta": "Start",
+      "disabledHint": "Pick a file first, then start."
+    },
+    "stats": {
+      "activeRuns": "Active runs",
+      "completedToday": "Done today",
+      "avgConfidence": "Avg confidence",
+      "personas": "Personas live"
+    },
+    "active": {
+      "title": "Active runs",
+      "emptyTitle": "No active runs",
+      "emptyHint": "Start a new run from a source above.",
+      "errorLabel": "Error",
+      "columns": {
+        "runId": "Run ID",
+        "project": "Project",
+        "phase": "Phase",
+        "progress": "Progress",
+        "started": "Started",
+        "actions": ""
+      },
+      "phase": {
+        "graph_build": "Graph build",
+        "simulation_prepare": "Personas",
+        "simulation_run": "Simulation",
+        "report_generate": "Report"
+      }
+    },
+    "system": {
+      "title": "System",
+      "ollama": "Ollama",
+      "neo4j": "Neo4j",
+      "oasis": "OASIS",
+      "disk": "Disk",
+      "diskFree": "free",
+      "statusReachable": "reachable",
+      "statusUnreachable": "offline",
+      "statusIdle": "idle",
+      "oasisHint": "Becomes active when a run starts.",
+      "ollamaHint": "{n} models available"
+    },
+    "reports": {
+      "title": "Recent reports",
+      "emptyTitle": "No reports yet",
+      "emptyHint": "Once a run completes, it shows up here.",
+      "columns": {
+        "reportId": "Report ID",
+        "project": "Project",
+        "personas": "Personas",
+        "confidence": "Confidence",
+        "date": "Date",
+        "actions": ""
+      }
+    },
+    "quick": {
+      "compare": "Compare",
+      "compareHint": "Branches & runs side-by-side",
+      "history": "History",
+      "historyHint": "Browse all runs",
+      "settings": "Settings",
+      "settingsHint": "LLM routing, API keys, audit"
+    },
+    "time": {
+      "secondsAgo": "{n}s ago",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago"
+    }
   }
 }

--- a/frontend/src/views/__tests__/AppShellWrappers.spec.ts
+++ b/frontend/src/views/__tests__/AppShellWrappers.spec.ts
@@ -1,8 +1,12 @@
 /**
- * AppShellWrappers — Smoke-Tests fuer DashboardView, RunsAppShellView,
- * RunDetailAppShellView (Slice F, Design-v4).
+ * AppShellWrappers — Smoke-Tests fuer RunsAppShellView, RunDetailAppShellView
+ * (Slice F, Design-v4).
  *
  * Prueft: mountet ohne Crash, AppShell wird gerendert.
+ *
+ * Hinweis: DashboardView ist seit dem Workbench-Rebuild (2026-05-14) ein
+ * eigener Spec unter src/views/v4/__tests__/DashboardView.spec.ts —
+ * nicht mehr Teil dieser Datei.
  */
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
@@ -45,7 +49,6 @@ vi.mock('@/views/RunDetailView.vue', () => ({
   },
 }))
 
-import DashboardView from '../v4/DashboardView.vue'
 import RunsAppShellView from '../v4/RunsAppShellView.vue'
 import RunDetailAppShellView from '../v4/RunDetailAppShellView.vue'
 
@@ -61,32 +64,6 @@ async function mountView(component: object, path: string) {
   await flushPromises()
   return wrapper
 }
-
-describe('DashboardView', () => {
-  beforeEach(() => vi.clearAllMocks())
-
-  it('mountet ohne Crash', async () => {
-    const w = await mountView(DashboardView, '/dashboard')
-    expect(w.exists()).toBe(true)
-  })
-
-  it('rendert AppShell', async () => {
-    const w = await mountView(DashboardView, '/dashboard')
-    expect(w.find('.app-shell-stub').exists()).toBe(true)
-  })
-
-  it('uebergibt Breadcrumb "Dashboard"', async () => {
-    const w = await mountView(DashboardView, '/dashboard')
-    const shell = w.findComponent({ name: 'AppShell' })
-    const crumbs = shell.props('breadcrumbs') as Array<{ label: string }>
-    expect(crumbs.map((c) => c.label)).toContain('Dashboard')
-  })
-
-  it('zeigt Slice-H-Hinweis', async () => {
-    const w = await mountView(DashboardView, '/dashboard')
-    expect(w.text()).toContain('Slice H')
-  })
-})
 
 describe('RunsAppShellView', () => {
   beforeEach(() => vi.clearAllMocks())

--- a/frontend/src/views/v4/DashboardView.vue
+++ b/frontend/src/views/v4/DashboardView.vue
@@ -1,39 +1,155 @@
-/**
- * DashboardView — AppShell-Wrapper fuer das Dashboard (Slice F, Design-v4).
- *
- * Bettet den Placeholder-Inhalt ein. Vollstaendige Home-Inhalt-Migration
- * erfolgt in Slice H, wenn Home.vue in Einzelkomponenten aufgeteilt wird.
- */
 <script setup lang="ts">
+/**
+ * DashboardView — Operator-Workbench (Slice F+, Design-v4, 2026-05-14).
+ *
+ * Ersetzt den Slice-F-Stub. Hängt useRunsPolling + useSystemStatus an,
+ * leitet Stats lokal ab und propagiert nach unten in die Sub-Components.
+ */
+import { computed, onMounted, onUnmounted } from 'vue'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
-import Card from '@/components/v4/forms/Card.vue'
+import HeroNewRun from '@/components/v4/dashboard/HeroNewRun.vue'
+import StatsRow from '@/components/v4/dashboard/StatsRow.vue'
+import ActiveRunsCard from '@/components/v4/dashboard/ActiveRunsCard.vue'
+import SystemHealthCard from '@/components/v4/dashboard/SystemHealthCard.vue'
+import RecentReportsCard from '@/components/v4/dashboard/RecentReportsCard.vue'
+import QuickActionsRow from '@/components/v4/dashboard/QuickActionsRow.vue'
+import { useRunsPolling } from '@/composables/useRunsPolling'
+import { useSystemStatus } from '@/composables/useSystemStatus'
+import type { RunDetail } from '@/contracts/runsContract'
 
 const BREADCRUMBS = [{ label: 'Dashboard' }]
+
+const {
+  runs,
+  loading: runsLoading,
+  error: runsError,
+  start: runsStart,
+  stop: runsStop,
+  refresh: runsRefresh,
+} = useRunsPolling(5000)
+
+const {
+  status: sysStatus,
+  loading: sysLoading,
+  error: sysError,
+  start: sysStart,
+  stop: sysStop,
+  refresh: sysRefresh,
+} = useSystemStatus(15000)
+
+onMounted(() => {
+  void runsStart()
+  void sysStart()
+})
+
+onUnmounted(() => {
+  runsStop()
+  sysStop()
+})
+
+const ACTIVE = ['pending', 'processing', 'paused']
+
+function isCompletedToday(r: RunDetail): boolean {
+  if (r.status !== 'completed') return false
+  const completedAt = r.completed_at ?? r.updated_at
+  if (!completedAt) return false
+  const ts = Date.parse(completedAt)
+  if (Number.isNaN(ts)) return false
+  const today0 = new Date()
+  today0.setHours(0, 0, 0, 0)
+  return ts >= today0.getTime()
+}
+
+const activeRunsCount = computed(() =>
+  runs.value.filter(r => ACTIVE.includes(r.status)).length,
+)
+
+const completedTodayCount = computed(() =>
+  runs.value.filter(isCompletedToday).length,
+)
+
+const avgConfidence = computed<number | null>(() => {
+  const samples: number[] = []
+  for (const r of runs.value) {
+    if (r.run_type !== 'report_generate') continue
+    if (r.status !== 'completed') continue
+    const meta = r.metadata as Record<string, unknown>
+    const cand = meta?.['confidence_score'] ?? meta?.['confidence']
+    if (typeof cand === 'number' && Number.isFinite(cand)) samples.push(cand)
+  }
+  if (samples.length === 0) return null
+  return samples.reduce((a, b) => a + b, 0) / samples.length
+})
+
+const personasInFlight = computed(() => {
+  let total = 0
+  for (const r of runs.value) {
+    if (!ACTIVE.includes(r.status)) continue
+    const n = r.summary?.persona_count
+    if (typeof n === 'number' && Number.isFinite(n)) total += n
+  }
+  return total
+})
 </script>
 
 <template>
   <AppShell :breadcrumbs="BREADCRUMBS">
     <PageHeader
-      title="Dashboard"
-      subtitle="Uebersicht ueber aktive Projekte, Runs und Aktivitaet."
+      :title="$t('dashboard.title')"
+      :subtitle="$t('dashboard.subtitle')"
     />
 
-    <Card title="Workspace-Uebersicht">
-      <p class="stub-hint">
-        Dashboard-Inhalt folgt in Slice H — die vollstaendige Home.vue-Migration
-        in AppShell-Komponenten. Die klassische Startseite ist weiterhin unter
-        <RouterLink to="/">/ (Landing)</RouterLink> erreichbar.
-      </p>
-    </Card>
+    <div class="dash-stack">
+      <HeroNewRun />
+
+      <StatsRow
+        :active-runs="activeRunsCount"
+        :completed-today="completedTodayCount"
+        :avg-confidence="avgConfidence"
+        :personas="personasInFlight"
+      />
+
+      <div class="dash-grid">
+        <ActiveRunsCard
+          :runs="runs"
+          :loading="runsLoading"
+          :error="runsError"
+          @refresh="() => void runsRefresh()"
+        />
+        <SystemHealthCard
+          :status="sysStatus"
+          :loading="sysLoading"
+          :error="sysError"
+          @refresh="() => void sysRefresh()"
+        />
+      </div>
+
+      <RecentReportsCard />
+
+      <QuickActionsRow />
+    </div>
   </AppShell>
 </template>
 
 <style scoped>
-.stub-hint {
-  color: var(--text-secondary);
-  font-size: 13px;
-  line-height: 1.5;
-  margin: 0;
+.dash-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 1280px;
+}
+
+.dash-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 1080px) {
+  .dash-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/frontend/src/views/v4/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/v4/__tests__/DashboardView.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
+
+import de from '../../../i18n/locales/de.json'
+import en from '../../../i18n/locales/en.json'
+
+// Composables stubben — wir testen die View-Orchestrierung, nicht die Polling-Logik
+vi.mock('@/composables/useRunsPolling', () => ({
+  useRunsPolling: () => ({
+    runs: ref([]),
+    loading: ref(false),
+    error: ref(''),
+    isRunning: ref(true),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('@/composables/useSystemStatus', () => ({
+  useSystemStatus: () => ({
+    status: ref(null),
+    loading: ref(false),
+    error: ref(''),
+    isRunning: ref(true),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+// Sub-Komponenten zu data-testid-Stubs reduzieren
+vi.mock('@/components/v4/dashboard/HeroNewRun.vue', () => ({
+  default: { name: 'HeroNewRun', template: '<section data-testid="hero-new-run" />' },
+}))
+vi.mock('@/components/v4/dashboard/StatsRow.vue', () => ({
+  default: { name: 'StatsRow', template: '<section data-testid="stats-row" />' },
+}))
+vi.mock('@/components/v4/dashboard/ActiveRunsCard.vue', () => ({
+  default: { name: 'ActiveRunsCard', template: '<section data-testid="active-runs-card" />' },
+}))
+vi.mock('@/components/v4/dashboard/SystemHealthCard.vue', () => ({
+  default: { name: 'SystemHealthCard', template: '<section data-testid="system-health-card" />' },
+}))
+vi.mock('@/components/v4/dashboard/RecentReportsCard.vue', () => ({
+  default: { name: 'RecentReportsCard', template: '<section data-testid="recent-reports-card" />' },
+}))
+vi.mock('@/components/v4/dashboard/QuickActionsRow.vue', () => ({
+  default: { name: 'QuickActionsRow', template: '<section data-testid="quick-actions-row" />' },
+}))
+
+import DashboardView from '../DashboardView.vue'
+
+function makeI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'de',
+    fallbackLocale: 'en',
+    messages: { de, en },
+  })
+}
+
+describe('DashboardView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('rendert Breadcrumb Dashboard', async () => {
+    const router = makeTestRouter()
+    await router.push('/dashboard')
+    const wrapper = mount(DashboardView, {
+      global: { plugins: [router, createPinia(), makeI18n()] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Dashboard')
+  })
+
+  it('rendert alle Dashboard-Sections', async () => {
+    const router = makeTestRouter()
+    await router.push('/dashboard')
+    const wrapper = mount(DashboardView, {
+      global: { plugins: [router, createPinia(), makeI18n()] },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="hero-new-run"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-row"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="active-runs-card"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="system-health-card"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="recent-reports-card"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="quick-actions-row"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Ersetzt den Slice-F-Dashboard-Stub (40 LOC Placeholder) durch ein vollständig überarbeitetes Live-Daten-Dashboard mit Workbench-These.
- Sechs neue Sub-Components unter `components/v4/dashboard/`: HeroNewRun (Datei-Drop + Modell+Sprache + Start-CTA), StatsRow (4 Mikro-Kennzahlen), ActiveRunsCard, SystemHealthCard, RecentReportsCard, QuickActionsRow.
- Neuer Composable `useSystemStatus` (Polling 15 s, Zod-validiert, last-known-good bei Schema-Drift) + Contract `systemStatusContract` + API-Wrapper `api/status.ts`.

## Design-These
„Operator-Workbench" — wenig Farbe, dichte aber gestaffelte Information, ID-Pillen monospace, exakt eine Accent-Aktion pro Region (Start-CTA im Hero). Tokens v4 only (Apple-Surfaces, Hairlines, `--accent #0066cc`, Status-Tones, Mono/Sans gemischt).

## Datenfluss
- `useRunsPolling(5000)` → Active Runs + Stats-Aggregation.
- `useSystemStatus(15000)` → Ollama / Neo4j / Disk aus `/api/status`.
- `RecentReportsCard` pollt `listRuns({run_type:'report_generate', status:'completed', limit:8})` alle 30 s.
- Hero greift auf bestehenden `setPendingUpload()`-Pfad zu und routet zu `/process/new`.

## Gates (lokal grün)
- `npm run typecheck` ✓
- `npm test -- --run` ✓ — 674 / 674 Tests in 80 / 80 Files (+19 neue Tests in 8 neuen Spec-Dateien)
- `npm run lint` ✓
- `npm run build` ✓

## Bundle-Delta
| Asset | main | neu | Δ |
|---|---:|---:|---:|
| `DashboardView` JS (lazy) | 0.91 kB | 22.61 kB | +21.70 kB |
| `DashboardView` CSS (lazy) | 0.10 kB | 12.58 kB | +12.48 kB |
| `index` JS | 677.46 kB | 681.19 kB | +3.73 kB |
| `index` CSS | 154.87 kB | 154.87 kB | 0 |

## Bekannte Gaps (im Worklog dokumentiert)
- OASIS hat keinen Health-Endpoint → gedimmter `idle`-Pill mit Hinweis.
- `metadata.confidence_score` ist nicht in jedem Report gesetzt → em-dash-Fallback.

## Test plan
- [ ] `cd frontend && npm run typecheck && npm test -- --run && npm run lint && npm run build` lokal grün
- [ ] `/dashboard` im Dev-Server: Hero · Stats · Active+System · Reports · Quick-Actions sichtbar, Sidebar-Active-State `dashboard`
- [ ] Ollama erreichbar → SystemHealth zeigt grünen Dot + Modell-Count
- [ ] Ollama offline → SystemHealth zeigt roten Dot + Fehler-Sub-Text
- [ ] Datei ablegen → Start-CTA aktiviert → Route `/process/new`
- [ ] Keine `--accent` -Aktion außerhalb des Hero-Bereichs

Worklog: `docu/2026-05-14-design-v4-dashboard-worklog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)