### PR TITLE
Add Python 3.14 PR check label for risky backend changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -13,6 +14,10 @@ jobs:
   security:
     name: Security scans
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'needs-python314'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -105,6 +110,10 @@ jobs:
   backend:
     name: Backend tests + lint
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'needs-python314'
     env:
       # Tests instantiate LLMClient() directly (e.g. test_ontology_generator);
       # the constructor rejects an empty API key. No HTTP calls are made.
@@ -114,11 +123,15 @@ jobs:
       FLASK_DEBUG: "true"
     strategy:
       fail-fast: false
-      # PRs laufen nur gegen die stabile Runtime; 3.14-dev läuft auf main
-      # (sowie via workflow_dispatch), damit jeder PR-Push nicht 2x Backend
-      # bezahlt.
+      # PRs laufen standardmäßig nur gegen die stabile Runtime (3.11).
+      # 3.14-dev läuft auf main, via workflow_dispatch oder in PRs mit dem Label 'needs-python314'.
       matrix:
-        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.11"]') || fromJSON('["3.11", "3.14-dev"]') }}
+        python-version: >-
+          ${{
+            (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'needs-python314'))
+            && fromJSON('["3.11"]')
+            || fromJSON('["3.11", "3.14-dev"]')
+          }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -167,6 +180,10 @@ jobs:
   frontend:
     name: Frontend build + lint
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'needs-python314'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -212,6 +229,10 @@ jobs:
   status-sync:
     name: STATUS.md drift check (MAI-16)
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'needs-python314'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Status: **v1.0.0 (2026-05-11)** · alle 14 PR-Slices der v1.0-Output-Vertrag-Roa
 ## Sofort wichtig
 
 - **Tool-Reihenfolge ist Pflicht** (Details § Tool-Pflicht): `code-review-graph::get_minimal_context_tool` → `context7::resolve-library-id`+`query-docs` → `sequential-thinking` → `context-mode` → **erst dann** `Read`/`rg`/`Bash`. Überspringen kostet Tokens und produziert Halluzinationen. Skip → eine Zeile im Worklog warum.
-- **Branch-Hygiene:** Nie auf `main` direkt pushen. Branch-Namen: `feat/task-XX-kurztitel`. Linear-FF-Merge auf main, keine Rewrites publizierter Commits.
+- **Branch-Hygiene:** Nie auf `main` direkt pushen. Branch-Namen: `feat/task-XX-kurztitel`. Riskante Backend-Änderungen: Label `needs-python314` setzen. Linear-FF-Merge auf main, keine Rewrites publizierter Commits.
 - **Tests sind die Spec.** Pflichttests vor Refactor lesen. TDD: erst RED, dann GREEN, dann Commit.
 - **Pakete unter Linux:** `nala` statt `apt`. Python-Deps via `uv`.
 - **Layer-Reihenfolge ist verbindlich** (siehe unten).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Status: **v1.0.0 (2026-05-11)** · alle 14 PR-Slices der v1.0-Output-Vertrag-Roa
 ## Sofort wichtig
 
 - **Tool-Reihenfolge ist Pflicht** (Details § Tool-Pflicht): `code-review-graph::get_minimal_context_tool` → `context7::resolve-library-id`+`query-docs` → `sequential-thinking` → `context-mode` → **erst dann** `Read`/`rg`/`Bash`. Überspringen kostet Tokens und produziert Halluzinationen. Skip → eine Zeile im Worklog warum.
-- **Branch-Hygiene:** Nie auf `main` direkt pushen. Branch-Namen: `feat/task-XX-kurztitel`. Riskante Backend-Änderungen: Label `needs-python314` setzen. Linear-FF-Merge auf main, keine Rewrites publizierter Commits.
+- **Branch-Hygiene:** Nie auf main direkt pushen. Branch-Namen: `feat/task-XX-kurztitel`. Riskante Backend-Änderungen: Label `needs-python314` setzen. Linear-FF-Merge auf main, keine Rewrites publizierter Commits.
 - **Tests sind die Spec.** Pflichttests vor Refactor lesen. TDD: erst RED, dann GREEN, dann Commit.
 - **Pakete unter Linux:** `nala` statt `apt`. Python-Deps via `uv`.
 - **Layer-Reihenfolge ist verbindlich** (siehe unten).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Agora ist ein experimenteller Open-Source-Fork unter AGPL-3.0. Diese Datei erkl�
 
 ## Branch- und PR-Hygiene
 
-1. **Nie auf `main` direkt pushen.** Branch-Name-Format: `feat/<task-scope>-<kurztitel>` (z.B. `feat/layer-meta-slice-44-doku-sync`).
+1. **Nie auf `main` direkt pushen.** Branch-Name-Format: `feat/<task-scope>-<kurztitel>` (z.B. `feat/layer-meta-slice-44-doku-sync`). Riskante Backend-Änderungen sollten mit dem Label `needs-python314` markiert werden, um den CI-Check gegen Python 3.14-dev zu triggern.
 
 2. **Nach `gh pr create` warten auf Gemini-Code-Assist Review** (~60–120 s). Workflow:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Agora ist ein experimenteller Open-Source-Fork unter AGPL-3.0. Diese Datei erkl�
 
 ## Branch- und PR-Hygiene
 
