### PR TITLE
feat(design-v4): Slice G2 — API Keys real (Backend + Frontend)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -211,6 +211,7 @@ def create_app(config_class=Config):
         logs_bp,
         settings_bp,
         llm_bp,
+        api_keys_bp,
     )
     from .utils.api_responses import install_api_error_handlers
     from .utils.auth import install_blueprint_guard, log_auth_mode
@@ -225,6 +226,7 @@ def create_app(config_class=Config):
         logs_bp,
         settings_bp,
         llm_bp,
+        api_keys_bp,
     ):
         install_blueprint_guard(bp)
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
@@ -236,6 +238,7 @@ def create_app(config_class=Config):
     app.register_blueprint(logs_bp, url_prefix='/api/logs')
     app.register_blueprint(settings_bp, url_prefix='/api/settings')
     app.register_blueprint(llm_bp, url_prefix='/api/llm')
+    app.register_blueprint(api_keys_bp, url_prefix='/api/api-keys')
     if should_log_startup:
         log_auth_mode(app, logger)
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -14,6 +14,7 @@ llm_bp = Blueprint('llm', __name__)  # Slice E.1 (#213): model-active SSE stream
 
 from .auth import auth_bp  # noqa: E402, F401 -- P0.2b: signed-ticket endpoint
 from .settings import settings_bp  # noqa: E402, F401 -- Issue #133: Settings-UI
+from .api_keys import api_keys_bp  # noqa: E402, F401 -- Slice G2: API-Keys real
 from . import graph  # noqa: E402, F401
 from . import simulation_common  # noqa: E402, F401
 from . import simulation_lifecycle  # noqa: E402, F401

--- a/backend/app/api/api_keys.py
+++ b/backend/app/api/api_keys.py
@@ -1,0 +1,69 @@
+"""API-Keys Blueprint (Slice G2, Single-Workspace-Scope).
+
+Endpunkte (hinter Standard-Blueprint-Guard, identisch zur restlichen
+``/api/*``-Konvention):
+
+  - GET    /api/api-keys           — Liste aller (auch revoked) Schlüssel
+  - POST   /api/api-keys           — neuen Schlüssel anlegen (201 + Klartext-Token einmalig)
+  - DELETE /api/api-keys/<key_id>  — Schlüssel revoken
+
+Audit-Log-Hook ist Out-of-Scope für G2 (kommt in G3).
+"""
+from __future__ import annotations
+
+from flask import Blueprint, request
+from pydantic import ValidationError
+
+from ..contracts.api_keys_contract import (
+    ApiKeyCreateRequest,
+    ApiKeysListResponse,
+)
+from ..services.api_keys_store import get_api_keys_store
+from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.logger import get_logger
+
+api_keys_bp = Blueprint("api_keys", __name__)
+logger = get_logger("agora.api.api_keys")
+
+
+@api_keys_bp.route("", methods=["GET"])
+@api_keys_bp.route("/", methods=["GET"])
+@handle_api_errors
+def list_api_keys():
+    store = get_api_keys_store()
+    items = store.list()
+    response = ApiKeysListResponse(items=items, total=len(items))
+    return json_success(response.model_dump(mode="json"))
+
+
+@api_keys_bp.route("", methods=["POST"])
+@api_keys_bp.route("/", methods=["POST"])
+@handle_api_errors
+def create_api_key():
+    payload = request.get_json(silent=True) or {}
+    try:
+        body = ApiKeyCreateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Invalid request body",
+            status=400,
+            code="invalid_request",
+            extra={"errors": exc.errors(include_url=False)},
+        )
+    store = get_api_keys_store()
+    created = store.create(label=body.label, scopes=list(body.scopes))
+    return json_success(created.model_dump(mode="json"), status=201)
+
+
+@api_keys_bp.route("/<key_id>", methods=["DELETE"])
+@handle_api_errors
+def revoke_api_key(key_id: str):
+    store = get_api_keys_store()
+    revoked = store.revoke(key_id)
+    if revoked is None:
+        return json_error(
+            f"API key does not exist: {key_id}",
+            status=404,
+            code="not_found",
+        )
+    return json_success(revoked.model_dump(mode="json"))

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -55,6 +55,14 @@ from .graph_diff import (
     NodePropertyShift,
 )
 from .persona_entity_context import EntityRelationship, PersonaEntityContext
