### PR TITLE
fix(report): update schema export comment

### DIFF
--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -171,7 +171,7 @@ __all__ = [
     # M11.8d — Plan-Response DTOs
     "PlanSection",
     "PlanResponse",
-    # M11.8d — Section-Metadata DTOs + mapper
+    # M11.8d — Section-Metadata DTOs
     "SectionKeyTakeaway",
     "SectionMetadata",
 ]


### PR DESCRIPTION
## Summary
- update the report schema `__all__` comment after internal helpers were removed from exports

## Verification
- `uv run ruff check app/services/report_agent/schemas.py`
- `LLM_API_KEY=dummy-ci-key FLASK_DEBUG=true uv run pytest tests/services/test_report_agent_strict_schema.py -q`

Follow-up to PR #447 / Gemini comment cleanup.