### PR TITLE
feat(llm): Multi-Provider-Hub — verschlüsselte Keys, Workspace-Routing, Per-Step-Modellauswahl

### DIFF
--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -163,7 +163,9 @@ def upsert_provider_api_key(provider_id: str):
                 logger.warning("Provider-Validate fehlgeschlagen für %s: %s", provider_id, exc)
                 entry = store.mark_validated(provider_id, ok=False) or entry
 
-    return json_success(entry.model_dump(mode="json"), status=201)
+    # POST → 201 Created; PUT → 200 OK (Gemini MEDIUM #8)
+    status_code = 201 if request.method == "POST" else 200
+    return json_success(entry.model_dump(mode="json"), status=status_code)
 
 
 @llm_bp.route("/providers/<provider_id>/api-key", methods=["DELETE"])

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -3,8 +3,15 @@ LLM Provider API.
 """
 
 from flask import request
+from pydantic import ValidationError
+
 from . import llm_bp
+from ..contracts.llm_provider_keys_contract import (
+    LlmProviderKeyCreateRequest,
+    LlmProviderKeysListResponse,
+)
 from ..services.llm_provider_registry import LlmProviderRegistry
+from ..services.llm_provider_secrets_store import get_llm_provider_secrets_store
 from ..services.model_catalog_service import ModelCatalogService
 from ..services.secret_resolver import SecretResolver
 from ..utils.api_responses import handle_api_errors, json_success, json_error
@@ -78,3 +85,94 @@ def test_provider(provider_id: str):
     except Exception as exc:
         logger.exception("Provider test failed for %s: %s", provider_id, exc)
         return json_error("Test failed: connectivity or authentication error", status=400)
+
+
+# ---------------------------------------------------------------------------
+# Provider-API-Key-CRUD (Frontend-Setup: speichern, anzeigen, widerrufen)
+# ---------------------------------------------------------------------------
+
+
+def _provider_or_404(provider_id: str):
+    providers = provider_registry.get_providers()
+    return next((p for p in providers if p.id == provider_id), None)
+
+
+@llm_bp.route("/providers/api-keys", methods=["GET"])
+@handle_api_errors(logger=logger)
+def list_provider_api_keys():
+    """List all provider API keys (masked)."""
+    items = get_llm_provider_secrets_store().list_entries()
+    response = LlmProviderKeysListResponse(items=items, total=len(items))
+    return json_success(response.model_dump(mode="json"))
+
+
+@llm_bp.route("/providers/<provider_id>/api-key", methods=["GET"])
+@handle_api_errors(logger=logger)
+def get_provider_api_key(provider_id: str):
+    """Return the stored (masked) key entry for one provider."""
+    if _provider_or_404(provider_id) is None:
+        return json_error(f"Provider not found: {provider_id}", status=404)
+    entry = get_llm_provider_secrets_store().get_entry(provider_id)
+    if entry is None:
+        return json_error("API key not configured", status=404, code="not_found")
+    return json_success(entry.model_dump(mode="json"))
+
+
+@llm_bp.route("/providers/<provider_id>/api-key", methods=["POST", "PUT"])
+@handle_api_errors(logger=logger)
+def upsert_provider_api_key(provider_id: str):
+    """Store or replace the API key for one provider."""
+    provider = _provider_or_404(provider_id)
+    if provider is None:
+        return json_error(f"Provider not found: {provider_id}", status=404)
+
+    payload = request.get_json(silent=True) or {}
+    try:
+        body = LlmProviderKeyCreateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Invalid request body",
+            status=400,
+            code="invalid_request",
+            extra={"errors": exc.errors(include_url=False)},
+        )
+
+    store = get_llm_provider_secrets_store()
+    try:
+        entry = store.upsert(
+            provider_id,
+            api_key=body.api_key,
+            base_url=body.base_url or provider.base_url,
+        )
+    except RuntimeError as exc:
+        logger.error("Secret-Store-Fehler beim Speichern: %s", exc)
+        return json_error(
+            "Secret store unavailable (AGORA_SECRET_KEY missing or invalid)",
+            status=503,
+            code="secret_store_unavailable",
+        )
+
+    # Optionaler Inline-Validate
+    if request.args.get("validate") == "1":
+        base_url = entry.base_url or provider.base_url
+        if base_url:
+            try:
+                model_catalog.get_models(provider_id, provider.type, base_url, body.api_key)
+                entry = store.mark_validated(provider_id, ok=True) or entry
+            except Exception as exc:
+                logger.warning("Provider-Validate fehlgeschlagen für %s: %s", provider_id, exc)
+                entry = store.mark_validated(provider_id, ok=False) or entry
+
+    return json_success(entry.model_dump(mode="json"), status=201)
+
+
+@llm_bp.route("/providers/<provider_id>/api-key", methods=["DELETE"])
+@handle_api_errors(logger=logger)
+def delete_provider_api_key(provider_id: str):
+    """Revoke the API key for one provider."""
+    if _provider_or_404(provider_id) is None:
+        return json_error(f"Provider not found: {provider_id}", status=404)
+    deleted = get_llm_provider_secrets_store().delete(provider_id)
+    if not deleted:
+        return json_error("API key not configured", status=404, code="not_found")
+    return json_success({"provider_id": provider_id, "status": "revoked"})

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -9,10 +9,12 @@ from collections import deque
 from flask import request
 from pydantic import ValidationError
 
-from . import runs_bp
+from . import runs_bp, llm_bp
 from ..services.runtime_run_config import RuntimeRunConfig
 from ..services.run_registry import RunRegistry
+from ..services.workspace_routing_store import get_workspace_routing_store
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
+from ..contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.logger import get_logger
@@ -147,3 +149,83 @@ def patch_stage_llm_routing(run_id: str, stage_id: str):
             code="validation_failed",
             extra={"details": exc.errors()},
         )
+
+
+# ---------------------------------------------------------------------------
+# Workspace-weite Routing-Defaults (gilt für neue Runs, bis Stage versiegelt)
+# ---------------------------------------------------------------------------
+
+
+@llm_bp.route("/routing/defaults", methods=["GET"])
+@handle_api_errors(logger=logger)
+def get_routing_defaults():
+    """Return the workspace-wide routing defaults."""
+    defaults = get_workspace_routing_store().load()
+    return json_success(defaults.model_dump(mode="json"))
+
+
+@llm_bp.route("/routing/defaults", methods=["PUT"])
+@handle_api_errors(logger=logger)
+def replace_routing_defaults():
+    """Replace the workspace-wide routing defaults."""
+    payload = request.get_json(silent=True) or {}
+    try:
+        model = WorkspaceLlmRoutingDefaults.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Validation failed",
+            status=400,
+            code="validation_failed",
+            extra={"details": exc.errors()},
+        )
+    stored = get_workspace_routing_store().save(model)
+    return json_success(stored.model_dump(mode="json"))
+
+
+@llm_bp.route("/routing/defaults/stages/<stage_id>", methods=["PATCH"])
+@handle_api_errors(logger=logger)
+def patch_routing_default_stage(stage_id: str):
+    """Set or clear the workspace-wide override for one stage.
+
+    Empty body or ``{"clear": true}`` clears the override; otherwise the body
+    is parsed as ``StageLLMRoute``.
+    """
+    if stage_id not in ALL_STAGE_IDS:
+        return json_error("Invalid stage_id", status=400, code="invalid_stage_id")
+
+    payload = request.get_json(silent=True) or {}
+    store = get_workspace_routing_store()
+
+    if payload.get("clear") is True or payload == {}:
+        defaults = store.set_stage_override(stage_id, None)
+        return json_success(defaults.model_dump(mode="json"))
+
+    try:
+        route = StageLLMRoute.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Validation failed",
+            status=400,
+            code="validation_failed",
+            extra={"details": exc.errors()},
+        )
+    defaults = store.set_stage_override(stage_id, route)
+    return json_success(defaults.model_dump(mode="json"))
+
+
+@llm_bp.route("/routing/defaults/global", methods=["PUT"])
+@handle_api_errors(logger=logger)
+def replace_global_default():
+    """Replace just the workspace-wide global default route."""
+    payload = request.get_json(silent=True) or {}
+    try:
+        route = StageLLMRoute.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Validation failed",
+            status=400,
+            code="validation_failed",
+            extra={"details": exc.errors()},
+        )
+    defaults = get_workspace_routing_store().set_global_default(route)
+    return json_success(defaults.model_dump(mode="json"))

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -38,6 +38,12 @@ from app.contracts.llm_profile_contract import (
     LlmProfileListResponse,
     LlmProfileCreateRequest,
 )
+from app.contracts.llm_provider_keys_contract import (
+    LlmProviderKeyCreateRequest,
+    LlmProviderKeyEntry,
+    LlmProviderKeysListResponse,
+)
+from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -65,6 +71,10 @@ CONTRACTS: dict[str, type] = {
     "llm-profile.schema.json": LlmProfile,
     "llm-profile-list-response.schema.json": LlmProfileListResponse,
     "llm-profile-create-request.schema.json": LlmProfileCreateRequest,
+    "llm-provider-key-entry.schema.json": LlmProviderKeyEntry,
+    "llm-provider-key-create-request.schema.json": LlmProviderKeyCreateRequest,
+    "llm-provider-keys-list-response.schema.json": LlmProviderKeysListResponse,
+    "workspace-llm-routing-defaults.schema.json": WorkspaceLlmRoutingDefaults,
 }
 
 

--- a/backend/app/contracts/llm_provider_keys_contract.py
+++ b/backend/app/contracts/llm_provider_keys_contract.py
@@ -1,0 +1,54 @@
+"""LLM-Provider-API-Keys Contract (Pydantic v2).
+
+Persistiert pro Provider-ID **einen** API-Key plus optionale Base-URL für
+``openai_compatible``-Provider (OpenRouter, Ollama, custom). Klartext-Keys
+verlassen das Backend nie — die API antwortet ausschließlich mit
+maskierten Werten (``sk-...abc`` Format, letzte vier Zeichen sichtbar).
+
+Strikt getrennt von ``api_keys_contract.py``: dort geht es um
+Agora-eigene Workspace-Auth-Tokens (``ago_<48-hex>``), hier um
+Drittanbieter-API-Keys (OpenAI, Google, Copilot, OpenAI-compat).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_STRICT = ConfigDict(extra="forbid")
+
+# "sk-...abc" → vier Zeichen vom Ende sichtbar, davor immer das gleiche Präfix
+MASKED_KEY_PATTERN = r"^.{1,8}\.\.\.[A-Za-z0-9_\-]{4}$"
+
+
+class LlmProviderKeyEntry(BaseModel):
+    """Persistierte Repräsentation eines Provider-Keys (ohne Klartext)."""
+
+    model_config = _STRICT
+
+    provider_id: str = Field(min_length=1, max_length=64)
+    masked_value: str = Field(pattern=MASKED_KEY_PATTERN)
+    base_url: Optional[str] = Field(default=None, max_length=512)
+    created_at: datetime
+    updated_at: datetime
+    last_validated_at: Optional[datetime] = None
+    last_validation_ok: Optional[bool] = None
+
+
+class LlmProviderKeyCreateRequest(BaseModel):
+    """Eingabe für POST /api/llm/providers/<provider_id>/api-key."""
+
+    model_config = _STRICT
+
+    api_key: str = Field(min_length=4, max_length=1024)
+    base_url: Optional[str] = Field(default=None, max_length=512)
+
+
+class LlmProviderKeysListResponse(BaseModel):
+    """Antwort auf GET /api/llm/providers/api-keys (Übersicht aller Provider)."""
+
+    model_config = _STRICT
+
+    items: list[LlmProviderKeyEntry]
+    total: int = Field(ge=0)

--- a/backend/app/contracts/llm_routing_contract.py
+++ b/backend/app/contracts/llm_routing_contract.py
@@ -71,7 +71,7 @@ class ProviderDescriptor(BaseModel):
 
     id: str
     label: str
-    type: Literal["ollama_local", "openai", "google", "openai_compatible"]
+    type: Literal["ollama_local", "openai", "google", "openai_compatible", "github_copilot"]
     base_url: Optional[str] = None
     api_key_ref: Optional[str] = None
     supports_models_endpoint: bool = False

--- a/backend/app/contracts/workspace_routing_contract.py
+++ b/backend/app/contracts/workspace_routing_contract.py
@@ -1,0 +1,32 @@
+"""Workspace-weite LLM-Routing-Defaults (Pydantic v2).
+
+Diese Defaults werden global pro Workspace persistiert (eine JSON-Datei).
+Beim Run-Start mergt ``llm_routing_seed.seed_run_stage_routing`` den
+Workspace-Default mit ggf. per Request übergebenen Overrides in die
+runspezifische ``RuntimeLlmRouting``.
+
+Strikt getrennt von ``RuntimeLlmRouting`` (per-Run, lebt im Run-Verzeichnis):
+hier sprechen wir über den Wunsch-Default des Workspaces, der bei jedem
+neuen Run wirksam wird, solange ein Stage noch nicht versiegelt ist.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .llm_routing_contract import StageId, StageLLMRoute
+
+_STRICT = ConfigDict(extra="forbid")
+
+
+class WorkspaceLlmRoutingDefaults(BaseModel):
+    """Workspace-weit gültiger LLM-Default plus optionale Stage-Overrides."""
+
+    model_config = _STRICT
+
+    global_default: StageLLMRoute = Field(default_factory=StageLLMRoute)
+    stage_overrides: Dict[StageId, StageLLMRoute] = Field(default_factory=dict)
+    updated_at: Optional[datetime] = None
+    version: int = 1

--- a/backend/app/services/llm_provider_registry.py
+++ b/backend/app/services/llm_provider_registry.py
@@ -50,6 +50,21 @@ class LlmProviderRegistry:
                 api_key_ref="LLM_API_KEY",
                 supports_models_endpoint=True,
                 fallback_models=[],
-            )
+            ),
+            ProviderDescriptor(
+                id="github_copilot",
+                label="GitHub Copilot",
+                type="github_copilot",
+                base_url="https://api.githubcopilot.com",
+                api_key_ref="GH_AUTH_TOKEN",
+                supports_models_endpoint=False,
+                fallback_models=list(_copilot_models()),
+            ),
         ]
         return providers
+
+
+def _copilot_models() -> tuple[str, ...]:
+    # Lazy-Import vermeidet Zirkularität wenn das Submodul später wächst.
+    from .llm_providers.github_copilot import GITHUB_COPILOT_MODELS
+    return GITHUB_COPILOT_MODELS

--- a/backend/app/services/llm_provider_secrets_store.py
+++ b/backend/app/services/llm_provider_secrets_store.py
@@ -41,7 +41,9 @@ from typing import Optional
 from cryptography.fernet import Fernet, InvalidToken
 
 from ..contracts.llm_provider_keys_contract import LlmProviderKeyEntry
+from ..utils.logger import get_logger
 
+logger = get_logger("agora.services.llm_provider_secrets_store")
 
 _DATA_DIR_ENV = "AGORA_DATA_DIR"
 _SECRET_KEY_ENV = "AGORA_SECRET_KEY"
@@ -93,15 +95,30 @@ class LlmProviderSecretsStore:
     Thread-safe via internen Lock. Lese-Operationen entschlüsseln on-demand und
     cachen Klartext NICHT — jeder Aufruf von ``get_plaintext`` macht einen
     Decrypt-Roundtrip.
+
+    Die ``Fernet``-Instanz wird beim ersten Zugriff einmalig erstellt und dann
+    gecacht, um das wiederholte Key-Parsing zu vermeiden (Gemini MEDIUM #1).
     """
 
     def __init__(self, *, data_dir: Optional[Path] = None) -> None:
         self._lock = threading.Lock()
         self._data_dir = data_dir or _resolve_data_dir()
         self._path = self._data_dir / _STORE_FILENAME
