### PR TITLE
fix(report): follow up CI and schema helper cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             registry-1.docker.io:443
+            registry.npmjs.org:443
             api.github.com:443
 
       - name: Checkout full history for secret scan

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -174,6 +174,4 @@ __all__ = [
     # M11.8d — Section-Metadata DTOs + mapper
     "SectionKeyTakeaway",
     "SectionMetadata",
-    "_make_table_metadata",
-    "_section_schema_for",
 ]

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2062 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2063 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- unblock Security scans by allowing `registry.npmjs.org` for `npm audit` under Harden Runner
- sync `docu/STATUS.md` backend collected-test count to 2063
- remove underscored report schema helpers from `__all__` per Gemini review on PR #446

## Verification
- `LLM_API_KEY=dummy-ci-key FLASK_DEBUG=true UV_CACHE_DIR=/private/tmp/uv-cache-agora-report-fix-1 uv run pytest tests/services/test_report_agent_strict_schema.py tests/test_llm_client.py tests/contracts/test_report_contract.py tests/storage/test_neo4j_fork.py -v`
- `UV_CACHE_DIR=/private/tmp/uv-cache-agora-report-fix-1 uv run ruff check app/storage/neo4j_storage.py app/services/report_agent/schemas.py app/utils/llm_client.py tests/services/test_report_agent_strict_schema.py tests/test_llm_client.py`
- `bash scripts/sync-status.sh --check`
- `cd frontend && npm audit --audit-level=high`

Follow-up to merged PR #446.