### PR TITLE
fix(observability): zookeeper auf offizielles Image (bitnami-Tag weg)

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -11,12 +11,16 @@ services:
       - "127.0.0.1:9000:9000"
 
   signoz-zookeeper:
-    image: bitnami/zookeeper:3.7.1
+    # bitnami/zookeeper:3.7.1 wurde Mitte 2025 nach Bitnami-Strategiewechsel
+    # vom Docker Hub entfernt. Offizielles Apache-Image als Drop-in-Ersatz.
+    image: zookeeper:3.9
     profiles: ["observability"]
     environment:
-      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok,stat"
+      ZOO_STANDALONE_ENABLED: "true"
     volumes:
-      - signoz-zookeeper-data:/bitnami/zookeeper
+      - signoz-zookeeper-data:/data
+      - signoz-zookeeper-datalog:/datalog
 
   signoz-query-service:
     image: signoz/query-service:0.51.0
@@ -56,4 +60,5 @@ services:
 volumes:
   signoz-clickhouse-data:
   signoz-zookeeper-data:
+  signoz-zookeeper-datalog:
   signoz-query-data:


### PR DESCRIPTION
## Summary

\`bitnami/zookeeper:3.7.1\` wurde Mitte 2025 nach Bitnami-Strategiewechsel vom Docker Hub entfernt — Pull-Versuch failed mit \`not found\`. Damit war \`docker compose -f docker-compose.observability.yml --profile observability up -d\` aus Slice 1a (PR #468) nicht mehr ausführbar.

**Fix:** offizielles \`zookeeper:3.9\` als Drop-in-Ersatz. ENV-Vars und Volume-Paths an Apache-Konvention angepasst.

## Test plan

- [x] Lokal verifiziert: alle 6 Container kommen in \`Up\`-State (clickhouse, zookeeper, query-service, frontend, alertmanager, otel-collector).
- [ ] Folge-Smoke gegen End-to-End-Trace (user-triggered, Slice 1f Test-plan-Box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)