### PR TITLE
feat: LLM-Auswahl Dropdown + Pipeline-Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ backend/.cache/
 /instance/
 backend/instance/settings.json
 backend/instance/settings.*.json.tmp
+backend/instance/active_llm_config.json
+backend/instance/.active_llm_*.tmp
 
 # Upload folder
 backend/uploads/

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -35,4 +35,5 @@ from . import status  # noqa: E402, F401
 from . import logs  # noqa: E402, F401 -- Issue #132: Backend-Log-Viewer
 from . import llm  # noqa: E402, F401 -- Slice E.1 (#213): model-active SSE stream
 from . import llm_providers  # noqa: E402, F401
+from . import llm_active  # noqa: E402, F401 -- Active provider/model selection
 from .llm_profiles import llm_profiles_bp  # noqa: E402, F401 -- P5.2: LLM-Profile CRUD

--- a/backend/app/api/llm_active.py
+++ b/backend/app/api/llm_active.py
@@ -93,11 +93,17 @@ def get_active_config():
 @llm_bp.route("/active-config", methods=["PUT"])
 @handle_api_errors(logger=logger)
 def put_active_config():
-    """Set the active provider/model selection."""
+    """Set the active provider/model selection.
+
+    Sicherheits-Hinweis: ``base_url`` wird NICHT aus dem Request-Body gelesen.
+    Sie wird ausschliesslich aus der server-seitigen Provider-Registry
+    abgeleitet, damit ein authentifizierter, aber boeswilliger Client die
+    LLM-Aufrufe nicht via SSRF-Vektor auf einen kontrollierten Host umlenken
+    kann (Gemini-Code-Assist Review PR #478).
+    """
     payload = request.get_json(silent=True) or {}
     provider_id = (payload.get("provider_id") or "").strip()
     model = (payload.get("model") or "").strip()
-    base_url = (payload.get("base_url") or "").strip() or None
 
     if not provider_id:
         return json_error("provider_id is required", status=400, code="invalid_request")
@@ -109,9 +115,6 @@ def put_active_config():
     if not provider:
         return json_error(f"Unknown provider: {provider_id}", status=404, code="provider_not_found")
 
-    if not base_url:
-        base_url = provider.base_url
-
-    saved = save_active_config(provider_id, model, base_url)
+    saved = save_active_config(provider_id, model, provider.base_url)
     logger.info("Active LLM config updated: provider=%s model=%s", provider_id, model)
     return json_success(saved)

--- a/backend/app/api/llm_active.py
+++ b/backend/app/api/llm_active.py
@@ -1,0 +1,117 @@
+"""Active LLM Config API.
+
+Persistiert die aktiv ausgewaehlte Provider/Modell-Kombination in
+``backend/instance/active_llm_config.json``. Wird von ``LLMClient``
+mit ``use_active_config=True`` gelesen, wenn kein expliziter Provider
+gesetzt ist.
+
+Endpoints:
+- GET /api/llm/active-config -> aktuelle Auswahl (oder leeres dict)
+- PUT /api/llm/active-config {"provider_id": "...", "model": "..."}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flask import request
+
+from . import llm_bp
+from ..services.llm_provider_registry import LlmProviderRegistry
+from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.api.llm_active")
+
+_provider_registry = LlmProviderRegistry()
+
+
+def _instance_dir() -> Path:
+    here = Path(__file__).resolve()
+    # backend/app/api/ -> backend/instance/
+    return here.parents[2] / "instance"
+
+
+def _config_path() -> Path:
+    return _instance_dir() / "active_llm_config.json"
+
+
+def load_active_config() -> Dict[str, Any]:
+    """Read the persisted active config; returns {} if not set."""
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read active LLM config: %s", exc)
+        return {}
+
+
+def _atomic_write(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".active_llm_", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def save_active_config(provider_id: str, model: str, base_url: Optional[str] = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "provider_id": provider_id,
+        "model": model,
+    }
+    if base_url:
+        payload["base_url"] = base_url
+    _atomic_write(_config_path(), payload)
+    return payload
+
+
+@llm_bp.route("/active-config", methods=["GET"])
+@handle_api_errors(logger=logger)
+def get_active_config():
+    """Return the active provider/model selection."""
+    cfg = load_active_config()
+    return json_success(cfg)
+
+
+@llm_bp.route("/active-config", methods=["PUT"])
+@handle_api_errors(logger=logger)
+def put_active_config():
+    """Set the active provider/model selection."""
+    payload = request.get_json(silent=True) or {}
+    provider_id = (payload.get("provider_id") or "").strip()
+    model = (payload.get("model") or "").strip()
+    base_url = (payload.get("base_url") or "").strip() or None
+
+    if not provider_id:
+        return json_error("provider_id is required", status=400, code="invalid_request")
+    if not model:
+        return json_error("model is required", status=400, code="invalid_request")
+
+    providers = _provider_registry.get_providers()
+    provider = next((p for p in providers if p.id == provider_id), None)
+    if not provider:
+        return json_error(f"Unknown provider: {provider_id}", status=404, code="provider_not_found")
+
+    if not base_url:
+        base_url = provider.base_url
+
+    saved = save_active_config(provider_id, model, base_url)
+    logger.info("Active LLM config updated: provider=%s model=%s", provider_id, model)
+    return json_success(saved)

--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -535,7 +535,8 @@ Please generate 3-5 interview questions."""
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                temperature=0.5
+                temperature=0.5,
+                max_tokens=8192,
             )
 
             return response.get("questions", [f"What is your perspective on {interview_requirement}?"])

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -33,6 +33,16 @@ _STRICT_UNSUPPORTED_HINTS = (
 )
 
 
