### PR TITLE
fix(report): Copilot-Followup auf PR #452 — Tool-Call-Mode + Provider-Fallback härten

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -168,7 +168,18 @@ class Config:
     # REPORT_TOOLCALL_MODE: "native" nutzt OpenAI function-calling (tools=/tool_choice=);
     # "xml" behält den Legacy-XML-Parsing-Pfad (<tool_call>...</tool_call>).
     # Default: "native" — Modelle wie deepseek-v4-flash:cloud senden keinen sauberen XML-Block.
-    REPORT_TOOLCALL_MODE: str = os.environ.get('REPORT_TOOLCALL_MODE', 'native')
+    # Casing-tolerant + Whitelist: ungültige Werte fallen auf "xml" (legacy-stable) zurück
+    # statt stillschweigend in den native-Pfad zu rutschen und 400er zu provozieren.
+    _RAW_REPORT_TOOLCALL_MODE = os.environ.get('REPORT_TOOLCALL_MODE', 'native')
+    _NORMALIZED_REPORT_TOOLCALL_MODE = _RAW_REPORT_TOOLCALL_MODE.strip().lower()
+    if _NORMALIZED_REPORT_TOOLCALL_MODE not in ('native', 'xml'):
+        import logging as _logging
+        _logging.getLogger(__name__).warning(
+            "Invalid REPORT_TOOLCALL_MODE=%r — falling back to 'xml' (legacy XML-parsing path)",
+            _RAW_REPORT_TOOLCALL_MODE,
+        )
+        _NORMALIZED_REPORT_TOOLCALL_MODE = 'xml'
+    REPORT_TOOLCALL_MODE: str = _NORMALIZED_REPORT_TOOLCALL_MODE
 
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -152,7 +152,10 @@ def generate_section_react(
     all_tools = {"insight_forge", "panorama_search", "quick_search", "interview_agents"}
     report_context = f"Section Title: {section.title}\nSimulation Requirement: {agent.simulation_requirement}"
 
-    _toolcall_mode = Config.REPORT_TOOLCALL_MODE
+    # Config normalisiert bereits, aber defense-in-depth: Runtime-Patches könnten
+    # andere Casings/Werte einschleusen. Unbekannte Werte fallen auf "xml".
+    _raw_toolcall_mode = (Config.REPORT_TOOLCALL_MODE or "xml").strip().lower()
+    _toolcall_mode = _raw_toolcall_mode if _raw_toolcall_mode in ("native", "xml") else "xml"
 
     for iteration in range(max_iterations):
         if progress_callback:
@@ -763,7 +766,11 @@ def chat(agent: Any, message: str, chat_history: List[Dict[str, str]] = None) ->
 
     tool_calls_made = []
     max_iterations = 2
-    _chat_toolcall_mode = Config.REPORT_TOOLCALL_MODE
+    # Casing-tolerant + Whitelist (symmetrisch zu generate_section_react).
+    _raw_chat_toolcall_mode = (Config.REPORT_TOOLCALL_MODE or "xml").strip().lower()
+    _chat_toolcall_mode = (
+        _raw_chat_toolcall_mode if _raw_chat_toolcall_mode in ("native", "xml") else "xml"
+    )
 
     for _ in range(max_iterations):
         if _chat_toolcall_mode == "native":

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -909,6 +909,33 @@ def _chat_with_tools(
         )
         return e2e_stub_chat_with_tools_response(messages=messages, tools=tools)
 
+    # Provider-Unknown-Short-Circuit: für nicht eindeutig identifizierbare Provider
+    # (weder Ollama lokal noch Ollama-Cloud noch OpenAI) können wir nicht garantieren,
+    # dass das Backend ``tools=``/``tool_choice=`` versteht. Statt einen 400er zu
+    # provozieren, fallen wir auf einen ``chat()``-Call ohne Tools zurück und liefern
+    # ``tool_calls=[]`` — der Caller (workflow.generate_section_react) erkennt das
+    # und nutzt den XML-Fallback-Parser. So bleibt das ReACT-Loop-Verhalten stabil.
+    provider = self._detect_provider()
+    if provider == "unknown":
+        logger.info(
+            "LLMClient.chat_with_tools: provider=unknown (model=%s, base=%s) — "
+            "skipping tools= and falling back to chat() for XML-tool-call parsing",
+            self.model,
+            self.base_url,
+        )
+        fallback_content = self.chat(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            context=context,
+        ) or ""
+        return ToolCallResponse(
+            content=fallback_content,
+            tool_calls=[],
+            finish_reason="stop",
+            raw_response=None,
+        )
+
     import time as _time
     _t0 = _time.monotonic()
 

--- a/backend/tests/services/report_agent/test_native_toolcalls.py
+++ b/backend/tests/services/report_agent/test_native_toolcalls.py
@@ -452,7 +452,10 @@ class TestReactLoopNativeToolCalls:
                     section_index=0,
                 )
 
