### PR TITLE
chore(python): unify on Python 3.14 — pyproject floor + ruff/mypy + all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14-dev"
+          python-version: "3.14"
 
       - name: Install uv
         run: python -m pip install --upgrade pip uv
@@ -115,15 +115,11 @@ jobs:
       FLASK_DEBUG: "true"
     strategy:
       fail-fast: false
-      # PRs laufen standardmäßig nur gegen die stabile Runtime (3.11).
-      # 3.14-dev läuft auf main, via workflow_dispatch oder in PRs mit dem Label 'needs-python314'.
+      # Python 3.14 ist seit Sub-Slice 41 (Issue #199 closed 2026-05-14)
+      # die einzige unterstützte Runtime. Matrix bleibt für späteres
+      # Multi-Version-Forward-Smoke offen, aktuell nur 3.14.
       matrix:
-        python-version: >-
-          ${{
-            (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'needs-python314'))
-            && fromJSON('["3.11"]')
-            || fromJSON('["3.11", "3.14-dev"]')
-          }}
+        python-version: ["3.14"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -242,7 +238,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install uv
         run: python -m pip install --upgrade pip uv

--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install --upgrade pip uv
       - name: Sync backend deps
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install --upgrade pip uv
       - name: Sync backend deps (für pytest --collect-only)
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
       - working-directory: backend
         run: uv sync --group dev
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
       - working-directory: backend
         run: uv sync --group dev
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
       - working-directory: backend
         run: uv sync --group dev
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install --upgrade pip uv
       - name: Install backend deps (inkl. radon)

--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ### Changed (chore/deps — 2026-05-17)
 
+- Python-Floor auf 3.14 vereinheitlicht. `pyproject.toml` (`requires-python`,
+  `tool.ruff.target-version`, `tool.mypy.python_version`) und alle CI-Workflows
+  (`ci.yml`, `contract-gates.yml`, `cve-monitor.yml`) sind jetzt auf `3.14`.
+  Vorher gemischt: pyproject `>=3.11`, Dockerfile `3.14`, CI-Matrix mit
+  `3.11`-Stable + `3.14-dev`-Preview. Issue #199 (cp314-Wheel-Lag bei tiktoken)
+  ist seit 2026-05-14 closed; der `tool.uv.override-dependencies`-Block bleibt
+  bestehen, weil er die cp314-Bumps für tiktoken/pillow/pandas/numpy/sentence-
+  transformers + den Sec-Override für `unstructured` (GHSA-Path-Traversal)
+  trägt. **Breaking für lokale Dev-Setups:** `.venv` muss mit
+  `uv venv --python 3.14` neu gebaut werden, sonst meckert `uv sync`.
 - Neo4j-Default-Image von `neo4j:5.18-community` (Feb 2024) auf `neo4j:5.26-community`
   (Nov 2024 LTS) gebumpt. Betrifft `docker-compose.yml` (Default-Image) und
   `.env.example` (Beispiel-Override-Kommentar). Gleiche 5.x-Linie, gleicher

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 name = "agora-backend"
 version = "1.0.0"
 description = "Agora - Hybrid Multi-Agent Resonance Simulator on Neo4j + Ollama"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 license = { text = "AGPL-3.0" }
 authors = [
     { name = "Alexander Schneider", email = "schneider@alexle135.de" }
@@ -124,7 +124,7 @@ skip_covered = false
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py314"
 exclude = [
     ".venv",
     "uploads",
@@ -172,7 +172,7 @@ ignore = [
 "scripts/security_verify.py" = ["E402"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.14"
 ignore_missing_imports = true
 follow_imports = "silent"
 show_error_codes = true


### PR DESCRIPTION
## Summary

Vereinheitlicht die Python-Version-Pins über das ganze Repo auf **3.14**. Vorher war alles gemischt:

| Stelle | Vorher | Nachher |
|---|---|---|
| `pyproject.toml` `requires-python` | `>=3.11` | `>=3.14` |
| `pyproject.toml` `tool.ruff.target-version` | `py311` | `py314` |
| `pyproject.toml` `tool.mypy.python_version` | `3.11` | `3.14` |
| `.github/workflows/ci.yml` matrix | `["3.11", "3.14-dev"]` dual | `["3.14"]` |
| `.github/workflows/ci.yml` isolated steps | `3.11` / `3.14-dev` | `3.14` |
| `.github/workflows/contract-gates.yml` | 6× `3.11` | 6× `3.14` |
| `.github/workflows/cve-monitor.yml` | `3.11` | `3.14` |
| `Dockerfile` | `python:3.14` | `python:3.14` *(unchanged, war schon)* |

## Warum jetzt

[Issue #199](https://github.com/arn0ld87/agora/issues/199) (cp314-Wheel-Lag bei `tiktoken`) ist seit **2026-05-14 closed**. Container baut produktiv auf `python:3.14` seit dem `chore(deps): bump`-PR von Anfang Mai. CI fuhr eine duale Matrix `[3.11, 3.14-dev]` — der 3.14-Pfad ist seitdem grün. Es gibt keinen Grund mehr, parallel 3.11-Pfade zu pflegen.

Der `[tool.uv].override-dependencies`-Block in `pyproject.toml` bleibt unangetastet — er trägt die cp314-Bumps für `tiktoken`/`pillow`/`pandas`/`numpy`/`sentence-transformers` und den GHSA-Override für `unstructured` (Path-Traversal).

## Breaking für lokale Dev-Setups

`.venv` mit Python < 3.14 wird beim nächsten `uv sync` abgelehnt. Local-Fix:

```bash
cd backend
rm -rf .venv
uv venv --python 3.14
uv sync --group dev
```

Wer Pyenv/Mise nutzt: `pyenv install 3.14 && pyenv local 3.14` o. ä.

## CRG-Impact

```
Blast radius for 5 changed file(s):
  - 0 nodes directly changed
  - 0 nodes impacted (within 2 hops)
  - 0 additional files affected
  Risk: low
```

Config-only Change — kein Code-Pfad tangiert. Verifikation läuft über CI selbst (typecheck, ruff, pytest, alle gegen 3.14).

## Test plan

- [ ] CI grün auf 3.14 (alle Workflows)
- [ ] `uv sync --python 3.14 --group dev` lokal durchlauffähig (3.14 Interpreter erforderlich)
- [ ] `uv run pytest` weiterhin grün
- [ ] `uv run mypy app` weiterhin grün gegen `python_version = "3.14"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)