### PR TITLE
feat(observability): werkzeug-Logger auf WARNING senken (Slice 1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -14,6 +14,7 @@
 6. [Dateistruktur](#6-dateistruktur)
 7. [Implementierungs-Phasen](#7-implementierungs-phasen)
 8. [Sicherheitsregeln](#8-sicherheitsregeln)
+9. [Aktive Welle: Observability, Run-Control & Model-Picker UX (2026-05-16)](#9-aktive-welle-observability-run-control--model-picker-ux-2026-05-16)
 
 ---
 
@@ -255,4 +256,44 @@ Override pro Run.
 
 ---
 
-*Zuletzt aktualisiert: Mai 2026*
+## 9. Aktive Welle: Observability, Run-Control & Model-Picker UX (2026-05-16)
+
+Sechs-Defekt-Welle aus User-Bericht 2026-05-16 (Backend-Log-Rauschen, fehlende
+Modell-Provenance, SSE-Reconnect, Aktiv-Modell-Anzeige, Stop-Button, Modell-
+Picker-Konsolidierung). Vollständiger Brief mit Symptomen, Decisions und Datei-
+Erstverdacht: `~/.claude/plans/nutze-code-review-graph-immer-derzeit-adaptive-iverson.md`.
+
+**Decisions (User-Sign-off 2026-05-16):**
+1. Stop → Teil-Report aus bereits erzeugten Stages, FSM `cancelled_partial`.
+2. Modell-Provenance doppelt: `report.metadata.model_attribution[]` + `evidence.json` (pro Eintrag).
+3. SSE-Reconnect unbegrenzt mit Exponential Backoff (1 s → 30 s cap).
+
+**Slices (PR pro Slice, Reihenfolge bindend für 4–8):**
+
+| # | Slice | Branch | Risiko | Owner-Modell |
+|---|---|---|---|---|
+| 1 | werkzeug-Logger silencen + Env-Flag | `slice/observability-1-werkzeug-mute` | low | Opus |
+| 2 | `/api/models` Endpoint + Provider-Discovery (Ollama/OpenRouter/Gemini/OpenAI) | `slice/observability-2-models-endpoint` | medium | Sonnet (`agora-refactor-worker`) |
+| 3 | `<ModelPicker />` Vue-Komponente + `useAvailableModels` Composable | `slice/observability-3-model-picker` | medium | Sonnet (`agora-frontend-worker`) |
+| 4 | SSE-Logs Heartbeat + Backoff-Reconnect + Traefik `X-Accel-Buffering` | `slice/observability-4-sse-stability` | medium | Sonnet (Refactor + Frontend) |
+| 5 | Active-Model-Push (Server) + `useActiveModel` Composable + stabile Anzeige | `slice/observability-5-active-model` | low | Sonnet (`agora-frontend-worker`) |
+| 6 | Run-Cancel-Endpoint + FSM-State `cancelled_partial` + asyncio-Task-Cancel | `slice/observability-6-run-cancel` | **high** | **Opus (Lead)** |
+| 7 | Report-Confirm-Dialog (Bestätigung nach Modell-Auswahl, kein Auto-Start) | `slice/observability-7-report-confirm` | low | Sonnet (`agora-frontend-worker`) |
+| 8 | Modell-Provenance in ReportV3 + evidence.json + Frontend-Sektion | `slice/observability-8-model-provenance` | **high** | **Opus (Lead)** — Layer 0 |
+
+Slices 1–3 parallel möglich; 4 wartet auf 2, 5 wartet auf 2, 6/7/8 sequenziell.
+
+**Verification (End-to-End nach allen Slices):**
+1. `docker logs agora -f` zeigt strukturierte JSON-Events ohne werkzeug-Flut
+2. Smoke-Run erzeugt sichtbare „Modell-Provenance"-Sektion (≥3 Stages) im Report
+3. Browser-Logs-Panel zeigt Live-Frames; Reconnect-Indikator nur bei Drift > 30 s
+4. Aktiv-Modell-Badge oben rechts bleibt während Run stabil
+5. Stop-Button bricht Run innerhalb 5 s ab, generiert Teil-Report
+6. Modell-Dropdown identisch auf allen Seiten, alphabetisch, ohne halluzinierte Einträge
+7. `pytest backend/tests/` grün, `ruff check app/ tests/` grün, `radon cc --min C` grün
+
+**Out of Scope:** Layer-0 Evidence-Gating-Anker (ADR-0002), OASIS-Source, neue Provider.
+
+---
+
+*Zuletzt aktualisiert: 2026-05-16 — Slice-Welle Observability/Run-Control/Model-Picker eröffnet*

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -50,6 +50,23 @@ from .utils.logger import (  # noqa: E402
 __version__ = "0.9.0"
 
 
+def configure_werkzeug_log_level() -> int:
+    """Setzt den werkzeug-Logger-Level aus ``AGORA_WERKZEUG_LOG_LEVEL``.
+
+    Default ``WARNING``: werkzeug loggt sonst jede Polling-Anfrage auf INFO
+    (/api/runs, /api/health) und verdrängt Pipeline-Stage-Events im
+    Container-Log. Per ``AGORA_WERKZEUG_LOG_LEVEL`` (DEBUG/INFO/WARNING/ERROR,
+    case-insensitiv) für ad-hoc Request-Debugging wieder aufdrehbar.
+    Ungültige Werte fallen still auf ``WARNING`` zurück.
+    """
+    raw = os.environ.get('AGORA_WERKZEUG_LOG_LEVEL', 'WARNING').upper()
+    level = logging.getLevelName(raw)
+    if not isinstance(level, int):
+        level = logging.WARNING
+    logging.getLogger('werkzeug').setLevel(level)
+    return level
+
+
 def create_app(config_class=Config):
     """Flask application factory function"""
     # Observability: Tracing + Metrics vor Flask-Instanz initialisieren,
@@ -88,6 +105,8 @@ def create_app(config_class=Config):
     # (z. B. /api/simulation/<id>/stream?ticket=<signed>); ohne Redaction
     # würden Tickets und Tokens im Klartext in stderr/Container-Logs landen.
     install_redaction_filter(logging.getLogger('werkzeug'))
+
+    configure_werkzeug_log_level()
 
     # Only print startup info in reloader subprocess (avoid printing twice in debug mode)
     is_reloader_process = os.environ.get('WERKZEUG_RUN_MAIN') == 'true'

--- a/backend/tests/test_werkzeug_log_level.py
+++ b/backend/tests/test_werkzeug_log_level.py
@@ -1,0 +1,45 @@
+"""Werkzeug-Access-Log-Level wird per AGORA_WERKZEUG_LOG_LEVEL gesteuert.
+
+Why: werkzeug INFO-Logs (jeder GET /api/runs Poll) verdecken Pipeline-Stage-
+Events im Container-Log. Default WARNING, per Env-Flag wieder aufdrehbar.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app import configure_werkzeug_log_level
+
+
+@pytest.fixture(autouse=True)
+def _reset_werkzeug_logger():
+    werkzeug = logging.getLogger("werkzeug")
+    werkzeug.setLevel(logging.NOTSET)
+    yield
+    werkzeug.setLevel(logging.NOTSET)
+
+
+def test_default_level_is_warning(monkeypatch):
+    monkeypatch.delenv("AGORA_WERKZEUG_LOG_LEVEL", raising=False)
+    assert configure_werkzeug_log_level() == logging.WARNING
+    assert logging.getLogger("werkzeug").level == logging.WARNING
+
+
+def test_override_to_info(monkeypatch):
+    monkeypatch.setenv("AGORA_WERKZEUG_LOG_LEVEL", "INFO")
+    assert configure_werkzeug_log_level() == logging.INFO
+    assert logging.getLogger("werkzeug").level == logging.INFO
+
+
+def test_override_to_debug_lowercase(monkeypatch):
+    monkeypatch.setenv("AGORA_WERKZEUG_LOG_LEVEL", "debug")
+    assert configure_werkzeug_log_level() == logging.DEBUG
+    assert logging.getLogger("werkzeug").level == logging.DEBUG
+
+
+def test_invalid_level_falls_back_to_warning(monkeypatch):
+    monkeypatch.setenv("AGORA_WERKZEUG_LOG_LEVEL", "BOGUS_LEVEL")
+    assert configure_werkzeug_log_level() == logging.WARNING
+    assert logging.getLogger("werkzeug").level == logging.WARNING


### PR DESCRIPTION
## Summary

Slice 1 von 8 der Observability/Run-Control/Model-Picker-Welle (siehe PLAN.md §9).

- werkzeug-Access-Log default WARNING statt INFO — Polling-Spam (`GET /api/runs` jede Sekunde) verdrängt nicht mehr die Pipeline-Stage-Events
- Per `AGORA_WERKZEUG_LOG_LEVEL=DEBUG|INFO|WARNING|ERROR` für ad-hoc Debugging wieder aufdrehbar
- Helper `configure_werkzeug_log_level()` als eigene Funktion → isolierte Unit-Tests ohne Flask-App-Setup
- PLAN.md um neue Sektion 9 mit 8-Slice-Plan und User-Decisions ergänzt

## Why now

User-Report 2026-05-16: ``docker logs agora -f`` ist unleserlich, weil werkzeug jede Polling-Anfrage als INFO loggt. Pipeline-Stage-Events (Ontology-Start, Simulation-Rounds, Report-Sektionen) gehen im Rauschen unter. Slice 1 ist der billigste Quick-Win der Welle — sechs Codezeilen + vier Tests.

## Test plan

- [x] `pytest backend/tests/test_werkzeug_log_level.py -v` → 4/4 grün
- [x] `pytest backend/tests/test_werkzeug_log_level.py backend/tests/test_config_security.py -q` → 16/16 grün
- [x] `ruff check backend/app/ backend/tests/` → all checks passed
- [ ] Smoke: nach Merge in dev/staging `docker logs agora -f` prüfen — werkzeug-Spam weg, Stage-Logs sichtbar

## Out of scope (folgt in späteren Slices)

- Slice 2: `/api/models` + Provider-Discovery
- Slice 4: SSE-Heartbeat + Backoff
- Slice 6: Run-Cancel + Teil-Report
- Slice 8: Modell-Provenance in ReportV3 + evidence.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)