### PR TITLE
chore: remove resolved Pillow CVEs from CI allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,31 +57,28 @@ jobs:
 
       - name: Run Python dependency audit
         # Temporary baseline: these advisories are pinned by upstream
-        # dependencies (camel-oasis==0.2.5 / camel-ai==0.2.78 /
-        # sentence-transformers==3.0.0). Tracked in
-        # docu/dependency-risk-register.md. Hardstop 2026-07-30 — afterwards
-        # this --ignore-vuln list MUST be empty. The weekly CVE-Monitor-
-        # Workflow (.github/workflows/cve-monitor.yml) enforces the deadline
-        # by failing on/after 2026-07-30 if any of these CVEs are still
-        # present in pip-audit's strict output.
+        # dependencies (camel-oasis==0.2.5 / sentence-transformers==3.0.0).
+        # Tracked in docu/dependency-risk-register.md. Hardstop 2026-07-30 —
+        # afterwards this --ignore-vuln list MUST be empty. The weekly
+        # CVE-Monitor-Workflow (.github/workflows/cve-monitor.yml) enforces
+        # the deadline by failing on/after 2026-07-30 if any of these CVEs
+        # are still present in pip-audit's strict output.
         # New pip-audit findings still fail the job.
         #
-        # CVE-2026-25990  pillow==10.3.0   via camel-ai      #121
-        # CVE-2026-40192  pillow==10.3.0   via camel-ai      #122
-        # CVE-2026-42308  pillow==10.3.0   via camel-oasis/camel-ai #296
-        # CVE-2026-42310  pillow==10.3.0   via camel-oasis/camel-ai #297
-        # CVE-2026-42311  pillow==10.3.0   via camel-oasis/camel-ai #298
+        # Resolved (2026-05-15, pillow==12.2.0 via uv override-dependencies):
+        #   CVE-2026-25990  pillow==10.3.0  via camel-ai      #121
+        #   CVE-2026-40192  pillow==10.3.0  via camel-ai      #122
+        #   CVE-2026-42308  pillow==10.3.0  via camel-oasis   #296
+        #   CVE-2026-42310  pillow==10.3.0  via camel-oasis   #297
+        #   CVE-2026-42311  pillow==10.3.0  via camel-oasis   #298
+        #
+        # Still open (upstream-blocked):
         # CVE-2025-71176  pytest==8.2.0    via camel-oasis   #123
         # CVE-2026-1839   transformers==4.57.6 via s-t       #124
         # CVE-2024-46455  unstructured==0.13.7 via camel-oasis #125
         # CVE-2025-64712  unstructured==0.13.7 via camel-oasis #126
         run: |
           uvx pip-audit --strict --no-deps --disable-pip \
-            --ignore-vuln CVE-2026-25990 \
-            --ignore-vuln CVE-2026-40192 \
-            --ignore-vuln CVE-2026-42308 \
-            --ignore-vuln CVE-2026-42310 \
-            --ignore-vuln CVE-2026-42311 \
             --ignore-vuln CVE-2025-71176 \
             --ignore-vuln CVE-2026-1839 \
             --ignore-vuln CVE-2024-46455 \