+def _read_active_config_safely() -> Optional[Dict[str, Any]]:
+    """Load the active LLM config without raising on missing/invalid file."""
+    try:
+        from ..api.llm_active import load_active_config
+        cfg = load_active_config()
+        return cfg or None
+    except Exception:  # noqa: BLE001 — never block LLMClient construction
+        return None
+
+
 def _try_repair_truncated_json(payload: str) -> Optional[str]:
     """Best-effort recovery for an LLM JSON answer cut off at the output cap.
 
@@ -93,7 +103,44 @@ class LLMClient:
         routing_version: Optional[int] = None,
         route_stage: Optional[str] = None,
         route_provider_id: Optional[str] = None,
+        use_active_config: bool = True,
     ):
+        # When no explicit model is set, fall back to the user's active
+        # provider/model selection (Settings → LLM-Auswahl). Falls back to
+        # Config.* if no active config exists. Resolves api_key+base_url via
+        # SecretResolver/Provider-Registry analogous to from_route().
+        active_provider_id: Optional[str] = None
+        if use_active_config and model is None:
+            active = _read_active_config_safely()
+            if active:
+                active_provider_id = active.get("provider_id")
+                active_model = active.get("model")
+                active_base = active.get("base_url")
+                if active_model:
+                    model = active_model
+                if active_base and not base_url:
+                    base_url = active_base
+                if active_provider_id and not api_key:
+                    try:
+                        from ..services.llm_provider_registry import LlmProviderRegistry
+                        from ..services.secret_resolver import SecretResolver
+                        registry = LlmProviderRegistry()
+                        descriptor = next(
+                            (p for p in registry.get_providers() if p.id == active_provider_id),
+                            None,
+                        )
+                        if descriptor is not None:
+                            if not base_url:
+                                base_url = descriptor.base_url
+                            resolver = SecretResolver()
+                            api_key = resolver.get_api_key(active_provider_id, descriptor.type)
+                    except Exception as exc:  # noqa: BLE001 — fall back to Config defaults
+                        logger.warning(
+                            "Failed to resolve active LLM config (provider=%s): %s",
+                            active_provider_id,
+                            exc,
+                        )
+
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
@@ -268,19 +315,22 @@ class LLMClient:
         """Infer the LLM provider from base_url and model name.
 
         Heuristics (in priority order):
-        1. Model suffix ``:cloud`` → ``"cloud"`` (Ollama Cloud proxy).
+        1. Base URL contains ``ollama.com`` → ``"cloud"`` (Ollama Cloud proxy).
         2. Base URL contains ``11434`` → ``"ollama"`` (local Ollama).
         3. Base URL contains ``openai.com`` or ``api.openai`` → ``"openai"``.
