### PR TITLE
fix(oasis): provider-aware ModelFactory dispatch (Gemini-3 + Ollama Cloud)

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -7,11 +7,52 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:
+    from camel.types import ModelPlatformType  # type: ignore[import]
 
 from dotenv import load_dotenv
 from opentelemetry import context as otel_context
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+def detect_oasis_platform(model: str, base_url: str) -> ModelPlatformType:
+    """Map model-name + base-url to the correct CAMEL ModelPlatformType.
+
+    Detection order (first match wins):
+
+    1. GEMINI — base_url contains ``generativelanguage.googleapis.com`` OR
+       model starts with ``gemini-``.  Gemini-3 requires a ``thought_signature``
+       echo in multi-turn tool calls; the OpenAI-compat wire path strips that
+       field and the API rejects every tool turn with HTTP 400.
+    2. OLLAMA — base_url contains ``ollama.com`` or ``:11434``  OR  model ends
+       with ``:cloud`` or ``:latest``.  Ollama Cloud no longer offers an
+       OpenAI-compat ``/v1`` endpoint; only the native ``/api/chat`` path works.
+       CAMEL's ``OllamaModel`` speaks the native protocol.
+    3. OPENAI — everything else (real OpenAI, Anthropic compat gateways, Qwen
+       Cloud via non-Ollama URLs, Mistral, DeepSeek, …).
+    """
+    from camel.types import ModelPlatformType  # type: ignore[import]
+
+    url = base_url or ""
+    m = model or ""
+
+    # --- 1. Gemini ---
+    if "generativelanguage.googleapis.com" in url or m.startswith("gemini-"):
+        return ModelPlatformType.GEMINI
+
+    # --- 2. Ollama ---
+    if (
+        "ollama.com" in url
+        or ":11434" in url
+        or m.endswith(":cloud")
+        or m.endswith(":latest")
+    ):
+        return ModelPlatformType.OLLAMA
+
+    # --- 3. OpenAI (default / compat gateway) ---
+    return ModelPlatformType.OPENAI
 
 
 def _is_ollama_route(model: str, base_url: str) -> bool:

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -45,7 +45,7 @@ def detect_oasis_platform(model: str, base_url: str) -> ModelPlatformType:
     # --- 2. Ollama ---
     if (
         "ollama.com" in url
-        or ":11434" in url
+        or re.search(r":11434(?:/|$)", url)
         or m.endswith(":cloud")
         or m.endswith(":latest")
     ):

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -85,7 +85,6 @@ try:
     from ._sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_parallel_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -100,7 +99,6 @@ except ImportError:  # direct script execution
     from _sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_parallel_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -1277,15 +1275,14 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
         # Ollama Cloud dropped its OpenAI-compat /v1 endpoint; only the native
         # /api/chat path works.  CAMEL's OllamaModel speaks it natively.
         # Local Ollama (port 11434) also benefits from the native path.
+        # Build extra_body inline: we already know this is Ollama, so the
+        # legacy _is_ollama_route gate inside build_camel_extra_body() would
+        # falsely drop think/num_ctx for :latest models or ollama.com URLs.
         os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
