### PR TITLE
fix(status): /api/status crasht nach Neo4j-Fork-Reset mit NoneType

### DIFF
--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -69,8 +69,11 @@ def _get_neo4j_status():
         }
 
     try:
-        # Verify connectivity using the driver's verify_connectivity method
-        storage._driver.verify_connectivity()
+        # Go through the storage's public probe so the fork-reset
+        # lazy-reconnect path is honored. Reaching into ``storage._driver``
+        # directly would crash with "'NoneType' object has no attribute
+        # 'verify_connectivity'" right after a gunicorn worker fork.
+        storage.verify_connectivity()
         last_success = getattr(storage, 'last_success_ts', None)
         return {
             "reachable": True,

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -117,16 +117,22 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
     def verify_connectivity(self) -> None:
         """Public connectivity probe for ``/api/status``.
 
-        Wraps the private retry loop with the lazy-reconnect path so callers
-        can probe health without reaching into ``self._driver`` directly. The
-        ``_get_session()`` call rebuilds the driver if a gunicorn fork-reset
-        nulled it; a single ``RETURN 1`` then forces an actual round-trip.
+        Wraps the lazy-reconnect path + a real ``RETURN 1`` round-trip in
+        :meth:`_call_with_retry` so the call (a) rebuilds the driver after a
+        gunicorn fork-reset, (b) retries transient errors, and (c) updates
+        the health-state attributes (``_is_connected``, ``_last_success_ts``,
+        ``_last_error``). That last point matters: ``/api/status`` reads
+        those properties straight back, so a successful probe must update
+        them or the UI would otherwise lag behind reality.
 
-        Raises whatever the driver raises — callers translate into the
-        ``reachable: false`` status payload.
+        Raises whatever the driver raises after retries are exhausted —
+        callers translate into the ``reachable: false`` status payload.
         """
-        with self._get_session() as session:
-            session.run("RETURN 1").consume()
+        def _probe():
+            with self._get_session() as session:
+                session.run("RETURN 1").consume()
+
+        self._call_with_retry(_probe)
 
     def _reset_driver_after_fork(self) -> None:
         """Close and discard the inherited driver after gunicorn fork.
@@ -142,6 +148,11 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
         finally:
             self._driver = None
             self._is_connected = False
+            # Re-init the lock: if the parent process happened to be holding
+            # it at fork time (unlikely with single-threaded gunicorn master,
+            # but cheap insurance) the child would inherit a locked mutex
+            # that nothing can ever release.
+            self._lock = threading.Lock()
 
     def set_ontology_mutation_service(self, service) -> None:
         """Late-bind the Issue #11 ``OntologyMutationService``.

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -8,6 +8,7 @@ Includes: CRUD, NER/RE-based text ingestion, hybrid search, retry logic.
 import logging
 import os
 import re
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -54,6 +55,13 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
         self._uri = uri or Config.NEO4J_URI
         self._user = user or Config.NEO4J_USER
         self._password = password or Config.NEO4J_PASSWORD
+
+        # Guards the lazy driver re-creation in :meth:`_get_session` after a
+        # ``_reset_driver_after_fork`` nulled ``_driver``. Without this lock
+        # gunicorn workers racing on the first request would each rebuild
+        # their own driver. Must live on the instance so ``__new__`` callers
+        # in tests can install one without going through ``__init__``.
+        self._lock = threading.Lock()
 
         self._driver = GraphDatabase.driver(
             self._uri, auth=(self._user, self._password)
@@ -105,6 +113,20 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
             # via neo4j_call_with_retry if it uses session.run or similar.
             # But here we just return the session.
         return self._driver.session(**kwargs)
+
+    def verify_connectivity(self) -> None:
+        """Public connectivity probe for ``/api/status``.
+
+        Wraps the private retry loop with the lazy-reconnect path so callers
+        can probe health without reaching into ``self._driver`` directly. The
+        ``_get_session()`` call rebuilds the driver if a gunicorn fork-reset
+        nulled it; a single ``RETURN 1`` then forces an actual round-trip.
+
+        Raises whatever the driver raises — callers translate into the
+        ``reachable: false`` status payload.
+        """
+        with self._get_session() as session:
+            session.run("RETURN 1").consume()
 
     def _reset_driver_after_fork(self) -> None:
         """Close and discard the inherited driver after gunicorn fork.

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -130,6 +130,9 @@ class TestStatusFunctions:
             side_effect=Exception("Connection refused")
         )
         mock_storage._driver = mock_driver
+        mock_storage.verify_connectivity = Mock(
+            side_effect=Exception("Connection refused")
+        )
         app.extensions['neo4j_storage'] = mock_storage
 
         with app.app_context():
@@ -138,3 +141,46 @@ class TestStatusFunctions:
             assert result['reachable'] is False
             assert result['error'] is not None
             assert 'uri' in result
+
+    def test_get_neo4j_status_after_fork_reset_driver_is_none(self):
+        """Regression: nach gunicorn-Fork-Reset ist storage._driver=None.
+
+        Direkter Zugriff auf ``storage._driver.verify_connectivity()`` würde
+        ``'NoneType' object has no attribute 'verify_connectivity'`` werfen
+        und im UI als Service-Ausfall sichtbar machen, obwohl Neo4j selbst
+        erreichbar ist. Der Status-Endpoint muss die Lazy-Reconnect-Logik
+        des Storage nutzen.
+        """
+        import threading
+        from flask import Flask
+        from app.storage.neo4j_storage import Neo4jStorage
+
+        app = Flask(__name__)
+        app.extensions = {}
+
+        # Bare Neo4jStorage instance — kein __init__-Call, damit kein echter
+        # Driver oder Server-Roundtrip nötig ist.
+        storage = Neo4jStorage.__new__(Neo4jStorage)
+        storage._driver = None
+        storage._lock = threading.Lock()
+        storage._uri = 'bolt://127.0.0.1:0'
+        storage._user = 'neo4j'
+        storage._password = 'invalid'
+        storage._is_connected = False
+        storage._last_error = None
+        storage._last_success_ts = None
+        app.extensions['neo4j_storage'] = storage
+
+        with app.app_context():
+            result = _get_neo4j_status()
+
+        assert result['reachable'] is False
+        assert result['error'] is not None
+        # Der konkrete NoneType-AttributeError darf nicht durchschlagen —
+        # er ist ein internes Symptom, nicht der echte Connectivity-Fehler.
+        assert "'NoneType'" not in result['error'], (
+            f"NoneType-AttributeError leakt durch: {result['error']!r}"
+        )
+        assert "verify_connectivity'" not in result['error'], (
+            f"NoneType-AttributeError leakt durch: {result['error']!r}"
+        )


### PR DESCRIPTION
## Summary

- `_get_neo4j_status` umging die Lazy-Reconnect-Logik von `Neo4jStorage`. Nach `os.register_at_fork`-Reset war `storage._driver=None`, `storage._driver.verify_connectivity()` crashte mit `AttributeError`. Im UI sichtbar als „Neo4j offline — 'NoneType' object has no attribute 'verify_connectivity'".
- Neue Public-API `Neo4jStorage.verify_connectivity()` mit `_get_session() + RETURN 1`. Status-Endpoint nutzt sie.
- Pre-existing Bug: `Neo4jStorage._lock` war nie initialisiert — `_get_session()` hätte im Fork-Worker erneut hart gecrasht. Lock jetzt im `__init__`. Macht `test_neo4j_storage_reconnect_after_fork` grün (vorher auf main rot).

## Root cause (kurz)

Nach `gunicorn --preload` + `register_fork_handlers` setzt `_reset_driver_after_fork` `self._driver = None`. Der nächste echte DB-Call würde via `_get_session()` einen neuen Driver bauen — der Status-Endpoint las das interne Attribut aber direkt ab und stolperte über die `None`-Lücke.

## Test plan

- [x] Neuer RED→GREEN-Test `test_get_neo4j_status_after_fork_reset_driver_is_none` reproduziert den Bug
- [x] Bestehende Status-Tests grün (9/9)
- [x] `test_neo4j_storage_reconnect_after_fork` jetzt grün (war pre-existing rot)
- [x] Full backend suite: 2049 pass, 9 skip (alle env-bedingt, nicht durch diesen PR verursacht)
- [x] `ruff check app/ tests/` clean
- [x] `mypy app` clean

## Out of scope

- Ollama-Probe `maximum recursion depth exceeded`: separater Slice. Hypothese: gevent-Patch-Order in Prod-gunicorn — wird über MAI-12-Preload-Verifikation oder eigenen `gunicorn.conf.py`-Pre-Hook adressiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)