### PR TITLE
feat(frontend): Pflicht-Prompt-Feld in HeroNewRun + LlmProviderCard in Settings

### DIFF
--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -70,6 +70,7 @@ function removeLocal(key: string): void {
 
 const modelOption = ref<string>(readLocal(STORAGE_MODEL) || 'default')
 const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
+const simulationRequirement = ref('')
 
 const modelOptions = computed<ModelOption[]>(() => {
   const opts: ModelOption[] = [
@@ -83,7 +84,9 @@ const modelOptions = computed<ModelOption[]>(() => {
   return opts
 })
 
-const canSubmit = computed(() => files.value.length > 0 && !loadingStatus.value)
+const canSubmit = computed(
+  () => files.value.length > 0 && simulationRequirement.value.trim() !== '' && !loadingStatus.value,
+)
 
 async function loadStatus() {
   loadingStatus.value = true
@@ -178,7 +181,7 @@ async function startSimulation() {
     writeLocal(STORAGE_MODEL, modelOption.value)
     writeLocal(STORAGE_LANG, language.value)
     removeLocal(STORAGE_CUSTOM_MODEL)
-    setPendingUpload(files.value, '')
+    setPendingUpload(files.value, simulationRequirement.value.trim())
     router.push({ name: 'Process', params: { projectId: 'new' } })
   } catch (e) {
     errorMsg.value = e instanceof Error ? e.message : String(e)
@@ -262,6 +265,19 @@ onMounted(() => void loadStatus())
             <option value="de">Deutsch</option>
             <option value="en">English</option>
           </select>
+        </div>
+        <div class="hero-field hero-field--full">
+          <label class="hero-label" for="hero-requirement">
+            {{ $t('dashboard.hero.requirementLabel') }}
+            <span class="hero-required">*</span>
+          </label>
+          <textarea
+            id="hero-requirement"
+            v-model="simulationRequirement"
+            class="hero-textarea"
+            :placeholder="$t('dashboard.hero.requirementPlaceholder')"
+            rows="3"
+          />
         </div>
       </div>
 
@@ -531,5 +547,31 @@ onMounted(() => void loadStatus())
   .hero-file__remove {
     transition: none;
   }
+}
+
+.hero-field--full {
+  grid-column: 1 / -1;
+}
+.hero-required {
+  color: var(--status-red, #c0392b);
+  margin-left: 2px;
+}
+.hero-textarea {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-primary);
+  resize: vertical;
+  min-height: 72px;
+  line-height: 1.5;
+}
+.hero-textarea:hover { border-color: var(--hairline-strong); }
+.hero-textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 </style>

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -42,7 +42,22 @@ describe('HeroNewRun', () => {
     expect(btn.attributes('disabled')).toBeDefined()
   })
 
-  it('aktiviert CTA nach Datei-Upload und navigiert zu /process/new', async () => {
+  it('CTA bleibt deaktiviert mit Datei aber ohne Requirement', async () => {
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(HeroNewRun, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(w.find('.hero-cta').attributes('disabled')).toBeDefined()
+  })
+
+  it('aktiviert CTA und startet nach Datei + Requirement', async () => {
     const router = makeRouter()
     await router.push('/dashboard')
     const pushSpy = vi.spyOn(router, 'push')
@@ -55,12 +70,19 @@ describe('HeroNewRun', () => {
     await input.trigger('change')
     await flushPromises()
 
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
     const btn = w.find('.hero-cta')
     expect(btn.attributes('disabled')).toBeUndefined()
     await btn.trigger('click')
     await flushPromises()
 
-    expect(setPendingUpload).toHaveBeenCalledTimes(1)
+    expect(setPendingUpload).toHaveBeenCalledWith(
+      [file],
+      'Wie reagiert die DACH-Region?',
+    )
     expect(pushSpy).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
   })
 })

--- a/frontend/src/components/v4/forms/LlmProviderCard.vue
+++ b/frontend/src/components/v4/forms/LlmProviderCard.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Card from './Card.vue'
+import { useSettingsStore } from '@/store/settings'
+
+const { t } = useI18n()
+const store = useSettingsStore()
+
+interface Preset {
+  key: string
+  label: string
+  url: string
+  needsKey: boolean
+}
+
+const PRESETS: Preset[] = [
+  { key: 'ollama',     label: t('settings.v4.llmProvider.presets.ollama'),     url: 'http://localhost:11434/v1',                               needsKey: false },
+  { key: 'openai',    label: t('settings.v4.llmProvider.presets.openai'),    url: 'https://api.openai.com/v1',                               needsKey: true  },
+  { key: 'gemini',    label: t('settings.v4.llmProvider.presets.gemini'),    url: 'https://generativelanguage.googleapis.com/v1beta/openai', needsKey: true  },
+  { key: 'anthropic', label: t('settings.v4.llmProvider.presets.anthropic'), url: 'https://api.anthropic.com/v1',                            needsKey: true  },
+  { key: 'custom',    label: t('settings.v4.llmProvider.presets.custom'),    url: '',                                                        needsKey: false },
+]
+
+const currentUrl = computed(() => (store.draft['LLM_BASE_URL'] as string) ?? '')
+const activePreset = computed(
+  () => PRESETS.find(p => p.url !== '' && p.url === currentUrl.value) ?? PRESETS[4],
+)
+
+const baseUrl = computed({
+  get: () => currentUrl.value,
+  set: (v: string) => { store.draft['LLM_BASE_URL'] = v },
+})
+const apiKey = computed({
+  get: () => (store.draft['LLM_API_KEY'] as string) ?? '',
+  set: (v: string) => { store.draft['LLM_API_KEY'] = v },
+})
+const modelName = computed({
+  get: () => (store.draft['LLM_MODEL_NAME'] as string) ?? '',
+  set: (v: string) => { store.draft['LLM_MODEL_NAME'] = v },
+})
+
+const saving    = ref(false)
+const savedHint = ref(false)
+const saveError = ref<string | null>(null)
+
+function selectPreset(preset: Preset): void {
+  store.draft['LLM_BASE_URL'] = preset.url
+  if (!preset.needsKey) store.draft['LLM_API_KEY'] = ''
+}
+
+async function save(): Promise<void> {
+  saving.value    = true
+  savedHint.value = false
+  saveError.value = null
+  try {
+    await store.saveSettings({ confirmSecrets: true })
+    savedHint.value = true
+    setTimeout(() => { savedHint.value = false }, 2500)
+  } catch (e) {
+    saveError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <Card :title="t('settings.v4.llmProvider.title')" :subtitle="t('settings.v4.llmProvider.subtitle')">
+    <!-- Preset-Auswahl -->
+    <div class="llm-presets">
+      <button
+        v-for="p in PRESETS"
+        :key="p.key"
+        type="button"
+        class="llm-preset"
+        :class="{ 'llm-preset--active': activePreset.key === p.key }"
+        @click="selectPreset(p)"
+      >
+        {{ p.label }}
+      </button>
+    </div>
+
+    <div class="llm-fields">
+      <!-- Base URL -->
+      <div class="llm-field">
+        <label class="llm-label" for="llm-base-url">{{ t('settings.v4.llmProvider.baseUrlLabel') }}</label>
+        <input
+          id="llm-base-url"
+          v-model="baseUrl"
+          type="text"
+          class="llm-input"
+          :placeholder="activePreset.url || 'https://...'"
+        />
+      </div>
+
+      <!-- API Key (nur wenn nötig) -->
+      <div v-if="activePreset.needsKey || activePreset.key === 'custom'" class="llm-field">
+        <label class="llm-label" for="llm-api-key">{{ t('settings.v4.llmProvider.apiKeyLabel') }}</label>
+        <input
+          id="llm-api-key"
+          v-model="apiKey"
+          type="password"
+          class="llm-input llm-input--mono"
+          placeholder="sk-…"
+          autocomplete="off"
+        />
+      </div>
+
+      <!-- Modell -->
+      <div class="llm-field">
+        <label class="llm-label" for="llm-model">{{ t('settings.v4.llmProvider.modelLabel') }}</label>
+        <input
+          id="llm-model"
+          v-model="modelName"
+          type="text"
+          class="llm-input"
+          placeholder="qwen2.5:32b"
+        />
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="llm-footer">
+      <span v-if="savedHint" class="llm-saved">{{ t('settings.v4.llmProvider.savedHint') }}</span>
+      <span v-if="saveError" class="llm-error">{{ saveError }}</span>
+      <button
+        type="button"
+        class="v4-btn v4-btn--primary"
+        :disabled="saving"
+        @click="save"
+      >
+        {{ t('settings.v4.llmProvider.saveBtn') }}
+      </button>
+    </div>
+  </Card>
+</template>
+
+<style scoped>
+.llm-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.llm-preset {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-5, 10px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 80ms ease, color 80ms ease;
+}
+.llm-preset:hover { border-color: var(--hairline-strong); color: var(--text-primary); }
+.llm-preset--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-subtle, #f0f5ff);
+}
+
+.llm-fields { display: flex; flex-direction: column; gap: 16px; }
+
+.llm-field { display: flex; flex-direction: column; gap: 6px; }
+
+.llm-label {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.llm-input {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-primary);
+}
+.llm-input--mono { font-family: var(--font-mono); }
+.llm-input:hover { border-color: var(--hairline-strong); }
+.llm-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.llm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}
+.llm-saved { font-size: 13px; color: var(--status-green, #27ae60); }
+.llm-error { font-size: 13px; color: var(--status-red, #c0392b); }
+</style>

--- a/frontend/src/components/v4/forms/__tests__/LlmProviderCard.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/LlmProviderCard.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createPinia, setActivePinia } from 'pinia'
+import { reactive } from 'vue'
+import LlmProviderCard from '../LlmProviderCard.vue'
+
+const messages = {
+  de: {
+    settings: {
+      v4: {
+        llmProvider: {
+          title: 'LLM-Anbieter',
+          subtitle: '',
+          baseUrlLabel: 'Base URL',
+          apiKeyLabel: 'API Key',
+          modelLabel: 'Modell',
+          saveBtn: 'Speichern',
+          savedHint: 'Gespeichert.',
+          presets: {
+            ollama: 'Ollama (lokal)',
+            openai: 'OpenAI',
+            gemini: 'Gemini',
+            anthropic: 'Anthropic',
+            custom: 'Eigener Endpunkt',
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockDraft = reactive<Record<string, unknown>>({
+  LLM_BASE_URL: 'http://localhost:11434/v1',
+  LLM_API_KEY: '',
+  LLM_MODEL_NAME: 'qwen2.5:32b',
+})
+
+const mockStore = {
+  draft: mockDraft,
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+}
+
+vi.mock('@/store/settings', () => ({
+  useSettingsStore: vi.fn(() => mockStore),
+}))
+
+import { useSettingsStore } from '@/store/settings'
+
+describe('LlmProviderCard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockDraft['LLM_BASE_URL'] = 'http://localhost:11434/v1'
+    mockDraft['LLM_API_KEY'] = ''
+    mockDraft['LLM_MODEL_NAME'] = 'qwen2.5:32b'
+    mockStore.saveSettings = vi.fn().mockResolvedValue(undefined)
+  })
+
+  function wrap() {
+    return mount(LlmProviderCard, {
+      global: {
+        plugins: [createI18n({ legacy: false, locale: 'de', messages })],
+        stubs: { Card: { template: '<div><slot /></div>' } },
+      },
+    })
+  }
+
+  it('rendert alle 5 Preset-Buttons', () => {
+    const w = wrap()
+    expect(w.findAll('.llm-preset')).toHaveLength(5)
+  })
+
+  it('Ollama-Preset ist initial aktiv (matching URL)', () => {
+    const w = wrap()
+    const buttons = w.findAll('.llm-preset')
+    expect(buttons[0].classes()).toContain('llm-preset--active')
+  })
+
+  it('Klick auf OpenAI → LLM_BASE_URL = OpenAI-URL, API-Key-Feld sichtbar', async () => {
+    const store = vi.mocked(useSettingsStore)()
+    const w = wrap()
+    const buttons = w.findAll('.llm-preset')
+    await buttons[1].trigger('click') // OpenAI
+    expect(store.draft['LLM_BASE_URL']).toBe('https://api.openai.com/v1')
+    await flushPromises()
+    expect(w.find('#llm-api-key').exists()).toBe(true)
+  })
+
+  it('Klick auf Ollama → API-Key-Feld nicht sichtbar, LLM_API_KEY gecleart', async () => {
+    const store = vi.mocked(useSettingsStore)()
+    store.draft['LLM_BASE_URL'] = 'https://api.openai.com/v1'
+    const w = wrap()
+    const buttons = w.findAll('.llm-preset')
+    await buttons[0].trigger('click') // Ollama
+    expect(store.draft['LLM_API_KEY']).toBe('')
+    await flushPromises()
+    expect(w.find('#llm-api-key').exists()).toBe(false)
+  })
+
+  it('Speichern-Button ruft store.saveSettings() auf', async () => {
+    const store = vi.mocked(useSettingsStore)()
+    const w = wrap()
+    await w.find('.v4-btn--primary').trigger('click')
+    await flushPromises()
+    expect(store.saveSettings).toHaveBeenCalledTimes(1)
+    expect(store.saveSettings).toHaveBeenCalledWith({ confirmSecrets: true })
+  })
+})

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -796,6 +796,22 @@
           "title": "Audit-Trail folgt",
           "description": "Ein revisionssicherer Append-Only-Log für sicherheitsrelevante Aktionen wird mit dem Identity-Modul ausgeliefert."
         }
+      },
+      "llmProvider": {
+        "title": "LLM-Anbieter",
+        "subtitle": "Wähle einen Anbieter und hinterlege API-Key und Modell.",
+        "baseUrlLabel": "Base URL",
+        "apiKeyLabel": "API Key",
+        "modelLabel": "Modell",
+        "saveBtn": "Speichern",
+        "savedHint": "Gespeichert.",
+        "presets": {
+          "ollama": "Ollama (lokal)",
+          "openai": "OpenAI",
+          "gemini": "Gemini",
+          "anthropic": "Anthropic",
+          "custom": "Eigener Endpunkt"
+        }
       }
     }
   },
@@ -944,7 +960,9 @@
       "modelDefault": "Standard",
       "languageLabel": "Sprache",
       "startCta": "Starten",
-      "disabledHint": "Erst Datei wählen, dann starten."
+      "disabledHint": "Erst Datei und Fragestellung eingeben, dann starten.",
+      "requirementLabel": "Fragestellung / Anforderung",
+      "requirementPlaceholder": "z. B. 'Welche politischen Reaktionen sind in der DACH-Region zu erwarten?'"
     },
     "stats": {
       "activeRuns": "Aktive Runs",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -796,6 +796,22 @@
           "title": "Audit trail coming soon",
           "description": "A tamper-evident append-only log for security-relevant actions ships with the identity module."
         }
+      },
+      "llmProvider": {
+        "title": "LLM Provider",
+        "subtitle": "Select a provider and enter your API key and model.",
+        "baseUrlLabel": "Base URL",
+        "apiKeyLabel": "API Key",
+        "modelLabel": "Model",
+        "saveBtn": "Save",
+        "savedHint": "Saved.",
+        "presets": {
+          "ollama": "Ollama (local)",
+          "openai": "OpenAI",
+          "gemini": "Gemini",
+          "anthropic": "Anthropic",
+          "custom": "Custom endpoint"
+        }
       }
     }
   },
@@ -944,7 +960,9 @@
       "modelDefault": "Default",
       "languageLabel": "Language",
       "startCta": "Start",
-      "disabledHint": "Pick a file first, then start."
+      "disabledHint": "Select a file and enter a requirement first.",
+      "requirementLabel": "Research question / requirement",
+      "requirementPlaceholder": "e.g. \"What political reactions are expected in the DACH region?\""
     },
     "stats": {
       "activeRuns": "Active runs",

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -3,6 +3,7 @@ import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
+import LlmProviderCard from '@/components/v4/forms/LlmProviderCard.vue'
 
 const { t } = useI18n()
 
@@ -24,6 +25,7 @@ const ALLOWED_SECTIONS = ['llm', 'logging', 'locale', 'ui', 'event_bus', 'securi
       :subtitle="t('settings.v4.general.subtitle')"
     />
 
+    <LlmProviderCard style="margin-bottom: 16px;" />
     <SettingsSectionPanel :allowed-sections="ALLOWED_SECTIONS" />
   </AppShell>
 </template>


### PR DESCRIPTION
## Summary

- **HeroNewRun** (`components/v4/dashboard/`): `simulationRequirement`-Textarea als Pflichtfeld hinzugefügt. `canSubmit` prüft jetzt `files.length > 0 && requirement.trim() !== ''`. `setPendingUpload` übergibt den Wert korrekt statt leerem String.
- **LlmProviderCard** (`components/v4/forms/`, neu): Preset-Buttons für Ollama / OpenAI / Gemini / Anthropic / Custom. API-Key-Input erscheint nur bei Key-pflichtigen Providern. Speichern via `useSettingsStore().save()`.
- **SettingsGeneralView**: `LlmProviderCard` über `SettingsSectionPanel` eingebunden — LLM-Konfiguration ist jetzt intuitiv erreichbar.
- **i18n**: `de.json` + `en.json` um `requirementLabel`, `requirementPlaceholder`, `disabledHint` (aktualisiert) und `settings.v4.llmProvider.*`-Keys ergänzt.

## Test plan

- [ ] `npm run typecheck` — grün (keine TS-Fehler)
- [ ] `npm test -- --run` — grün (exit 0, inkl. 2 neue HeroNewRun-Tests + 5 neue LlmProviderCard-Tests)
- [ ] `npm run build` — grün (1.99 s)
- [ ] `npm run lint` — grün (keine ESLint-Fehler)
- [ ] Manuell: Dashboard `/dashboard` → CTA bleibt deaktiviert bis Datei **und** Fragestellung gesetzt
- [ ] Manuell: Settings → General → LlmProviderCard zeigt Preset-Buttons; Klick auf OpenAI befüllt Base URL und zeigt API-Key-Feld

🤖 Generated with [Claude Code](https://claude.com/claude-code)