### PR TITLE
test(neo4j): fix stale match string in test_ensure_vector_index_dim_sanitization

### DIFF
--- a/backend/tests/test_neo4j_index_security.py
+++ b/backend/tests/test_neo4j_index_security.py
@@ -35,9 +35,9 @@ def test_ensure_vector_index_dim_sanitization():
 
     # Case 2: Invalid index name (Cypher injection attempt) should raise ValueError
     hostile_name = "idx`; DROP DATABASE neo4j; //"
-    with pytest.raises(ValueError, match="Invalid index name for DROP INDEX"):
+    with pytest.raises(ValueError, match="Invalid index name"):
         storage._ensure_vector_index_dim(mock_session, hostile_name, 256)
 
     # Case 3: Another invalid name
-    with pytest.raises(ValueError, match="Invalid index name for DROP INDEX"):
+    with pytest.raises(ValueError, match="Invalid index name"):
         storage._ensure_vector_index_dim(mock_session, "invalid-name-with-dashes", 256)

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2018 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 84 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2033 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 85 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._


### PR DESCRIPTION
## Summary

PR #348 änderte die `ValueError`-Meldung in `_ensure_vector_index_dim()` von
`"Invalid index name for DROP INDEX"` auf `"Invalid index name: {name}"`,
aber der `pytest.raises(match=...)` im Test wurde nicht angepasst.

Ergebnis: Pre-existing CI-Failure in `test_ensure_vector_index_dim_sanitization` auf allen PRs.

## Fix

`match="Invalid index name for DROP INDEX"` → `match="Invalid index name"` (passt zum tatsächlichen Fehlertext).

## Test plan

- [x] `pytest tests/test_neo4j_index_security.py` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)