-        extra_body = build_camel_extra_body(
-            model=llm_model,
-            base_url=llm_base_url,
-            num_ctx=runtime_settings["ollama_num_ctx"],
-            think=think_on,
-        )
-        if extra_body:
-            model_cfg["extra_body"] = extra_body
+        extra_body: Dict[str, Any] = {"think": think_on}
+        if runtime_settings["ollama_num_ctx"] is not None:
+            extra_body["options"] = {"num_ctx": runtime_settings["ollama_num_ctx"]}
+        model_cfg["extra_body"] = extra_body
         return ModelFactory.create(
             model_platform=ModelPlatformType.OLLAMA,
             model_type=llm_model,
@@ -1296,7 +1293,7 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
 
     else:
         # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
-        # Keep byte-identical behaviour to the pre-refactor code.
+        # No extra_body: think/num_ctx are Ollama-only and would 400 here.
         if llm_api_key:
             os.environ["OPENAI_API_KEY"] = llm_api_key
 
@@ -1309,15 +1306,6 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
             os.environ["OPENAI_BASE_URL"] = llm_base_url
             os.environ["OPENAI_API_BASE"] = llm_base_url
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-
-        extra_body = build_camel_extra_body(
-            model=llm_model,
-            base_url=llm_base_url,
-            num_ctx=runtime_settings["ollama_num_ctx"],
-            think=think_on,
-        )
-        if extra_body:
-            model_cfg["extra_body"] = extra_body
 
         return ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -88,6 +88,7 @@ try:
         build_camel_extra_body,
         build_parallel_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -102,6 +103,7 @@ except ImportError:  # direct script execution
         build_camel_extra_body,
         build_parallel_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -1239,53 +1241,89 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
     if not llm_model:
         llm_model = "qwen3-coder-next:cloud"
     
-    # Set environment variables required by camel-ai
-    if llm_api_key:
-        os.environ["OPENAI_API_KEY"] = llm_api_key
-    
-    if not os.environ.get("OPENAI_API_KEY"):
-        raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
-    
-    if llm_base_url:
-        os.environ["OPENAI_BASE_URL"] = llm_base_url
-        os.environ["OPENAI_API_BASE"] = llm_base_url
-        os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-    
     runtime_settings = resolve_model_runtime_settings(llm_model)
+    platform = detect_oasis_platform(llm_model, llm_base_url)
+    think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
+
     print(
-        f"{config_label} model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}..., "
+        f"{config_label} model={llm_model}, "
+        f"base_url={llm_base_url[:40] if llm_base_url else 'default'}..., "
+        f"platform={platform.value}, "
         f"completion_max_tokens={runtime_settings['completion_max_tokens']}, "
         f"memory_token_limit={runtime_settings['memory_token_limit']}, "
         f"ollama_num_ctx={runtime_settings['ollama_num_ctx']}",
         flush=True,
     )
 
-    # Suppress reasoning output on Qwen3/Nemotron/DeepSeek/GPT-OSS etc.
-    # so that `content` isn't starved by `reasoning` tokens. `think` ist
-    # ein Ollama-only-Parameter; OpenAI/Anthropic kennen ihn nicht und
-    # antworten 400. build_camel_extra_body filtert provider-aware.
-    think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
-    extra_body = build_camel_extra_body(
-        model=llm_model,
-        base_url=llm_base_url,
-        num_ctx=runtime_settings["ollama_num_ctx"],
-        think=think_on,
-    )
-    # GPT-5/o1/o3/o4 verlangen `max_completion_tokens`; ältere Modelle
-    # akzeptieren weiterhin `max_tokens`. build_camel_completion_params
-    # liefert genau einen passenden Schlüssel.
     model_cfg: Dict[str, Any] = build_camel_completion_params(
         model=llm_model,
         completion_max_tokens=runtime_settings["completion_max_tokens"],
     )
-    if extra_body:
-        model_cfg["extra_body"] = extra_body
 
-    return ModelFactory.create(
-        model_platform=ModelPlatformType.OPENAI,
-        model_type=llm_model,
-        model_config_dict=model_cfg,
-    )
+    if platform == ModelPlatformType.GEMINI:
+        # Gemini-3 requires thought_signature echo in multi-turn tool calls.
+        # The OpenAI-compat wire path strips that field → HTTP 400 on every
+        # tool turn.  Route directly via CAMEL's GeminiModel instead.
+        # Auth: GOOGLE_API_KEY (not OPENAI_API_KEY).
+        # Do NOT set OPENAI_BASE_URL — it would break CAMEL's Gemini backend.
+        os.environ["GOOGLE_API_KEY"] = llm_api_key or os.environ.get("GOOGLE_API_KEY", "")
+        return ModelFactory.create(
+            model_platform=ModelPlatformType.GEMINI,
+            model_type=llm_model,
+            model_config_dict=model_cfg,
+        )
+
+    elif platform == ModelPlatformType.OLLAMA:
+        # Ollama Cloud dropped its OpenAI-compat /v1 endpoint; only the native
+        # /api/chat path works.  CAMEL's OllamaModel speaks it natively.
+        # Local Ollama (port 11434) also benefits from the native path.
+        os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
+        extra_body = build_camel_extra_body(
+            model=llm_model,
+            base_url=llm_base_url,
+            num_ctx=runtime_settings["ollama_num_ctx"],
+            think=think_on,
+        )
+        if extra_body:
+            model_cfg["extra_body"] = extra_body
+        return ModelFactory.create(
+            model_platform=ModelPlatformType.OLLAMA,
+            model_type=llm_model,
+            url=llm_base_url or None,
+            api_key=llm_api_key or None,
+            model_config_dict=model_cfg,
+        )
+
+    else:
+        # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
+        # Keep byte-identical behaviour to the pre-refactor code.
+        if llm_api_key:
+            os.environ["OPENAI_API_KEY"] = llm_api_key
+
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError(
+                "Missing API Key configuration, please set LLM_API_KEY in .env file in project root"
+            )
+
+        if llm_base_url:
+            os.environ["OPENAI_BASE_URL"] = llm_base_url
+            os.environ["OPENAI_API_BASE"] = llm_base_url
+            os.environ["OPENAI_API_BASE_URL"] = llm_base_url
+
+        extra_body = build_camel_extra_body(
+            model=llm_model,
+            base_url=llm_base_url,
+            num_ctx=runtime_settings["ollama_num_ctx"],
+            think=think_on,
+        )
+        if extra_body:
+            model_cfg["extra_body"] = extra_body
+
+        return ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI,
+            model_type=llm_model,
+            model_config_dict=model_cfg,
+        )
 
 
 def get_active_agents_for_round(

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -37,6 +37,7 @@ try:
         build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -52,6 +53,7 @@ except ImportError:  # direct script execution
         build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -475,52 +477,87 @@ class RedditSimulationRunner:
         llm_api_key = os.environ.get("LLM_API_KEY", "")
         llm_base_url = os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("LLM_MODEL_NAME", "")
-        
+
         # If not in .env, use config as fallback
         if not llm_model:
             llm_model = self.config.get("llm_model", "qwen3-coder-next:cloud")
-        
-        # Set environment variables required by camel-ai
-        if llm_api_key:
-            os.environ["OPENAI_API_KEY"] = llm_api_key
-        
-        if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
-        
-        if llm_base_url:
-            os.environ["OPENAI_BASE_URL"] = llm_base_url
-            os.environ["OPENAI_API_BASE"] = llm_base_url
-            os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-        
-        print(f"LLM configuration: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
 
-        # `think` und `options.num_ctx` sind Ollama-only. OpenAI/Anthropic
-        # antworten 400 sobald `think` in extra_body landet.
+        platform = detect_oasis_platform(llm_model, llm_base_url)
         think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
         ctx_limit = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-        extra_body = build_camel_extra_body(
-            model=llm_model,
-            base_url=llm_base_url,
-            num_ctx=ctx_limit,
-            think=think_on,
-        )
-        # GPT-5/o1/o3/o4 verlangen `max_completion_tokens`, alle anderen
-        # Modelle akzeptieren `max_tokens`.
-        # GPT-5/o1/o3/o4 verlangen `max_completion_tokens`, alle anderen
-        # Modelle akzeptieren `max_tokens`.
         completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "8192"))
