### PR TITLE
chore(deps): bump Neo4j default image to 5.26-community (LTS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,7 @@ NEO4J_USER=neo4j
 # Nicht-Debug-Betrieb von Config.validate() hart abgelehnt.
 NEO4J_PASSWORD=change-me
 # Compose-Defaults fuer Neo4j. Nur anpassen, wenn Host-RAM/Policy abweichen.
-# NEO4J_IMAGE=neo4j:5.18-community
+# NEO4J_IMAGE=neo4j:5.26-community
 # NEO4J_HEAP_INITIAL=512m
 # NEO4J_HEAP_MAX=2g
 # NEO4J_PAGECACHE_SIZE=4g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (chore/deps — 2026-05-17)
+
+- Neo4j-Default-Image von `neo4j:5.18-community` (Feb 2024) auf `neo4j:5.26-community`
+  (Nov 2024 LTS) gebumpt. Betrifft `docker-compose.yml` (Default-Image) und
+  `.env.example` (Beispiel-Override-Kommentar). Gleiche 5.x-Linie, gleicher
+  Cypher-Dialect, keine Code-Anpassungen nötig. Wer `NEO4J_IMAGE` lokal pinnt,
+  bleibt unangetastet.
+
 ### Added (Sub-Slice S1 — 2026-05-17)
 
 - Report-Quality Slice 1: Evidence-Coverage-Floor (min=2) — Claims mit <2 Evidence-Items werden zur Hypothesis geroutet, Cap auf 0.59 in compute_confidence. Reviewer-Feedback report_4fe2dacd80ba. (#493)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       retries: 5
 
   neo4j:
-    image: ${NEO4J_IMAGE:-neo4j:5.18-community}
+    image: ${NEO4J_IMAGE:-neo4j:5.26-community}
     container_name: agora-neo4j
     # Loopback-Bind: Browser/Bolt nur lokal erreichbar. Container-zu-
     # Container-Verbindungen laufen weiter über das Compose-Netzwerk


### PR DESCRIPTION
## Summary

Bump des Default-Neo4j-Images von `5.18-community` (Feb 2024) auf `5.26-community` (Nov 2024, aktueller 5.x-LTS).

## Risiko-Assessment

- **Same major + Cypher-Dialect:** 5.18 und 5.26 sind beide Cypher 5. Keine Breaking Changes in der Major-Linie.
- **Vector-Index-API:** Im Repo nur über `_ensure_vector_index_dim` / `_run_node_vector_search` (`backend/app/storage/neo4j_storage.py`, `search_service.py`). Diese nutzen die seit 5.13 stabile API, unverändert.
- **APOC-Plugin:** `NEO4J_PLUGINS=["apoc"]` in `docker-compose.yml` triggert auto-matching APOC-Version zum Image. Unverändert.
- **Lokale Overrides:** Wer `NEO4J_IMAGE=...` in der `.env` gesetzt hat (z. B. Pin auf eine Sicherheits-getestete Variante), bleibt unangetastet — geändert wird nur der Compose-Default und der Beispiel-Kommentar in `.env.example`.

## Changes

- `docker-compose.yml:123` — Default-Image-Pin gebumpt.
- `.env.example:87` — Beispiel-Override-Kommentar synchronisiert.
- `CHANGELOG.md` — `[Unreleased] / Changed (chore/deps)`-Eintrag.

## Test plan

- [ ] `docker compose pull neo4j && docker compose up -d neo4j` zieht das neue Image, startet sauber durch.
- [ ] `docker compose logs neo4j` zeigt keine APOC-Mismatch-Warnings.
- [ ] Backend-Smoke gegen den hochgezogenen Container (z. B. `pytest tests/storage/test_neo4j_filtered_entities.py`) bleibt grün.
- [ ] Vorhandene Datenvolumes (`neo4j_data`) migrieren automatisch (5.x-store-Format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)