### PR TITLE
fix(report): Section-Metadata + Evidence-Gating gegen LLM-Halluzination härten

### DIFF
--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
@@ -362,12 +363,25 @@ def generate_section_metadata(
     schema_cls = _section_schema_for(section_title)
     schema_name = f"section_metadata_{schema_cls.__name__.lower()}"
 
+    schema_json = json.dumps(
+        schema_cls.model_json_schema(), ensure_ascii=False, indent=2
+    )
     system_msg = (
         "Du bist ein Analyse-Assistent. Extrahiere strukturierte Metadaten "
-        f"aus dem folgenden Report-Abschnitt. Halte dich streng an das "
-        f"vorgegebene JSON-Schema ({schema_cls.__name__}). "
-        "Verwende nur Informationen, die explizit im Text stehen. "
-        "Erfinde keine Daten."
+        "aus dem folgenden Report-Abschnitt.\n\n"
+        f"## Pflicht-Schema ({schema_cls.__name__})\n"
+        f"```json\n{schema_json}\n```\n\n"
+        "## Harte Regeln\n"
+        "1. Verwende AUSSCHLIESSLICH die im Schema definierten Feldnamen "
+        "in snake_case (z. B. `section_title`, NICHT `sectionTitle`; "
+        "`key_takeaways`, NICHT `keyFindings`).\n"
+        "2. KEINE zusätzlichen Felder. Das Schema ist strict "
+        "(`additionalProperties=false`); jedes unbekannte Feld lässt die "
+        "Validierung fehlschlagen.\n"
+        "3. Verwende nur Informationen, die explizit im Abschnittstext stehen. "
+        "Erfinde keine Daten.\n"
+        "4. Bei fehlenden Informationen: leere Liste oder Default-Wert. "
+        "Nicht halluzinieren, nicht auffüllen."
     )
     user_msg = (
         f"## Abschnittstitel\n{section_title}\n\n"

--- a/backend/app/services/report_prompts/sections.py
+++ b/backend/app/services/report_prompts/sections.py
@@ -83,8 +83,15 @@ You classify the level yourself and set confidence_label accordingly.
 
 <self_check>
 Before writing a claim, check in this exact order:
+0. Did the `interview_agents` tool call actually return successful
+   interviews for this section?
+   → No / empty results / API error: there is NO agent_quote evidence
+     available. You MUST NOT label any claim "high" or "verified".
+     Fabricating <simulated_quote> tags inline does NOT create
+     evidence[] entries — the validator only sees the structured
+     evidence[] list, not the markdown body.
 1. Do I have any evidence at all?
-   → No: Do not formulate as claim.
+   → No: Do not formulate as claim. Use hypotheses[] instead.
 2. Is the evidence a real agent quote, or only seed text?
    → Seed only: max low + hedge word required.
 3. Do I have quotes from at least 2 stakeholder groups, consistent direction?
@@ -92,6 +99,27 @@ Before writing a claim, check in this exact order:
    → Yes: high is allowed; name stakeholder groups in claim text
 4. Never set high or verified without supports_claim=True.
 </self_check>
+
+<critical_distinction>
+Two different things, do not confuse them:
+
+A) `<simulated_quote persona_id="..." seed_anchor="...">…</simulated_quote>`
+   is a markdown formatting tag for rendering persona statements in the
+   section body. It is purely cosmetic for the reader.
+
+B) `evidence[]` is the structured list on each claim, containing
+   EvidenceItem objects with `source_kind`, `persona_stakeholder_group`,
+   `supports_claim`, `match_score`, `quote`, etc.
+
+The Pydantic validator only inspects B. Adding (A) to the body text
+without adding matching (B) entries on the claim is treated as
+"no evidence" by the validator and will hard-fail the report build.
+
+If `interview_agents` produced no usable answers:
+- Do NOT invent <simulated_quote> blocks to fill the gap.
+- Either downgrade the claim to "low" with seed_corpus evidence + hedge,
+  or move it to hypotheses[] entirely.
+</critical_distinction>
 
 <negative_examples>
 WRONG: "Employees will embrace the initiative." (no quote, no hedge)