--- a/docu/2026-05-15-ci-pillow-cve-allowlist-cleanup-worklog.md
+++ b/docu/2026-05-15-ci-pillow-cve-allowlist-cleanup-worklog.md
@@ -1,0 +1,103 @@
+# Worklog: CI Pillow CVE Allowlist Cleanup (2026-05-15)
+
+**Branch:** `chore/ci-pillow-cve-allowlist-cleanup`
+**Scope:** `.github/workflows/ci.yml`, `docu/dependency-risk-register.md`
+
+---
+
+## Ausgangslage
+
+CI enthielt 9 `--ignore-vuln`-Flags in `pip-audit`. Davon bezogen sich 5 auf
+Pillow-CVEs (CVE-2026-25990, 40192, 42308, 42310, 42311), die alle auf
+`pillow==10.3.0` zielten. Das `tool.uv.override-dependencies`-Setup im
+`backend/pyproject.toml` hatte Pillow bereits auf `12.2.0` gehoben — die
+Flags waren daher nutzlos und trübten die Übersichtlichkeit der Allowlist.
+
+---
+
+## Verifikation (Pflicht-Schritt vor jeder Änderung)
+
+### 1. Pillow-Version aus uv export
+
+```
+cd /private/tmp/agora-ci-cve-allowlist/backend
+uv export --frozen --no-dev --no-hashes --no-emit-project \
+  --format requirements.txt --output-file /tmp/agora-reqs-ci-cleanup.txt
+grep -E '^pillow' /tmp/agora-reqs-ci-cleanup.txt
+```
+
+**Ergebnis:**
+```
+pillow==12.2.0
+    # via
+    #   agora-backend
+    #   camel-ai
+    #   camel-oasis
+    #   sentence-transformers
+```
+
+Pillow 12.2.0 ist installiert. Das uv-Override greift korrekt — alle
+transitive Dependents (camel-ai, camel-oasis, sentence-transformers) erhalten
+die gepinnte Version aus dem Override.
+
+### 2. pip-audit ohne die 5 Pillow-CVEs
+
+```
+uvx pip-audit --strict --no-deps --disable-pip \
+  --ignore-vuln CVE-2025-71176 \
+  --ignore-vuln CVE-2026-1839 \
+  --ignore-vuln CVE-2024-46455 \
+  --ignore-vuln CVE-2025-64712 \
+  -r /tmp/agora-reqs-ci-cleanup.txt
+```
+
+**Ergebnis:**
+```
+No known vulnerabilities found, 4 ignored
+```
+
+PASS. Keine Pillow-CVE taucht auf. Die 4 ignorierten sind die verbliebenen
+offenen CVEs (pytest, transformers, unstructured x2) — diese bleiben in der
+Allowlist.
+
+---
+
+## Durchgefuehrte Aenderungen
+
+### `.github/workflows/ci.yml`
+
+- Kommentar aktualisiert: Pillow-CVEs als "Resolved (2026-05-15)" markiert,
+  verbleibende CVEs als "Still open (upstream-blocked)" hervorgehoben.
+- 5 `--ignore-vuln`-Zeilen entfernt:
+  - `--ignore-vuln CVE-2026-25990`
+  - `--ignore-vuln CVE-2026-40192`
+  - `--ignore-vuln CVE-2026-42308`
+  - `--ignore-vuln CVE-2026-42310`
+  - `--ignore-vuln CVE-2026-42311`
+- 4 verbleibende `--ignore-vuln`-Flags bleiben unberuehrt.
+
+YAML-Syntax: `python3 -c "import yaml; yaml.safe_load(open(...)); print('OK')"` → OK.
+
+### `docu/dependency-risk-register.md`
+
+- Stand-Datum: 2026-05-11 → 2026-05-15.
+- 5 Pillow-CVE-Zeilen aus der aktiven Baseline entfernt.
+- `pillow`-Zeile aus den Pin-Begruendungen entfernt.
+- 5 Eintraege in die Abgeschlossen-Tabelle verschoben mit:
+  - Aufloesung: `pillow==12.2.0 via uv override-dependencies`
+  - Datum: 2026-05-15
+  - Hinweis: Issues #121/#122/#296/#297/#298 schliessen.
+
+---
+
+## Verbleibende offene CVEs
+
+| CVE | Paket | Issue | Grund |
+|---|---|---|---|
+| CVE-2025-71176 | pytest==8.2.0 | #123 | camel-oasis==0.2.5 pinnt pytest==8.2.0 |
+| CVE-2026-1839 | transformers==4.57.6 | #124 | sentence-transformers==3.0.0 limitiert transformers<5 |
+| CVE-2024-46455 | unstructured==0.13.7 | #125 | camel-oasis==0.2.5 pinnt unstructured==0.13.7 |
+| CVE-2025-64712 | unstructured==0.13.7 | #126 | camel-oasis==0.2.5 pinnt unstructured==0.13.7 |
+
+Hardstop: 2026-07-30. Pfad: uv-Override-Strategie (wie bei Pillow) oder
+camel-oasis-Fork (`arn0ld87/camel-oasis@agora-pins`).

--- a/docu/dependency-risk-register.md
+++ b/docu/dependency-risk-register.md
@@ -1,6 +1,6 @@
 # Dependency Risk Register
 
-**Stand:** 2026-05-11, Europe/Berlin
+**Stand:** 2026-05-15, Europe/Berlin
 **Ausgeloest durch:** Repo-Review PR4 — CVE-Baseline aktiv abbauen.
 Automation: [.github/workflows/cve-monitor.yml](../.github/workflows/cve-monitor.yml) läuft wöchentlich Mo 06:00 UTC pip-audit --strict ohne --ignore-vuln und schreibt das Ergebnis in das Workflow-Summary. Hardstop am 2026-07-30 — danach failt der Job, wenn ignored CVEs noch offen sind.
 Supply-Chain-Baseline: [.github/workflows/scorecard.yml](../.github/workflows/scorecard.yml) läuft wöchentlich Mo 04:30 UTC und auf `push` nach `main`. SARIF-Ergebnisse werden ins Code-Scanning-Dashboard hochgeladen; der erste Remote-Run nach Merge ist die Scorecard-Baseline.
@@ -15,11 +15,6 @@ nicht hinzugefuegt werden ohne dass sie zuerst als Issue aufgenommen werden.
 
 | CVE | Paket | Version | Owner | Frist | Status | Issue | Upstream-Release-Watch |
 |---|---|---|---|---|---|---|---|
