### PR TITLE
feat(llm): Slice A3 — Home.vue (Landing /home) nutzt projektweiten ModelPicker

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -248,6 +248,7 @@
     "model": {
       "label": "LLM-Modell",
       "placeholder": "Modell wählen …",
+      "workspaceDefaultHint": "Keine Auswahl: Workspace-Default aus /settings/llm-providers wird verwendet.",
       "presetGroup": "Empfohlen",
       "ollamaGroup": "Lokal verfügbar",
       "customGroup": "Eigene Eingabe",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -247,6 +247,7 @@
     },
     "model": {
       "label": "LLM-Modell",
+      "placeholder": "Modell wählen …",
       "presetGroup": "Empfohlen",
       "ollamaGroup": "Lokal verfügbar",
       "customGroup": "Eigene Eingabe",
@@ -254,7 +255,7 @@
       "customPlaceholder": "z. B. qwen3-coder-next:cloud",
       "refresh": "Liste aktualisieren",
       "loadingModels": "Lade verfügbare Modelle…",
-      "noOllama": "Keine Verbindung zu Ollama. Custom-Eingabe nutzen oder Ollama starten.",
+      "noOllama": "Keine Verbindung zu Ollama. Provider unter /settings/llm-providers konfigurieren oder Ollama starten.",
       "openAiDefault": "OpenAI-Standardmodell aktiv.",
       "default": "Standard aus .env"
     },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -248,6 +248,7 @@
     "model": {
       "label": "LLM model",
       "placeholder": "Select model …",
+      "workspaceDefaultHint": "No selection: workspace default from /settings/llm-providers will be used.",
       "presetGroup": "Recommended",
       "ollamaGroup": "Locally available",
       "customGroup": "Custom",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -247,6 +247,7 @@
     },
     "model": {
       "label": "LLM model",
+      "placeholder": "Select model …",
       "presetGroup": "Recommended",
       "ollamaGroup": "Locally available",
       "customGroup": "Custom",
@@ -254,7 +255,7 @@
       "customPlaceholder": "e.g. qwen3-coder-next:cloud",
       "refresh": "Refresh list",
       "loadingModels": "Loading available models…",
-      "noOllama": "No connection to Ollama. Use custom input or start Ollama.",
+      "noOllama": "No connection to Ollama. Configure a provider in /settings/llm-providers or start Ollama.",
       "openAiDefault": "OpenAI default model active.",
       "default": "Default from .env"
     },

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -50,7 +50,8 @@ function loadStoredRoute() {
     if (!parsed.success) return null
     if (!parsed.data.provider_id || !parsed.data.model) return null
     return parsed.data
-  } catch {
+  } catch (err) {
+    console.warn('[Home] agora.home.route lokal nicht parsbar — Auswahl zurückgesetzt:', err)
     return null
   }
 }
@@ -348,6 +349,9 @@ const differentiators = computed(() => tm('home.differentiators'))
               :placeholder="t('step2.model.placeholder')"
               @update:model-value="onPickRoute"
             />
+            <p v-if="!selectedRoute && !loadingModels" class="console-meta" style="margin-top: 4px;">
+              {{ t('step2.model.workspaceDefaultHint') }}
+            </p>
             <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !selectedRoute" class="console-warning" style="margin-top: 4px;">
               {{ t('step2.model.noOllama') }}
             </p>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import HistoryDatabase from '../components/HistoryDatabase.vue'
@@ -8,18 +8,13 @@ import Button from '@/components/v4/forms/Button.vue'
 import Badge from '../components/ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
 import Select from '../components/ui/Select.vue'
-import Field from '../components/ui/Field.vue'
 import AgoraGlyph from '../components/ui/AgoraGlyph.vue'
 import AgoraBrand from '../components/brand/AgoraBrand.vue'
+import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
 import { getAvailableModels } from '../api/simulation'