@@ -107,6 +135,15 @@ WRONG: "Competitors will adopt this approach." (only competitor quote,
 FIX:   confidence_label="medium". Competitor quote is strategic position,
        not stakeholder consensus. Label as competitive positioning in
        claim text.
+
+WRONG: interview_agents returned no successful interviews, but the
+       section still contains claims with confidence_label="high" and
+       inline <simulated_quote> tags as substitute for missing data.
+FIX:   Set confidence_label="low" with source_kind="seed_corpus" and
+       a hedge word, OR move the assertion to hypotheses[] with a
+       rationale field. The cross_stakeholder_for_high validator will
+       reject "high" without two distinct persona_stakeholder_group
+       entries in evidence[].
 </negative_examples>
 </evidence_gating>
 


### PR DESCRIPTION
## Summary

Zwei Prompt-Härtungen ohne ADR-0002-Touch. Behebt den Report-Generation-Fail-Mode aus User-Logs:

```
Interview API call failed: No successful interviews
…
EvidenceMapModel: Label 'high' verlangt unterstützende agent_quote-Evidence
(supports_claim=True) aus mindestens 2 unterschiedlichen Stakeholder-Gruppen.
Gefunden: ∅.

SectionMetadata: sectionTitle/keyFindings/quotes/sentiment — Extra inputs are not permitted
```

### Root Cause
OASIS-Interview-API liefert `success=False` → keine `agent_quote`-Evidence. Das LLM:
1. fabriziert `<simulated_quote>`-Tags im Fließtext und vergibt `confidence_label=high` → `cross_stakeholder_for_high` (ADR-0002 Anker 4) blockt korrekt;
2. ratet bei `SectionMetadata`-Extraktion die Feldnamen (`sectionTitle` statt `section_title`) → `extra="forbid"` blockt.

### Fixes
- `workflow.py::generate_section_metadata`: bettet `schema_cls.model_json_schema()` inline in den System-Prompt + harte snake_case-/`additionalProperties=false`-Regeln. Entkoppelt Feldnamen-Auswahl vom LLM-Klassennamen-Rätselraten.
- `report_prompts/sections.py <evidence_gating>`:
  - `<self_check>` Schritt 0 prüft jetzt explizit Interview-API-Erfolg vor Label-Vergabe.
  - Neuer `<critical_distinction>`-Block trennt `<simulated_quote>`-Markdown-Tag (Body-Formatting) von `evidence[]`-Pydantic-Struktur (Validator-Input).
  - Neues Negative-Example deckt exakt den Fail-Mode aus dem Log ab.

ADR-0002-Anker (Validator-Code, Enum, Snapshot, Validator-Methoden) **unverändert** — gating bleibt hard.

### Was NICHT in diesem PR ist
- OASIS-Interview-API-Repair (Root Cause der Quote-Leere) — eigener Slice, betrifft `graph_tools.py:270 SimulationRunner.interview_agents_batch` und ggf. gevent/Subprozess-Smoke via `scripts/verify-deploy.sh`.
- Auto-Downgrade von `high→medium` vor `model_validate` als Sicherheitsnetz — bewusst zurückgestellt, um den Validator nicht zu unterlaufen.

## Test plan
- [x] `pytest tests/services/test_report_agent_strict_schema.py` → 26/26 grün
- [x] `pytest tests/contracts/ tests/services/test_report_agent_provenance.py tests/services/test_report_agent_quote_anchors.py tests/services/test_report_modes_workflow.py tests/services/test_report_v3_hypotheses.py tests/services/test_report_agent_workflow_quote_validation.py tests/eval/` → 210/210 grün
- [x] `python -m app.contracts.dump_schemas` + `git diff --exit-code schemas/` → kein Drift
- [x] `ruff check` → grün
- [x] Wording-Glossar v1 Check auf Diff → keine Verstöße
- [ ] Manuelle Verifikation: Report-Run gegen Sim mit gefailter Interview-API erzeugt `incomplete`/`low`-Labels statt Hard-Fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)