+        self._fernet_instance: Optional[Fernet] = None
+        self._fernet_key_raw: Optional[str] = None  # Wert aus Env beim letzten Cache-Fill
 
     def _fernet(self) -> Fernet:
-        return _load_fernet()
+        """Lazy-cached Fernet-Instanz.
+
+        Der Cache wird nur dann wiederverwendet, wenn der Env-Var-Wert von
+        ``AGORA_SECRET_KEY`` unverändert ist. Key-Rotation (oder Testwechsel)
+        invalidiert den Cache automatisch.
+        """
+        current_key_raw = os.environ.get(_SECRET_KEY_ENV)
+        if self._fernet_instance is None or self._fernet_key_raw != current_key_raw:
+            self._fernet_instance = _load_fernet()
+            self._fernet_key_raw = current_key_raw
+        return self._fernet_instance
 
     def _read_raw(self) -> dict:
         if not self._path.exists():
@@ -114,12 +131,26 @@ class LlmProviderSecretsStore:
             ) from exc
 
     def _write_raw(self, raw: dict) -> None:
+        """Atomisches Schreiben mit File-Level-Lock.
+
+        ``threading.Lock`` schützt nur innerhalb eines Prozesses. Bei mehreren
+        Gunicorn-Workern ist zusätzlich ``fcntl.flock`` nötig, um Lost-Updates
+        zu verhindern (Gemini MEDIUM #2).
+        """
+        import fcntl  # POSIX-only — Agora läuft ausschließlich auf Linux/macOS
+
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        # Atomic write via tmp + rename, damit kein halb-geschriebenes File
-        # liegen bleibt wenn der Prozess crasht.
-        tmp_path = self._path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(raw, indent=2, sort_keys=True), encoding="utf-8")
-        os.replace(tmp_path, self._path)
+        lock_path = self._path.with_suffix(".lock")
+        with open(lock_path, "w", encoding="utf-8") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            try:
+                tmp_path = self._path.with_suffix(".tmp")
+                tmp_path.write_text(
+                    json.dumps(raw, indent=2, sort_keys=True), encoding="utf-8"
+                )
+                os.replace(tmp_path, self._path)
+            finally:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
     def list_entries(self) -> list[LlmProviderKeyEntry]:
         with self._lock:

--- a/backend/app/services/llm_provider_secrets_store.py
+++ b/backend/app/services/llm_provider_secrets_store.py
@@ -1,0 +1,253 @@
+"""Persistenter, Fernet-verschlüsselter Store für LLM-Provider-API-Keys.
+
+Storage-Layout (`backend/data/llm_provider_secrets.json`):
+
+    {
+      "version": 1,
+      "entries": {
+        "openai": {
+          "ciphertext": "<fernet-base64>",
+          "base_url": null,
+          "created_at": "2026-...",
+          "updated_at": "2026-...",
+          "last_validated_at": null,
+          "last_validation_ok": null
+        },
+        ...
+      }
+    }
+
+Master-Key:
+    `AGORA_SECRET_KEY` (Pflicht; Fail-Fast wenn nicht gesetzt). Wert muss ein
+    gültiger Fernet-Key sein (URL-safe base64, 32 Bytes). Ungesetzt oder
+    invalid → ``RuntimeError`` beim ersten Zugriff. Dadurch kann die Flask-App
+    beim Start (oder beim ersten Request) einen klaren Fehler werfen.
+
+Security:
+    - Klartext-Keys werden ausschließlich beim Encrypt-Roundtrip im Speicher
+      gehalten und nie geloggt.
+    - ``masked_value`` ist die einzige Repräsentation, die das Modul nach außen
+      gibt; sie wird aus dem Klartext abgeleitet, nicht aus dem Ciphertext.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from ..contracts.llm_provider_keys_contract import LlmProviderKeyEntry
+
+
+_DATA_DIR_ENV = "AGORA_DATA_DIR"
+_SECRET_KEY_ENV = "AGORA_SECRET_KEY"
+_STORE_FILENAME = "llm_provider_secrets.json"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _mask_key(plaintext: str) -> str:
+    """Erzeugt ein Maskierungsformat ``sk-...abcd`` aus einem Klartext-Key."""
+    if len(plaintext) <= 4:
+        # zu kurz für sinnvolle Maskierung — Sentinel, aber Pattern-konform
+        return f"key-...{plaintext.rjust(4, '_')[-4:]}"
+    prefix = plaintext[:2] if plaintext.startswith(("sk", "gh", "go", "AI")) else plaintext[:3]
+    if not prefix:
+        prefix = "key"
+    return f"{prefix}-...{plaintext[-4:]}"
+
+
+def _resolve_data_dir() -> Path:
+    raw = os.environ.get(_DATA_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    # backend/app/services/llm_provider_secrets_store.py → backend/data/
+    return Path(__file__).resolve().parents[2] / "data"
+
+
+def _load_fernet() -> Fernet:
+    raw = os.environ.get(_SECRET_KEY_ENV)
+    if not raw:
+        raise RuntimeError(
+            f"{_SECRET_KEY_ENV} ist nicht gesetzt. Erzeugen mit:\n"
+            "  python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'\n"
+            f"Anschließend in der Umgebung exportieren ({_SECRET_KEY_ENV}=…)."
+        )
+    try:
+        return Fernet(raw.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise RuntimeError(
+            f"{_SECRET_KEY_ENV} ist kein gültiger Fernet-Key: {exc}"
+        ) from exc
+
+
+class LlmProviderSecretsStore:
+    """File-backed, Fernet-encrypted Multi-Provider-Secret-Store.
+
+    Thread-safe via internen Lock. Lese-Operationen entschlüsseln on-demand und
+    cachen Klartext NICHT — jeder Aufruf von ``get_plaintext`` macht einen
+    Decrypt-Roundtrip.
+    """
+
+    def __init__(self, *, data_dir: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._data_dir = data_dir or _resolve_data_dir()
+        self._path = self._data_dir / _STORE_FILENAME
+
+    def _fernet(self) -> Fernet:
+        return _load_fernet()
+
+    def _read_raw(self) -> dict:
+        if not self._path.exists():
+            return {"version": 1, "entries": {}}
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Konnte LLM-Secrets-Store nicht lesen ({self._path}): {exc}"
+            ) from exc
+
+    def _write_raw(self, raw: dict) -> None:
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        # Atomic write via tmp + rename, damit kein halb-geschriebenes File
+        # liegen bleibt wenn der Prozess crasht.
+        tmp_path = self._path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(raw, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp_path, self._path)
+
+    def list_entries(self) -> list[LlmProviderKeyEntry]:
+        with self._lock:
+            raw = self._read_raw()
+        return [self._to_entry(pid, payload) for pid, payload in raw.get("entries", {}).items()]
+
+    def get_entry(self, provider_id: str) -> Optional[LlmProviderKeyEntry]:
+        with self._lock:
+            raw = self._read_raw()
+        payload = raw.get("entries", {}).get(provider_id)
+        if payload is None:
+            return None
+        return self._to_entry(provider_id, payload)
+
+    def get_plaintext(self, provider_id: str) -> Optional[str]:
+        """Entschlüsselt und gibt den Klartext-Key zurück. ``None`` wenn fehlt."""
+        with self._lock:
+            raw = self._read_raw()
+        payload = raw.get("entries", {}).get(provider_id)
+        if payload is None:
+            return None
+        ciphertext = payload.get("ciphertext")
+        if not ciphertext:
+            return None
+        try:
+            return self._fernet().decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+        except InvalidToken as exc:
+            raise RuntimeError(
+                "LLM-Provider-Key konnte nicht entschlüsselt werden. "
+                f"AGORA_SECRET_KEY passt nicht zum Ciphertext für '{provider_id}'."
+            ) from exc
+
+    def upsert(
+        self,
+        provider_id: str,
+        *,
+        api_key: str,
+        base_url: Optional[str] = None,
+    ) -> LlmProviderKeyEntry:
+        if not api_key or len(api_key) < 4:
+            raise ValueError("api_key zu kurz")
+        ciphertext = self._fernet().encrypt(api_key.encode("utf-8")).decode("utf-8")
+        masked = _mask_key(api_key)
+        now = _now()
+        with self._lock:
+            raw = self._read_raw()
+            entries = raw.setdefault("entries", {})
+            existing = entries.get(provider_id)
+            created_at = existing["created_at"] if existing else now.isoformat()
+            entry_payload = {
+                "ciphertext": ciphertext,
+                "masked_value": masked,
+                "base_url": base_url,
+                "created_at": created_at,
+                "updated_at": now.isoformat(),
+                "last_validated_at": existing.get("last_validated_at") if existing else None,
+                "last_validation_ok": existing.get("last_validation_ok") if existing else None,
+            }
+            entries[provider_id] = entry_payload
+            raw["version"] = 1
+            self._write_raw(raw)
+        return self._to_entry(provider_id, entry_payload)
+
+    def mark_validated(self, provider_id: str, *, ok: bool) -> Optional[LlmProviderKeyEntry]:
+        now = _now()
+        with self._lock:
+            raw = self._read_raw()
+            entry = raw.get("entries", {}).get(provider_id)
+            if entry is None:
+                return None
+            entry["last_validated_at"] = now.isoformat()
+            entry["last_validation_ok"] = ok
+            self._write_raw(raw)
+        return self._to_entry(provider_id, entry)
+
+    def delete(self, provider_id: str) -> bool:
+        with self._lock:
+            raw = self._read_raw()
+            entries = raw.get("entries", {})
+            if provider_id not in entries:
+                return False
+            del entries[provider_id]
+            self._write_raw(raw)
+        return True
+
+    def reset_for_tests(self) -> None:
+        """Nur in Tests — löscht das gesamte Store-File."""
+        with self._lock:
+            if self._path.exists():
+                self._path.unlink()
+
+    @staticmethod
+    def _to_entry(provider_id: str, payload: dict) -> LlmProviderKeyEntry:
+        masked = payload.get("masked_value")
+        if not masked:
+            # Legacy-Fallback, falls jemand das File manuell editiert hat
+            masked = "key-...XXXX"
+        return LlmProviderKeyEntry(
+            provider_id=provider_id,
+            masked_value=masked,
+            base_url=payload.get("base_url"),
+            created_at=datetime.fromisoformat(payload["created_at"]),
+            updated_at=datetime.fromisoformat(payload["updated_at"]),
+            last_validated_at=(
+                datetime.fromisoformat(payload["last_validated_at"])
+                if payload.get("last_validated_at")
+                else None
+            ),
+            last_validation_ok=payload.get("last_validation_ok"),
+        )
+
+
+_store_singleton: Optional[LlmProviderSecretsStore] = None
+_singleton_lock = threading.Lock()
+
+
+def get_llm_provider_secrets_store() -> LlmProviderSecretsStore:
+    """Singleton-Accessor — pro Prozess geteilt."""
+    global _store_singleton
+    if _store_singleton is None:
+        with _singleton_lock:
+            if _store_singleton is None:
+                _store_singleton = LlmProviderSecretsStore()
+    return _store_singleton
+
+
+def reset_singleton_for_tests() -> None:
+    """Nur in Tests aufrufen — zwingt Neuinitialisierung des Singletons."""
+    global _store_singleton
+    with _singleton_lock:
+        _store_singleton = None

--- a/backend/app/services/llm_providers/__init__.py
+++ b/backend/app/services/llm_providers/__init__.py
@@ -1,0 +1,6 @@
+"""Provider-spezifische Helpers (Sub-Module von services).
+
+Aktuell beheimatet das Paket nur den GitHub-Copilot-Token-Resolver.
+Wenn weitere Provider eigene Auth-Flows brauchen (z. B. AWS-Bedrock-Signaturen,
+Azure-OpenAI-Tenant-Resolution), kommen sie hier rein.
+"""

--- a/backend/app/services/llm_providers/github_copilot.py
+++ b/backend/app/services/llm_providers/github_copilot.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
+import time
+import threading
 from typing import Optional
 
 logger = logging.getLogger("agora.llm.github_copilot")
@@ -33,9 +35,20 @@ GITHUB_COPILOT_MODELS: tuple[str, ...] = (
 
 GITHUB_COPILOT_BASE_URL = "https://api.githubcopilot.com"
 
+# Token-Cache: vermeidet wiederholte subprocess-Spawns (Gemini MEDIUM #3).
+# TTL 300 s — kurz genug um Token-Rotationen zu erfassen, lang genug um
+# den Overhead bei Per-Request-Auflösung zu vermeiden.
+_TOKEN_CACHE_TTL: float = 300.0
+_token_cache: Optional[str] = None
+_token_cache_ts: float = 0.0
+_token_cache_lock = threading.Lock()
+
 
 def resolve_copilot_token(timeout_seconds: float = 3.0) -> Optional[str]:
     """Resolve a GitHub Copilot token via ``gh auth token``.
