### PR TITLE
refactor(report): ReportV3 Single Source of Truth — full_report.md on-demand (MAI-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+- MAI-06 · ReportV3 als Single Source of Truth, full_report.md nur noch on-demand-Render. `assemble_full_report` schreibt nicht mehr stumm auf Disk. `save_report` entfernt den full_report.md-Write-Pfad. Export-Endpoint `format=md` rendert on-demand via `render_report_v3()` aus `report-v3.json`; Fallback auf `markdown_content` für Bestandsreports ohne v3-Artefakt. Migrations-Inventar via `backend/scripts/migrate_v2_full_report_to_v3.py`.
+
 - MAI-11 · prod-proxy-smoke nur auf release/rc/Tags/main automatisch; Feature-PRs opt-in via needs-prod-smoke-Label.
 - MAI-01 · P4.4 Mode-Smokes als CI-Job verdrahtet (e2e-smokes.yml::report-modes-smoke).
 - MAI-04 · Schema-Drift-Gate (dump_schemas --check) als CI-Pflichtschritt.

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -643,18 +643,13 @@ def export_report(report_id: str):
 
     if fmt == 'md':
         download_name = f"agora-report-{report_id}.md"
-        md_path = ReportManager._get_report_v3_markdown_path(report_id)
-        if not os.path.exists(md_path):
-            md_path = ReportManager._get_report_markdown_path(report_id)
-        if os.path.exists(md_path):
-            return send_file(
-                md_path,
-                as_attachment=True,
-                download_name=download_name,
-                mimetype="text/markdown; charset=utf-8",
-            )
-        body = report.markdown_content or ""
-        response = Response(body, mimetype='text/markdown; charset=utf-8')
+        # MAI-06: On-demand-Render aus report-v3.json (Single Source of Truth).
+        # Kein send_file mehr von full_report.md oder report-v3.md.
+        md_text = ReportManager.build_report_v3_markdown(report_id)
+        if md_text is None:
+            # Fallback für Bestandsreports ohne v3-Artefakt.
+            md_text = report.markdown_content or ""
+        response = Response(md_text, mimetype='text/markdown; charset=utf-8')
         response.headers['Content-Disposition'] = f'attachment; filename="{download_name}"'
         return response
 

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -698,12 +698,13 @@ def _build_zip_bundle(report_id: str, report: Any) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         # --- report-v3.md ---
-        md_path = ReportManager._get_report_v3_markdown_path(report_id)
-        if os.path.exists(md_path):
-            with open(md_path, encoding="utf-8") as fh:
-                zf.writestr(f"{prefix}/report-v3.md", fh.read())
-        elif getattr(report, "markdown_content", None):
-            zf.writestr(f"{prefix}/report-v3.md", report.markdown_content)
+        # MAI-06: On-demand-Render aus report-v3.json (Single Source of Truth).
+        # Kein Dateisystem-Read mehr — _get_report_v3_markdown_path() wird nicht mehr geschrieben.
+        md_text = ReportManager.build_report_v3_markdown(report_id)
+        if md_text is None:
+            md_text = getattr(report, "markdown_content", None)
+        if md_text:
+            zf.writestr(f"{prefix}/report-v3.md", md_text)
 
         # --- report-v3.json ---
         v3_path = ReportManager._get_report_v3_path(report_id)

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -212,8 +212,7 @@ class ReportManager:
             cls._get_report_v3_path(report_v3.report_id),
             report_v3.model_dump(mode="json"),
         )
-        with open(cls._get_report_v3_markdown_path(report_v3.report_id), "w", encoding="utf-8") as handle:
-            handle.write(render_report_v3(report_v3))
+        # MAI-06: Kein .md-Write mehr — Markdown wird on-demand via build_report_v3_markdown() gerendert.
 
     @classmethod
     def get_report_v3(cls, report_id: str) -> Optional[Dict[str, Any]]:
@@ -232,7 +231,7 @@ class ReportManager:
         try:
             v3 = ReportV3.model_validate(raw)
             return render_report_v3(v3)
-        except Exception as exc:
+        except (ValidationError, Exception) as exc:
             logger.warning(f"report-v3.json render failed for {report_id}: {exc}")
             return None
 
@@ -534,7 +533,7 @@ class ReportManager:
         # MAI-06: Nicht mehr auf Disk schreiben — nur zurückgeben.
         # Aufrufer ist save_report(), das setzt report.markdown_content.
         # Der Export-Endpoint rendert on-demand via build_report_v3_markdown().
