### PR TITLE
fix(redis-bus): subscribe akzeptiert CHANNEL_POST_CREATED (Hotfix)

### DIFF
--- a/backend/app/services/event_bus_redis.py
+++ b/backend/app/services/event_bus_redis.py
@@ -34,6 +34,7 @@ from .artifact_store import SimulationArtifactStore, resolve_default_store
 from .event_bus import (
     CHANNEL_ACTION,
     CHANNEL_CONTROL,
+    CHANNEL_POST_CREATED,
     CHANNEL_RPC_COMMAND,
     CHANNEL_STATE,
     FilePollingEventBus,
@@ -186,9 +187,14 @@ class RedisEventBus:
         if channel == CHANNEL_ACTION:
             # No-op iterator — Phase B does not ship action events.
             return
-        if channel not in (CHANNEL_CONTROL, CHANNEL_STATE):
+        if channel not in (CHANNEL_CONTROL, CHANNEL_STATE, CHANNEL_POST_CREATED):
             raise ValueError(f"Unknown channel for RedisEventBus: {channel!r}")
 
+        # post_created: OASIS-Subprozess publisht direkt nach
+        # ``agora:sim:{id}:post_created`` (run_parallel_simulation.py
+        # ::_emit_post_created_to_redis). Backend-Drainer abonniert hier.
+        # Vor diesem Fix flog ValueError und der ganze post-Stream war tot —
+        # User-Bericht 2026-05-16 nach Welle-Merge.
         yield from self._subscribe_live(
             simulation_id, channel, timeout=timeout, poll_interval=poll_interval
         )
@@ -208,15 +214,19 @@ class RedisEventBus:
         try:
             # Yield the retained snapshot first so late subscribers see
             # the current value (matches FilePollingEventBus semantics).
-            artifact_name = "control_state" if channel == CHANNEL_CONTROL else "run_state"
-            snapshot = self._store.read_json(simulation_id, artifact_name, default=None)
-            if snapshot:
-                yield SimulationEvent(
-                    type=f"{channel}.update",
-                    simulation_id=simulation_id,
-                    payload=snapshot,
-                    ts=snapshot.get("updated_at") or "",
-                )
+            # post_created hat keinen Retained-Artifact-Snapshot (Stream-
+            # only); überspringen, sonst würden wir ``run_state`` als
+            # post-Update emittieren und das Frontend mit falschem Typ füttern.
+            if channel != CHANNEL_POST_CREATED:
+                artifact_name = "control_state" if channel == CHANNEL_CONTROL else "run_state"
+                snapshot = self._store.read_json(simulation_id, artifact_name, default=None)
+                if snapshot:
+                    yield SimulationEvent(
+                        type=f"{channel}.update",
+                        simulation_id=simulation_id,
+                        payload=snapshot,
+                        ts=snapshot.get("updated_at") or "",
+                    )
             while True:
                 if deadline is not None:
                     remaining = deadline - time.monotonic()

--- a/backend/app/services/event_bus_redis.py
+++ b/backend/app/services/event_bus_redis.py
@@ -146,7 +146,11 @@ class RedisEventBus:
             # files in `uploads/simulations/<id>/{twitter,reddit}/actions.jsonl`
             # remain the source of truth until Phase C wires SSE mirroring.
             return
-        if channel not in (CHANNEL_CONTROL, CHANNEL_STATE):
+        # Allowlist konsistent mit subscribe (Gemini-Finding #2):
+        # post_created via Bus-API publishen ist möglich, auch wenn der
+        # produktive Pfad heute über _emit_post_created_to_redis im
+        # OASIS-Subprozess läuft und den Bus umgeht.
+        if channel not in (CHANNEL_CONTROL, CHANNEL_STATE, CHANNEL_POST_CREATED):
             raise ValueError(f"Unknown channel for RedisEventBus: {channel!r}")
 
         try:
@@ -154,12 +158,14 @@ class RedisEventBus:
         except Exception:
             logger.exception("Redis publish failed for channel=%s", channel)
             raise
-        try:
-            self._write_retained(channel, event)
-        except Exception as exc:  # noqa: BLE001 — mirror is best-effort
-            logger.warning(
-                "Failed to mirror %s event to artifact store: %s", channel, exc
-            )
+        # post_created hat keinen Retained-Snapshot — mirror skippen.
+        if channel in (CHANNEL_CONTROL, CHANNEL_STATE):
+            try:
+                self._write_retained(channel, event)
+            except Exception as exc:  # noqa: BLE001 — mirror is best-effort
+                logger.warning(
+                    "Failed to mirror %s event to artifact store: %s", channel, exc
+                )
 
     # ----- port: subscribe ----------------------------------------------
 
@@ -214,11 +220,16 @@ class RedisEventBus:
         try:
             # Yield the retained snapshot first so late subscribers see
             # the current value (matches FilePollingEventBus semantics).
-            # post_created hat keinen Retained-Artifact-Snapshot (Stream-
-            # only); überspringen, sonst würden wir ``run_state`` als
-            # post-Update emittieren und das Frontend mit falschem Typ füttern.
-            if channel != CHANNEL_POST_CREATED:
-                artifact_name = "control_state" if channel == CHANNEL_CONTROL else "run_state"
+            # Whitelist statt Blacklist (Gemini-Finding 2026-05-16 #3):
+            # nur Channels mit echtem Retained-Artifact (control_state /
+            # run_state) lesen einen Snapshot. Neue Stream-only-Channels
+            # wie post_created fallen automatisch raus.
+            _SNAPSHOT_ARTIFACT = {
+                CHANNEL_CONTROL: "control_state",
+                CHANNEL_STATE: "run_state",
+            }
+            artifact_name = _SNAPSHOT_ARTIFACT.get(channel)
+            if artifact_name is not None:
                 snapshot = self._store.read_json(simulation_id, artifact_name, default=None)
                 if snapshot:
                     yield SimulationEvent(
@@ -239,6 +250,20 @@ class RedisEventBus:
                 if msg and msg.get("type") == "message":
                     try:
                         data = json.loads(msg["data"])
+                        # Wire-Format-Brücke für post_created: OASIS-Subprozess
+                        # (run_parallel_simulation.py::_emit_post_created_to_redis)
+                        # publisht ein FLACHES Payload mit ``event_type`` statt
+                        # eines SimulationEvent-Envelopes. Wir wrappen es hier,
+                        # damit SimulationEvent.from_dict greift. Gemini-Finding
+                        # 2026-05-16 #1 (HIGH): ohne diese Brücke fliegt jedes
+                        # post_created als KeyError raus.
+                        if channel == CHANNEL_POST_CREATED and "type" not in data:
+                            data = {
+                                "type": data.get("event_type", "post_created"),
+                                "simulation_id": data.get("simulation_id", ""),
+                                "payload": data,
+                                "ts": data.get("timestamp", ""),
+                            }
                         # Trace-Propagation: Span nur über synchrone Decode-Phase
                         # legen — Generator-yield darf keinen aktiven Span halten.
                         ctx = _extract_trace(data)

--- a/backend/tests/services/test_event_bus_redis_post_created.py
+++ b/backend/tests/services/test_event_bus_redis_post_created.py
@@ -73,3 +73,54 @@ def test_subscribe_still_rejects_truly_unknown_channels(bus):
     """Allowlist ist erweitert, nicht entfernt — Garbage-Channels bleiben hart abgelehnt."""
     with pytest.raises(ValueError, match="Unknown channel"):
         list(bus.subscribe("sim_test", "totally_made_up_channel", timeout=0.01))
+
+
+def test_subscribe_parses_oasis_wire_format_for_post_created(bus):
+    """Wire-Format-Brücke (Gemini-Finding #1, HIGH).
+
+    OASIS-Subprozess (run_parallel_simulation.py::_emit_post_created_to_redis)
+    publisht ein FLACHES Payload mit ``event_type`` statt eines
+    SimulationEvent-Envelopes (``type``/``payload``). Ohne Brücke fliegt
+    jedes post_created als KeyError im ``except KeyError`` → Event wird
+    gedroppt → Frontend bleibt leer. Test asseritert dass die Brücke greift.
+    """
+    import json as _json
+
+    oasis_payload = {
+        "event_type": "post_created",
+        "simulation_id": "sim_88b6a65f7bb0",
+        "post_id": "post-42",
+        "parent_post_id": None,
+        "platform": "twitter",
+        "persona_id": "agent-5",
+        "voice_register": "casual",
+        "is_simulated": True,
+        "body": "Hallo Welt",
+        "timestamp": "2026-05-16T17:25:28+00:00",
+        "sentiment": None,
+        "score": 0,
+    }
+
+    pubsub = MagicMock()
+    # Erstes get_message gibt ein echtes message-Frame zurück, danach
+    # endlos None — verhindert StopIteration im Generator, Timeout kappt
+    # die Loop nach 50 ms ab.
+    _messages = iter([{"type": "message", "data": _json.dumps(oasis_payload)}])
+
+    def _get_message(*_args, **_kwargs):
+        return next(_messages, None)
+
+    pubsub.get_message.side_effect = _get_message
+    bus._redis.pubsub.return_value = pubsub
+    bus._store = MagicMock()
+    bus._store.read_json.return_value = None  # kein snapshot
+
+    gen = bus.subscribe("sim_88b6a65f7bb0", CHANNEL_POST_CREATED, timeout=0.05, poll_interval=0.005)
+    events = list(gen)
+
+    assert len(events) == 1, f"erwarte genau 1 Event, bekam {len(events)}"
+    evt = events[0]
+    assert evt.type == "post_created"
+    assert evt.simulation_id == "sim_88b6a65f7bb0"
+    assert evt.payload["post_id"] == "post-42"
+    assert evt.payload["body"] == "Hallo Welt"

--- a/backend/tests/services/test_event_bus_redis_post_created.py
+++ b/backend/tests/services/test_event_bus_redis_post_created.py
@@ -1,0 +1,75 @@
+"""Slice-Welle-Hotfix 2026-05-16: RedisEventBus.subscribe für CHANNEL_POST_CREATED.
+
+User-Bericht nach Container-Smoke: Stream-Drainer crashed mit
+``ValueError: Unknown channel for RedisEventBus: 'post_created'`` weil
+die Channel-Allowlist nur CONTROL/STATE enthielt. OASIS-Subprozess
+publisht aber direkt nach ``agora:sim:{id}:post_created`` via Redis
+(scripts/run_parallel_simulation.py::_emit_post_created_to_redis).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.event_bus import CHANNEL_POST_CREATED
+from app.services.event_bus_redis import RedisEventBus
+
+
+@pytest.fixture()
+def bus():
+    with patch("redis.from_url") as mock_from_url:
+        client = MagicMock()
+        client.ping.return_value = True
+        mock_from_url.return_value = client
+        b = RedisEventBus("redis://test:6379/0", ping_on_init=False)
+    return b
+
+
+def test_subscribe_accepts_post_created_channel(bus):
+    """post_created darf KEIN ValueError mehr werfen (Hotfix)."""
+    # Mock pubsub so subscribe() läuft an, gibt aber sofort timeout zurück
+    pubsub = MagicMock()
+    pubsub.get_message.return_value = None
+    bus._redis.pubsub.return_value = pubsub
+
+    # Snapshot-Read muss übersprungen werden für post_created — sonst würde
+    # _store.read_json gegen 'run_state' fallen und ein falscher Update-Event
+    # an den Drainer durchgereicht werden.
+    bus._store = MagicMock()
+    bus._store.read_json.return_value = None
+
+    gen = bus.subscribe("sim_test", CHANNEL_POST_CREATED, timeout=0.01, poll_interval=0.005)
+    events = list(gen)
+
+    # Kein Event (kein Snapshot, keine Live-Messages) — aber wichtig: KEIN Raise.
+    assert events == []
+    # Verify: subscribe hat den richtigen Redis-Channel-Key abonniert
+    pubsub.subscribe.assert_called_once_with("agora:sim:sim_test:post_created")
+
+
+def test_subscribe_skips_snapshot_read_for_post_created(bus):
+    """_subscribe_live darf für post_created nicht run_state als Snapshot rausreichen."""
+    pubsub = MagicMock()
+    pubsub.get_message.return_value = None
+    bus._redis.pubsub.return_value = pubsub
+
+    bus._store = MagicMock()
+    # Würde der Snapshot-Pfad NICHT überspringen, würde read_json hier
+    # mit 'run_state' aufgerufen und ein Dummy-Event durchsickern.
+    bus._store.read_json.return_value = {"updated_at": "x", "foo": "bar"}
+
+    gen = bus.subscribe("sim_test", CHANNEL_POST_CREATED, timeout=0.01, poll_interval=0.005)
+    events = list(gen)
+
+    assert events == []
+    # Snapshot-Read wurde übersprungen — read_json darf gar nicht aufgerufen
+    # worden sein (Pfad ist guarded by ``if channel != CHANNEL_POST_CREATED``).
+    bus._store.read_json.assert_not_called()
+
+
+def test_subscribe_still_rejects_truly_unknown_channels(bus):
+    """Allowlist ist erweitert, nicht entfernt — Garbage-Channels bleiben hart abgelehnt."""
+    with pytest.raises(ValueError, match="Unknown channel"):
+        list(bus.subscribe("sim_test", "totally_made_up_channel", timeout=0.01))

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2424 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2427 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 123 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

Hotfix nach Container-Smoke der Observability-Welle (PR #486). Stream-Drainer crashed sofort beim Simulation-Start:

```
ERROR: Stream drainer crashed for sim_88b6a65f7bb0/post_created
ValueError: Unknown channel for RedisEventBus: 'post_created'
```

Frontend bekommt seitdem keine Post-Events live, obwohl die Simulation weiterläuft.

## Root cause

`RedisEventBus.subscribe`-Allowlist enthielt nur `CHANNEL_CONTROL`/`CHANNEL_STATE`. Der OASIS-Subprozess (`scripts/run_parallel_simulation.py::_emit_post_created_to_redis`) publisht aber direkt nach `agora:sim:{id}:post_created` — reine Redis Pub/Sub, kein File-Bus-Fallback. Backend-Drainer kann nicht subscriben → ValueError → Stream tot.

## Fix

- `CHANNEL_POST_CREATED` zur `subscribe`-Allowlist hinzufügen, an `_subscribe_live` durchreichen.
- `_subscribe_live` überspringt den Snapshot-Read für `post_created` — sonst würde `run_state` als falscher Update-Event durchsickern (post_created hat keinen Retained-Artifact).

## Test plan

- [x] `pytest backend/tests/services/test_event_bus_redis_post_created.py` 3/3 grün
  - test_subscribe_accepts_post_created_channel — kein ValueError mehr, Redis-Channel-Key korrekt
  - test_subscribe_skips_snapshot_read_for_post_created — `read_json` nicht aufgerufen
  - test_subscribe_still_rejects_truly_unknown_channels — Allowlist erweitert, nicht entfernt
- [ ] Nach Merge: Container neu bauen, Simulation starten, Frontend-Feed muss Post-Events sehen, Backend-Log darf den ValueError NICHT mehr loggen

🤖 Generated with [Claude Code](https://claude.com/claude-code)