### PR TITLE
fix(settings): persist instance/ via docker volume mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,8 +107,9 @@ backend/logs/
 backend/.cache/
 
 # Runtime artifacts and local instances
-instance/
-backend/instance/
+/instance/
+backend/instance/settings.json
+backend/instance/settings.*.json.tmp
 
 # Upload folder
 backend/uploads/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - ALL
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      # Persist UI-saved settings (LLM provider, keys, model) across container restarts.
+      - ./backend/instance:/app/backend/instance
       # Persist HuggingFace model cache on the external disk so OASIS-pulled
       # models (z. B. Twitter/twhin-bert-base, ~1.1 GB) das 256 MB tmpfs nicht
       # sprengen und beim Container-Restart nicht neu gezogen werden.


### PR DESCRIPTION
## Summary

- `backend/instance/` fehlte im Repo → nach `git clone` und im Container nie vorhanden
- Kein Docker-Volume-Mount → UI-gespeicherte Settings (LLM-Provider, API-Key, Modell) gingen beim Container-Neustart verloren
- Root-Cause: `instance/`-Pattern in `.gitignore` hat rekursiv alle Ebenen gematcht

## Änderungen

- `backend/instance/.gitkeep` — Verzeichnis wird jetzt mit dem Repo ausgecheckt
- `.gitignore` — `instance/` → `/instance/` (Root-only) + explizite Muster für `settings.json` und `*.tmp`
- `docker-compose.yml` — `./backend/instance:/app/backend/instance` Volume-Mount (wirkt auch im Prod-Override via Inherit)

## Test plan

- [ ] `docker compose up -d --build` starten
- [ ] Settings → General → LLM-Provider ändern und „Speichern" klicken
- [ ] Source-Badge wechselt von `.env` auf `file`
- [ ] Container neu starten (`docker compose restart agora`)
- [ ] Settings öffnen → Werte bleiben erhalten, Source zeigt `file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)