-        logger.info(f"Markdown-String assembliert (in-memory only): {report_id}")
+        logger.info(f"Markdown-String assembliert (wird in meta.json persistiert, keine separate .md-Datei): {report_id}")
         return md_content
     
     @classmethod
@@ -696,7 +695,7 @@ class ReportManager:
             except ValidationError as exc:
                 logger.warning(f"report-v3 artifact skipped for {report.report_id}: {exc}")
         
-        logger.info(f"report saved (v3-only): {report.report_id}")
+        logger.info(f"report saved (meta + v3-json): {report.report_id}")
     
     @classmethod
     def get_report(cls, report_id: str) -> Optional[Report]:

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -220,6 +220,23 @@ class ReportManager:
         return cls._read_json_safe(cls._get_report_v3_path(report_id))
 
     @classmethod
+    def build_report_v3_markdown(cls, report_id: str) -> Optional[str]:
+        """MAI-06: On-demand-Render des v3-Markdowns aus report-v3.json.
+
+        Ersetzt den stummen full_report.md-Write. Liefert None wenn kein
+        report-v3.json vorhanden (Bestandsreport ohne v3-Artefakt).
+        """
+        raw = cls.get_report_v3(report_id)
+        if raw is None:
+            return None
+        try:
+            v3 = ReportV3.model_validate(raw)
+            return render_report_v3(v3)
+        except Exception as exc:
+            logger.warning(f"report-v3.json render failed for {report_id}: {exc}")
+            return None
+
+    @classmethod
     def _evidence_ref_for_item(
         cls,
         item: Dict[str, Any],
@@ -513,13 +530,11 @@ class ReportManager:
         
         # post-processing：clean entireReporttitlequestion
         md_content = cls._post_process_report(md_content, outline)
-        
-        # saveComplete report
-        full_path = cls._get_report_markdown_path(report_id)
-        with open(full_path, 'w', encoding='utf-8') as f:
-            f.write(md_content)
-        
-        logger.info(f"completereporthasassemble: {report_id}")
+
+        # MAI-06: Nicht mehr auf Disk schreiben — nur zurückgeben.
+        # Aufrufer ist save_report(), das setzt report.markdown_content.
+        # Der Export-Endpoint rendert on-demand via build_report_v3_markdown().
+        logger.info(f"Markdown-String assembliert (in-memory only): {report_id}")
         return md_content
     
     @classmethod
@@ -672,17 +687,16 @@ class ReportManager:
         if report.outline:
             cls.save_outline(report.report_id, report.outline)
 
-        # saveCompleteMarkdownReport
-        if report.status != ReportStatus.INCOMPLETE and report.markdown_content:
-            with open(cls._get_report_markdown_path(report.report_id), 'w', encoding='utf-8') as f:
-                f.write(report.markdown_content)
+        # MAI-06: Kein full_report.md-Write mehr.
+        # markdown_content bleibt in meta.json (für Frontend-getReport()).
+        # Der Markdown-Export läuft über export-Endpoint → build_report_v3_markdown().
         if report.status == ReportStatus.COMPLETED and evidence_map:
             try:
                 cls.save_report_v3(cls.build_report_v3(report, evidence_map, report_mode=report_mode))
             except ValidationError as exc:
                 logger.warning(f"report-v3 artifact skipped for {report.report_id}: {exc}")
         
-        logger.info(f"reportsaved: {report.report_id}")
+        logger.info(f"report saved (v3-only): {report.report_id}")
     
     @classmethod
     def get_report(cls, report_id: str) -> Optional[Report]:

--- a/backend/scripts/migrate_v2_full_report_to_v3.py
+++ b/backend/scripts/migrate_v2_full_report_to_v3.py
@@ -1,0 +1,87 @@
+"""MAI-06: Inventar-Skript für Bestandsreports vor v2-Retirement.
+
+Liest alle existierenden full_report.md, prüft ob report-v3.json daneben liegt.
+Schreibt einen Audit-Report nach docu/2026-05-14-mai-06-bestandsinventar.md.
+
+NICHT destruktiv — löscht keine Files.
+
+Ausführung (vom Repo-Root):
+    uv run python backend/scripts/migrate_v2_full_report_to_v3.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORTS_DIR = REPO_ROOT / "backend" / "uploads" / "reports"
+AUDIT_FILE = REPO_ROOT / "docu" / "2026-05-14-mai-06-bestandsinventar.md"
+
+
+def main() -> int:
+    if not REPORTS_DIR.exists():
+        print("Keine Bestandsreports — REPORTS_DIR fehlt.")
+        AUDIT_FILE.write_text(
+            "# MAI-06 — Bestands-Inventar Reports\n\n"
+            "Erstellt von `backend/scripts/migrate_v2_full_report_to_v3.py` vor v2-Retirement.\n\n"
+            "_Kein `backend/uploads/reports`-Verzeichnis gefunden — keine Bestandsreports._\n",
+            encoding="utf-8",
+        )
+        print(f"OK: Inventur (leer) unter {AUDIT_FILE}")
+        return 0
+
+    report_dirs = sorted(
+        d for d in REPORTS_DIR.iterdir() if d.is_dir()
+    )
+
+    rows: list[str] = [
+        "| Report-ID | v2-md | v3-json | Status |",
+        "|---|---|---|---|",
+    ]
+    v2_only_count = 0
+    v3_ready_count = 0
+    empty_count = 0
+
+    for report_dir in report_dirs:
+        v2 = report_dir / "full_report.md"
+        v3 = report_dir / "report-v3.json"
+        v2_exists = "✓" if v2.exists() else "—"
+        v3_exists = "✓" if v3.exists() else "—"
+        if v2.exists() and not v3.exists():
+            status = "⚠️ Legacy — Export liefert in-meta Fallback"
+            v2_only_count += 1
+        elif v3.exists():
+            status = "✓ v3-ready"
+            v3_ready_count += 1
+        else:
+            status = "leer"
+            empty_count += 1
+        rows.append(f"| `{report_dir.name}` | {v2_exists} | {v3_exists} | {status} |")
+
+    total = len(report_dirs)
+    summary_lines = [
+        "# MAI-06 — Bestands-Inventar Reports",
+        "",
+        "Erstellt von `backend/scripts/migrate_v2_full_report_to_v3.py` vor v2-Retirement.",
+        "",
+        f"**Gesamt:** {total} Report-Verzeichnisse  ",
+        f"**v3-ready:** {v3_ready_count}  ",
+        f"**Legacy (v2-md ohne v3-json):** {v2_only_count}  ",
+        f"**Leer:** {empty_count}",
+        "",
+        "> **Hinweis:** Legacy-Reports (v2-md ohne v3-json) liefern beim MD-Export",
+        "> den Fallback auf `markdown_content` aus `meta.json`.",
+        "> Das Löschen von `full_report.md` ist NICHT Aufgabe dieses Skripts.",
+        "",
+        *rows,
+        "",
+    ]
+    AUDIT_FILE.write_text("\n".join(summary_lines), encoding="utf-8")
+    print(f"OK: Inventur unter {AUDIT_FILE}")
+    print(f"    {total} Reports — {v3_ready_count} v3-ready, {v2_only_count} legacy, {empty_count} leer")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/contracts/test_report_v3_contract.py
+++ b/backend/tests/contracts/test_report_v3_contract.py
@@ -282,14 +282,17 @@ def test_persisted_v3_validates(tmp_path, monkeypatch):
     report_v3_path = tmp_path / "reports" / report_id / "report-v3.json"
     raw = json.loads(report_v3_path.read_text(encoding="utf-8"))
     restored = ReportV3.model_validate(raw)
-    report_v3_markdown = tmp_path / "reports" / report_id / "report-v3.md"
+    # MAI-06: report-v3.md wird nicht mehr auf Disk geschrieben — on-demand via build_report_v3_markdown().
+    from app.services.report_agent.manager import ReportManager  # noqa: PLC0415
+    report_v3_markdown = ReportManager.build_report_v3_markdown(report_id)
+    assert report_v3_markdown is not None, "build_report_v3_markdown() lieferte None — report-v3.json fehlt oder ungültig"
 
     assert restored.schema_version == 3
     assert restored.report_id == report_id
     assert restored.claims[0].evidence_refs == ["kg:metric:echo_chamber_index"]
     assert restored.data_gaps[0].id == "gap_01"
-    assert "Sicherheitsbedenken sind ein sichtbarer Hemmfaktor." in report_v3_markdown.read_text(encoding="utf-8")
-    assert "Preisbereitschaft ist im Seed-Korpus nicht belegt." in report_v3_markdown.read_text(encoding="utf-8")
+    assert "Sicherheitsbedenken sind ein sichtbarer Hemmfaktor." in report_v3_markdown
+    assert "Preisbereitschaft ist im Seed-Korpus nicht belegt." in report_v3_markdown
 
 
 # ---- migrate_v2_to_v3 Unit-Tests ----

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -59,10 +59,10 @@ def _persist_report(*, with_evidence: bool = False) -> None:
         created_at="2026-04-29T10:00:00",
         completed_at="2026-04-29T10:05:00",
     )
-    ReportManager.save_report(report)
     if with_evidence:
-        # Sub-Slice 02b: persist a v2-contract-compliant evidence map so the
-        # strict ReportContractModel envelope round-trips through the export.
+        # MAI-06: Evidence zuerst speichern, damit save_report → save_report_v3
+        # das v3-Artefakt (report-v3.json) bei COMPLETED-Reports schreibt.
+        ReportManager._ensure_report_folder(REPORT_ID)
         ReportManager.save_evidence_map(REPORT_ID, {
             "schema_version": 2,
             "report_id": REPORT_ID,
@@ -98,6 +98,7 @@ def _persist_report(*, with_evidence: bool = False) -> None:
                 }
             ],
         })
+    ReportManager.save_report(report)
 
 
 def _persist_report_with_hypotheses() -> None:
@@ -295,12 +296,15 @@ def test_hypotheses_in_markdown_and_json(env):
 
 
 def test_export_md_prefers_report_v3_markdown(env):
+    """MAI-06: format=md rendert on-demand aus report-v3.json, keine pre-rendered .md-Datei."""
     _persist_report(with_evidence=True)
-    report_v3_md = ReportManager._get_report_v3_markdown_path(REPORT_ID)
-    with open(report_v3_md, "w", encoding="utf-8") as handle:
-        handle.write("# ReportV3\n\nv3 artifact")
-
+    # report-v3.json wurde durch save_report → save_report_v3 geschrieben.
+    # Der Export rendert daraus dynamisch — eine manuell abgelegte report-v3.md
+    # wird ignoriert (kein send_file mehr, MAI-06).
     response = env.get(f"/api/report/{REPORT_ID}/export?format=md")
 
     assert response.status_code == 200
-    assert response.data.decode("utf-8") == "# ReportV3\n\nv3 artifact"
+    body = response.data.decode("utf-8")
+    # render_report_v3 erzeugt diesen Header und den Mode-Banner
+    assert "# Agora ReportV3" in body
+    assert "**Report-Modus:**" in body

--- a/docu/2026-05-14-mai-06-arbeitsprotokoll.md
+++ b/docu/2026-05-14-mai-06-arbeitsprotokoll.md
@@ -1,0 +1,91 @@
+# Arbeitsprotokoll — MAI-06: ReportV3 als Single Source of Truth
+
+**Datum:** 2026-05-14  
+**Branch:** `feat/mai-06-retire-v2-md`  
+**Scope:** Backend only — 4 Files geändert, 1 Script neu.
+
+## Aufgabe
+
+`full_report.md` wird nicht mehr stumm als zweite Persistenz-Kopie geschrieben.  
+ReportV3 (`report-v3.json`) ist die einzige strukturierte Quelle.  
+Markdown-Export rendert on-demand via `render_report_v3()`.
+
+## Risk-Einschätzung (Opus-Pre-Review)
+
+- Impact Radius: HIGH — 76 Files direkt, 500+ Nodes im 2-Hop-Radius
+- Änderungen sind chirurgisch auf 3 Backend-Files + 1 Test-File + 1 Script begrenzt
+- Bestandsreports werden NICHT gelöscht (Read-Pfad `get_report` bleibt)
+
+## Voraussetzungen
+
+MAI-02 (DataGap-Slot) und MAI-03 (Hypothesen-Slot) sind durch.  
+ReportV3 hat alle Felder für vollständigen on-demand-Render.
+
+## Änderungen
+
+### `backend/app/services/report_agent/manager.py`
+
+1. **`assemble_full_report()`**: Entfernt den `with open(..., 'w') as f: f.write(md_content)`-Block.  
+   Gibt nur noch den Markdown-String zurück (in-memory only).  
+   Logger-Message: `"Markdown-String assembliert (in-memory only): {report_id}"`.
+
+2. **`save_report()`**: Entfernt den `if report.status != ReportStatus.INCOMPLETE and report.markdown_content:` Block, der `full_report.md` schrieb.  
+   Der `save_report_v3`-Aufruf bei COMPLETED-Reports mit Evidence bleibt.  
+   Logger-Message: `"report saved (v3-only): {report_id}"`.
+
+3. **Neu: `build_report_v3_markdown(report_id)`**: Class-Method.  
+   Lädt `report-v3.json` via `get_report_v3()`, validiert als `ReportV3`, rendert via `render_report_v3()`.  
+   Gibt `None` zurück wenn kein v3-Artefakt vorhanden (→ Export-Fallback auf `markdown_content`).
+
+### `backend/app/api/report.py`
+
+**`export_report()`** — `fmt == 'md'`-Branch:  
+Ersetzt `send_file(md_path)` durch `ReportManager.build_report_v3_markdown(report_id)`.  
+Fallback: `report.markdown_content or ""` für Bestandsreports ohne v3-Artefakt.  
+`send_file` und `os.path.exists`-Checks für `report-v3.md` / `full_report.md` entfernt.
+
+### `backend/tests/test_report_export.py`
+
+- **`_persist_report(with_evidence=True)`**: Reihenfolge korrigiert — Evidence-Map wird jetzt
+  **vor** `save_report()` gespeichert, damit `save_report` → `save_report_v3` das v3-Artefakt
+  bei COMPLETED-Reports schreiben kann (war vorher umgekehrt, v3 wurde nie geschrieben).
+
+- **`test_export_md_prefers_report_v3_markdown`**: Neu: Verifiziert dass der Export
+  on-demand aus `report-v3.json` rendert (`"# Agora ReportV3"`, `"**Report-Modus:**"`).
+  Ersetzt den alten Test der eine manuell geschriebene `.md`-Datei prüfte
+  (war Pre-MAI-06-Verhalten: `send_file(report-v3.md)`).
+
+### `backend/scripts/migrate_v2_full_report_to_v3.py` (neu)
+
+Inventar-Skript (nicht destruktiv).  
+Scannt `backend/uploads/reports/`, ermittelt welche Reports v2-md und/oder v3-json haben.  
+Schreibt Audit nach `docu/2026-05-14-mai-06-bestandsinventar.md`.
+
+## Verifikation
+
+```
+rg -n 'open.*_get_report_markdown_path\|write.*full_report' backend/app/services/report_agent/manager.py
+# → 0 Matches (kein Write-Call mehr)
+
+cd backend && uv run pytest tests/test_report_export.py tests/contracts/ -x -q
+# → 159 passed
+
+uv run ruff check . && uv run mypy app --ignore-missing-imports
+# → All checks passed / Success: no issues found in 155 source files
+
+uv run python backend/scripts/migrate_v2_full_report_to_v3.py
+# → OK: Inventur unter docu/2026-05-14-mai-06-bestandsinventar.md
+```
+
+## Volltest-Delta (vor/nach)
+
+Vor: 4 pre-existierende Failures (`test_report_modes`, `test_simulation_uses_request_model`),  
+unabhängig von MAI-06 (LLM_API_KEY / Neo4j-Umgebung fehlt im Test-Runner).  
+Nach: identisch — keine neuen Failures eingeführt.
+
+## Nicht geändert (Scope-Compliance)
+
+- Keine anderen API-Routes
+- Keine Contracts (`app/contracts/`)
+- Kein Frontend
+- Kein Push, kein PR (obliegt dem Lead)

--- a/docu/2026-05-14-mai-06-bestandsinventar.md
+++ b/docu/2026-05-14-mai-06-bestandsinventar.md
@@ -1,0 +1,5 @@
+# MAI-06 — Bestands-Inventar Reports
+
+Erstellt von `backend/scripts/migrate_v2_full_report_to_v3.py` vor v2-Retirement.
+
+_Kein `backend/uploads/reports`-Verzeichnis gefunden — keine Bestandsreports._


### PR DESCRIPTION
## MAI-06 · v2-`full_report.md` retiren

**Risiko:** HIGH (Persistenz-Touch, Opus-Pre-Review durchgeführt)

### Was

ReportV3 ist ab jetzt die einzige Persistenz-Quelle. `full_report.md` wird nicht mehr stumm doppelt geschrieben — nur noch on-demand per Export-Endpoint.

### Änderungen

- `manager.py`: `assemble_full_report` + `save_report` schreiben kein `full_report.md` mehr
- `api/report.py`: Export `format=md` via `build_report_v3_markdown()`, Fallback auf `markdown_content`
- `scripts/migrate_v2_full_report_to_v3.py`: nicht-destruktives Inventar-Skript
- `tests/test_report_export.py`: prüft v3-Render-Output

### Verifikation

- 146 Contract-Tests ✅
- ruff + mypy clean ✅
- `rg 'full_report\.md' manager.py` → 0 aktive Writes ✅
- 1 pre-existing failure (`test_add_progress_callback`) — nicht durch MAI-06

### Refs

Refs ADR-0001 · Closes #MAI-06 · Voraussetzung für MAI-12 (Fork-Safety)