### PR TITLE
feat(settings): LLM-Profile-Manager UI (P5.4)

### DIFF
--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2018 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 84 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2062 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/api/llmProfiles.ts
+++ b/frontend/src/api/llmProfiles.ts
@@ -1,11 +1,11 @@
 /**
- * LLM-Profile-API-Client (P5.5)
+ * LLM-Profile-API-Client (P5.4)
  *
- * Holt persistierte Profile aus GET /api/settings/llm-profiles.
+ * GET/POST/PUT/DELETE /api/settings/llm-profiles
  * Zod-strict-Parse ist Pflicht (Layer-0-Boundary).
  */
-import type { LlmProfile } from '../contracts/llmProfileContract'
-import { LlmProfileListResponseSchema } from '../contracts/llmProfileContract'
+import type { LlmProfile, LlmProfileCreateRequest } from '../contracts/llmProfileContract'
+import { LlmProfileListResponseSchema, LlmProfileSchema } from '../contracts/llmProfileContract'
 import service from './index'
 
 export async function fetchLlmProfiles(): Promise<LlmProfile[]> {
@@ -15,4 +15,26 @@ export async function fetchLlmProfiles(): Promise<LlmProfile[]> {
   const payload = (res as { data?: unknown })?.data ?? res
   const parsed = LlmProfileListResponseSchema.parse(payload)
   return parsed.profiles
+}
+
+export async function createLlmProfile(req: LlmProfileCreateRequest): Promise<LlmProfile> {
+  const res = await service.post('/api/settings/llm-profiles', req)
+  const payload = (res as { data?: unknown })?.data ?? res
+  return LlmProfileSchema.parse(payload)
+}
+
+export async function updateLlmProfile(id: string, req: LlmProfileCreateRequest): Promise<LlmProfile> {
+  const res = await service.put(`/api/settings/llm-profiles/${id}`, req)
+  const payload = (res as { data?: unknown })?.data ?? res
+  return LlmProfileSchema.parse(payload)
+}
+
+export async function deleteLlmProfile(id: string): Promise<void> {
+  await service.delete(`/api/settings/llm-profiles/${id}`)
+}
+
+export async function setDefaultLlmProfile(id: string): Promise<LlmProfile> {
+  const res = await service.post(`/api/settings/llm-profiles/${id}/default`)
+  const payload = (res as { data?: unknown })?.data ?? res
+  return LlmProfileSchema.parse(payload)
 }

--- a/frontend/src/api/llmProfiles.ts
+++ b/frontend/src/api/llmProfiles.ts
@@ -8,25 +8,26 @@ import type { LlmProfile, LlmProfileCreateRequest } from '../contracts/llmProfil
 import { LlmProfileListResponseSchema, LlmProfileSchema } from '../contracts/llmProfileContract'
 import service from './index'
 
+// service-Interceptor packt response.data bereits aus. Backend-Shape ist
+// { success: true, data: <payload> } — wir greifen darum noch eine Ebene
+// tiefer, falls der Envelope durchgereicht wurde.
+function unwrap(res: unknown): unknown {
+  return (res as { data?: unknown })?.data ?? res
+}
+
 export async function fetchLlmProfiles(): Promise<LlmProfile[]> {
   const res = await service.get('/api/settings/llm-profiles')
-  // service-Interceptor packt bereits response.data aus (Envelope-Unwrap).
-  // Backend-Shape: { success: true, data: { profiles: [...] } }
-  const payload = (res as { data?: unknown })?.data ?? res
-  const parsed = LlmProfileListResponseSchema.parse(payload)
-  return parsed.profiles
+  return LlmProfileListResponseSchema.parse(unwrap(res)).profiles
 }
 
 export async function createLlmProfile(req: LlmProfileCreateRequest): Promise<LlmProfile> {
   const res = await service.post('/api/settings/llm-profiles', req)
-  const payload = (res as { data?: unknown })?.data ?? res
-  return LlmProfileSchema.parse(payload)
+  return LlmProfileSchema.parse(unwrap(res))
 }
 
 export async function updateLlmProfile(id: string, req: LlmProfileCreateRequest): Promise<LlmProfile> {
   const res = await service.put(`/api/settings/llm-profiles/${id}`, req)
-  const payload = (res as { data?: unknown })?.data ?? res
-  return LlmProfileSchema.parse(payload)
+  return LlmProfileSchema.parse(unwrap(res))
 }
 
 export async function deleteLlmProfile(id: string): Promise<void> {
@@ -35,6 +36,5 @@ export async function deleteLlmProfile(id: string): Promise<void> {
 
 export async function setDefaultLlmProfile(id: string): Promise<LlmProfile> {
   const res = await service.post(`/api/settings/llm-profiles/${id}/default`)
-  const payload = (res as { data?: unknown })?.data ?? res
-  return LlmProfileSchema.parse(payload)
+  return LlmProfileSchema.parse(unwrap(res))
 }

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -1,0 +1,582 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Card from './Card.vue'
+import { useLlmProfilesStore } from '@/store/llmProfiles'
+import type { LlmProfile, LlmProvider } from '@/contracts/llmProfileContract'
+
+const { t } = useI18n()
+const store = useLlmProfilesStore()
+
+// ---------------------------------------------------------------------------
+// Preset-Definitionen (analog zu LlmProviderCard)
+// ---------------------------------------------------------------------------
+interface Preset {
+  key: LlmProvider
+  label: string
+  url: string
+  needsKey: boolean
+}
+
+const PRESETS = computed<Preset[]>(() => [
+  { key: 'ollama',     label: t('settings.v4.llmProfiles.presets.ollama'),     url: 'http://localhost:11434/v1',                               needsKey: false },
+  { key: 'openai',    label: t('settings.v4.llmProfiles.presets.openai'),    url: 'https://api.openai.com/v1',                               needsKey: true  },
+  { key: 'gemini',    label: t('settings.v4.llmProfiles.presets.gemini'),    url: 'https://generativelanguage.googleapis.com/v1beta/openai', needsKey: true  },
+  { key: 'anthropic', label: t('settings.v4.llmProfiles.presets.anthropic'), url: 'https://api.anthropic.com/v1',                            needsKey: true  },
+  { key: 'custom',    label: t('settings.v4.llmProfiles.presets.custom'),    url: '',                                                        needsKey: false },
+])
+
+// ---------------------------------------------------------------------------
+// Form-State
+// ---------------------------------------------------------------------------
+type FormMode = 'idle' | 'create' | 'edit'
+const formMode = ref<FormMode>('idle')
+const editingId = ref<string | null>(null)
+
+const formName     = ref('')
+const formProvider = ref<LlmProvider>('ollama')
+const formBaseUrl  = ref('')
+const formModel    = ref('')
+
+// api_key-Edit-Semantik:
+// 'unchanged' → api_key: null senden (Server lässt Key unberührt)
+// 'clear'     → api_key: ""  senden (Server entfernt Key)
+// 'new'       → api_key: formApiKeyDraft.value senden
+type ApiKeyEditMode = 'unchanged' | 'clear' | 'new'
+const apiKeyEditMode = ref<ApiKeyEditMode>('unchanged')
+const apiKeyDraft    = ref('')
+
+// ---------------------------------------------------------------------------
+// Hilfsfunktionen
+// ---------------------------------------------------------------------------
+function resetForm(): void {
+  formName.value     = ''
+  formProvider.value = 'ollama'
+  formBaseUrl.value  = ''
+  formModel.value    = ''
+  apiKeyEditMode.value = 'unchanged'
+  apiKeyDraft.value    = ''
+}
+
+function openCreate(): void {
+  resetForm()
+  editingId.value = null
+  formMode.value  = 'create'
+}
+
+function openEdit(profile: LlmProfile): void {
+  formName.value     = profile.name
+  formProvider.value = profile.provider
+  formBaseUrl.value  = profile.base_url
+  formModel.value    = profile.model_name
+  // api_key bleibt initial leer ("unchanged")
+  apiKeyEditMode.value = 'unchanged'
+  apiKeyDraft.value    = ''
+  editingId.value = profile.id
+  formMode.value  = 'edit'
+}
+
+function cancel(): void {
+  formMode.value  = 'idle'
+  editingId.value = null
+  resetForm()
+}
+
+function selectPreset(preset: Preset): void {
+  formProvider.value = preset.key
+  formBaseUrl.value  = preset.url
+  if (!preset.needsKey) {
+    apiKeyEditMode.value = 'unchanged'
+    apiKeyDraft.value    = ''
+  }
+}
+
+function onApiKeyInput(e: Event): void {
+  const val = (e.target as HTMLInputElement).value
+  apiKeyDraft.value    = val
+  apiKeyEditMode.value = 'new'
+}
+
+function clearKey(): void {
+  apiKeyEditMode.value = 'clear'
+  apiKeyDraft.value    = ''
+}
+
+function undoClearKey(): void {
+  apiKeyEditMode.value = 'unchanged'
+  apiKeyDraft.value    = ''
+}
+
+// ---------------------------------------------------------------------------
+// Computed: welcher api_key-Wert wird gesendet?
+// ---------------------------------------------------------------------------
+const resolvedApiKey = computed<string | null>(() => {
+  if (formMode.value === 'create') {
+    // Neues Profil: leeres Feld → null (kein Key)
+    return apiKeyDraft.value === '' ? null : apiKeyDraft.value
+  }
+  // Edit-Pfade
+  if (apiKeyEditMode.value === 'unchanged') return null
+  if (apiKeyEditMode.value === 'clear')     return ''
+  return apiKeyDraft.value
+})
+
+// ---------------------------------------------------------------------------
+// Submit
+// ---------------------------------------------------------------------------
+async function submit(): Promise<void> {
+  const req = {
+    name:       formName.value.trim(),
+    provider:   formProvider.value,
+    base_url:   formBaseUrl.value.trim(),
+    model_name: formModel.value.trim(),
+    api_key:    resolvedApiKey.value,
+    is_default: false,
+  }
+
+  if (formMode.value === 'create') {
+    await store.create(req)
+  } else if (formMode.value === 'edit' && editingId.value) {
+    await store.update(editingId.value, req)
+  }
+
+  if (!store.error) {
+    cancel()
+  }
+}
+
+async function handleDelete(profile: LlmProfile): Promise<void> {
+  if (!window.confirm(t('settings.v4.llmProfiles.deleteConfirm'))) return
+  await store.remove(profile.id)
+}
+
+async function handleSetDefault(profile: LlmProfile): Promise<void> {
+  await store.setDefault(profile.id)
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+onMounted(() => {
+  void store.fetch()
+})
+</script>
+
+<template>
+  <Card
+    :title="t('settings.v4.llmProfiles.title')"
+    :subtitle="t('settings.v4.llmProfiles.subtitle')"
+  >
+    <!-- Fehleranzeige -->
+    <div v-if="store.error" class="pm-error" role="alert">
+      {{ store.error }}
+    </div>
+
+    <!-- Ladezustand -->
+    <div v-if="store.loading" class="pm-loading">…</div>
+
+    <!-- Profil-Liste -->
+    <template v-if="!store.loading">
+      <div v-if="store.profiles.length === 0 && formMode === 'idle'" class="pm-empty">
+        {{ t('settings.v4.llmProfiles.emptyState') }}
+      </div>
+
+      <ul v-else class="pm-list">
+        <li
+          v-for="profile in store.profiles"
+          :key="profile.id"
+          class="pm-item"
+          :class="{ 'pm-item--editing': editingId === profile.id && formMode === 'edit' }"
+        >
+          <div class="pm-item-header">
+            <span class="pm-item-name">{{ profile.name }}</span>
+            <span class="pm-provider-badge">{{ profile.provider }}</span>
+            <span class="pm-item-model">{{ profile.model_name }}</span>
+            <span v-if="profile.is_default" class="pm-default-badge">
+              {{ t('settings.v4.llmProfiles.defaultBadge') }}
+            </span>
+          </div>
+          <div class="pm-item-actions">
+            <button
+              type="button"
+              class="pm-action-btn"
+              :disabled="store.saving"
+              @click="openEdit(profile)"
+            >
+              {{ t('settings.v4.llmProfiles.editBtn') }}
+            </button>
+            <button
+              type="button"
+              class="pm-action-btn"
+              :disabled="profile.is_default || store.saving"
+              @click="handleSetDefault(profile)"
+            >
+              {{ t('settings.v4.llmProfiles.setDefaultBtn') }}
+            </button>
+            <button
+              type="button"
+              class="pm-action-btn pm-action-btn--danger"
+              :disabled="store.saving"
+              @click="handleDelete(profile)"
+            >
+              {{ t('settings.v4.llmProfiles.deleteBtn') }}
+            </button>
+          </div>
+        </li>
+      </ul>
+    </template>
+
+    <!-- Inline-Formular (Create oder Edit) -->
+    <div v-if="formMode !== 'idle'" class="pm-form">
+      <!-- Preset-Auswahl -->
+      <div class="llm-presets">
+        <button
+          v-for="p in PRESETS"
+          :key="p.key"
+          type="button"
+          class="llm-preset"
+          :class="{ 'llm-preset--active': formProvider === p.key }"
+          @click="selectPreset(p)"
+        >
+          {{ p.label }}
+        </button>
+      </div>
+
+      <div class="llm-fields">
+        <!-- Name -->
+        <div class="llm-field">
+          <label class="llm-label" for="pm-name">{{ t('settings.v4.llmProfiles.nameLabel') }}</label>
+          <input
+            id="pm-name"
+            v-model="formName"
+            type="text"
+            class="llm-input"
+            :placeholder="t('settings.v4.llmProfiles.nameLabel')"
+          />
+        </div>
+
+        <!-- Base URL -->
+        <div class="llm-field">
+          <label class="llm-label" for="pm-base-url">{{ t('settings.v4.llmProfiles.baseUrlLabel') }}</label>
+          <input
+            id="pm-base-url"
+            v-model="formBaseUrl"
+            type="text"
+            class="llm-input"
+            placeholder="https://..."
+          />
+        </div>
+
+        <!-- Modell -->
+        <div class="llm-field">
+          <label class="llm-label" for="pm-model">{{ t('settings.v4.llmProfiles.modelLabel') }}</label>
+          <input
+            id="pm-model"
+            v-model="formModel"
+            type="text"
+            class="llm-input"
+            placeholder="qwen2.5:32b"
+          />
+        </div>
+
+        <!-- API Key -->
+        <div class="llm-field">
+          <label class="llm-label" for="pm-api-key">{{ t('settings.v4.llmProfiles.apiKeyLabel') }}</label>
+          <div class="pm-apikey-row">
+            <input
+              id="pm-api-key"
+              :value="apiKeyDraft"
+              type="password"
+              class="llm-input llm-input--mono pm-apikey-input"
+              :placeholder="formMode === 'edit' ? t('settings.v4.llmProfiles.apiKeyPlaceholderEdit') : 'sk-…'"
+              :disabled="apiKeyEditMode === 'clear'"
+              autocomplete="off"
+              @input="onApiKeyInput"
+            />
+            <!-- Edit-Mode: Key-Aktionen -->
+            <template v-if="formMode === 'edit'">
+              <button
+                v-if="apiKeyEditMode !== 'clear'"
+                type="button"
+                class="pm-action-btn pm-action-btn--danger"
+                @click="clearKey"
+              >
+                {{ t('settings.v4.llmProfiles.clearKeyBtn') }}
+              </button>
+              <button
+                v-else
+                type="button"
+                class="pm-action-btn"
+                @click="undoClearKey"
+              >
+                {{ t('settings.v4.llmProfiles.cancelBtn') }}
+              </button>
+            </template>
+          </div>
+          <span v-if="apiKeyEditMode === 'clear'" class="pm-key-hint">
+            {{ t('settings.v4.llmProfiles.clearKeyBtn') }} — {{ t('settings.v4.llmProfiles.apiKeyPlaceholderEdit') }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Form-Footer -->
+      <div class="llm-footer">
+        <button
+          type="button"
+          class="pm-action-btn"
+          :disabled="store.saving"
+          @click="cancel"
+        >
+          {{ t('settings.v4.llmProfiles.cancelBtn') }}
+        </button>
+        <button
+          type="button"
+          class="v4-btn v4-btn--primary"
+          :disabled="store.saving || !formName.trim() || !formBaseUrl.trim() || !formModel.trim()"
+          @click="submit"
+        >
+          {{ t('settings.v4.llmProfiles.saveBtn') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- "Neues Profil"-Button (nur wenn kein Formular offen) -->
+    <div v-if="formMode === 'idle'" class="pm-add-row">
+      <button
+        type="button"
+        class="v4-btn v4-btn--primary"
+        :disabled="store.loading"
+        @click="openCreate"
+      >
+        {{ t('settings.v4.llmProfiles.addBtn') }}
+      </button>
+    </div>
+  </Card>
+</template>
+
+<style scoped>
+/* Liste */
+.pm-list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pm-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+}
+
+.pm-item--editing {
+  border-color: var(--accent);
+}
+
+.pm-item-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pm-item-name {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.pm-provider-badge {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: var(--r-5, 10px);
+  border: 1px solid var(--hairline);
+  color: var(--text-secondary);
+  background: var(--surface-elevated, #fff);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pm-item-model {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.pm-default-badge {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--r-5, 10px);
+  background: var(--accent-subtle, #f0f5ff);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.pm-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Buttons */
+.pm-action-btn {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 80ms ease, color 80ms ease;
+}
+.pm-action-btn:hover:not(:disabled) {
+  border-color: var(--hairline-strong);
+  color: var(--text-primary);
+}
+.pm-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.pm-action-btn--danger:hover:not(:disabled) {
+  border-color: var(--status-red, #c0392b);
+  color: var(--status-red, #c0392b);
+}
+
+/* Inline-Form */
+.pm-form {
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  padding: 16px;
+  background: var(--surface-elevated, #fff);
+  margin-bottom: 16px;
+}
+
+.pm-add-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+/* API-Key-Zeile */
+.pm-apikey-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.pm-apikey-input {
+  flex: 1;
+}
+
+.pm-key-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* Zustände */
+.pm-empty {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-secondary);
+  padding: 8px 0 16px;
+}
+
+.pm-loading {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-secondary);
+  padding: 8px 0;
+}
+
+.pm-error {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--status-red, #c0392b);
+  padding: 8px 12px;
+  border: 1px solid var(--status-red, #c0392b);
+  border-radius: var(--r-4, 8px);
+  margin-bottom: 12px;
+}
+
+/* Wiederverwendete LlmProviderCard-Klassen */
+.llm-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.llm-preset {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-5, 10px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 80ms ease, color 80ms ease;
+}
+.llm-preset:hover {
+  border-color: var(--hairline-strong);
+  color: var(--text-primary);
+}
+.llm-preset--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-subtle, #f0f5ff);
+}
+
+.llm-fields { display: flex; flex-direction: column; gap: 16px; }
+.llm-field  { display: flex; flex-direction: column; gap: 6px; }
+
+.llm-label {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.llm-input {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  color: var(--text-primary);
+}
+.llm-input--mono { font-family: var(--font-mono); }
+.llm-input:hover { border-color: var(--hairline-strong); }
+.llm-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+.llm-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.llm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}
+</style>

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -32,6 +32,9 @@ const PRESETS = computed<Preset[]>(() => [
 type FormMode = 'idle' | 'create' | 'edit'
 const formMode = ref<FormMode>('idle')
 const editingId = ref<string | null>(null)
+// is_default vom existierenden Profil beim Edit übernehmen, sonst löscht
+// das Hardcoden `is_default: false` den Standard-Status beim Bearbeiten.
+const editingIsDefault = ref(false)
 
 const formName     = ref('')
 const formProvider = ref<LlmProvider>('ollama')
@@ -72,13 +75,15 @@ function openEdit(profile: LlmProfile): void {
   // api_key bleibt initial leer ("unchanged")
   apiKeyEditMode.value = 'unchanged'
   apiKeyDraft.value    = ''
-  editingId.value = profile.id
-  formMode.value  = 'edit'
+  editingId.value        = profile.id
+  editingIsDefault.value = profile.is_default
+  formMode.value         = 'edit'
 }
 
 function cancel(): void {
-  formMode.value  = 'idle'
-  editingId.value = null
+  formMode.value         = 'idle'
+  editingId.value        = null
+  editingIsDefault.value = false
   resetForm()
 }
 
@@ -131,7 +136,10 @@ async function submit(): Promise<void> {
     base_url:   formBaseUrl.value.trim(),
     model_name: formModel.value.trim(),
     api_key:    resolvedApiKey.value,
-    is_default: false,
+    // Edit: bestehenden is_default beibehalten — sonst verliert das aktuelle
+    // Default-Profil beim Bearbeiten seinen Status. Create: immer false; der
+    // User setzt den Default explizit über den „Als Standard"-Button.
+    is_default: formMode.value === 'edit' ? editingIsDefault.value : false,
   }
 
   if (formMode.value === 'create') {

--- a/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createTestingPinia } from '@pinia/testing'
+import LlmProfileManager from '../LlmProfileManager.vue'
+
+// Kein echter API-Aufruf in Tests — fetch-Action wird durch createTestingPinia gestubbt.
+vi.mock('@/api/llmProfiles', () => ({
+  fetchLlmProfiles: vi.fn().mockResolvedValue([]),
+  createLlmProfile: vi.fn().mockResolvedValue({}),
+  updateLlmProfile: vi.fn().mockResolvedValue({}),
+  deleteLlmProfile: vi.fn().mockResolvedValue(undefined),
+  setDefaultLlmProfile: vi.fn().mockResolvedValue({}),
+}))
+
+const messages = {
+  de: {
+    settings: {
+      v4: {
+        llmProfiles: {
+          title: 'LLM-Profile',
+          subtitle: '',
+          addBtn: 'Neues Profil',
+          nameLabel: 'Anzeigename',
+          providerLabel: 'Anbieter',
+          baseUrlLabel: 'Base URL',
+          modelLabel: 'Modell',
+          apiKeyLabel: 'API Key',
+          apiKeyPlaceholderEdit: 'Leer lassen = unverändert',
+          clearKeyBtn: 'Key entfernen',
+          setDefaultBtn: 'Als Standard setzen',
+          defaultBadge: 'Standard',
+          deleteConfirm: 'Dieses Profil wirklich löschen?',
+          saveBtn: 'Speichern',
+          cancelBtn: 'Abbrechen',
+          editBtn: 'Bearbeiten',
+          deleteBtn: 'Löschen',
+          emptyState: 'Noch keine Profile angelegt.',
+          presets: {
+            ollama: 'Ollama (lokal)',
+            openai: 'OpenAI',
+            gemini: 'Gemini',
+            anthropic: 'Anthropic',
+            custom: 'Eigener Endpunkt',
+          },
+        },
+      },
+    },
+  },
+}
+
+const i18n = createI18n({ legacy: false, locale: 'de', messages })
+
+const PROFILE_A = {
+  id: 'p1',
+  name: 'Lokales Ollama',
+  provider: 'ollama' as const,
+  base_url: 'http://localhost:11434/v1',
+  model_name: 'qwen2.5:32b',
+  api_key: null,
+  is_default: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const PROFILE_B = {
+  id: 'p2',
+  name: 'OpenAI GPT-4o',
+  provider: 'openai' as const,
+  base_url: 'https://api.openai.com/v1',
+  model_name: 'gpt-4o',
+  api_key: null,
+  is_default: false,
+  created_at: '2026-01-02T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+}
+
+function wrap(storeOverrides?: object) {
+  return mount(LlmProfileManager, {
+    global: {
+      plugins: [
+        i18n,
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            llmProfiles: {
+              profiles: [PROFILE_A, PROFILE_B],
+              loading: false,
+              saving: false,
+              error: null,
+              ...storeOverrides,
+            },
+          },
+          stubActions: true,
+        }),
+      ],
+      stubs: { Card: { template: '<div><slot /></div>' } },
+    },
+  })
+}
+
+describe('LlmProfileManager', () => {
+  it('rendert beide Profile aus dem Pinia-Store', async () => {
+    const w = wrap()
+    await flushPromises()
+    expect(w.text()).toContain('Lokales Ollama')
+    expect(w.text()).toContain('OpenAI GPT-4o')
+  })
+
+  it('store.create wird mit erwartetem Payload aufgerufen beim Anlegen', async () => {
+    const w = wrap()
+    await flushPromises()
+
+    // Store-Referenz aus dem aktiven Pinia holen (createTestingPinia hat es registriert)
+    const { useLlmProfilesStore } = await import('@/store/llmProfiles')
+    const store = useLlmProfilesStore()
+
+    // Neues-Profil-Formular öffnen
+    await w.find('button.v4-btn--primary').trigger('click')
+    await flushPromises()
+
+    // Felder befüllen
+    await w.find('#pm-name').setValue('Mein Testprofil')
+    await w.find('#pm-base-url').setValue('http://localhost:11434/v1')
+    await w.find('#pm-model').setValue('llama3:8b')
+
+    // Speichern klicken (stubActions: true → create ist bereits ein vi.fn spy)
+    const saveBtn = w.findAll('button.v4-btn--primary').find(b => b.text() === 'Speichern')
+    await saveBtn!.trigger('click')
+    await flushPromises()
+
+    expect(store.create).toHaveBeenCalledWith({
+      name: 'Mein Testprofil',
+      provider: 'ollama',
+      base_url: 'http://localhost:11434/v1',
+      model_name: 'llama3:8b',
+      api_key: null,
+      is_default: false,
+    })
+  })
+
+  it('store.setDefault wird beim Klick auf "Als Standard setzen" aufgerufen', async () => {
+    const w = wrap()
+    await flushPromises()
+
+    const { useLlmProfilesStore } = await import('@/store/llmProfiles')
+    const store = useLlmProfilesStore()
+
+    // "Als Standard setzen" ist für PROFILE_B (p2) aktiv (p1 ist schon default)
+    const setDefaultBtns = w.findAll('button').filter(b => b.text() === 'Als Standard setzen')
+    // p1 ist deaktiviert (is_default=true), p2 ist aktiv
+    // @vue/test-utils gibt für disabled="" den leeren String, nicht undefined.
+    const activeBtn = setDefaultBtns.find(b => b.attributes('disabled') === undefined)
+    await activeBtn!.trigger('click')
+    await flushPromises()
+
+    // stubActions: true → setDefault ist bereits ein vi.fn spy
+    expect(store.setDefault).toHaveBeenCalledWith('p2')
+  })
+})

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -797,6 +797,33 @@
           "description": "Ein revisionssicherer Append-Only-Log für sicherheitsrelevante Aktionen wird mit dem Identity-Modul ausgeliefert."
         }
       },
+      "llmProfiles": {
+        "title": "LLM-Profile",
+        "subtitle": "Verwalte mehrere benannte LLM-Konfigurationen. Pro Schritt eines Runs wählbar.",
+        "addBtn": "Neues Profil",
+        "nameLabel": "Anzeigename",
+        "providerLabel": "Anbieter",
+        "baseUrlLabel": "Base URL",
+        "modelLabel": "Modell",
+        "apiKeyLabel": "API Key",
+        "apiKeyPlaceholderEdit": "Leer lassen = unverändert",
+        "clearKeyBtn": "Key entfernen",
+        "setDefaultBtn": "Als Standard setzen",
+        "defaultBadge": "Standard",
+        "deleteConfirm": "Dieses Profil wirklich löschen?",
+        "saveBtn": "Speichern",
+        "cancelBtn": "Abbrechen",
+        "editBtn": "Bearbeiten",
+        "deleteBtn": "Löschen",
+        "emptyState": "Noch keine Profile angelegt.",
+        "presets": {
+          "ollama": "Ollama (lokal)",
+          "openai": "OpenAI",
+          "gemini": "Gemini",
+          "anthropic": "Anthropic",
+          "custom": "Eigener Endpunkt"
+        }
+      },
       "llmProvider": {
         "title": "LLM-Anbieter",
         "subtitle": "Wähle einen Anbieter und hinterlege API-Key und Modell.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -797,6 +797,33 @@
           "description": "A tamper-evident append-only log for security-relevant actions ships with the identity module."
         }
       },
+      "llmProfiles": {
+        "title": "LLM Profiles",
+        "subtitle": "Manage multiple named LLM configurations. Selectable per run step.",
+        "addBtn": "New Profile",
+        "nameLabel": "Display Name",
+        "providerLabel": "Provider",
+        "baseUrlLabel": "Base URL",
+        "modelLabel": "Model",
+        "apiKeyLabel": "API Key",
+        "apiKeyPlaceholderEdit": "Leave empty to keep current",
+        "clearKeyBtn": "Remove Key",
+        "setDefaultBtn": "Set as Default",
+        "defaultBadge": "Default",
+        "deleteConfirm": "Really delete this profile?",
+        "saveBtn": "Save",
+        "cancelBtn": "Cancel",
+        "editBtn": "Edit",
+        "deleteBtn": "Delete",
+        "emptyState": "No profiles yet.",
+        "presets": {
+          "ollama": "Ollama (local)",
+          "openai": "OpenAI",
+          "gemini": "Gemini",
+          "anthropic": "Anthropic",
+          "custom": "Custom endpoint"
+        }
+      },
       "llmProvider": {
         "title": "LLM Provider",
         "subtitle": "Select a provider and enter your API key and model.",

--- a/frontend/src/store/llmProfiles.ts
+++ b/frontend/src/store/llmProfiles.ts
@@ -1,0 +1,127 @@
+/**
+ * llmProfiles — Pinia-Store für LLM-Profil-Verwaltung.
+ *
+ * P5.4 — Frontend-Anteil.
+ * Composition-API-Style analog zu store/apiKeys.ts.
+ */
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { LlmProfile, LlmProfileCreateRequest } from '../contracts/llmProfileContract'
+import {
+  fetchLlmProfiles,
+  createLlmProfile,
+  updateLlmProfile,
+  deleteLlmProfile,
+  setDefaultLlmProfile,
+} from '../api/llmProfiles'
+
+export const useLlmProfilesStore = defineStore('llmProfiles', () => {
+  const profiles = ref<LlmProfile[]>([])
+  const loading = ref(false)
+  const saving = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetch(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      profiles.value = await fetchLlmProfiles()
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Laden der LLM-Profile.'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(req: LlmProfileCreateRequest): Promise<void> {
+    saving.value = true
+    error.value = null
+    try {
+      const created = await createLlmProfile(req)
+      profiles.value = [created, ...profiles.value]
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Anlegen des Profils.'
+      throw err
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function update(id: string, req: LlmProfileCreateRequest): Promise<void> {
+    saving.value = true
+    error.value = null
+    try {
+      const updated = await updateLlmProfile(id, req)
+      const idx = profiles.value.findIndex((p) => p.id === id)
+      if (idx !== -1) {
+        profiles.value = [
+          ...profiles.value.slice(0, idx),
+          updated,
+          ...profiles.value.slice(idx + 1),
+        ]
+      }
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Aktualisieren des Profils.'
+      throw err
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function remove(id: string): Promise<void> {
+    saving.value = true
+    error.value = null
+    try {
+      await deleteLlmProfile(id)
+      profiles.value = profiles.value.filter((p) => p.id !== id)
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Löschen des Profils.'
+      throw err
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function setDefault(id: string): Promise<void> {
+    saving.value = true
+    error.value = null
+    try {
+      const updated = await setDefaultLlmProfile(id)
+      // Alle is_default lokal zurücksetzen, dann das zurückgegebene ersetzen.
+      const reset = profiles.value.map((p) => ({ ...p, is_default: false }))
+      const idx = reset.findIndex((p) => p.id === id)
+      if (idx !== -1) {
+        profiles.value = [
+          ...reset.slice(0, idx),
+          updated,
+          ...reset.slice(idx + 1),
+        ]
+      } else {
+        profiles.value = reset
+      }
+    } catch (err) {
+      const e = err as Error
+      error.value = e?.message ?? 'Fehler beim Setzen des Standard-Profils.'
+      throw err
+    } finally {
+      saving.value = false
+    }
+  }
+
+  return {
+    profiles,
+    loading,
+    saving,
+    error,
+    fetch,
+    create,
+    update,
+    remove,
+    setDefault,
+  }
+})

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -4,6 +4,7 @@ import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
 import LlmProviderCard from '@/components/v4/forms/LlmProviderCard.vue'
+import LlmProfileManager from '@/components/v4/forms/LlmProfileManager.vue'
 
 const { t } = useI18n()
 
@@ -25,6 +26,7 @@ const ALLOWED_SECTIONS = ['llm', 'logging', 'locale', 'ui', 'event_bus', 'securi
       :subtitle="t('settings.v4.general.subtitle')"
     />
 
+    <LlmProfileManager style="margin-bottom: 16px;" />
     <LlmProviderCard style="margin-bottom: 16px;" />
     <SettingsSectionPanel :allowed-sections="ALLOWED_SECTIONS" />
   </AppShell>

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -45,6 +45,12 @@ vi.mock('@/components/v4/forms/ComingSoonCard.vue', () => ({
     template: '<div class="coming-soon-stub"><h3>{{ title }}</h3><p>{{ description }}</p></div>',
   },
 }))
+vi.mock('@/components/v4/forms/LlmProfileManager.vue', () => ({
+  default: {
+    name: 'LlmProfileManager',
+    template: '<div class="llm-profile-manager-stub" />',
+  },
+}))
 
 import SettingsGeneralView from '../Settings/SettingsGeneralView.vue'
 import SettingsIntegrationsView from '../Settings/SettingsIntegrationsView.vue'


### PR DESCRIPTION
## Summary

- Frontend-UI für CRUD aller `llm_profiles`-Einträge, verdrahtet gegen das Backend aus #440 — User können Profile jetzt ohne `curl`-Workaround anlegen, bearbeiten, löschen, als Standard setzen.
- Inline-Form mit Preset-Auswahl (Ollama / OpenAI / Gemini / Anthropic / Custom) im v4-Look, analog zu `LlmProviderCard.vue`. `LlmProviderCard` bleibt als Schnellauswahl für den globalen Default-Slot erhalten.
- Liefert die UI-Grundlage für **P5.5 Step-LLM-Picker**; der Pinia-Store wird dort wiederverwendet.

## Changes

| File | Δ |
|---|---|
| `frontend/src/store/llmProfiles.ts` (neu, 127 LOC) | Pinia-Composition-Store: `fetch / create / update / remove / setDefault`. Lokale Pflege der `is_default`-Invariante. |
| `frontend/src/components/v4/forms/LlmProfileManager.vue` (neu, 582 LOC inkl. scoped CSS) | Card-Liste + Inline-Form. `api_key`-Edit-Semantik als explizite State-Machine (`unchanged` / `clear` / `new`) mit „Key entfernen"-Button + Undo. |
| `frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts` (neu) | 3 Tests: Liste rendert, Create-Payload, setDefault-Call. |
| `frontend/src/api/llmProfiles.ts` | Erweitert um `create / update / delete / setDefault`. Zod-strict-Parse auf jeder Response. Envelope-Unwrap-Pattern (`res.data?.data ?? res`) konsistent. |
| `frontend/src/views/Settings/SettingsGeneralView.vue` | `LlmProfileManager` **über** `LlmProviderCard` eingebunden. |
| `frontend/src/views/__tests__/SettingsSubViews.spec.ts` | Stub für `LlmProfileManager` ergänzt, damit existierende Settings-Specs ohne Pinia-Setup grün bleiben. |
| `frontend/src/i18n/locales/{de,en}.json` | Block `settings.v4.llmProfiles.*` mit Labels, Hinweisen, Preset-Namen. |

## Backend-Vertrag (PR #440 / `LlmProfileCreateRequest`)

Backend nutzt `LlmProfileCreateRequest` auch für PUT — `name`, `provider`, `base_url`, `model_name` sind beim Update Pflicht. `api_key: Optional[str]`-Semantik:

| Wert | Server-Verhalten |
|---|---|
| `null` | bestehender Key bleibt unverändert |
| `""` | Key wird gelöscht |
| `"sk-..."` | Key wird gesetzt |

Diese Semantik bildet der Manager 1:1 ab. Kein naiver `if (form.api_key) {...}`-Check.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run` — 702 Tests grün (+3 neue Specs in `LlmProfileManager.spec.ts`)
- [x] `npm run build` — Bundle stabil; `SettingsGeneralView`-Chunk wächst um den Manager-Inhalt auf 11.80 kB. Index-Bundle 691.82 kB / gzip 226.11 kB.
- [x] `npm run lint`
- [ ] Manueller Smoke: Profile anlegen / bearbeiten / Key entfernen / als Standard setzen → folgt im Browser nach Merge

## Folge-Slices

- **P5.5** — Step-LLM-Picker in `HeroNewRun.vue` / Step 2 (nutzt diesen Store wieder).
- **Out of Scope:** Backend, `LlmProviderCard.vue`, `HeroNewRun.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)