### PR TITLE
hotfix(contracts): Zod-Spiegel kennt EvidenceItem.source_model

### DIFF
--- a/frontend/src/contracts/__tests__/reportContract.spec.ts
+++ b/frontend/src/contracts/__tests__/reportContract.spec.ts
@@ -248,6 +248,40 @@ describe('ReportContractSchema (Zod-Spiegel)', () => {
     }
   });
 
+  it('akzeptiert source_model aus Backend Slice 8 (Zod-Drift-Hotfix)', () => {
+    const item = {
+      type: 'graph_fact',
+      source: 'graph',
+      snippet: 'Snippet aus dem Knowledge-Graph.',
+      source_model: 'ollama/qwen2.5:32b',
+    };
+    const result = EvidenceItemSchema.safeParse(item);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.source_model).toBe('ollama/qwen2.5:32b');
+    }
+  });
+
+  it('akzeptiert source_model=null (Pre-Slice-8-Daten)', () => {
+    const item = {
+      type: 'graph_fact',
+      source: 'graph',
+      snippet: 'Snippet aus dem Knowledge-Graph.',
+      source_model: null,
+    };
+    expect(EvidenceItemSchema.safeParse(item).success).toBe(true);
+  });
+
+  it('rejects source_model > 200 chars', () => {
+    const item = {
+      type: 'graph_fact',
+      source: 'graph',
+      snippet: 'Snippet.',
+      source_model: 'x'.repeat(201),
+    };
+    expect(EvidenceItemSchema.safeParse(item).success).toBe(false);
+  });
+
   // Sub-Slice 05.8 — sentiment_score Zod-Spiegel zu EvidenceItemModel
   // (Backend hat es seit MAI-14). Live-Smoke mit Gemini 3 zeigte das Feld
   // im Output, der Zod-Frontend-Strict-Mode rejectete es als "Unrecognized

--- a/frontend/src/contracts/reportContract.ts
+++ b/frontend/src/contracts/reportContract.ts
@@ -70,6 +70,11 @@ export const EvidenceItemSchema = z.object({
   // ADR-0002 Anker 3 (Sub-Slice M11.7b)
   source_kind: EvidenceSourceKindSchema.default("seed_corpus"),
   persona_stakeholder_group: z.string().min(1).max(200).optional().nullable(),
+  // Slice 8 (2026-05-16) — Provider+Modell, das diese Evidence-Zeile
+  // extrahiert hat. Pendant zu EvidenceItemModel.source_model. Format
+  // "<provider>/<model_id>" (z. B. "ollama/qwen2.5:32b"). None bei
+  // Pre-Slice-8-Daten — daher .nullable().optional().
+  source_model: z.string().max(200).nullable().optional(),
 }).strict().superRefine((value, ctx) => {
   // Spiegelt EvidenceItemModel.reject_inference_in_evidence
   if (FORBIDDEN_EVIDENCE_TYPES.has(value.type)) {


### PR DESCRIPTION
## Summary

Frontend warf bei jedem Report-Render `Unrecognized key: \"source_model\"` für jedes EvidenceItem (mehrere Dutzend Warnings pro Bericht).

**Root Cause**: Slice 8 (2026-05-16, Commit-Welle Backend) ergänzte `EvidenceItemModel.source_model` in `backend/app/contracts/report_contract.py:119`. Der manuell gepflegte Zod-Spiegel in `frontend/src/contracts/reportContract.ts:52` kennt das Feld nicht und ist `.strict()`.

**Schema-Drift-Gate griff nicht**, weil es Pydantic→JSON-Schema vergleicht, nicht JSON-Schema→Zod. Follow-up (nicht Teil dieses Hotfixes): eigener CI-Gate gegen Zod-Drift.

## Changes

- `frontend/src/contracts/reportContract.ts`: `source_model: z.string().max(200).nullable().optional()` in `EvidenceItemSchema`
- `frontend/src/contracts/__tests__/reportContract.spec.ts`: 3 neue Cases (Slice-8-Daten, null, Length-Cap)

## Verification

- `npx vitest run src/contracts/__tests__/reportContract.spec.ts` → **25 passed** (3 neu)
- `npx vitest run` → **980 passed in 127 files**
- `npx vue-tsc --noEmit` → **0 errors**

## Test plan

- [ ] Report neu bauen → keine `Unrecognized key: "source_model"`-Warnings mehr im Frontend-Render

🤖 Generated with [Claude Code](https://claude.com/claude-code)