### PR TITLE
fix(settings-contract): allow updated_keys in SettingsValuesPayloadSchema

### DIFF
--- a/frontend/src/contracts/settingsContract.ts
+++ b/frontend/src/contracts/settingsContract.ts
@@ -54,6 +54,7 @@ export type SettingsFieldMeta = z.infer<typeof SettingsFieldMetaSchema>
 export const SettingsValuesPayloadSchema = z.object({
   sections: z.array(SettingsSectionSchema),
   fields: z.record(z.string(), z.array(SettingsFieldMetaSchema)),
+  updated_keys: z.array(z.string()).optional(),
 }).strict()
 export type SettingsValuesPayload = z.infer<typeof SettingsValuesPayloadSchema>
 


### PR DESCRIPTION
## Summary

- `PUT /api/settings` gibt `updated_keys: string[]` zurück, `GET` nicht
- `SettingsValuesPayloadSchema.strict()` hat den PUT-Response als Schema-Drift abgelehnt
- `saveSettings()` hat nach erfolgreichem Backend-Write geworfen statt den State upzudaten

## Fix

`updated_keys` als `z.array(z.string()).optional()` in `SettingsValuesPayloadSchema` — GET-Parsing unverändert (Feld absent = valid), PUT-Parsing akzeptiert das Feld.

## Test plan

- [ ] Settings speichern → kein „Schema-Drift"-Fehler mehr
- [ ] Source-Badge wechselt nach Save von `env` auf `file`
- [ ] 697 Frontend-Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)