### PR TITLE
fix(report): native OpenAI tool-calling für ReACT-Loop

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -165,6 +165,11 @@ class Config:
     ]
 
     # Report Agent configuration
+    # REPORT_TOOLCALL_MODE: "native" nutzt OpenAI function-calling (tools=/tool_choice=);
+    # "xml" behält den Legacy-XML-Parsing-Pfad (<tool_call>...</tool_call>).
+    # Default: "native" — Modelle wie deepseek-v4-flash:cloud senden keinen sauberen XML-Block.
+    REPORT_TOOLCALL_MODE: str = os.environ.get('REPORT_TOOLCALL_MODE', 'native')
+
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))
     REPORT_AGENT_TEMPERATURE = float(os.environ.get('REPORT_AGENT_TEMPERATURE', '0.5'))

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -40,6 +40,7 @@ from .tools import (
     describe_tools,
     define_tools,
     execute_tool_call,
+    get_openai_tools_schema,
     is_valid_tool_call,
     parse_tool_calls,
 )
@@ -632,6 +633,10 @@ class ReportAgent:
 
     def _get_tools_description(self) -> str:
         return describe_tools(self.tools)
+
+    def _get_openai_tools_schema(self) -> List[Dict[str, Any]]:
+        """Liefert die Tool-Definitionen im OpenAI function-calling Format."""
+        return get_openai_tools_schema(self)
 
     def plan_outline(
         self,

--- a/backend/app/services/report_agent/tools.py
+++ b/backend/app/services/report_agent/tools.py
@@ -105,6 +105,43 @@ parse_tool_calls = _parse_tool_calls
 is_valid_tool_call = _is_valid_tool_call
 
 
+def get_openai_tools_schema(agent: Any) -> List[Dict[str, Any]]:
+    """Liefert die Tool-Definitionen im OpenAI function-calling Format.
+
+    Wandelt die internen ``define_tools(agent)``-Einträge
+    ``{name, description, parameters: {param_name: description, ...}}``
+    in das OpenAI-Schema-Format um:
+    ``[{"type": "function", "function": {"name", "description", "parameters": {...}}}]``.
+
+    ``parameters`` wird als valides JSON-Schema aufgebaut:
+    alle Einträge sind ``string``-typed optional properties.
+    """
+    tools = define_tools(agent)
+    result: List[Dict[str, Any]] = []
+    for tool_name, tool_def in tools.items():
+        properties: Dict[str, Any] = {}
+        for param_name, param_desc in tool_def.get("parameters", {}).items():
+            properties[param_name] = {
+                "type": "string",
+                "description": str(param_desc),
+            }
+        result.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "description": tool_def.get("description", ""),
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": [],
+                    },
+                },
+            }
+        )
+    return result
+
+
 def describe_tools(tools: Dict[str, Dict[str, Any]]) -> str:
     desc_parts = ["Available Tools:"]
     for name, tool in tools.items():
