### PR TITLE
docs(env): dokumentiere AGORA_ALLOW_SMALL_SIM Override für Klein-Runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS=60
 # unauthentifiziert sein soll (z.B. lokales Klassenraum-Demo). Niemals in Prod.
 # AGORA_ALLOW_ANONYMOUS=true
 
+# Simulation-Floor-Override. Default: mindestens 30 Personas pro Run
+# (Schutz vor Aussage-armen Mini-Samples). Auf "1" setzen, um Test-/Smoke-
+# Runs mit weniger als 30 Personas zu erlauben — die Auswertung verliert
+# statistische Aussagekraft. Validierung in
+# backend/app/services/simulation_config_generator.py::_validate_persona_quota.
+# AGORA_ALLOW_SMALL_SIM=1
+
 # Zusätzliche erlaubte Frontend-Origins (kommagetrennt), z.B. Tailscale / LAN.
 # AGORA_EXTRA_ORIGINS=http://100.64.0.10:5173,https://agora.tailnet.example
 


### PR DESCRIPTION
## Summary

Trivialer Doku-Patch. `AGORA_ALLOW_SMALL_SIM=1` Override war nur via `ValueError`-Message diskoverable. Jetzt in `.env.example` mit Code-Verweis dokumentiert.

## Hintergrund

`backend/app/services/simulation_config_generator.py::_validate_persona_quota` setzt einen Hard-Floor von 30 Personas pro Run als Schutz vor aussagearmer Mini-Samples. Override war geplant, aber bisher nur via Quelltext / Error-Message bekannt.

Frontend (HeroNewRun-Slider) erlaubt 10-100 Personas mit Warning bei <30 — User stoßen beim Submit ohne Override gegen den Backend-Floor. Folge-Ticket für UX-Konsistenz (Frontend-Slider hart auf 30 ODER Backend-Floor dynamisch) bleibt offen.

## Test plan

- [x] `.env.example` ist syntaktisch ok (kommentierte Zeile, keine harte Setzung).
- [x] User aktiviert via `AGORA_ALLOW_SMALL_SIM=1` in `.env` + `docker compose restart backend`, Klein-Sim mit <30 Personas läuft durch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)