### PR TITLE
Harden LLM routing snapshots and remove unsafe provider_options

### DIFF
--- a/backend/app/contracts/llm_routing_contract.py
+++ b/backend/app/contracts/llm_routing_contract.py
@@ -21,6 +21,8 @@ StageId = Literal[
 
 ReasoningEffort = Literal["none", "minimal", "low", "medium", "high"]
 
+ALLOWED_PROVIDER_OPTIONS = {"num_ctx", "temperature", "max_tokens", "reasoning_effort"}
+
 
 class StageLLMRoute(BaseModel):
     """Configuration for a single stage route."""

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -12,7 +12,7 @@ Resolution order:
 
 import logging
 import os
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 
 from ..config import Config
 from .llm_provider_secrets_store import get_llm_provider_secrets_store
@@ -25,6 +25,56 @@ class SecretResolver:
 
     def __init__(self, session_api_keys: Optional[Dict[str, str]] = None):
         self._session_keys = session_api_keys or {}
+
+    def get_base_url(self, provider_id: str, provider_type: str, provider_options: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """Resolve the real base URL for a provider (including credentials)."""
+        # 0. Try explicit provider_options (highest precedence)
+        if provider_options and provider_options.get("base_url"):
+            return provider_options["base_url"]
+
+        # 1. Try ProviderRegistry
+        try:
+            from .llm_provider_registry import LlmProviderRegistry
+            registry = LlmProviderRegistry()
+            descriptor = next((p for p in registry.get_providers() if p.id == provider_id), None)
+            if descriptor and descriptor.base_url:
+                return descriptor.base_url
+        except Exception:
+            pass
+
+        # 2. Try Workspace-Routing-Store (contains potential secrets, but is protected)
+        try:
+            from .workspace_routing_store import get_workspace_routing_store
+            ws_store = get_workspace_routing_store()
+            defaults = ws_store.load()
+
+            # Check stage overrides first (more specific)
+            for route in defaults.stage_overrides.values():
+                if route.provider_id == provider_id:
+                    url = route.provider_options.get("base_url")
+                    if url:
+                        return url
+
+            # Check global default
+            if defaults.global_default.provider_id == provider_id:
+                url = defaults.global_default.provider_options.get("base_url")
+                if url:
+                    return url
+        except Exception:
+            pass
+
+        # 3. Provider-specific Environment fallbacks
+        if provider_type == "openai":
+            return os.environ.get("OPENAI_BASE_URL") or os.environ.get("LLM_BASE_URL") or Config.LLM_BASE_URL
+        if provider_type == "google":
+            return "https://generativelanguage.googleapis.com/v1beta/openai/"
+        if provider_type == "github_copilot":
+            return "https://api.githubcopilot.com"
+        if provider_type == "ollama_local":
+            return os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+
+        # 4. Global fallback
+        return os.environ.get("LLM_BASE_URL") or Config.LLM_BASE_URL
 
     def get_api_key(self, provider_id: str, provider_type: str) -> Optional[str]:
         """Resolve API key for a provider."""
@@ -44,7 +94,7 @@ class SecretResolver:
 
         # 3. Provider-spezifische Environment-Variablen
         if provider_type == "openai":
-            return os.environ.get("OPENAI_API_KEY") or Config.LLM_API_KEY
+            return os.environ.get("OPENAI_API_KEY") or os.environ.get("LLM_API_KEY") or Config.LLM_API_KEY
         if provider_type == "google":
             return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
         if provider_type == "github_copilot":
@@ -56,7 +106,7 @@ class SecretResolver:
             return resolve_copilot_token()
 
         # 4. Global fallback
-        return Config.LLM_API_KEY
+        return os.environ.get("LLM_API_KEY") or Config.LLM_API_KEY
 
     def sanitize_url(self, url: Optional[str]) -> Optional[str]:
         """Remove secrets from URL (no userinfo, no query string)."""

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -8,7 +8,8 @@ from typing import Optional
 from ..contracts.llm_routing_contract import (
     RuntimeLlmRouting,
     ResolvedRoute,
-    StageId
+    StageId,
+    ALLOWED_PROVIDER_OPTIONS
 )
 from .runtime_run_config import RuntimeRunConfig, _detect_default_provider_id
 from .secret_resolver import SecretResolver
@@ -41,6 +42,13 @@ class StageModelRouter:
         # Fallback auf Best-Effort-Detection aus base_url / model.
         provider_id = route.provider_id or _detect_default_provider_id(base_url, route.model)
 
+        # Harden provider_options: only allow safe keys in ResolvedRoute (snapshot-ready)
+        raw_options = route.provider_options or {}
+        safe_options = {
+            k: v for k, v in raw_options.items()
+            if k.lower() in ALLOWED_PROVIDER_OPTIONS
+        }
+
         resolved = ResolvedRoute(
             stage=stage_id,
             provider_id=provider_id,
@@ -48,7 +56,7 @@ class StageModelRouter:
             base_url_sanitized=resolver.sanitize_url(base_url),
             reasoning_effort=route.reasoning_effort,
             routing_version=cfg.routing_version,
-            provider_options=route.provider_options,
+            provider_options=safe_options,
             started_at=datetime.now().isoformat()
         )
         return resolved

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -135,32 +135,30 @@ class LLMClient:
     ) -> "LLMClient":
         """Factory: create LLMClient from a resolved stage route.
 
-        Resolves actual base_url and api_key from the provider configuration,
-        falling back to sanitized/config defaults if no resolver is provided.
+        Resolves actual base_url and api_key from the provider configuration.
         """
         base_url = route.base_url_sanitized
         api_key = api_key_override
 
-        # If a secret resolver is provided, we try to get the real secrets.
-        # This prevents leaking them into ResolvedRoute but allows LLMClient
-        # to use them.
-        if secret_resolver:
-            # We need to know the provider type to resolve the key correctly.
-            # ResolvedRoute only has provider_id.
-            # In a full implementation, we'd look up the provider descriptor.
-            # For now, we use the fallback logic in SecretResolver.
-            from ..services.llm_provider_registry import LlmProviderRegistry
-            registry = LlmProviderRegistry()
-            descriptor = next((p for p in registry.get_providers() if p.id == route.provider_id), None)
+        # 1. Resolve actual secrets (not in ResolvedRoute) via SecretResolver
+        from ..services.secret_resolver import SecretResolver
+        resolver = secret_resolver or SecretResolver()
 
-            p_type = descriptor.type if descriptor else "unknown"
-            if not api_key:
-                api_key = secret_resolver.get_api_key(route.provider_id, p_type)
+        # 2. Map provider_id to provider_type
+        from ..services.llm_provider_registry import LlmProviderRegistry
+        registry = LlmProviderRegistry()
+        descriptor = next((p for p in registry.get_providers() if p.id == route.provider_id), None)
+        p_type = descriptor.type if descriptor else "openai_compatible"
 
-            # Use real base_url from provider_options if present, otherwise from descriptor
-            real_base = route.provider_options.get("base_url") or (descriptor.base_url if descriptor else None)
-            if real_base:
-                base_url = real_base
+        # 3. Resolve API key
+        if not api_key:
+            api_key = resolver.get_api_key(route.provider_id, p_type)
+
+        # 4. Resolve real base_url (including credentials/query tokens)
+        # Pass route.provider_options as override (if it somehow contained a base_url, though it shouldn't anymore)
+        real_base = resolver.get_base_url(route.provider_id, p_type, route.provider_options)
+        if real_base:
+            base_url = real_base
 
         return cls(
             api_key=api_key,

--- a/backend/tests/services/test_llm_routing_hardening.py
+++ b/backend/tests/services/test_llm_routing_hardening.py
@@ -1,0 +1,136 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+from app.services.stage_model_router import StageModelRouter
+from app.services.runtime_run_config import RuntimeRunConfig
+from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, ResolvedRoute
+from app.services.secret_resolver import SecretResolver
+from app.utils.llm_client import LLMClient
+
+@pytest.fixture
+def temp_run_dir(tmp_path):
+    run_id = "proj_hardening123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    with patch("app.utils.artifact_locator.ArtifactLocator.run_dir", return_value=str(run_dir)):
+        yield run_id
+
+def test_stage_model_router_filters_provider_options(temp_run_dir):
+    service = RuntimeRunConfig(temp_run_dir)
+    # Route with sensitive fields in provider_options
+    global_default = StageLLMRoute(
+        provider_id="openai",
+        model="gpt-4o",
+        provider_options={
+            "api_key": "secret-key",
+            "base_url": "https://user:pass@api.openai.com/v1?token=abc",
+            "num_ctx": 4096,
+            "temperature": 0.5
+        }
+    )
+    config = RuntimeLlmRouting(global_default=global_default, routing_version=1)
+    service.save_config(config)
+
+    router = StageModelRouter(temp_run_dir)
+    resolved = router.resolve("document_ingest")
+
+    # Verify filtering
+    assert "api_key" not in resolved.provider_options
+    assert "base_url" not in resolved.provider_options
+    assert resolved.provider_options["num_ctx"] == 4096
+    assert resolved.provider_options["temperature"] == 0.5
+
+    # Verify sanitized URL
+    assert resolved.base_url_sanitized == "https://api.openai.com/v1"
+
+def test_secret_resolver_resolves_base_url():
+    resolver = SecretResolver()
+
+    # 1. From provider_options (highest precedence)
+    url = resolver.get_base_url("any", "openai", {"base_url": "https://custom.openai.com"})
+    assert url == "https://custom.openai.com"
+
+    # 2. From environment (using a provider_id NOT in registry to reach env fallback)
+    with patch.dict(os.environ, {"OPENAI_BASE_URL": "https://env.openai.com"}):
+        url = resolver.get_base_url("not-in-registry", "openai")
+        assert url == "https://env.openai.com"
+
+    # 3. From registry
+    # "openai" is a standard provider ID in LlmProviderRegistry
+    url = resolver.get_base_url("openai", "openai")
+    assert url == "https://api.openai.com/v1"
+
+def test_secret_resolver_sanitize_url():
+    resolver = SecretResolver()
+    assert resolver.sanitize_url("https://user:pass@host:1234/path?query=1#frag") == "https://host:1234/path"
+    assert resolver.sanitize_url("http://localhost:11434") == "http://localhost:11434"
+    assert resolver.sanitize_url(None) is None
+
+def test_llm_client_from_route_restores_secrets(temp_run_dir):
+    # This test simulates the full cycle:
+    # StageLLMRoute (with secrets) -> ResolvedRoute (clean) -> LLMClient (with secrets)
+
+    # Mocking SecretResolver to return secrets we expect
+    mock_resolver = MagicMock(spec=SecretResolver)
+    mock_resolver.get_api_key.return_value = "real-api-key"
+    mock_resolver.get_base_url.return_value = "https://user:pass@api.openai.com/v1"
+
+    resolved = ResolvedRoute(
+        stage="document_ingest",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=1,
+        provider_options={"num_ctx": 4096}
+    )
+
+    with patch("app.services.secret_resolver.SecretResolver", return_value=mock_resolver):
+        client = LLMClient.from_route(resolved)
+
+        assert client.api_key == "real-api-key"
+        assert client.base_url == "https://user:pass@api.openai.com/v1"
+        assert client.model == "gpt-4o"
+        assert client.provider_options == {"num_ctx": 4096}
+
+def test_integration_full_hardening_cycle(temp_run_dir):
+    # Real integration test for StageModelRouter + LLMClient
+    service = RuntimeRunConfig(temp_run_dir)
+
+    # User provides a route with secrets
+    user_route = StageLLMRoute(
+        provider_id="openai_compatible",
+        model="custom-model",
+        provider_options={
+            "api_key": "user-secret",
+            "base_url": "https://secret-token@proxy.com/v1",
+            "num_ctx": 8192
+        }
+    )
+    config = RuntimeLlmRouting(global_default=user_route)
+    # Normally save_config would already sanitize, but we want to test ResolvedRoute hardening
+    service.save_config(config)
+
+    router = StageModelRouter(temp_run_dir)
+    resolved = router.resolve("graph_build")
+
+    # 1. Check ResolvedRoute is clean
+    assert "api_key" not in resolved.provider_options
+    assert "base_url" not in resolved.provider_options
+    assert resolved.base_url_sanitized == "https://proxy.com/v1"
+
+    # 2. Check Snapshot on disk is clean
+    router.lock_stage("graph_build", resolved)
+    snapshot = service.load_stage_snapshot("graph_build")
+    assert "api_key" not in snapshot["provider_options"]
+    assert "base_url" not in snapshot["provider_options"]
+
+    # 3. Rebuild Client from Snapshot
+    # Since it's a custom provider, we need to make sure SecretResolver can find the base_url
+    # For "openai_compatible", it falls back to Config.LLM_BASE_URL if no other source is found.
+    # But wait, our get_base_url logic for "openai_compatible" uses global fallback.
+
+    # Let's test that it can resolve from environment if we set it there
+    with patch.dict(os.environ, {"LLM_API_KEY": "env-key", "LLM_BASE_URL": "https://env-url.com"}):
+        client = LLMClient.from_route(resolved)
+        assert client.api_key == "env-key"
+        assert client.base_url == "https://env-url.com"

--- a/docu/STATUS.md
+++ b/docu/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-11 (v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2214 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2207 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 88 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Harden LLM routing snapshots by implementing allowlist-based filtering for provider_options and enhancing SecretResolver for secure runtime URL resolution. This ensures that sensitive credentials never reach persisted artifacts while remaining available for execution.

Fixes #458

---
*PR created automatically by Jules for task [8168775006408373808](https://jules.google.com/task/8168775006408373808) started by @arn0ld87*