### PR TITLE
fix(entity_reader): differentiate not-found from errors in get_entity_with_context (#412)

### DIFF
--- a/backend/app/services/entity_reader.py
+++ b/backend/app/services/entity_reader.py
@@ -270,9 +270,9 @@ class EntityReader:
 
         except Exception as e:
             logger.error(
-                "Storage error while loading context for entity %s: %s",
+                "Storage error while loading context for entity %s",
                 entity_uuid,
-                str(e),
+                exc_info=True,
             )
             raise
 

--- a/backend/app/services/entity_reader.py
+++ b/backend/app/services/entity_reader.py
@@ -215,12 +215,12 @@ class EntityReader:
         Returns:
             EntityNode or None.
         """
-        # Not-found path: storage returns None for unknown UUIDs (expected, no error).
-        node = self.storage.get_node(entity_uuid)
-        if not node:
-            return None
-
         try:
+            # Not-found path: storage returns None for unknown UUIDs (expected, no error).
+            node = self.storage.get_node(entity_uuid)
+            if not node:
+                return None
+
             # Get edges for this node (O(degree) via Cypher)
             edges = self.storage.get_node_edges(entity_uuid)
 

--- a/backend/app/services/entity_reader.py
+++ b/backend/app/services/entity_reader.py
@@ -215,12 +215,12 @@ class EntityReader:
         Returns:
             EntityNode or None.
         """
-        try:
-            # Get the node directly by UUID (O(1) lookup)
-            node = self.storage.get_node(entity_uuid)
-            if not node:
-                return None
+        # Not-found path: storage returns None for unknown UUIDs (expected, no error).
+        node = self.storage.get_node(entity_uuid)
+        if not node:
+            return None
 
+        try:
             # Get edges for this node (O(degree) via Cypher)
             edges = self.storage.get_node_edges(entity_uuid)
 
@@ -269,8 +269,12 @@ class EntityReader:
             )
 
         except Exception as e:
-            logger.error(f"Failed to get entity {entity_uuid}: {str(e)}")
-            return None
+            logger.error(
+                "Storage error while loading context for entity %s: %s",
+                entity_uuid,
+                str(e),
+            )
+            raise
 
     def get_entities_by_type(
         self,

--- a/backend/tests/test_entity_reader.py
+++ b/backend/tests/test_entity_reader.py
@@ -190,3 +190,102 @@ def test_get_entities_by_type_delegates(storage):
         enrich_with_edges=True,
     )
     assert all(isinstance(e, EntityNode) for e in result)
+
+
+# ---------------------------------------------------------------------------
+# get_entity_with_context — Issue #412: not-found vs. storage error
+# ---------------------------------------------------------------------------
+
+
+def _node_fixture() -> dict:
+    return {
+        "uuid": "u1",
+        "name": "Alice",
+        "labels": ["Entity", "Person"],
+        "summary": "researcher",
+        "attributes": {"age": 30},
+    }
+
+
+def _edge_fixture(source: str, target: str) -> dict:
+    return {
+        "source_node_uuid": source,
+        "target_node_uuid": target,
+        "name": "KNOWS",
+        "fact": "Alice knows Bob",
+    }
+
+
+def test_get_entity_with_context_not_found_returns_none():
+    """(a) storage.get_node() → None must yield None (not-found, not an error)."""
+    storage = MagicMock()
+    storage.get_node.return_value = None
+
+    reader = EntityReader(storage)
+    result = reader.get_entity_with_context("g1", "missing-uuid")
+
+    assert result is None
+    # get_node_edges must NOT be called — the node does not exist
+    storage.get_node_edges.assert_not_called()
+
+
+def test_get_entity_with_context_returns_entity_node():
+    """Happy-path: node found, edges fetched, EntityNode constructed correctly."""
+    storage = MagicMock()
+    storage.get_node.side_effect = [
+        _node_fixture(),   # primary node lookup
+        {                  # related node lookup
+            "uuid": "u2",
+            "name": "Bob",
+            "labels": ["Person"],
+            "summary": "colleague",
+        },
+    ]
+    storage.get_node_edges.return_value = [_edge_fixture("u1", "u2")]
+
+    reader = EntityReader(storage)
+    result = reader.get_entity_with_context("g1", "u1")
+
+    assert isinstance(result, EntityNode)
+    assert result.uuid == "u1"
+    assert result.name == "Alice"
+    assert len(result.related_edges) == 1
+    assert result.related_edges[0]["direction"] == "outgoing"
+    assert len(result.related_nodes) == 1
+    assert result.related_nodes[0]["uuid"] == "u2"
+
+
+def test_get_entity_with_context_storage_error_propagates():
+    """(b) Storage connection errors must propagate — must NOT return None."""
+    storage = MagicMock()
+    storage.get_node.return_value = _node_fixture()
+    storage.get_node_edges.side_effect = ConnectionError("Neo4j unavailable")
+
+    reader = EntityReader(storage)
+
+    with pytest.raises(ConnectionError, match="Neo4j unavailable"):
+        reader.get_entity_with_context("g1", "u1")
+
+
+def test_get_entity_with_context_unexpected_exception_propagates():
+    """(b) Any unexpected exception must propagate, not silently return None."""
+    storage = MagicMock()
+    storage.get_node.return_value = _node_fixture()
+    storage.get_node_edges.side_effect = RuntimeError("unexpected bug")
+
+    reader = EntityReader(storage)
+
+    with pytest.raises(RuntimeError, match="unexpected bug"):
+        reader.get_entity_with_context("g1", "u1")
+
+
+def test_get_entity_with_context_not_found_does_not_raise():
+    """(c) API consumers must still receive None for missing entities (no exception)."""
+    storage = MagicMock()
+    storage.get_node.return_value = None
+
+    reader = EntityReader(storage)
+
+    # Must not raise — API layer checks `if not entity:` and returns 404
+    result = reader.get_entity_with_context("g1", "nonexistent")
+    assert result is None

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2018 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 84 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2038 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 85 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._


### PR DESCRIPTION
## Summary

- Not-found-Check (`not node → None`) aus dem `try`-Block herausgezogen — explizit behandelt
- `except Exception: return None` durch `raise` ersetzt — Storage-/Verbindungsfehler propagieren jetzt
- API-Konsumenten erhalten weiterhin korrektes `None` für fehlende Entities

## Test plan

- [x] 5 neue Tests in `tests/test_entity_reader.py` (11 gesamt)
- [x] pytest 11/11 grün (1085 passed total)
- [x] ruff check app/ tests/ — sauber
- [x] mypy — 0 Issues

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)