### PR TITLE
feat(llm): projektweiter ModelPicker + Subprocess-Env-Fix für Gemini

### DIFF
--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -124,13 +124,25 @@ def build_route_subprocess_env(
     api_key: Optional[str],
     run_id: Optional[str] = None,
 ) -> dict[str, str]:
-    """Translate a resolved route into the subprocess env contract used by OASIS."""
+    """Translate a resolved route into the subprocess env contract used by OASIS.
+
+    Setzt zusätzlich die provider-spezifische ``api_key_ref``-Env-Var aus der
+    ``LlmProviderRegistry`` (z. B. ``GOOGLE_API_KEY`` für Gemini), damit OASIS-
+    Subprozesse den im ``LlmProviderSecretsStore`` hinterlegten Key finden,
+    ohne dass eine ``.env`` zwingend gepflegt sein muss.
+    """
     env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
     if run_id:
         env["AGORA_RUN_ID"] = run_id
     if api_key:
         env["LLM_API_KEY"] = api_key
         env["OPENAI_API_KEY"] = api_key
+        provider = next(
+            (p for p in LlmProviderRegistry().get_providers() if p.id == route.provider_id),
+            None,
+        )
+        if provider and provider.api_key_ref:
+            env[provider.api_key_ref] = api_key
     if route.base_url_sanitized:
         env["LLM_BASE_URL"] = route.base_url_sanitized
         env["OPENAI_BASE_URL"] = route.base_url_sanitized

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -126,10 +126,10 @@ def build_route_subprocess_env(
 ) -> dict[str, str]:
     """Translate a resolved route into the subprocess env contract used by OASIS.
 
-    Setzt zusätzlich die provider-spezifische ``api_key_ref``-Env-Var aus der
-    ``LlmProviderRegistry`` (z. B. ``GOOGLE_API_KEY`` für Gemini), damit OASIS-
-    Subprozesse den im ``LlmProviderSecretsStore`` hinterlegten Key finden,
-    ohne dass eine ``.env`` zwingend gepflegt sein muss.
+    Also sets the provider-specific api_key_ref environment variable from the
+    LlmProviderRegistry (e.g., GOOGLE_API_KEY for Gemini). This ensures
+    OASIS subprocesses can find the key stored in the LlmProviderSecretsStore
+    without requiring a .env file.
     """
     env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
     if run_id:

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -108,6 +108,59 @@ def test_build_route_subprocess_env_uses_resolved_route_values():
     assert env["LLM_MODEL_NAME"] == "gpt-4o-mini"
 
 