-        assert "Segment-Analyse" in result or result  # Final Answer wurde zurückgegeben
+        # Final Answer wurde zurückgegeben — strenge Substring-Assertion (vorher: `in r or r`
+        # war wegen Truthiness-Bug immer True, hat also nichts verifiziert).
+        assert isinstance(result, str)
+        assert "Segment-Analyse" in result
         assert agent.llm.chat_with_tools.called
         assert agent._execute_tool.call_count >= 3
 

--- a/backend/tests/services/report_agent/test_toolcall_mode_followup.py
+++ b/backend/tests/services/report_agent/test_toolcall_mode_followup.py
@@ -1,0 +1,253 @@
+"""Followup-Tests zu PR #452 (Copilot-Findings).
+
+Adressiert:
+- Config.REPORT_TOOLCALL_MODE casing/whitelist robustness.
+- workflow.py defense-in-depth: unbekannte Mode-Werte fallen auf "xml".
+- LLMClient.chat_with_tools provider=unknown short-circuit (kein 400, leerer
+  tool_calls-Return → Caller nutzt XML-Fallback).
+"""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Config.REPORT_TOOLCALL_MODE — Casing + Whitelist
+# ---------------------------------------------------------------------------
+
+
+def _reload_config() -> Any:
+    """Re-import app.config so REPORT_TOOLCALL_MODE picks up the patched env."""
+    import app.config as cfg_module
+
+    return importlib.reload(cfg_module)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("native", "native"),
+        ("xml", "xml"),
+        ("NATIVE", "native"),
+        ("Xml", "xml"),
+        ("  native  ", "native"),
+        (" XML\n", "xml"),
+    ],
+)
+def test_report_toolcall_mode_normalizes_casing_and_whitespace(
+    raw: str, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Casing/Whitespace-Drift wird beim Import normalisiert."""
+    monkeypatch.setenv("REPORT_TOOLCALL_MODE", raw)
+    cfg_module = _reload_config()
+    assert cfg_module.Config.REPORT_TOOLCALL_MODE == expected
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    ["foo", "json", "auto", "true", "1", "Native!", ""],
+)
+def test_report_toolcall_mode_invalid_falls_back_to_xml(
+    invalid: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unbekannte Werte werden NICHT als 'native' interpretiert (verhindert 400er)."""
+    monkeypatch.setenv("REPORT_TOOLCALL_MODE", invalid)
+    cfg_module = _reload_config()
+    assert cfg_module.Config.REPORT_TOOLCALL_MODE == "xml", (
+        f"Invalid mode {invalid!r} should fall back to 'xml', got "
+        f"{cfg_module.Config.REPORT_TOOLCALL_MODE!r}"
+    )
+
+
+def test_report_toolcall_mode_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default ist 'native' (Modelle wie deepseek-v4-flash:cloud)."""
+    monkeypatch.delenv("REPORT_TOOLCALL_MODE", raising=False)
+    cfg_module = _reload_config()
+    assert cfg_module.Config.REPORT_TOOLCALL_MODE == "native"
+
+
+# ---------------------------------------------------------------------------
+# workflow.py — defense-in-depth bei Runtime-Patches
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_unknown_mode_uses_legacy_xml_path() -> None:
+    """Wenn jemand Config.REPORT_TOOLCALL_MODE auf 'Native' (Casing-Drift) patcht,
+    soll workflow trotzdem auf den XML-Pfad fallen oder native akzeptieren —
+    nie schweigend in den unknown-Pfad rutschen, der keinen Tool-Call mehr macht.
+    """
+    from app.services.report_agent import workflow as wf
+
+    # Wir testen die zentrale Normalisierungs-Logik durch direktes Aufrufen.
+    # generate_section_react liest Config.REPORT_TOOLCALL_MODE einmal am Anfang.
+    # Wir bauen ein minimales Agent-Mock und prüfen, dass bei "FooBar"-Mode der
+    # XML-Pfad (chat) statt chat_with_tools angerufen wird.
+    agent = MagicMock()
+    agent.simulation_requirement = "test"
+    agent.MAX_TOOL_CALLS_PER_SECTION = 3
+    agent.REACT_INSUFFICIENT_TOOLS_MSG = "more tools {tool_calls_count}/{min_tool_calls}{unused_hint}"
+    agent.REACT_INSUFFICIENT_TOOLS_MSG_ALT = "alt {tool_calls_count}/{min_tool_calls}{unused_hint}"
+    agent.REACT_TOOL_LIMIT_MSG = "limit {tool_calls_count}/{max_tool_calls}"
+    agent.REACT_OBSERVATION_TEMPLATE = "obs {tool_name}{result}{tool_calls_count}{max_tool_calls}{used_tools_str}{unused_hint}"
+    agent.REACT_UNUSED_TOOLS_HINT = " unused: {unused_list}"
+    agent.REACT_FORCE_FINAL_MSG = "force final"
+    agent._get_react_messages.return_value = [{"role": "system", "content": "sys"}]
+    agent._parse_tool_calls.return_value = []
+    agent.report_logger = None
+    agent._current_section_index = None
+    agent.llm.chat.return_value = "Final Answer: ok"
+
+    section = MagicMock()
+    section.title = "T"
+    outline = MagicMock()
+    outline.title = "O"
+    outline.summary = "S"
+
+    with patch("app.services.report_agent.workflow.Config") as mock_cfg:
+        mock_cfg.REPORT_TOOLCALL_MODE = "FooBar"  # ungültiger Wert
+        mock_cfg.REPORT_LANGUAGE = "German"
+        wf.generate_section_react(
+            agent=agent,
+            section=section,
+            outline=outline,
+            previous_sections=[],
+            section_index=0,
+        )
+
+    # FooBar → fällt auf "xml" → chat() wird aufgerufen, chat_with_tools nicht
+    assert agent.llm.chat.called, "Legacy chat() path must be used on invalid mode"
+    assert not agent.llm.chat_with_tools.called, (
+        "chat_with_tools must NOT be called when mode is unknown — would risk 400"
+    )
+
+
+def test_workflow_native_mode_case_insensitive() -> None:
+    """'NATIVE' (Casing-Drift) wird wie 'native' behandelt."""
+    from app.services.report_agent import workflow as wf
+
+    agent = MagicMock()
+    agent.simulation_requirement = "test"
+    agent.MAX_TOOL_CALLS_PER_SECTION = 3
+    agent.REACT_INSUFFICIENT_TOOLS_MSG = "{tool_calls_count}{min_tool_calls}{unused_hint}"
+    agent.REACT_INSUFFICIENT_TOOLS_MSG_ALT = "{tool_calls_count}{min_tool_calls}{unused_hint}"
+    agent.REACT_TOOL_LIMIT_MSG = "{tool_calls_count}{max_tool_calls}"
+    agent.REACT_OBSERVATION_TEMPLATE = "{tool_name}{result}{tool_calls_count}{max_tool_calls}{used_tools_str}{unused_hint}"
+    agent.REACT_UNUSED_TOOLS_HINT = "{unused_list}"
+    agent.REACT_FORCE_FINAL_MSG = "force"
+    agent._get_react_messages.return_value = [{"role": "system", "content": "sys"}]
+    agent._parse_tool_calls.return_value = []
+    agent.report_logger = None
+    agent._current_section_index = None
+    agent._get_openai_tools_schema.return_value = []
+    agent.llm.chat_with_tools.return_value = {
+        "content": "Final Answer: native ok",
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "raw_response": None,
+    }
+
+    section = MagicMock()
+    section.title = "T"
+    outline = MagicMock()
+    outline.title = "O"
+    outline.summary = "S"
+
+    with patch("app.services.report_agent.workflow.Config") as mock_cfg:
+        mock_cfg.REPORT_TOOLCALL_MODE = "NATIVE"  # uppercase
+        mock_cfg.REPORT_LANGUAGE = "German"
+        wf.generate_section_react(
+            agent=agent,
+            section=section,
+            outline=outline,
+            previous_sections=[],
+            section_index=0,
+        )
+
+    assert agent.llm.chat_with_tools.called, "NATIVE casing must route to native path"
+
+
+# ---------------------------------------------------------------------------
+# llm_client.chat_with_tools — provider=unknown short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_chat_with_tools_provider_unknown_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bei unbekanntem Provider wird kein tools=-Request abgesetzt; stattdessen
+    fällt der Client auf chat() zurück und liefert tool_calls=[] — der Caller
+    soll dann den XML-Parser nutzen können.
+    """
+    # Stelle sicher, dass der E2E-Stub-Pfad nicht greift
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+    from app.utils.llm_client import LLMClient
+
+    # base_url ohne 11434/openai.com → provider = "unknown"
+    client = LLMClient(
+        model="weird-private-model",
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+    )
+    # Provider muss als "unknown" detektiert werden
+    assert client._detect_provider() == "unknown"
+
+    # chat() wird gemockt, damit kein echter HTTP-Call passiert
+    with patch.object(
+        client, "chat", return_value="Some textual response without tool calls"
+    ) as mocked_chat:
+        result = client.chat_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "noop", "description": "noop", "parameters": {}},
+                }
+            ],
+            tool_choice="auto",
+            temperature=0.5,
+            max_tokens=128,
+            context="report",
+        )
+
+    # chat() muss aufgerufen worden sein, NICHT der eigentliche tools=-Pfad
+    assert mocked_chat.called, "chat() fallback must be invoked for unknown provider"
+    assert result["tool_calls"] == [], "tool_calls must be empty for unknown provider"
+    assert result["content"] == "Some textual response without tool calls"
+    assert result["finish_reason"] == "stop"
+
+
+def test_chat_with_tools_provider_unknown_handles_none_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wenn chat() None liefert, gibt der Short-Circuit content='' zurück
+    (kein TypeError, kein crash)."""
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+    from app.utils.llm_client import LLMClient
+
+    client = LLMClient(
+        model="weird-private-model",
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+    )
+    assert client._detect_provider() == "unknown"
+
+    with patch.object(client, "chat", return_value=None):
+        result = client.chat_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            tool_choice="auto",
+            temperature=0.5,
+            max_tokens=128,
+            context="report",
+        )
+
+    assert result["content"] == ""
+    assert result["tool_calls"] == []

--- a/docu/2026-05-15-copilot-followup-pr452-worklog.md
+++ b/docu/2026-05-15-copilot-followup-pr452-worklog.md
@@ -1,0 +1,110 @@
+# Arbeitsprotokoll — Copilot-Followup auf PR #452 (Native Tool-Calls Hardening)
+
+**Datum:** 2026-05-15
+**Branch:** `fix/copilot-followup-pr452`
+**Worktree:** `/private/tmp/agora-copilot-followup-pr452`
+**Base:** `origin/main` (ac6a6fa — Merge PR #452)
+**Vorgängerwelle:** PR #452 (Native OpenAI function-calling für ReACT-Report) + 620fb27 (Gemini-Followup auf PR #452)
+
+## Kontext
+
+Copilot hat nach Merge von PR #452 vier echte Inline-Findings + zwei
+suppressed Comments (low confidence, aber inhaltlich korrekt) gemeldet.
+Drei davon sind HIGH (Casing/Whitelist-Drift bei `REPORT_TOOLCALL_MODE`,
+unbehandelte Mode-Werte in `workflow.py`, fehlender Soft-Fallback für
+`provider=unknown` in `chat_with_tools`). Ein MEDIUM (Test-Assertion
+`"X" in result or result` ist immer truthy).
+
+Diese Followup-Slice adressiert alle vier Findings + zwei verwandte
+Härtungen. Keine Layer-0-Touches, keine Wording-Glossar-Verstöße, keine
+neuen externen Abhängigkeiten.
+
+## Änderungen
+
+### 1) `backend/app/config.py` — Whitelist + Normalisierung (Finding #1, HIGH)
+
+`REPORT_TOOLCALL_MODE` wird beim Import einmal normalisiert:
+
+- `.strip().lower()` (Casing/Whitespace tolerant)
+- Whitelist `("native", "xml")`
+- Ungültige Werte → Warning-Log + Fallback auf `"xml"` (legacy-stable,
+  vermeidet 400er-Fehler bei Backends ohne Tool-Use-Support)
+
+### 2) `backend/app/services/report_agent/workflow.py` — Defense-in-Depth (Finding #2, HIGH)
+
+Zwei Stellen (`generate_section_react` Z. 155, `chat()` Z. 766) lesen
+`Config.REPORT_TOOLCALL_MODE` und normalisieren erneut. Schützt vor
+Runtime-Patches, die das normalisierte Config-Modul umgehen (z. B.
+Tests, die `Config.REPORT_TOOLCALL_MODE = "Native"` setzen).
+
+Bei unbekannten Werten → Fallback auf `"xml"`, NIE schweigend in den
+unknown-Pfad, der die Schleife ohne Tool-Use durchläuft.
+
+### 3) `backend/app/utils/llm_client.py` — Provider-Unknown Short-Circuit (Finding #3, HIGH)
+
+`chat_with_tools` prüft jetzt vor dem API-Call das Ergebnis von
+`_detect_provider()`. Bei `"unknown"` fällt der Client auf einen
+regulären `chat()`-Call ohne `tools=`/`tool_choice=` zurück und liefert
+`ToolCallResponse(content=..., tool_calls=[], finish_reason="stop")`.
+
+Der Caller (`workflow.generate_section_react`) erkennt das leere
+`tool_calls` und nutzt den XML-Fallback-Parser — exakt das Verhalten,
+das der Docstring bereits versprochen hatte, aber in der Implementation
+fehlte. Vermeidet 400er bei privat gehosteten Backends ohne OpenAI-
+Tool-Use-Kompatibilität.
+
+### 4) `backend/tests/services/report_agent/test_native_toolcalls.py` — Echte Assertion (Finding #4, MEDIUM)
+
+`assert "Segment-Analyse" in result or result` war wegen Truthiness
+immer True. Ersetzt durch:
+
+```python
+assert isinstance(result, str)
+assert "Segment-Analyse" in result
+```
+
+### 5) Neue Tests `backend/tests/services/report_agent/test_toolcall_mode_followup.py`
+
+18 neue Tests in drei Gruppen:
+
+- **Config-Casing/Whitelist (12 Tests):** parametrize über alle valide
+  Casing-Varianten + ungültige Werte → Fallback auf `xml`. Default-
+  Verhalten bei unset env.
+- **workflow.py defense-in-depth (2 Tests):** Unknown mode → XML-Pfad,
+  `NATIVE` uppercase → native Pfad.
+- **chat_with_tools short-circuit (2 Tests):** Provider `unknown` →
+  `chat()`-Fallback, leeres `tool_calls`. Robust gegen `chat()=None`.
+
+## Verify-Gate
+
+```
+$ uv run pytest tests/services/report_agent/ tests/api/test_report_modes.py \
+    tests/test_config_validate.py tests/test_config_security.py
+58 passed in 1.07s
+
+$ uv run ruff check app/ tests/
+All checks passed!
+
+$ uv run mypy app/config.py app/services/report_agent/workflow.py app/utils/llm_client.py
+Success: no issues found in 3 source files
+```
+
+## Was bewusst NICHT geändert wurde
+
+- **Konflikt-Resolution im native-Pfad (Suppressed Comment #1):** Der
+  bestehende Code setzt `has_final_answer=False` und verlässt sich auf
+  den nächsten Loop-Iteration-Reset. Das ist symmetrisch zum
+  XML-Pfad, weil `conflict_retries` ≤ 2 erlaubt ist und die LLM zur
+  Klarstellung aufgefordert wird. Refaktor wäre Scope-Erweiterung —
+  Issue für separate Slice empfohlen, wenn das in Produktion auffällt.
+- **chat()-Loop bei :798 (Suppressed Comment #2):** Wird durch
+  Normalisierung in (2) abgedeckt — `_chat_toolcall_mode` ist jetzt
+  garantiert `"native"` oder `"xml"`.
+
+## Rückmeldung
+
+- **Branch:** `fix/copilot-followup-pr452`
+- **Test-Delta:** +18 neue Tests, 1 Test-Assertion gehärtet. 58/58 grün
+  im fokussierten Scope, kein Regression in `report_agent/`-Suite.
+- **Bundle-Delta:** keine Frontend-Touches.
+- **Gaps:** keine.

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2128 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2146 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

Adressiert vier Copilot-Findings (3 HIGH, 1 MEDIUM) nach Merge von #452:

- **config.py:** `REPORT_TOOLCALL_MODE` normalisiert (`.strip().lower()`) + Whitelist `("native", "xml")`. Ungültige Werte → Warning + Fallback auf `"xml"` (legacy-stable) statt 400er im native-Pfad.
- **workflow.py:** Defense-in-depth in `generate_section_react` (Z. 155) und `chat()` (Z. 766) — unbekannte Mode-Werte fallen auf XML statt schweigend in den unknown-Branch ohne Tool-Use.
- **llm_client.py::chat_with_tools:** Short-Circuit bei `provider="unknown"` → `chat()`-Fallback ohne `tools=`, leerer `tool_calls`-Return. Caller nutzt XML-Fallback-Parser. Endlich das im Docstring versprochene Verhalten.
- **test_native_toolcalls.py:** Truthy-Bug `"X" in r or r` ersetzt durch strenge Assertions.

Plus 18 neue Tests in `test_toolcall_mode_followup.py`.

## Test plan

- [x] `pytest tests/services/report_agent/ tests/api/test_report_modes.py tests/test_config_validate.py tests/test_config_security.py` → 58/58 grün
- [x] `ruff check app/ tests/` → clean
- [x] `mypy app/config.py workflow.py llm_client.py` → clean
- [ ] CI grün (Backend + Frontend + STATUS-Drift)
- [ ] Gemini-Findings nach ~90s sichten

## Refs

- PR #452 (Native OpenAI function-calling, merged ac6a6fa)
- Copilot review on PR #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)