### PR TITLE
docs(observability): Plan-Skelette für Slices 2-4

### DIFF
--- a/docu/plans/2026-05-15-observability-slice-2-metrics.md
+++ b/docu/plans/2026-05-15-observability-slice-2-metrics.md
@@ -35,7 +35,7 @@
 ## Task 1 — Foundation `metrics.py`
 
 - [ ] **TDD:** `test_metrics.py` mit `InMemoryMetricReader`. Zwei Cases: (a) Counter-Increment landet in Reader, (b) NoOp wenn `OTEL_METRICS_ENABLED=false`.
-- [ ] `metrics.py::init_metrics(service_name)` analog zu `init_tracing`. Module-Cache, OTLP-gRPC-Exporter, `PeriodicExportingMetricReader(export_interval_millis=10_000)`.
+- [ ] metrics.py::init_metrics(service_name) analog zu init_tracing. Module-Cache, OTLP-gRPC-Exporter, PeriodicExportingMetricReader(export_interval_millis=10_000). Hinweis: force_flush() für Runner-Scripts einplanen.
 - [ ] Helper-Factories: `sim_counter()`, `sim_duration_histogram()`, `sim_active_gauge()`, `bus_event_drop_counter()`, `llm_token_counter()`.
 - [ ] Test grün, Commit.
 