+def test_build_route_subprocess_env_injects_google_api_key_for_gemini():
+    """OASIS subprocess findet den Gemini-Key ohne .env, sobald der Workspace-
+    Secrets-Store ihn liefert (`api_key_ref="GOOGLE_API_KEY"` aus Registry)."""
+    route = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="google",
+        model="models/gemini-2.5-flash",
+        base_url_sanitized="https://generativelanguage.googleapis.com/v1beta/openai/",
+        routing_version=3,
+    )
+
+    env = build_route_subprocess_env(route, api_key="goog-server-key", run_id="run_gemini")
+
+    assert env["GOOGLE_API_KEY"] == "goog-server-key"
+    assert env["LLM_API_KEY"] == "goog-server-key"
+    assert env["OPENAI_API_KEY"] == "goog-server-key"
+    assert env["LLM_MODEL_NAME"] == "models/gemini-2.5-flash"
+
+
+def test_build_route_subprocess_env_injects_ollama_api_key_for_ollama_cloud():
+    """Ollama Cloud bekommt OLLAMA_API_KEY aus der Registry — kein .env nötig."""
+    route = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="ollama_cloud",
+        model="qwen3-coder-next:cloud",
+        base_url_sanitized="https://ollama.com/v1",
+        routing_version=1,
+    )
+
+    env = build_route_subprocess_env(route, api_key="ollama-cloud-key")
+
+    assert env["OLLAMA_API_KEY"] == "ollama-cloud-key"
+    assert env["LLM_API_KEY"] == "ollama-cloud-key"
+
+
+def test_build_route_subprocess_env_does_not_set_provider_key_without_api_key():
+    """Ohne resolved api_key bleiben sowohl generische als auch provider-
+    spezifische Env-Vars leer — die Subprozesse müssen dann selbst entscheiden,
+    ob sie aus dem Parent-Env (`.env`-Fallback) ziehen."""
+    route = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="google",
+        model="models/gemini-2.5-flash",
+        routing_version=1,
+    )
+
+    env = build_route_subprocess_env(route, api_key=None)
+
+    assert "GOOGLE_API_KEY" not in env
+    assert "LLM_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
 def test_build_runtime_llm_config_maps_resolved_route_for_legacy_callers():
     route = ResolvedRoute(
         stage="persona_generation",

--- a/docs/superpowers/specs/2026-05-17-llm-dropdown-and-key-passthrough-design.md
+++ b/docs/superpowers/specs/2026-05-17-llm-dropdown-and-key-passthrough-design.md
@@ -1,0 +1,109 @@
+# Spec — Projektweites ModelPicker + Backend-Key-Passthrough ohne .env
+
+**Datum:** 2026-05-17
+**Branch:** `feat/llm-dropdown-and-key-passthrough`
+**Scope:** Frontend-UI-Konsolidierung + Backend-Subprocess-Env-Fix
+
+---
+
+## Problem
+
+1. **Aufgabe 1 — Inkonsistente Modell-Auswahl im Frontend.** Auf `/settings/llm-providers` zeigt der „Workspace-Default"-Card ein gruppiertes/alphabetisch sortiertes Dropdown (alle Provider mit hinterlegtem Key, OptGroup pro Provider). An anderen Stellen wird die Modell-Auswahl **nicht** über diese Komponente gemacht:
+   - `LlmRoutingView.vue` baut eigenes `<select>` mit `modelsFor(provider_id)` und fällt für Ollama auf ein `<input>` zurück.
+   - `Step4Report.vue` nutzt einen externen Sub-Component `ReportModelControls` mit getrennten v-models für `reportModelOption` und `customReportModel`.
+   - `HeroNewRun.vue` bindet `modelOption` an einen String (Profile-IDs, Presets, Ollama-Modelle).
+
+2. **Aufgabe 2 — `.env`-Zwang für Gemini-Runs.** Auch wenn der User unter `/settings/llm-providers` einen Google-API-Key speichert (`LlmProviderSecretsStore`, Fernet-verschlüsselt), schlägt der Sim-Start fehl, weil der OASIS-Subprocess `os.environ["GOOGLE_API_KEY"]` liest. `build_route_subprocess_env` (`backend/app/services/llm_routing_seed.py`) injiziert pro Subprocess nur `LLM_API_KEY` und `OPENAI_API_KEY`, aber **nicht** `GOOGLE_API_KEY`. Ergebnis: `.env` ist Pflicht für Gemini, obwohl der Key bereits verschlüsselt im Backend-Store liegt.
+
+---
+
+## Lösung
+
+### A. Frontend — Canon-ModelPicker projektweit
+
+Canon-Komponente: `frontend/src/components/v4/forms/ModelPicker.vue`. Sie wird bereits in `LlmProvidersView.vue` für den Workspace-Default genutzt, hat OptGroup-Rendering, sortiert nach Provider-Label, versteckt Provider ohne Key (Ausnahme: github_copilot), emittiert `StageLLMRoute`.
+
+**Migrations:**
+
+| Datei | Aktuell | Ziel |
+|---|---|---|
+| `components/LlmRouting/LlmRoutingView.vue` | Eigenes `<select>` + Ollama-`<input>` fallback | `<ModelPicker v-model>` für `global_default` und jeden Stage-Override |
+| `components/Step4Report.vue` (über `ReportModelControls`) | `v-model:report-model-option` + `v-model:custom-report-model` | `<ModelPicker v-model>` für gewähltes Modell; Custom-Text-Fall bleibt Spezial-Eingabe (Ollama-Custom-Model), aber Provider+Modell-Quelle ist Picker |
+| `components/v4/dashboard/HeroNewRun.vue` | Single-String `modelOption` mit Profilen/Presets/Ollama | Hybrid: Profile/Preset-Picker bleibt, ZUSÄTZLICH `<ModelPicker>` für „Direkt Provider+Modell auswählen". Optional, kein UX-Bruch. |
+
+**Datenquelle:** `useLlmProvidersStore` (Pinia). `availableProviders` (mit Key) → `store.models[provider_id]` (live-discovery). Keine Hardcoded-Listen.
+
+**Erweiterung ModelPicker:** Falls für `Step4Report`/`HeroNewRun` nötig, ein optionales `allow-empty` und `placeholder`-Prop (existieren schon) reichen aus. Kein `allowCustom` als Erweiterung — das übernimmt der Eltern-Code, der Custom-Text-Fall ist außerhalb der Picker-Verantwortung.
+
+### B. Backend — Provider-spezifische Env-Vars im Subprocess
+
+**Fix-Punkt:** `backend/app/services/llm_routing_seed.py::build_route_subprocess_env`.
+
+**Vorher:**
+```python
+env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
+if api_key:
+    env["LLM_API_KEY"] = api_key
+    env["OPENAI_API_KEY"] = api_key
+```
+
+**Nachher:**
+```python
+env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
+if api_key:
+    env["LLM_API_KEY"] = api_key
+    env["OPENAI_API_KEY"] = api_key
+    # Provider-spezifische Env-Vars für OASIS-Subprocess.
+    # OASIS liest GOOGLE_API_KEY für Gemini, ANTHROPIC_API_KEY für Anthropic.
+    provider_type = _provider_type_for(route.provider_id)
+    if provider_type == "google":
+        env["GOOGLE_API_KEY"] = api_key
+    elif provider_type == "anthropic":
+        env["ANTHROPIC_API_KEY"] = api_key
+```
+
+Helfer `_provider_type_for` konsultiert `LlmProviderRegistry`.
+
+**Auflösungsreihenfolge bleibt unverändert** (`SecretResolver.get_api_key`):
+1. Frontend-Override (Session-Key, runtime payload)
+2. `LlmProviderSecretsStore` (verschlüsselter Disk-Store, vom Frontend gespeichert)
+3. `os.environ` (`.env`-Fallback)
+
+Heißt: wer eine `.env` hat, behält sie. Wer keine hat, kommt mit dem Frontend-Store aus.
+
+### C. Sicherheit
+
+- Plaintext-Keys bleiben im **Backend-Memory** während des Sim-Start-Requests. Frontend bekommt nur `masked_value` zurück.
+- Subprocess-Env-Vars sind nicht in Logs sichtbar (`build_route_subprocess_env` wird nicht geloggt; nur die Tatsache, dass ein Run gestartet wurde).
+- Keine neue Storage-Form: keine `localStorage`-Keys, keine HTTP-Header mit Plaintext-Keys.
+
+---
+
+## Out of Scope
+
+- Komplette HeroNewRun-Umbau (LLM-Profile + Presets + Ollama-Quick-Pick). Bleibt funktional; ModelPicker wird **zusätzlich** als „Direkt-Auswahl"-Option angeboten, nicht als Ersatz.
+- LiteLLM-Routing-Migration. Aktueller Routing-Stack (`StageModelRouter`, `ResolvedRoute`) bleibt.
+- Neue Crypto. `LlmProviderSecretsStore` (Fernet) bleibt unverändert.
+
+---
+
+## Tests
+
+- **Backend:** Erweitere `backend/tests/services/test_llm_routing_seed.py` um Cases:
+  - `build_route_subprocess_env(route_with_provider_id="google", api_key="X")` → `env["GOOGLE_API_KEY"] == "X"`.
+  - Idempotent für openai/anthropic.
+  - Kein `GOOGLE_API_KEY` im Env wenn `api_key=None`.
+- **Frontend:** vorhandene ModelPicker-Unit-Tests laufen weiter; neue Integration: `LlmRoutingView.vue` rendert `<ModelPicker>` und speichert via `setGlobalDefault`.
+
+## Verification
+
+- `cd backend && ruff check app/ tests/ && pytest tests/services/test_llm_routing_seed.py tests/scripts/test_oasis_provider_dispatch.py -x`
+- `cd frontend && pnpm typecheck && pnpm test:unit --run`
+- Manuell auf `localhost:5180`: `/settings/llm-providers` Workspace-Default Dropdown unverändert; `/settings/llm-routing` zeigt jetzt gleichen Dropdown-Stil.
+- Manuell: Sim-Start mit Gemini-Provider ohne `.env`-Eintrag → läuft durch.
+
+## PR
+
+Titel: `feat(llm): projektweiter ModelPicker + Subprocess-Env-Fix für Gemini`
+
+Body verweist auf dieses Spec.

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -2,20 +2,19 @@
 import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
-  listLlmProviders,
-  listProviderModels,
   getRunLlmRouting,
   updateRunLlmRouting,
-  patchStageLlmRouting
+  patchStageLlmRouting,
 } from '../../api/llmRouting';
 import {
-  ProviderDescriptor,
   RuntimeLlmRouting,
   StageLLMRoute,
   StageId,
   ReasoningEffort,
   LlmInvocationEvent,
 } from '../../contracts/llmRoutingContract';