-| CVE-2026-25990 | `pillow` | `10.3.0` | camel-ai | 2026-07-30 | open (tracked) | [#121](https://github.com/arn0ld87/agora/issues/121) | [camel-ai/releases](https://github.com/camel-ai/camel/releases) |
-| CVE-2026-40192 | `pillow` | `10.3.0` | camel-ai | 2026-07-30 | open (tracked) | [#122](https://github.com/arn0ld87/agora/issues/122) | [camel-ai/releases](https://github.com/camel-ai/camel/releases) |
-| CVE-2026-42308 | `pillow` | `10.3.0` | camel-oasis / camel-ai | 2026-07-30 | open | [#296](https://github.com/arn0ld87/agora/issues/296) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases), [camel-ai/releases](https://github.com/camel-ai/camel/releases) |
-| CVE-2026-42310 | `pillow` | `10.3.0` | camel-oasis / camel-ai | 2026-07-30 | open | [#297](https://github.com/arn0ld87/agora/issues/297) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases), [camel-ai/releases](https://github.com/camel-ai/camel/releases) |
-| CVE-2026-42311 | `pillow` | `10.3.0` | camel-oasis / camel-ai | 2026-07-30 | open | [#298](https://github.com/arn0ld87/agora/issues/298) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases), [camel-ai/releases](https://github.com/camel-ai/camel/releases) |
 | CVE-2025-71176 | `pytest` | `8.2.0` | camel-oasis | 2026-07-30 | open | [#123](https://github.com/arn0ld87/agora/issues/123) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases) |
 | CVE-2026-1839 | `transformers` | `4.57.6` | sentence-transformers | 2026-07-30 | open | [#124](https://github.com/arn0ld87/agora/issues/124) | [UKPLab/sentence-transformers/releases](https://github.com/UKPLab/sentence-transformers/releases) |
 | CVE-2024-46455 | `unstructured` | `0.13.7` | camel-oasis | 2026-07-30 | open | [#125](https://github.com/arn0ld87/agora/issues/125) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases) |
@@ -29,7 +24,6 @@ nicht hinzugefuegt werden ohne dass sie zuerst als Issue aufgenommen werden.
 
 | Paket | Pinned Version | Upstream-Pin | Erklaerung |
 |---|---|---|---|
-| `pillow` | `10.3.0` | `camel-oasis==0.2.5`, `camel-ai==0.2.78` | `camel-oasis` pinnt `pillow==10.3.0`; `camel-ai` limitiert `pillow<11`. |
 | `pytest` | `8.2.0` | `camel-oasis==0.2.5` | `camel-oasis` pinnt `pytest==8.2.0`. Fix: `>=9.0.3`. |
 | `transformers` | `4.57.6` | `sentence-transformers==3.0.0` | `sentence-transformers` limitiert `transformers<5`. |
 | `unstructured` | `0.13.7` | `camel-oasis==0.2.5` | `camel-oasis` pinnt `unstructured==0.13.7`. |
@@ -67,4 +61,8 @@ Der CVE-Monitor-Workflow erzwingt die Entscheidung: ab Hardstop-Datum schlägt e
 
 | CVE | Paket | Aufloesung | Datum |
 |---|---|---|---|
-| — | — | — | — |
+| CVE-2026-25990 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #121 schließen. | 2026-05-15 |
+| CVE-2026-40192 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #122 schließen. | 2026-05-15 |
+| CVE-2026-42308 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #296 schließen. | 2026-05-15 |
+| CVE-2026-42310 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #297 schließen. | 2026-05-15 |
+| CVE-2026-42311 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #298 schließen. | 2026-05-15 |


### PR DESCRIPTION
## Summary

- Five Pillow CVEs (CVE-2026-25990, -40192, -42308, -42310, -42311) are resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` is installed for all transitive dependents (camel-ai, camel-oasis, sentence-transformers).
- Verified locally: `uv export --frozen` shows `pillow==12.2.0`; `uvx pip-audit --strict` without the 5 Pillow flags passes with `No known vulnerabilities found, 4 ignored`.
- Remaining 4 open CVEs (pytest/CVE-2025-71176, transformers/CVE-2026-1839, unstructured/CVE-2024-46455 + CVE-2025-64712) stay in the allowlist — still upstream-blocked via camel-oasis==0.2.5.
- Risk register (`docu/dependency-risk-register.md`) updated: 5 Pillow entries moved to Abgeschlossen table. Issues #121/#122/#296/#297/#298 can be closed after merge.

## Verification evidence

```
pillow==12.2.0
    # via
    #   agora-backend
    #   camel-ai
    #   camel-oasis
    #   sentence-transformers
```

```
uvx pip-audit --strict --no-deps --disable-pip \
  --ignore-vuln CVE-2025-71176 \
  --ignore-vuln CVE-2026-1839 \
  --ignore-vuln CVE-2024-46455 \
  --ignore-vuln CVE-2025-64712 \
  -r /tmp/agora-reqs-ci-cleanup.txt

→ No known vulnerabilities found, 4 ignored
```

Full details in [`docu/2026-05-15-ci-pillow-cve-allowlist-cleanup-worklog.md`](docu/2026-05-15-ci-pillow-cve-allowlist-cleanup-worklog.md).

## Test plan

- [ ] CI `security` job passes without the removed `--ignore-vuln` flags
- [ ] YAML syntax check passed locally (`python3 -c "import yaml; yaml.safe_load(...)"` → OK)
- [ ] No backend/frontend code touched

Closes #121, #122, #296, #297, #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)