+
+        print(
+            f"LLM configuration: model={llm_model}, "
+            f"base_url={llm_base_url[:40] if llm_base_url else 'default'}..., "
+            f"platform={platform.value}",
+            flush=True,
+        )
+
         model_cfg: dict = build_camel_completion_params(
             model=llm_model,
             completion_max_tokens=completion_max_tokens,
         )
-        if extra_body:
-            model_cfg["extra_body"] = extra_body
 
-        return ModelFactory.create(
-            model_platform=ModelPlatformType.OPENAI,
-            model_type=llm_model,
-            model_config_dict=model_cfg,
-        )
+        if platform == ModelPlatformType.GEMINI:
+            # Gemini-3 requires thought_signature echo in multi-turn tool calls.
+            # Route via CAMEL's GeminiModel; do NOT touch OPENAI_BASE_URL.
+            os.environ["GOOGLE_API_KEY"] = llm_api_key or os.environ.get("GOOGLE_API_KEY", "")
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.GEMINI,
+                model_type=llm_model,
+                model_config_dict=model_cfg,
+            )
+
+        elif platform == ModelPlatformType.OLLAMA:
+            # Ollama Cloud no longer serves OpenAI-compat /v1.
+            # CAMEL's OllamaModel speaks the native /api/chat endpoint.
+            os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
+            extra_body = build_camel_extra_body(
+                model=llm_model,
+                base_url=llm_base_url,
+                num_ctx=ctx_limit,
+                think=think_on,
+            )
+            if extra_body:
+                model_cfg["extra_body"] = extra_body
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.OLLAMA,
+                model_type=llm_model,
+                url=llm_base_url or None,
+                api_key=llm_api_key or None,
+                model_config_dict=model_cfg,
+            )
+
+        else:
+            # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
+            if llm_api_key:
+                os.environ["OPENAI_API_KEY"] = llm_api_key
+
+            if not os.environ.get("OPENAI_API_KEY"):
+                raise ValueError(
+                    "Missing API Key configuration, please set LLM_API_KEY in .env file in project root"
+                )
+
+            if llm_base_url:
+                os.environ["OPENAI_BASE_URL"] = llm_base_url
+                os.environ["OPENAI_API_BASE"] = llm_base_url
+                os.environ["OPENAI_API_BASE_URL"] = llm_base_url
+
+            extra_body = build_camel_extra_body(
+                model=llm_model,
+                base_url=llm_base_url,
+                num_ctx=ctx_limit,
+                think=think_on,
+            )
+            if extra_body:
+                model_cfg["extra_body"] = extra_body
+
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.OPENAI,
+                model_type=llm_model,
+                model_config_dict=model_cfg,
+            )
     
     def _get_active_agents_for_round(
         self, 

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -34,7 +34,6 @@ try:
     from ._sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -50,7 +49,6 @@ except ImportError:  # direct script execution
     from _sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -512,15 +510,14 @@ class RedditSimulationRunner:
         elif platform == ModelPlatformType.OLLAMA:
             # Ollama Cloud no longer serves OpenAI-compat /v1.
             # CAMEL's OllamaModel speaks the native /api/chat endpoint.
+            # Build extra_body inline: we already know this is Ollama, so the
+            # legacy _is_ollama_route gate inside build_camel_extra_body() would
+            # falsely drop think/num_ctx for :latest models or ollama.com URLs.
             os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
-            extra_body = build_camel_extra_body(
-                model=llm_model,
-                base_url=llm_base_url,
-                num_ctx=ctx_limit,
-                think=think_on,
-            )
-            if extra_body:
-                model_cfg["extra_body"] = extra_body
+            extra_body: dict = {"think": think_on}
+            if ctx_limit is not None:
+                extra_body["options"] = {"num_ctx": ctx_limit}
+            model_cfg["extra_body"] = extra_body
             return ModelFactory.create(
                 model_platform=ModelPlatformType.OLLAMA,
                 model_type=llm_model,
@@ -531,6 +528,7 @@ class RedditSimulationRunner:
 
         else:
             # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
+            # No extra_body: think/num_ctx are Ollama-only and would 400 here.
             if llm_api_key:
                 os.environ["OPENAI_API_KEY"] = llm_api_key
 
@@ -543,15 +541,6 @@ class RedditSimulationRunner:
                 os.environ["OPENAI_BASE_URL"] = llm_base_url
                 os.environ["OPENAI_API_BASE"] = llm_base_url
                 os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-
-            extra_body = build_camel_extra_body(
-                model=llm_model,
-                base_url=llm_base_url,
-                num_ctx=ctx_limit,
-                think=think_on,
-            )
-            if extra_body:
-                model_cfg["extra_body"] = extra_body
 
             return ModelFactory.create(
                 model_platform=ModelPlatformType.OPENAI,

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -34,7 +34,6 @@ try:
     from ._sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -50,7 +49,6 @@ except ImportError:  # direct script execution
     from _sim_common import (
         apply_camel_context_floor,
         build_camel_completion_params,
-        build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
         detect_oasis_platform,
@@ -499,15 +497,14 @@ class TwitterSimulationRunner:
         elif platform == ModelPlatformType.OLLAMA:
             # Ollama Cloud no longer serves OpenAI-compat /v1.
             # CAMEL's OllamaModel speaks the native /api/chat endpoint.
+            # Build extra_body inline: we already know this is Ollama, so the
+            # legacy _is_ollama_route gate inside build_camel_extra_body() would
+            # falsely drop think/num_ctx for :latest models or ollama.com URLs.
             os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
-            extra_body = build_camel_extra_body(
-                model=llm_model,
-                base_url=llm_base_url,
-                num_ctx=ctx_limit,
-                think=think_on,
-            )
-            if extra_body:
-                model_cfg["extra_body"] = extra_body
+            extra_body: dict = {"think": think_on}
+            if ctx_limit is not None:
+                extra_body["options"] = {"num_ctx": ctx_limit}
+            model_cfg["extra_body"] = extra_body
             return ModelFactory.create(
                 model_platform=ModelPlatformType.OLLAMA,
                 model_type=llm_model,
@@ -518,6 +515,7 @@ class TwitterSimulationRunner:
 
         else:
             # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
+            # No extra_body: think/num_ctx are Ollama-only and would 400 here.
             if llm_api_key:
                 os.environ["OPENAI_API_KEY"] = llm_api_key
 
@@ -530,15 +528,6 @@ class TwitterSimulationRunner:
                 os.environ["OPENAI_BASE_URL"] = llm_base_url
                 os.environ["OPENAI_API_BASE"] = llm_base_url
                 os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-
-            extra_body = build_camel_extra_body(
-                model=llm_model,
-                base_url=llm_base_url,
-                num_ctx=ctx_limit,
-                think=think_on,
-            )
-            if extra_body:
-                model_cfg["extra_body"] = extra_body
 
             return ModelFactory.create(
                 model_platform=ModelPlatformType.OPENAI,

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -37,6 +37,7 @@ try:
         build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -52,6 +53,7 @@ except ImportError:  # direct script execution
         build_camel_extra_body,
         build_single_platform_parser,
         compute_start_hour_offset,
+        detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
         install_max_tokens_warning_filter,
@@ -462,52 +464,87 @@ class TwitterSimulationRunner:
         llm_api_key = os.environ.get("LLM_API_KEY", "")
         llm_base_url = os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("LLM_MODEL_NAME", "")
-        
+
         # If not in .env, use config as fallback
         if not llm_model:
             llm_model = self.config.get("llm_model", "qwen3-coder-next:cloud")
-        
-        # Set environment variables required by camel-ai
-        if llm_api_key:
-            os.environ["OPENAI_API_KEY"] = llm_api_key
-        
-        if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("Missing API Key configuration, please set LLM_API_KEY in .env file in project root")
-        
-        if llm_base_url:
-            os.environ["OPENAI_BASE_URL"] = llm_base_url
-            os.environ["OPENAI_API_BASE"] = llm_base_url
-            os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-        
-        print(f"LLM configuration: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
-        
-        # `think` und `options.num_ctx` sind Ollama-only. OpenAI/Anthropic
-        # antworten 400 sobald `think` in extra_body landet.
+
+        platform = detect_oasis_platform(llm_model, llm_base_url)
         think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
         ctx_limit = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-        extra_body = build_camel_extra_body(
-            model=llm_model,
-            base_url=llm_base_url,
-            num_ctx=ctx_limit,
-            think=think_on,
-        )
-        # GPT-5/o1/o3/o4 verlangen `max_completion_tokens`, alle anderen
-        # Modelle akzeptieren `max_tokens`.
-        # GPT-5/o1/o3/o4 verlangen `max_completion_tokens`, alle anderen
-        # Modelle akzeptieren `max_tokens`.
         completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "8192"))
+
+        print(
+            f"LLM configuration: model={llm_model}, "
+            f"base_url={llm_base_url[:40] if llm_base_url else 'default'}..., "
+            f"platform={platform.value}",
+            flush=True,
+        )
+
         model_cfg: dict = build_camel_completion_params(
             model=llm_model,
             completion_max_tokens=completion_max_tokens,
         )
-        if extra_body:
-            model_cfg["extra_body"] = extra_body
 
-        return ModelFactory.create(
-            model_platform=ModelPlatformType.OPENAI,
-            model_type=llm_model,
-            model_config_dict=model_cfg,
-        )
+        if platform == ModelPlatformType.GEMINI:
+            # Gemini-3 requires thought_signature echo in multi-turn tool calls.
+            # Route via CAMEL's GeminiModel; do NOT touch OPENAI_BASE_URL.
+            os.environ["GOOGLE_API_KEY"] = llm_api_key or os.environ.get("GOOGLE_API_KEY", "")
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.GEMINI,
+                model_type=llm_model,
+                model_config_dict=model_cfg,
+            )
+
+        elif platform == ModelPlatformType.OLLAMA:
+            # Ollama Cloud no longer serves OpenAI-compat /v1.
+            # CAMEL's OllamaModel speaks the native /api/chat endpoint.
+            os.environ["OPENAI_API_KEY"] = llm_api_key or "dummy"  # CAMEL guard
+            extra_body = build_camel_extra_body(
+                model=llm_model,
+                base_url=llm_base_url,
+                num_ctx=ctx_limit,
+                think=think_on,
+            )
+            if extra_body:
+                model_cfg["extra_body"] = extra_body
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.OLLAMA,
+                model_type=llm_model,
+                url=llm_base_url or None,
+                api_key=llm_api_key or None,
+                model_config_dict=model_cfg,
+            )
+
+        else:
+            # OPENAI — real OpenAI, Anthropic compat gateways, Qwen Cloud, etc.
+            if llm_api_key:
+                os.environ["OPENAI_API_KEY"] = llm_api_key
+
+            if not os.environ.get("OPENAI_API_KEY"):
+                raise ValueError(
+                    "Missing API Key configuration, please set LLM_API_KEY in .env file in project root"
+                )
+
+            if llm_base_url:
+                os.environ["OPENAI_BASE_URL"] = llm_base_url
+                os.environ["OPENAI_API_BASE"] = llm_base_url
+                os.environ["OPENAI_API_BASE_URL"] = llm_base_url
+
+            extra_body = build_camel_extra_body(
+                model=llm_model,
+                base_url=llm_base_url,
+                num_ctx=ctx_limit,
+                think=think_on,
+            )
+            if extra_body:
+                model_cfg["extra_body"] = extra_body
+
+            return ModelFactory.create(
+                model_platform=ModelPlatformType.OPENAI,
+                model_type=llm_model,
+                model_config_dict=model_cfg,
+            )
     
     def _get_active_agents_for_round(
         self, 

--- a/backend/tests/scripts/test_oasis_provider_dispatch.py
+++ b/backend/tests/scripts/test_oasis_provider_dispatch.py
@@ -1,0 +1,177 @@
+"""Tests for detect_oasis_platform() and create_model() dispatch routing.
+
+Verifies that the three-way GEMINI / OLLAMA / OPENAI detection heuristic
+maps model-name + base-url to the correct CAMEL ModelPlatformType, and that
+create_model() sets the right environment variables (GOOGLE_API_KEY vs
+OPENAI_BASE_URL) depending on the detected platform.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap — scripts/ is not on the default pytest sys.path.
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _BACKEND_DIR / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# Use the real camel.types — camel-ai is always installed in this venv.
+from camel.types import ModelPlatformType  # type: ignore[import]  # noqa: E402
+
+from _sim_common import detect_oasis_platform  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# detect_oasis_platform — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOasisPlatform:
+    def test_detect_gemini_url(self) -> None:
+        result = detect_oasis_platform(
+            "gemini-3-flash-preview",
+            "https://generativelanguage.googleapis.com/v1beta/openai/",
+        )
+        assert result == ModelPlatformType.GEMINI
+
+    def test_detect_gemini_by_model_prefix(self) -> None:
+        result = detect_oasis_platform("gemini-2.5-flash", "")
+        assert result == ModelPlatformType.GEMINI
+
+    def test_detect_gemini_by_model_prefix_non_google_url(self) -> None:
+        result = detect_oasis_platform(
+            "gemini-2.0-flash-lite", "https://api.example.com/v1"
+        )
+        assert result == ModelPlatformType.GEMINI
+
+    def test_detect_ollama_cloud_by_url(self) -> None:
+        result = detect_oasis_platform(
+            "llama3.2:latest", "https://ollama.com/api"
+        )
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_detect_ollama_cloud_by_model_suffix(self) -> None:
+        result = detect_oasis_platform(
+            "qwen3-coder-next:cloud", "https://ollama.com"
+        )
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_detect_ollama_local(self) -> None:
+        result = detect_oasis_platform(
+            "qwen3:8b", "http://localhost:11434"
+        )
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_detect_ollama_local_ip(self) -> None:
+        result = detect_oasis_platform(
+            "qwen3:8b", "http://127.0.0.1:11434/v1"
+        )
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_detect_ollama_latest_suffix(self) -> None:
+        result = detect_oasis_platform("llama3:latest", "")
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_detect_openai(self) -> None:
+        result = detect_oasis_platform(
+            "gpt-5-nano", "https://api.openai.com/v1"
+        )
+        assert result == ModelPlatformType.OPENAI
+
+    def test_detect_fallback_openai_empty(self) -> None:
+        result = detect_oasis_platform("gpt-4o-mini", "")
+        assert result == ModelPlatformType.OPENAI
+
+    def test_detect_fallback_cloud_suffix_triggers_ollama(self) -> None:
+        result = detect_oasis_platform(
+            "qwen3-coder-next:cloud", "https://any-compat-gateway.example.com"
+        )
+        assert result == ModelPlatformType.OLLAMA
+
+    def test_gemini_prefix_beats_ollama_url(self) -> None:
+        result = detect_oasis_platform(
+            "gemini-2.5-pro", "http://localhost:11434"
+        )
+        assert result == ModelPlatformType.GEMINI
+
+
+# ---------------------------------------------------------------------------
+# create_model() environment-variable routing — integration-level mocks
+# ---------------------------------------------------------------------------
+
+
+def _make_model_factory_mock() -> tuple[MagicMock, list[dict[str, Any]]]:
+    """Return (mock_factory_module, calls_list).
+
+    The calls_list is appended to on each ModelFactory.create() invocation,
+    capturing keyword arguments for assertions.
+    """
+    calls: list[dict[str, Any]] = []
+
+    mock_factory = MagicMock()
+    mock_factory.create = MagicMock(
+        side_effect=lambda *a, **kw: calls.append({"args": a, "kwargs": kw}) or MagicMock()
+    )
+    return mock_factory, calls
+
+
+class TestCreateModelGeminiBranch:
+    """create_model() with a Gemini model must not touch OPENAI_BASE_URL."""
+
+    def test_gemini_sets_google_api_key_not_openai_base_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_MODEL_NAME", "gemini-3-flash-preview")
+        monkeypatch.setenv("LLM_API_KEY", "my-google-key")
+        monkeypatch.setenv("LLM_BASE_URL", "https://generativelanguage.googleapis.com/v1beta/openai/")
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        config: dict[str, Any] = {}
+        rps.create_model(config, use_boost=False)
+
+        assert os.environ.get("OPENAI_BASE_URL", "") == "", \
+            "OPENAI_BASE_URL must not be set for Gemini branch"
+        assert os.environ.get("GOOGLE_API_KEY") == "my-google-key"
+        assert len(calls) == 1
+        platform_arg = calls[0]["args"][0] if calls[0]["args"] else calls[0]["kwargs"].get("model_platform")
+        assert platform_arg == ModelPlatformType.GEMINI
+
+
+class TestCreateModelOpenAIBranch:
+    """create_model() with an OpenAI model must set OPENAI_BASE_URL (unchanged behaviour)."""
+
+    def test_openai_sets_base_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_MODEL_NAME", "gpt-5-nano")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test-key")
+        monkeypatch.setenv("LLM_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        config: dict[str, Any] = {}
+        rps.create_model(config, use_boost=False)
+
+        assert os.environ.get("OPENAI_BASE_URL") == "https://api.openai.com/v1"
+        assert len(calls) == 1
+        platform_arg = calls[0]["args"][0] if calls[0]["args"] else calls[0]["kwargs"].get("model_platform")
+        assert platform_arg == ModelPlatformType.OPENAI

--- a/backend/tests/scripts/test_oasis_provider_dispatch.py
+++ b/backend/tests/scripts/test_oasis_provider_dispatch.py
@@ -175,3 +175,93 @@ class TestCreateModelOpenAIBranch:
         assert len(calls) == 1
         platform_arg = calls[0]["args"][0] if calls[0]["args"] else calls[0]["kwargs"].get("model_platform")
         assert platform_arg == ModelPlatformType.OPENAI
+        # Regression: OPENAI branch must not leak Ollama-only fields into the
+        # request body — think/num_ctx would 400 on real OpenAI.
+        model_cfg = calls[0]["kwargs"].get("model_config_dict", {})
+        assert "extra_body" not in model_cfg, \
+            "OPENAI branch must not emit extra_body (think/num_ctx are Ollama-only)"
+
+
+class TestCreateModelOllamaBranch:
+    """create_model() with an Ollama model must route via OllamaModel with url/api_key
+    and emit think/num_ctx in extra_body — even for ``:latest`` suffixes and
+    ``ollama.com`` URLs where the legacy ``_is_ollama_route`` heuristic would
+    fail.
+    """
+
+    def test_ollama_sets_url_and_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_MODEL_NAME", "llama3:latest")
+        monkeypatch.setenv("LLM_API_KEY", "my-ollama-key")
+        monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        config: dict[str, Any] = {}
+        rps.create_model(config, use_boost=False)
+
+        assert os.environ.get("OPENAI_BASE_URL", "") == "", \
+            "OPENAI_BASE_URL must not be set for Ollama branch"
+        assert os.environ.get("GOOGLE_API_KEY", "") == "", \
+            "GOOGLE_API_KEY must not be set for Ollama branch"
+        assert len(calls) == 1
+        kwargs = calls[0]["kwargs"]
+        assert kwargs.get("model_platform") == ModelPlatformType.OLLAMA
+        assert kwargs.get("url") == "http://localhost:11434"
+        assert kwargs.get("api_key") == "my-ollama-key"
+
+    def test_ollama_latest_suffix_emits_extra_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression for Gemini-Finding: ``:latest`` is detected as Ollama by
+        ``detect_oasis_platform`` but was dropped by the legacy
+        ``_is_ollama_route`` gate, silently losing ``think`` and ``num_ctx``.
+        """
+        monkeypatch.setenv("LLM_MODEL_NAME", "llama3:latest")
+        monkeypatch.setenv("LLM_API_KEY", "my-ollama-key")
+        monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
+        monkeypatch.setenv("OLLAMA_THINKING", "true")
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        rps.create_model({}, use_boost=False)
+
+        kwargs = calls[0]["kwargs"]
+        model_cfg = kwargs.get("model_config_dict", {})
+        assert "extra_body" in model_cfg, \
+            ":latest model must emit extra_body with think/num_ctx"
+        assert model_cfg["extra_body"].get("think") is True
+
+    def test_ollama_cloud_host_emits_extra_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression for Gemini-Finding: ``ollama.com`` URL → OLLAMA route,
+        must still produce ``extra_body`` even though the legacy heuristic
+        only matched ``:11434``.
+        """
+        monkeypatch.setenv("LLM_MODEL_NAME", "qwen3-coder-next:cloud")
+        monkeypatch.setenv("LLM_API_KEY", "cloud-key")
+        monkeypatch.setenv("LLM_BASE_URL", "https://ollama.com")
+        monkeypatch.setenv("OLLAMA_THINKING", "false")
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        rps.create_model({}, use_boost=False)
+
+        kwargs = calls[0]["kwargs"]
+        assert kwargs.get("model_platform") == ModelPlatformType.OLLAMA
+        model_cfg = kwargs.get("model_config_dict", {})
+        assert "extra_body" in model_cfg
+        assert model_cfg["extra_body"].get("think") is False


### PR DESCRIPTION
## Summary

- Drei-Wege-Provider-Dispatch in `create_model()` / `_create_model()` der OASIS-Subprozesse
- Neue `detect_oasis_platform()`-Heuristik in `_sim_common.py` (Model-Name + Base-URL)
- GEMINI → native `GeminiModel` (`thought_signature`-Echo für Tool-Calls)
- OLLAMA → native `OllamaModel` (`/api/chat` statt OpenAI-Compat `/v1`)
- OPENAI → unverändertes Verhalten (OpenAI, Anthropic-Gateways, Qwen etc.)
- 14 neue Tests (12 Unit + 2 Integration) in `test_oasis_provider_dispatch.py`

## Background

Gemini 3 erfordert `thought_signature` in `functionCall`-Parts bei Multi-Turn-Tool-Calls.
Die OpenAI-Compat-Schicht in CAMEL strippt dieses Feld → HTTP 400 auf jeden Tool-Turn.

Ollama Cloud hat seinen OpenAI-Compat `/v1`-Endpunkt eingestellt; nur native `/api/chat` funktioniert.

## Test plan

- [x] ruff clean
- [x] 14/14 dispatch tests green
- [x] 8/8 regression tests (`test_simulation_runtime.py`) green
- [ ] Manual smoke: Gemini-3-Simulation durchlaufen lassen
- [ ] Manual smoke: Ollama-Cloud-Simulation durchlaufen lassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)