--- a/docu/plans/2026-05-15-observability-slice-2-metrics.md
+++ b/docu/plans/2026-05-15-observability-slice-2-metrics.md
@@ -1,0 +1,76 @@
+# Observability Slice 2 — Metrics-Pipeline
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` oder `superpowers:executing-plans`.
+
+**Status:** Plan, Implementation offen. Baut auf Slice 1 (Tracing) auf. Trigger frühestens nach 2026-05-22.
+
+**Goal:** Sim-Lifecycle und kritische Backend-Pfade emittieren OpenTelemetry-Metrics (Counter, Histogram, UpDownCounter) parallel zu den existierenden Spans. SigNoz zeigt Sim-Latenz-Histogramm, Error-Rate, Active-Sim-Gauge und LLM-Token-Verbrauch in einem Dashboard.
+
+**Architecture:** OTLP-Metrics-Exporter über den existierenden Collector (Slice 1a). ClickHouse-Backend von SigNoz unterstützt Metrics nativ. Frontend bekommt einen einfachen Counter für Stream-Reconnects.
+
+**Tech Stack:** `opentelemetry-sdk` (Metrics-Provider), `opentelemetry-exporter-otlp-proto-grpc` (bereits aus Slice 1b), neues Modul `backend/app/observability/metrics.py`. Default-Off via `OTEL_METRICS_ENABLED=false`.
+
+**Aufwand:** ~3–4 Tage in 3 Sub-Slices.
+
+---
+
+## File Structure
+
+### Neu
+- `backend/app/observability/metrics.py` — `init_metrics(service_name)` + Helper für die 4 Hot-Counter.
+- `backend/tests/observability/test_metrics.py` — InMemoryMetricReader-Smoke + Counter-Increment-Roundtrip.
+- `deploy/observability/signoz-dashboard-sim-overview.json` — exportierbares Dashboard-JSON.
+
+### Modify
+- `backend/pyproject.toml` — Dep `opentelemetry-sdk` (Metrics ist im selben Paket, kein Extra).
+- `backend/app/observability/__init__.py` — Re-Export `init_metrics`.
+- `backend/app/__init__.py` — `init_metrics()` neben `init_tracing()`.
+- `backend/app/services/simulation_runner.py` — `sim_started` (Counter), `sim_duration_seconds` (Histogram), `sim_active` (UpDownCounter).
+- `backend/app/services/event_bus_redis.py` — `bus_events_dropped_total` (Counter mit `reason`-Label) für KeyError/JSONDecodeError-Pfad.
+- `backend/app/utils/llm_client.py` — `llm_tokens_total` (Counter mit `provider`, `model`, `direction`-Labels).
+- `.env.example` — `OTEL_METRICS_ENABLED`.
+
+---
+
+## Task 1 — Foundation `metrics.py`
+
+- [ ] **TDD:** `test_metrics.py` mit `InMemoryMetricReader`. Zwei Cases: (a) Counter-Increment landet in Reader, (b) NoOp wenn `OTEL_METRICS_ENABLED=false`.
+- [ ] `metrics.py::init_metrics(service_name)` analog zu `init_tracing`. Module-Cache, OTLP-gRPC-Exporter, `PeriodicExportingMetricReader(export_interval_millis=10_000)`.
+- [ ] Helper-Factories: `sim_counter()`, `sim_duration_histogram()`, `sim_active_gauge()`, `bus_event_drop_counter()`, `llm_token_counter()`.
+- [ ] Test grün, Commit.
+
+## Task 2 — Verdrahtung in Sim-Lifecycle
+
+- [ ] In `simulation_runner.py` an den FSM-Übergängen `PENDING → RUNNING` und `RUNNING → DONE|FAILED`:
+  - `sim_counter().add(1, {"status": "started"|"done"|"failed"})`
+  - `sim_active_gauge().add(+1 | -1)`
+  - `sim_duration_histogram().record(elapsed_seconds, {"status": ...})`
+- [ ] In `event_bus_redis.py::_subscribe_live`-Except-Block: `bus_event_drop_counter().add(1, {"reason": "decode_error" | "schema_error"})`.
+- [ ] In `llm_client.py`: nach jeder erfolgreichen `chat()`-/`chat_json()`-Antwort `llm_token_counter().add(prompt_tokens, {"direction": "in"})` und analog für `completion_tokens`.
+
+## Task 3 — Dashboard + Worklog
+
+- [ ] SigNoz-Dashboard `Sim Overview` (Panels: Active-Sim-Gauge, p50/p95/p99-Duration, Started/Done/Failed-Rate, Drop-Counter-Sparkline, Token-Verbrauch nach Provider).
+- [ ] Export als `signoz-dashboard-sim-overview.json`, in `deploy/observability/` versionieren.
+- [ ] Worklog `docu/2026-05-XX-observability-slice-2-worklog.md`.
+- [ ] STATUS.md ergänzen, `scripts/sync-status.sh` ausführen.
+- [ ] **Ein PR**, analog Slice 1.
+
+---
+
+## Akzeptanzkriterien
+
+1. `OTEL_METRICS_ENABLED=false`: keine Metric-Emission, Sim-Performance unverändert.
+2. `OTEL_METRICS_ENABLED=true`: SigNoz-UI zeigt nach einer Sim mindestens diese vier Series: `agora.sim.started`, `agora.sim.duration_seconds`, `agora.bus.events.dropped`, `agora.llm.tokens`.
+3. Backend pytest grün, kein Bestehender Test gebrochen.
+4. Dashboard-JSON in Repo versioniert, lokaler Import in SigNoz testbar.
+
+---
+
+## Risk Register
+
+| Risiko | Wahrscheinlichkeit | Gegenmaßnahme |
+|---|---|---|
+| PeriodicExportingMetricReader Memory unter gevent | Niedrig | Export-Interval = 10s konservativ; Daten gehen über lokalen Collector, kein Backpressure |
+| LLM-Token-Counter doppelt gezählt bei Retry | Mittel | Nur in erfolgreichem Antwort-Pfad incrementieren, nicht im Retry-Loop |
+| Cardinality-Explosion bei Labels | Niedrig | Keine `simulation_id` als Label, nur Status/Provider/Model |

--- a/docu/plans/2026-05-15-observability-slice-3-logs-correlation.md
+++ b/docu/plans/2026-05-15-observability-slice-3-logs-correlation.md
@@ -61,4 +61,4 @@
 |---|---|---|
 | Doppelte Log-Formatter überschreiben sich | Mittel | Logger-Hierarchie + idempotenter Setup mit Module-Cache |
 | Subprocess-Logs verlieren `trace_id` | Mittel | `init_runner_logging` muss nach `init_runner_tracing` laufen, da Tracer-Context-Propagation Voraussetzung ist |
-| JSON-Logs brechen `tail -f`-Workflow | Niedrig | Pretty-Print-Toggle via `LOG_FORMAT=text\|json`, Default für Dev = `text` |
+| JSON-Logs brechen tail -f-Workflow | Niedrig | LOG_FORMAT=text\|json Toggle; bei OTEL_LOGS_ENABLED=true JSON erzwingen |

--- a/docu/plans/2026-05-15-observability-slice-3-logs-correlation.md
+++ b/docu/plans/2026-05-15-observability-slice-3-logs-correlation.md
@@ -1,0 +1,64 @@
+# Observability Slice 3 — Logs-Korrelation via trace_id
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` oder `superpowers:executing-plans`.
+
+**Status:** Plan, Implementation offen. Baut auf Slice 1 + 2 auf. Trigger nach Slice 2.
+
+**Goal:** Jeder Python-Log-Eintrag im Sim-Pfad trägt im JSON-Format das aktuelle `trace_id` und `span_id`. SigNoz-Logs-Ansicht zeigt für jeden Trace alle korrelierten Logs auf einen Klick. Existierender `app.logger`-Aufrufstil bleibt unverändert.
+
+**Architecture:** `LoggingInstrumentor` aus `opentelemetry-instrumentation-logging` patcht den Root-Logger so, dass `trace_id` / `span_id` als LogRecord-Attribute landen. Custom `JSONFormatter` (oder `python-json-logger`) gibt JSON aus, das vom OTel-Collector via filelog-receiver oder direkt vom Backend via OTLP-Logs-Exporter zu SigNoz geht.
+
+**Tech Stack:** `opentelemetry-instrumentation-logging`, `python-json-logger` (oder eigener `logging.Formatter`), `opentelemetry-sdk._logs` + `opentelemetry-exporter-otlp-proto-grpc` für OTLP-Logs.
+
+**Aufwand:** ~3 Tage in 2 Sub-Slices.
+
+---
+
+## File Structure
+
+### Neu
+- `backend/app/observability/logging_bridge.py` — `init_logging(service_name)` + `JsonTraceFormatter`.
+- `backend/tests/observability/test_logging_bridge.py` — Roundtrip: `app.logger.info("test")` innerhalb eines Spans erzeugt JSON-LogRecord mit korrektem `trace_id`.
+- `deploy/observability/otel-collector-logs.yaml` oder Erweiterung von `otel-collector.yaml` mit filelog-Receiver.
+
+### Modify
+- `backend/pyproject.toml` — neue Deps.
+- `backend/app/observability/__init__.py` — Re-Export.
+- `backend/app/__init__.py` — `init_logging(service_name)` direkt nach `init_tracing`.
+- `backend/scripts/_sim_common.py` — `init_runner_logging` analog zu `init_runner_tracing`.
+- `.env.example` — `OTEL_LOGS_ENABLED`.
+
+---
+
+## Task 1 — Foundation `logging_bridge.py`
+
+- [ ] **TDD:** Test, der innerhalb eines aktiven Spans `logger.info("hello")` ruft und prüft, dass die geparste JSON-Zeile `trace_id` + `span_id` enthält.
+- [ ] `JsonTraceFormatter` mit Feldern: `timestamp`, `level`, `logger`, `message`, `trace_id`, `span_id`, `service.name`. Format ist eine JSON-Zeile pro Record.
+- [ ] `LoggingInstrumentor().instrument(set_logging_format=False)` (eigener Formatter ist vorrangig).
+- [ ] OTLP-Logs-Exporter über bestehenden Collector (zusätzlicher Pipeline-Block `logs` in `otel-collector.yaml`).
+
+## Task 2 — Verdrahtung + Dashboard
+
+- [ ] Alle bestehenden `print(...)`-Stellen in Prod-Code auf `logger.info|warning|error` umstellen (siehe CLAUDE.md-Verbot von `print`). Falls Stellen außerhalb des Sim-Pfads betroffen sind: aus dem Scope nehmen und als TODO in Worklog.
+- [ ] Runner-Scripts `run_*_simulation.py` bekommen `init_runner_logging("agora-oasis-runner")` direkt nach `init_runner_tracing`.
+- [ ] SigNoz-Dashboard-Panel: „Logs für aktuellen Trace" als Deep-Link aus dem SimDetail-Panel (Slice 1e) wiederverwendet (`http://localhost:3301/logs?traceID=<id>`).
+- [ ] Worklog + STATUS.md + `sync-status.sh` + Single PR.
+
+---
+
+## Akzeptanzkriterien
+
+1. `OTEL_LOGS_ENABLED=false`: Logs gehen weiter an stdout im bisherigen Format (kein Bruch).
+2. `OTEL_LOGS_ENABLED=true`: Logs sind JSON, enthalten `trace_id`/`span_id` und sind in SigNoz unter „Logs" suchbar.
+3. SimDetail-Panel-Trace-Link zeigt auf Wunsch auch die Logs für diesen Trace.
+4. Kein `print()` mehr im Prod-Code-Pfad, der vom Sim-Lifecycle berührt wird.
+
+---
+
+## Risk Register
+
+| Risiko | Wahrscheinlichkeit | Gegenmaßnahme |
+|---|---|---|
+| Doppelte Log-Formatter überschreiben sich | Mittel | Logger-Hierarchie + idempotenter Setup mit Module-Cache |
+| Subprocess-Logs verlieren `trace_id` | Mittel | `init_runner_logging` muss nach `init_runner_tracing` laufen, da Tracer-Context-Propagation Voraussetzung ist |
+| JSON-Logs brechen `tail -f`-Workflow | Niedrig | Pretty-Print-Toggle via `LOG_FORMAT=text\|json`, Default für Dev = `text` |