-import { STORAGE_CUSTOM_MODEL, STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
-import {
-  defaultRuntimeModelForProvider,
-  isRuntimeModelForProvider,
-  runtimeModelOptionsForProvider,
-  useRuntimeLlmOptions,
-} from '../composables/useRuntimeLlmOptions'
+import { STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
 import { setPendingUpload } from '../store/pendingUpload'
+import { StageLLMRouteSchema } from '../contracts/llmRoutingContract'
 
 const { t, tm } = useI18n()
 const router = useRouter()
@@ -33,36 +28,49 @@ const errorMsg = ref('')
 
 const ALLOWED = ['.pdf', '.md', '.txt', '.markdown']
 
-// ---- Model + language selection (persisted) ----
-const ollamaModels = ref([])
-const presetModels = ref([])
-const defaultModel = ref('')
+// ---- Service-Health + Sprache (persisted) ----
 const defaultProvider = ref('unknown')
 const ollamaReachable = ref(false)
 const ollamaError = ref(null)
 const neo4jReachable = ref(false)
 const neo4jError = ref(null)
 const loadingModels = ref(true)
-const modelOption = ref(localStorage.getItem(STORAGE_MODEL) || 'default')
-const customModel = ref('')
 const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
-const showRuntimeOptions = ref(false)
-const {
-  runtimeProvider,
-  runtimeApiKey,
-  runtimeBaseUrl,
-  runtimeProviderOptions,
-  runtimeProviderEnabled,
-} = useRuntimeLlmOptions(t)
+
+// ---- LLM-Route (Slice A3: projektweiter ModelPicker, Slice A1/A2-Pattern). ----
+//   Persistenz: agora.home.route (JSON-serialized, Zod-validiert).
+//   Spiegelung auf STORAGE_MODEL für die bestehende Step2/MainView-Pipeline.
+const STORAGE_HOME_ROUTE = 'agora.home.route'
+
+function loadStoredRoute() {
+  try {
+    const raw = localStorage.getItem(STORAGE_HOME_ROUTE)
+    if (!raw) return null
+    const parsed = StageLLMRouteSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) return null
+    if (!parsed.data.provider_id || !parsed.data.model) return null
+    return parsed.data
+  } catch {
+    return null
+  }
+}
+
+const selectedRoute = ref(loadStoredRoute())
+
+function onPickRoute(route) {
+  selectedRoute.value = route
+  if (route?.provider_id && route?.model) {
+    localStorage.setItem(STORAGE_HOME_ROUTE, JSON.stringify(route))
+  } else {
+    localStorage.removeItem(STORAGE_HOME_ROUTE)
+  }
+}
 
 async function loadStatus() {
   loadingModels.value = true
   try {
     const res = await getAvailableModels()
     if (res?.success) {
-      ollamaModels.value = res.data?.ollama || []
-      presetModels.value = res.data?.presets || []
-      defaultModel.value = res.data?.current_default || ''
       defaultProvider.value = res.data?.default_provider || 'unknown'
       ollamaReachable.value = !!res.data?.ollama_reachable
       ollamaError.value = res.data?.ollama_error || null
@@ -80,25 +88,6 @@ async function loadStatus() {
   }
 }
 
-const modelOptions = computed(() => {
-  if (runtimeProviderEnabled.value) {
-    return [
-      ...runtimeModelOptionsForProvider(runtimeProvider.value),
-      { value: 'custom', label: t('step2.model.customGroup') },
-    ]
-  }
-  const opts = [{ value: 'default', label: `${t('step2.model.default')} — ${defaultModel.value || '?'}` }]
-  for (const p of presetModels.value) {
-    opts.push({ value: p.name, label: p.label || p.name })
-  }
-  for (const m of ollamaModels.value) {
-    if (presetModels.value.some(p => p.name === m.name)) continue
-    opts.push({ value: m.name, label: `${m.label || m.name} (Ollama)` })
-  }
-  opts.push({ value: 'custom', label: t('step2.model.customGroup') })
-  return opts
-})
-
 const serverDefaultRequiresOllama = computed(() => defaultProvider.value === 'ollama')
 const llmStatusOk = computed(() => !serverDefaultRequiresOllama.value || ollamaReachable.value)
 const llmStatusLabel = computed(() => {
@@ -108,18 +97,19 @@ const llmStatusLabel = computed(() => {
   return 'LLM'
 })
 
+// Wenn der User unter /settings/llm-providers einen anderen Provider als Default
+// gewählt hat (selectedRoute !== null), gilt der Ollama-Reachability-Check nicht
+// mehr — der gewählte Provider übernimmt.
 const servicesReady = computed(() => (
   neo4jReachable.value &&
-  (!serverDefaultRequiresOllama.value || ollamaReachable.value || runtimeProviderEnabled.value || modelOption.value === 'custom')
+  (!serverDefaultRequiresOllama.value || ollamaReachable.value || selectedRoute.value !== null)
 ))
 
 const canSubmit = computed(() => {
   return (
     simulationPrompt.value.trim() !== '' &&
     files.value.length > 0 &&
-    servicesReady.value &&
-    (modelOption.value !== 'custom' || customModel.value.trim() !== '') &&
-    (!runtimeProviderEnabled.value || runtimeApiKey.value.trim() !== '')
+    servicesReady.value
   )
 })
 
@@ -151,11 +141,11 @@ async function startSimulation() {
   loading.value = true
   errorMsg.value = ''
   try {
-    // Persist selection so Step2 picks it up.
-    localStorage.setItem(STORAGE_MODEL, modelOption.value)
-    if (modelOption.value === 'custom') {
-      localStorage.setItem(STORAGE_CUSTOM_MODEL, customModel.value.trim())
-    }
+    // Spiegele die ModelPicker-Auswahl auf STORAGE_MODEL, damit der bestehende
+    // MainView/Step2-Pfad (storedEffectiveModel → llm_model) sie aufgreift.
+    // Provider+Key resolved das Backend serverseitig via SecretResolver (PR #499).
+    const routeModel = selectedRoute.value?.model
+    localStorage.setItem(STORAGE_MODEL, routeModel || 'default')
     localStorage.setItem(STORAGE_LANG, language.value)
 
     setPendingUpload(files.value, simulationPrompt.value)
@@ -169,25 +159,7 @@ async function startSimulation() {
 
 onMounted(() => {
   loadStatus()
-  const stored = localStorage.getItem(STORAGE_CUSTOM_MODEL) || localStorage.getItem('agora.customModel')
-  if (stored) customModel.value = stored
 })
-
-watch(runtimeProvider, (provider, previousProvider) => {
-  const providerDefault = defaultRuntimeModelForProvider(provider)
-  if (provider !== 'default') {
-    if (
-      modelOption.value !== 'custom' &&
-      !isRuntimeModelForProvider(provider, modelOption.value)
-    ) {
-      modelOption.value = providerDefault || 'custom'
-    }
-    return
-  }
-  if (previousProvider && isRuntimeModelForProvider(previousProvider, modelOption.value)) {
-    modelOption.value = 'default'
-  }
-}, { immediate: true })
 
 function scrollToConsole() {
   document.getElementById('console')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -370,12 +342,13 @@ const differentiators = computed(() => tm('home.differentiators'))
         </div>
         <div class="model-grid">
           <div>
-            <Select
-              v-model="modelOption"
-              :label="t('step2.model.label')"
-              :options="modelOptions"
+            <label class="home-field-label">{{ t('step2.model.label') }}</label>
+            <ModelPicker
+              :model-value="selectedRoute"
+              :placeholder="t('step2.model.placeholder')"
+              @update:model-value="onPickRoute"
             />
-            <p v-if="!runtimeProviderEnabled && serverDefaultRequiresOllama && !ollamaReachable && !loadingModels" class="console-warning" style="margin-top: 4px;">
+            <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !selectedRoute" class="console-warning" style="margin-top: 4px;">
               {{ t('step2.model.noOllama') }}
             </p>
           </div>
@@ -392,44 +365,6 @@ const differentiators = computed(() => tm('home.differentiators'))
               {{ t('step2.language.hint') }}
             </p>
           </div>
-        </div>
-        <Field
-          v-if="modelOption === 'custom'"
-          v-model="customModel"
-          :label="t('step2.model.customLabel')"
-          :placeholder="t('step2.model.customPlaceholder')"
-        />
-
-        <button
-          type="button"
-          class="runtime-toggle"
-          :aria-expanded="showRuntimeOptions"
-          @click="showRuntimeOptions = !showRuntimeOptions"
-        >
-          <span>{{ t('step2.runtimeProvider.toggle') }}</span>
-          <span class="console-meta">
-            {{ runtimeProviderEnabled ? t('step2.runtimeProvider.active') : t('step2.runtimeProvider.default') }}
-          </span>
-        </button>
-        <div v-if="showRuntimeOptions" class="runtime-panel">
-          <Select
-            v-model="runtimeProvider"
-            :label="t('step2.runtimeProvider.label')"
-            :options="runtimeProviderOptions"
-          />
-          <Field
-            v-if="runtimeProviderEnabled"
-            v-model="runtimeApiKey"
-            type="password"
-            :label="t('step2.runtimeProvider.apiKey')"
-            :placeholder="t('step2.runtimeProvider.apiKeyPlaceholder')"
-          />
-          <Field
-            v-if="runtimeProviderEnabled"
-            v-model="runtimeBaseUrl"
-            :label="t('step2.runtimeProvider.baseUrl')"
-            :placeholder="t('step2.runtimeProvider.baseUrlPlaceholder')"
-          />
         </div>
 
         <!-- Prompt -->
@@ -464,9 +399,6 @@ const differentiators = computed(() => tm('home.differentiators'))
           </span>
           <span v-else-if="!servicesReady" class="console-warning">
             Dienste nicht bereit. {{ neo4jError || (serverDefaultRequiresOllama ? ollamaError : '') || '' }}
-          </span>
-          <span v-else-if="runtimeProviderEnabled && !runtimeApiKey.trim()" class="console-warning">
-            {{ t('step2.runtimeProvider.missingKey') }}
           </span>
         </div>
         <p v-if="errorMsg" class="error-line">{{ errorMsg }}</p>
@@ -886,37 +818,17 @@ const differentiators = computed(() => tm('home.differentiators'))
   grid-template-columns: 1fr 1fr;
   gap: var(--s-5) var(--s-7);
 }
-.runtime-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--s-3);
-  width: 100%;
-  min-height: var(--ctl-h-md);
-  padding: 0 var(--ctl-pad-x);
-  border: 1px solid var(--rule-strong);
-  border-radius: var(--r-1);
-  background: var(--bg-elevated);
-  color: var(--fg);
-  cursor: pointer;
+.home-field-label {
+  display: block;
+  margin-bottom: 4px;
   font-family: var(--ff-mono);
-  font-size: 12px;
+  font-size: 11px;
   letter-spacing: var(--ls-mono);
   text-transform: uppercase;
-}
-.runtime-toggle:hover { border-color: color-mix(in oklch, var(--fg) 30%, transparent); }
-.runtime-panel {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--s-4);
-  padding: var(--s-4);
-  border: 1px solid var(--rule);
-  border-radius: var(--r-1);
-  background: var(--bg-subtle);
+  color: var(--fg-muted);
 }
 @media (max-width: 720px) {
   .model-grid { grid-template-columns: 1fr; }
-  .runtime-panel { grid-template-columns: 1fr; }
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary

Fünfter und letzter Schritt der LLM-Dropdown-Konsolidierung. **Home.vue** (Legacy-Landing-Page auf `/home`, `/` redirected ohnehin auf Dashboard mit HeroNewRun) wird auf denselben `ModelPicker` umgestellt wie die anderen vier Stellen — Workspace-Default (#499), LlmRoutingView (#499), Step4Report (#503), HeroNewRun (#504).

## Was sich ändert

### `frontend/src/views/Home.vue`

**Entfernt:**
- String-`<Select>` mit `modelOption` und gemischter Source (Server-Default + Presets + Ollama + Custom)
- Custom-Model-Free-Text-Input
- `runtimeProvider`-Toggle (Step2-Style Provider-Override mit ApiKey/BaseUrl-Inputs) — Credentials laufen jetzt zentral über `/settings/llm-providers`, Auflösung serverseitig via `SecretResolver` (PR #499)
- `ollamaModels`, `presetModels`, `defaultModel`, `modelOption`, `customModel`, `showRuntimeOptions`, `runtimeProvider*` State
- `defaultRuntimeModelForProvider`/`isRuntimeModelForProvider`/`runtimeModelOptionsForProvider`/`useRuntimeLlmOptions` Imports + `watch(runtimeProvider, …)` Hook
- `runtime-toggle` und `runtime-panel` CSS

**Neu:**
- `<ModelPicker>` als einzige Modell-Auswahl
- `selectedRoute: ref<StageLLMRoute | null>` mit localStorage-Persistenz `agora.home.route` (Zod-validiert)
- `onPickRoute`-Handler
- Spiegelung auf `STORAGE_MODEL` (= `route.model`), damit bestehende MainView/Step2-Pipeline ohne Touch greift
- Service-Health-Check (`servicesReady`) berücksichtigt eine gesetzte Route als legitimen Override für den Ollama-Reachability-Block

### i18n

- Neu in `de.json`/`en.json`: `step2.model.placeholder`
- `step2.model.noOllama` umformuliert: Hinweis auf `/settings/llm-providers` statt Custom-Eingabe.

## CRG-Impact

- `Home.vue` hat 1 Importer (Router). Kein versteckter Konsument.
- `useRuntimeLlmOptions` und `runtimeLlmPayloadFromStorage` werden anderswo noch genutzt (MainView, Step2EnvSetup) — bewusst nicht entfernt.

## Test plan

- [x] `bun run typecheck` → exit 0
- [x] `bun run lint` → clean
- [x] `bun run test --run` → 991/991 grün
- [x] `bash scripts/sync-status.sh --check` → in sync
- [ ] Manuell auf `localhost:5180/home`:
  - [ ] ModelPicker rendert gruppierte Provider-Modelle
  - [ ] Service-Health-Status (Neo4j/Ollama) wird angezeigt
  - [ ] Auswahl bleibt nach Reload erhalten (`agora.home.route`)
  - [ ] Submit → setPendingUpload → /process/new mit `llm_model = route.model`

## Komplettbild der LLM-Konsolidierung (5 PRs)

| PR | Slice | Was |
|---|---|---|
| #499 | Backend + LlmRoutingView | Subprocess-Env-Fix für Gemini, LlmRoutingView nutzt ModelPicker |
| #500 / #502 | Deps | Neo4j 5.26-LTS + uv.lock refresh |
| #501 | Python | Floor + ruff/mypy + alle CI-Workflows auf 3.14 |
| #503 | A1 | Step4Report nutzt ModelPicker (full migration) |
| #504 | A2 | HeroNewRun (Hybrid: Profile + ModelPicker) + i18n + radon allowlist + STATUS drift |
| **#505** (dieser) | **A3** | **Home.vue (full migration), runtimeProvider-UI entfernt** |

Danach laufen Modell-Auswahl und Provider-Credentials projektweit über `useLlmProvidersStore` und `LlmProviderSecretsStore` — keine localStorage-Plaintext-Keys, kein .env-Zwang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)