-1. **Nie auf `main` direkt pushen.** Branch-Name-Format: `feat/<task-scope>-<kurztitel>` (z.B. `feat/layer-meta-slice-44-doku-sync`). Riskante Backend-Änderungen sollten mit dem Label `needs-python314` markiert werden, um den CI-Check gegen Python 3.14-dev zu triggern.
+1. **Nie auf main direkt pushen.** Branch-Name-Format: `feat/<task-scope>-<kurztitel>` (z.B. `feat/layer-meta-slice-44-doku-sync`). Riskante Backend-Änderungen sollten mit dem Label `needs-python314` markiert werden, um den CI-Check gegen Python 3.14-dev zu triggern.
 
 2. **Nach `gh pr create` warten auf Gemini-Code-Assist Review** (~60–120 s). Workflow:
    ```bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ PDF wird ausschließlich über den Browser-Print-Dialog erzeugt — Button „Al
 - **Drei Vertrauensmodi**: `strict` (nur belegte Claims, harter Anchor-Validator), `balanced` (Default — belegte Claims + markierte Hypothesen), `explorative` (alles durch, EXPLORATIVE-Modus). Frontend-Selektor mit localStorage-Persistenz und i18n.
 - **Export-Vollständigkeit**: Markdown, JSON, CSV (Personas/Segmente/Claims, RFC-4180), ZIP-Bundle (serverseitig via Python-stdlib, kein jszip), Browser-Print-PDF.
 - **Live-Settings**: `GET`/`PUT /api/settings` mit Pydantic-Validierung, Secret-Redaction, `settings.changed`-Event-Bus. Services lesen via `settings_layer.get_*()` — Live-Übernahme ohne Container-Restart (`AGORA_PARALLEL_PERSONA_COUNT`, `AGORA_PERSONA_DETAIL_LEVEL`, `ONTOLOGY_MAX_TOKENS`).
-- **CI-Hardening**: `step-security/harden-runner` (audit-mode) in 9 Workflows, `aquasecurity/trivy-action` für Container-Scans, `ossf/scorecard-action` für Supply-Chain-Score.
+- **CI-Hardening**: `step-security/harden-runner` (audit-mode) in 9 Workflows, `aquasecurity/trivy-action` für Container-Scans, `ossf/scorecard-action` für Supply-Chain-Score, optionaler Python 3.14-dev Check via PR-Label.
 - **Compare- und Diff-Stack** (aus v0.9.x übernommen): Graph-Diff, Simulation-Compare, Runs Dashboard.
 - **Production-Hardening** (aus v0.9.x übernommen): Reverse-Proxy-Sidecar, gevent, Bundle-Token-Gate, signed Tickets, Prod-Smoke auf `main`/Tags/`workflow_dispatch`.
 - **Security-Watchlist**: CVE-Monitor wöchentlich, Hardstop 2026-07-30, Dependency Risk Register mit Eskalationspfad.

--- a/docu/2026-05-15-python314-label-arbeitsprotokoll.md
+++ b/docu/2026-05-15-python314-label-arbeitsprotokoll.md
@@ -1,0 +1,26 @@
+# Arbeitsprotokoll: Python 3.14-dev PR Label Check
+
+## Ziel
+Einführung eines label-basierten CI-Checks für Python 3.14-dev in Pull Requests, um riskante Backend-Änderungen gezielt prüfen zu können, ohne die Standard-PR-Laufzeit zu erhöhen.
+
+## Befund
+- `main` und `workflow_dispatch` testen bereits Python 3.11 und 3.14-dev.
+- Pull Requests testen standardmäßig nur Python 3.11.
+- Das CI-Budget soll geschont werden, daher ist eine selektive Zuschaltung von 3.14-dev sinnvoll.
+
+## Geänderte Dateien
+- `.github/workflows/ci.yml`: Trigger erweitert um `labeled`/`unlabeled`; Job-Filter für Label-Events hinzugefügt; Matrix-Logik angepasst.
+- `README.md`: Hinweis auf den optionalen 3.14-Check unter CI-Hardening.
+- `CONTRIBUTING.md`: Erklärung des `needs-python314` Labels.
+- `CLAUDE.md`: PR-Workflow ergänzt.
+
+## Akzeptanz-Checks
+- [x] PR ohne Label: Fährt nur Python 3.11 (Matrix-Logik verifiziert).
+- [x] PR mit `needs-python314`: Fährt 3.11 + 3.14-dev (Matrix-Logik verifiziert).
+- [x] `main`/`workflow_dispatch`: Fährt weiterhin 3.11 + 3.14-dev.
+- [x] YAML-Validität: `yaml.safe_load` erfolgreich.
+- [x] Label-Filter: Andere Labels lösen keinen unnötigen Run aus.
+
+## Folgen
+- Entwickler können bei riskanten Backend-Änderungen proaktiv den 3.14-Check anfordern.
+- Transparenz über den 3.14-Status im PR-Feedback.


### PR DESCRIPTION
This PR introduces an optional Python 3.14-dev CI check for backend changes that can be triggered by adding the `needs-python314` label to a Pull Request.

By default, PRs only test against Python 3.11 to save CI costs. However, for risky backend changes, developers can now opt-in to the 3.14-dev check. The `main` branch and manual triggers continue to test both versions.

The implementation includes:
- Modification of `.github/workflows/ci.yml` to support label-based triggers.
- Job-level `if` conditions to ensure that only the `needs-python314` label triggers a re-run on label events.
- Updated documentation in `README.md`, `CONTRIBUTING.md`, and `CLAUDE.md`.
- A detailed work protocol in `docu/2026-05-15-python314-label-arbeitsprotokoll.md`.

YAML validity has been verified.

Fixes #462

---
*PR created automatically by Jules for task [5564975970214929892](https://jules.google.com/task/5564975970214929892) started by @arn0ld87*