+import ModelPicker from '@/components/v4/forms/ModelPicker.vue';
+import { useLlmProvidersStore } from '@/store/llmProviders';
 
 const props = defineProps<{
   runId: string;
@@ -23,11 +22,10 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
-const providers = ref<ProviderDescriptor[]>([]);
+const providersStore = useLlmProvidersStore();
 const routing = ref<RuntimeLlmRouting | null>(null);
 const snapshots = ref<Record<string, any>>({});
 const invocationEvents = ref<LlmInvocationEvent[]>([]);
-const modelOptions = ref<Record<string, Array<{ id: string; name: string }>>>({});
 const loading = ref(false);
 const error = ref<string | null>(null);
 
@@ -46,30 +44,13 @@ const REASONING_EFFORTS: ReasoningEffort[] = ["none", "minimal", "low", "medium"
 async function load() {
   loading.value = true;
   try {
-    const [p, r] = await Promise.all([
-      listLlmProviders(),
-      getRunLlmRouting(props.runId)
+    const [r] = await Promise.all([
+      getRunLlmRouting(props.runId),
+      providersStore.loadProviders(),
     ]);
-    providers.value = p;
     routing.value = r.runtime_config;
     snapshots.value = r.snapshots;
     invocationEvents.value = [...(r.invocation_events || [])].reverse();
-
-    const discoveries = await Promise.allSettled(
-      p
-        .filter((provider) => !!provider.base_url)
-        .map(async (provider) => ({
-          providerId: provider.id,
-          models: await listProviderModels(provider.id, provider.base_url || undefined),
-        })),
-    );
-
-    const nextOptions: Record<string, Array<{ id: string; name: string }>> = {};
-    for (const result of discoveries) {
-      if (result.status !== 'fulfilled') continue;
-      nextOptions[result.value.providerId] = result.value.models || [];
-    }
-    modelOptions.value = nextOptions;
   } catch (e: any) {
     error.value = e.message;
   } finally {
@@ -105,10 +86,23 @@ async function saveStage(stageId: StageId, route: StageLLMRoute) {
 const isStageLocked = (stageId: string) => !!snapshots.value[stageId];
 const formatLatency = (latencyMs: number) => `${Math.round(latencyMs)} ms`;
 const formatTimestamp = (timestamp: number) => new Date(timestamp * 1000).toLocaleString();
-const modelsFor = (providerId?: string | null) => {
-  if (!providerId) return [];
-  return modelOptions.value[providerId] || [];
-};
+
+function onGlobalDefaultPicked(route: StageLLMRoute | null) {
+  if (!routing.value || !route) return;
+  routing.value.global_default.provider_id = route.provider_id;
+  routing.value.global_default.model = route.model;
+}
+
+function onStageOverridePicked(stageId: StageId, route: StageLLMRoute | null) {
+  if (!routing.value || !route) return;
+  const current = routing.value.stage_overrides[stageId];
+  const base = current ? { ...current } : { ...routing.value.global_default };
+  routing.value.stage_overrides[stageId] = {
+    ...base,
+    provider_id: route.provider_id,
+    model: route.model,
+  };
+}
 
 </script>
 
@@ -122,18 +116,12 @@ const modelsFor = (providerId?: string | null) => {
       <div class="config-pane">
         <h3>{{ t('llm.routing.global_default') }}</h3>
         <div class="card">
-          <label>{{ t('llm.provider') }}</label>
-          <select v-model="routing.global_default.provider_id">
-            <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.label }}</option>
-          </select>
-
           <label>{{ t('llm.model') }}</label>
-          <select v-if="modelsFor(routing.global_default.provider_id).length > 0" v-model="routing.global_default.model">
-            <option v-for="model in modelsFor(routing.global_default.provider_id)" :key="model.id" :value="model.id">
-              {{ model.name }}
-            </option>
-          </select>
-          <input v-else v-model="routing.global_default.model" />
+          <ModelPicker
+            :model-value="routing.global_default"
+            :placeholder="t('llm.routing.model_placeholder', 'Modell wählen …')"
+            @update:model-value="onGlobalDefaultPicked"
+          />
 
           <label>{{ t('llm.reasoning_effort') }}</label>
           <select v-model="routing.global_default.reasoning_effort">
@@ -151,53 +139,12 @@ const modelsFor = (providerId?: string | null) => {
           </div>
 
           <div class="stage-controls">
-            <label>{{ t('llm.provider') }}</label>
-            <select
-              :value="routing.stage_overrides[stage]?.provider_id || routing.global_default.provider_id"
-              @change="(e: any) => {
-                if (!routing) return;
-                if (!routing.stage_overrides[stage]) {
-                  routing.stage_overrides[stage] = { ...routing.global_default };
-                }
-                routing.stage_overrides[stage].provider_id = e.target.value;
-              }"
-              :disabled="isStageLocked(stage)"
-            >
-              <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.label }}</option>
-            </select>
-
             <label>{{ t('llm.model') }}</label>
-            <select
-              v-if="modelsFor(routing.stage_overrides[stage]?.provider_id || routing.global_default.provider_id).length > 0"
-              :value="routing.stage_overrides[stage]?.model || routing.global_default.model"
-              @change="(e: any) => {
-                if (!routing) return;
-                if (!routing.stage_overrides[stage]) {
-                  routing.stage_overrides[stage] = { ...routing.global_default };
-                }
-                routing.stage_overrides[stage].model = e.target.value;
-              }"
+            <ModelPicker
+              :model-value="routing.stage_overrides[stage] || routing.global_default"
               :disabled="isStageLocked(stage)"
-            >
-              <option
-                v-for="model in modelsFor(routing.stage_overrides[stage]?.provider_id || routing.global_default.provider_id)"
-                :key="model.id"
-                :value="model.id"
-              >
-                {{ model.name }}
-              </option>
-            </select>
-            <input
-              v-else
-              :value="routing.stage_overrides[stage]?.model || routing.global_default.model"
-              @input="(e: any) => {
-                if (!routing) return;
-                if (!routing.stage_overrides[stage]) {
-                  routing.stage_overrides[stage] = { ...routing.global_default };
-                }
-                routing.stage_overrides[stage].model = e.target.value;
-              }"
-              :disabled="isStageLocked(stage)"
+              :placeholder="t('llm.routing.model_placeholder', 'Modell wählen …')"
+              @update:model-value="(route) => onStageOverridePicked(stage, route)"
             />
 
             <button


### PR DESCRIPTION
## Summary

Adressiert zwei zusammenhängende User-Pain-Points beim LLM-Routing:

- **Aufgabe 1 (Frontend):** Die LlmRoutingView hatte ein eigenes Provider+Model-Select-Konstrukt; das Workspace-Default-Dropdown unter `/settings/llm-providers` lieferte hingegen schon das gewünschte gruppierte/sortierte Verhalten. Jetzt nutzt LlmRoutingView denselben Canon-ModelPicker (`frontend/src/components/v4/forms/ModelPicker.vue`) wie das Workspace-Default — gleiche OptGroup-Logik, gleiche Single-Source aus `useLlmProvidersStore`.
- **Aufgabe 2 (Backend):** Beim Sim-Start mit Gemini war eine `.env`-Pflege erforderlich, obwohl der Key bereits unter `/settings/llm-providers` im verschlüsselten `LlmProviderSecretsStore` lag. Ursache: `build_route_subprocess_env` injizierte nur `LLM_API_KEY` und `OPENAI_API_KEY` in das Subprocess-Env. OASIS-Scripts (run_parallel_simulation.py, run_reddit_simulation.py, run_twitter_simulation.py) lesen für Gemini aber `GOOGLE_API_KEY`. Fix: provider-spezifische Env-Var aus `LlmProviderRegistry.api_key_ref` mit-injizieren.

## Changes

- `backend/app/services/llm_routing_seed.py` — `build_route_subprocess_env` konsultiert `LlmProviderRegistry`, setzt `provider.api_key_ref` zusätzlich zu den generischen Keys.
- `backend/tests/services/test_llm_routing_seed.py` — drei neue Cases: Gemini→`GOOGLE_API_KEY`, Ollama Cloud→`OLLAMA_API_KEY`, `None`-api_key→keine Provider-Vars.
- `frontend/src/components/LlmRouting/LlmRoutingView.vue` — ersetzt manuelle Provider+Model-Selects in `global_default` und `stage_overrides` durch `<ModelPicker>`. Reasoning-Effort-Select bleibt separat.
- `docs/superpowers/specs/2026-05-17-llm-dropdown-and-key-passthrough-design.md` — Spec-Dokument mit Out-of-Scope-Sektion.

## Auflösungsreihenfolge der API-Keys (unverändert)

1. **Request-Override** (`RuntimeLlmConfig.api_key`, vom Frontend pro Run gesendet)
2. **`LlmProviderSecretsStore`** (Fernet-verschlüsselt auf Disk, persistiert via `/settings/llm-providers`)
3. **`os.environ` / `.env`** (Fallback, **nicht mehr Pflicht**)

Keys verlassen nie Klartext den Backend-Memory. Frontend bekommt nur `masked_value` zurück. Keine neuen Storage-Pfade (kein localStorage mit Plaintext, keine Header-Sniffing-Oberfläche).

## Out of Scope (Follow-up)

- `ReportModelControls.vue` (Step4Report) hat dual-state (Option-Select + Custom-Text-Input + separate Provider/Key/BaseUrl Inputs). Migration auf ModelPicker bedingt Refaktorisierung der `regenerateWithModel`-Logik in Step4Report.
- `HeroNewRun.vue` mischt Profile-IDs, Presets und Ollama-Modelle in einem Single-String. Hybrid-Lösung (ModelPicker als zusätzliche Option neben Profile-Picker) ist im Spec dokumentiert, aber bewusst nicht in diesem PR.

## Test plan

- [x] `cd backend && .venv/bin/pytest tests/services/test_llm_routing_seed.py -x` → 8/8 grün (5 alte + 3 neue)
- [x] `cd backend && .venv/bin/ruff check app/ tests/` → All checks passed
- [x] `cd frontend && bun run typecheck` → exit 0
- [x] `cd frontend && bun run lint` → eslint clean
- [x] `cd frontend && bun run test --run` → 997/997 grün
- [ ] Manuelle Verifikation auf `localhost:5180`:
  - [ ] `/settings/llm-providers` Workspace-Default Dropdown unverändert
  - [ ] `/settings/llm-routing` (oder LlmRoutingView in Run-Kontext) zeigt jetzt identischen Picker
  - [ ] Sim-Start mit Gemini ohne `.env`-Eintrag (nur Frontend-Key) läuft durch

## Anmerkungen

- Pre-existing vitest-Teardown-Flake in `CompareView.spec.ts` (EnvironmentTeardownError beim Worker-RPC-Close) ist nicht durch diesen PR verursacht — alle 997 Tests selbst passen.
- Bekannte Dependabot-Alerts (2 moderate) sind unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)