@@ -119,6 +156,7 @@ __all__ = [
     "define_tools",
     "describe_tools",
     "execute_tool_call",
+    "get_openai_tools_schema",
     "parse_tool_calls",
     "parse_tool_calls_response",
     "is_valid_tool_call",

--- a/backend/app/services/report_agent/tools.py
+++ b/backend/app/services/report_agent/tools.py
@@ -113,18 +113,30 @@ def get_openai_tools_schema(agent: Any) -> List[Dict[str, Any]]:
     in das OpenAI-Schema-Format um:
     ``[{"type": "function", "function": {"name", "description", "parameters": {...}}}]``.
 
-    ``parameters`` wird als valides JSON-Schema aufgebaut:
-    alle Einträge sind ``string``-typed optional properties.
+    ``parameters`` wird als valides JSON-Schema aufgebaut. Typ- und
+    Required-Heuristik basiert auf Parameter-Name und -Beschreibung:
+    ``limit``/``max_*`` → ``integer``, ``include_expired`` → ``boolean``,
+    Rest ``string``. Parameter mit ``optional`` in der Beschreibung sind
+    nicht required.
     """
     tools = define_tools(agent)
     result: List[Dict[str, Any]] = []
     for tool_name, tool_def in tools.items():
         properties: Dict[str, Any] = {}
+        required_params: List[str] = []
         for param_name, param_desc in tool_def.get("parameters", {}).items():
+            desc_str = str(param_desc)
+            p_type = "string"
+            if param_name == "limit" or param_name.startswith("max_"):
+                p_type = "integer"
+            elif param_name == "include_expired":
+                p_type = "boolean"
             properties[param_name] = {
-                "type": "string",
-                "description": str(param_desc),
+                "type": p_type,
+                "description": desc_str,
             }
+            if "optional" not in desc_str.lower():
+                required_params.append(param_name)
         result.append(
             {
                 "type": "function",
@@ -134,7 +146,7 @@ def get_openai_tools_schema(agent: Any) -> List[Dict[str, Any]]:
                     "parameters": {
                         "type": "object",
                         "properties": properties,
-                        "required": [],
+                        "required": required_params,
                     },
                 },
             }

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -152,6 +152,8 @@ def generate_section_react(
     all_tools = {"insight_forge", "panorama_search", "quick_search", "interview_agents"}
     report_context = f"Section Title: {section.title}\nSimulation Requirement: {agent.simulation_requirement}"
 
+    _toolcall_mode = Config.REPORT_TOOLCALL_MODE
+
     for iteration in range(max_iterations):
         if progress_callback:
             progress_callback(
@@ -160,7 +162,46 @@ def generate_section_react(
                 f"Deep retrieval and writing in progress ({tool_calls_count}/{agent.MAX_TOOL_CALLS_PER_SECTION})",
             )
 
-        response = agent.llm.chat(messages=messages, temperature=0.5, max_tokens=4096)
+        if _toolcall_mode == "native":
+            # Nativer OpenAI function-calling Pfad
+            openai_tools = agent._get_openai_tools_schema()
+            native_result = agent.llm.chat_with_tools(
+                messages=messages,
+                tools=openai_tools,
+                tool_choice="auto",
+                temperature=0.5,
+                max_tokens=4096,
+                context="report",
+            )
+            response = native_result["content"]
+            native_tool_calls = native_result["tool_calls"]
+
+            if native_tool_calls:
+                # Normalisiere zu internem Format {name, parameters}
+                tool_calls = [
+                    {"name": tc["name"], "parameters": tc["arguments"]}
+                    for tc in native_tool_calls
+                ]
+                has_tool_calls = True
+                has_final_answer = False
+            else:
+                # Kein nativer Tool-Call — Soft-Fallback: XML-Parser einmal probieren
+                xml_fallback = agent._parse_tool_calls(response)
+                if xml_fallback:
+                    tool_calls = xml_fallback
+                    has_tool_calls = True
+                    has_final_answer = False
+                else:
+                    tool_calls = []
+                    has_tool_calls = False
+                    has_final_answer = "Final Answer:" in response
+        else:
+            # Legacy XML-Pfad
+            response = agent.llm.chat(messages=messages, temperature=0.5, max_tokens=4096)
+            tool_calls = []
+            has_tool_calls = False
+            has_final_answer = False
+
         if response is None:
             logger.warning(f"Section {section.title} round {iteration + 1} iteration: LLM returned None")
             if iteration < max_iterations - 1:
@@ -169,10 +210,11 @@ def generate_section_react(
                 continue
             break
 
-        logger.debug(f"LLM response: {response[:200]}...")
-        tool_calls = agent._parse_tool_calls(response)
-        has_tool_calls = bool(tool_calls)
-        has_final_answer = "Final Answer:" in response
+        if _toolcall_mode == "xml":
+            logger.debug(f"LLM response: {response[:200]}...")
+            tool_calls = agent._parse_tool_calls(response)
+            has_tool_calls = bool(tool_calls)
+            has_final_answer = "Final Answer:" in response
 
         if has_tool_calls and has_final_answer:
             conflict_retries += 1
@@ -319,7 +361,18 @@ def generate_section_react(
 
     logger.warning(f"Section {section.title} reachedmaximumiterationscount，Forcegenerate")
     messages.append({"role": "user", "content": agent.REACT_FORCE_FINAL_MSG})
-    response = agent.llm.chat(messages=messages, temperature=0.5, max_tokens=4096)
+    if _toolcall_mode == "native":
+        force_result = agent.llm.chat_with_tools(
+            messages=messages,
+            tools=agent._get_openai_tools_schema(),
+            tool_choice="none",
+            temperature=0.5,
+            max_tokens=4096,
+            context="report",
+        )
+        response = force_result["content"]
+    else:
+        response = agent.llm.chat(messages=messages, temperature=0.5, max_tokens=4096)
     if response is None:
         final_answer = "(ThisSectiongeneratefailed: LLM returnedemptyresponse, pleaselaterretry)"
     elif "Final Answer:" in response:
@@ -710,15 +763,39 @@ def chat(agent: Any, message: str, chat_history: List[Dict[str, str]] = None) ->
 
     tool_calls_made = []
     max_iterations = 2
+    _chat_toolcall_mode = Config.REPORT_TOOLCALL_MODE
+
     for _ in range(max_iterations):
-        response = agent.llm.chat(messages=messages, temperature=0.5)
+        if _chat_toolcall_mode == "native":
+            chat_result = agent.llm.chat_with_tools(
+                messages=messages,
+                tools=agent._get_openai_tools_schema(),
+                tool_choice="auto",
+                temperature=0.5,
+                max_tokens=4096,
+                context="report",
+            )
+            response = chat_result["content"]
+            native_calls = chat_result["tool_calls"]
+            tool_calls = (
+                [{"name": tc["name"], "parameters": tc["arguments"]} for tc in native_calls]
+                if native_calls
+                else agent._parse_tool_calls(response)
+            )
+        else:
+            response = agent.llm.chat(messages=messages, temperature=0.5)
+            tool_calls = []
+
         if response is None:
             return {
                 "response": "",
                 "tool_calls": tool_calls_made,
                 "sources": [tc.get("parameters", {}).get("query", "") for tc in tool_calls_made],
             }
-        tool_calls = agent._parse_tool_calls(response)
+
+        if _chat_toolcall_mode == "xml":
+            tool_calls = agent._parse_tool_calls(response)
+
         if not tool_calls:
             clean_response = re.sub(r'<tool_call>.*?</tool_call>', '', response, flags=re.DOTALL)
             clean_response = re.sub(r'\[TOOL_CALL\].*?\)', '', clean_response)
@@ -738,7 +815,18 @@ def chat(agent: Any, message: str, chat_history: List[Dict[str, str]] = None) ->
         observation = "\n".join([f"[{r['tool']}result]\n{r['result']}" for r in tool_results])
         messages.append({"role": "user", "content": observation + agent.CHAT_OBSERVATION_SUFFIX})
 
-    final_response = agent.llm.chat(messages=messages, temperature=0.5)
+    if _chat_toolcall_mode == "native":
+        final_result = agent.llm.chat_with_tools(
+            messages=messages,
+            tools=agent._get_openai_tools_schema(),
+            tool_choice="none",
+            temperature=0.5,
+            max_tokens=4096,
+            context="report",
+        )
+        final_response = final_result["content"]
+    else:
+        final_response = agent.llm.chat(messages=messages, temperature=0.5)
     if final_response is None:
         final_response = ""
     clean_response = re.sub(r'<tool_call>.*?</tool_call>', '', final_response, flags=re.DOTALL)

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -760,6 +760,254 @@ class LLMClient:
 
 
 # ---------------------------------------------------------------------------
+# Native OpenAI Function-Calling (chat_with_tools)
+# ---------------------------------------------------------------------------
+
+from typing import TypedDict  # noqa: E402 — conditional import after class def
+
+
+class ToolCallItem(TypedDict):
+    id: str
+    name: str
+    arguments: dict
+
+
+class ToolCallResponse(TypedDict):
+    content: str
+    tool_calls: List[ToolCallItem]
+    finish_reason: str
+    raw_response: Any
+
+
+def _extract_tool_calls_from_message(message: Any) -> List[ToolCallItem]:
+    """Normalisiert OpenAI-SDK ToolCall-Objekte zu ``ToolCallItem``-Dicts."""
+    result: List[ToolCallItem] = []
+    tool_calls = getattr(message, "tool_calls", None)
+    if not tool_calls:
+        return result
+    for tc in tool_calls:
+        tc_id = getattr(tc, "id", "") or ""
+        func = getattr(tc, "function", None)
+        name = getattr(func, "name", "") or ""
+        args_raw = getattr(func, "arguments", "") or ""
+        try:
+            arguments: dict = json.loads(args_raw) if args_raw else {}
+        except json.JSONDecodeError:
+            arguments = {}
+        result.append(ToolCallItem(id=tc_id, name=name, arguments=arguments))
+    return result
+
+
+def _accumulate_streaming_tool_calls(
+    chunks: Any,
+) -> tuple[str, List[ToolCallItem], str]:
+    """Akkumuliert Streaming-Chunks und baut content + tool_calls zusammen.
+
+    Gibt ``(content, tool_calls, finish_reason)`` zurück.
+    """
+    content_parts: List[str] = []
+    finish_reason: str = "stop"
+
+    # Indexed accumulator: index → {id, name, arguments_parts}
+    tc_acc: dict[int, dict] = {}
+
+    for chunk in chunks:
+        if not chunk.choices:
+            continue
+        choice = chunk.choices[0]
+        if choice.finish_reason:
+            finish_reason = choice.finish_reason
+        delta = choice.delta
+
+        # Textinhalt akkumulieren
+        piece = getattr(delta, "content", None)
+        if piece:
+            content_parts.append(piece)
+
+        # Tool-Call-Deltas akkumulieren
+        tc_deltas = getattr(delta, "tool_calls", None)
+        if tc_deltas:
+            for tc_delta in tc_deltas:
+                idx = getattr(tc_delta, "index", 0) or 0
+                if idx not in tc_acc:
+                    tc_acc[idx] = {"id": "", "name": "", "arguments_parts": []}
+                entry = tc_acc[idx]
+                tc_id = getattr(tc_delta, "id", None)
+                if tc_id:
+                    entry["id"] = tc_id
+                func_delta = getattr(tc_delta, "function", None)
+                if func_delta:
+                    fname = getattr(func_delta, "name", None)
+                    if fname:
+                        entry["name"] = fname
+                    fargs = getattr(func_delta, "arguments", None)
+                    if fargs:
+                        entry["arguments_parts"].append(fargs)
+
+    content = "".join(content_parts)
+
+    tool_calls: List[ToolCallItem] = []
+    for idx in sorted(tc_acc.keys()):
+        entry = tc_acc[idx]
+        args_str = "".join(entry["arguments_parts"])
+        try:
+            arguments = json.loads(args_str) if args_str else {}
+        except json.JSONDecodeError:
+            arguments = {}
+        tool_calls.append(
+            ToolCallItem(id=entry["id"], name=entry["name"], arguments=arguments)
+        )
+
+    return content, tool_calls, finish_reason
+
+
+# P5.4: Native OpenAI function-calling method
+# Wird in LLMClient eingebunden als Methode — hier als Funktion definiert,
+# damit der TypedDict-Import nicht in der Klasse wiederholt werden muss.
+
+
+def _chat_with_tools(
+    self: "LLMClient",
+    messages: List[Dict[str, Any]],
+    tools: List[Dict[str, Any]],
+    tool_choice: str = "auto",
+    temperature: float = 0.5,
+    max_tokens: int = 4096,
+    context: Literal[
+        "chat", "chat_json", "embedding", "report", "persona", "graph", "unknown"
+    ] = "report",
+) -> ToolCallResponse:
+    """Native OpenAI function-calling: sendet ``tools=`` + ``tool_choice=`` an die API.
+
+    Streaming-Pfad (Ollama): Tool-Call-Deltas werden akkumuliert.
+    Nicht-Streaming-Pfad: ``message.tool_calls`` direkt normalisiert.
+
+    Bei Provider ``unknown`` oder wenn die API keine ``tool_calls`` zurückgibt,
+    bleibt ``tool_calls=[]`` und ``content`` enthält den Freitext — der Caller
+    kann dann auf den XML-Fallback-Parser zurückgreifen.
+
+    E2E-Stub-Pfad: analog zu ``chat()`` via ``AGORA_E2E_LLM_MODE=stub``.
+    """
+    self._publish_model_active(context, max_tokens=max_tokens, temperature=temperature)
+
+    # E2E-Stub-Pfad
+    if os.environ.get("AGORA_E2E_LLM_MODE") == "stub":
+        from app.utils.llm_e2e_stub import e2e_stub_chat_with_tools_response
+        logger.info(
+            "LLMClient.chat_with_tools: E2E-Stub aktiv — ueberspringe LLM-Call (context=%s)",
+            context,
+        )
+        return e2e_stub_chat_with_tools_response(messages=messages, tools=tools)
+
+    import time as _time
+    _t0 = _time.monotonic()
+
+    kwargs: Dict[str, Any] = {
+        "model": self.model,
+        "messages": messages,
+        "temperature": temperature,
+        "tools": tools,
+        "tool_choice": tool_choice,
+    }
+    kwargs.update(self._completion_token_kwargs(max_tokens))
+
+    if self._is_ollama():
+        extra_body: Dict[str, Any] = {}
+        if self._num_ctx:
+            extra_body["options"] = {"num_ctx": self._num_ctx}
+        extra_body["think"] = self._think
+        kwargs["extra_body"] = extra_body
+
+    force_stream = (
+        self._is_ollama()
+        and os.environ.get("LLM_FORCE_STREAM", "true").lower() in ("1", "true", "yes")
+    )
+
+    def _create(call_kwargs: Dict[str, Any]) -> Any:
+        return llm_call_with_retry(
+            self.client.chat.completions.create,
+            max_retries=self._max_retries,
+            initial_delay=self._retry_initial_delay,
+            max_delay=self._retry_max_delay,
+            **call_kwargs,
+        )
+
+    def _create_with_fallback(call_kwargs: Dict[str, Any]) -> Any:
+        try:
+            return _create(call_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            if not self._is_token_key_400(exc):
+                raise
+            swapped = self._swap_token_kwargs(call_kwargs)
+            if swapped is None:
+                raise
+            logger.warning(
+                "LLM 400 on token-limit key (tools path) — retrying once with swapped key "
+                "(model=%s, msg=%s)",
+                self.model,
+                str(exc)[:200],
+            )
+            return _create(swapped)
+
+    content: str = ""
+    tool_calls: List[ToolCallItem] = []
+    finish_reason: str = "stop"
+    raw_response: Any = None
+
+    try:
+        if force_stream:
+            kwargs["stream"] = True
+            stream = _create_with_fallback(kwargs)
+            content, tool_calls, finish_reason = _accumulate_streaming_tool_calls(stream)
+        else:
+            raw_response = _create_with_fallback(kwargs)
+            choice = raw_response.choices[0]
+            finish_reason = getattr(choice, "finish_reason", "stop") or "stop"
+            message = choice.message
+            content = getattr(message, "content", None) or ""
+            tool_calls = _extract_tool_calls_from_message(message)
+    except Exception as exc:  # noqa: BLE001
+        elapsed = _time.monotonic() - _t0
+        self._log_invocation_event(
+            stage=context,
+            latency_ms=elapsed * 1000,
+            success=False,
+            error_type=exc.__class__.__name__,
+            http_status=getattr(exc, "status_code", None),
+        )
+        raise
+
+    elapsed = _time.monotonic() - _t0
+    logger.info(
+        "LLM chat_with_tools returned model=%s finish=%s tool_call_count=%d elapsed=%.1fs stream=%s",
+        self.model,
+        finish_reason,
+        len(tool_calls),
+        elapsed,
+        force_stream,
+    )
+    self._log_invocation_event(
+        stage=context,
+        latency_ms=elapsed * 1000,
+        success=True,
+    )
+
+    # <think>...</think> aus Textinhalt entfernen (analog zu chat())
+    content = re.sub(r"<think>[\s\S]*?</think>", "", content, flags=re.IGNORECASE).strip()
+
+    return ToolCallResponse(
+        content=content,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+        raw_response=raw_response,
+    )
+
+
+# Methode in LLMClient einbinden
+LLMClient.chat_with_tools = _chat_with_tools  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
 # P5.3: Profile-basierte Client-Factory
 # ---------------------------------------------------------------------------
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -793,6 +793,11 @@ def _extract_tool_calls_from_message(message: Any) -> List[ToolCallItem]:
         try:
             arguments: dict = json.loads(args_raw) if args_raw else {}
         except json.JSONDecodeError:
+            logger.warning(
+                "LLMClient: failed to parse tool arguments as JSON (tool=%s): %s",
+                name,
+                args_raw[:200],
+            )
             arguments = {}
         result.append(ToolCallItem(id=tc_id, name=name, arguments=arguments))
     return result
@@ -853,6 +858,11 @@ def _accumulate_streaming_tool_calls(
         try:
             arguments = json.loads(args_str) if args_str else {}
         except json.JSONDecodeError:
+            logger.warning(
+                "LLMClient: failed to parse streaming tool arguments (tool=%s): %s",
+                entry["name"],
+                args_str[:200],
+            )
             arguments = {}
         tool_calls.append(
             ToolCallItem(id=entry["id"], name=entry["name"], arguments=arguments)

--- a/backend/app/utils/llm_e2e_stub.py
+++ b/backend/app/utils/llm_e2e_stub.py
@@ -414,6 +414,53 @@ def e2e_stub_chat_response(
     return _STUB_FINAL_ANSWER_TEMPLATE
 
 
+def e2e_stub_chat_with_tools_response(
+    *,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Deterministischer Return für LLMClient.chat_with_tools() im Stub-Modus.
+
+    Entscheidungslogik analog zu e2e_stub_chat_response:
+    - Weniger als 3 assistant-Nachrichten → gibt einen Tool-Call zurück.
+    - Ab 3 assistant-Nachrichten → Final-Answer-Content, tool_calls=[].
+
+    Der Tool-Name wird aus der tools-Liste genommen (erster Eintrag), falls vorhanden.
+    Fallback: "panorama_search".
+    """
+    from app.utils.llm_client import ToolCallResponse, ToolCallItem  # noqa: PLC0415
+
+    assistant_count = _count_assistant_messages(messages)
+
+    if assistant_count < 3:
+        # Tool-Namen aus übergebener tools-Liste holen
+        tool_name = "panorama_search"
+        if tools:
+            first = tools[0]
+            func = first.get("function", {})
+            tool_name = func.get("name", "panorama_search")
+        return ToolCallResponse(
+            content="",
+            tool_calls=[
+                ToolCallItem(
+                    id=f"stub-call-{assistant_count:02d}",
+                    name=tool_name,
+                    arguments={"query": f"E2E-Smoke-Stub-Query-{assistant_count}"},
+                )
+            ],
+            finish_reason="tool_calls",
+            raw_response=None,
+        )
+
+    return ToolCallResponse(
+        content=_STUB_FINAL_ANSWER_TEMPLATE,
+        tool_calls=[],
+        finish_reason="stop",
+        raw_response=None,
+    )
+
+
 def e2e_stub_response(
     *,
     schema: dict[str, Any] | None,

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from unittest.mock import patch
 from flask import Flask

--- a/backend/tests/services/report_agent/test_native_toolcalls.py
+++ b/backend/tests/services/report_agent/test_native_toolcalls.py
@@ -1,0 +1,556 @@
+"""
+Tests für native OpenAI function-calling im ReACT-Report-Loop.
+
+B-1 (RED → GREEN nach Implementation).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen / Factories
+# ---------------------------------------------------------------------------
+
+def _make_tool_call_obj(id_: str, name: str, arguments: dict) -> MagicMock:
+    """Erzeugt einen Mock, der einem OpenAI ToolCall-Objekt ähnelt."""
+    tc = MagicMock()
+    tc.id = id_
+    tc.type = "function"
+    tc.function = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = json.dumps(arguments)
+    return tc
+
+
+def _make_openai_response(
+    content: str = "",
+    tool_calls: list | None = None,
+    finish_reason: str = "tool_calls",
+) -> MagicMock:
+    choice = MagicMock()
+    choice.finish_reason = finish_reason
+    choice.message = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = tool_calls
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = MagicMock()
+    response.usage.completion_tokens = 42
+    return response
+
+
+def _make_stream_chunk(
+    content: str | None = None,
+    tool_call_delta: dict | None = None,
+    finish_reason: str | None = None,
+    tool_call_index: int = 0,
+) -> MagicMock:
+    """Erzeugt einen Mock-Stream-Chunk."""
+    chunk = MagicMock()
+    choice = MagicMock()
+    choice.finish_reason = finish_reason
+    delta = MagicMock()
+    delta.content = content
+    if tool_call_delta:
+        tc_delta = MagicMock()
+        tc_delta.index = tool_call_delta.get("index", tool_call_index)
+        tc_delta.id = tool_call_delta.get("id")
+        tc_delta.type = tool_call_delta.get("type")
+        func_delta = MagicMock()
+        func_delta.name = tool_call_delta.get("function", {}).get("name")
+        func_delta.arguments = tool_call_delta.get("function", {}).get("arguments", "")
+        tc_delta.function = func_delta
+        delta.tool_calls = [tc_delta]
+    else:
+        delta.tool_calls = None
+    choice.delta = delta
+    chunk.choices = [choice]
+    chunk.usage = None
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# B-6: Schema-Test — get_openai_tools_schema()
+# ---------------------------------------------------------------------------
+
+class TestToolsSchemaOpenAIFormat:
+    """B-6: tools.py::get_openai_tools_schema() liefert valides OpenAI-Format."""
+
+    def test_tools_schema_has_openai_format(self) -> None:
+        from app.services.report_agent.tools import get_openai_tools_schema
+
+        agent = MagicMock()
+        agent.web_tools = MagicMock()
+        agent.web_tools.is_available.return_value = False
+
+        schema = get_openai_tools_schema(agent)
+
+        assert isinstance(schema, list)
+        assert len(schema) >= 4  # mind. 4 core tools
+
+        for tool in schema:
+            assert tool["type"] == "function"
+            func = tool["function"]
+            assert "name" in func
+            assert "description" in func
+            assert "parameters" in func
+            params = func["parameters"]
+            # Valides JSON-Schema
+            assert params.get("type") == "object"
+            assert "properties" in params
+
+    def test_tools_schema_includes_web_tools_when_available(self) -> None:
+        from app.services.report_agent.tools import get_openai_tools_schema
+
+        agent = MagicMock()
+        agent.web_tools = MagicMock()
+        agent.web_tools.is_available.return_value = True
+
+        schema = get_openai_tools_schema(agent)
+        names = [t["function"]["name"] for t in schema]
+        assert "web_search" in names
+        assert "fetch_url" in names
+
+
+# ---------------------------------------------------------------------------
+# B-3: LLMClient.chat_with_tools — nicht-streaming (OpenAI-Provider)
+# ---------------------------------------------------------------------------
+
+class TestChatWithToolsOpenAIProvider:
+    """B-3: chat_with_tools gibt normalisiertes ToolCallResponse zurück."""
+
+    def _make_client(self) -> Any:
+        from app.utils.llm_client import LLMClient
+        with patch.object(LLMClient, "__init__", lambda self, **kw: None):
+            client = LLMClient.__new__(LLMClient)
+        # Minimale Attribute setzen
+        client.model = "gpt-4o"
+        client.base_url = "https://api.openai.com/v1"
+        client.api_key = "test-key"
+        client.reasoning_effort = "none"
+        client.provider_options = {}
+        client.run_id = None
+        client.routing_version = None
+        client.route_stage = None
+        client.route_provider_id = None
+        client._num_ctx = 8192
+        client._think = False
+        client._max_retries = 1
+        client._retry_initial_delay = 0.0
+        client._retry_max_delay = 0.0
+        return client
+
+    def test_chat_with_tools_returns_tool_calls_on_openai_provider(self) -> None:
+        """Mockt OpenAI-SDK-Response mit message.tool_calls → normalisierten Return."""
+        client = self._make_client()
+
+        tool_call_obj = _make_tool_call_obj(
+            "call_abc123", "insight_forge", {"query": "Zielgruppenanalyse"}
+        )
+        mock_response = _make_openai_response(
+            content="",
+            tool_calls=[tool_call_obj],
+            finish_reason="tool_calls",
+        )
+
+        mock_openai = MagicMock()
+        mock_openai.chat.completions.create.return_value = mock_response
+        client.client = mock_openai
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "insight_forge",
+                    "description": "Deep analysis tool",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            }
+        ]
+
+        with patch.dict("os.environ", {}, clear=False):
+            result = client.chat_with_tools(
+                messages=[{"role": "user", "content": "Analysiere Zielgruppe"}],
+                tools=tools,
+                temperature=0.5,
+                max_tokens=4096,
+                context="report",
+            )
+
+        assert result["finish_reason"] == "tool_calls"
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["id"] == "call_abc123"
+        assert tc["name"] == "insight_forge"
+        assert tc["arguments"] == {"query": "Zielgruppenanalyse"}
+
+    def test_chat_with_tools_falls_back_to_xml_when_no_native_tool_calls(self) -> None:
+        """Wenn message.tool_calls leer/None und Content XML enthält → leere tool_calls."""
+        client = self._make_client()
+
+        xml_content = '<tool_call>{"name": "quick_search", "parameters": {"query": "test"}}</tool_call>'
+        mock_response = _make_openai_response(
+            content=xml_content,
+            tool_calls=None,
+            finish_reason="stop",
+        )
+
+        mock_openai = MagicMock()
+        mock_openai.chat.completions.create.return_value = mock_response
+        client.client = mock_openai
+
+        tools: list = []
+
+        with patch.dict("os.environ", {}, clear=False):
+            result = client.chat_with_tools(
+                messages=[{"role": "user", "content": "Suche"}],
+                tools=tools,
+                temperature=0.5,
+                max_tokens=1024,
+                context="report",
+            )
+
+        # Native tool_calls ist leer, aber content enthält XML
+        assert result["tool_calls"] == []
+        assert xml_content in result["content"]
+
+    def test_chat_with_tools_unknown_provider_returns_empty_tool_calls(self) -> None:
+        """Bei Provider 'unknown' → tool_calls=[], content enthält Text."""
+        client = self._make_client()
+        client.model = "some-unknown-model"
+        client.base_url = "http://some-unknown-proxy.local/v1"
+
+        mock_openai = MagicMock()
+        # Simuliere eine Antwort ohne tool_calls
+        mock_response = _make_openai_response(
+            content="Ich kann keine Tools aufrufen.",
+            tool_calls=None,
+            finish_reason="stop",
+        )
+        mock_openai.chat.completions.create.return_value = mock_response
+        client.client = mock_openai
+
+        tools: list = [
+            {"type": "function", "function": {"name": "insight_forge", "description": "test", "parameters": {}}}
+        ]
+
+        with patch.dict("os.environ", {}, clear=False):
+            result = client.chat_with_tools(
+                messages=[{"role": "user", "content": "test"}],
+                tools=tools,
+                temperature=0.5,
+                max_tokens=512,
+                context="report",
+            )
+
+        assert result["tool_calls"] == []
+        assert "Ich kann keine Tools" in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# B-3: Streaming-Pfad — Tool-Call-Delta-Akkumulation
+# ---------------------------------------------------------------------------
+
+class TestChatWithToolsStreaming:
+    """B-3: Streaming-Chunks mit Tool-Call-Deltas werden korrekt reassembliert."""
+
+    def _make_ollama_client(self) -> Any:
+        from app.utils.llm_client import LLMClient
+        with patch.object(LLMClient, "__init__", lambda self, **kw: None):
+            client = LLMClient.__new__(LLMClient)
+        client.model = "qwen3-coder-next:cloud"
+        client.base_url = "http://localhost:11434/v1"
+        client.api_key = "test-key"
+        client.reasoning_effort = "none"
+        client.provider_options = {}
+        client.run_id = None
+        client.routing_version = None
+        client.route_stage = None
+        client.route_provider_id = None
+        client._num_ctx = 8192
+        client._think = False
+        client._max_retries = 1
+        client._retry_initial_delay = 0.0
+        client._retry_max_delay = 0.0
+        return client
+
+    def test_chat_with_tools_streaming_path_accumulates_tool_calls(self) -> None:
+        """Streaming-Chunks mit Tool-Call-Deltas werden zu einem Tool-Call zusammengefügt."""
+        client = self._make_ollama_client()
+
+        # Simuliere OpenAI-Streaming-Chunks für einen Tool-Call
+        chunks = [
+            _make_stream_chunk(
+                tool_call_delta={
+                    "index": 0,
+                    "id": "call_stream_01",
+                    "type": "function",
+                    "function": {"name": "panorama_search", "arguments": ""},
+                }
+            ),
+            _make_stream_chunk(
+                tool_call_delta={
+                    "index": 0,
+                    "id": None,
+                    "type": None,
+                    "function": {"name": None, "arguments": '{"query":'},
+                }
+            ),
+            _make_stream_chunk(
+                tool_call_delta={
+                    "index": 0,
+                    "id": None,
+                    "type": None,
+                    "function": {"name": None, "arguments": ' "Marktanalyse"}'},
+                }
+            ),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_openai = MagicMock()
+        mock_openai.chat.completions.create.return_value = iter(chunks)
+        client.client = mock_openai
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "panorama_search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            }
+        ]
+
+        with patch.dict("os.environ", {"LLM_FORCE_STREAM": "true"}, clear=False):
+            result = client.chat_with_tools(
+                messages=[{"role": "user", "content": "Suche Markt"}],
+                tools=tools,
+                temperature=0.5,
+                max_tokens=1024,
+                context="report",
+            )
+
+        assert result["finish_reason"] == "tool_calls"
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["name"] == "panorama_search"
+        assert tc["arguments"]["query"] == "Marktanalyse"
+
+
+# ---------------------------------------------------------------------------
+# B-4: ReACT-Loop — native tool_calls (Feature-Flag = "native")
+# ---------------------------------------------------------------------------
+
+class TestReactLoopNativeToolCalls:
+    """B-4: generate_section_react nutzt chat_with_tools wenn Flag = 'native'."""
+
+    def _make_minimal_agent(self) -> MagicMock:
+        agent = MagicMock()
+        agent.llm = MagicMock()
+        agent.SECTION_SYSTEM_PROMPT_TEMPLATE = (
+            "System {report_title} {report_summary} {simulation_requirement} "
+            "{section_title} {tools_description} {language}"
+        )
+        agent.SECTION_USER_PROMPT_TEMPLATE = (
+            "User {previous_content} {section_title}"
+        )
+        agent.REACT_INSUFFICIENT_TOOLS_MSG = "Insufficient tools {tool_calls_count} {min_tool_calls} {unused_hint}"
+        agent.REACT_INSUFFICIENT_TOOLS_MSG_ALT = "Alt {tool_calls_count} {min_tool_calls} {unused_hint}"
+        agent.REACT_TOOL_LIMIT_MSG = "Limit {tool_calls_count} {max_tool_calls}"
+        agent.REACT_UNUSED_TOOLS_HINT = "Unused {unused_list}"
+        agent.REACT_OBSERVATION_TEMPLATE = (
+            "Obs {tool_name} {result} {tool_calls_count} {max_tool_calls} {used_tools_str} {unused_hint}"
+        )
+        agent.REACT_FORCE_FINAL_MSG = "Force final"
+        agent.MAX_TOOL_CALLS_PER_SECTION = 5
+        agent.report_logger = None
+        agent.console_logger = None
+        agent._current_section_index = None
+        agent._active_section_evidence = []
+        agent.simulation_requirement = "Test-Requirement"
+        agent._get_tools_description.return_value = "Tools desc"
+        agent._get_openai_tools_schema.return_value = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "panorama_search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            }
+        ]
+        agent._execute_tool.return_value = "Tool result stub"
+        agent._parse_tool_calls.return_value = []
+        return agent
+
+    def _make_section(self, title: str = "Segment-Analyse") -> MagicMock:
+        section = MagicMock()
+        section.title = title
+        return section
+
+    def _make_outline(self) -> MagicMock:
+        outline = MagicMock()
+        outline.title = "Test Report"
+        outline.summary = "Test Summary"
+        return outline
+
+    def test_react_loop_uses_native_tool_calls_when_flag_enabled(self) -> None:
+        """Mit REPORT_TOOLCALL_MODE=native ruft generate_section_react chat_with_tools auf."""
+        from app.services.report_agent.workflow import generate_section_react
+
+        agent = self._make_minimal_agent()
+
+        # Erster Call: tool_call zurückgeben
+        # Zweiter-Vierter Call: weitere tool_calls (min_tool_calls=3)
+        # Fünfter Call: Final Answer
+        tool_calls_sequence = [
+            {
+                "content": "",
+                "tool_calls": [{"id": "c1", "name": "panorama_search", "arguments": {"query": "q1"}}],
+                "finish_reason": "tool_calls",
+                "raw_response": None,
+            },
+            {
+                "content": "",
+                "tool_calls": [{"id": "c2", "name": "panorama_search", "arguments": {"query": "q2"}}],
+                "finish_reason": "tool_calls",
+                "raw_response": None,
+            },
+            {
+                "content": "",
+                "tool_calls": [{"id": "c3", "name": "panorama_search", "arguments": {"query": "q3"}}],
+                "finish_reason": "tool_calls",
+                "raw_response": None,
+            },
+            {
+                "content": "Final Answer: Hier ist die Segment-Analyse.",
+                "tool_calls": [],
+                "finish_reason": "stop",
+                "raw_response": None,
+            },
+        ]
+        agent.llm.chat_with_tools.side_effect = tool_calls_sequence
+
+        section = self._make_section()
+        outline = self._make_outline()
+
+        with patch.dict("os.environ", {"REPORT_TOOLCALL_MODE": "native"}):
+            # Config muss neu gelesen werden — patch Config direkt
+            with patch("app.services.report_agent.workflow.Config") as mock_cfg:
+                mock_cfg.REPORT_TOOLCALL_MODE = "native"
+                mock_cfg.REPORT_LANGUAGE = "German"
+                result = generate_section_react(
+                    agent=agent,
+                    section=section,
+                    outline=outline,
+                    previous_sections=[],
+                    section_index=0,
+                )
+
+        assert "Segment-Analyse" in result or result  # Final Answer wurde zurückgegeben
+        assert agent.llm.chat_with_tools.called
+        assert agent._execute_tool.call_count >= 3
+
+    def test_react_loop_falls_back_to_xml_when_flag_disabled(self) -> None:
+        """Mit REPORT_TOOLCALL_MODE=xml bleibt der alte XML-Parsing-Pfad aktiv."""
+        from app.services.report_agent.workflow import generate_section_react
+
+        agent = self._make_minimal_agent()
+
+        # chat() gibt XML-Tool-Calls zurück, dann Final Answer
+        chat_responses = [
+            '<tool_call>{"name": "panorama_search", "parameters": {"query": "q1"}}</tool_call>',
+            '<tool_call>{"name": "quick_search", "parameters": {"query": "q2"}}</tool_call>',
+            '<tool_call>{"name": "insight_forge", "parameters": {"query": "q3"}}</tool_call>',
+            "Final Answer: Ergebnis der Analyse.",
+        ]
+        agent.llm.chat.side_effect = chat_responses
+
+        # _parse_tool_calls muss für XML-Content funktionieren
+        from app.services.tool_validation import parse_tool_calls as real_parse
+        agent._parse_tool_calls.side_effect = real_parse
+
+        section = self._make_section()
+        outline = self._make_outline()
+
+        with patch("app.services.report_agent.workflow.Config") as mock_cfg:
+            mock_cfg.REPORT_TOOLCALL_MODE = "xml"
+            mock_cfg.REPORT_LANGUAGE = "German"
+            result = generate_section_react(
+                agent=agent,
+                section=section,
+                outline=outline,
+                previous_sections=[],
+                section_index=0,
+            )
+
+        # XML-Pfad: chat() wurde aufgerufen, NICHT chat_with_tools
+        assert agent.llm.chat.called
+        assert not agent.llm.chat_with_tools.called
+        assert "Ergebnis" in result
+
+
+# ---------------------------------------------------------------------------
+# B-3 / B-stub: E2E-Stub-Pfad für chat_with_tools
+# ---------------------------------------------------------------------------
+
+class TestChatWithToolsE2EStub:
+    """B-3: AGORA_E2E_LLM_MODE=stub liefert deterministischen Tool-Call-Return."""
+
+    def _make_client(self) -> Any:
+        from app.utils.llm_client import LLMClient
+        with patch.object(LLMClient, "__init__", lambda self, **kw: None):
+            client = LLMClient.__new__(LLMClient)
+        client.model = "gpt-4o"
+        client.base_url = "https://api.openai.com/v1"
+        client.api_key = "test-key"
+        client.reasoning_effort = "none"
+        client.provider_options = {}
+        client.run_id = None
+        client.routing_version = None
+        client.route_stage = None
+        client.route_provider_id = None
+        client._num_ctx = 8192
+        client._think = False
+        client._max_retries = 1
+        client._retry_initial_delay = 0.0
+        client._retry_max_delay = 0.0
+        return client
+
+    def test_e2e_stub_chat_with_tools_response(self) -> None:
+        """AGORA_E2E_LLM_MODE=stub gibt ToolCallResponse ohne echten LLM-Call zurück."""
+        client = self._make_client()
+        # client.client darf nicht aufgerufen werden im Stub-Modus
+        client.client = MagicMock()
+        client.client.chat.completions.create.side_effect = RuntimeError(
+            "Sollte im Stub-Modus nicht aufgerufen werden"
+        )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "panorama_search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        with patch.dict("os.environ", {"AGORA_E2E_LLM_MODE": "stub"}):
+            result = client.chat_with_tools(
+                messages=[{"role": "user", "content": "test"}],
+                tools=tools,
+                context="report",
+            )
+
+        assert "tool_calls" in result
+        assert "content" in result
+        assert "finish_reason" in result
+        # Stub darf kein RuntimeError werfen
+        client.client.chat.completions.create.assert_not_called()

--- a/backend/tests/services/report_agent/test_native_toolcalls.py
+++ b/backend/tests/services/report_agent/test_native_toolcalls.py
@@ -554,3 +554,115 @@ class TestChatWithToolsE2EStub:
         assert "finish_reason" in result
         # Stub darf kein RuntimeError werfen
         client.client.chat.completions.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Gemini-Followup: Schema-Heuristik + JSON-Parse-Logging
+# ---------------------------------------------------------------------------
+
+
+class TestToolsSchemaHeuristics:
+    """Schema-Generierung markiert Parameter mit korrektem Typ und required-Flag."""
+
+    def _schema_for_tool(self, tool_name: str) -> dict:
+        from app.services.report_agent.tools import get_openai_tools_schema
+
+        agent = MagicMock()
+        agent.web_tools = MagicMock()
+        agent.web_tools.is_available.return_value = False
+        schema = get_openai_tools_schema(agent)
+        match = next((t for t in schema if t["function"]["name"] == tool_name), None)
+        assert match is not None, f"Tool {tool_name} nicht im Schema"
+        return match["function"]["parameters"]
+
+    def test_limit_param_is_integer_type(self) -> None:
+        params = self._schema_for_tool("quick_search")
+        props = params["properties"]
+        assert "limit" in props
+        assert props["limit"]["type"] == "integer"
+
+    def test_max_agents_param_is_integer_type(self) -> None:
+        params = self._schema_for_tool("interview_agents")
+        props = params["properties"]
+        if "max_agents" in props:
+            assert props["max_agents"]["type"] == "integer"
+
+    def test_required_params_include_query(self) -> None:
+        params = self._schema_for_tool("quick_search")
+        assert "query" in params["required"], (
+            "query muss als required markiert sein, sonst lässt das LLM es weg"
+        )
+
+    def test_optional_params_excluded_from_required(self) -> None:
+        from app.services.report_agent.tools import get_openai_tools_schema
+
+        fake_agent = MagicMock()
+        fake_agent.web_tools = MagicMock()
+        fake_agent.web_tools.is_available.return_value = False
+
+        with patch(
+            "app.services.report_agent.tools.define_tools",
+            return_value={
+                "fake_tool": {
+                    "description": "Fake tool",
+                    "parameters": {
+                        "query": "the search query",
+                        "extra": "optional additional filter",
+                    },
+                },
+            },
+        ):
+            schema = get_openai_tools_schema(fake_agent)
+
+        params = schema[0]["function"]["parameters"]
+        assert "query" in params["required"]
+        assert "extra" not in params["required"]
+
+
+class TestToolArgumentJsonLogging:
+    """Ungültiges Tool-Argument-JSON wird mit warning geloggt."""
+
+    def test_non_streaming_logs_warning_on_invalid_json(self) -> None:
+        from app.utils import llm_client as llm_client_mod
+
+        msg = MagicMock()
+        tc = MagicMock()
+        tc.id = "tc1"
+        tc.function = MagicMock()
+        tc.function.name = "quick_search"
+        tc.function.arguments = "not valid {json"
+        msg.tool_calls = [tc]
+
+        with patch.object(llm_client_mod.logger, "warning") as warn:
+            result = llm_client_mod._extract_tool_calls_from_message(msg)
+
+        assert result == [{"id": "tc1", "name": "quick_search", "arguments": {}}]
+        assert warn.called
+        msg_fmt = warn.call_args[0][0]
+        assert "failed to parse tool arguments" in msg_fmt
+
+    def test_streaming_logs_warning_on_invalid_json(self) -> None:
+        from app.utils import llm_client as llm_client_mod
+
+        chunks = [
+            _make_stream_chunk(
+                tool_call_delta={
+                    "index": 0,
+                    "id": "tc1",
+                    "function": {"name": "quick_search", "arguments": "{broken"},
+                },
+            ),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        with patch.object(llm_client_mod.logger, "warning") as warn:
+            content, tool_calls, finish = (
+                llm_client_mod._accumulate_streaming_tool_calls(chunks)
+            )
+
+        assert finish == "tool_calls"
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["arguments"] == {}
+        assert warn.called
+        msg_fmt = warn.call_args[0][0]
+        assert "failed to parse streaming tool arguments" in msg_fmt

--- a/backend/tests/services/test_llm_provider_secrets_store.py
+++ b/backend/tests/services/test_llm_provider_secrets_store.py
@@ -1,7 +1,6 @@
 """Tests für den Fernet-encrypted LLM-Provider-Secrets-Store."""
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest

--- a/backend/tests/services/test_secret_resolver_store.py
+++ b/backend/tests/services/test_secret_resolver_store.py
@@ -8,7 +8,6 @@ from cryptography.fernet import Fernet
 
 from app.services import llm_provider_secrets_store as store_module
 from app.services.llm_provider_secrets_store import (
-    LlmProviderSecretsStore,
     reset_singleton_for_tests,
 )
 from app.services.secret_resolver import SecretResolver

--- a/docu/2026-05-15-report-native-toolcalls-worklog.md
+++ b/docu/2026-05-15-report-native-toolcalls-worklog.md
@@ -1,0 +1,89 @@
+# Slice — Native function-calling für ReACT-Report
+
+- **Branch:** `feat/task-report-native-toolcalls`
+- **Worktree:** `/private/tmp/agora-report-native-toolcalls/`
+- **Base:** `origin/main` @ `6e46771`
+- **Started:** 2026-05-15
+- **Lead:** Opus 4.7 (Cross-Layer-Entscheidung), Implementation via `agora-refactor-worker`, Tests via `agora-test-worker`
+- **Schließt:** kein offenes Issue (Bug aus Live-Run 2026-05-15 03:51–03:55, Report `report_a3c014f77ed3` / `report_cb521d2d493f`)
+
+## Root Cause
+
+`backend/app/services/report_agent/workflow.py:163,173` ruft `agent.llm.chat(...)` und
+parst Tool-Calls per Regex aus dem Antwort-Text (`<tool_call>...</tool_call>`).
+`LLMClient.chat` (`backend/app/utils/llm_client.py:355-502`) hat **keinen** `tools=`
+Parameter — Tool-Use läuft ausschließlich über Prompt-Engineering + XML-Parsing.
+
+Beobachteter Bug: `deepseek-v4-flash:cloud` emittiert narrativen Selbstkommentar
+("Ich rufe nun das erste Tool auf"), aber **keinen** `<tool_call>`-Block. 5 leere
+Iterationen → Force-Generate → `confidence=high`-Claims ohne Evidence →
+`EvidenceMapModel`-Validator killt den gesamten Report.
+
+## Ziel
+
+Native function-calling auf der `LLMClient`-Ebene + ReACT-Loop nutzt
+`message.tool_calls` statt Text-Regex. XML-Pfad bleibt als Legacy-Fallback hinter
+Feature-Flag bestehen, damit Modelle ohne Tool-Use-Support nicht abreißen.
+
+## Provider-Smoke-Matrix (Akzeptanz)
+
+| Provider | Modell | tool_calls native | Notiz |
+|---|---|---|---|
+| Ollama-lokal | qwen3:8b | TBD | TDD-Pflicht |
+| Ollama-Cloud | gpt-oss | TBD | TDD-Pflicht |
+| Ollama-Cloud | qwen3-coder-next | TBD | TDD-Pflicht |
+| Ollama-Cloud | deepseek-v4-flash | TBD | erwartet: **nicht** native — Fallback-Pfad |
+| Anthropic | claude-sonnet-4-6 | TBD | TDD-Pflicht |
+
+## Slices (intern)
+
+- B-1 — `LLMClient.chat_with_tools` Vertrag + Provider-Adapter (Opus-Lead)
+- B-2 — Tools als OpenAI-Schema deklarieren (`tools.py`)
+- B-3 — ReACT-Loop auf native umstellen, XML als Fallback
+- B-4 — Provider-Smoke-Matrix als parametrisierter Test
+- B-5 — Frontend: kein Touch (Backend-only)
+
+## Verboten
+
+- ADR-0002 (Evidence-Gating) anfassen — Validator bleibt streng
+- Legacy-XML-Pfad löschen — bleibt Fallback hinter Flag
+- Default-Flag auf `xml` lassen — Default ist `native` nach Smoke-Grün
+
+## Verifikations-Gates
+
+```bash
+cd /private/tmp/agora-report-native-toolcalls/backend
+uv run pytest -x -q tests/services/report_agent/
+uv run pytest tests/services/report_agent/test_native_toolcalls.py -v
+uv run ruff check app/ tests/
+uv run mypy app
+```
+
+## Status
+
+- [x] Worktree angelegt
+- [x] B-1 Test-Scaffold RED → commit `ca18303`
+- [x] B-2 Tools-Schema (`get_openai_tools_schema`) → commit `a465e62`
+- [x] B-3 `LLMClient.chat_with_tools` + Streaming-Pfad + E2E-Stub → commit `a465e62`
+- [x] B-4 ReACT-Loop + chat()-Loop migriert (native/xml Flag) → commit `da8dc89`
+- [x] B-5 `_get_openai_tools_schema()` in agent.py → commit `da8dc89`
+- [x] chore: `REPORT_TOOLCALL_MODE` Feature-Flag default native → commit `70a66ae`
+- [x] Gates grün (9/9 neue Tests, 2084 bestehende bestehen, 0 neue ruff/mypy-Fehler)
+- [ ] Provider-Smoke-Matrix Live-Tests (Follow-up nach Code-Review)
+- [ ] PR eröffnet (Push-Verbot laut Brief — wartet auf Lead-Freigabe)
+
+## Implementierungs-Notizen
+
+### Abweichungen vom Brief
+
+- `tool_validation.py` und `tool_execution.py` liegen in `app/services/` (nicht `report_agent/`) — korrekte Pfade via `rg`-Verifikation gefunden.
+- `TypedDict`-Import für `ToolCallResponse`/`ToolCallItem` inline im Modul-Scope nach der Klasse (kein separates `llm_types.py` nötig, da Umfang überschaubar).
+- `e2e_stub_chat_with_tools_response` importiert `ToolCallResponse`/`ToolCallItem` lazy aus `llm_client` (zirkulären Import vermieden).
+
+### Streaming-Reassembly
+
+Der Akkumulator in `_accumulate_streaming_tool_calls()` verwaltet einen Index-basierten dict (`tc_acc`) und konkateniert `function.arguments`-Deltas. Das entspricht exakt dem OpenAI-Streaming-Protokoll für parallel tool_calls (mehrere Indizes möglich).
+
+### Soft-Fallback
+
+Wenn `chat_with_tools` `tool_calls=[]` zurückgibt und `content` einen `<tool_call>`-Block enthält, ruft der ReACT-Loop einmalig `agent._parse_tool_calls(response)` auf. Damit funktioniert der Legacy-Pfad als Sicherheitsnetz ohne explizite Flag-Umschaltung.

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2113 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2128 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2063 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2113 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

- ReACT-Loop in `report_agent/workflow.py` migriert von XML-Regex-Parsing (`<tool_call>...</tool_call>`) auf native OpenAI `tools=`/`tool_choice="auto"`-Function-Calling. Legacy-XML-Pfad bleibt als Soft-Fallback und hinter Feature-Flag `REPORT_TOOLCALL_MODE=xml` aktivierbar.
- Bug 2026-05-15 03:51–03:55: `deepseek-v4-flash:cloud` emittierte narrativen Selbstkommentar statt `<tool_call>`-Block → 5 leere ReACT-Iterationen → Force-Generate → `EvidenceMapModel`-Validator killte den Report mit `Label 'high' verlangt agent_quote-Evidence aus 2 Stakeholder-Gruppen. Gefunden: ∅`.
- Neuer `LLMClient.chat_with_tools(messages, tools, tool_choice)` mit normalisiertem `ToolCallResponse`, Streaming-Reassembly für Ollama-Cloud (Index-basierte Argument-Konkat) und E2E-Stub-Pfad.

## Geänderte Dateien

| Datei | Delta |
|---|---|
| `backend/app/utils/llm_client.py` | +248 LOC (`ToolCallResponse`, `_extract_tool_calls_from_message`, `_accumulate_streaming_tool_calls`, `chat_with_tools`) |
| `backend/app/utils/llm_e2e_stub.py` | +47 LOC |
| `backend/app/services/report_agent/tools.py` | +38 LOC (`get_openai_tools_schema`) |
| `backend/app/services/report_agent/agent.py` | +5 LOC |
| `backend/app/services/report_agent/workflow.py` | +106/-9 LOC (native/xml-Branching in `generate_section_react` + `chat`-Loop) |
| `backend/app/config.py` | +5 LOC (`REPORT_TOOLCALL_MODE` default `native`) |
| `backend/tests/services/report_agent/test_native_toolcalls.py` | +556 LOC (neu) |
| `docu/2026-05-15-report-native-toolcalls-worklog.md` | +89 LOC (neu) |

## Test plan

- [x] `pytest tests/services/report_agent/test_native_toolcalls.py -v` — 9/9 passed
- [x] `pytest tests/services/report_agent/` Suite grün (2084 bestehende Tests bleiben grün)
- [x] `ruff check app/ tests/` — All checks passed
- [x] `mypy app` — Success: no issues found in 166 source files
- [ ] Live-Smoke: Report-Run mit `qwen3-coder-next:cloud` über UI durchziehen (Follow-up nach Merge)
- [ ] Live-Smoke: gleicher Run mit `deepseek-v4-flash:cloud` — erwartet: Fallback-Pfad greift sauber, keine Endlos-Iteration

## Bekannte Gaps (Follow-up)

1. **`tool_choice="none"` Ollama-Verhalten** im Force-Generate-Pfad noch nicht live verifiziert. Worst-Case ignoriert Ollama den Parameter — XML-Soft-Fallback greift.
2. **Anthropic-Provider** kennt aktuell keinen eigenen Branch in `_detect_provider()` — fällt auf `unknown` und damit auf XML-Soft-Fallback.

Beide bewusst out-of-scope, getrennte Slices nach Live-Smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>