### PR TITLE
UX/Config Batch Mai 2026 — 7 Tasks (TZ · Tokens · Graph · LogDrawer · Feed · Sim-Zeit)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,12 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # LLM_DISABLE_JSON_MODE=true
 # OLLAMA_THINKING=false
 
+# Max-Output-Tokens fuer Sim-Runner (run_reddit_simulation / run_twitter_simulation).
+# Default seit 2026-05-16: 16384. Verhindert silent OOM/Truncation bei
+# Multi-Agent-Workloads mit grossem num_ctx (CAMEL-Issue). Auf 8192 oder
+# kleiner setzen, wenn LLM-Provider strikte Output-Limits hat.
+# LLM_MAX_OUTPUT_TOKENS=16384
+
 # Persona-Detail-Level (Issue #217 Stufe 2b) — steuert Output-Groesse pro Persona.
 # Direkter Hebel auf Cloud-LLM-Inference-Zeit:
 # - compact:  300-500 Woerter, ~3x schneller als rich, knapper Stil (gut fuer Bulk-Sims)

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /bin/
 ENV UV_HTTP_TIMEOUT=1800
 ENV UV_HTTP_RETRIES=5
 
+ENV TZ=Europe/Berlin
+
 WORKDIR /app
 RUN useradd -m -u 1000 agora \
   && mkdir -p /app/backend/uploads /app/backend/logs \
@@ -121,6 +123,14 @@ ENV PYTHONUNBUFFERED=1 \
     PATH="/app/backend/.venv/bin:$PATH"
 
 WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends tzdata \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -snf /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
+  && echo "Europe/Berlin" > /etc/timezone
+
+ENV TZ=Europe/Berlin
 
 RUN useradd -m -u 1000 -s /usr/sbin/nologin agora \
   && mkdir -p /app/backend/uploads /app/backend/logs /app/frontend/dist /home/agora/.cache /home/agora/.gunicorn \

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -157,11 +157,13 @@ def get_logs():
         # Backend lebt, auch wenn die heutige Logdatei noch nicht
         # geschrieben wurde. Ohne den message-Marker stand im Drawer ein
         # generisches "leer", obwohl der Pfad einfach noch nicht existiert.
+        # Wir liefern den i18n-Key, das Frontend übersetzt — vermeidet
+        # hardkodierten EN-Text in der API-Response (Gemini-Finding).
         return json_success({
             'lines': [],
             'offset': 0,
             'file': None,
-            'message': 'log file for today not yet written',
+            'message': 'logs.drawer.noFileYet',
         })
     lines, offset = _read_tail(path, n)
     filtered = _filter_lines(lines, level)

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -153,7 +153,16 @@ def get_logs():
     n = _parse_tail_arg()
     level = request.args.get('level')
     if path is None:
-        return json_success({'lines': [], 'offset': 0, 'file': None})
+        # Task 7 — Frontend-LogDrawer braucht ein Live-Signal, dass das
+        # Backend lebt, auch wenn die heutige Logdatei noch nicht
+        # geschrieben wurde. Ohne den message-Marker stand im Drawer ein
+        # generisches "leer", obwohl der Pfad einfach noch nicht existiert.
+        return json_success({
+            'lines': [],
+            'offset': 0,
+            'file': None,
+            'message': 'log file for today not yet written',
+        })
     lines, offset = _read_tail(path, n)
     filtered = _filter_lines(lines, level)
     return json_success({

--- a/backend/app/contracts/post_event_contract.py
+++ b/backend/app/contracts/post_event_contract.py
@@ -64,6 +64,25 @@ class PostCreatedEvent(BaseModel):
         default=0,
         description="Voting-Score (Reddit-Pattern). Twitter-Posts haben kein Voting → 0.",
     )
+    sim_time: datetime | None = Field(
+        default=None,
+        description=(
+            "Simulierte Agenten-Wallclock (Sim-Round → Wallclock, tz-aware). "
+            "Quelle: run_parallel_simulation leitet aus start_time + "
+            "start_hour_offset + simulated_minutes pro CREATE_POST ab. "
+            "None bei Pre-Slice-5-Daten und für Persistenz-Snapshots ohne Feld."
+        ),
+    )
+
+    @field_validator("sim_time")
+    @classmethod
+    def sim_time_tz_aware(cls, v: datetime | None) -> datetime | None:
+        # Layer-0 erzwingt tz-aware Timestamps für sim_time. Naive datetimes
+        # würden im Frontend zu „local time"-Drift führen, sobald der Container
+        # eine andere TZ als der Browser hat.
+        if v is not None and v.tzinfo is None:
+            raise ValueError("sim_time muss tz-aware sein (UTC + Offset)")
+        return v
 
     @field_validator("sentiment")
     @classmethod

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -71,7 +71,7 @@ import logging
 import random
 import signal
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional, Tuple
 
 
@@ -219,6 +219,7 @@ async def _emit_post_created_to_redis(
     platform: str,
     action_data: Dict[str, Any],
     redis_url: Optional[str],
+    sim_time_iso: Optional[str] = None,
 ) -> None:
     """Publish a PostCreatedEvent to Redis after a CREATE_POST action.
 
@@ -268,6 +269,8 @@ async def _emit_post_created_to_redis(
         "sentiment": None,
         # Phase B: Voting-Score — 0 als neutraler Default (Twitter hat kein Voting).
         "score": 0,
+        # Task 1 — virtuelle Sim-Zeit pro CREATE_POST. None bei alten Callern.
+        "sim_time": sim_time_iso,
     }
     channel = f"agora:sim:{simulation_id}:post_created"
     try:
@@ -1538,6 +1541,12 @@ async def run_twitter_simulation(
         log_info(f"Short run: shifting simulated clock to start at hour {start_hour_offset:02d}:00 (active-hour overlap)")
 
     start_time = datetime.now()
+    # Task 1 — Anker für virtuelle Sim-Zeit. tz-aware UTC, 00:00 als
+    # Tagesbasis, damit sim_time deterministisch aus
+    # (start_hour_offset, simulated_minutes) ableitbar bleibt.
+    sim_clock_anchor = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
 
     for round_num in range(total_rounds):
         # Check if received exit signal
@@ -1594,15 +1603,20 @@ async def run_twitter_simulation(
         else:
             actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)
-        
+
         # Get actual executed actions from Database and log
         actual_actions, last_rowid = fetch_new_actions_from_db(
             db_path, last_rowid, agent_names
         )
-        
+
         round_action_count = 0
         _sim_id_for_emit = config.get("simulation_id") or os.path.basename(simulation_dir.rstrip("/"))
         _redis_url_for_emit = os.environ.get("REDIS_URL")
+        # Sim-Zeit für CREATE_POST-Frames dieser Round.
+        _sim_dt = sim_clock_anchor + timedelta(
+            minutes=start_hour_offset * 60 + simulated_minutes
+        )
+        _sim_time_iso = _sim_dt.isoformat()
         for action_data in actual_actions:
             if action_logger:
                 action_logger.log_action(
@@ -1621,6 +1635,7 @@ async def run_twitter_simulation(
                     platform="twitter",
                     action_data=action_data,
                     redis_url=_redis_url_for_emit,
+                    sim_time_iso=_sim_time_iso,
                 )
 
         if action_logger:
@@ -1806,6 +1821,10 @@ async def run_reddit_simulation(
         log_info(f"Short run: shifting simulated clock to start at hour {start_hour_offset:02d}:00 (active-hour overlap)")
 
     start_time = datetime.now()
+    # Task 1 — Anker für virtuelle Sim-Zeit (siehe Twitter-Branch oben).
+    sim_clock_anchor = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
 
     for round_num in range(total_rounds):
         # Check if received exit signal
@@ -1862,15 +1881,19 @@ async def run_reddit_simulation(
         else:
             actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)
-        
+
         # Get actual executed actions from Database and log
         actual_actions, last_rowid = fetch_new_actions_from_db(
             db_path, last_rowid, agent_names
         )
-        
+
         round_action_count = 0
         _sim_id_for_emit = config.get("simulation_id") or os.path.basename(simulation_dir.rstrip("/"))
         _redis_url_for_emit = os.environ.get("REDIS_URL")
+        _sim_dt = sim_clock_anchor + timedelta(
+            minutes=start_hour_offset * 60 + simulated_minutes
+        )
+        _sim_time_iso = _sim_dt.isoformat()
         for action_data in actual_actions:
             if action_logger:
                 action_logger.log_action(
@@ -1889,6 +1912,7 @@ async def run_reddit_simulation(
                     platform="reddit",
                     action_data=action_data,
                     redis_url=_redis_url_for_emit,
+                    sim_time_iso=_sim_time_iso,
                 )
 
         if action_logger:

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -483,7 +483,7 @@ class RedditSimulationRunner:
         platform = detect_oasis_platform(llm_model, llm_base_url)
         think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
         ctx_limit = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-        completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "8192"))
+        completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "16384"))
 
         print(
             f"LLM configuration: model={llm_model}, "

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -470,7 +470,7 @@ class TwitterSimulationRunner:
         platform = detect_oasis_platform(llm_model, llm_base_url)
         think_on = os.environ.get("OLLAMA_THINKING", "false").lower() in ("1", "true", "yes")
         ctx_limit = int(os.environ.get("LLM_CONTEXT_LIMIT", "262144"))
-        completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "8192"))
+        completion_max_tokens = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "16384"))
 
         print(
             f"LLM configuration: model={llm_model}, "

--- a/backend/tests/contracts/test_post_event_contract_sim_time.py
+++ b/backend/tests/contracts/test_post_event_contract_sim_time.py
@@ -1,0 +1,70 @@
+"""Task 1 — PostCreatedEvent.sim_time Contract-Tests.
+
+Sichert ab:
+- sim_time ist optional und akzeptiert None / fehlt
+- tz-aware Werte werden akzeptiert (UTC, +0200)
+- tz-naive Werte werden abgelehnt (Layer-0 erzwingt Offset)
+- Snapshot-Drift: schemas/post-created-event.schema.json enthält das Feld
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.post_event_contract import PostCreatedEvent
+
+
+def _base_payload(**overrides):
+    payload = {
+        "event_type": "post_created",
+        "simulation_id": "sim-1",
+        "post_id": "p-1",
+        "parent_post_id": None,
+        "platform": "twitter",
+        "persona_id": "persona-1",
+        "voice_register": "casual",
+        "is_simulated": True,
+        "body": "Hello",
+        "timestamp": datetime.now(timezone.utc),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_sim_time_field_is_optional_default_none() -> None:
+    event = PostCreatedEvent(**_base_payload())
+    assert event.sim_time is None
+
+
+def test_sim_time_accepts_tz_aware_utc() -> None:
+    dt = datetime(2026, 5, 16, 10, 30, tzinfo=timezone.utc)
+    event = PostCreatedEvent(**_base_payload(sim_time=dt))
+    assert event.sim_time == dt
+
+
+def test_sim_time_accepts_tz_aware_offset() -> None:
+    tz = timezone(timedelta(hours=2))
+    dt = datetime(2026, 5, 16, 12, 30, tzinfo=tz)
+    event = PostCreatedEvent(**_base_payload(sim_time=dt))
+    assert event.sim_time == dt
+
+
+def test_sim_time_rejects_naive_datetime() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        PostCreatedEvent(**_base_payload(sim_time=datetime(2026, 5, 16, 10, 30)))
+    msg = str(exc_info.value)
+    assert "tz-aware" in msg or "tzinfo" in msg or "UTC" in msg or "Offset" in msg or "offset" in msg
+
+
+def test_schema_dump_contains_sim_time_field() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    schema_path = repo_root / "schemas" / "post-created-event.schema.json"
+    assert schema_path.exists(), f"Schema-Dump fehlt: {schema_path}"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    props = schema.get("properties", {})
+    assert "sim_time" in props, "sim_time muss im dumped Schema vorhanden sein"

--- a/backend/tests/scripts/test_run_simulation_default_tokens.py
+++ b/backend/tests/scripts/test_run_simulation_default_tokens.py
@@ -1,0 +1,34 @@
+"""Regression: LLM_MAX_OUTPUT_TOKENS-Default in den Sim-Runnern.
+
+Hintergrund: Mit 8192 als Default kam es bei Multi-Agent-Workloads und
+großem num_ctx zu silent Truncation (CAMEL-Issue). Default seit
+2026-05-16: 16384. Kein Subprocess-Spawn — die Konstante wird direkt
+aus dem Source gelesen.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = (
+    "backend/scripts/run_reddit_simulation.py",
+    "backend/scripts/run_twitter_simulation.py",
+)
+
+_PATTERN = re.compile(
+    r'os\.environ\.get\(\s*"LLM_MAX_OUTPUT_TOKENS"\s*,\s*"(?P<default>\d+)"\s*\)'
+)
+
+
+@pytest.mark.parametrize("rel_path", SCRIPTS)
+def test_llm_max_output_tokens_default_is_16384(rel_path: str) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    src = (repo_root / rel_path).read_text(encoding="utf-8")
+    match = _PATTERN.search(src)
+    assert match, f"LLM_MAX_OUTPUT_TOKENS-Default nicht gefunden in {rel_path}"
+    assert match.group("default") == "16384", (
+        f"{rel_path}: erwartet Default 16384, gefunden {match.group('default')!r}"
+    )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,6 +70,8 @@ services:
       # Verbindung kaputt machen.
       - LLM_BASE_URL=${LLM_BASE_URL:-http://host.docker.internal:11434/v1}
       - EMBEDDING_BASE_URL=${EMBEDDING_BASE_URL:-http://host.docker.internal:11434}
+      # Container-Zeitzone (siehe docker-compose.yml).
+      - TZ=Europe/Berlin
 
   neo4j:
     ports: !reset []

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,8 @@ services:
       - EMBEDDING_BASE_URL=${EMBEDDING_BASE_URL:-http://host.docker.internal:11434}
       # Container-Zeitzone (siehe docker-compose.yml).
       - TZ=Europe/Berlin
+      # LLM-Default für Sim-Runner — siehe docker-compose.yml.
+      - LLM_MAX_OUTPUT_TOKENS=${LLM_MAX_OUTPUT_TOKENS:-16384}
 
   neo4j:
     ports: !reset []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,10 @@ services:
       # Date-Schwelle (backend/app/utils/logger.py) laufen auf Europe/Berlin.
       # sim_time (Layer-0) bleibt unabhängig — ist tz-aware (UTC + Offset).
       - TZ=Europe/Berlin
+      # LLM-Default für Sim-Runner. 16384 verhindert silent OOM/Truncation
+      # bei Multi-Agent-Workloads mit großem num_ctx (CAMEL-Issue). Override
+      # via .env oder LLM_MAX_OUTPUT_TOKENS=… docker compose up.
+      - LLM_MAX_OUTPUT_TOKENS=${LLM_MAX_OUTPUT_TOKENS:-16384}
 
   redis:
     image: redis:7-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,10 @@ services:
       # urllib3 versucht IPv6 (ENETUNREACH) ohne IPv4-Fallback (kein Happy Eyeballs).
       # Workaround: urllib3 auf IPv4-only setzen. Quelle: docker/for-mac#7332
       - DOCKER_IPV4_ONLY=1
+      # Container-Zeitzone: alle datetime.now()-Naiv-Calls und LogDrawer-
+      # Date-Schwelle (backend/app/utils/logger.py) laufen auf Europe/Berlin.
+      # sim_time (Layer-0) bleibt unabhängig — ist tz-aware (UTC + Offset).
+      - TZ=Europe/Berlin
 
   redis:
     image: redis:7-alpine

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2445 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 123 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2452 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 126 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -12,6 +12,7 @@
       @download-svg="canvasRef?.downloadSvg()"
       @download-png="canvasRef?.downloadPng()"
       @print-pdf="canvasRef?.printPdf()"
+      @download-html="canvasRef?.downloadHtml()"
     />
 
     <GraphCanvas

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -13,6 +13,7 @@
       @download-png="canvasRef?.downloadPng()"
       @print-pdf="canvasRef?.printPdf()"
       @download-html="canvasRef?.downloadHtml()"
+      @close-graph="$emit('close-graph')"
     />
 
     <GraphCanvas
@@ -58,7 +59,7 @@ const props = defineProps({
   batchSignal: { type: Object, default: null },
 })
 
-defineEmits(['refresh', 'toggle-maximize'])
+defineEmits(['refresh', 'toggle-maximize', 'close-graph'])
 
 const canvasRef = ref(null)
 

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -38,7 +38,7 @@
       <div ref="scrollEl" class="drawer-body">
         <div v-if="loading && !lines.length" class="meta">{{ t('logs.drawer.loading') }}</div>
         <div v-else-if="errorMessage" class="meta is-error">{{ errorMessage }}</div>
-        <div v-else-if="fileNotice" class="meta">{{ fileNotice }}</div>
+        <div v-else-if="fileNotice" class="meta">{{ t(fileNotice) }}</div>
         <div v-else-if="!filteredLines.length" class="meta">{{ t('logs.drawer.empty') }}</div>
         <template v-else>
           <div

--- a/frontend/src/components/LogDrawer.vue
+++ b/frontend/src/components/LogDrawer.vue
@@ -36,13 +36,18 @@
     </header>
     <div class="drawer-body-wrap">
       <div ref="scrollEl" class="drawer-body">
-        <div v-if="!filteredLines.length" class="meta">{{ t('logs.drawer.empty') }}</div>
-        <div
-          v-for="(line, i) in filteredLines"
-          :key="'l' + i"
-          class="log-line"
-          :class="{ 'is-error': isErrorLine(line) }"
-        >{{ line }}</div>
+        <div v-if="loading && !lines.length" class="meta">{{ t('logs.drawer.loading') }}</div>
+        <div v-else-if="errorMessage" class="meta is-error">{{ errorMessage }}</div>
+        <div v-else-if="fileNotice" class="meta">{{ fileNotice }}</div>
+        <div v-else-if="!filteredLines.length" class="meta">{{ t('logs.drawer.empty') }}</div>
+        <template v-else>
+          <div
+            v-for="(line, i) in filteredLines"
+            :key="'l' + i"
+            class="log-line"
+            :class="{ 'is-error': isErrorLine(line) }"
+          >{{ line }}</div>
+        </template>
       </div>
       <StickyScrollBanner :count="sticky.unreadCount.value" @jump="sticky.scrollToBottom" />
     </div>
@@ -68,6 +73,12 @@ const search = ref('')
 const paused = ref(false)
 const streamFailed = ref(false)
 const streamReconnecting = ref(false)
+// Task 7 — Loading/Error/Backend-Marker an die UI durchreichen, damit der
+// User unterscheiden kann zwischen "Backend lebt, hat aber noch keine
+// Datei für heute" und "Request fehlgeschlagen".
+const loading = ref(false)
+const errorMessage = ref(null)
+const fileNotice = ref(null)
 const scrollEl = ref(null)
 const sticky = useStickyScroll(scrollEl)
 // Letzter Datei-Offset aus dem Tail-Response — geben wir dem Stream als
@@ -99,6 +110,9 @@ let _eventSource = null
 let _streamGeneration = 0
 
 async function reload() {
+  loading.value = true
+  errorMessage.value = null
+  fileNotice.value = null
   try {
     const res = await fetchLogs({ tail: 500, level: level.value || null })
     if (res?.data?.success) {
@@ -107,9 +121,20 @@ async function reload() {
       lines.value = incoming
       const off = data.offset
       lastOffset = Number.isInteger(off) && off >= 0 ? off : null
+      // Backend-Marker bei file=null durchreichen (z. B. heutige Logdatei
+      // noch nicht angelegt) — User sieht so, dass das Backend lebt.
+      if (data.file === null && data.message) {
+        fileNotice.value = data.message
+      }
       nextTick(() => sticky.scrollToBottom())
+    } else {
+      errorMessage.value = res?.data?.error || t('logs.drawer.unknownError')
     }
-  } catch { /* swallow */ }
+  } catch (err) {
+    errorMessage.value = err?.message || String(err)
+  } finally {
+    loading.value = false
+  }
 }
 
 function appendLine(line, { bypassPause = false } = {}) {

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -27,6 +27,10 @@ import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
 import StickyScrollBanner from './ui/StickyScrollBanner.vue'
 import { tokenizeFeedText } from '../utils/feedHighlight'
+import FeedColumn from './v4/sim-feed/FeedColumn.vue'
+import TwitterPost from './v4/sim-feed/TwitterPost.vue'
+import RedditThread from './v4/sim-feed/RedditThread.vue'
+import { useSimFeed, clearSimFeed } from '../composables/useSimFeed'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -202,9 +206,21 @@ function addLog(msg) { emit('add-log', msg) }
 // Issue #9 Phase C: run-state now arrives via SSE (backend subscribes to
 // the event bus), so the 2.5 s status-polling loop is gone. Detail + console
 // stay on HTTP polls — they read different artifacts.
+// Task 2 — Dual-Column Sim-Feed. Reddit + Twitter werden über useSimFeed
+// dedupliziert und nach Platform geroutet. ingest() füttert beide Columns
+// vom selben SSE-Frame (post_created). Stats nutzen weiter allActions
+// (HTTP-Polling in pollDetail) — die beiden Quellen koexistieren absichtlich.
+const _feedStore = computed(() => useSimFeed(props.simulationId || '__unset__'))
+const twitterPosts = computed(() => _feedStore.value.twitterPosts.value)
+const redditPosts = computed(() => _feedStore.value.redditPosts.value)
+const redditTree = computed(() => _feedStore.value.redditTree.value)
+
 const statusStream = useEventStream(() => props.simulationId, {
   state: (msg) => applyRunStateEvent(msg?.payload),
   control: (msg) => applyControlEvent(msg?.payload),
+  post_created: (data) => {
+    if (data) _feedStore.value.ingest(data)
+  },
 })
 // Slice 1e: last SSE trace_id for the SigNoz deep-link button.
 const { lastTraceId } = statusStream
@@ -477,6 +493,13 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('keydown', handleToolPanelHotkey)
   stopPolling()
+  if (props.simulationId) clearSimFeed(props.simulationId)
+})
+
+// Sim-Wechsel im selben Component-Lifetime (z. B. nach Reload mit neuer ID):
+// alten Store droppen, damit dedupe-Cache und LRU sauber bleiben.
+watch(() => props.simulationId, (newId, oldId) => {
+  if (oldId && oldId !== newId) clearSimFeed(oldId)
 })
 </script>
 
@@ -583,53 +606,46 @@ onUnmounted(() => {
             </button>
           </div>
         </header>
-        <div class="logs-grid">
-          <div class="log-pane">
-            <div class="log-pane-head">
-              <span class="meta">Live-Feed</span>
-              <div class="density-toggle" role="group" :aria-label="t('step3.feed.density.label')">
-                <button
-                  type="button"
-                  class="density-btn"
-                  :class="{ active: feedDensity === 'comfort' }"
-                  :aria-pressed="feedDensity === 'comfort'"
-                  @click="setFeedDensity('comfort')"
-                >{{ t('step3.feed.density.comfort') }}</button>
-                <button
-                  type="button"
-                  class="density-btn"
-                  :class="{ active: feedDensity === 'compact' }"
-                  :aria-pressed="feedDensity === 'compact'"
-                  @click="setFeedDensity('compact')"
-                >{{ t('step3.feed.density.compact') }}</button>
-              </div>
-              <span class="meta">{{ allActions.length }}</span>
-            </div>
-            <div class="log-pane-scroll-wrap">
-              <div
-                ref="scrollEl"
-                class="feed log-block log-pane-body"
-                :class="['density-' + feedDensity]"
-              >
-                <div v-if="!allActions.length" class="meta">{{ t('step3.feed.empty') }}</div>
-                <div v-for="(a, i) in allActions" :key="i" class="feed-line">
-                  <span class="ts">[R{{ a.round_num }} · {{ a.platform.toUpperCase() }}]</span>
-                  <span class="who">{{ a.agent_name || ('agent_' + a.agent_id) }}</span>
-                  <span class="act">{{ a.action_type }}</span>
-                  <span class="content" v-if="a.action_args?.content">
-                    — <template
-                      v-for="(tok, ti) in (a._tokens || [])"
-                      :key="ti"
-                    ><span :class="['tok', 'tok-' + tok.type]">{{ tok.value }}</span></template>
-                  </span>
-                </div>
-              </div>
-              <StickyScrollBanner
-                :count="feedSticky.unreadCount.value"
-                @jump="feedSticky.scrollToBottom"
-              />
-            </div>
+        <div class="card-head feed-density-row">
+          <div class="density-toggle" role="group" :aria-label="t('step3.feed.density.label')">
+            <button
+              type="button"
+              class="density-btn"
+              :class="{ active: feedDensity === 'comfort' }"
+              :aria-pressed="feedDensity === 'comfort'"
+              @click="setFeedDensity('comfort')"
+            >{{ t('step3.feed.density.comfort') }}</button>
+            <button
+              type="button"
+              class="density-btn"
+              :class="{ active: feedDensity === 'compact' }"
+              :aria-pressed="feedDensity === 'compact'"
+              @click="setFeedDensity('compact')"
+            >{{ t('step3.feed.density.compact') }}</button>
           </div>
+          <span class="meta">{{ allActions.length }}</span>
+        </div>
+        <div class="feed-grid" :data-density="feedDensity">
+          <FeedColumn :title="t('feed.twitter')" channel="twitter">
+            <TransitionGroup name="slide-in" tag="div" class="post-list">
+              <TwitterPost
+                v-for="post in twitterPosts"
+                :key="post.post_id"
+                :post="post"
+              />
+            </TransitionGroup>
+            <p v-if="!twitterPosts.length" class="meta">{{ t('step3.feed.empty') }}</p>
+          </FeedColumn>
+          <FeedColumn :title="t('feed.reddit')" channel="reddit">
+            <TransitionGroup name="slide-in" tag="div" class="post-list">
+              <RedditThread
+                v-for="node in redditTree"
+                :key="node.post_id"
+                :node="node"
+              />
+            </TransitionGroup>
+            <p v-if="!redditPosts.length" class="meta">{{ t('step3.feed.empty') }}</p>
+          </FeedColumn>
         </div>
       </article>
 
@@ -803,6 +819,25 @@ onUnmounted(() => {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--s-3);
+}
+/* Task 2 — Dual-Column Sim-Feed. min-height analog log-pane-body damit beide
+   Columns mit dem alten Live-Feed identische Höhe haben. */
+.feed-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-3);
+  min-height: 0;
+}
+.feed-grid > * { min-height: 480px; max-height: clamp(480px, 60vh, 720px); }
+.feed-density-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: none;
+  padding-top: var(--s-2);
+}
+@media (max-width: 880px) {
+  .feed-grid { grid-template-columns: 1fr; }
 }
 .log-pane {
   display: flex;

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -873,6 +873,7 @@ watch(() => props.simulationId, (newId, oldId) => {
   grid-template-columns: 1fr 1fr;
   gap: var(--s-3);
   min-height: 0;
+  overflow: visible;  /* Scrollen läuft pro FeedColumn (.fc-scroll). */
 }
 .feed-grid > * { min-height: 480px; max-height: clamp(480px, 60vh, 720px); }
 .feed-density-row {
@@ -881,6 +882,21 @@ watch(() => props.simulationId, (newId, oldId) => {
   align-items: center;
   border-bottom: none;
   padding-top: var(--s-2);
+}
+/* Density-Toggle wirkt jetzt am Container und vererbt via CSS-Vars an die
+   FeedColumn-Kinder. Comfort = Default; Compact = engere Skalen. */
+.feed-grid[data-density="comfort"] {
+  --feed-post-padding: var(--s-3);
+  --feed-post-gap: var(--s-2);
+  --feed-post-fs: var(--fs-13, 13px);
+  --feed-post-lh: 1.6;
+}
+.feed-grid[data-density="compact"] {
+  --feed-post-padding: var(--s-2);
+  --feed-post-gap: 4px;
+  --feed-post-fs: 12px;
+  --feed-post-lh: 1.35;
+  gap: var(--s-2);
 }
 @media (max-width: 880px) {
   .feed-grid { grid-template-columns: 1fr; }

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -31,6 +31,7 @@ import FeedColumn from './v4/sim-feed/FeedColumn.vue'
 import TwitterPost from './v4/sim-feed/TwitterPost.vue'
 import RedditThread from './v4/sim-feed/RedditThread.vue'
 import { useSimFeed, clearSimFeed } from '../composables/useSimFeed'
+import { useSimClock, clearSimClock } from '../composables/useSimClock'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -215,11 +216,35 @@ const twitterPosts = computed(() => _feedStore.value.twitterPosts.value)
 const redditPosts = computed(() => _feedStore.value.redditPosts.value)
 const redditTree = computed(() => _feedStore.value.redditTree.value)
 
+// Task 1 — Sim-Zeit-Composable. ingest pumpt aus dem post_created-Handler.
+const _simClock = computed(() => useSimClock(props.simulationId || '__unset__'))
+const currentSimTime = computed(() => _simClock.value.currentSimTime.value)
+const simElapsedSec = computed(() => _simClock.value.elapsed.value)
+
+const _berlinFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'short',
+  timeStyle: 'medium',
+  timeZone: 'Europe/Berlin',
+})
+function formatBerlin(d) {
+  return d ? _berlinFormatter.format(d) : ''
+}
+function formatElapsed(seconds) {
+  const s = Math.max(0, Math.floor(seconds))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const pad = (n) => String(n).padStart(2, '0')
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
+}
+
 const statusStream = useEventStream(() => props.simulationId, {
   state: (msg) => applyRunStateEvent(msg?.payload),
   control: (msg) => applyControlEvent(msg?.payload),
   post_created: (data) => {
-    if (data) _feedStore.value.ingest(data)
+    if (!data) return
+    _feedStore.value.ingest(data)
+    _simClock.value.ingest(data)
   },
 })
 // Slice 1e: last SSE trace_id for the SigNoz deep-link button.
@@ -493,13 +518,19 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('keydown', handleToolPanelHotkey)
   stopPolling()
-  if (props.simulationId) clearSimFeed(props.simulationId)
+  if (props.simulationId) {
+    clearSimFeed(props.simulationId)
+    clearSimClock(props.simulationId)
+  }
 })
 
 // Sim-Wechsel im selben Component-Lifetime (z. B. nach Reload mit neuer ID):
 // alten Store droppen, damit dedupe-Cache und LRU sauber bleiben.
 watch(() => props.simulationId, (newId, oldId) => {
-  if (oldId && oldId !== newId) clearSimFeed(oldId)
+  if (oldId && oldId !== newId) {
+    clearSimFeed(oldId)
+    clearSimClock(oldId)
+  }
 })
 </script>
 
@@ -566,6 +597,11 @@ watch(() => props.simulationId, (newId, oldId) => {
         <header class="card-head">
           <Kicker num="02">{{ t('step3.feed.title') }}</Kicker>
           <span class="meta">{{ t('step3.feed.actions', { count: totalActions }) }}</span>
+          <div v-if="currentSimTime" class="sim-clock" :title="t('step3.simClock.tooltip')">
+            <span class="meta">SIM</span>
+            <time :datetime="currentSimTime.toISOString()">{{ formatBerlin(currentSimTime) }}</time>
+            <span class="meta">({{ formatElapsed(simElapsedSec) }})</span>
+          </div>
         </header>
         <div class="stats-grid">
           <div class="stat">
@@ -815,6 +851,16 @@ watch(() => props.simulationId, (newId, oldId) => {
 }
 
 .log-meta { display: flex; gap: var(--s-2); }
+.sim-clock {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--s-2);
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: var(--ls-mono);
+  color: var(--fg);
+}
+.sim-clock time { color: var(--accent); }
 .logs-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/frontend/src/components/__tests__/LogDrawer.spec.ts
+++ b/frontend/src/components/__tests__/LogDrawer.spec.ts
@@ -104,6 +104,7 @@ const i18n = createI18n({
           empty: 'Noch keine Log-Zeilen.',
           loading: 'Logs werden geladen…',
           unknownError: 'Logs konnten nicht geladen werden.',
+          noFileYet: 'Heutige Logdatei wurde noch nicht geschrieben — Backend ist erreichbar.',
           connectionError: 'SSE-Verbindung unterbrochen, Browser versucht Reconnect…',
           reconnectExhausted: 'Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.',
           reconnect: 'Erneut verbinden',
@@ -173,7 +174,7 @@ describe('LogDrawer — SSE Reconnect (Slice 4, unbegrenzte Reconnects)', () => 
     ;(fetchLogs as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       data: {
         success: true,
-        data: { lines: [], offset: 0, file: null, message: 'log file for today not yet written' },
+        data: { lines: [], offset: 0, file: null, message: 'logs.drawer.noFileYet' },
       },
     })
 
@@ -184,7 +185,7 @@ describe('LogDrawer — SSE Reconnect (Slice 4, unbegrenzte Reconnects)', () => 
     await flushPromises()
     await nextTick()
 
-    expect(wrapper.text()).toContain('log file for today not yet written')
+    expect(wrapper.text()).toContain('Heutige Logdatei wurde noch nicht geschrieben')
   })
 
   it('zeigt Loading-State während fetchLogs läuft (Task 7)', async () => {

--- a/frontend/src/components/__tests__/LogDrawer.spec.ts
+++ b/frontend/src/components/__tests__/LogDrawer.spec.ts
@@ -102,6 +102,8 @@ const i18n = createI18n({
           search: 'Suchen…',
           pause: 'Auto-Scroll pausieren',
           empty: 'Noch keine Log-Zeilen.',
+          loading: 'Logs werden geladen…',
+          unknownError: 'Logs konnten nicht geladen werden.',
           connectionError: 'SSE-Verbindung unterbrochen, Browser versucht Reconnect…',
           reconnectExhausted: 'Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.',
           reconnect: 'Erneut verbinden',
@@ -150,6 +152,62 @@ describe('LogDrawer — SSE Reconnect (Slice 4, unbegrenzte Reconnects)', () => 
     expect(wrapper.find('.reconnect-btn').exists()).toBe(false)
 
     wrapper.unmount()
+  })
+
+  it('zeigt Fehlermeldung wenn fetchLogs einen Fehler wirft (Task 7)', async () => {
+    const { fetchLogs } = await import('../../api/logs')
+    ;(fetchLogs as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
+
+    const wrapper = mount(LogDrawer, {
+      props: { open: true },
+      global: globalConfig,
+    })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('boom')
+  })
+
+  it('zeigt Backend-Marker bei file=null (Task 7)', async () => {
+    const { fetchLogs } = await import('../../api/logs')
+    ;(fetchLogs as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: { lines: [], offset: 0, file: null, message: 'log file for today not yet written' },
+      },
+    })
+
+    const wrapper = mount(LogDrawer, {
+      props: { open: true },
+      global: globalConfig,
+    })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('log file for today not yet written')
+  })
+
+  it('zeigt Loading-State während fetchLogs läuft (Task 7)', async () => {
+    const { fetchLogs } = await import('../../api/logs')
+    let resolveFetch: (val: unknown) => void = () => {}
+    ;(fetchLogs as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFetch = resolve }),
+    )
+
+    const wrapper = mount(LogDrawer, {
+      props: { open: true },
+      global: globalConfig,
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Logs werden geladen…')
+
+    resolveFetch({ data: { success: true, data: { lines: ['ok'], offset: 0 } } })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Logs werden geladen…')
   })
 
   it('reconnect-indicator bleibt versteckt, wenn onmessage rechtzeitig kommt', async () => {

--- a/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
@@ -1,0 +1,238 @@
+// Task 2 — Dual-Column Sim-Feed Smoke-Test.
+//
+// Mountet Step3Simulation mit gestubbtem useEventStream und feuert zwei
+// post_created-Events (1 reddit, 1 twitter) über den Store. Erwartung:
+// Card 3 enthält genau zwei FeedColumn-Stubs, und beide Columns rendern
+// jeweils einen Post-Stub. Stats (allActions) und Console bleiben
+// unangetastet — der Test isoliert den Feed-Pfad.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { nextTick, ref } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+const localStorageMock = (() => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v },
+    removeItem: (k: string) => { delete store[k] },
+    clear: () => { Object.keys(store).forEach((k) => delete store[k]) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// API-Stubs — Step3Simulation feuert pollDetail() onMounted; wir lassen
+// alles still durchlaufen.
+vi.mock('../../api/simulation', () => ({
+  startSimulation: vi.fn(),
+  stopSimulation: vi.fn(),
+  pauseSimulation: vi.fn(),
+  resumeSimulation: vi.fn(),
+  getRunStatus: vi.fn().mockResolvedValue({ success: false }),
+  getRunStatusDetail: vi.fn().mockResolvedValue({ success: false }),
+  getSimulationConsoleLog: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('../../api/report', () => ({
+  generateReport: vi.fn(),
+}))
+
+// useEventStream-Mock: speichert die Handlers, gibt sie für den Test frei.
+let capturedHandlers: Record<string, (data: unknown) => void> = {}
+vi.mock('../../composables/useEventStream', () => ({
+  useEventStream: (_id: unknown, handlers: Record<string, (d: unknown) => void>) => {
+    capturedHandlers = handlers
+    return {
+      isStreaming: ref(false),
+      error: ref(null),
+      lastEventAt: ref(null),
+      lastTraceId: ref<string | null>(null),
+      start: vi.fn(),
+      stop: vi.fn(),
+    }
+  },
+}))
+
+vi.mock('../../composables/useIncrementalLogPolling', () => ({
+  useIncrementalLogPolling: () => ({
+    lines: { value: [] },
+    polling: { start: vi.fn(), stop: vi.fn() },
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../../composables/usePolling', () => ({
+  usePolling: () => ({ start: vi.fn(), stop: vi.fn() }),
+}))
+
+vi.mock('../../composables/useStickyScroll', () => ({
+  useStickyScroll: () => ({
+    unreadCount: { value: 0 },
+    scrollToBottom: vi.fn(),
+    markAppended: vi.fn(),
+  }),
+}))
+
+vi.mock('../../utils/feedHighlight', () => ({
+  tokenizeFeedText: (s: string) => [{ type: 'text', value: s }],
+}))
+
+vi.mock('../../observability/tracing', () => ({
+  traceIdToSigNozUrl: () => null,
+}))
+
+vi.mock('../../composables/useEnvForm', () => ({
+  storedEffectiveModel: () => 'mock',
+  STORAGE_CUSTOM_MODEL: 'k1',
+  STORAGE_MODEL: 'k2',
+}))
+
+vi.mock('../../composables/useRuntimeLlmOptions', () => ({
+  runtimeLlmPayloadFromStorage: () => ({}),
+  runtimeProviderMissingKeyEverywhere: () => false,
+}))
+
+// useSimFeed: echtes Modul behalten — wir wollen die Routing- und
+// Dedupe-Logik mittesten.
+import { clearSimFeed } from '../../composables/useSimFeed'
+import Step3Simulation from '../Step3Simulation.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    de: {
+      step3: {
+        feed: {
+          title: 'Live-Feed',
+          empty: 'Noch keine Posts.',
+          actions: 'Aktionen: {count}',
+          density: { label: 'Dichte', comfort: 'Komfort', compact: 'Kompakt' },
+        },
+        toolPanel: {
+          toggle: 'Tool-Panel',
+          show: 'Anzeigen',
+          hide: 'Verbergen',
+          unread: '{n} ungelesen',
+          empty: '—',
+          noErrors: '—',
+          filter: 'Filter',
+          filterAll: 'Alle',
+          filterErrors: 'Errors',
+          copyAsJson: 'Kopieren',
+        },
+        status: {
+          ready: 'Bereit',
+          paused: 'Pause',
+          running: 'Läuft',
+          completed: 'Fertig',
+          failed: 'Fehler',
+        },
+        controls: {
+          start: 'Start',
+          stop: 'Stop',
+          pause: 'Pause',
+          resume: 'Resume',
+          pauseHint: 'Pausieren…',
+        },
+      },
+      feed: { reddit: 'Reddit', twitter: 'Twitter' },
+      common: { close: 'Schließen' },
+    },
+  },
+})
+
+const stubs = {
+  Button: { template: '<button><slot /></button>' },
+  Badge: { template: '<span><slot /></span>' },
+  Kicker: { template: '<h3><slot /></h3>' },
+  StickyScrollBanner: { template: '<div />' },
+  FeedColumn: {
+    name: 'FeedColumn',
+    props: ['title', 'channel'],
+    template: '<section :data-channel="channel"><slot /></section>',
+  },
+  TwitterPost: {
+    name: 'TwitterPost',
+    props: ['post'],
+    template: '<article class="tw-post" :data-id="post.post_id" />',
+  },
+  RedditThread: {
+    name: 'RedditThread',
+    props: ['node'],
+    template: '<article class="rd-thread" :data-id="node.post_id" />',
+  },
+}
+
+beforeEach(() => {
+  capturedHandlers = {}
+  clearSimFeed('sim-task2')
+})
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+})
+
+describe('Step3Simulation — Dual-Column Feed (Task 2)', () => {
+  it('rendert beide FeedColumns und füttert Twitter/Reddit aus post_created', async () => {
+    const wrapper = mount(Step3Simulation, {
+      props: { simulationId: 'sim-task2', maxRounds: 3 },
+      global: { plugins: [i18n, router], stubs },
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    // Phase 0 — Card 3 hängt an phase >= 1; wir setzen phase manuell.
+    const vm = wrapper.vm as unknown as { phase: number }
+    vm.phase = 1
+    await nextTick()
+
+    const columns = wrapper.findAllComponents({ name: 'FeedColumn' })
+    expect(columns).toHaveLength(2)
+    expect(columns[0].props('channel')).toBe('twitter')
+    expect(columns[1].props('channel')).toBe('reddit')
+
+    // post_created-Frames feuern.
+    expect(typeof capturedHandlers.post_created).toBe('function')
+    capturedHandlers.post_created({
+      event_type: 'post_created',
+      simulation_id: 'sim-task2',
+      post_id: 't-1',
+      parent_post_id: null,
+      platform: 'twitter',
+      persona_id: 'p-1',
+      voice_register: 'casual',
+      is_simulated: true,
+      body: 'Tweet body',
+      timestamp: '2026-05-16T10:00:00+00:00',
+      sentiment: null,
+      score: 0,
+    })
+    capturedHandlers.post_created({
+      event_type: 'post_created',
+      simulation_id: 'sim-task2',
+      post_id: 'r-1',
+      parent_post_id: null,
+      platform: 'reddit',
+      persona_id: 'p-2',
+      voice_register: 'formal',
+      is_simulated: true,
+      body: 'Reddit body',
+      timestamp: '2026-05-16T10:01:00+00:00',
+      sentiment: null,
+      score: 0,
+    })
+    await nextTick()
+
+    expect(wrapper.findAll('.tw-post')).toHaveLength(1)
+    expect(wrapper.findAll('.rd-thread')).toHaveLength(1)
+    expect(wrapper.find('.tw-post').attributes('data-id')).toBe('t-1')
+    expect(wrapper.find('.rd-thread').attributes('data-id')).toBe('r-1')
+  })
+})

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -30,6 +30,19 @@ const localStorageMock = (() => {
 })()
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
+// IntersectionObserver-Polyfill: FeedColumn nutzt ihn in onMounted; jsdom
+// liefert ihn nicht. Minimaler No-Op-Mock reicht für den Smoketest.
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return [] }
+  root = null
+  rootMargin = ''
+  thresholds: number[] = []
+}
+;(globalThis as unknown as { IntersectionObserver: typeof MockIntersectionObserver }).IntersectionObserver = MockIntersectionObserver
+
 // Mutable reference so individual tests can override getRunStatusDetail.
 import * as simulationApi from '../../api/simulation'
 

--- a/frontend/src/components/graph/GraphCanvas.vue
+++ b/frontend/src/components/graph/GraphCanvas.vue
@@ -230,13 +230,12 @@ async function downloadPng() {
   }
 }
 
-// Slice 5.5 — PDF for the graph piggybacks on the browser print dialog.
-// No jsPDF / weasyprint dependency: open a fresh window pointing at a
-// Blob URL with the standalone SVG, trigger print, let the user pick
-// "Save as PDF".
-function printPdf() {
+// Slice 5.5 — PDF und HTML-Export teilen sich denselben standalone-HTML-Bauplan.
+// printPdf() öffnet ein neues Fenster + print(); downloadHtml() triggert
+// einen Blob-Download mit identischem Markup, das sich offline öffnen lässt.
+function _buildStandaloneHtml() {
   const out = _buildStandaloneSvg()
-  if (!out) return
+  if (!out) return null
   const gid = props.graphData?.graph_id || 'graph'
   const html = `<!doctype html>
 <html lang="de"><head><meta charset="utf-8" />
@@ -250,7 +249,13 @@ function printPdf() {
 </head><body>
 ${out.body}
 </body></html>`
-  const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+  return { html, gid }
+}
+
+function printPdf() {
+  const built = _buildStandaloneHtml()
+  if (!built) return
+  const blob = new Blob([built.html], { type: 'text/html;charset=utf-8' })
   const url = URL.createObjectURL(blob)
   const w = window.open(url, '_blank')
   if (!w) {
@@ -268,11 +273,21 @@ ${out.body}
   })
 }
 
+function downloadHtml() {
+  const built = _buildStandaloneHtml()
+  if (!built) return
+  _triggerBlobDownload(
+    new Blob([built.html], { type: 'text/html;charset=utf-8' }),
+    `agora-graph-${built.gid}.html`,
+  )
+}
+
 defineExpose({
   downloadGraphml,
   downloadSvg,
   downloadPng,
   printPdf,
+  downloadHtml,
   isPaused,
   togglePause,
 })

--- a/frontend/src/components/graph/GraphToolbar.vue
+++ b/frontend/src/components/graph/GraphToolbar.vue
@@ -53,6 +53,14 @@
       >
         <span class="btn-text">.pdf</span>
       </button>
+      <button
+        v-if="hasGraphData"
+        class="tool-btn"
+        title="Export as standalone HTML"
+        @click="$emit('download-html')"
+      >
+        <span class="btn-text">.html</span>
+      </button>
       <button class="tool-btn" title="Maximize/Restore" @click="$emit('toggle-maximize')">
         <span class="icon-maximize">⛶</span>
       </button>
@@ -74,6 +82,7 @@ defineEmits([
   'download-svg',
   'download-png',
   'print-pdf',
+  'download-html',
   'toggle-maximize',
   'toggle-pause',
 ])

--- a/frontend/src/components/graph/GraphToolbar.vue
+++ b/frontend/src/components/graph/GraphToolbar.vue
@@ -56,7 +56,7 @@
       <button
         v-if="hasGraphData"
         class="tool-btn"
-        title="Export as standalone HTML"
+        :title="$t('graph.ui.exportHtml')"
         @click="$emit('download-html')"
       >
         <span class="btn-text">.html</span>

--- a/frontend/src/components/graph/GraphToolbar.vue
+++ b/frontend/src/components/graph/GraphToolbar.vue
@@ -64,6 +64,9 @@
       <button class="tool-btn" title="Maximize/Restore" @click="$emit('toggle-maximize')">
         <span class="icon-maximize">⛶</span>
       </button>
+      <button class="tool-btn" :title="$t('graph.ui.closePanel')" @click="$emit('close-graph')">
+        <span class="icon-close">✕</span>
+      </button>
     </div>
   </div>
 </template>
@@ -85,6 +88,7 @@ defineEmits([
   'download-html',
   'toggle-maximize',
   'toggle-pause',
+  'close-graph',
 ])
 </script>
 

--- a/frontend/src/components/graph/__tests__/GraphCanvas.downloadHtml.spec.ts
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.downloadHtml.spec.ts
@@ -1,0 +1,123 @@
+// Task 6 — Graph standalone HTML download.
+//
+// Verifies that GraphCanvas.downloadHtml() emits a Blob-Download mit MIME
+// "text/html", einem Filename-Pattern `agora-graph-<gid>.html` und einem
+// HTML-Body, der das eingebettete <svg>-Markup enthält. Der eigentliche
+// D3-Render läuft in jsdom nicht — graphSvg.value reicht als leere SVG.
+
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import GraphCanvas from '../GraphCanvas.vue'
+
+vi.mock('../../../composables/useGraphRender', () => ({
+  useGraphRender: () => ({
+    selectedItem: ref(null),
+    render: vi.fn(),
+    isPaused: ref(false),
+    togglePause: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../api/graph', () => ({
+  exportGraphMl: vi.fn(),
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  messages: {
+    de: { graph: { ui: { toggleEdgeLabels: 'Edge-Labels' } } },
+  },
+})
+
+interface CapturedDownload {
+  blobType: string
+  filename: string
+  blob: Blob
+}
+
+let captured: CapturedDownload | null = null
+let originalCreateObjectURL: typeof URL.createObjectURL
+let originalRevokeObjectURL: typeof URL.revokeObjectURL
+let originalCreateElement: typeof document.createElement
+
+beforeEach(() => {
+  captured = null
+
+  originalCreateObjectURL = URL.createObjectURL
+  originalRevokeObjectURL = URL.revokeObjectURL
+  originalCreateElement = document.createElement.bind(document)
+
+  URL.createObjectURL = vi.fn((blob: Blob) => {
+    captured = {
+      blobType: blob.type,
+      filename: '<pending>',
+      blob,
+    }
+    return 'blob:mock-url'
+  }) as unknown as typeof URL.createObjectURL
+  URL.revokeObjectURL = vi.fn() as unknown as typeof URL.revokeObjectURL
+
+  document.createElement = ((tag: string) => {
+    const el = originalCreateElement(tag)
+    if (tag.toLowerCase() === 'a') {
+      Object.defineProperty(el, 'click', {
+        value: () => {
+          if (captured) captured.filename = (el as HTMLAnchorElement).download
+        },
+      })
+    }
+    return el
+  }) as typeof document.createElement
+})
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL
+  URL.revokeObjectURL = originalRevokeObjectURL
+  document.createElement = originalCreateElement
+  vi.restoreAllMocks()
+})
+
+describe('GraphCanvas.downloadHtml', () => {
+  it('builds a standalone HTML Blob with the graph_id in the filename', async () => {
+    const wrapper = mount(GraphCanvas, {
+      global: { plugins: [i18n] },
+      props: {
+        graphData: { graph_id: 'gid-42', nodes: [], edges: [] },
+        entityTypes: [],
+      },
+    })
+
+    // The component exposes downloadHtml via defineExpose; in the test runtime
+    // we reach it through the component instance.
+    const vm = wrapper.vm as unknown as { downloadHtml: () => void }
+    vm.downloadHtml()
+
+    expect(captured).not.toBeNull()
+    expect(captured!.blobType).toMatch(/^text\/html/)
+    expect(captured!.filename).toBe('agora-graph-gid-42.html')
+    const text = await captured!.blob.text()
+    expect(text).toMatch(/<!doctype html>/i)
+    expect(text).toContain('<svg')
+    expect(text).toContain('Agora-Graph')
+  })
+
+  it('falls back to "graph" as filename slug when graph_id is missing', async () => {
+    const wrapper = mount(GraphCanvas, {
+      global: { plugins: [i18n] },
+      props: {
+        graphData: { nodes: [], edges: [] },
+        entityTypes: [],
+      },
+    })
+
+    const vm = wrapper.vm as unknown as { downloadHtml: () => void }
+    vm.downloadHtml()
+
+    expect(captured).not.toBeNull()
+    expect(captured!.filename).toBe('agora-graph-graph.html')
+  })
+})

--- a/frontend/src/composables/__tests__/useSimClock.spec.ts
+++ b/frontend/src/composables/__tests__/useSimClock.spec.ts
@@ -1,0 +1,98 @@
+// Task 1 — useSimClock Composable-Tests.
+//
+// Sichert ab:
+// - ingest() setzt start beim ersten sim_time != null
+// - currentSimTime ist monoton (kleinere Werte werden ignoriert)
+// - elapsed extrapoliert via 1-Hz-Forecast
+// - stop() gibt Interval frei und reset-et State
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { useSimClock, clearSimClock } from '../useSimClock'
+import type { PostCreatedEvent } from '@/contracts/postEventContract'
+
+function makeEvent(overrides: Partial<PostCreatedEvent> = {}): PostCreatedEvent {
+  return {
+    event_type: 'post_created',
+    simulation_id: 'sim-clock',
+    post_id: 'p-' + Math.random().toString(36).slice(2),
+    parent_post_id: null,
+    platform: 'twitter',
+    persona_id: 'persona-1',
+    voice_register: 'casual',
+    is_simulated: true,
+    body: 'tick',
+    timestamp: '2026-05-16T10:00:00.000Z',
+    sentiment: null,
+    score: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-16T08:00:00Z'))
+  clearSimClock('sim-clock')
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  clearSimClock('sim-clock')
+})
+
+describe('useSimClock', () => {
+  it('setzt start auf den ersten gesehenen sim_time', () => {
+    const clock = useSimClock('sim-clock')
+    expect(clock.start.value).toBeNull()
+    expect(clock.currentSimTime.value).toBeNull()
+
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:00:00.000Z' }))
+
+    expect(clock.start.value).toEqual(new Date('2026-05-16T10:00:00.000Z'))
+    expect(clock.currentSimTime.value).toEqual(new Date('2026-05-16T10:00:00.000Z'))
+  })
+
+  it('ignoriert sim_time === null oder fehlend', () => {
+    const clock = useSimClock('sim-clock')
+    clock.ingest(makeEvent({ sim_time: null }))
+    clock.ingest(makeEvent({}))
+    expect(clock.start.value).toBeNull()
+    expect(clock.currentSimTime.value).toBeNull()
+  })
+
+  it('ist monoton — out-of-order kleinere Werte werden ignoriert', () => {
+    const clock = useSimClock('sim-clock')
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:00:00.000Z' }))
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:30:00.000Z' }))
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:15:00.000Z' })) // < latest
+
+    expect(clock.currentSimTime.value).toEqual(new Date('2026-05-16T10:30:00.000Z'))
+  })
+
+  it('elapsed extrapoliert mit 1-Hz-Forecast', () => {
+    const clock = useSimClock('sim-clock')
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:00:00.000Z' }))
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:00:30.000Z' }))
+
+    // baseSec = 30, forecast = 0 (frame just received)
+    expect(clock.elapsed.value).toBeGreaterThanOrEqual(30)
+    expect(clock.elapsed.value).toBeLessThan(31)
+
+    // Advance Wallclock 2 s → forecast = 2
+    vi.advanceTimersByTime(2_000)
+    const after = clock.elapsed.value
+    expect(after).toBeGreaterThanOrEqual(32)
+    expect(after).toBeLessThan(33)
+  })
+
+  it('stop() resettet State und gibt Interval frei', () => {
+    const clock = useSimClock('sim-clock')
+    clock.ingest(makeEvent({ sim_time: '2026-05-16T10:00:00.000Z' }))
+    expect(clock.currentSimTime.value).not.toBeNull()
+
+    clock.stop()
+    expect(clock.currentSimTime.value).toBeNull()
+    expect(clock.start.value).toBeNull()
+    expect(clock.elapsed.value).toBe(0)
+  })
+})

--- a/frontend/src/composables/useSimClock.ts
+++ b/frontend/src/composables/useSimClock.ts
@@ -1,0 +1,119 @@
+/**
+ * useSimClock — Layer-0 Sim-Zeit-Composable (Task 1).
+ *
+ * Konsumiert PostCreatedEvent.sim_time (ISO-8601, tz-aware, optional).
+ * Singleton pro simulationId — wie useSimFeed.
+ *
+ * Responsibilities:
+ * - `start`: erster gesehener sim_time → Anker
+ * - `currentSimTime`: letzter Wert (monoton; ignoriert kleinere Werte)
+ * - `elapsed`: Sekunden seit `start`, leicht extrapoliert via setInterval(1 s)
+ * - `ingest(post)`: vom SSE-Handler aufgerufen
+ * - `stop()`: gibt Interval frei (z. B. on simulationId-Wechsel)
+ *
+ * Bewusst NICHT abhängig von der Sim-Rate — ein ruhiger 1-Hz-Tick reicht für
+ * UI-Anzeige; präzise Werte landen mit jedem post_created-Frame.
+ */
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import type { PostCreatedEvent } from '@/contracts/postEventContract'
+
+export interface UseSimClockReturn {
+  currentSimTime: Ref<Date | null>
+  start: Ref<Date | null>
+  elapsed: ComputedRef<number>
+  ingest: (post: PostCreatedEvent) => void
+  stop: () => void
+}
+
+interface ClockState {
+  api: UseSimClockReturn
+  refCount: number
+}
+
+const stores = new Map<string, ClockState>()
+const MAX_STORES = 10
+
+function createClock(): UseSimClockReturn {
+  const currentSimTime = ref<Date | null>(null)
+  const start = ref<Date | null>(null)
+  // Wallclock-Anker: wann ist `currentSimTime` zuletzt aus einem echten
+  // Frame gesetzt worden? Für die 1-Hz-Extrapolation.
+  let lastWallReceivedAt: number | null = null
+  // ticker-tick-Ref nur damit `elapsed` reaktiv ist; der Wert selbst ist egal.
+  const tick = ref(0)
+  let intervalId: ReturnType<typeof setInterval> | null = null
+
+  function ensureInterval(): void {
+    if (intervalId !== null) return
+    intervalId = setInterval(() => {
+      tick.value = (tick.value + 1) % 1_000_000
+    }, 1_000)
+  }
+
+  function ingest(post: PostCreatedEvent): void {
+    const iso = post?.sim_time
+    if (!iso) return
+    const parsed = new Date(iso)
+    if (Number.isNaN(parsed.getTime())) return
+    if (start.value === null) {
+      start.value = parsed
+    }
+    // Monotonie: kleinere Werte ignorieren (out-of-order SSE-Frames).
+    if (currentSimTime.value !== null && parsed.getTime() < currentSimTime.value.getTime()) {
+      return
+    }
+    currentSimTime.value = parsed
+    lastWallReceivedAt = Date.now()
+    ensureInterval()
+  }
+
+  const elapsed = computed<number>(() => {
+    // Touch tick so the computed re-runs every second.
+    void tick.value
+    if (start.value === null || currentSimTime.value === null) return 0
+    const baseSec = (currentSimTime.value.getTime() - start.value.getTime()) / 1000
+    const forecast = lastWallReceivedAt !== null
+      ? Math.max(0, (Date.now() - lastWallReceivedAt) / 1000)
+      : 0
+    return baseSec + forecast
+  })
+
+  function stop(): void {
+    if (intervalId !== null) {
+      clearInterval(intervalId)
+      intervalId = null
+    }
+    currentSimTime.value = null
+    start.value = null
+    lastWallReceivedAt = null
+    tick.value = 0
+  }
+
+  return { currentSimTime, start, elapsed, ingest, stop }
+}
+
+export function useSimClock(simulationId: string): UseSimClockReturn {
+  let state = stores.get(simulationId)
+  if (!state) {
+    if (stores.size >= MAX_STORES) {
+      const oldestKey = stores.keys().next().value
+      if (oldestKey !== undefined) {
+        const old = stores.get(oldestKey)
+        old?.api.stop()
+        stores.delete(oldestKey)
+      }
+    }
+    state = { api: createClock(), refCount: 0 }
+    stores.set(simulationId, state)
+  }
+  state.refCount += 1
+  return state.api
+}
+
+export function clearSimClock(simulationId: string): void {
+  const state = stores.get(simulationId)
+  if (!state) return
+  state.api.stop()
+  stores.delete(simulationId)
+}

--- a/frontend/src/contracts/postEventContract.ts
+++ b/frontend/src/contracts/postEventContract.ts
@@ -32,6 +32,9 @@ export const PostCreatedEventSchema = z
     // Phase B — Sentiment-Heatbar + Voting-Score
     sentiment: z.number().min(-1).max(1).nullable().optional(),
     score: z.number().int().default(0),
+    // Task 1 — virtuelle Sim-Zeit (tz-aware ISO-8601 mit Offset). null oder
+    // weggelassen bei Pre-Task-1-Daten.
+    sim_time: z.string().datetime({ offset: true }).nullable().optional(),
   })
   .strict()
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -617,7 +617,8 @@
     "ui": {
       "toggleEdgeLabels": "Beziehungslabels",
       "pauseLayout": "Layout pausieren",
-      "resumeLayout": "Layout fortsetzen"
+      "resumeLayout": "Layout fortsetzen",
+      "closePanel": "Graph-Panel schließen"
     },
     "edgeLabels": {
       "RELATES_TO": "verbunden mit",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -621,7 +621,8 @@
       "toggleEdgeLabels": "Beziehungslabels",
       "pauseLayout": "Layout pausieren",
       "resumeLayout": "Layout fortsetzen",
-      "closePanel": "Graph-Panel schließen"
+      "closePanel": "Graph-Panel schließen",
+      "exportHtml": "Als standalone HTML exportieren"
     },
     "edgeLabels": {
       "RELATES_TO": "verbunden mit",
@@ -769,6 +770,7 @@
       "empty": "Noch keine Log-Zeilen.",
       "loading": "Logs werden geladen…",
       "unknownError": "Logs konnten nicht geladen werden.",
+      "noFileYet": "Heutige Logdatei wurde noch nicht geschrieben — Backend ist erreichbar.",
       "connectionError": "SSE-Verbindung unterbrochen, Browser versucht Reconnect…",
       "reconnectExhausted": "Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.",
       "reconnect": "Erneut verbinden",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -764,6 +764,8 @@
       "search": "Suchen…",
       "pause": "Auto-Scroll pausieren",
       "empty": "Noch keine Log-Zeilen.",
+      "loading": "Logs werden geladen…",
+      "unknownError": "Logs konnten nicht geladen werden.",
       "connectionError": "SSE-Verbindung unterbrochen, Browser versucht Reconnect…",
       "reconnectExhausted": "Verbindung zum Log-Stream nach mehreren Versuchen abgebrochen.",
       "reconnect": "Erneut verbinden",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -454,6 +454,9 @@
       "failed": "Fehlgeschlagen",
       "elapsed": "Dauer: {time}"
     },
+    "simClock": {
+      "tooltip": "Virtuelle Sim-Uhr (Agenten-Wallclock, Europe/Berlin)"
+    },
     "feed": {
       "title": "Live-Feed",
       "actions": "Aktionen: {count}",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -454,6 +454,9 @@
       "failed": "Failed",
       "elapsed": "Elapsed: {time}"
     },
+    "simClock": {
+      "tooltip": "Virtual sim clock (agent wallclock, Europe/Berlin)"
+    },
     "feed": {
       "title": "Live feed",
       "actions": "Actions: {count}",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -617,7 +617,8 @@
     "ui": {
       "toggleEdgeLabels": "Edge Labels",
       "pauseLayout": "Pause layout",
-      "resumeLayout": "Resume layout"
+      "resumeLayout": "Resume layout",
+      "closePanel": "Close graph panel"
     },
     "edgeLabels": {
       "RELATES_TO": "relates to",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -764,6 +764,8 @@
       "search": "Search…",
       "pause": "Pause auto-scroll",
       "empty": "No log lines yet.",
+      "loading": "Loading logs…",
+      "unknownError": "Failed to load logs.",
       "connectionError": "SSE connection interrupted, browser will attempt reconnect…",
       "reconnectExhausted": "Log stream connection lost after multiple attempts.",
       "reconnect": "Reconnect",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -621,7 +621,8 @@
       "toggleEdgeLabels": "Edge Labels",
       "pauseLayout": "Pause layout",
       "resumeLayout": "Resume layout",
-      "closePanel": "Close graph panel"
+      "closePanel": "Close graph panel",
+      "exportHtml": "Export as standalone HTML"
     },
     "edgeLabels": {
       "RELATES_TO": "relates to",
@@ -769,6 +770,7 @@
       "empty": "No log lines yet.",
       "loading": "Loading logs…",
       "unknownError": "Failed to load logs.",
+      "noFileYet": "Today's log file has not been written yet — backend is reachable.",
       "connectionError": "SSE connection interrupted, browser will attempt reconnect…",
       "reconnectExhausted": "Log stream connection lost after multiple attempts.",
       "reconnect": "Reconnect",

--- a/frontend/src/views/SimulationRunView.vue
+++ b/frontend/src/views/SimulationRunView.vue
@@ -30,8 +30,27 @@ const { t } = useI18n()
 
 defineProps({ simulationId: String })
 
-const { viewMode, workspaceModes, leftPanelStyle, rightPanelStyle, toggleMaximize } =
+const { viewMode, workspaceModes, leftPanelStyle: baseLeftStyle, rightPanelStyle: baseRightStyle, toggleMaximize } =
   useWorkspaceMode('split')
+
+// Task 5 — Close-Button im GraphPanel. graphClosed override-t den Mode-Switch
+// und kollabiert das linke Panel komplett, bis der User den Mode bewusst neu
+// auswählt (Graph/Split). graphData bleibt im State erhalten — kein Reload
+// nötig, wenn der User wieder einblendet.
+const graphClosed = ref(false)
+const HIDDEN_STYLE = { width: '0%', opacity: 0 }
+const FULL_STYLE = { width: '100%', opacity: 1 }
+const leftPanelStyle = computed(() => (graphClosed.value ? HIDDEN_STYLE : baseLeftStyle.value))
+const rightPanelStyle = computed(() => (graphClosed.value ? FULL_STYLE : baseRightStyle.value))
+
+function closeGraphPanel() {
+  graphClosed.value = true
+}
+
+// Mode-Wechsel via WorkspaceModeSwitch heben den Close-Override wieder auf.
+watch(viewMode, () => {
+  graphClosed.value = false
+})
 
 const currentSimulationId = ref(route.params.simulationId)
 const maxRounds = ref(route.query.maxRounds ? parseInt(route.query.maxRounds) : null)
@@ -156,6 +175,10 @@ async function loadGraph(graphId) {
   if (!isSimulating.value) graphLoading.value = true
   try {
     const res = await getGraphData(graphId)
+    // Task 5 — Graph nach Sim-Ende erhalten: graphData NIE im Fehlerpfad
+    // zurücksetzen. Beim Übergang processing→completed schickt das 30-s-
+    // Polling noch eine letzte Runde; falls die fehlschlägt (kurzer
+    // Backend-Reload), behalten wir den letzten erfolgreichen Snapshot.
     if (res.success) graphData.value = res.data
   } finally {
     graphLoading.value = false
@@ -230,6 +253,7 @@ onMounted(() => {
           :isSimulating="isSimulating"
           @refresh="refreshGraph"
           @toggle-maximize="toggleMaximize('graph')"
+          @close-graph="closeGraphPanel"
         />
       </template>
 

--- a/frontend/src/views/__tests__/SimulationRunView.spec.ts
+++ b/frontend/src/views/__tests__/SimulationRunView.spec.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 // ── vue-i18n minimal stubben ────────────────────────────────────────────────
@@ -46,10 +47,10 @@ vi.mock('../../composables/useSystemLog', () => ({
 
 vi.mock('../../composables/useWorkspaceMode', () => ({
   useWorkspaceMode: () => ({
-    viewMode: 'split',
+    viewMode: ref('split'),
     workspaceModes: [],
-    leftPanelStyle: {},
-    rightPanelStyle: {},
+    leftPanelStyle: ref({ width: '50%', opacity: 1 }),
+    rightPanelStyle: ref({ width: '50%', opacity: 1 }),
     toggleMaximize: vi.fn(),
   }),
 }))
@@ -134,6 +135,28 @@ describe('SimulationRunView (Slice J.2 / Issue #220)', () => {
     await new Promise((r) => setTimeout(r, 50))
 
     expect(getRunStatus).not.toHaveBeenCalled()
+  })
+
+  it('blendet das Graph-Panel auf @close-graph aus und behält graphData', async () => {
+    const wrapper = await mountView()
+
+    const vm = wrapper.vm as unknown as {
+      graphData: unknown
+      leftPanelStyle: { width: string; opacity: number }
+      rightPanelStyle: { width: string; opacity: number }
+      closeGraphPanel: () => void
+    }
+    // Snapshot setzen, damit wir prüfen können, dass close-graph ihn nicht killt.
+    ;(vm as unknown as { graphData: { graph_id: string } }).graphData = { graph_id: 'g1' }
+
+    vm.closeGraphPanel()
+    await wrapper.vm.$nextTick()
+
+    expect(vm.leftPanelStyle.width).toBe('0%')
+    expect(vm.leftPanelStyle.opacity).toBe(0)
+    expect(vm.rightPanelStyle.width).toBe('100%')
+    // graphData darf NICHT geleert werden — Task 5 acceptance criterion.
+    expect((vm as unknown as { graphData: { graph_id: string } }).graphData).toEqual({ graph_id: 'g1' })
   })
 
   it('propagiert update-progress-Event korrekt in statusText', async () => {

--- a/schemas/post-created-event.schema.json
+++ b/schemas/post-created-event.schema.json
@@ -85,6 +85,20 @@
       "description": "Sentiment-Score -1.0 (negativ) bis 1.0 (positiv). None wenn Sentiment-Service nicht aktiv.",
       "title": "Sentiment"
     },
+    "sim_time": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Simulierte Agenten-Wallclock (Sim-Round \u2192 Wallclock, tz-aware). Quelle: run_parallel_simulation leitet aus start_time + start_hour_offset + simulated_minutes pro CREATE_POST ab. None bei Pre-Slice-5-Daten und f\u00fcr Persistenz-Snapshots ohne Feld.",
+      "title": "Sim Time"
+    },
     "simulation_id": {
       "minLength": 1,
       "title": "Simulation Id",


### PR DESCRIPTION
## Summary

Sieben unabhängige UX/Config-Bugs nach v1.0.0, gebündelt als sieben isolierte Commits in der risikoarm→Layer-0-Reihenfolge aus BIG_PLAN.md.

| # | Commit | Layer | Scope |
|---|---|---|---|
| Task 4 | `69ba6a1` fix(docker): TZ=Europe/Berlin | Config | Dockerfile (tzdata) + compose env |
| Task 3 | `793ffe5` feat(sim): LLM_MAX_OUTPUT_TOKENS=16384 | Config | Sim-Scripts default + ENV-Override |
| Task 6 | `a4fce02` feat(graph): standalone HTML export | FE | GraphCanvas.downloadHtml() + .html-Button |
| Task 5 | `2634f8c` feat(graph): close-button + persistence | FE | GraphToolbar/GraphPanel + SimulationRunView graphClosed |
| Task 7 | `e1d2385` fix(logs): loading/error/empty + backend marker | FE+BE | LogDrawer-Refs + logs API file=null marker |
| Task 2 | `e4dae6e` feat(step3): dual-column sim feed | FE | Card 3: FeedColumn(twitter)|FeedColumn(reddit) |
| Task 1 | `81eb9b9` feat(layer-0): virtuelle Sim-Zeit | **L0** | PostCreatedEvent.sim_time + useSimClock |

Wording-Glossar v1 unangetastet. ADR-0002-Hartanker (5 Anker) nicht berührt — kein Supersedes-ADR nötig.

## Verification

- `cd backend && uv run ruff check app/ tests/ scripts/` → **All checks passed**
- `cd backend && uv run pytest tests/contracts/ tests/test_logs_api.py tests/scripts/test_run_simulation_default_tokens.py -q` → **220 passed**
- `cd backend && uv run python -m app.contracts.dump_schemas --check` → **alle 27 Schemas matchen** (MAI-04 Drift-Gate ok)
- `cd frontend && npx vue-tsc --noEmit` → **0 errors**
- `cd frontend && npx vitest run` → **977 passed in 127 files**

## Test plan

- [ ] `docker compose up -d --build agora && docker compose exec agora date` → CEST `+0200`
- [ ] `LLM_MAX_OUTPUT_TOKENS=32768 docker compose up -d` → Logs zeigen den Override
- [ ] Step3-Header zeigt SIM-Clock + elapsed im DE-Format während laufender Sim
- [ ] Card 3 zeigt Twitter | Reddit als 2 FeedColumns
- [ ] Sim laufen lassen → stoppen → Graph bleibt → ✕-Button blendet aus → Mode-Switch reaktiviert
- [ ] GraphToolbar `.html`-Button → standalone .html in Downloads, offline öffnen
- [ ] LogDrawer (Ctrl+Shift+L) zeigt Loading/Error/Empty oder file-Marker statt generisch leer

🤖 Generated with [Claude Code](https://claude.com/claude-code)