--- a/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
+++ b/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
@@ -68,7 +68,7 @@
 | Risiko | Wahrscheinlichkeit | Gegenmaßnahme |
 |---|---|---|
 | Alert-Fatigue durch zu strenge Burn-Rate-Schwellen | Mittel | Multi-Window-Multi-Burnrate nach SRE-Workbook (kurz UND lang müssen feuern) |
-| Webhook ohne Auth-Token | Hoch lokal, niedrig prod | Im ADR Token-Anforderung notieren, in `docker-compose.observability.yml` Default-Off |
+| Webhook ohne Auth-Token | Hoch lokal, niedrig prod | Token-Anforderung notieren; host.docker.internal für lokale Tests nutzen |
 | ClickHouse-Query-Last bei vielen Rules | Niedrig | Rule-Cardinality begrenzen, kein `simulation_id`-Label |
 
 ---

--- a/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
+++ b/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
@@ -1,0 +1,80 @@
+# Observability Slice 4 — SLOs + Burn-Rate-Alerts
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` oder `superpowers:executing-plans`.
+
+**Status:** Plan, Implementation offen. Setzt Slice 1 + 2 + 3 voraus.
+
+**Goal:** Vier SLOs (Service Level Objectives) für Agora definiert, mit Burn-Rate-Alerts in SigNoz Alertmanager. Wenn ein SLO innerhalb von 5 min mit ≥ 14.4× Burn-Rate verletzt wird, schickt SigNoz einen Alert (lokal: Webhook → Notification; mittelfristig: Slack/Telegram).
+
+**Architecture:** SigNoz-Alertmanager (bereits in `docker-compose.observability.yml` aus Slice 1a). Alert-Rules werden als YAML versioniert. Zwei Burn-Rate-Fenster: kurz (5 min, 14.4×) und lang (1 h, 6×) — Multi-Window-Multi-Burnrate nach Google-SRE-Workbook.
+
+**Tech Stack:** SigNoz Alertmanager + YAML-Rules, keine neuen Python-Deps. Optional: `signoz-cli` für Rules-Sync, falls man API benutzen will.
+
+**Aufwand:** ~2 Tage in 2 Sub-Slices.
+
+---
+
+## SLOs (Definitionen)
+
+| SLO | Indicator | Objective | Datenquelle |
+|---|---|---|---|
+| Sim-Erfolgsrate | `1 - rate(agora_sim_started{status="failed"}) / rate(agora_sim_started)` | ≥ 95 % über 7 Tage | Slice 2 Counter |
+| Sim-Latenz p95 | `histogram_quantile(0.95, agora_sim_duration_seconds_bucket)` | ≤ 90 s (Stub-Mode 30 s) | Slice 2 Histogram |
+| Backend-Verfügbarkeit | `1 - rate(http_server_duration_seconds_count{status_code=~"5.."}) / rate(http_server_duration_seconds_count)` | ≥ 99 % über 7 Tage | Flask-Auto-Instrumentation aus Slice 1b |
+| Bus-Event-Loss | `rate(agora_bus_events_dropped_total)` | ≤ 0.1 events/s über 1 h | Slice 2 Counter |
+
+---
+
+## File Structure
+
+### Neu
+- `deploy/observability/alerts/sim-success-rate-slo.yaml`
+- `deploy/observability/alerts/sim-latency-p95-slo.yaml`
+- `deploy/observability/alerts/backend-availability-slo.yaml`
+- `deploy/observability/alerts/bus-event-loss-slo.yaml`
+- `docu/decisions/0003-observability-slos.md` — ADR mit Begründungen + Stakeholder-Kontext.
+
+### Modify
+- `docker-compose.observability.yml` — Alert-Rules-Volume-Mount in `signoz-alertmanager`.
+- `deploy/observability/README.md` — Abschnitt „Alerts und SLOs", Webhook-Setup-Hinweis.
+
+---
+
+## Task 1 — SLO-Rules + ADR
+
+- [ ] ADR `0003-observability-slos.md` schreiben. Begründung pro SLO: warum dieser Objective-Wert, welcher Stakeholder hat ihn definiert, was passiert bei Verletzung.
+- [ ] Vier Alert-Rule-YAMLs nach SigNoz-Schema (Promtool-kompatibel). Jeweils zwei Rules: `burnrate_5m_short` und `burnrate_1h_long`.
+- [ ] Volume-Mount im `docker-compose.observability.yml` ergänzen.
+
+## Task 2 — Webhook + Smoke + Worklog
+
+- [ ] Lokaler Webhook-Receiver (`scripts/dev/alert-webhook.py` mit Flask, druckt eingehende Alerts auf stdout) als Smoke-Empfänger.
+- [ ] Smoke: artificial Failure produzieren (z. B. Sim mit invalidem Provider triggern), 5 min warten, prüfen ob Burn-Rate-Alert feuert.
+- [ ] Worklog + STATUS.md + `sync-status.sh` + Single PR.
+
+---
+
+## Akzeptanzkriterien
+
+1. Vier YAML-Rules sind im Repo versioniert, Promtool-validiert.
+2. SigNoz Alertmanager lädt die Rules ohne Parse-Errors (`docker logs signoz-alertmanager`).
+3. Artificial Failure-Smoke erzeugt einen Burn-Rate-Alert binnen 5 min.
+4. ADR-0003 dokumentiert die SLOs und Eskalationspfad.
+
+---
+
+## Risk Register
+
+| Risiko | Wahrscheinlichkeit | Gegenmaßnahme |
+|---|---|---|
+| Alert-Fatigue durch zu strenge Burn-Rate-Schwellen | Mittel | Multi-Window-Multi-Burnrate nach SRE-Workbook (kurz UND lang müssen feuern) |
+| Webhook ohne Auth-Token | Hoch lokal, niedrig prod | Im ADR Token-Anforderung notieren, in `docker-compose.observability.yml` Default-Off |
+| ClickHouse-Query-Last bei vielen Rules | Niedrig | Rule-Cardinality begrenzen, kein `simulation_id`-Label |
+
+---
+
+## Out of Scope
+
+- Pager-Duty / On-Call-Schedule — Solo-Setup, manueller Slack/Telegram-Ping reicht.
+- Anomaly-Detection — Slice 5 (möglicherweise mit lokalem LLM via Ollama).
+- Long-Term-Retention von Metrics jenseits SigNoz-Default — kommt mit Production-Slice.

--- a/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
+++ b/docu/plans/2026-05-15-observability-slice-4-slos-alerts.md
@@ -18,7 +18,7 @@
 
 | SLO | Indicator | Objective | Datenquelle |
 |---|---|---|---|
-| Sim-Erfolgsrate | `1 - rate(agora_sim_started{status="failed"}) / rate(agora_sim_started)` | ≥ 95 % über 7 Tage | Slice 2 Counter |
+| Sim-Erfolgsrate | 1 - (rate(agora_sim_started{status="failed"}) / rate(agora_sim_started) or vector(0)) | ≥ 95 % über 7 Tage | Slice 2 Counter |
 | Sim-Latenz p95 | `histogram_quantile(0.95, agora_sim_duration_seconds_bucket)` | ≤ 90 s (Stub-Mode 30 s) | Slice 2 Histogram |
 | Backend-Verfügbarkeit | `1 - rate(http_server_duration_seconds_count{status_code=~"5.."}) / rate(http_server_duration_seconds_count)` | ≥ 99 % über 7 Tage | Flask-Auto-Instrumentation aus Slice 1b |
 | Bus-Event-Loss | `rate(agora_bus_events_dropped_total)` | ≤ 0.1 events/s über 1 h | Slice 2 Counter |


### PR DESCRIPTION
## Summary

Drei Plan-Skelette als Folge auf das gerade gemergte Observability-Slice 1 (PR #468):

- **Slice 2 Metrics** ([`docu/plans/2026-05-15-observability-slice-2-metrics.md`](docu/plans/2026-05-15-observability-slice-2-metrics.md)) — OpenTelemetry-Metrics über den existierenden Collector. Vier Hot-Counter (sim_started/duration_histogram/bus_event_drops/llm_tokens) + SigNoz-Dashboard. ~3–4 Tage in 3 Sub-Slices.
- **Slice 3 Logs-Korrelation** ([`...-slice-3-logs-correlation.md`](docu/plans/2026-05-15-observability-slice-3-logs-correlation.md)) — JSON-LogRecords mit `trace_id`/`span_id` via `LoggingInstrumentor`. ~3 Tage in 2 Sub-Slices.
- **Slice 4 SLOs + Burn-Rate-Alerts** ([`...-slice-4-slos-alerts.md`](docu/plans/2026-05-15-observability-slice-4-slos-alerts.md)) — vier SLOs mit Multi-Window-Multi-Burnrate nach SRE-Workbook. ~2 Tage in 2 Sub-Slices.

Default-Off bleibt Prinzip durch alle Slices (`OTEL_METRICS_ENABLED`, `OTEL_LOGS_ENABLED`).

## Was das nicht ist

- Keine Implementierung. Nur Pläne. Implementations-PRs folgen separat, einer pro Slice.
- Keine Bindung an Termine. Trigger nach Bedarf.

## Test plan

- [x] Drei Plan-Files im Repo verlinkt von keinem anderen Plan, also kein Sync-Drift möglich.
- [ ] Manuelle Sichtung durch User: passt die Slice-Aufteilung, sind die Aufwände realistisch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)