### PR TITLE
chore(observability): silence upstream warnings (sentence-transformers + camel-ai)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -9,7 +9,29 @@ import warnings
 # Must be set before all other imports
 warnings.filterwarnings("ignore", message=".*resource_tracker.*")
 
+# Upstream-Bugs / Deprecations, die wir nicht selbst beheben können.
+# Müssen VOR den Library-Imports stehen, damit der Filter beim ersten
+# Modulimport greift.
+#  - sentence-transformers < 4.1: SyntaxWarning("\g","\d","\_") in
+#    eigenen Modulen (raw-strings fehlen). Bump im uv-Override
+#    adressiert das; Filter bleibt als Defense-in-Depth.
+#  - transformers < 5.x BertSdpaSelfAttention: empfiehlt
+#    attn_implementation="eager"; OASIS lädt die Models, nicht Agora —
+#    deshalb hier nur silenced.
+warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"sentence_transformers.*")
+warnings.filterwarnings(
+    "ignore",
+    message=r".*BertSdpaSelfAttention.*scaled_dot_product_attention.*",
+)
+
 import logging  # noqa: E402
+
+# camel-ai chat_agent loggt bei jedem Multi-Message-Step eine WARNING
+# ("Multiple messages returned in `step()`"). Bei langen Sims spammt das
+# das Log. Upstream-Verhalten, nicht durch Agora-Code triggerbar — also
+# Level auf ERROR ziehen (keine Filter-Klasse nötig, weil wir den
+# Spam komplett unterdrücken).
+logging.getLogger("camel.camel.agents.chat_agent").setLevel(logging.ERROR)
 import uuid  # noqa: E402
 
 from flask import Flask, g, request  # noqa: E402

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -21,7 +21,9 @@ warnings.filterwarnings("ignore", message=".*resource_tracker.*")
 warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"sentence_transformers.*")
 warnings.filterwarnings(
     "ignore",
+    category=UserWarning,
     message=r".*BertSdpaSelfAttention.*scaled_dot_product_attention.*",
+    module=r"transformers.*",
 )
 
 import logging  # noqa: E402

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -228,4 +228,10 @@ override-dependencies = [
     # Attachment (critical, Arbitrary File Write) plus < 0.14.3 XXE.
     # camel-oasis 0.2.5 pinned 0.13.7 — Override zieht 0.18.18 trotzdem hoch.
     "unstructured>=0.18.18",
+    # sentence-transformers 3.0.0 (camel-oasis-Pin) hat drei
+    # SyntaxWarning("invalid escape sequence") in eigenen Modulen
+    # (SentenceEvaluator.py, model_card.py, DenoisingAutoEncoderLoss.py).
+    # 4.1+ liefert raw-Strings. Major-Bump 3→4 ist konservativ; 5.x
+    # bringt Transformers-v5-Compat aber zusätzliche API-Brüche.
+    "sentence-transformers>=4.1.0,<5",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -24,6 +24,7 @@ overrides = [
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=12.1.1" },
+    { name = "sentence-transformers", specifier = ">=4.1.0,<5" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "unstructured", specifier = ">=0.18.18" },
 ]
@@ -3918,21 +3919,21 @@ wheels = [
 
 [[package]]
 name = "sentence-transformers"
-version = "3.0.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
     { name = "pillow" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/c0/7051c672a48fe561decf7208cc18bbbdd4efa3323873aa1c86a3fb77fd97/sentence_transformers-3.0.0.tar.gz", hash = "sha256:52d4101654ed107a28e9fa5110fce399084b55e7838fd8256471353ddc299033", size = 174658, upload-time = "2024-05-28T11:53:39.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/84/b30d1b29ff58cfdff423e36a50efd622c8e31d7039b1a0d5e72066620da1/sentence_transformers-4.1.0.tar.gz", hash = "sha256:f125ffd1c727533e0eca5d4567de72f84728de8f7482834de442fd90c2c3d50b", size = 272420, upload-time = "2025-04-15T13:46:13.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c4/99a9386808025d5a546576243bfd3b1eb669f978b8a0e05a1253eaf89bf0/sentence_transformers-3.0.0-py3-none-any.whl", hash = "sha256:9bf851b688b796e5fb06c920921efd5e5e05ee616e85cb3026fbdfe4dcf15bf3", size = 224681, upload-time = "2024-05-28T11:53:37.037Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/1151b371f28caae565ad384fdc38198f1165571870217aedda230b9d7497/sentence_transformers-4.1.0-py3-none-any.whl", hash = "sha256:382a7f6be1244a100ce40495fb7523dbe8d71b3c10b299f81e6b735092b3b8ca", size = 345695, upload-time = "2025-04-15T13:46:12.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Räumt das Backend-Log auf, das beim Sim-Start aktuell mit drei Klassen von Upstream-Lärm zugeschüttet wird (siehe Beispielausgabe unten):

1. **`sentence-transformers` 3.0.0 → 4.1.0** via uv-override. \`SentenceEvaluator.py\` (\`\g\`), \`model_card.py\` (\`\d\`) und \`DenoisingAutoEncoderLoss.py\` (\`\_\`) sind in 4.x als raw-strings gefixt. Major-Bump 3→4 ist konservativ; 5.x bringt zusätzliche API-Brüche — abwarten bis \`transformers\` selbst stabilisiert ist.
2. **`warnings.filterwarnings`** in \`app/__init__.py\` vor dem ersten Library-Import — als Defense-in-Depth für die SyntaxWarnings (falls Bump zurückgerollt wird) und für die \`BertSdpaSelfAttention\`-UserWarning (\`transformers\`). Agora lädt die HF-Models nicht direkt, das macht OASIS im Subprozess — also können wir hier nur silencen, nicht \`attn_implementation="eager"\` setzen.
3. **\`camel.camel.agents.chat_agent\` Logger auf ERROR**. Upstream-WARNING \"Multiple messages returned in \`step()\`. Record selected message manually\" wird pro multi-message-step gefeuert und spammt das Log bei langen Sims.

## Why
User hat heute live im Backend-Log diese Warnings/Logs gesehen und angefordert, das aufzuräumen. Sind alles Upstream-Issues, kein Bug in Agora — pragmatische Lösung: bumpen wo möglich, filtern wo nicht.

## Test plan
- [x] \`uv lock\` resolved sentence-transformers auf 4.1.0
- [x] \`uv sync --extra dev\` durchläuft sauber
- [x] \`pytest tests/contracts/\` → **179 passed**
- [x] Smoke: \`uv run python -c \"import app\"\` zeigt keine SyntaxWarnings mehr
- [ ] CI: voller Test-Lauf
- [ ] Smoke nach Merge: lange Sim laufen lassen, prüfen ob \`chat_agent\` WARNING wirklich weg ist

## Out of scope (eigene Slices)
- \`transformers\` 4.x → 5.x (Dependabot Alert #9) — RC, breaking
- \`pytest\` 8 → 9 (Dependabot Alert #10) — Dev-Only
- Radon D-rank-Drift auf main (\`contract-gates\`-Workflow ist seit Stunden rot, betrifft 6 Bestandsfunktionen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)