-        4. Fallback → ``"unknown"``.
+        4. Model suffix ``:cloud`` → ``"cloud"`` (Ollama Cloud Model-Tag-Hint).
+        5. Fallback → ``"unknown"``.
         """
         model_name = self.model or ""
-        base = self.base_url or ""
-        if model_name.endswith(":cloud"):
+        base = (self.base_url or "").lower()
+        if "ollama.com" in base:
             return "cloud"
         if "11434" in base:
             return "ollama"
         if "openai.com" in base or "api.openai" in base:
             return "openai"
+        if model_name.endswith(":cloud"):
+            return "cloud"
         return "unknown"
 
     def _publish_model_active(

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -41,3 +41,19 @@ export async function patchStageLlmRouting(runId: string, stageId: string, route
   const resp = await service.patch<ApiSuccessEnvelope<RuntimeLlmRouting>>(`/api/runs/${runId}/llm-routing/stages/${stageId}`, route);
   return (resp as any).data;
 }
+
+export interface ActiveLlmConfig {
+  provider_id?: string;
+  model?: string;
+  base_url?: string;
+}
+
+export async function getActiveLlmConfig(): Promise<ActiveLlmConfig> {
+  const resp = await service.get<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config");
+  return (resp as any).data || {};
+}
+
+export async function setActiveLlmConfig(cfg: ActiveLlmConfig): Promise<ActiveLlmConfig> {
+  const resp = await service.put<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config", cfg);
+  return (resp as any).data;
+}

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -45,7 +45,13 @@ export async function patchStageLlmRouting(runId: string, stageId: string, route
 export interface ActiveLlmConfig {
   provider_id?: string;
   model?: string;
+  /** Server-managed; returned by GET, never sent by clients. */
   base_url?: string;
+}
+
+export interface ActiveLlmConfigUpdate {
+  provider_id: string;
+  model: string;
 }
 
 export async function getActiveLlmConfig(): Promise<ActiveLlmConfig> {
@@ -53,7 +59,11 @@ export async function getActiveLlmConfig(): Promise<ActiveLlmConfig> {
   return (resp as any).data || {};
 }
 
-export async function setActiveLlmConfig(cfg: ActiveLlmConfig): Promise<ActiveLlmConfig> {
-  const resp = await service.put<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config", cfg);
+export async function setActiveLlmConfig(cfg: ActiveLlmConfigUpdate): Promise<ActiveLlmConfig> {
+  const payload: ActiveLlmConfigUpdate = {
+    provider_id: cfg.provider_id,
+    model: cfg.model,
+  };
+  const resp = await service.put<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config", payload);
   return (resp as any).data;
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -810,6 +810,27 @@
       "oasis": "OASIS",
       "security": "Secrets"
     },
+    "llmActive": {
+      "tab": "LLM-Auswahl",
+      "ariaPanel": "LLM-Auswahl",
+      "title": "Aktiver LLM-Anbieter & Modell",
+      "subtitle": "Diese Auswahl wird für alle LLM-Aufrufe im Backend verwendet, sofern keine explizite Stage-Route gesetzt ist.",
+      "providerLabel": "Provider",
+      "modelLabel": "Modell",
+      "providerPlaceholder": "Provider wählen…",
+      "providerLoading": "Lade Provider…",
+      "modelPlaceholder": "Modell wählen…",
+      "modelLoading": "Lade Modelle…",
+      "modelEmpty": "Keine Modelle gefunden",
+      "modelNeedsProvider": "Erst Provider wählen",
+      "save": "Speichern",
+      "flashSaved": "Auswahl gespeichert.",
+      "errorSelectionMissing": "Bitte Provider und Modell wählen.",
+      "errorLoadProviders": "Fehler beim Laden der Provider",
+      "errorLoadModels": "Fehler beim Laden der Modelle",
+      "errorLoadActive": "Fehler beim Laden der aktiven Auswahl",
+      "errorSaveFailed": "Speichern fehlgeschlagen."
+    },
     "v4": {
       "noSections": "Keine Einstellungen in dieser Kategorie.",
       "general": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -810,6 +810,27 @@
       "oasis": "OASIS",
       "security": "Secrets"
     },
+    "llmActive": {
+      "tab": "LLM selection",
+      "ariaPanel": "LLM selection",
+      "title": "Active LLM provider & model",
+      "subtitle": "This selection is used for all backend LLM calls unless an explicit stage route overrides it.",
+      "providerLabel": "Provider",
+      "modelLabel": "Model",
+      "providerPlaceholder": "Choose provider…",
+      "providerLoading": "Loading providers…",
+      "modelPlaceholder": "Choose model…",
+      "modelLoading": "Loading models…",
+      "modelEmpty": "No models found",
+      "modelNeedsProvider": "Choose provider first",
+      "save": "Save",
+      "flashSaved": "Selection saved.",
+      "errorSelectionMissing": "Please choose provider and model.",
+      "errorLoadProviders": "Failed to load providers",
+      "errorLoadModels": "Failed to load models",
+      "errorLoadActive": "Failed to load active selection",
+      "errorSaveFailed": "Save failed."
+    },
     "v4": {
       "noSections": "No settings in this category.",
       "general": {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -54,7 +54,7 @@ async function loadLlmProviders() {
   try {
     llmProviders.value = await listLlmProviders()
   } catch (err) {
-    llmError.value = (err && err.message) || 'Fehler beim Laden der Provider'
+    llmError.value = (err && err.message) || t('settings.llmActive.errorLoadProviders')
   } finally {
     llmLoadingProviders.value = false
   }
@@ -71,7 +71,7 @@ async function loadLlmModels(providerId) {
     llmModels.value = await listProviderModels(providerId)
   } catch (err) {
     llmModels.value = []
-    llmError.value = (err && err.message) || 'Fehler beim Laden der Modelle'
+    llmError.value = (err && err.message) || t('settings.llmActive.errorLoadModels')
   } finally {
     llmLoadingModels.value = false
   }
@@ -88,7 +88,7 @@ async function loadLlmActiveConfig() {
       selectedModel.value = cfg.model
     }
   } catch (err) {
-    llmError.value = (err && err.message) || 'Fehler beim Laden der aktiven Auswahl'
+    llmError.value = (err && err.message) || t('settings.llmActive.errorLoadActive')
   }
 }
 
@@ -101,7 +101,7 @@ async function onProviderChange(providerId) {
 
 async function saveLlmActive() {
   if (!selectedProviderId.value || !selectedModel.value) {
-    llmError.value = 'Bitte Provider und Modell waehlen.'
+    llmError.value = t('settings.llmActive.errorSelectionMissing')
     return
   }
   llmSaving.value = true
@@ -112,9 +112,9 @@ async function saveLlmActive() {
       provider_id: selectedProviderId.value,
       model: selectedModel.value,
     })
-    llmFlash.value = 'Auswahl gespeichert.'
+    llmFlash.value = t('settings.llmActive.flashSaved')
   } catch (err) {
-    llmError.value = (err && err.message) || 'Speichern fehlgeschlagen.'
+    llmError.value = (err && err.message) || t('settings.llmActive.errorSaveFailed')
   } finally {
     llmSaving.value = false
   }
@@ -259,7 +259,7 @@ function sourceVariant(source) {
             :class="{ 'tab--active': isLlmActiveTab }"
             @click="setActive(LLM_ACTIVE_SECTION)"
           >
-            <span class="tab-label">LLM-Auswahl</span>
+            <span class="tab-label">{{ t('settings.llmActive.tab') }}</span>
           </button>
           <button
             v-for="section in sections"
@@ -286,19 +286,18 @@ function sourceVariant(source) {
         <section
           v-if="isLlmActiveTab"
           class="panel panel--llm-active"
-          aria-label="LLM-Auswahl"
+          :aria-label="t('settings.llmActive.ariaPanel')"
         >
           <div class="llm-active">
             <header class="llm-active__head">
-              <h2 class="llm-active__title">Aktiver LLM-Anbieter & Modell</h2>
+              <h2 class="llm-active__title">{{ t('settings.llmActive.title') }}</h2>
               <p class="llm-active__subtitle">
-                Diese Auswahl wird fuer alle LLM-Aufrufe im Backend verwendet,
-                sofern keine explizite Stage-Route gesetzt ist.
+                {{ t('settings.llmActive.subtitle') }}
               </p>
             </header>
 
             <div class="llm-active__row">
-              <label class="llm-active__label" for="llm-provider-select">Provider</label>
+              <label class="llm-active__label" for="llm-provider-select">{{ t('settings.llmActive.providerLabel') }}</label>
               <select
                 id="llm-provider-select"
                 class="input"
@@ -307,7 +306,7 @@ function sourceVariant(source) {
                 @change="onProviderChange($event.target.value)"
               >
                 <option value="" disabled>
-                  {{ llmLoadingProviders ? 'Lade Provider…' : 'Provider waehlen…' }}
+                  {{ llmLoadingProviders ? t('settings.llmActive.providerLoading') : t('settings.llmActive.providerPlaceholder') }}
                 </option>
                 <option
                   v-for="p in llmProviders"
@@ -320,7 +319,7 @@ function sourceVariant(source) {
             </div>
 
             <div class="llm-active__row">
-              <label class="llm-active__label" for="llm-model-select">Modell</label>
+              <label class="llm-active__label" for="llm-model-select">{{ t('settings.llmActive.modelLabel') }}</label>
               <select
                 id="llm-model-select"
                 class="input"
@@ -331,10 +330,10 @@ function sourceVariant(source) {
                 <option value="" disabled>
                   {{
                     !selectedProviderId
-                      ? 'Erst Provider waehlen'
+                      ? t('settings.llmActive.modelNeedsProvider')
                       : llmLoadingModels
-                        ? 'Lade Modelle…'
-                        : (llmModels.length ? 'Modell waehlen…' : 'Keine Modelle gefunden')
+                        ? t('settings.llmActive.modelLoading')
+                        : (llmModels.length ? t('settings.llmActive.modelPlaceholder') : t('settings.llmActive.modelEmpty'))
                   }}
                 </option>
                 <option
@@ -357,7 +356,7 @@ function sourceVariant(source) {
                 :disabled="!selectedProviderId || !selectedModel || llmSaving"
                 @click="saveLlmActive"
               >
-                Speichern
+                {{ t('settings.llmActive.save') }}
               </Button>
             </div>
           </div>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -12,7 +12,7 @@
 // dazukommen (z. B. Multi-Select für CORS-Origins), darf das
 // extrahiert werden.
 
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -21,13 +21,106 @@ import AppFooter from '../components/AppFooter.vue'
 import Badge from '../components/ui/Badge.vue'
 import Button from '@/components/v4/forms/Button.vue'
 import { useSettingsStore } from '../store/settings'
+import {
+  listLlmProviders,
+  listProviderModels,
+  getActiveLlmConfig,
+  setActiveLlmConfig,
+} from '../api/llmRouting'
+
+const LLM_ACTIVE_SECTION = '__llm_active__'
 
 const { t } = useI18n()
 const router = useRouter()
 const settingsStore = useSettingsStore()
 const { sections, schema, fields, dirtyKeys, dirtySectionFlags } = storeToRefs(settingsStore)
 
-const activeSection = ref('llm')
+const activeSection = ref(LLM_ACTIVE_SECTION)
+
+// --- LLM-Auswahl (dedicated panel) ----------------------------------------
+const llmProviders = ref([])
+const llmModels = ref([])
+const selectedProviderId = ref('')
+const selectedModel = ref('')
+const llmLoadingProviders = ref(false)
+const llmLoadingModels = ref(false)
+const llmSaving = ref(false)
+const llmError = ref('')
+const llmFlash = ref('')
+
+async function loadLlmProviders() {
+  llmLoadingProviders.value = true
+  llmError.value = ''
+  try {
+    llmProviders.value = await listLlmProviders()
+  } catch (err) {
+    llmError.value = (err && err.message) || 'Fehler beim Laden der Provider'
+  } finally {
+    llmLoadingProviders.value = false
+  }
+}
+
+async function loadLlmModels(providerId) {
+  if (!providerId) {
+    llmModels.value = []
+    return
+  }
+  llmLoadingModels.value = true
+  llmError.value = ''
+  try {
+    llmModels.value = await listProviderModels(providerId)
+  } catch (err) {
+    llmModels.value = []
+    llmError.value = (err && err.message) || 'Fehler beim Laden der Modelle'
+  } finally {
+    llmLoadingModels.value = false
+  }
+}
+
+async function loadLlmActiveConfig() {
+  try {
+    const cfg = await getActiveLlmConfig()
+    if (cfg && cfg.provider_id) {
+      selectedProviderId.value = cfg.provider_id
+      await loadLlmModels(cfg.provider_id)
+    }
+    if (cfg && cfg.model) {
+      selectedModel.value = cfg.model
+    }
+  } catch (err) {
+    llmError.value = (err && err.message) || 'Fehler beim Laden der aktiven Auswahl'
+  }
+}
+
+async function onProviderChange(providerId) {
+  selectedProviderId.value = providerId
+  selectedModel.value = ''
+  llmFlash.value = ''
+  await loadLlmModels(providerId)
+}
+
+async function saveLlmActive() {
+  if (!selectedProviderId.value || !selectedModel.value) {
+    llmError.value = 'Bitte Provider und Modell waehlen.'
+    return
+  }
+  llmSaving.value = true
+  llmError.value = ''
+  llmFlash.value = ''
+  try {
+    await setActiveLlmConfig({
+      provider_id: selectedProviderId.value,
+      model: selectedModel.value,
+    })
+    llmFlash.value = 'Auswahl gespeichert.'
+  } catch (err) {
+    llmError.value = (err && err.message) || 'Speichern fehlgeschlagen.'
+  } finally {
+    llmSaving.value = false
+  }
+}
+
+const isLlmActiveTab = computed(() => activeSection.value === LLM_ACTIVE_SECTION)
 const showSecretsModal = ref(false)
 const flashMessage = ref('')
 
@@ -51,6 +144,15 @@ onMounted(async () => {
     await settingsStore.connectStream()
   } catch {
     // Fehler steht bereits im Store; UI zeigt loadError-Banner.
+  }
+  await loadLlmProviders()
+  await loadLlmActiveConfig()
+})
+
+watch(activeSection, (next) => {
+  if (next === LLM_ACTIVE_SECTION) {
+    llmFlash.value = ''
+    llmError.value = ''
   }
 })
 
@@ -150,6 +252,16 @@ function sourceVariant(source) {
       <div v-if="!settingsStore.loading && sections.length" class="settings-body">
         <nav class="tabs" role="tablist" :aria-label="t('settings.ariaTablist')">
           <button
+            type="button"
+            role="tab"
+            :aria-selected="isLlmActiveTab"
+            class="tab"
+            :class="{ 'tab--active': isLlmActiveTab }"
+            @click="setActive(LLM_ACTIVE_SECTION)"
+          >
+            <span class="tab-label">LLM-Auswahl</span>
+          </button>
+          <button
             v-for="section in sections"
             :key="section"
             type="button"
@@ -171,7 +283,91 @@ function sourceVariant(source) {
           </button>
         </nav>
 
-        <section class="panel" :aria-label="t('settings.ariaSection', { section: sectionLabel(activeSection) })">
+        <section
+          v-if="isLlmActiveTab"
+          class="panel panel--llm-active"
+          aria-label="LLM-Auswahl"
+        >
+          <div class="llm-active">
+            <header class="llm-active__head">
+              <h2 class="llm-active__title">Aktiver LLM-Anbieter & Modell</h2>
+              <p class="llm-active__subtitle">
+                Diese Auswahl wird fuer alle LLM-Aufrufe im Backend verwendet,
+                sofern keine explizite Stage-Route gesetzt ist.
+              </p>
+            </header>
+
+            <div class="llm-active__row">
+              <label class="llm-active__label" for="llm-provider-select">Provider</label>
+              <select
+                id="llm-provider-select"
+                class="input"
+                :value="selectedProviderId"
+                :disabled="llmLoadingProviders"
+                @change="onProviderChange($event.target.value)"
+              >
+                <option value="" disabled>
+                  {{ llmLoadingProviders ? 'Lade Provider…' : 'Provider waehlen…' }}
+                </option>
+                <option
+                  v-for="p in llmProviders"
+                  :key="p.id"
+                  :value="p.id"
+                >
+                  {{ p.label || p.id }}
+                </option>
+              </select>
+            </div>
+
+            <div class="llm-active__row">
+              <label class="llm-active__label" for="llm-model-select">Modell</label>
+              <select
+                id="llm-model-select"
+                class="input"
+                :value="selectedModel"
+                :disabled="!selectedProviderId || llmLoadingModels"
+                @change="selectedModel = $event.target.value"
+              >
+                <option value="" disabled>
+                  {{
+                    !selectedProviderId
+                      ? 'Erst Provider waehlen'
+                      : llmLoadingModels
+                        ? 'Lade Modelle…'
+                        : (llmModels.length ? 'Modell waehlen…' : 'Keine Modelle gefunden')
+                  }}
+                </option>
+                <option
+                  v-for="m in llmModels"
+                  :key="m.id"
+                  :value="m.id"
+                >
+                  {{ m.id }}{{ m.label && m.label !== m.id ? ` — ${m.label}` : '' }}
+                </option>
+              </select>
+            </div>
+
+            <p v-if="llmFlash" class="llm-active__flash">{{ llmFlash }}</p>
+            <p v-if="llmError" class="llm-active__flash llm-active__flash--error">{{ llmError }}</p>
+
+            <div class="llm-active__actions">
+              <Button
+                variant="accent"
+                :loading="llmSaving"
+                :disabled="!selectedProviderId || !selectedModel || llmSaving"
+                @click="saveLlmActive"
+              >
+                Speichern
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section
+          v-else
+          class="panel"
+          :aria-label="t('settings.ariaSection', { section: sectionLabel(activeSection) })"
+        >
           <table class="fields">
             <thead>
               <tr>
@@ -260,7 +456,7 @@ function sourceVariant(source) {
           </table>
         </section>
 
-        <footer class="actions">
+        <footer v-if="!isLlmActiveTab" class="actions">
           <span v-if="flashMessage" class="flash">{{ flashMessage }}</span>
           <span v-else-if="settingsStore.saveError" class="flash flash--error">
             {{ t('settings.saveFailed', { message: settingsStore.saveError }) }}
@@ -579,5 +775,74 @@ function sourceVariant(source) {
   justify-content: flex-end;
   gap: var(--s-3);
   margin-top: var(--s-5);
+}
+
+.panel--llm-active {
+  padding: var(--s-6);
+}
+.llm-active {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
+  max-width: 640px;
+}
+.llm-active__head { display: flex; flex-direction: column; gap: var(--s-2); }
+.llm-active__title {
+  margin: 0;
+  font-family: var(--ff-sans);
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+.llm-active__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: var(--fs-14);
+}
+.llm-active__row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+.llm-active__label {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: var(--ls-mono-wide);
+  text-transform: uppercase;
+  color: var(--fg-meta);
+}
+.llm-active .input {
+  width: 100%;
+  font-family: var(--ff-sans);
+  font-size: var(--fs-14);
+  height: var(--ctl-h-md);
+  padding: 0 var(--ctl-pad-x);
+  background: var(--bg-page);
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--r-pill);
+  color: var(--fg);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+.llm-active .input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.llm-active .input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.llm-active__flash {
+  margin: 0;
+  font-family: var(--ff-mono);
+  font-size: 12px;
+  letter-spacing: var(--ls-mono);
+  color: var(--fg-muted);
+}
+.llm-active__flash--error { color: var(--err); }
+.llm-active__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--s-3);
 }
 </style>

--- a/frontend/src/views/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsView.spec.ts
@@ -20,6 +20,12 @@ vi.mock('../../api/settings', () => ({
   putSettings: vi.fn(),
   putSecrets: vi.fn(),
 }))
+vi.mock('../../api/llmRouting', () => ({
+  listLlmProviders: vi.fn().mockResolvedValue([]),
+  listProviderModels: vi.fn().mockResolvedValue([]),
+  getActiveLlmConfig: vi.fn().mockResolvedValue({}),
+  setActiveLlmConfig: vi.fn().mockResolvedValue({}),
+}))
 
 import {
   fetchSettings,
@@ -118,12 +124,13 @@ describe('SettingsView', () => {
   it('rendert die Sektions-Tabs inklusive UI-Sektion aus dem Backend-Schema', async () => {
     const wrapper = await mountView()
     const tabLabels = wrapper.findAll('[role="tab"]').map((el) => el.text())
-    expect(tabLabels).toEqual(['LLM', 'UI', 'Secrets'])
+    expect(tabLabels).toEqual(['LLM-Auswahl', 'LLM', 'UI', 'Secrets'])
   })
 
   it('rendert Secret-Field als password-Input ohne Klartext', async () => {
     const wrapper = await mountView()
-    await wrapper.findAll('[role="tab"]')[2].trigger('click')
+    // Tab 0 = LLM-Auswahl (default), Tab 3 = Secrets in [LLM-Auswahl, llm, ui, security]
+    await wrapper.findAll('[role="tab"]')[3].trigger('click')
     const secretInput = wrapper.find<HTMLInputElement>('input[type="password"]')
     expect(secretInput.exists()).toBe(true)
     expect(secretInput.element.value).toBe('')
@@ -133,6 +140,8 @@ describe('SettingsView', () => {
 
   it('zeigt Inline-Validation-Hints aus dem Pinia-Store', async () => {
     const wrapper = await mountView()
+    // LLM-Auswahl-Panel hat keine Schema-Fields; auf LLM-Tab wechseln (Index 1).
+    await wrapper.findAll('[role="tab"]')[1].trigger('click')
     const store = useSettingsStore()
     store.validationErrors = [
       { key: 'LLM_MODEL_NAME', code: 'type_error', message: 'Mein Validation-Hint' },
@@ -146,6 +155,6 @@ describe('SettingsView', () => {
     const wrapper = await mountView('en')
     expect(wrapper.find('h1.title').text()).toBe('Settings')
     const tabLabels = wrapper.findAll('[role="tab"]').map((el) => el.text())
-    expect(tabLabels).toEqual(['LLM', 'UI', 'Secrets'])
+    expect(tabLabels).toEqual(['LLM selection', 'LLM', 'UI', 'Secrets'])
   })
 })


### PR DESCRIPTION
## Zusammenfassung

Einheitliches LLM-Auswahl-Dropdown in den Settings + Pipeline-Fixes für Provider-Erkennung und Token-Limits.

## Änderungen

### Backend
- **Neue API**: `GET/PUT /api/llm/active-config` in `backend/app/api/llm_active.py` — persistiert aktive Provider/Modell-Auswahl in `backend/instance/active_llm_config.json`
- **LLMClient**: Liest automatisch die aktive Config wenn kein explizites model übergeben wird (`use_active_config=True`)
- **Provider-Detection-Fix**: `_detect_provider()` erkennt jetzt `ollama.com` in der base_url → `"cloud"` statt `"unknown"`
- **max_tokens-Fix**: Interview-Questions in `graph_tools.py` von 4096 auf 8192 erhöht — behebt truncated JSON bei kimi-k2.6

### Frontend
- **SettingsView.vue**: Neuer "LLM-Auswahl" Tab (Provider-Dropdown + Modell-Dropdown + Speichern-Button)
- **llmRouting.ts**: Neue API-Funktionen `getActiveLlmConfig()` + `setActiveLlmConfig()`

## Smoke-Tests (alle ✅)
| Test | Ergebnis |
|------|----------|
| GET /health | ✅ |
| GET /api/status | ✅ |
| GET /api/llm/providers | ✅ |
| GET/PUT /api/llm/active-config | ✅ |
| GET /api/runs | ✅ |
| Frontend :5180 | ✅ |

## Commits
- 84dcb4c fix(commands-store): remove duplicate stopPolling declaration
- 485dd09 feat(llm): active provider/model config + ollama.com detection
- 4646970 feat(frontend): LLM-Auswahl panel in SettingsView