+from .api_keys_contract import (
+    ApiKeyCreateRequest,
+    ApiKeyCreateResponse,
+    ApiKeyModel,
+    ApiKeyScope,
+    ApiKeyStatus,
+    ApiKeysListResponse,
+)
 from .report_v3 import (
     Claim,
     ChangeRecommendation,
@@ -73,6 +81,12 @@ from .report_v3 import (
 )
 
 __all__ = [
+    "ApiKeyCreateRequest",
+    "ApiKeyCreateResponse",
+    "ApiKeyModel",
+    "ApiKeyScope",
+    "ApiKeyStatus",
+    "ApiKeysListResponse",
     "BranchComparison",
     "BranchMetrics",
     "BridgeAgentShift",

--- a/backend/app/contracts/api_keys_contract.py
+++ b/backend/app/contracts/api_keys_contract.py
@@ -1,0 +1,73 @@
+"""API-Keys-Contract v1 (Pydantic v2).
+
+Single-Workspace-Scope: API-Schlüssel sind keine User-Identity, sondern
+Workspace-Zugänge mit Scopes (read|write|admin). Klartext-Token (`ago_<48-hex>`)
+wird nur einmal im CreateResponse zurückgegeben; persistiert wird nur der Prefix
+zur UI-Anzeige.
+
+Status:
+  active   — Schlüssel ist verwendbar.
+  revoked  — Manuell zurückgezogen, kein erneutes Aktivieren.
+
+Siehe ADR-Slice G2 + docu/2026-05-14-design-v4-slice-g2-api-keys-worklog.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ApiKeyScope = Literal["read", "write", "admin"]
+ApiKeyStatus = Literal["active", "revoked"]
+
+_STRICT = ConfigDict(extra="forbid")
+
+# Klartext-Token-Format: ago_<48-hex>
+TOKEN_PREFIX_LENGTH = 12  # "ago_" + 8 Hex-Zeichen
+
+
+class ApiKeyModel(BaseModel):
+    """Persistierte Repräsentation eines API-Schlüssels (ohne Klartext)."""
+
+    model_config = _STRICT
+
+    id: str = Field(min_length=1)
+    label: str = Field(min_length=1, max_length=120)
+    prefix: str = Field(
+        min_length=TOKEN_PREFIX_LENGTH,
+        max_length=TOKEN_PREFIX_LENGTH,
+        pattern=r"^ago_[0-9a-f]{8}$",
+    )
+    scopes: list[ApiKeyScope] = Field(min_length=1)
+    status: ApiKeyStatus
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+    revoked_at: Optional[datetime] = None
+
+
+class ApiKeyCreateRequest(BaseModel):
+    """Eingabe für POST /api/api-keys."""
+
+    model_config = _STRICT
+
+    label: str = Field(min_length=1, max_length=120)
+    scopes: list[ApiKeyScope] = Field(min_length=1)
+
+
+class ApiKeyCreateResponse(BaseModel):
+    """Antwort auf POST /api/api-keys — Klartext-Token erscheint hier genau einmal."""
+
+    model_config = _STRICT
+
+    key: ApiKeyModel
+    token: str = Field(pattern=r"^ago_[0-9a-f]{48}$")
+
+
+class ApiKeysListResponse(BaseModel):
+    """Antwort auf GET /api/api-keys."""
+
+    model_config = _STRICT
+
+    items: list[ApiKeyModel]
+    total: int = Field(ge=0)

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -27,6 +27,12 @@ from app.contracts.llm_routing_contract import (
     ProviderDescriptor,
     ResolvedRoute,
 )
+from app.contracts.api_keys_contract import (
+    ApiKeyCreateRequest,
+    ApiKeyCreateResponse,
+    ApiKeyModel,
+    ApiKeysListResponse,
+)
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -47,6 +53,10 @@ CONTRACTS: dict[str, type] = {
     "llm-runtime-routing.schema.json": RuntimeLlmRouting,
     "llm-provider-descriptor.schema.json": ProviderDescriptor,
     "llm-resolved-route.schema.json": ResolvedRoute,
+    "api-key.schema.json": ApiKeyModel,
+    "api-key-create-request.schema.json": ApiKeyCreateRequest,
+    "api-key-create-response.schema.json": ApiKeyCreateResponse,
+    "api-keys-list-response.schema.json": ApiKeysListResponse,
 }
 
 

--- a/backend/app/services/api_keys_store.py
+++ b/backend/app/services/api_keys_store.py
@@ -1,0 +1,99 @@
+"""Thread-safe In-Memory-Store für API-Schlüssel (Slice G2).
+
+Single-Workspace-Scope: kein Identity-Modul, keine Persistenz auf Disk.
+Klartext-Token (``ago_<48-hex>``) wird genau einmal beim Anlegen
+zurückgegeben; persistiert wird nur Prefix + Metadata.
+
+Audit-Log-Hook ist Out-of-Scope für G2 (kommt in G3).
+"""
+from __future__ import annotations
+
+import secrets
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from ..contracts.api_keys_contract import (
+    ApiKeyCreateResponse,
+    ApiKeyModel,
+    ApiKeyScope,
+)
+
+_TOKEN_RANDOM_HEX = 48
+_PREFIX_HEX_LEN = 8
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _generate_token() -> tuple[str, str]:
+    """Erzeugt (Klartext-Token, Prefix). Prefix ist ``ago_`` + erste 8 Hex-Zeichen."""
+    body = secrets.token_hex(_TOKEN_RANDOM_HEX // 2)
+    token = f"ago_{body}"
+    prefix = f"ago_{body[:_PREFIX_HEX_LEN]}"
+    return token, prefix
+
+
+class ApiKeysStore:
+    """Thread-safe In-Memory-Store. Pro Prozess eine Instanz (Modul-Singleton)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._keys: dict[str, ApiKeyModel] = {}
+
+    def list(self) -> list[ApiKeyModel]:
+        with self._lock:
+            return sorted(
+                self._keys.values(),
+                key=lambda k: k.created_at,
+                reverse=True,
+            )
+
+    def get(self, key_id: str) -> Optional[ApiKeyModel]:
+        with self._lock:
+            return self._keys.get(key_id)
+
+    def create(self, label: str, scopes: list[ApiKeyScope]) -> ApiKeyCreateResponse:
+        token, prefix = _generate_token()
+        key_id = uuid.uuid4().hex
+        model = ApiKeyModel(
+            id=key_id,
+            label=label,
+            prefix=prefix,
+            scopes=list(scopes),
+            status="active",
+            created_at=_now(),
+            last_used_at=None,
+            revoked_at=None,
+        )
+        with self._lock:
+            self._keys[key_id] = model
+        return ApiKeyCreateResponse(key=model, token=token)
+
+    def revoke(self, key_id: str) -> Optional[ApiKeyModel]:
+        with self._lock:
+            existing = self._keys.get(key_id)
+            if existing is None:
+                return None
+            if existing.status == "revoked":
+                return existing
+            revoked = existing.model_copy(
+                update={"status": "revoked", "revoked_at": _now()}
+            )
+            self._keys[key_id] = revoked
+            return revoked
+
+    def reset_for_tests(self) -> None:
+        """Nur in Tests aufrufen — leert den Store hart."""
+        with self._lock:
+            self._keys.clear()
+
+
+_store_singleton = ApiKeysStore()
+
+
+def get_api_keys_store() -> ApiKeysStore:
+    """Modul-Singleton — pro Flask-Prozess geteilt."""
+    return _store_singleton

--- a/backend/tests/api/test_api_keys_api.py
+++ b/backend/tests/api/test_api_keys_api.py
@@ -1,0 +1,153 @@
+"""API-Tests für /api/api-keys (Slice G2)."""
+from __future__ import annotations
+
+import re
+
+import pytest
+from flask import Flask
+
+from app.api import api_keys_bp
+from app.services.api_keys_store import get_api_keys_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    get_api_keys_store().reset_for_tests()
+    yield
+    get_api_keys_store().reset_for_tests()
+
+
+@pytest.fixture
+def app() -> Flask:
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(api_keys_bp, url_prefix="/api/api-keys")
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+class TestListApiKeys:
+    def test_empty_list(self, client) -> None:
+        resp = client.get("/api/api-keys")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["data"]["items"] == []
+        assert body["data"]["total"] == 0
+
+    def test_list_after_create(self, client) -> None:
+        client.post(
+            "/api/api-keys", json={"label": "CI", "scopes": ["read"]}
+        )
+        resp = client.get("/api/api-keys")
+        assert resp.status_code == 200
+        items = resp.get_json()["data"]["items"]
+        assert len(items) == 1
+        assert items[0]["label"] == "CI"
+        assert items[0]["status"] == "active"
+        # Klartext-Token darf in der Liste nicht auftauchen
+        assert "token" not in items[0]
+
+
+class TestCreateApiKey:
+    def test_happy_path_returns_201_and_one_time_token(self, client) -> None:
+        resp = client.post(
+            "/api/api-keys",
+            json={"label": "Deploy bot", "scopes": ["read", "write"]},
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["success"] is True
+        token = body["data"]["token"]
+        assert re.fullmatch(r"ago_[0-9a-f]{48}", token)
+        key = body["data"]["key"]
+        assert key["label"] == "Deploy bot"
+        assert key["scopes"] == ["read", "write"]
+        assert key["status"] == "active"
+        # Prefix sollte die ersten 8 Hex-Zeichen aus dem Klartext spiegeln
+        assert token.startswith(key["prefix"])
+
+    def test_create_with_invalid_scope_returns_400(self, client) -> None:
+        resp = client.post(
+            "/api/api-keys",
+            json={"label": "X", "scopes": ["root"]},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["code"] == "invalid_request"
+
+    def test_create_with_empty_label_returns_400(self, client) -> None:
+        resp = client.post(
+            "/api/api-keys",
+            json={"label": "", "scopes": ["read"]},
+        )
+        assert resp.status_code == 400
+
+    def test_create_with_empty_scopes_returns_400(self, client) -> None:
+        resp = client.post(
+            "/api/api-keys",
+            json={"label": "X", "scopes": []},
+        )
+        assert resp.status_code == 400
+
+    def test_create_with_extra_field_returns_400(self, client) -> None:
+        resp = client.post(
+            "/api/api-keys",
+            json={"label": "X", "scopes": ["read"], "secret": "x"},
+        )
+        assert resp.status_code == 400
+
+    def test_tokens_are_unique_across_creates(self, client) -> None:
+        first = client.post(
+            "/api/api-keys", json={"label": "a", "scopes": ["read"]}
+        ).get_json()["data"]["token"]
+        second = client.post(
+            "/api/api-keys", json={"label": "b", "scopes": ["read"]}
+        ).get_json()["data"]["token"]
+        assert first != second
+
+
+class TestRevokeApiKey:
+    def test_revoke_existing_key_returns_revoked_state(self, client) -> None:
+        created = client.post(
+            "/api/api-keys", json={"label": "X", "scopes": ["read"]}
+        ).get_json()["data"]["key"]
+        key_id = created["id"]
+
+        resp = client.delete(f"/api/api-keys/{key_id}")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["data"]["status"] == "revoked"
+        assert body["data"]["revoked_at"] is not None
+
+    def test_revoke_returns_404_for_unknown_id(self, client) -> None:
+        resp = client.delete("/api/api-keys/not-there")
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert body["code"] == "not_found"
+
+    def test_revoke_is_idempotent(self, client) -> None:
+        created = client.post(
+            "/api/api-keys", json={"label": "X", "scopes": ["read"]}
+        ).get_json()["data"]["key"]
+        key_id = created["id"]
+        client.delete(f"/api/api-keys/{key_id}")
+        resp = client.delete(f"/api/api-keys/{key_id}")
+        # Zweiter Revoke gibt nach wie vor 200 + revoked-Status zurück
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["status"] == "revoked"
+
+    def test_revoked_key_still_listed(self, client) -> None:
+        created = client.post(
+            "/api/api-keys", json={"label": "X", "scopes": ["read"]}
+        ).get_json()["data"]["key"]
+        client.delete(f"/api/api-keys/{created['id']}")
+        resp = client.get("/api/api-keys")
+        items = resp.get_json()["data"]["items"]
+        assert len(items) == 1
+        assert items[0]["status"] == "revoked"

--- a/backend/tests/contracts/test_api_keys_contract.py
+++ b/backend/tests/contracts/test_api_keys_contract.py
@@ -1,0 +1,148 @@
+"""Contract-Tests für api_keys_contract (Slice G2)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.api_keys_contract import (
+    ApiKeyCreateRequest,
+    ApiKeyCreateResponse,
+    ApiKeyModel,
+    ApiKeysListResponse,
+)
+
+
+def _valid_model_kwargs() -> dict:
+    return {
+        "id": "abc123",
+        "label": "CI bot",
+        "prefix": "ago_deadbeef",
+        "scopes": ["read"],
+        "status": "active",
+        "created_at": datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc),
+    }
+
+
+class TestApiKeyModel:
+    def test_minimal_valid_model(self) -> None:
+        model = ApiKeyModel(**_valid_model_kwargs())
+        assert model.label == "CI bot"
+        assert model.scopes == ["read"]
+        assert model.status == "active"
+        assert model.last_used_at is None
+        assert model.revoked_at is None
+
+    def test_prefix_pattern_rejects_bad_prefix(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["prefix"] = "key_deadbee"
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_prefix_rejects_uppercase_hex(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["prefix"] = "ago_DEADBEEF"
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_scopes_must_not_be_empty(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["scopes"] = []
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_invalid_scope_rejected(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["scopes"] = ["root"]
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_invalid_status_rejected(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["status"] = "expired"
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_extra_field_forbidden(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["secret"] = "leak"
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+    def test_label_max_length_enforced(self) -> None:
+        kwargs = _valid_model_kwargs()
+        kwargs["label"] = "x" * 121
+        with pytest.raises(ValidationError):
+            ApiKeyModel(**kwargs)
+
+
+class TestApiKeyCreateRequest:
+    def test_minimal_request_valid(self) -> None:
+        req = ApiKeyCreateRequest(label="CI", scopes=["read"])
+        assert req.label == "CI"
+
+    def test_empty_label_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateRequest(label="", scopes=["read"])
+
+    def test_empty_scopes_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateRequest(label="CI", scopes=[])
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateRequest.model_validate(
+                {"label": "CI", "scopes": ["read"], "tenant": "x"}
+            )
+
+    def test_multi_scope_allowed(self) -> None:
+        req = ApiKeyCreateRequest(label="CI", scopes=["read", "write", "admin"])
+        assert set(req.scopes) == {"read", "write", "admin"}
+
+
+class TestApiKeyCreateResponse:
+    def test_token_pattern_validates_48_hex(self) -> None:
+        token = "ago_" + ("a" * 48)
+        resp = ApiKeyCreateResponse(
+            key=ApiKeyModel(**_valid_model_kwargs()),
+            token=token,
+        )
+        assert resp.token == token
+
+    def test_token_with_wrong_prefix_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateResponse(
+                key=ApiKeyModel(**_valid_model_kwargs()),
+                token="key_" + ("a" * 48),
+            )
+
+    def test_token_with_uppercase_hex_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateResponse(
+                key=ApiKeyModel(**_valid_model_kwargs()),
+                token="ago_" + ("A" * 48),
+            )
+
+    def test_token_too_short_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeyCreateResponse(
+                key=ApiKeyModel(**_valid_model_kwargs()),
+                token="ago_" + ("a" * 16),
+            )
+
+
+class TestApiKeysListResponse:
+    def test_empty_list_valid(self) -> None:
+        resp = ApiKeysListResponse(items=[], total=0)
+        assert resp.total == 0
+
+    def test_negative_total_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeysListResponse(items=[], total=-1)
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiKeysListResponse.model_validate(
+                {"items": [], "total": 0, "cursor": "x"}
+            )

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 1968 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 82 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2000 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 84 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/api/apiKeys.ts
+++ b/frontend/src/api/apiKeys.ts
@@ -1,0 +1,37 @@
+/**
+ * API-Keys — HTTP-Client-Funktionen.
+ *
+ * Der Axios-Interceptor in api/index.ts gibt bereits `response.data` zurück
+ * (das Envelope-Objekt `{ success, data }`). Bei `success: false` wirft er
+ * einen `ApiError`. Hier greifen wir auf `.data` des Envelopes zu und parsen
+ * strict via Zod.
+ */
+import service from './index'
+import {
+  ApiKeyCreateRequestSchema,
+  ApiKeyCreateResponseSchema,
+  ApiKeyModelSchema,
+  ApiKeysListResponseSchema,
+  type ApiKeyCreateRequest,
+  type ApiKeyCreateResponse,
+  type ApiKeyModel,
+  type ApiKeysListResponse,
+} from '../contracts/apiKeysContract'
+
+type Envelope<T> = { success: true; data: T }
+
+export async function listApiKeys(): Promise<ApiKeysListResponse> {
+  const envelope = await service.get('/api/api-keys') as Envelope<unknown>
+  return ApiKeysListResponseSchema.parse(envelope.data)
+}
+
+export async function createApiKey(req: ApiKeyCreateRequest): Promise<ApiKeyCreateResponse> {
+  ApiKeyCreateRequestSchema.parse(req)
+  const envelope = await service.post('/api/api-keys', req) as Envelope<unknown>
+  return ApiKeyCreateResponseSchema.parse(envelope.data)
+}
+
+export async function revokeApiKey(id: string): Promise<ApiKeyModel> {
+  const envelope = await service.delete(`/api/api-keys/${id}`) as Envelope<unknown>
+  return ApiKeyModelSchema.parse(envelope.data)
+}

--- a/frontend/src/contracts/apiKeysContract.ts
+++ b/frontend/src/contracts/apiKeysContract.ts
@@ -1,0 +1,62 @@
+/**
+ * API-Keys-Contract v1 — Zod-Spiegel.
+ *
+ * Hand-gepflegt, 1:1 zu schemas/api-key*.schema.json. Änderungen am
+ * Pydantic-Modell (backend/app/contracts/api_keys_contract.py) →
+ * Schema-Dump → diese Datei synchronisieren.
+ */
+import { z } from "zod";
+
+// === ApiKeyScope ===
+export const ApiKeyScopeSchema = z.enum(["read", "write", "admin"]);
+export type ApiKeyScope = z.infer<typeof ApiKeyScopeSchema>;
+
+// === ApiKeyStatus ===
+export const ApiKeyStatusSchema = z.enum(["active", "revoked"]);
+export type ApiKeyStatus = z.infer<typeof ApiKeyStatusSchema>;
+
+// === ApiKeyModel (persistierte Repräsentation, ohne Klartext) ===
+export const ApiKeyModelSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1).max(120),
+    prefix: z
+      .string()
+      .min(12)
+      .max(12)
+      .regex(/^ago_[0-9a-f]{8}$/),
+    scopes: z.array(ApiKeyScopeSchema).min(1),
+    status: ApiKeyStatusSchema,
+    created_at: z.string(),
+    last_used_at: z.string().nullable().optional(),
+    revoked_at: z.string().nullable().optional(),
+  })
+  .strict();
+export type ApiKeyModel = z.infer<typeof ApiKeyModelSchema>;
+
+// === ApiKeyCreateRequest ===
+export const ApiKeyCreateRequestSchema = z
+  .object({
+    label: z.string().min(1).max(120),
+    scopes: z.array(ApiKeyScopeSchema).min(1),
+  })
+  .strict();
+export type ApiKeyCreateRequest = z.infer<typeof ApiKeyCreateRequestSchema>;
+
+// === ApiKeyCreateResponse (Klartext-Token erscheint hier genau einmal) ===
+export const ApiKeyCreateResponseSchema = z
+  .object({
+    key: ApiKeyModelSchema,
+    token: z.string().regex(/^ago_[0-9a-f]{48}$/),
+  })
+  .strict();
+export type ApiKeyCreateResponse = z.infer<typeof ApiKeyCreateResponseSchema>;
+
+// === ApiKeysListResponse ===
+export const ApiKeysListResponseSchema = z
+  .object({
+    items: z.array(ApiKeyModelSchema),
+    total: z.number().int().min(0),
+  })
+  .strict();
+export type ApiKeysListResponse = z.infer<typeof ApiKeysListResponseSchema>;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -777,7 +777,8 @@
         "errors": {
           "loadFailed": "API-Schlüssel konnten nicht geladen werden.",
           "createFailed": "Schlüssel konnte nicht angelegt werden.",
-          "revokeFailed": "Schlüssel konnte nicht widerrufen werden."
+          "revokeFailed": "Schlüssel konnte nicht widerrufen werden.",
+          "copyFailed": "Schlüssel konnte nicht in die Zwischenablage kopiert werden."
         }
       },
       "usersTeams": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -726,9 +726,58 @@
       "apiKeys": {
         "title": "API-Schlüssel",
         "subtitle": "API-Zugänge erstellen und verwalten.",
+        "actions": {
+          "create": "Schlüssel anlegen",
+          "revoke": "Widerrufen",
+          "cancel": "Abbrechen",
+          "close": "Schließen",
+          "copy": "Kopieren",
+          "copied": "Kopiert"
+        },
+        "create": {
+          "modalTitle": "Neuen API-Schlüssel anlegen",
+          "modalSubtitle": "Vergib einen Namen und wähle die Berechtigungen für diesen Schlüssel.",
+          "labelField": "Bezeichnung",
+          "scopesField": "Berechtigungen",
+          "scopes": {
+            "read": "Lesen (read)",
+            "write": "Schreiben (write)",
+            "admin": "Verwaltung (admin)"
+          },
+          "submit": "Schlüssel anlegen"
+        },
+        "created": {
+          "title": "Schlüssel erstellt — jetzt kopieren",
+          "warning": "Dieser Schlüssel wird nur jetzt angezeigt. Verloren = neu anlegen.",
+          "tokenLabel": "Klartext-Token"
+        },
+        "revoke": {
+          "modalTitle": "Schlüssel widerrufen?",
+          "modalSubtitle": "Bestehende Clients verlieren sofort Zugriff. Diese Aktion kann nicht rückgängig gemacht werden.",
+          "confirm": "Widerrufen"
+        },
+        "table": {
+          "label": "Bezeichnung",
+          "prefix": "Prefix",
+          "scopes": "Berechtigungen",
+          "status": "Status",
+          "createdAt": "Erstellt",
+          "lastUsedAt": "Zuletzt verwendet",
+          "never": "Nie",
+          "actions": "Aktionen"
+        },
+        "status": {
+          "active": "Aktiv",
+          "revoked": "Widerrufen"
+        },
         "empty": {
-          "title": "API-Schlüssel-Verwaltung folgt",
-          "description": "Backend-Support für persönliche und Service-Schlüssel ist in Vorbereitung. Bis dahin werden Zugriffe zentral über das Auth-Token gesteuert."
+          "title": "Noch keine API-Schlüssel",
+          "description": "Lege einen Schlüssel an, um externen Clients Zugriff zu geben."
+        },
+        "errors": {
+          "loadFailed": "API-Schlüssel konnten nicht geladen werden.",
+          "createFailed": "Schlüssel konnte nicht angelegt werden.",
+          "revokeFailed": "Schlüssel konnte nicht widerrufen werden."
         }
       },
       "usersTeams": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -726,9 +726,58 @@
       "apiKeys": {
         "title": "API keys",
         "subtitle": "Create and manage API access.",
+        "actions": {
+          "create": "Create key",
+          "revoke": "Revoke",
+          "cancel": "Cancel",
+          "close": "Close",
+          "copy": "Copy",
+          "copied": "Copied"
+        },
+        "create": {
+          "modalTitle": "Create new API key",
+          "modalSubtitle": "Give it a name and choose the permissions for this key.",
+          "labelField": "Label",
+          "scopesField": "Permissions",
+          "scopes": {
+            "read": "Read",
+            "write": "Write",
+            "admin": "Admin"
+          },
+          "submit": "Create key"
+        },
+        "created": {
+          "title": "Key created — copy it now",
+          "warning": "This key is only shown once. If lost, create a new one.",
+          "tokenLabel": "Plain-text token"
+        },
+        "revoke": {
+          "modalTitle": "Revoke key?",
+          "modalSubtitle": "Existing clients will immediately lose access. This action cannot be undone.",
+          "confirm": "Revoke"
+        },
+        "table": {
+          "label": "Label",
+          "prefix": "Prefix",
+          "scopes": "Permissions",
+          "status": "Status",
+          "createdAt": "Created",
+          "lastUsedAt": "Last used",
+          "never": "Never",
+          "actions": "Actions"
+        },
+        "status": {
+          "active": "Active",
+          "revoked": "Revoked"
+        },
         "empty": {
-          "title": "API-key management coming soon",
-          "description": "Backend support for personal and service keys is in preparation. Until then, access is governed centrally via the auth token."
+          "title": "No API keys yet",
+          "description": "Create a key to grant external clients access."
+        },
+        "errors": {
+          "loadFailed": "Failed to load API keys.",
+          "createFailed": "Failed to create key.",
+          "revokeFailed": "Failed to revoke key."
         }
       },
       "usersTeams": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -777,7 +777,8 @@
         "errors": {
           "loadFailed": "Failed to load API keys.",
           "createFailed": "Failed to create key.",
-          "revokeFailed": "Failed to revoke key."
+          "revokeFailed": "Failed to revoke key.",
+          "copyFailed": "Failed to copy key to clipboard."
         }
       },
       "usersTeams": {

--- a/frontend/src/store/__tests__/apiKeys.spec.ts
+++ b/frontend/src/store/__tests__/apiKeys.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * apiKeys-Store — Vitest-Smokes (Slice G2).
+ *
+ * Tests:
+ *  1. list() setzt items korrekt.
+ *  2. create() setzt lastCreatedToken + pusht key an ersten Position.
+ *  3. revoke() ersetzt das betroffene Item mit der revoked-Version.
+ *  4. clearLastCreatedToken() löscht den Klartext-Token.
+ *  5. list() setzt error bei API-Fehler.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// localStorage-Mock (vor allen Modulimporten)
+const localStorageMock = (() => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach((k) => delete store[k]) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// Mock API-Modul — verhindert echte HTTP-Calls
+vi.mock('../../api/apiKeys', () => ({
+  listApiKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+}))
+
+import { listApiKeys, createApiKey, revokeApiKey } from '../../api/apiKeys'
+import { useApiKeysStore } from '../apiKeys'
+import type { ApiKeyModel } from '../../contracts/apiKeysContract'
+
+type MockFn = ReturnType<typeof vi.fn>
+const _listApiKeys = listApiKeys as unknown as MockFn
+const _createApiKey = createApiKey as unknown as MockFn
+const _revokeApiKey = revokeApiKey as unknown as MockFn
+
+// --- Fixtures ---
+function makeKey(overrides: Partial<ApiKeyModel> = {}): ApiKeyModel {
+  return {
+    id: 'key-001',
+    label: 'Test-Key',
+    prefix: 'ago_abcd1234',
+    scopes: ['read'],
+    status: 'active',
+    created_at: '2026-05-14T10:00:00Z',
+    last_used_at: null,
+    revoked_at: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('useApiKeysStore', () => {
+  it('Test 1: list() setzt items aus API-Response', async () => {
+    const key1 = makeKey({ id: 'key-001', label: 'Key 1' })
+    const key2 = makeKey({ id: 'key-002', label: 'Key 2', scopes: ['read', 'write'] })
+    _listApiKeys.mockResolvedValue({ items: [key1, key2], total: 2 })
+
+    const store = useApiKeysStore()
+    await store.list()
+
+    expect(store.items).toHaveLength(2)
+    expect(store.items[0].id).toBe('key-001')
+    expect(store.items[1].id).toBe('key-002')
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('Test 2: create() setzt lastCreatedToken + pusht key an erster Position', async () => {
+    const existingKey = makeKey({ id: 'old-key', label: 'Existing' })
+    _listApiKeys.mockResolvedValue({ items: [existingKey], total: 1 })
+
+    const newKey = makeKey({ id: 'new-key', label: 'Neuer Key', scopes: ['read', 'write'] })
+    const token = 'ago_' + 'a'.repeat(48)
+    _createApiKey.mockResolvedValue({ key: newKey, token })
+
+    const store = useApiKeysStore()
+    await store.list()
+    await store.create('Neuer Key', ['read', 'write'])
+
+    expect(store.lastCreatedToken).toBe(token)
+    expect(store.items[0].id).toBe('new-key')
+    expect(store.items[1].id).toBe('old-key')
+    expect(store.creating).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('Test 3: revoke() ersetzt Item mit revoked-Version', async () => {
+    const key = makeKey({ id: 'key-001', status: 'active' })
+    _listApiKeys.mockResolvedValue({ items: [key], total: 1 })
+
+    const revokedKey: ApiKeyModel = { ...key, status: 'revoked', revoked_at: '2026-05-14T12:00:00Z' }
+    _revokeApiKey.mockResolvedValue(revokedKey)
+
+    const store = useApiKeysStore()
+    await store.list()
+    await store.revoke('key-001')
+
+    expect(store.items).toHaveLength(1)
+    expect(store.items[0].status).toBe('revoked')
+    expect(store.items[0].revoked_at).toBe('2026-05-14T12:00:00Z')
+    expect(store.error).toBeNull()
+  })
+
+  it('Test 4: clearLastCreatedToken() setzt lastCreatedToken auf null', async () => {
+    const newKey = makeKey({ id: 'new-key', label: 'Test' })
+    const token = 'ago_' + 'b'.repeat(48)
+    _createApiKey.mockResolvedValue({ key: newKey, token })
+
+    const store = useApiKeysStore()
+    await store.create('Test', ['read'])
+
+    expect(store.lastCreatedToken).toBe(token)
+    store.clearLastCreatedToken()
+    expect(store.lastCreatedToken).toBeNull()
+  })
+
+  it('Test 5: list() setzt error bei API-Fehler', async () => {
+    _listApiKeys.mockRejectedValue(new Error('Netzwerkfehler'))
+
+    const store = useApiKeysStore()
+    await expect(store.list()).rejects.toThrow('Netzwerkfehler')
+
+    expect(store.error).toBe('Netzwerkfehler')
+    expect(store.loading).toBe(false)
+    expect(store.items).toHaveLength(0)
+  })
+})

--- a/frontend/src/store/apiKeys.ts
+++ b/frontend/src/store/apiKeys.ts
@@ -1,0 +1,88 @@
+/**
+ * apiKeys — Pinia-Store für API-Schlüssel-Verwaltung.
+ *
+ * Slice G2 — Frontend-Anteil.
+ * lastCreatedToken wird NIEMALS persistiert (nur im JS-Heap).
+ */
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  type ApiKeyModel,
+  type ApiKeyScope,
+} from '../contracts/apiKeysContract'
+import { listApiKeys, createApiKey, revokeApiKey } from '../api/apiKeys'
+
+export const useApiKeysStore = defineStore('apiKeys', () => {
+  const items = ref<ApiKeyModel[]>([])
+  const loading = ref(false)
+  const creating = ref(false)
+  const error = ref<string | null>(null)
+  // Klartext-Token: erscheint nur einmal nach POST, niemals in localStorage o.ä.
+  const lastCreatedToken = ref<string | null>(null)
+
+  async function list(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listApiKeys()
+      items.value = result.items
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Laden der API-Schlüssel.'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(label: string, scopes: ApiKeyScope[]): Promise<void> {
+    creating.value = true
+    error.value = null
+    try {
+      const result = await createApiKey({ label, scopes })
+      lastCreatedToken.value = result.token
+      items.value = [result.key, ...items.value]
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Anlegen des API-Schlüssels.'
+      throw err
+    } finally {
+      creating.value = false
+    }
+  }
+
+  async function revoke(id: string): Promise<void> {
+    error.value = null
+    try {
+      const revoked = await revokeApiKey(id)
+      const idx = items.value.findIndex((k) => k.id === id)
+      if (idx !== -1) {
+        items.value = [
+          ...items.value.slice(0, idx),
+          revoked,
+          ...items.value.slice(idx + 1),
+        ]
+      }
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Widerrufen des API-Schlüssels.'
+      throw err
+    }
+  }
+
+  function clearLastCreatedToken(): void {
+    lastCreatedToken.value = null
+  }
+
+  return {
+    items,
+    loading,
+    creating,
+    error,
+    lastCreatedToken,
+    list,
+    create,
+    revoke,
+    clearLastCreatedToken,
+  }
+})

--- a/frontend/src/views/Settings/SettingsApiKeysView.vue
+++ b/frontend/src/views/Settings/SettingsApiKeysView.vue
@@ -9,7 +9,7 @@ import Input from '@/components/v4/forms/Input.vue'
 import { useApiKeysStore } from '@/store/apiKeys'
 import type { ApiKeyModel, ApiKeyScope } from '@/contracts/apiKeysContract'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const store = useApiKeysStore()
 
 const BREADCRUMBS = [
@@ -64,11 +64,18 @@ async function submitCreate(): Promise<void> {
 // --- Copy-to-Clipboard ---
 const tokenCopied = ref(false)
 
+const copyError = ref<string | null>(null)
+
 async function copyToken(): Promise<void> {
   if (!store.lastCreatedToken) return
-  await navigator.clipboard.writeText(store.lastCreatedToken)
-  tokenCopied.value = true
-  setTimeout(() => { tokenCopied.value = false }, 2000)
+  copyError.value = null
+  try {
+    await navigator.clipboard.writeText(store.lastCreatedToken)
+    tokenCopied.value = true
+    setTimeout(() => { tokenCopied.value = false }, 2000)
+  } catch {
+    copyError.value = t('settings.v4.apiKeys.errors.copyFailed')
+  }
 }
 
 // --- Revoke-Dialog-State ---
@@ -99,7 +106,7 @@ async function confirmRevoke(): Promise<void> {
 // --- Helpers ---
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return t('settings.v4.apiKeys.table.never')
-  return new Date(iso).toLocaleDateString('de-DE', {
+  return new Date(iso).toLocaleDateString(locale.value, {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
@@ -231,6 +238,9 @@ onMounted(() => {
               <button class="v4-btn v4-btn--secondary" @click="copyToken">
                 {{ tokenCopied ? t('settings.v4.apiKeys.actions.copied') : t('settings.v4.apiKeys.actions.copy') }}
               </button>
+            </div>
+            <div v-if="copyError" class="api-keys__form-error" role="alert">
+              {{ copyError }}
             </div>
             <div class="v4-modal__footer">
               <button class="v4-btn v4-btn--primary" @click="closeCreateModal">

--- a/frontend/src/views/Settings/SettingsApiKeysView.vue
+++ b/frontend/src/views/Settings/SettingsApiKeysView.vue
@@ -1,15 +1,120 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
-import ComingSoonCard from '@/components/v4/forms/ComingSoonCard.vue'
+import Card from '@/components/v4/forms/Card.vue'
+import Badge from '@/components/v4/forms/Badge.vue'
+import Input from '@/components/v4/forms/Input.vue'
+import { useApiKeysStore } from '@/store/apiKeys'
+import type { ApiKeyModel, ApiKeyScope } from '@/contracts/apiKeysContract'
 
 const { t } = useI18n()
+const store = useApiKeysStore()
 
 const BREADCRUMBS = [
   { label: 'Settings', to: { name: 'SettingsGeneral' } },
   { label: 'API Keys' },
 ]
+
+// --- Create-Modal-State ---
+const createModalOpen = ref(false)
+const createLabel = ref('')
+const createScopes = ref<ApiKeyScope[]>(['read'])
+const createError = ref<string | null>(null)
+
+function openCreateModal(): void {
+  createLabel.value = ''
+  createScopes.value = ['read']
+  createError.value = null
+  createModalOpen.value = true
+}
+
+function closeCreateModal(): void {
+  createModalOpen.value = false
+  store.clearLastCreatedToken()
+}
+
+function toggleScope(scope: ApiKeyScope): void {
+  const idx = createScopes.value.indexOf(scope)
+  if (idx === -1) {
+    createScopes.value = [...createScopes.value, scope]
+  } else {
+    createScopes.value = createScopes.value.filter((s) => s !== scope)
+  }
+}
+
+async function submitCreate(): Promise<void> {
+  createError.value = null
+  if (!createLabel.value.trim()) {
+    createError.value = t('settings.v4.apiKeys.create.labelField') + ' ' + t('common.required', 'ist erforderlich.')
+    return
+  }
+  if (createScopes.value.length === 0) {
+    createError.value = t('settings.v4.apiKeys.create.scopesField') + ' ' + t('common.required', 'ist erforderlich.')
+    return
+  }
+  try {
+    await store.create(createLabel.value.trim(), createScopes.value)
+  } catch {
+    createError.value = t('settings.v4.apiKeys.errors.createFailed')
+  }
+}
+
+// --- Copy-to-Clipboard ---
+const tokenCopied = ref(false)
+
+async function copyToken(): Promise<void> {
+  if (!store.lastCreatedToken) return
+  await navigator.clipboard.writeText(store.lastCreatedToken)
+  tokenCopied.value = true
+  setTimeout(() => { tokenCopied.value = false }, 2000)
+}
+
+// --- Revoke-Dialog-State ---
+const revokeTarget = ref<ApiKeyModel | null>(null)
+const revokeError = ref<string | null>(null)
+
+function openRevokeDialog(key: ApiKeyModel): void {
+  revokeTarget.value = key
+  revokeError.value = null
+}
+
+function closeRevokeDialog(): void {
+  revokeTarget.value = null
+  revokeError.value = null
+}
+
+async function confirmRevoke(): Promise<void> {
+  if (!revokeTarget.value) return
+  revokeError.value = null
+  try {
+    await store.revoke(revokeTarget.value.id)
+    closeRevokeDialog()
+  } catch {
+    revokeError.value = t('settings.v4.apiKeys.errors.revokeFailed')
+  }
+}
+
+// --- Helpers ---
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return t('settings.v4.apiKeys.table.never')
+  return new Date(iso).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+function statusTone(status: ApiKeyModel['status']): 'green' | 'gray' {
+  return status === 'active' ? 'green' : 'gray'
+}
+
+const SCOPES: ApiKeyScope[] = ['read', 'write', 'admin']
+
+onMounted(() => {
+  store.list().catch(() => { /* error set on store.error */ })
+})
 </script>
 
 <template>
@@ -19,9 +124,475 @@ const BREADCRUMBS = [
       :subtitle="t('settings.v4.apiKeys.subtitle')"
     />
 
-    <ComingSoonCard
-      :title="t('settings.v4.apiKeys.empty.title')"
-      :description="t('settings.v4.apiKeys.empty.description')"
-    />
+    <!-- Fehler-Banner beim Laden -->
+    <div v-if="store.error && !store.loading" class="api-keys__error-banner" role="alert">
+      {{ store.error }}
+    </div>
+
+    <!-- Karte 1: Schlüssel anlegen -->
+    <Card :title="t('settings.v4.apiKeys.actions.create')">
+      <template #right>
+        <button class="v4-btn v4-btn--primary" @click="openCreateModal">
+          {{ t('settings.v4.apiKeys.actions.create') }}
+        </button>
+      </template>
+      <p class="api-keys__hint">
+        {{ t('settings.v4.apiKeys.empty.description') }}
+      </p>
+    </Card>
+
+    <!-- Karte 2: Schlüssel-Liste -->
+    <Card
+      :title="t('settings.v4.apiKeys.title')"
+      style="margin-top: 16px;"
+    >
+      <div v-if="store.loading" class="api-keys__loading">
+        {{ t('common.loading') }}
+      </div>
+
+      <div v-else-if="store.items.length === 0" class="api-keys__empty">
+        <p class="api-keys__empty-title">{{ t('settings.v4.apiKeys.empty.title') }}</p>
+        <p class="api-keys__empty-desc">{{ t('settings.v4.apiKeys.empty.description') }}</p>
+      </div>
+
+      <div v-else class="api-keys__table-wrap">
+        <table class="api-keys__table">
+          <thead>
+            <tr>
+              <th>{{ t('settings.v4.apiKeys.table.label') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.prefix') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.scopes') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.status') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.createdAt') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.lastUsedAt') }}</th>
+              <th>{{ t('settings.v4.apiKeys.table.actions') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="key in store.items" :key="key.id">
+              <td>{{ key.label }}</td>
+              <td><code class="api-keys__prefix">{{ key.prefix }}</code></td>
+              <td>
+                <span class="api-keys__scope-list">
+                  <Badge
+                    v-for="scope in key.scopes"
+                    :key="scope"
+                    tone="blue"
+                    :dot="false"
+                  >{{ scope }}</Badge>
+                </span>
+              </td>
+              <td>
+                <Badge :tone="statusTone(key.status)" :dot="true">
+                  {{ t(`settings.v4.apiKeys.status.${key.status}`) }}
+                </Badge>
+              </td>
+              <td>{{ formatDate(key.created_at) }}</td>
+              <td>{{ formatDate(key.last_used_at) }}</td>
+              <td>
+                <button
+                  v-if="key.status === 'active'"
+                  class="v4-btn v4-btn--ghost v4-btn--danger"
+                  @click="openRevokeDialog(key)"
+                >
+                  {{ t('settings.v4.apiKeys.actions.revoke') }}
+                </button>
+                <span v-else class="api-keys__revoked-label">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </Card>
+
+    <!-- Create-Modal -->
+    <Teleport to="body">
+      <div
+        v-if="createModalOpen"
+        class="v4-modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        @click.self="closeCreateModal"
+      >
+        <div class="v4-modal">
+          <!-- Token-Display-Mode nach Erstellung -->
+          <template v-if="store.lastCreatedToken">
+            <h2 class="v4-modal__title">{{ t('settings.v4.apiKeys.created.title') }}</h2>
+            <p class="v4-modal__subtitle v4-modal__warning">
+              {{ t('settings.v4.apiKeys.created.warning') }}
+            </p>
+            <label class="v4-form-label">{{ t('settings.v4.apiKeys.created.tokenLabel') }}</label>
+            <div class="api-keys__token-row">
+              <Input
+                :model-value="store.lastCreatedToken"
+                :mono="true"
+                :disabled="true"
+              />
+              <button class="v4-btn v4-btn--secondary" @click="copyToken">
+                {{ tokenCopied ? t('settings.v4.apiKeys.actions.copied') : t('settings.v4.apiKeys.actions.copy') }}
+              </button>
+            </div>
+            <div class="v4-modal__footer">
+              <button class="v4-btn v4-btn--primary" @click="closeCreateModal">
+                {{ t('settings.v4.apiKeys.actions.close') }}
+              </button>
+            </div>
+          </template>
+
+          <!-- Create-Form-Mode -->
+          <template v-else>
+            <h2 class="v4-modal__title">{{ t('settings.v4.apiKeys.create.modalTitle') }}</h2>
+            <p class="v4-modal__subtitle">{{ t('settings.v4.apiKeys.create.modalSubtitle') }}</p>
+
+            <div class="v4-form-group">
+              <label class="v4-form-label" for="api-key-label">
+                {{ t('settings.v4.apiKeys.create.labelField') }}
+              </label>
+              <Input
+                id="api-key-label"
+                v-model="createLabel"
+                :placeholder="t('settings.v4.apiKeys.create.labelField')"
+              />
+            </div>
+
+            <div class="v4-form-group">
+              <label class="v4-form-label">{{ t('settings.v4.apiKeys.create.scopesField') }}</label>
+              <div class="api-keys__scopes">
+                <label
+                  v-for="scope in SCOPES"
+                  :key="scope"
+                  class="api-keys__scope-check"
+                >
+                  <input
+                    type="checkbox"
+                    :value="scope"
+                    :checked="createScopes.includes(scope)"
+                    @change="toggleScope(scope)"
+                  />
+                  {{ t(`settings.v4.apiKeys.create.scopes.${scope}`) }}
+                </label>
+              </div>
+            </div>
+
+            <div v-if="createError" class="api-keys__form-error" role="alert">
+              {{ createError }}
+            </div>
+
+            <div class="v4-modal__footer">
+              <button
+                class="v4-btn v4-btn--ghost"
+                :disabled="store.creating"
+                @click="closeCreateModal"
+              >
+                {{ t('settings.v4.apiKeys.actions.cancel') }}
+              </button>
+              <button
+                class="v4-btn v4-btn--primary"
+                :disabled="store.creating"
+                @click="submitCreate"
+              >
+                {{ store.creating ? t('common.loading') : t('settings.v4.apiKeys.create.submit') }}
+              </button>
+            </div>
+          </template>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Revoke-Confirm-Dialog -->
+    <Teleport to="body">
+      <div
+        v-if="revokeTarget"
+        class="v4-modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        @click.self="closeRevokeDialog"
+      >
+        <div class="v4-modal v4-modal--narrow">
+          <h2 class="v4-modal__title">{{ t('settings.v4.apiKeys.revoke.modalTitle') }}</h2>
+          <p class="v4-modal__subtitle">{{ t('settings.v4.apiKeys.revoke.modalSubtitle') }}</p>
+          <p class="api-keys__revoke-target">
+            <strong>{{ revokeTarget.label }}</strong>
+            <code class="api-keys__prefix">{{ revokeTarget.prefix }}</code>
+          </p>
+
+          <div v-if="revokeError" class="api-keys__form-error" role="alert">
+            {{ revokeError }}
+          </div>
+
+          <div class="v4-modal__footer">
+            <button class="v4-btn v4-btn--ghost" @click="closeRevokeDialog">
+              {{ t('settings.v4.apiKeys.actions.cancel') }}
+            </button>
+            <button class="v4-btn v4-btn--danger" @click="confirmRevoke">
+              {{ t('settings.v4.apiKeys.revoke.confirm') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </AppShell>
 </template>
+
+<style scoped>
+/* Error Banner */
+.api-keys__error-banner {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: var(--status-red-bg, #fff1f0);
+  color: var(--status-red, #c0392b);
+  border-radius: var(--r-4, 8px);
+  font-size: 14px;
+}
+
+/* Hint text in create card */
+.api-keys__hint {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+/* Loading / Empty state */
+.api-keys__loading,
+.api-keys__empty {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.api-keys__empty-title {
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text-primary);
+}
+
+.api-keys__empty-desc {
+  margin: 0;
+}
+
+/* Table */
+.api-keys__table-wrap {
+  overflow-x: auto;
+}
+
+.api-keys__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.api-keys__table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--separator, #e5e5ea);
+  white-space: nowrap;
+}
+
+.api-keys__table td {
+  padding: 10px 12px;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--hairline, #f2f2f7);
+}
+
+.api-keys__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.api-keys__prefix {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  background: var(--surface-inset, #f2f2f7);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+}
+
+.api-keys__scope-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.api-keys__revoked-label {
+  color: var(--text-tertiary);
+}
+
+/* Modal */
+.v4-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.v4-modal {
+  background: var(--surface-elevated, #fff);
+  border-radius: 16px;
+  padding: 28px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+}
+
+.v4-modal--narrow {
+  max-width: 400px;
+}
+
+.v4-modal__title {
+  margin: 0 0 6px;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.v4-modal__subtitle {
+  margin: 0 0 20px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.v4-modal__warning {
+  color: var(--status-red, #c0392b);
+  background: var(--status-red-bg, #fff1f0);
+  padding: 10px 12px;
+  border-radius: 8px;
+}
+
+.v4-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+/* Form */
+.v4-form-group {
+  margin-bottom: 16px;
+}
+
+.v4-form-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.api-keys__scopes {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.api-keys__scope-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.api-keys__token-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.api-keys__token-row .v4-btn {
+  flex: none;
+}
+
+.api-keys__form-error {
+  padding: 10px 12px;
+  background: var(--status-red-bg, #fff1f0);
+  color: var(--status-red, #c0392b);
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.api-keys__revoke-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+
+/* Buttons — lokale Definitionen (kein globales v4-Btn-System vorhanden) */
+.v4-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--ctl-h-md, 36px);
+  padding: 0 16px;
+  border-radius: var(--r-4, 8px);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: background 120ms ease, opacity 120ms ease;
+  white-space: nowrap;
+}
+
+.v4-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.v4-btn--primary {
+  background: var(--accent, #0071e3);
+  color: #fff;
+}
+
+.v4-btn--primary:hover:not(:disabled) {
+  background: var(--accent-hover, #0077ed);
+}
+
+.v4-btn--secondary {
+  background: var(--surface-inset, #f2f2f7);
+  color: var(--text-primary);
+}
+
+.v4-btn--secondary:hover:not(:disabled) {
+  background: var(--gray-5, #e5e5ea);
+}
+
+.v4-btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.v4-btn--ghost:hover:not(:disabled) {
+  background: var(--surface-inset, #f2f2f7);
+}
+
+.v4-btn--danger {
+  background: var(--status-red, #c0392b);
+  color: #fff;
+}
+
+.v4-btn--danger:hover:not(:disabled) {
+  background: var(--status-red-hover, #a93226);
+}
+
+.v4-btn--ghost.v4-btn--danger {
+  background: transparent;
+  color: var(--status-red, #c0392b);
+}
+
+.v4-btn--ghost.v4-btn--danger:hover:not(:disabled) {
+  background: var(--status-red-bg, #fff1f0);
+}
+</style>

--- a/frontend/src/views/__tests__/SettingsApiKeysView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsApiKeysView.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * SettingsApiKeysView — Smoke-Tests (Slice G2).
+ *
+ * Prüft:
+ *  1. View mountet ohne Crash.
+ *  2. PageHeader erhält lokalisierten Titel.
+ *  3. Breadcrumb enthält "API Keys".
+ *  4. "Schlüssel anlegen"-Button ist sichtbar.
+ *  5. i18n-Keys lösen auf (kein "settings.v4.apiKeys.*"-Rohdot im DOM).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
+
+import de from '@/i18n/locales/de.json'
+import en from '@/i18n/locales/en.json'
+
+// localStorage-Mock
+const localStorageMock = (() => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach((k) => delete store[k]) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// Mock API-Modul — kein echtes HTTP
+vi.mock('@/api/apiKeys', () => ({
+  listApiKeys: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+}))
+
+// Shell-Stubs (identisch mit SettingsSubViews.spec.ts)
+vi.mock('@/components/v4/shell/AppShell.vue', () => ({
+  default: {
+    name: 'AppShell',
+    props: ['breadcrumbs'],
+    template: '<div class="app-shell-stub" data-breadcrumbs="true"><slot /></div>',
+  },
+}))
+vi.mock('@/components/v4/shell/PageHeader.vue', () => ({
+  default: {
+    name: 'PageHeader',
+    props: ['title', 'subtitle'],
+    template: '<div class="page-header-stub"><h1>{{ title }}</h1><p>{{ subtitle }}</p></div>',
+  },
+}))
+
+import SettingsApiKeysView from '../Settings/SettingsApiKeysView.vue'
+
+function makeI18n(locale = 'de') {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: { de, en },
+  })
+}
+
+async function mountView() {
+  const router = makeTestRouter()
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const i18n = makeI18n()
+  await router.push('/settings/api-keys')
+  await router.isReady()
+  const wrapper = mount(SettingsApiKeysView, {
+    global: { plugins: [router, pinia, i18n] },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('SettingsApiKeysView (Slice G2)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('Test 1: mountet ohne Crash', async () => {
+    const w = await mountView()
+    expect(w.exists()).toBe(true)
+  })
+
+  it('Test 2: PageHeader erhält lokalisierten Titel', async () => {
+    const w = await mountView()
+    const header = w.findComponent({ name: 'PageHeader' })
+    expect(header.exists()).toBe(true)
+    expect(header.props('title')).toBe('API-Schlüssel')
+  })
+
+  it('Test 3: Breadcrumb enthält "API Keys"', async () => {
+    const w = await mountView()
+    const shell = w.findComponent({ name: 'AppShell' })
+    const crumbs = shell.props('breadcrumbs') as Array<{ label: string }>
+    expect(crumbs.map((c) => c.label)).toContain('API Keys')
+  })
+
+  it('Test 4: "Schlüssel anlegen"-Button ist sichtbar', async () => {
+    const w = await mountView()
+    const buttons = w.findAll('button')
+    const createBtn = buttons.find((b) => b.text().includes('Schlüssel anlegen'))
+    expect(createBtn).toBeDefined()
+  })
+
+  it('Test 5: keine ungepatchten i18n-Rohkeys im DOM', async () => {
+    const w = await mountView()
+    expect(w.text()).not.toMatch(/settings\.v4\.apiKeys\./)
+  })
+})

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -140,7 +140,10 @@ describe('SettingsIntegrationsView (Slice G1, real)', () => {
   })
 })
 
-describe('SettingsApiKeysView (Slice G1, coming soon)', () => {
+// Slice G2: SettingsApiKeysView ist jetzt real — eigene Smoke-Tests in
+// views/__tests__/SettingsApiKeysView.spec.ts. Dieser Block prüft nur
+// noch, dass kein ComingSoonCard-Stub mehr erscheint.
+describe('SettingsApiKeysView (Slice G2, real)', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('rendert Breadcrumb "API Keys"', async () => {
@@ -150,11 +153,10 @@ describe('SettingsApiKeysView (Slice G1, coming soon)', () => {
     expect(crumbs.map((c) => c.label)).toContain('API Keys')
   })
 
-  it('rendert ComingSoonCard mit lokalisiertem Titel', async () => {
+  it('rendert keine ComingSoonCard mehr (View ist real)', async () => {
     const w = await mountView(SettingsApiKeysView, '/settings/api-keys')
     const card = w.findComponent({ name: 'ComingSoonCard' })
-    expect(card.exists()).toBe(true)
-    expect(card.props('title')).toBe('API-Schlüssel-Verwaltung folgt')
+    expect(card.exists()).toBe(false)
   })
 
   it('zeigt keinen "Slice G folgt"-Stub mehr', async () => {

--- a/schemas/api-key-create-request.schema.json
+++ b/schemas/api-key-create-request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "https://alexle135.de/schemas/api-key-create-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Eingabe f\u00fcr POST /api/api-keys.",
+  "properties": {
+    "label": {
+      "maxLength": 120,
+      "minLength": 1,
+      "title": "Label",
+      "type": "string"
+    },
+    "scopes": {
+      "items": {
+        "enum": [
+          "read",
+          "write",
+          "admin"
+        ],
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Scopes",
+      "type": "array"
+    }
+  },
+  "required": [
+    "label",
+    "scopes"
+  ],
+  "title": "ApiKeyCreateRequest",
+  "type": "object"
+}

--- a/schemas/api-key-create-response.schema.json
+++ b/schemas/api-key-create-response.schema.json
@@ -1,0 +1,110 @@
+{
+  "$defs": {
+    "ApiKeyModel": {
+      "additionalProperties": false,
+      "description": "Persistierte Repr\u00e4sentation eines API-Schl\u00fcssels (ohne Klartext).",
+      "properties": {
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "label": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        },
+        "last_used_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Used At"
+        },
+        "prefix": {
+          "maxLength": 12,
+          "minLength": 12,
+          "pattern": "^ago_[0-9a-f]{8}$",
+          "title": "Prefix",
+          "type": "string"
+        },
+        "revoked_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Revoked At"
+        },
+        "scopes": {
+          "items": {
+            "enum": [
+              "read",
+              "write",
+              "admin"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Scopes",
+          "type": "array"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "revoked"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "prefix",
+        "scopes",
+        "status",
+        "created_at"
+      ],
+      "title": "ApiKeyModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/api-key-create-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Antwort auf POST /api/api-keys \u2014 Klartext-Token erscheint hier genau einmal.",
+  "properties": {
+    "key": {
+      "$ref": "#/$defs/ApiKeyModel"
+    },
+    "token": {
+      "pattern": "^ago_[0-9a-f]{48}$",
+      "title": "Token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "key",
+    "token"
+  ],
+  "title": "ApiKeyCreateResponse",
+  "type": "object"
+}

--- a/schemas/api-key.schema.json
+++ b/schemas/api-key.schema.json
@@ -1,0 +1,88 @@
+{
+  "$id": "https://alexle135.de/schemas/api-key.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Persistierte Repr\u00e4sentation eines API-Schl\u00fcssels (ohne Klartext).",
+  "properties": {
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "id": {
+      "minLength": 1,
+      "title": "Id",
+      "type": "string"
+    },
+    "label": {
+      "maxLength": 120,
+      "minLength": 1,
+      "title": "Label",
+      "type": "string"
+    },
+    "last_used_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Used At"
+    },
+    "prefix": {
+      "maxLength": 12,
+      "minLength": 12,
+      "pattern": "^ago_[0-9a-f]{8}$",
+      "title": "Prefix",
+      "type": "string"
+    },
+    "revoked_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Revoked At"
+    },
+    "scopes": {
+      "items": {
+        "enum": [
+          "read",
+          "write",
+          "admin"
+        ],
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Scopes",
+      "type": "array"
+    },
+    "status": {
+      "enum": [
+        "active",
+        "revoked"
+      ],
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "label",
+    "prefix",
+    "scopes",
+    "status",
+    "created_at"
+  ],
+  "title": "ApiKeyModel",
+  "type": "object"
+}

--- a/schemas/api-keys-list-response.schema.json
+++ b/schemas/api-keys-list-response.schema.json
@@ -1,0 +1,114 @@
+{
+  "$defs": {
+    "ApiKeyModel": {
+      "additionalProperties": false,
+      "description": "Persistierte Repr\u00e4sentation eines API-Schl\u00fcssels (ohne Klartext).",
+      "properties": {
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "label": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        },
+        "last_used_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Used At"
+        },
+        "prefix": {
+          "maxLength": 12,
+          "minLength": 12,
+          "pattern": "^ago_[0-9a-f]{8}$",
+          "title": "Prefix",
+          "type": "string"
+        },
+        "revoked_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Revoked At"
+        },
+        "scopes": {
+          "items": {
+            "enum": [
+              "read",
+              "write",
+              "admin"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Scopes",
+          "type": "array"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "revoked"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "prefix",
+        "scopes",
+        "status",
+        "created_at"
+      ],
+      "title": "ApiKeyModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/api-keys-list-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Antwort auf GET /api/api-keys.",
+  "properties": {
+    "items": {
+      "items": {
+        "$ref": "#/$defs/ApiKeyModel"
+      },
+      "title": "Items",
+      "type": "array"
+    },
+    "total": {
+      "minimum": 0,
+      "title": "Total",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "items",
+    "total"
+  ],
+  "title": "ApiKeysListResponse",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- **Backend (Layer 0 + 1):** Neuer Pydantic-Contract `api_keys_contract` (ApiKey, ApiKeyCreateRequest/Response, ApiKeysListResponse) mit `extra="forbid"`; Service `api_keys_store` als **thread-safe In-Memory-Store** (Single-Workspace-Scope, kein Identity-Modul, keine Persistenz auf Disk — Audit-Log + Disk-Persistenz sind out-of-scope für G2 und kommen in G3); Flask-Route `/api/api-keys` (CRUD) im Standard-Envelope. JSON-Schemas via `dump_schemas` reproduzierbar generiert.
- **Frontend (Layer 4 + 6):** Zod-Spiegel `apiKeysContract`, axios-API-Client mit strict-Parse, Pinia-Store mit Create/List/Revoke, `SettingsApiKeysView.vue` an den Store verdrahtet; i18n-Keys (de + en) gepflegt.
- **Gemini-Followups:** HIGH adressiert (PR-Description korrigiert: In-Memory ist gewollter Slice-Scope). MEDIUM-Fixes nachgepatcht — i18n-Locale statt hardcoded `'de-DE'` in `formatDate`, try/catch um `navigator.clipboard.writeText` mit `copyFailed`-i18n-Key.
- **Tests:** Backend 32/32 passed (Contracts + API). Frontend 689/689 passed inkl. Store-, View- und Subview-Mount-Smokes.

Bestätigt Design-v4 App-Shell-Epic Slice G (Settings) — Sub-Slice G2 baut auf G1 ("SettingsGeneral + SettingsIntegrations real") auf und ersetzt die Mock-View `SettingsApiKeysView` durch echte CRUD-Logik.

## Verify-Gates lokal (alle grün)

| Gate | Resultat |
|---|---|
| `uv run pytest tests/contracts/test_api_keys_contract.py tests/api/test_api_keys_api.py` | 32 passed in 4.13s |
| `uv run ruff check app/ tests/` | All checks passed |
| `uv run mypy app` | Success, no issues found in 151 source files |
| `npm run typecheck` | ✓ |
| `npm test -- --run` | 84 files, 689 passed |
| `npm run lint` | ✓ |
| `npm run build` | built in 4.88s |
| `git diff --exit-code schemas/` | idempotent (Schemas nach dump deterministisch) |
| `bash scripts/sync-status.sh --check` | grün (Backend 2000 / Frontend 84 Test-Files) |

## Architektur-Notiz

- Layer 0 erweitert: Vier neue Contracts + Re-Export aus `app.contracts`.
- Layer 1 ausgebaut: In-Memory-Store trennt Generator-Logik (Token + Prefix) von der Route. **Disk-Persistenz bewusst out-of-scope für G2** — kommt in G3 zusammen mit Audit-Log-Hook.
- Layer 4: Frontend ohne neue Komponenten-Hierarchie — nutzt v4-`SettingsSectionPanel` aus G1.
- Keine OASIS/CAMEL-Berührung, keine Schwächung der Evidence-Gating-Anker (ADR-0002).

## Pre-existing CI-Failure

- `Security scans` failed mit `pillow==12.2.0` ↔ requirements-Konflikt — gleiches Bild auf `origin/main` (siehe Dependabot-Aufräumen aus CLAUDE.md). **Nicht G2-verursacht.**

## Test plan

- [ ] CI `Backend tests + lint`, `Frontend build + lint`, `Pydantic-Contract-Tests`, `Schema-Drift`, `STATUS.md-Drift` grün
- [ ] Playwright-Smokes (Health/Upload/Minimalreport) grün
- [ ] `Security scans` separat (pre-existing, siehe oben)
- [ ] Gemini-Code-Assist Re-Review nach den Followup-Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)