+
+    Ergebnis wird für ``_TOKEN_CACHE_TTL`` Sekunden gecacht, um wiederholte
+    subprocess-Spawns zu vermeiden (Gemini MEDIUM #3).
 
     Returns
     -------
@@ -43,6 +56,24 @@ def resolve_copilot_token(timeout_seconds: float = 3.0) -> Optional[str]:
         Token-String, oder ``None`` wenn ``gh`` nicht installiert ist bzw.
         der User nicht angemeldet ist. Niemals ein leerer String.
     """
+    global _token_cache, _token_cache_ts
+
+    now = time.monotonic()
+    with _token_cache_lock:
+        if _token_cache is not None and (now - _token_cache_ts) < _TOKEN_CACHE_TTL:
+            return _token_cache
+
+    token = _resolve_copilot_token_uncached(timeout_seconds)
+
+    with _token_cache_lock:
+        _token_cache = token
+        _token_cache_ts = time.monotonic()
+
+    return token
+
+
+def _resolve_copilot_token_uncached(timeout_seconds: float) -> Optional[str]:
+    """Interner uncached Resolver — nicht direkt aufrufen."""
     gh_path = shutil.which("gh")
     if gh_path is None:
         logger.debug("`gh` CLI nicht im PATH — Copilot-Token nicht auflösbar")
@@ -63,8 +94,6 @@ def resolve_copilot_token(timeout_seconds: float = 3.0) -> Optional[str]:
         return None
 
     if proc.returncode != 0:
-        # gh schreibt im Fehlerfall eine Begründung nach stderr, aber sie kann
-        # den Token nicht enthalten — daher loggen wir sie.
         logger.info("`gh auth token` non-zero exit (%s): %s", proc.returncode, proc.stderr.strip())
         return None
 
@@ -73,3 +102,11 @@ def resolve_copilot_token(timeout_seconds: float = 3.0) -> Optional[str]:
         return None
     logger.info("GitHub-Copilot-Token aufgelöst (len=%d)", len(token))
     return token
+
+
+def clear_token_cache() -> None:
+    """Nur für Tests — leert den Token-Cache."""
+    global _token_cache, _token_cache_ts
+    with _token_cache_lock:
+        _token_cache = None
+        _token_cache_ts = 0.0

--- a/backend/app/services/llm_providers/github_copilot.py
+++ b/backend/app/services/llm_providers/github_copilot.py
@@ -1,0 +1,75 @@
+"""GitHub-Copilot-Token-Resolver.
+
+GitHub Copilot benutzt keinen klassischen API-Key, sondern einen OAuth-Token
+aus der GitHub-CLI-Session (``gh auth login``). Dieser Resolver ruft
+``gh auth token`` als Subprozess und gibt den Klartext-Token zurück.
+
+Phase 1 — Modell-Discovery:
+    Die ``/v1/models``-Antwort des Copilot-Backends ist instabil (Endpoint
+    wechselt, Auth-Flow nicht öffentlich dokumentiert). Daher liefern wir
+    in Phase 1 eine statische Liste. Sobald der API-Pfad gefestigt ist,
+    kann ``fetch_live_models`` den Endpoint anbinden.
+
+Security:
+    Der Resolver loggt NIE den Token-Wert. Bei Erfolg geht nur eine Info-Zeile
+    mit der Token-Länge raus.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger("agora.llm.github_copilot")
+
+# Phase-1 statische Modellliste. Kann jederzeit ergänzt werden.
+GITHUB_COPILOT_MODELS: tuple[str, ...] = (
+    "gpt-4o-copilot",
+    "gpt-4o-mini-copilot",
+    "claude-sonnet-4.5-copilot",
+    "o1-mini-copilot",
+)
+
+GITHUB_COPILOT_BASE_URL = "https://api.githubcopilot.com"
+
+
+def resolve_copilot_token(timeout_seconds: float = 3.0) -> Optional[str]:
+    """Resolve a GitHub Copilot token via ``gh auth token``.
+
+    Returns
+    -------
+    Optional[str]
+        Token-String, oder ``None`` wenn ``gh`` nicht installiert ist bzw.
+        der User nicht angemeldet ist. Niemals ein leerer String.
+    """
+    gh_path = shutil.which("gh")
+    if gh_path is None:
+        logger.debug("`gh` CLI nicht im PATH — Copilot-Token nicht auflösbar")
+        return None
+    try:
+        proc = subprocess.run(
+            [gh_path, "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("`gh auth token` hat das Timeout (%.1fs) überschritten", timeout_seconds)
+        return None
+    except OSError as exc:
+        logger.warning("`gh auth token` konnte nicht ausgeführt werden: %s", exc)
+        return None
+
+    if proc.returncode != 0:
+        # gh schreibt im Fehlerfall eine Begründung nach stderr, aber sie kann
+        # den Token nicht enthalten — daher loggen wir sie.
+        logger.info("`gh auth token` non-zero exit (%s): %s", proc.returncode, proc.stderr.strip())
+        return None
+
+    token = proc.stdout.strip()
+    if not token:
+        return None
+    logger.info("GitHub-Copilot-Token aufgelöst (len=%d)", len(token))
+    return token

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -15,12 +15,14 @@ from .llm_provider_registry import LlmProviderRegistry
 from .llm_runtime import RuntimeLlmConfig
 from .runtime_run_config import RuntimeRunConfig
 from .secret_resolver import SecretResolver
+from .workspace_routing_store import get_workspace_routing_store
 
 _PROVIDER_ID_MAP = {
     "default": None,
     "openai": "openai",
     "google": "google",
     "custom_openai": "openai_compatible",
+    "github_copilot": "github_copilot",
 }
 
 _ROUTE_TO_RUNTIME_PROVIDER = {
@@ -28,6 +30,7 @@ _ROUTE_TO_RUNTIME_PROVIDER = {
     "google": "google",
     "openai_compatible": "custom_openai",
     "ollama_local": "custom_openai",
+    "github_copilot": "custom_openai",
 }
 
 
@@ -52,6 +55,19 @@ def seed_run_stage_routing(
     has_existing_config = os.path.exists(config_service.config_path)
     config = config_service.load_config()
 
+    # Bei frischen Runs: Workspace-Defaults als Seed übernehmen. Versiegelte Stages
+    # (= bereits in den Per-Run-Snapshots vorhanden) werden NICHT überschrieben.
+    if not has_existing_config:
+        try:
+            workspace_defaults = get_workspace_routing_store().load()
+        except Exception:  # noqa: BLE001 — Defaults sind „best effort", kein Run-Stopper
+            workspace_defaults = None
+        if workspace_defaults is not None:
+            if workspace_defaults.global_default.model:
+                config.global_default = workspace_defaults.global_default
+            for ws_stage_id, ws_route in workspace_defaults.stage_overrides.items():
+                config.stage_overrides[ws_stage_id] = ws_route
+
     runtime = llm_runtime or RuntimeLlmConfig()
     route_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
 
@@ -59,9 +75,14 @@ def seed_run_stage_routing(
         provider_options = {}
         if runtime.base_url:
             provider_options["base_url"] = runtime.base_url
+        # Wenn der Request "default" als Provider schickt, mappt das Provider-ID-Dict
+        # auf None. ResolvedRoute.provider_id ist Pflichtfeld; deshalb auf den
+        # global_default des Runs zurückfallen statt None zu persistieren.
+        effective_provider_id = route_provider_id or config.global_default.provider_id
+        effective_model = llm_model_override or config.global_default.model
         config.stage_overrides[stage_id] = StageLLMRoute(
-            provider_id=route_provider_id,
-            model=llm_model_override,
+            provider_id=effective_provider_id,
+            model=effective_model,
             provider_options=provider_options,
         )
         if has_existing_config:

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -76,6 +76,11 @@ class ModelCatalogService:
 
     def _fetch_live(self, provider_type: str, base_url: str, api_key: Optional[str]) -> List[str]:
         """Discovery implementation per provider type."""
+        if provider_type == "github_copilot":
+            # Phase 1: kein Live-Discovery. Wir geben die statische Modellliste
+            # über die ``_get_fallbacks``-Branch zurück — daher hier keine Live-IDs.
+            return []
+
         if provider_type == "ollama_local":
             # Ollama has /api/tags (native) and /v1/models (OpenAI compatible)
             # We prefer /api/tags for full metadata if available
@@ -120,4 +125,7 @@ class ModelCatalogService:
             return ["gpt-4o", "gpt-4o-mini", "o1-preview"]
         if provider_type == "google":
             return ["gemini-1.5-pro", "gemini-1.5-flash"]
+        if provider_type == "github_copilot":
+            from .llm_providers.github_copilot import GITHUB_COPILOT_MODELS
+            return list(GITHUB_COPILOT_MODELS)
         return []

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -1,11 +1,24 @@
 """
 Secret Resolver.
-Resolves API keys from environment or session without exposing them in serializable objects.
+Resolves API keys from session, persistent store, or environment without
+exposing them in serializable objects.
+
+Resolution order:
+  1. Session-only override (höchste Priorität, für ad-hoc Tests)
+  2. Persistenter Fernet-encrypted Store (vom Frontend befüllt)
+  3. Provider-spezifische Environment-Variablen
+  4. Globaler Fallback (Config.LLM_API_KEY)
 """
 
+import logging
 import os
 from typing import Optional, Dict
+
 from ..config import Config
+from .llm_provider_secrets_store import get_llm_provider_secrets_store
+
+logger = logging.getLogger("agora.secret_resolver")
+
 
 class SecretResolver:
     """Resolves secrets for LLM providers."""
@@ -19,13 +32,30 @@ class SecretResolver:
         if provider_id in self._session_keys:
             return self._session_keys[provider_id]
 
-        # 2. Provider-specific environment variables
+        # 2. Persistenter Store (Fernet-encrypted, vom Frontend befüllt)
+        try:
+            stored = get_llm_provider_secrets_store().get_plaintext(provider_id)
+            if stored:
+                return stored
+        except RuntimeError as exc:
+            # AGORA_SECRET_KEY fehlt o. ä. — auf env-Fallback weiterleiten.
+            # Hier explizit ohne Key-Werte loggen.
+            logger.warning("Secret-Store-Zugriff fehlgeschlagen, fallback auf env: %s", exc)
+
+        # 3. Provider-spezifische Environment-Variablen
         if provider_type == "openai":
             return os.environ.get("OPENAI_API_KEY") or Config.LLM_API_KEY
         if provider_type == "google":
             return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        if provider_type == "github_copilot":
+            # GitHub Copilot: Token-Auflösung über separates Modul (Slice B).
+            try:
+                from .llm_providers.github_copilot import resolve_copilot_token
+            except ImportError:
+                return None
+            return resolve_copilot_token()
 
-        # 3. Global fallback
+        # 4. Global fallback
         return Config.LLM_API_KEY
 
     def sanitize_url(self, url: Optional[str]) -> Optional[str]:

--- a/backend/app/services/workspace_routing_store.py
+++ b/backend/app/services/workspace_routing_store.py
@@ -15,6 +15,9 @@ from typing import Optional
 
 from ..contracts.llm_routing_contract import StageId, StageLLMRoute
 from ..contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.services.workspace_routing_store")
 
 _DATA_DIR_ENV = "AGORA_DATA_DIR"
 _STORE_FILENAME = "workspace_llm_routing.json"
@@ -48,7 +51,25 @@ class WorkspaceRoutingStore:
             return WorkspaceLlmRoutingDefaults()
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except OSError as exc:
+            # Dateisystem-Fehler beim Lesen — nicht silent schlucken (Gemini MEDIUM #4)
+            logger.error(
+                "Workspace-Routing-Store konnte nicht gelesen werden (%s): %s — "
+                "verwende leere Defaults",
+                self._path,
+                exc,
+            )
+            return WorkspaceLlmRoutingDefaults()
+        except json.JSONDecodeError as exc:
+            # Korrupte Datei: laut loggen statt silent Default zurückgeben.
+            # Beim nächsten save() würde die Datei überschrieben, was zu
+            # Datenverlust führt. Der Nutzer muss die Korruption sehen.
+            logger.error(
+                "Workspace-Routing-Store ist korrupt (%s): %s — "
+                "verwende leere Defaults. Bitte Datei manuell prüfen oder löschen.",
+                self._path,
+                exc,
+            )
             return WorkspaceLlmRoutingDefaults()
         return WorkspaceLlmRoutingDefaults.model_validate(raw)
 

--- a/backend/app/services/workspace_routing_store.py
+++ b/backend/app/services/workspace_routing_store.py
@@ -1,0 +1,111 @@
+"""Persistenter JSON-Store für Workspace-LLM-Routing-Defaults.
+
+Storage-Pfad: ``backend/data/workspace_llm_routing.json`` (überschreibbar via
+``AGORA_DATA_DIR``-Env). File-Locking via threading.Lock; atomic write über
+tmp-File + rename.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from ..contracts.llm_routing_contract import StageId, StageLLMRoute
+from ..contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+
+_DATA_DIR_ENV = "AGORA_DATA_DIR"
+_STORE_FILENAME = "workspace_llm_routing.json"
+
+
+def _resolve_data_dir() -> Path:
+    raw = os.environ.get(_DATA_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path(__file__).resolve().parents[2] / "data"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class WorkspaceRoutingStore:
+    """File-backed JSON-Store für Workspace-Routing-Defaults."""
+
+    def __init__(self, *, data_dir: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._data_dir = data_dir or _resolve_data_dir()
+        self._path = self._data_dir / _STORE_FILENAME
+
+    def load(self) -> WorkspaceLlmRoutingDefaults:
+        with self._lock:
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> WorkspaceLlmRoutingDefaults:
+        if not self._path.exists():
+            return WorkspaceLlmRoutingDefaults()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return WorkspaceLlmRoutingDefaults()
+        return WorkspaceLlmRoutingDefaults.model_validate(raw)
+
+    def _save_unlocked(self, model: WorkspaceLlmRoutingDefaults) -> WorkspaceLlmRoutingDefaults:
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        payload = model.model_copy(update={"updated_at": _now()})
+        tmp_path = self._path.with_suffix(".tmp")
+        tmp_path.write_text(
+            json.dumps(payload.model_dump(mode="json"), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, self._path)
+        return payload
+
+    def save(self, model: WorkspaceLlmRoutingDefaults) -> WorkspaceLlmRoutingDefaults:
+        with self._lock:
+            return self._save_unlocked(model)
+
+    def set_stage_override(
+        self, stage_id: StageId, route: Optional[StageLLMRoute]
+    ) -> WorkspaceLlmRoutingDefaults:
+        with self._lock:
+            current = self._load_unlocked()
+            overrides = dict(current.stage_overrides)
+            if route is None:
+                overrides.pop(stage_id, None)
+            else:
+                overrides[stage_id] = route
+            updated = current.model_copy(update={"stage_overrides": overrides})
+            return self._save_unlocked(updated)
+
+    def set_global_default(self, route: StageLLMRoute) -> WorkspaceLlmRoutingDefaults:
+        with self._lock:
+            current = self._load_unlocked()
+            updated = current.model_copy(update={"global_default": route})
+            return self._save_unlocked(updated)
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            if self._path.exists():
+                self._path.unlink()
+
+
+_store_singleton: Optional[WorkspaceRoutingStore] = None
+_singleton_lock = threading.Lock()
+
+
+def get_workspace_routing_store() -> WorkspaceRoutingStore:
+    global _store_singleton
+    if _store_singleton is None:
+        with _singleton_lock:
+            if _store_singleton is None:
+                _store_singleton = WorkspaceRoutingStore()
+    return _store_singleton
+
+
+def reset_singleton_for_tests() -> None:
+    global _store_singleton
+    with _singleton_lock:
+        _store_singleton = None

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -1,17 +1,20 @@
+import os
 import pytest
 from unittest.mock import patch
 from flask import Flask
 from app.api import llm_bp, runs_bp
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
+    # _expected_token() reads os.environ directly — clear it so the auth guard
+    # stays in open-mode regardless of what .env provides.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
     from app.utils.api_responses import install_api_error_handlers
     install_api_error_handlers(app)
     app.register_blueprint(llm_bp, url_prefix="/api/llm")
     app.register_blueprint(runs_bp, url_prefix="/api/runs")
     app.config["TESTING"] = True
-    # Disable auth for tests
     app.config["AGORA_AUTH_TOKEN"] = ""
     return app
 

--- a/backend/tests/contracts/test_llm_provider_keys_contract.py
+++ b/backend/tests/contracts/test_llm_provider_keys_contract.py
@@ -1,0 +1,57 @@
+"""Contract-Tests für llm_provider_keys_contract.py."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.llm_provider_keys_contract import (
+    LlmProviderKeyCreateRequest,
+    LlmProviderKeyEntry,
+    LlmProviderKeysListResponse,
+)
+
+
+def test_entry_accepts_masked_value():
+    entry = LlmProviderKeyEntry(
+        provider_id="openai",
+        masked_value="sk-...abcd",
+        base_url=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    assert entry.provider_id == "openai"
+
+
+def test_entry_rejects_plain_key_as_masked_value():
+    with pytest.raises(ValidationError):
+        LlmProviderKeyEntry(
+            provider_id="openai",
+            masked_value="sk-1234567890abcdef",  # echtes Format ohne "..."
+            base_url=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+
+def test_create_request_rejects_short_key():
+    with pytest.raises(ValidationError):
+        LlmProviderKeyCreateRequest(api_key="abc")
+
+
+def test_create_request_accepts_optional_base_url():
+    body = LlmProviderKeyCreateRequest(api_key="sk-abcdefgh12345", base_url="https://x.test/v1")
+    assert body.base_url == "https://x.test/v1"
+
+
+def test_create_request_extra_forbid():
+    with pytest.raises(ValidationError):
+        LlmProviderKeyCreateRequest.model_validate(
+            {"api_key": "sk-abcdefgh12345", "garbage": "no"}
+        )
+
+
+def test_list_response_roundtrip():
+    payload = LlmProviderKeysListResponse(items=[], total=0)
+    assert payload.model_dump(mode="json") == {"items": [], "total": 0}

--- a/backend/tests/services/test_github_copilot_provider.py
+++ b/backend/tests/services/test_github_copilot_provider.py
@@ -9,15 +9,19 @@ import pytest
 from app.services.llm_provider_registry import LlmProviderRegistry
 from app.services.llm_providers.github_copilot import (
     GITHUB_COPILOT_MODELS,
+    clear_token_cache,
     resolve_copilot_token,
 )
 from app.services.model_catalog_service import ModelCatalogService
 
 
 @pytest.fixture(autouse=True)
-def clear_catalog_cache():
+def reset_caches():
+    """Vor jedem Test Token-Cache und Catalog-Cache leeren."""
+    clear_token_cache()
     ModelCatalogService._cache.clear()
     yield
+    clear_token_cache()
     ModelCatalogService._cache.clear()
 
 

--- a/backend/tests/services/test_github_copilot_provider.py
+++ b/backend/tests/services/test_github_copilot_provider.py
@@ -1,0 +1,73 @@
+"""Tests für GitHub-Copilot-Provider (Token-Resolver + Modellliste)."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from app.services.llm_provider_registry import LlmProviderRegistry
+from app.services.llm_providers.github_copilot import (
+    GITHUB_COPILOT_MODELS,
+    resolve_copilot_token,
+)
+from app.services.model_catalog_service import ModelCatalogService
+
+
+@pytest.fixture(autouse=True)
+def clear_catalog_cache():
+    ModelCatalogService._cache.clear()
+    yield
+    ModelCatalogService._cache.clear()
+
+
+def test_resolve_copilot_token_returns_stdout():
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="gho_secrettoken\n", stderr="")
+    with patch("app.services.llm_providers.github_copilot.shutil.which", return_value="/usr/local/bin/gh"):
+        with patch("app.services.llm_providers.github_copilot.subprocess.run", return_value=completed):
+            assert resolve_copilot_token() == "gho_secrettoken"
+
+
+def test_resolve_copilot_token_missing_gh_returns_none():
+    with patch("app.services.llm_providers.github_copilot.shutil.which", return_value=None):
+        assert resolve_copilot_token() is None
+
+
+def test_resolve_copilot_token_nonzero_exit_returns_none():
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="not logged in"
+    )
+    with patch("app.services.llm_providers.github_copilot.shutil.which", return_value="/usr/local/bin/gh"):
+        with patch("app.services.llm_providers.github_copilot.subprocess.run", return_value=completed):
+            assert resolve_copilot_token() is None
+
+
+def test_resolve_copilot_token_timeout_returns_none():
+    with patch("app.services.llm_providers.github_copilot.shutil.which", return_value="/usr/local/bin/gh"):
+        with patch(
+            "app.services.llm_providers.github_copilot.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=3.0),
+        ):
+            assert resolve_copilot_token() is None
+
+
+def test_registry_contains_copilot():
+    providers = {p.id: p for p in LlmProviderRegistry().get_providers()}
+    assert "github_copilot" in providers
+    copilot = providers["github_copilot"]
+    assert copilot.type == "github_copilot"
+    assert copilot.supports_models_endpoint is False
+    assert set(copilot.fallback_models) == set(GITHUB_COPILOT_MODELS)
+
+
+def test_catalog_returns_static_copilot_models():
+    catalog = ModelCatalogService()
+    models = catalog.get_models(
+        "github_copilot",
+        "github_copilot",
+        "https://api.githubcopilot.com",
+        api_key="gho_xxx",
+    )
+    ids = [m.id for m in models]
+    assert ids == list(GITHUB_COPILOT_MODELS)
+    assert all(m.source == "fallback" for m in models)

--- a/backend/tests/services/test_llm_provider_secrets_store.py
+++ b/backend/tests/services/test_llm_provider_secrets_store.py
@@ -1,0 +1,116 @@
+"""Tests für den Fernet-encrypted LLM-Provider-Secrets-Store."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.services.llm_provider_secrets_store import (
+    LlmProviderSecretsStore,
+    _mask_key,
+    get_llm_provider_secrets_store,
+    reset_singleton_for_tests,
+)
+
+
+@pytest.fixture
+def secret_env(monkeypatch):
+    key = Fernet.generate_key().decode("utf-8")
+    monkeypatch.setenv("AGORA_SECRET_KEY", key)
+    yield key
+
+
+@pytest.fixture
+def temp_store(tmp_path: Path, secret_env):
+    store = LlmProviderSecretsStore(data_dir=tmp_path)
+    yield store
+    if (tmp_path / "llm_provider_secrets.json").exists():
+        (tmp_path / "llm_provider_secrets.json").unlink()
+
+
+def test_upsert_roundtrip_encrypts_and_returns_masked_entry(temp_store):
+    entry = temp_store.upsert("openai", api_key="sk-test1234567890abcdef")
+    assert entry.provider_id == "openai"
+    assert entry.masked_value.endswith("cdef")
+    assert "test" not in entry.masked_value
+    assert temp_store.get_plaintext("openai") == "sk-test1234567890abcdef"
+
+
+def test_upsert_keeps_created_at_on_replace(temp_store):
+    first = temp_store.upsert("openai", api_key="sk-aaaaaaaaaaaaaa01")
+    second = temp_store.upsert("openai", api_key="sk-bbbbbbbbbbbbbb02")
+    assert first.created_at == second.created_at
+    assert second.updated_at >= first.updated_at
+    assert temp_store.get_plaintext("openai") == "sk-bbbbbbbbbbbbbb02"
+
+
+def test_delete_removes_entry(temp_store):
+    temp_store.upsert("openai", api_key="sk-xxxxxxxxxxxx9999")
+    assert temp_store.delete("openai") is True
+    assert temp_store.get_entry("openai") is None
+    assert temp_store.delete("openai") is False
+
+
+def test_mark_validated_updates_timestamp(temp_store):
+    temp_store.upsert("openai", api_key="sk-yyyyyyyyyyyy7777")
+    updated = temp_store.mark_validated("openai", ok=True)
+    assert updated is not None
+    assert updated.last_validation_ok is True
+    assert updated.last_validated_at is not None
+
+
+def test_list_entries_returns_all_providers(temp_store):
+    temp_store.upsert("openai", api_key="sk-aaa00000aaaa0001")
+    temp_store.upsert("google", api_key="AIza000000000bbbb")
+    entries = temp_store.list_entries()
+    assert {e.provider_id for e in entries} == {"openai", "google"}
+
+
+def test_missing_secret_key_raises(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGORA_SECRET_KEY", raising=False)
+    store = LlmProviderSecretsStore(data_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="AGORA_SECRET_KEY"):
+        store.upsert("openai", api_key="sk-ccc00000cccc0002")
+
+
+def test_invalid_secret_key_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGORA_SECRET_KEY", "not-a-valid-fernet-key")
+    store = LlmProviderSecretsStore(data_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="kein gültiger Fernet-Key"):
+        store.upsert("openai", api_key="sk-ddd00000dddd0003")
+
+
+def test_decrypt_with_wrong_key_raises(monkeypatch, tmp_path):
+    key_a = Fernet.generate_key().decode("utf-8")
+    monkeypatch.setenv("AGORA_SECRET_KEY", key_a)
+    store = LlmProviderSecretsStore(data_dir=tmp_path)
+    store.upsert("openai", api_key="sk-eee00000eeee0004")
+
+    # Schlüssel rotieren ohne Re-Encrypt → Lookup muss klar fehlschlagen
+    key_b = Fernet.generate_key().decode("utf-8")
+    monkeypatch.setenv("AGORA_SECRET_KEY", key_b)
+    with pytest.raises(RuntimeError, match="entschlüsselt"):
+        store.get_plaintext("openai")
+
+
+def test_mask_key_format():
+    assert _mask_key("sk-1234567890abcd") == "sk-...abcd"
+    assert _mask_key("AIzaSyABCDEFGHIJKL") == "AI-...IJKL"
+    assert _mask_key("ghp_xxxxxxxxxxxxYY99") == "gh-...YY99"
+    # Sehr kurzer Key fällt auf Sentinel zurück
+    short = _mask_key("abc")
+    assert "..." in short
+
+
+def test_singleton_persists_across_calls(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("AGORA_SECRET_KEY", Fernet.generate_key().decode("utf-8"))
+    reset_singleton_for_tests()
+    a = get_llm_provider_secrets_store()
+    b = get_llm_provider_secrets_store()
+    assert a is b
+    a.upsert("openai", api_key="sk-fff00000ffff0005")
+    assert b.get_plaintext("openai") == "sk-fff00000ffff0005"
+    reset_singleton_for_tests()

--- a/backend/tests/services/test_secret_resolver_store.py
+++ b/backend/tests/services/test_secret_resolver_store.py
@@ -1,0 +1,67 @@
+"""Tests für SecretResolver-Integration mit dem persistenten Store."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.services import llm_provider_secrets_store as store_module
+from app.services.llm_provider_secrets_store import (
+    LlmProviderSecretsStore,
+    reset_singleton_for_tests,
+)
+from app.services.secret_resolver import SecretResolver
+
+
+@pytest.fixture
+def configured_store(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AGORA_SECRET_KEY", Fernet.generate_key().decode("utf-8"))
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    reset_singleton_for_tests()
+    yield store_module.get_llm_provider_secrets_store()
+    reset_singleton_for_tests()
+
+
+def test_store_overrides_env(monkeypatch, configured_store):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key-should-lose")
+    configured_store.upsert("openai", api_key="sk-store-wins-aaaa")
+
+    resolver = SecretResolver()
+    assert resolver.get_api_key("openai", "openai") == "sk-store-wins-aaaa"
+
+
+def test_env_used_when_store_empty(monkeypatch, configured_store):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-fallback")
+    resolver = SecretResolver()
+    assert resolver.get_api_key("openai", "openai") == "env-fallback"
+
+
+def test_session_overrides_store(configured_store):
+    configured_store.upsert("openai", api_key="sk-store-aaaa1111")
+    resolver = SecretResolver(session_api_keys={"openai": "session-wins"})
+    assert resolver.get_api_key("openai", "openai") == "session-wins"
+
+
+def test_google_key_from_env(monkeypatch, configured_store):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-env-key")
+    resolver = SecretResolver()
+    assert resolver.get_api_key("google", "google") == "google-env-key"
+
+
+def test_google_key_from_store_overrides_env(monkeypatch, configured_store):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-env-key")
+    configured_store.upsert("google", api_key="AIzaSyStoreWinsxx99")
+    resolver = SecretResolver()
+    assert resolver.get_api_key("google", "google") == "AIzaSyStoreWinsxx99"
+
+
+def test_missing_secret_key_falls_back_to_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGORA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "env-only-key")
+    reset_singleton_for_tests()
+    resolver = SecretResolver()
+    # Store wirft RuntimeError ohne Master-Key — Resolver soll auf env fallen
+    assert resolver.get_api_key("openai", "openai") == "env-only-key"
+    reset_singleton_for_tests()

--- a/backend/tests/services/test_workspace_routing_store.py
+++ b/backend/tests/services/test_workspace_routing_store.py
@@ -1,0 +1,68 @@
+"""Tests für Workspace-Routing-Store."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.contracts.llm_routing_contract import StageLLMRoute
+from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+from app.services.workspace_routing_store import (
+    WorkspaceRoutingStore,
+    get_workspace_routing_store,
+    reset_singleton_for_tests,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    s = WorkspaceRoutingStore(data_dir=tmp_path)
+    yield s
+
+
+def test_load_empty_returns_defaults(store):
+    defaults = store.load()
+    assert isinstance(defaults, WorkspaceLlmRoutingDefaults)
+    assert defaults.stage_overrides == {}
+
+
+def test_save_and_load_roundtrip(store):
+    payload = WorkspaceLlmRoutingDefaults(
+        global_default=StageLLMRoute(provider_id="openai", model="gpt-4o-mini"),
+        stage_overrides={
+            "report_generation": StageLLMRoute(provider_id="openai", model="gpt-4o"),
+        },
+    )
+    store.save(payload)
+    loaded = store.load()
+    assert loaded.global_default.model == "gpt-4o-mini"
+    assert loaded.stage_overrides["report_generation"].model == "gpt-4o"
+    assert loaded.updated_at is not None
+
+
+def test_set_stage_override(store):
+    route = StageLLMRoute(provider_id="google", model="gemini-1.5-pro")
+    updated = store.set_stage_override("persona_generation", route)
+    assert updated.stage_overrides["persona_generation"].model == "gemini-1.5-pro"
+
+
+def test_clear_stage_override(store):
+    route = StageLLMRoute(provider_id="google", model="gemini-1.5-pro")
+    store.set_stage_override("persona_generation", route)
+    cleared = store.set_stage_override("persona_generation", None)
+    assert "persona_generation" not in cleared.stage_overrides
+
+
+def test_set_global_default(store):
+    route = StageLLMRoute(provider_id="openai", model="gpt-4o-mini")
+    updated = store.set_global_default(route)
+    assert updated.global_default.model == "gpt-4o-mini"
+
+
+def test_singleton_uses_env_data_dir(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    reset_singleton_for_tests()
+    s = get_workspace_routing_store()
+    s.set_global_default(StageLLMRoute(provider_id="openai", model="gpt-4o"))
+    assert (tmp_path / "workspace_llm_routing.json").exists()
+    reset_singleton_for_tests()

--- a/frontend/src/api/llmProviderKeys.ts
+++ b/frontend/src/api/llmProviderKeys.ts
@@ -1,0 +1,66 @@
+/**
+ * LLM-Provider-API-Keys — HTTP-Client.
+ *
+ * Bedient die in backend/app/api/llm_providers.py ergänzten CRUD-Endpunkte
+ * für persistierte (Fernet-verschlüsselte) Provider-Keys.
+ */
+import service from "./index";
+import {
+  LlmProviderKeyCreateRequest,
+  LlmProviderKeyCreateRequestSchema,
+  LlmProviderKeyEntry,
+  LlmProviderKeyEntrySchema,
+  LlmProviderKeysListResponse,
+  LlmProviderKeysListResponseSchema,
+} from "../contracts/llmProviderKeysContract";
+import { ApiSuccessEnvelope } from "./envelope";
+
+export async function listLlmProviderKeys(): Promise<LlmProviderKeysListResponse> {
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>("/api/llm/providers/api-keys");
+  return LlmProviderKeysListResponseSchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function getLlmProviderKey(providerId: string): Promise<LlmProviderKeyEntry> {
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/providers/${providerId}/api-key`,
+  );
+  return LlmProviderKeyEntrySchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function upsertLlmProviderKey(
+  providerId: string,
+  req: LlmProviderKeyCreateRequest,
+  options: { validate?: boolean } = {},
+): Promise<LlmProviderKeyEntry> {
+  LlmProviderKeyCreateRequestSchema.parse(req);
+  const query = options.validate ? "?validate=1" : "";
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/providers/${providerId}/api-key${query}`,
+    req,
+  );
+  return LlmProviderKeyEntrySchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function deleteLlmProviderKey(providerId: string): Promise<void> {
+  await service.delete(`/api/llm/providers/${providerId}/api-key`);
+}
+
+export interface ProviderTestResult {
+  connectivity: "ok" | "failed";
+  models_found?: number;
+  inference?: "ok";
+  response_preview?: string;
+}
+
+export async function testLlmProvider(
+  providerId: string,
+  payload: { base_url?: string; api_key?: string } = {},
+  options: { inference?: boolean } = {},
+): Promise<ProviderTestResult> {
+  const query = options.inference ? "?inference=1" : "";
+  const resp = await service.post<ApiSuccessEnvelope<ProviderTestResult>>(
+    `/api/llm/providers/${providerId}/test${query}`,
+    payload,
+  );
+  return (resp as unknown as { data: ProviderTestResult }).data;
+}

--- a/frontend/src/api/llmRoutingDefaults.ts
+++ b/frontend/src/api/llmRoutingDefaults.ts
@@ -1,0 +1,49 @@
+/**
+ * Workspace-Routing-Defaults — HTTP-Client.
+ *
+ * Bedient die in backend/app/api/llm_routing.py ergänzten Defaults-Endpunkte.
+ */
+import service from "./index";
+import {
+  WorkspaceLlmRoutingDefaults,
+  WorkspaceLlmRoutingDefaultsSchema,
+} from "../contracts/workspaceRoutingContract";
+import { StageId, StageLLMRoute } from "../contracts/llmRoutingContract";
+import { ApiSuccessEnvelope } from "./envelope";
+
+export async function getRoutingDefaults(): Promise<WorkspaceLlmRoutingDefaults> {
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>("/api/llm/routing/defaults");
+  return WorkspaceLlmRoutingDefaultsSchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function replaceRoutingDefaults(
+  payload: WorkspaceLlmRoutingDefaults,
+): Promise<WorkspaceLlmRoutingDefaults> {
+  const resp = await service.put<ApiSuccessEnvelope<unknown>>(
+    "/api/llm/routing/defaults",
+    payload,
+  );
+  return WorkspaceLlmRoutingDefaultsSchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function patchRoutingDefaultStage(
+  stageId: StageId,
+  route: StageLLMRoute | null,
+): Promise<WorkspaceLlmRoutingDefaults> {
+  const body = route === null ? { clear: true } : route;
+  const resp = await service.patch<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/routing/defaults/stages/${stageId}`,
+    body,
+  );
+  return WorkspaceLlmRoutingDefaultsSchema.parse((resp as unknown as { data: unknown }).data);
+}
+
+export async function replaceGlobalDefault(
+  route: StageLLMRoute,
+): Promise<WorkspaceLlmRoutingDefaults> {
+  const resp = await service.put<ApiSuccessEnvelope<unknown>>(
+    "/api/llm/routing/defaults/global",
+    route,
+  );
+  return WorkspaceLlmRoutingDefaultsSchema.parse((resp as unknown as { data: unknown }).data);
+}

--- a/frontend/src/components/v4/forms/ModelPicker.vue
+++ b/frontend/src/components/v4/forms/ModelPicker.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+/**
+ * ModelPicker — wählt eine LLM-Route (Provider + Modell) per Dropdown.
+ *
+ * - Zeigt OptGroups je Provider an, sortiert alphabetisch nach Provider-Label.
+ * - Versteckt Provider ohne hinterlegten API-Key (Ausnahme: Ollama + Copilot,
+ *   die auch ohne expliziten Key benutzbar sein können).
+ * - Emit `update:modelValue` mit der gewählten ``StageLLMRoute`` oder ``null``
+ *   für „nichts gewählt / nutze Default des Eltern-Kontextes".
+ */
+import { computed, onMounted, ref, watch } from 'vue'
+import { useLlmProvidersStore } from '@/store/llmProviders'
+import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+
+const props = withDefaults(defineProps<{
+  modelValue?: StageLLMRoute | null
+  placeholder?: string
+  allowClear?: boolean
+  disabled?: boolean
+}>(), {
+  modelValue: null,
+  placeholder: 'Modell wählen …',
+  allowClear: true,
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: StageLLMRoute | null]
+}>()
+
+const store = useLlmProvidersStore()
+const loadingModels = ref<Record<string, boolean>>({})
+
+const PROVIDERS_WITHOUT_KEY = new Set(['ollama_local', 'github_copilot'])
+
+const availableProviders = computed(() =>
+  store.providers.filter((p) =>
+    PROVIDERS_WITHOUT_KEY.has(p.type) || store.hasKey(p.id),
+  ),
+)
+
+onMounted(async () => {
+  if (store.providers.length === 0) {
+    await store.loadProviders()
+  }
+  for (const p of availableProviders.value) {
+    if (!(p.id in store.models)) {
+      void hydrateModels(p.id)
+    }
+  }
+})
+
+watch(
+  () => availableProviders.value.map((p) => p.id).join(','),
+  (key) => {
+    if (!key) return
+    for (const p of availableProviders.value) {
+      if (!(p.id in store.models)) {
+        void hydrateModels(p.id)
+      }
+    }
+  },
+)
+
+async function hydrateModels(providerId: string): Promise<void> {
+  loadingModels.value = { ...loadingModels.value, [providerId]: true }
+  try {
+    await store.fetchModels(providerId)
+  } catch (err) {
+    // Fehler landet im store.lastError — wir lassen die Option leer, kein Throw
+    console.warn('ModelPicker: fetchModels failed', providerId, err)
+  } finally {
+    loadingModels.value = { ...loadingModels.value, [providerId]: false }
+  }
+}
+
+const selectedValue = computed(() => {
+  if (!props.modelValue?.provider_id || !props.modelValue?.model) return ''
+  return `${props.modelValue.provider_id}::${props.modelValue.model}`
+})
+
+function onChange(event: Event): void {
+  const target = event.target as HTMLSelectElement
+  const raw = target.value
+  if (!raw) {
+    emit('update:modelValue', null)
+    return
+  }
+  const sep = raw.indexOf('::')
+  if (sep < 0) return
+  const providerId = raw.slice(0, sep)
+  const model = raw.slice(sep + 2)
+  emit('update:modelValue', {
+    stage: null,
+    provider_id: providerId,
+    model,
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+  })
+}
+</script>
+
+<template>
+  <div class="model-picker">
+    <select
+      class="model-picker__select"
+      :disabled="disabled"
+      :value="selectedValue"
+      @change="onChange"
+    >
+      <option value="">{{ placeholder }}</option>
+      <template v-for="provider in availableProviders" :key="provider.id">
+        <optgroup :label="provider.label">
+          <option
+            v-for="model in (store.models[provider.id]?.models ?? []).map(m => m.id)"
+            :key="`${provider.id}::${model}`"
+            :value="`${provider.id}::${model}`"
+          >
+            {{ model }}
+          </option>
+          <option
+            v-if="(store.models[provider.id]?.models ?? []).length === 0 && (provider.fallback_models ?? []).length"
+            disabled
+          >
+            (Modelle laden …)
+          </option>
+        </optgroup>
+      </template>
+    </select>
+  </div>
+</template>
+
+<style scoped>
+.model-picker {
+  display: block;
+  min-width: 220px;
+}
+.model-picker__select {
+  width: 100%;
+  height: var(--ctl-h-md, 36px);
+  padding: 0 32px 0 12px;
+  border-radius: var(--r-4, 8px);
+  border: 1px solid var(--hairline);
+  background: var(--surface-elevated, #fff);
+  font-family: var(--font-sans);
+  font-size: var(--fs-callout, 14px);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.model-picker__select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/v4/forms/ModelPicker.vue
+++ b/frontend/src/components/v4/forms/ModelPicker.vue
@@ -15,12 +15,10 @@ import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
 const props = withDefaults(defineProps<{
   modelValue?: StageLLMRoute | null
   placeholder?: string
-  allowClear?: boolean
   disabled?: boolean
 }>(), {
   modelValue: null,
   placeholder: 'Modell wählen …',
-  allowClear: true,
   disabled: false,
 })
 

--- a/frontend/src/components/v4/forms/StepModelOverrideChip.vue
+++ b/frontend/src/components/v4/forms/StepModelOverrideChip.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+/**
+ * StepModelOverrideChip — Per-Step-Modellauswahl-Chip.
+ *
+ * Zeigt das aktuell effektive Modell (Workspace-Default oder Stage-Override)
+ * für genau eine Stage und erlaubt per Popover den Wechsel. Der Wechsel
+ * patcht den Workspace-Default. Der Backend-Seed-Hook mergt das beim
+ * Run-Start in die ``RuntimeLlmRouting``.
+ *
+ * Wenn ``locked`` gesetzt ist, wird der Chip read-only dargestellt (Run
+ * läuft bereits und die Stage ist versiegelt).
+ */
+import { computed, onMounted, ref } from 'vue'
+import { useLlmProvidersStore } from '@/store/llmProviders'
+import { useLlmRoutingDefaultsStore } from '@/store/llmRoutingDefaults'
+import ModelPicker from './ModelPicker.vue'
+import type { StageId, StageLLMRoute } from '@/contracts/llmRoutingContract'
+
+const props = withDefaults(defineProps<{
+  stageId: StageId
+  label?: string
+  locked?: boolean
+}>(), {
+  label: 'Modell',
+  locked: false,
+})
+
+const providersStore = useLlmProvidersStore()
+const defaultsStore = useLlmRoutingDefaultsStore()
+
+const open = ref(false)
+
+const effectiveRoute = computed<StageLLMRoute>(() => defaultsStore.effectiveRouteForStage(props.stageId))
+const hasOverride = computed(() => props.stageId in defaultsStore.stageOverrides)
+
+const displayLabel = computed(() => {
+  const route = effectiveRoute.value
+  if (!route?.model) return 'Modell wählen …'
+  return `${route.provider_id ?? '?'} · ${route.model}`
+})
+
+async function ensureLoaded(): Promise<void> {
+  if (providersStore.providers.length === 0) {
+    await providersStore.loadProviders()
+  }
+  if (!defaultsStore.defaults.updated_at) {
+    try {
+      await defaultsStore.load()
+    } catch {
+      /* defaults bleiben leer — Chip zeigt "Modell wählen …" */
+    }
+  }
+}
+
+onMounted(() => {
+  void ensureLoaded()
+})
+
+function toggle(): void {
+  if (props.locked) return
+  open.value = !open.value
+}
+
+async function selectRoute(route: StageLLMRoute | null): Promise<void> {
+  if (route === null) {
+    await defaultsStore.clearStageOverride(props.stageId)
+  } else {
+    await defaultsStore.setStageOverride(props.stageId, route)
+  }
+  open.value = false
+}
+</script>
+
+<template>
+  <div class="step-model-chip-wrap">
+    <button
+      type="button"
+      class="step-model-chip"
+      :class="{ 'step-model-chip--override': hasOverride, 'step-model-chip--locked': locked }"
+      :aria-expanded="open"
+      :disabled="locked"
+      @click="toggle"
+    >
+      <span class="step-model-chip__label">{{ label }}:</span>
+      <span class="step-model-chip__value">{{ displayLabel }}</span>
+      <span v-if="hasOverride && !locked" class="step-model-chip__badge">override</span>
+      <span v-if="locked" class="step-model-chip__lock" aria-hidden="true">🔒</span>
+    </button>
+
+    <div v-if="open && !locked" class="step-model-chip__popover">
+      <ModelPicker
+        :model-value="effectiveRoute.model ? effectiveRoute : null"
+        placeholder="Modell wählen …"
+        @update:model-value="selectRoute"
+      />
+      <div class="step-model-chip__actions">
+        <button
+          v-if="hasOverride"
+          type="button"
+          class="step-model-chip__clear"
+          @click="selectRoute(null)"
+        >
+          Override entfernen → Default nutzen
+        </button>
+        <button type="button" class="step-model-chip__close" @click="open = false">
+          Schließen
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.step-model-chip-wrap {
+  position: relative;
+  display: inline-block;
+}
+.step-model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  background: var(--surface-elevated, #fff);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+.step-model-chip:hover:not(:disabled) {
+  border-color: var(--accent, #0a84ff);
+}
+.step-model-chip--override {
+  border-color: var(--accent, #0a84ff);
+  background: rgba(10, 132, 255, 0.06);
+}
+.step-model-chip--locked {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+.step-model-chip__label {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.step-model-chip__value {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-primary);
+}
+.step-model-chip__badge {
+  font-size: 10px;
+  color: var(--accent, #0a84ff);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.step-model-chip__popover {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 280px;
+  padding: 12px;
+  background: var(--surface-elevated, #fff);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-4, 8px);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.step-model-chip__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+}
+.step-model-chip__clear,
+.step-model-chip__close {
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.step-model-chip__clear:hover,
+.step-model-chip__close:hover {
+  color: var(--text-primary);
+}
+</style>

--- a/frontend/src/components/v4/forms/StepModelOverrideChip.vue
+++ b/frontend/src/components/v4/forms/StepModelOverrideChip.vue
@@ -43,7 +43,9 @@ async function ensureLoaded(): Promise<void> {
   if (providersStore.providers.length === 0) {
     await providersStore.loadProviders()
   }
-  if (!defaultsStore.defaults.updated_at) {
+  // hasLoadedOnce ist robuster als updated_at-Proxy: updated_at ist legitimerweise
+  // null bei einer frischen Workspace ohne gespeicherte Defaults (Gemini MEDIUM #5).
+  if (!defaultsStore.hasLoadedOnce) {
     try {
       await defaultsStore.load()
     } catch {

--- a/frontend/src/components/v4/shell/Sidebar.vue
+++ b/frontend/src/components/v4/shell/Sidebar.vue
@@ -114,6 +114,7 @@ const navSettings: NavSettingsItem[] = [
   { id: 'integrations',  label: 'Integrations',  to: { name: 'SettingsIntegrations' } },
   { id: 'users-teams',   label: 'Users & Teams', to: { name: 'SettingsUsersTeams' } },
   { id: 'api-keys',      label: 'API Keys',      to: { name: 'SettingsApiKeys' } },
+  { id: 'llm-providers', label: 'LLM Providers', to: { name: 'SettingsLlmProviders' } },
   { id: 'llm-routing',   label: 'LLM Routing',   to: { name: 'SettingsLlmRouting' } },
   { id: 'audit',         label: 'Audit Logs',    to: { name: 'SettingsAuditLogs' } },
 ]

--- a/frontend/src/components/v4/shell/__tests__/testRouter.ts
+++ b/frontend/src/components/v4/shell/__tests__/testRouter.ts
@@ -20,6 +20,7 @@ const BASE_ROUTES: RouteRecordRaw[] = [
   { path: '/settings/users-teams',   name: 'SettingsUsersTeams',  component: stub },
   { path: '/settings/api-keys',      name: 'SettingsApiKeys',     component: stub },
   { path: '/settings/audit-logs',    name: 'SettingsAuditLogs',   component: stub },
+  { path: '/settings/llm-providers', name: 'SettingsLlmProviders',component: stub },
   { path: '/settings/llm-routing',   name: 'SettingsLlmRouting',  component: stub },
 ]
 

--- a/frontend/src/contracts/llmProviderKeysContract.ts
+++ b/frontend/src/contracts/llmProviderKeysContract.ts
@@ -1,0 +1,39 @@
+/**
+ * LLM-Provider-API-Keys Contract — Zod-Spiegel.
+ *
+ * Spiegelt backend/app/contracts/llm_provider_keys_contract.py 1:1.
+ * Klartext-Keys werden im Frontend NIE aus der Antwort gelesen — nur
+ * maskierte Werte (sk-...abcd) treten hier auf.
+ */
+import { z } from "zod";
+
+export const MASKED_KEY_PATTERN = /^.{1,8}\.\.\.[A-Za-z0-9_\-]{4}$/;
+
+export const LlmProviderKeyEntrySchema = z
+  .object({
+    provider_id: z.string().min(1).max(64),
+    masked_value: z.string().regex(MASKED_KEY_PATTERN),
+    base_url: z.string().nullable().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    last_validated_at: z.string().nullable().optional(),
+    last_validation_ok: z.boolean().nullable().optional(),
+  })
+  .strict();
+export type LlmProviderKeyEntry = z.infer<typeof LlmProviderKeyEntrySchema>;
+
+export const LlmProviderKeyCreateRequestSchema = z
+  .object({
+    api_key: z.string().min(4).max(1024),
+    base_url: z.string().max(512).nullable().optional(),
+  })
+  .strict();
+export type LlmProviderKeyCreateRequest = z.infer<typeof LlmProviderKeyCreateRequestSchema>;
+
+export const LlmProviderKeysListResponseSchema = z
+  .object({
+    items: z.array(LlmProviderKeyEntrySchema),
+    total: z.number().int().min(0),
+  })
+  .strict();
+export type LlmProviderKeysListResponse = z.infer<typeof LlmProviderKeysListResponseSchema>;

--- a/frontend/src/contracts/llmRoutingContract.ts
+++ b/frontend/src/contracts/llmRoutingContract.ts
@@ -39,7 +39,7 @@ export type RuntimeLlmRouting = z.infer<typeof RuntimeLlmRoutingSchema>;
 export const ProviderDescriptorSchema = z.object({
   id: z.string(),
   label: z.string(),
-  type: z.enum(["ollama_local", "openai", "google", "openai_compatible"]),
+  type: z.enum(["ollama_local", "openai", "google", "openai_compatible", "github_copilot"]),
   base_url: z.string().url().optional().nullable(),
   api_key_ref: z.string().optional().nullable(),
   supports_models_endpoint: z.boolean().default(false),

--- a/frontend/src/contracts/workspaceRoutingContract.ts
+++ b/frontend/src/contracts/workspaceRoutingContract.ts
@@ -1,0 +1,17 @@
+/**
+ * Workspace-Routing-Defaults — Zod-Spiegel.
+ *
+ * Spiegelt backend/app/contracts/workspace_routing_contract.py.
+ */
+import { z } from "zod";
+import { StageIdSchema, StageLLMRouteSchema } from "./llmRoutingContract";
+
+export const WorkspaceLlmRoutingDefaultsSchema = z
+  .object({
+    global_default: StageLLMRouteSchema,
+    stage_overrides: z.partialRecord(StageIdSchema, StageLLMRouteSchema).default({}),
+    updated_at: z.string().nullable().optional(),
+    version: z.number().int().min(1).default(1),
+  })
+  .strict();
+export type WorkspaceLlmRoutingDefaults = z.infer<typeof WorkspaceLlmRoutingDefaultsSchema>;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -839,6 +839,38 @@
           "anthropic": "Anthropic",
           "custom": "Eigener Endpunkt"
         }
+      },
+      "llmProviders": {
+        "title": "LLM-Provider",
+        "subtitle": "Hinterlege API-Schlüssel, ziehe Modelle live und wähle pro Schritt das passende Modell aus.",
+        "keyLabel": "API-Key (maskiert)",
+        "keyPlaceholder": "Neuen API-Key einfügen …",
+        "baseUrlPlaceholder": "https://api.example.com/v1",
+        "status": {
+          "connected": "verbunden",
+          "missing": "Key fehlt",
+          "local": "lokal",
+          "cli": "gh CLI"
+        },
+        "actions": {
+          "save": "Speichern",
+          "test": "Test",
+          "refreshModels": "Modelle laden",
+          "disconnect": "Trennen"
+        },
+        "test": {
+          "saved": "Gespeichert.",
+          "ok": "{count} Modelle gefunden.",
+          "failed": "Verbindung fehlgeschlagen."
+        },
+        "models": {
+          "title": "Modelle"
+        },
+        "defaults": {
+          "title": "Workspace-Default",
+          "subtitle": "Wird automatisch beim Start eines neuen Runs für alle Schritte übernommen.",
+          "placeholder": "Standardmodell wählen …"
+        }
       }
     }
   },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -839,6 +839,38 @@
           "anthropic": "Anthropic",
           "custom": "Custom endpoint"
         }
+      },
+      "llmProviders": {
+        "title": "LLM Providers",
+        "subtitle": "Store provider API keys, pull live model lists, and pick the right model per step.",
+        "keyLabel": "API key (masked)",
+        "keyPlaceholder": "Paste a new API key …",
+        "baseUrlPlaceholder": "https://api.example.com/v1",
+        "status": {
+          "connected": "connected",
+          "missing": "key missing",
+          "local": "local",
+          "cli": "gh CLI"
+        },
+        "actions": {
+          "save": "Save",
+          "test": "Test",
+          "refreshModels": "Refresh models",
+          "disconnect": "Disconnect"
+        },
+        "test": {
+          "saved": "Saved.",
+          "ok": "{count} models discovered.",
+          "failed": "Connection failed."
+        },
+        "models": {
+          "title": "Models"
+        },
+        "defaults": {
+          "title": "Workspace default",
+          "subtitle": "Applied automatically when a new run starts.",
+          "placeholder": "Pick a default model …"
+        }
       }
     }
   },

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -78,6 +78,11 @@ const routes: RouteRecordRaw[] = [
     name: 'SettingsLlmRouting',
     component: () => import('../views/Settings/LlmRoutingView.vue'),
   },
+  {
+    path: '/settings/llm-providers',
+    name: 'SettingsLlmProviders',
+    component: () => import('../views/Settings/LlmProvidersView.vue'),
+  },
   // Klassische SettingsView bleibt erreichbar fuer Slice-G-Migration
   {
     path: '/settings-classic',

--- a/frontend/src/store/llmProviders.ts
+++ b/frontend/src/store/llmProviders.ts
@@ -20,8 +20,8 @@ import {
   testLlmProvider,
   type ProviderTestResult,
 } from "../api/llmProviderKeys";
-import { ProviderDescriptor } from "../contracts/llmRoutingContract";
-import { LlmProviderKeyEntry } from "../contracts/llmProviderKeysContract";
+import type { ProviderDescriptor } from "../contracts/llmRoutingContract";
+import type { LlmProviderKeyEntry } from "../contracts/llmProviderKeysContract";
 import service from "../api";
 import type { ApiSuccessEnvelope } from "../api/envelope";
 

--- a/frontend/src/store/llmProviders.ts
+++ b/frontend/src/store/llmProviders.ts
@@ -1,0 +1,175 @@
+/**
+ * llmProviders — Pinia-Store für LLM-Provider-Verwaltung.
+ *
+ * Aggregiert:
+ *   - statische Provider-Beschreibungen (GET /api/llm/providers)
+ *   - persistierte API-Key-Entries (GET /api/llm/providers/api-keys)
+ *   - dynamische Modelllisten (GET /api/llm/providers/<id>/models, 10-min-Cache)
+ *
+ * Klartext-Keys laufen ausschließlich durch ``upsertKey`` ans Backend und
+ * werden hier NIE im State gehalten — `lastError`, `models`, `entries` sind die
+ * einzigen sichtbaren Daten.
+ */
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { listLlmProviders } from "../api/llmRouting";
+import {
+  deleteLlmProviderKey,
+  listLlmProviderKeys,
+  upsertLlmProviderKey,
+  testLlmProvider,
+  type ProviderTestResult,
+} from "../api/llmProviderKeys";
+import { ProviderDescriptor } from "../contracts/llmRoutingContract";
+import { LlmProviderKeyEntry } from "../contracts/llmProviderKeysContract";
+import service from "../api";
+import type { ApiSuccessEnvelope } from "../api/envelope";
+
+interface ModelEntry {
+  id: string;
+  name: string;
+  provider_id: string;
+  source: "live" | "cached" | "fallback" | "custom";
+  refreshed_at: number;
+}
+
+interface ModelCache {
+  models: ModelEntry[];
+  fetchedAt: number;
+}
+
+const MODEL_CACHE_TTL_MS = 10 * 60 * 1000;
+
+export const useLlmProvidersStore = defineStore("llmProviders", () => {
+  const providers = ref<ProviderDescriptor[]>([]);
+  const entries = ref<Record<string, LlmProviderKeyEntry>>({});
+  const models = ref<Record<string, ModelCache>>({});
+  const loading = ref(false);
+  const busy = ref<Record<string, boolean>>({});
+  const lastError = ref<Record<string, string | null>>({});
+
+  async function loadProviders(): Promise<void> {
+    loading.value = true;
+    try {
+      const [list, keys] = await Promise.all([listLlmProviders(), listLlmProviderKeys()]);
+      providers.value = list;
+      entries.value = Object.fromEntries(keys.items.map((k) => [k.provider_id, k]));
+    } catch (err) {
+      console.error("Failed to load LLM providers:", err);
+      throw err;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function fetchModels(providerId: string, opts: { force?: boolean } = {}): Promise<ModelEntry[]> {
+    const cached = models.value[providerId];
+    if (!opts.force && cached && Date.now() - cached.fetchedAt < MODEL_CACHE_TTL_MS) {
+      return cached.models;
+    }
+    busy.value = { ...busy.value, [providerId]: true };
+    lastError.value = { ...lastError.value, [providerId]: null };
+    try {
+      const provider = providers.value.find((p) => p.id === providerId);
+      const baseUrl = entries.value[providerId]?.base_url || provider?.base_url || undefined;
+      const query = baseUrl ? `?base_url=${encodeURIComponent(baseUrl)}` : "";
+      const resp = await service.get<ApiSuccessEnvelope<ModelEntry[]>>(
+        `/api/llm/providers/${providerId}/models${query}`,
+      );
+      const list = (resp as unknown as { data: ModelEntry[] }).data;
+      models.value = {
+        ...models.value,
+        [providerId]: { models: list, fetchedAt: Date.now() },
+      };
+      return list;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError.value = { ...lastError.value, [providerId]: message };
+      throw err;
+    } finally {
+      busy.value = { ...busy.value, [providerId]: false };
+    }
+  }
+
+  async function saveKey(
+    providerId: string,
+    apiKey: string,
+    baseUrl?: string,
+    options: { validate?: boolean } = {},
+  ): Promise<LlmProviderKeyEntry> {
+    busy.value = { ...busy.value, [providerId]: true };
+    lastError.value = { ...lastError.value, [providerId]: null };
+    try {
+      const entry = await upsertLlmProviderKey(
+        providerId,
+        { api_key: apiKey, base_url: baseUrl || null },
+        options,
+      );
+      entries.value = { ...entries.value, [providerId]: entry };
+      // Modell-Cache invalidieren, weil neuer Key u. U. mehr Modelle freigibt
+      delete models.value[providerId];
+      return entry;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError.value = { ...lastError.value, [providerId]: message };
+      throw err;
+    } finally {
+      busy.value = { ...busy.value, [providerId]: false };
+    }
+  }
+
+  async function revokeKey(providerId: string): Promise<void> {
+    busy.value = { ...busy.value, [providerId]: true };
+    lastError.value = { ...lastError.value, [providerId]: null };
+    try {
+      await deleteLlmProviderKey(providerId);
+      const next = { ...entries.value };
+      delete next[providerId];
+      entries.value = next;
+      delete models.value[providerId];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError.value = { ...lastError.value, [providerId]: message };
+      throw err;
+    } finally {
+      busy.value = { ...busy.value, [providerId]: false };
+    }
+  }
+
+  async function testProvider(
+    providerId: string,
+    payload: { api_key?: string; base_url?: string } = {},
+    options: { inference?: boolean } = {},
+  ): Promise<ProviderTestResult> {
+    busy.value = { ...busy.value, [providerId]: true };
+    lastError.value = { ...lastError.value, [providerId]: null };
+    try {
+      return await testLlmProvider(providerId, payload, options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError.value = { ...lastError.value, [providerId]: message };
+      throw err;
+    } finally {
+      busy.value = { ...busy.value, [providerId]: false };
+    }
+  }
+
+  function hasKey(providerId: string): boolean {
+    return providerId in entries.value;
+  }
+
+  return {
+    providers,
+    entries,
+    models,
+    loading,
+    busy,
+    lastError,
+    loadProviders,
+    fetchModels,
+    saveKey,
+    revokeKey,
+    testProvider,
+    hasKey,
+  };
+});

--- a/frontend/src/store/llmRoutingDefaults.ts
+++ b/frontend/src/store/llmRoutingDefaults.ts
@@ -35,6 +35,8 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
   const defaults = ref<WorkspaceLlmRoutingDefaults>(EMPTY_DEFAULTS);
   const loading = ref(false);
   const lastError = ref<string | null>(null);
+  /** Explizites Loaded-Flag — robuster als updated_at-Proxy (Gemini MEDIUM #5). */
+  const hasLoadedOnce = ref(false);
 
   const globalDefault = computed(() => defaults.value.global_default);
   const stageOverrides = computed(() => defaults.value.stage_overrides);
@@ -48,6 +50,7 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
     lastError.value = null;
     try {
       defaults.value = await getRoutingDefaults();
+      hasLoadedOnce.value = true;
     } catch (err) {
       lastError.value = err instanceof Error ? err.message : String(err);
       throw err;
@@ -97,6 +100,7 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
     defaults,
     loading,
     lastError,
+    hasLoadedOnce,
     globalDefault,
     stageOverrides,
     effectiveRouteForStage,

--- a/frontend/src/store/llmRoutingDefaults.ts
+++ b/frontend/src/store/llmRoutingDefaults.ts
@@ -1,0 +1,109 @@
+/**
+ * llmRoutingDefaults — Pinia-Store für Workspace-weite LLM-Defaults.
+ *
+ * Hält die globale Default-Route (z. B. "openai gpt-4o-mini") plus optionale
+ * Stage-Overrides (z. B. "Report-Stage nutzt gpt-4o"). Wird beim Run-Start
+ * vom Backend in die runspezifische `RuntimeLlmRouting` gemergt.
+ */
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+import {
+  getRoutingDefaults,
+  patchRoutingDefaultStage,
+  replaceGlobalDefault,
+  replaceRoutingDefaults,
+} from "../api/llmRoutingDefaults";
+import type { StageId, StageLLMRoute } from "../contracts/llmRoutingContract";
+import type { WorkspaceLlmRoutingDefaults } from "../contracts/workspaceRoutingContract";
+
+const EMPTY_DEFAULTS: WorkspaceLlmRoutingDefaults = {
+  global_default: {
+    stage: null,
+    provider_id: null,
+    model: null,
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: "none",
+    provider_options: {},
+  },
+  stage_overrides: {},
+  version: 1,
+  updated_at: null,
+};
+
+export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () => {
+  const defaults = ref<WorkspaceLlmRoutingDefaults>(EMPTY_DEFAULTS);
+  const loading = ref(false);
+  const lastError = ref<string | null>(null);
+
+  const globalDefault = computed(() => defaults.value.global_default);
+  const stageOverrides = computed(() => defaults.value.stage_overrides);
+
+  function effectiveRouteForStage(stageId: StageId): StageLLMRoute {
+    return defaults.value.stage_overrides[stageId] ?? defaults.value.global_default;
+  }
+
+  async function load(): Promise<void> {
+    loading.value = true;
+    lastError.value = null;
+    try {
+      defaults.value = await getRoutingDefaults();
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function setGlobalDefault(route: StageLLMRoute): Promise<void> {
+    lastError.value = null;
+    try {
+      defaults.value = await replaceGlobalDefault(route);
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  async function setStageOverride(
+    stageId: StageId,
+    route: StageLLMRoute | null,
+  ): Promise<void> {
+    lastError.value = null;
+    try {
+      defaults.value = await patchRoutingDefaultStage(stageId, route);
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  async function replaceAll(payload: WorkspaceLlmRoutingDefaults): Promise<void> {
+    lastError.value = null;
+    try {
+      defaults.value = await replaceRoutingDefaults(payload);
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  function clearStageOverride(stageId: StageId): Promise<void> {
+    return setStageOverride(stageId, null);
+  }
+
+  return {
+    defaults,
+    loading,
+    lastError,
+    globalDefault,
+    stageOverrides,
+    effectiveRouteForStage,
+    load,
+    setGlobalDefault,
+    setStageOverride,
+    replaceAll,
+    clearStageOverride,
+  };
+});

--- a/frontend/src/views/Settings/LlmProvidersView.vue
+++ b/frontend/src/views/Settings/LlmProvidersView.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+/**
+ * LlmProvidersView — Workspace-weite LLM-Provider-Konfiguration.
+ *
+ * Pro Provider eine Karte mit:
+ *   - Status-Badge (connected / missing / fallback)
+ *   - Key-Eingabe (type=password) + optional Base-URL (für openai_compatible)
+ *   - Buttons: Speichern, Test, Modelle laden, Trennen
+ *   - Sichtbare Modellliste (Source: live/cached/fallback)
+ *   - Inline Global-Default-Picker (Workspace-Default-Routing)
+ *
+ * Klartext-Keys verlassen niemals das Backend nach dem Speichern. Im Frontend
+ * wird nur ``masked_value`` (sk-...abcd) angezeigt.
+ */
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppShell from '@/components/v4/shell/AppShell.vue'
+import PageHeader from '@/components/v4/shell/PageHeader.vue'
+import Card from '@/components/v4/forms/Card.vue'
+import Badge from '@/components/v4/forms/Badge.vue'
+import Input from '@/components/v4/forms/Input.vue'
+import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
+import { useLlmProvidersStore } from '@/store/llmProviders'
+import { useLlmRoutingDefaultsStore } from '@/store/llmRoutingDefaults'
+import type { ProviderDescriptor, StageLLMRoute } from '@/contracts/llmRoutingContract'
+
+const { t } = useI18n()
+
+const providersStore = useLlmProvidersStore()
+const defaultsStore = useLlmRoutingDefaultsStore()
+
+const BREADCRUMBS = [
+  { label: 'Settings', to: { name: 'SettingsGeneral' } },
+  { label: t('settings.v4.llmProviders.title', 'LLM-Provider') },
+]
+
+interface DraftState {
+  apiKey: string
+  baseUrl: string
+  testMessage: string | null
+  testOk: boolean | null
+}
+
+const drafts = reactive<Record<string, DraftState>>({})
+
+function ensureDraft(providerId: string): DraftState {
+  if (!(providerId in drafts)) {
+    drafts[providerId] = {
+      apiKey: '',
+      baseUrl: providersStore.entries[providerId]?.base_url || '',
+      testMessage: null,
+      testOk: null,
+    }
+  }
+  return drafts[providerId]
+}
+
+function statusBadgeVariant(p: ProviderDescriptor): 'success' | 'neutral' | 'warning' {
+  if (providersStore.hasKey(p.id)) return 'success'
+  if (p.type === 'ollama_local') return 'neutral'
+  return 'warning'
+}
+
+function statusLabel(p: ProviderDescriptor): string {
+  if (providersStore.hasKey(p.id)) return t('settings.v4.llmProviders.status.connected', 'verbunden')
+  if (p.type === 'ollama_local') return t('settings.v4.llmProviders.status.local', 'lokal')
+  if (p.type === 'github_copilot') return t('settings.v4.llmProviders.status.cli', 'gh CLI')
+  return t('settings.v4.llmProviders.status.missing', 'Key fehlt')
+}
+
+async function save(p: ProviderDescriptor): Promise<void> {
+  const draft = ensureDraft(p.id)
+  draft.testMessage = null
+  draft.testOk = null
+  if (!draft.apiKey.trim()) return
+  try {
+    await providersStore.saveKey(p.id, draft.apiKey.trim(), draft.baseUrl.trim() || undefined, {
+      validate: true,
+    })
+    draft.apiKey = ''
+    draft.testOk = true
+    draft.testMessage = t('settings.v4.llmProviders.test.saved', 'Gespeichert.')
+  } catch (err) {
+    draft.testOk = false
+    draft.testMessage = err instanceof Error ? err.message : String(err)
+  }
+}
+
+async function runTest(p: ProviderDescriptor): Promise<void> {
+  const draft = ensureDraft(p.id)
+  draft.testMessage = null
+  draft.testOk = null
+  try {
+    const result = await providersStore.testProvider(p.id, {
+      api_key: draft.apiKey.trim() || undefined,
+      base_url: draft.baseUrl.trim() || undefined,
+    })
+    draft.testOk = result.connectivity === 'ok'
+    draft.testMessage = draft.testOk
+      ? t('settings.v4.llmProviders.test.ok', { count: result.models_found ?? 0 })
+      : t('settings.v4.llmProviders.test.failed')
+  } catch (err) {
+    draft.testOk = false
+    draft.testMessage = err instanceof Error ? err.message : String(err)
+  }
+}
+
+async function loadModels(p: ProviderDescriptor): Promise<void> {
+  await providersStore.fetchModels(p.id, { force: true })
+}
+
+async function disconnect(p: ProviderDescriptor): Promise<void> {
+  await providersStore.revokeKey(p.id)
+  const draft = ensureDraft(p.id)
+  draft.testMessage = null
+  draft.testOk = null
+}
+
+const defaultRoute = computed<StageLLMRoute | null>(() => {
+  const r = defaultsStore.globalDefault
+  if (!r?.provider_id || !r?.model) return null
+  return r
+})
+
+async function setDefault(route: StageLLMRoute | null): Promise<void> {
+  if (!route) return
+  await defaultsStore.setGlobalDefault(route)
+}
+
+onMounted(async () => {
+  await providersStore.loadProviders()
+  await defaultsStore.load()
+})
+</script>
+
+<template>
+  <AppShell>
+    <PageHeader
+      :title="t('settings.v4.llmProviders.title', 'LLM-Provider')"
+      :subtitle="t('settings.v4.llmProviders.subtitle', 'Hinterlege API-Schlüssel, ziehe Modelle und wähle pro Schritt das passende Modell aus.')"
+      :breadcrumbs="BREADCRUMBS"
+    />
+
+    <div class="llm-providers-grid">
+      <Card
+        :title="t('settings.v4.llmProviders.defaults.title', 'Workspace-Default')"
+        :subtitle="t('settings.v4.llmProviders.defaults.subtitle', 'Wird automatisch beim Start eines neuen Runs für alle Schritte übernommen.')"
+      >
+        <div class="llm-default-row">
+          <ModelPicker
+            :model-value="defaultRoute"
+            :placeholder="t('settings.v4.llmProviders.defaults.placeholder', 'Standardmodell wählen …')"
+            @update:model-value="setDefault"
+          />
+          <span v-if="defaultRoute" class="llm-default-current">
+            {{ defaultRoute.provider_id }} · {{ defaultRoute.model }}
+          </span>
+        </div>
+      </Card>
+
+      <Card
+        v-for="provider in providersStore.providers"
+        :key="provider.id"
+        :title="provider.label"
+        :subtitle="provider.base_url || ''"
+      >
+        <template #right>
+          <Badge :variant="statusBadgeVariant(provider)">
+            {{ statusLabel(provider) }}
+          </Badge>
+        </template>
+
+        <div class="llm-card-body">
+          <div v-if="providersStore.entries[provider.id]" class="llm-key-line">
+            <span class="llm-key-line__label">
+              {{ t('settings.v4.llmProviders.keyLabel', 'API-Key (maskiert)') }}
+            </span>
+            <code class="llm-key-line__value">
+              {{ providersStore.entries[provider.id].masked_value }}
+            </code>
+          </div>
+
+          <div class="llm-key-form">
+            <Input
+              v-model="ensureDraft(provider.id).apiKey"
+              type="password"
+              autocomplete="off"
+              spellcheck="false"
+              :placeholder="t('settings.v4.llmProviders.keyPlaceholder', 'Neuen API-Key einfügen …')"
+            />
+            <Input
+              v-if="provider.type === 'openai_compatible'"
+              v-model="ensureDraft(provider.id).baseUrl"
+              :placeholder="t('settings.v4.llmProviders.baseUrlPlaceholder', 'https://api.example.com/v1')"
+            />
+          </div>
+
+          <div class="llm-actions">
+            <button
+              type="button"
+              class="llm-btn llm-btn--primary"
+              :disabled="!ensureDraft(provider.id).apiKey.trim() || providersStore.busy[provider.id]"
+              @click="save(provider)"
+            >
+              {{ t('settings.v4.llmProviders.actions.save', 'Speichern') }}
+            </button>
+            <button
+              type="button"
+              class="llm-btn"
+              :disabled="providersStore.busy[provider.id]"
+              @click="runTest(provider)"
+            >
+              {{ t('settings.v4.llmProviders.actions.test', 'Test') }}
+            </button>
+            <button
+              type="button"
+              class="llm-btn"
+              :disabled="providersStore.busy[provider.id]"
+              @click="loadModels(provider)"
+            >
+              {{ t('settings.v4.llmProviders.actions.refreshModels', 'Modelle laden') }}
+            </button>
+            <button
+              v-if="providersStore.hasKey(provider.id)"
+              type="button"
+              class="llm-btn llm-btn--danger"
+              :disabled="providersStore.busy[provider.id]"
+              @click="disconnect(provider)"
+            >
+              {{ t('settings.v4.llmProviders.actions.disconnect', 'Trennen') }}
+            </button>
+          </div>
+
+          <div
+            v-if="ensureDraft(provider.id).testMessage"
+            class="llm-test-result"
+            :class="{ 'llm-test-result--ok': ensureDraft(provider.id).testOk, 'llm-test-result--fail': ensureDraft(provider.id).testOk === false }"
+          >
+            {{ ensureDraft(provider.id).testMessage }}
+          </div>
+
+          <div v-if="(providersStore.models[provider.id]?.models?.length ?? 0) > 0" class="llm-model-list">
+            <span class="llm-model-list__title">
+              {{ t('settings.v4.llmProviders.models.title', 'Modelle') }}
+              <small>({{ providersStore.models[provider.id].models[0].source }})</small>
+            </span>
+            <ul>
+              <li v-for="model in providersStore.models[provider.id].models" :key="model.id">
+                {{ model.id }}
+              </li>
+            </ul>
+          </div>
+        </div>
+      </Card>
+    </div>
+  </AppShell>
+</template>
+
+<style scoped>
+.llm-providers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 16px;
+  padding: 16px;
+}
+.llm-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.llm-key-line {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--surface-muted, rgba(0, 0, 0, 0.03));
+  padding: 8px 10px;
+  border-radius: var(--r-4, 8px);
+}
+.llm-key-line__label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.llm-key-line__value {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.llm-key-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.llm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.llm-btn {
+  border: 1px solid var(--hairline);
+  background: var(--surface-elevated, #fff);
+  padding: 6px 12px;
+  border-radius: var(--r-4, 8px);
+  font-size: 13px;
+  cursor: pointer;
+}
+.llm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.llm-btn--primary {
+  background: var(--accent, #0a84ff);
+  color: #fff;
+  border-color: var(--accent, #0a84ff);
+}
+.llm-btn--danger {
+  color: var(--danger, #d33);
+  border-color: var(--danger, #d33);
+}
+.llm-test-result {
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-muted, rgba(0, 0, 0, 0.04));
+}
+.llm-test-result--ok { color: var(--success, #176f3a); }
+.llm-test-result--fail { color: var(--danger, #d33); }
+.llm-model-list ul {
+  margin: 4px 0 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  max-height: 140px;
+  overflow-y: auto;
+}
+.llm-model-list__title {
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.llm-default-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.llm-default-current {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/frontend/src/views/v4/steps/StepEnvSetupView.vue
+++ b/frontend/src/views/v4/steps/StepEnvSetupView.vue
@@ -8,7 +8,11 @@
     <PageHeader
       title="Personas"
       subtitle="Zielgruppenquoten und Umgebungsparameter konfigurieren"
-    />
+    >
+      <template #right>
+        <StepModelOverrideChip stage-id="persona_generation" />
+      </template>
+    </PageHeader>
     <PipelineStepper :current-step="2" />
     <Step2EnvSetup :simulation-id="projectId" />
   </AppShell>
@@ -20,6 +24,7 @@ import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import PipelineStepper from '@/components/v4/steps/PipelineStepper.vue'
 import Step2EnvSetup from '@/components/Step2EnvSetup.vue'
+import StepModelOverrideChip from '@/components/v4/forms/StepModelOverrideChip.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
 const props = defineProps<{

--- a/frontend/src/views/v4/steps/StepGraphBuildView.vue
+++ b/frontend/src/views/v4/steps/StepGraphBuildView.vue
@@ -8,7 +8,11 @@
     <PageHeader
       title="Graph Build"
       subtitle="Wissensgraph aus hochgeladenen Dokumenten aufbauen"
-    />
+    >
+      <template #right>
+        <StepModelOverrideChip stage-id="graph_build" />
+      </template>
+    </PageHeader>
     <PipelineStepper :current-step="1" />
     <!-- Step1GraphBuild empfaengt projectData/graphData via Store, kein direkter projectId-Prop -->
     <Step1GraphBuild />
@@ -21,6 +25,7 @@ import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import PipelineStepper from '@/components/v4/steps/PipelineStepper.vue'
 import Step1GraphBuild from '@/components/Step1GraphBuild.vue'
+import StepModelOverrideChip from '@/components/v4/forms/StepModelOverrideChip.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
 const props = defineProps<{

--- a/frontend/src/views/v4/steps/StepReportView.vue
+++ b/frontend/src/views/v4/steps/StepReportView.vue
@@ -8,7 +8,11 @@
     <PageHeader
       title="Report"
       subtitle="Simulationsergebnisse und Quellenbelege einsehen"
-    />
+    >
+      <template #right>
+        <StepModelOverrideChip stage-id="report_generation" />
+      </template>
+    </PageHeader>
     <PipelineStepper :current-step="4" />
     <Step4Report :report-id="reportId" />
   </AppShell>
@@ -20,6 +24,7 @@ import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import PipelineStepper from '@/components/v4/steps/PipelineStepper.vue'
 import Step4Report from '@/components/Step4Report.vue'
+import StepModelOverrideChip from '@/components/v4/forms/StepModelOverrideChip.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
 const props = defineProps<{

--- a/frontend/src/views/v4/steps/StepSimulationView.vue
+++ b/frontend/src/views/v4/steps/StepSimulationView.vue
@@ -8,7 +8,11 @@
     <PageHeader
       title="Simulation"
       subtitle="Multi-Agent-Simulationslauf starten und beobachten"
-    />
+    >
+      <template #right>
+        <StepModelOverrideChip stage-id="simulation_rounds" />
+      </template>
+    </PageHeader>
     <PipelineStepper :current-step="3" />
     <Step3Simulation :simulation-id="simulationId" />
   </AppShell>
@@ -20,6 +24,7 @@ import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import PipelineStepper from '@/components/v4/steps/PipelineStepper.vue'
 import Step3Simulation from '@/components/Step3Simulation.vue'
+import StepModelOverrideChip from '@/components/v4/forms/StepModelOverrideChip.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
 const props = defineProps<{

--- a/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
@@ -149,6 +149,34 @@ vi.mock('@/store/settings', () => ({
   }),
 }))
 
+vi.mock('@/store/llmProviders', () => ({
+  useLlmProvidersStore: () => ({
+    providers: [],
+    entries: {},
+    models: {},
+    busy: {},
+    hasKey: vi.fn().mockReturnValue(false),
+    loadProviders: vi.fn().mockResolvedValue(undefined),
+    saveKey: vi.fn().mockResolvedValue(undefined),
+    revokeKey: vi.fn().mockResolvedValue(undefined),
+    testProvider: vi.fn().mockResolvedValue({ connectivity: 'ok', models_found: 0 }),
+    fetchModels: vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+vi.mock('@/store/llmRoutingDefaults', () => ({
+  useLlmRoutingDefaultsStore: () => ({
+    defaults: { updated_at: null, global_default: null, stage_overrides: {} },
+    globalDefault: null,
+    stageOverrides: {},
+    effectiveRouteForStage: vi.fn().mockReturnValue({ provider_id: '', model: '' }),
+    load: vi.fn().mockResolvedValue(undefined),
+    setGlobalDefault: vi.fn().mockResolvedValue(undefined),
+    setStageOverride: vi.fn().mockResolvedValue(undefined),
+    clearStageOverride: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
 // ── Router-Stub ───────────────────────────────────────────────────────────────
 const stubComp = { template: '<div />' }
 const router = createRouter({
@@ -186,6 +214,8 @@ async function mountView<T extends object>(
         Step5Interaction: { template: '<div class="stub-step5" />' },
         // Sidebar stub (Slice F, nicht angefasst)
         Sidebar: { template: '<nav class="stub-sidebar" />' },
+        // Model-Override-Chip (Slice E) — eigene Spec; hier nur Shell getestet
+        StepModelOverrideChip: { template: '<div class="stub-model-chip" />' },
       },
     },
   })

--- a/schemas/llm-provider-descriptor.schema.json
+++ b/schemas/llm-provider-descriptor.schema.json
@@ -53,7 +53,8 @@
         "ollama_local",
         "openai",
         "google",
-        "openai_compatible"
+        "openai_compatible",
+        "github_copilot"
       ],
       "title": "Type",
       "type": "string"

--- a/schemas/llm-provider-key-create-request.schema.json
+++ b/schemas/llm-provider-key-create-request.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-provider-key-create-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Eingabe f\u00fcr POST /api/llm/providers/<provider_id>/api-key.",
+  "properties": {
+    "api_key": {
+      "maxLength": 1024,
+      "minLength": 4,
+      "title": "Api Key",
+      "type": "string"
+    },
+    "base_url": {
+      "anyOf": [
+        {
+          "maxLength": 512,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Base Url"
+    }
+  },
+  "required": [
+    "api_key"
+  ],
+  "title": "LlmProviderKeyCreateRequest",
+  "type": "object"
+}

--- a/schemas/llm-provider-key-entry.schema.json
+++ b/schemas/llm-provider-key-entry.schema.json
@@ -1,0 +1,75 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-provider-key-entry.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Persistierte Repr\u00e4sentation eines Provider-Keys (ohne Klartext).",
+  "properties": {
+    "base_url": {
+      "anyOf": [
+        {
+          "maxLength": 512,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Base Url"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "last_validated_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Validated At"
+    },
+    "last_validation_ok": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Validation Ok"
+    },
+    "masked_value": {
+      "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-]{4}$",
+      "title": "Masked Value",
+      "type": "string"
+    },
+    "provider_id": {
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Provider Id",
+      "type": "string"
+    },
+    "updated_at": {
+      "format": "date-time",
+      "title": "Updated At",
+      "type": "string"
+    }
+  },
+  "required": [
+    "provider_id",
+    "masked_value",
+    "created_at",
+    "updated_at"
+  ],
+  "title": "LlmProviderKeyEntry",
+  "type": "object"
+}

--- a/schemas/llm-provider-keys-list-response.schema.json
+++ b/schemas/llm-provider-keys-list-response.schema.json
@@ -1,0 +1,101 @@
+{
+  "$defs": {
+    "LlmProviderKeyEntry": {
+      "additionalProperties": false,
+      "description": "Persistierte Repr\u00e4sentation eines Provider-Keys (ohne Klartext).",
+      "properties": {
+        "base_url": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Url"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "last_validated_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Validated At"
+        },
+        "last_validation_ok": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Validation Ok"
+        },
+        "masked_value": {
+          "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-]{4}$",
+          "title": "Masked Value",
+          "type": "string"
+        },
+        "provider_id": {
+          "maxLength": 64,
+          "minLength": 1,
+          "title": "Provider Id",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider_id",
+        "masked_value",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "LlmProviderKeyEntry",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/llm-provider-keys-list-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Antwort auf GET /api/llm/providers/api-keys (\u00dcbersicht aller Provider).",
+  "properties": {
+    "items": {
+      "items": {
+        "$ref": "#/$defs/LlmProviderKeyEntry"
+      },
+      "title": "Items",
+      "type": "array"
+    },
+    "total": {
+      "minimum": 0,
+      "title": "Total",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "items",
+    "total"
+  ],
+  "title": "LlmProviderKeysListResponse",
+  "type": "object"
+}

--- a/schemas/workspace-llm-routing-defaults.schema.json
+++ b/schemas/workspace-llm-routing-defaults.schema.json
@@ -1,0 +1,152 @@
+{
+  "$defs": {
+    "StageLLMRoute": {
+      "additionalProperties": false,
+      "description": "Configuration for a single stage route.",
+      "properties": {
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Tokens"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "provider_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider Id"
+        },
+        "provider_options": {
+          "additionalProperties": true,
+          "title": "Provider Options",
+          "type": "object"
+        },
+        "reasoning_effort": {
+          "anyOf": [
+            {
+              "enum": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "none",
+          "title": "Reasoning Effort"
+        },
+        "stage": {
+          "anyOf": [
+            {
+              "enum": [
+                "document_ingest",
+                "ontology_generation",
+                "graph_build",
+                "persona_generation",
+                "simulation_rounds",
+                "report_generation",
+                "evaluation"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stage"
+        },
+        "temperature": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temperature"
+        }
+      },
+      "title": "StageLLMRoute",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/workspace-llm-routing-defaults.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Workspace-weit g\u00fcltiger LLM-Default plus optionale Stage-Overrides.",
+  "properties": {
+    "global_default": {
+      "$ref": "#/$defs/StageLLMRoute"
+    },
+    "stage_overrides": {
+      "additionalProperties": {
+        "$ref": "#/$defs/StageLLMRoute"
+      },
+      "propertyNames": {
+        "enum": [
+          "document_ingest",
+          "ontology_generation",
+          "graph_build",
+          "persona_generation",
+          "simulation_rounds",
+          "report_generation",
+          "evaluation"
+        ]
+      },
+      "title": "Stage Overrides",
+      "type": "object"
+    },
+    "updated_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Updated At"
+    },
+    "version": {
+      "default": 1,
+      "title": "Version",
+      "type": "integer"
+    }
+  },
+  "title": "WorkspaceLlmRoutingDefaults",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Implementiert das vollständige LLM-Provider-Hub-Feature (5 Slices A–E, geplant unter CLAUDE.md Bugfix #17).

### Was neu ist

**Backend — Slice A: Verschlüsselte Key-Storage**
- `LlmProviderSecretsStore`: Fernet-AES-Store unter `backend/data/llm_provider_secrets.json` (Schlüssel: `AGORA_SECRET_KEY` — Pflicht, Fail-Fast)
- Speichert pro Provider: `ciphertext`, `masked_value` (`sk-...abcd`), `created_at`, `last_validated_at`
- Atomisches Schreiben (tmp + `os.replace()`), Singleton + `reset_singleton_for_tests()`
- `SecretResolver` erweitert: Session-Override → Fernet-Store → Env-Vars → `Config.LLM_API_KEY`
- Neue Pydantic-v2-Contracts (`extra="forbid"`): `LlmProviderKeyEntry`, `LlmProviderKeyCreateRequest`, `LlmProviderKeysListResponse`
- Neue API-Endpunkte: `GET/POST/PUT/DELETE /api/llm/providers/<id>/api-key`, `GET /api/llm/providers/api-keys` (nur `masked_value`, nie Klartext). Optional `?validate=1` triggert Inline-Test.

**Backend — Slice B: GitHub Copilot Provider**
- `llm_providers/github_copilot.py`: `resolve_copilot_token()` via `gh auth token` subprocess (3 s Timeout, gh-not-found-safe, kein Token-Logging)
- Statische Modellliste Phase 1: `gpt-4o-copilot`, `gpt-4o-mini-copilot`, `claude-sonnet-4.5-copilot`, `o1-mini-copilot`
- Registry-Eintrag: `github_copilot` (type=`github_copilot`, `supports_models_endpoint=False`)

**Backend — Slice C: Workspace-Default-Routing-API**
- `WorkspaceRoutingStore`: JSON-Store (`backend/data/workspace_llm_routing.json`) mit `global_default`, `stage_overrides`
- Neue Endpunkte: `GET/PUT /api/llm/routing/defaults`, `PATCH /api/llm/routing/defaults/stages/<stage_id>`, `PUT /api/llm/routing/defaults/global`
- `llm_routing_seed.py`: seeded Workspace-Default beim Run-Start (nur fresh runs, kein Überschreiben laufender Konfigurationen)
- 4 neue JSON-Schemas

**Frontend — Slice D: Multi-Provider-Hub-View + Pinia-Stores**
- `useLlmProvidersStore`: Provider-Liste, Key-CRUD, Test, Modell-Fetch (10-min-Cache)
- `useLlmRoutingDefaultsStore`: `globalDefault`, `stageOverrides`, `effectiveRouteForStage(stageId)`
- Zod-Contracts spiegeln die Backend-Pydantic-Schemas
- API-Wrapper: `llmProviderKeys.ts`, `llmRoutingDefaults.ts`
- `ModelPicker.vue`: `<select>` mit OptGroups je Provider (zeigt nur Provider mit Key oder keyless-Typen)
- `LlmProvidersView.vue` unter `/settings/llm-providers`:
  - Workspace-Default-Card mit `ModelPicker`
  - Provider-Cards-Grid (Status-Badge, Key-Input `type=password autocomplete=off`, Base-URL für `openai_compatible`, Save/Test/Modelle/Trennen)
- Sidebar: neuer Nav-Item "LLM Providers"
- i18n: `settings.v4.llmProviders.*` in `de.json` + `en.json`

**Frontend — Slice E: Per-Step-Modellauswahl**
- `StepModelOverrideChip.vue`: Pill-Button mit Popover-`ModelPicker` pro Stage
  - Zeigt effektives Modell (Default oder Override); "override"-Badge wenn aktiv; `locked`-Prop für versiegelte Stages
- Eingebaut in alle 4 Step-Wrapper-Views: `graph_build` / `persona_generation` / `simulation_rounds` / `report_generation`

### Sicherheits-Constraints eingehalten
- API-Keys **nie** in localStorage / sessionStorage / Pinia-persisted-Plugin
- Key-Inputs `type="password"`, `autocomplete="off"`, `spellcheck="false"`
- `GET /api/llm/providers/<id>/api-key` gibt nur `masked_value` zurück
- `AGORA_SECRET_KEY` wird bei `flask run` validiert (Fail-Fast)
- GitHub-Copilot-Token-Resolver loggt keinen Token-Klartext

### Test-Ergebnisse

| Bereich | Ergebnis |
|---|---|
| Backend (pytest) | 2083/2083 grün |
| Frontend (vitest) | 702/702 grün |
| ruff check app/ | sauber |
| mypy app (165 Files) | sauber |
| vue-tsc --noEmit | sauber |
| npm run build | sauber |
| Schema-Drift (git diff schemas/) | kein Drift |

**34 neue Backend-Tests** — Contracts, Secrets-Store-Roundtrip, SecretResolver-Integration, GitHub-Copilot-Token-Resolver, Workspace-Routing-Store, API-Endpunkte.

### Nicht im Scope (separate Slices)
- Anthropic-Provider (User abgewählt)
- Live-Fetch der GitHub-Copilot-Modellliste (Phase 1 = statisch)
- Multi-User-Workspace / Per-User-Keys
- Cleanup von `LlmProviderCard.vue` (separater Followup-PR)
- Token-Usage-Tracking / Kosten-Anzeige

## Test plan

- [ ] `AGORA_SECRET_KEY=test-key flask run` — kein Crash, Startup-Log zeigt "Auth: AGORA_AUTH_TOKEN aktiv"
- [ ] `curl /api/llm/providers` → 4 Provider (openai, google, openai_compatible, github_copilot)
- [ ] `POST /api/llm/providers/openai/api-key {"api_key":"sk-test"}` → 200, masked_value=`sk-...test`
- [ ] `GET /api/llm/providers/openai/api-key` → 200, masked_value sichtbar, kein Klartext
- [ ] `DELETE /api/llm/providers/openai/api-key` → 200, Key gelöscht
- [ ] `GET /api/llm/routing/defaults` → 200, global_default leer bei erstem Aufruf
- [ ] `PATCH /api/llm/routing/defaults/stages/report_generation {"provider_id":"openai","model":"gpt-4o-mini"}` → 200
- [ ] UI `/settings/llm-providers`: 4 Cards rendern, Save + Test funktioniert
- [ ] Step1–4-Header: Override-Chip zeigt "Modell wählen …" initial, nach PATCH Stage-Override korrekte Anzeige
- [ ] Run starten → `run_dir/llm_routing.json` enthält geseeded Workspace-Default

🤖 Generated with [Claude Code](https://claude.com/claude-code)