### PR TITLE
feat(sim-floor): UI-Backend-Sync für AGORA_ALLOW_SMALL_SIM Override

### DIFF
--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -60,7 +60,10 @@ def _get_backend_status():
         "ok": True,
         "version": __version__,
         "auth_mode": _get_auth_mode(),
-        "allow_small_sim": os.environ.get("AGORA_ALLOW_SMALL_SIM", "").strip() == "1",
+        # Exakter Vergleich gegen "1" — kein .strip() — damit die UI das
+        # gleiche Bit sieht wie der Validator in simulation_config_generator
+        # (_validate_persona_quota nutzt ebenfalls `!= "1"` ohne strip).
+        "allow_small_sim": os.environ.get("AGORA_ALLOW_SMALL_SIM") == "1",
     }
 
 

--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -49,11 +49,18 @@ def _get_auth_mode():
 
 
 def _get_backend_status():
-    """Get backend health, version, and active auth mode."""
+    """Get backend health, version, and active auth mode.
+
+    ``allow_small_sim`` mirrors the ``AGORA_ALLOW_SMALL_SIM`` env-var so the
+    frontend can adjust the persona-slider lower bound dynamically instead of
+    letting the user submit a run that the simulation_config_generator's
+    persona-quota validator rejects with a hard 422.
+    """
     return {
         "ok": True,
         "version": __version__,
         "auth_mode": _get_auth_mode(),
+        "allow_small_sim": os.environ.get("AGORA_ALLOW_SMALL_SIM", "").strip() == "1",
     }
 
 

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -18,11 +18,29 @@ from app.api.status import (
 class TestStatusFunctions:
     """Test suite for status helper functions"""
 
-    def test_get_backend_status(self):
+    def test_get_backend_status(self, monkeypatch):
         """Test backend status returns correct version and ok=true."""
+        # ENV-Drift aus dem lokalen .env-File abklemmen, damit die Assertion
+        # gegen den Default deterministisch bleibt.
+        monkeypatch.delenv("AGORA_ALLOW_SMALL_SIM", raising=False)
         result = _get_backend_status()
         assert result['ok'] is True
         assert result['version'] == __version__
+        # Slice "small-sim-floor-frontend-sync": default ohne ENV-Override ist
+        # der 30-Personas-Floor scharf, also allow_small_sim=False.
+        assert result['allow_small_sim'] is False
+
+    def test_get_backend_status_reflects_allow_small_sim_env(self, monkeypatch):
+        """Backend exponiert AGORA_ALLOW_SMALL_SIM=1 als allow_small_sim=True."""
+        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "1")
+        assert _get_backend_status()['allow_small_sim'] is True
+
+        # Andere Werte (z. B. "0", "true", leer) zählen NICHT als aktiviert —
+        # Backend-Validator akzeptiert ausschließlich "1".
+        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "true")
+        assert _get_backend_status()['allow_small_sim'] is False
+        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "0")
+        assert _get_backend_status()['allow_small_sim'] is False
 
     def test_get_disk_status(self):
         """Test disk status returns expected fields."""

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -35,11 +35,15 @@ class TestStatusFunctions:
         monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "1")
         assert _get_backend_status()['allow_small_sim'] is True
 
-        # Andere Werte (z. B. "0", "true", leer) zählen NICHT als aktiviert —
-        # Backend-Validator akzeptiert ausschließlich "1".
+        # Andere Werte (z. B. "0", "true", leer, gepaddetes "1") zaehlen NICHT
+        # als aktiviert — Backend-Validator (simulation_config_generator.
+        # _validate_persona_quota) vergleicht ebenfalls strict gegen "1" ohne
+        # strip, der Status-Endpoint muss exakt das gleiche Bit liefern.
         monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "true")
         assert _get_backend_status()['allow_small_sim'] is False
         monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "0")
+        assert _get_backend_status()['allow_small_sim'] is False
+        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", " 1 ")
         assert _get_backend_status()['allow_small_sim'] is False
 
     def test_get_disk_status(self):

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2492 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 2493 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 127 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -19,6 +19,7 @@ import { setPendingUpload } from '../../../store/pendingUpload'
 import { STORAGE_LANG, STORAGE_MODEL } from '../../../composables/useEnvForm'
 import type { LlmProfile } from '../../../contracts/llmProfileContract'
 import { StageLLMRouteSchema, type StageLLMRoute } from '../../../contracts/llmRoutingContract'
+import { getSystemStatus } from '../../../api/status'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -96,18 +97,29 @@ const selectedRoute = ref<StageLLMRoute | null>(loadStoredRoute())
 const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
 const simulationRequirement = ref('')
 
-const NUM_AGENTS_MIN = 10
-const NUM_AGENTS_FLOOR = 30
+// Persona-Floor synchron mit Backend (simulation_config_generator._validate_persona_quota).
+// Hard-Floor=30, optional override via AGORA_ALLOW_SMALL_SIM=1. Wert wird beim
+// Mount per /api/status (backend.allow_small_sim) gezogen — bis dahin pessimistisch
+// auf den harten Floor klemmen, damit der User keine Run-Konfig zusammenklicken kann
+// die das Backend dann mit 422 ablehnt.
+const NUM_AGENTS_HARD_FLOOR = 30
+const NUM_AGENTS_OVERRIDE_FLOOR = 10
+const NUM_AGENTS_DEFAULT = NUM_AGENTS_HARD_FLOOR
 const NUM_AGENTS_MAX = 100
 const NUM_ROUNDS_MIN = 3
 const NUM_ROUNDS_DEFAULT = 10
 const NUM_ROUNDS_MAX = 30
 
-const numAgents = ref<number>(NUM_AGENTS_FLOOR)
+const allowSmallSim = ref<boolean>(false)
+const numAgents = ref<number>(NUM_AGENTS_DEFAULT)
 const numRounds = ref<number>(NUM_ROUNDS_DEFAULT)
 
+const numAgentsMin = computed<number>(
+  () => (allowSmallSim.value ? NUM_AGENTS_OVERRIDE_FLOOR : NUM_AGENTS_HARD_FLOOR),
+)
+
 const showAgentsWarning = computed<boolean>(
-  () => numAgents.value >= NUM_AGENTS_MIN && numAgents.value < NUM_AGENTS_FLOOR,
+  () => allowSmallSim.value && numAgents.value >= NUM_AGENTS_OVERRIDE_FLOOR && numAgents.value < NUM_AGENTS_HARD_FLOOR,
 )
 
 const profileOptions = computed(() => {
@@ -233,6 +245,19 @@ onMounted(() => {
   fetchLlmProfiles()
     .then(profiles => { llmProfiles.value = profiles })
     .catch(() => { /* Fallback: Profile-Picker bleibt leer, ModelPicker greift */ })
+  // backend.allow_small_sim aus /api/status spiegelt AGORA_ALLOW_SMALL_SIM
+  // wider. Default-pessimistisch bei Fetch-Fehler: harter 30er-Floor bleibt.
+  getSystemStatus()
+    .then(envelope => {
+      const backend = (envelope?.data?.backend ?? envelope?.backend) as { allow_small_sim?: boolean } | undefined
+      allowSmallSim.value = !!backend?.allow_small_sim
+      // Wenn der Override nach Mount inaktiv ist, klemmen wir einen ggf. aus
+      // dem letzten Override-Run persistenten Slider-Wert wieder hoch.
+      if (!allowSmallSim.value && numAgents.value < NUM_AGENTS_HARD_FLOOR) {
+        numAgents.value = NUM_AGENTS_HARD_FLOOR
+      }
+    })
+    .catch(() => { /* Fail-safe: allowSmallSim bleibt false → 30er-Floor aktiv */ })
 })
 </script>
 
@@ -324,17 +349,20 @@ onMounted(() => {
           <label class="hero-label" for="hero-num-agents">
             {{ $t('dashboard.hero.numAgentsLabel') }}
             <span class="hero-slider-value">{{ numAgents }}</span>
+            <span v-if="allowSmallSim" class="hero-small-sim-badge" :title="$t('dashboard.hero.smallSimActiveTooltip')">
+              {{ $t('dashboard.hero.smallSimBadge') }}
+            </span>
           </label>
           <input
             id="hero-num-agents"
             v-model.number="numAgents"
             type="range"
-            :min="NUM_AGENTS_MIN"
+            :min="numAgentsMin"
             :max="NUM_AGENTS_MAX"
             step="1"
             class="hero-slider"
             :aria-valuenow="numAgents"
-            :aria-valuemin="NUM_AGENTS_MIN"
+            :aria-valuemin="numAgentsMin"
             :aria-valuemax="NUM_AGENTS_MAX"
           />
           <div v-if="showAgentsWarning" class="hero-warning" role="alert">
@@ -661,6 +689,22 @@ onMounted(() => {
   font-weight: 600;
   color: var(--text-secondary);
   margin-left: 6px;
+}
+
+.hero-small-sim-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border: 1px solid #f97316;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #c2410c;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: help;
 }
 
 /* Warning-Badge */

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
@@ -12,6 +12,20 @@ vi.mock('../../forms/ModelPicker.vue', () => ({
   },
 }))
 
+// Slice "small-sim-floor-frontend-sync": HeroNewRun fragt beim Mount /api/status
+// ab. In den Profile-Tests interessiert uns nur das Profil-Verhalten — minimaler
+// Status-Mock mit allow_small_sim=false (Default-Pfad).
+vi.mock('../../../../api/status', () => ({
+  getSystemStatus: vi.fn().mockResolvedValue({
+    success: true,
+    backend: { ok: true, version: '1.0.0', auth_mode: 'open', allow_small_sim: false },
+    neo4j: { reachable: true },
+    ollama: { reachable: false, models_available: [] },
+    disk: { uploads: { path: '/tmp', total_bytes: 0, free_bytes: 0, used_pct: 0 } },
+    timestamp: '2026-05-17T00:00:00Z',
+  }),
+}))
+
 // LLM-Profile-API: zwei Profile
 vi.mock('../../../../api/llmProfiles', () => ({
   fetchLlmProfiles: vi.fn().mockResolvedValue([

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -6,6 +6,18 @@ vi.mock('../../../../api/llmProfiles', () => ({
   fetchLlmProfiles: vi.fn().mockResolvedValue([]),
 }))
 
+// Default: allow_small_sim=false → Slider-Floor 30, kein Warning-Pfad
+vi.mock('../../../../api/status', () => ({
+  getSystemStatus: vi.fn().mockResolvedValue({
+    success: true,
+    backend: { ok: true, version: '1.0.0', auth_mode: 'open', allow_small_sim: false },
+    neo4j: { reachable: true },
+    ollama: { reachable: false, models_available: [] },
+    disk: { uploads: { path: '/tmp', total_bytes: 0, free_bytes: 0, used_pct: 0 } },
+    timestamp: '2026-05-17T00:00:00Z',
+  }),
+}))
+
 // Slice A2: ModelPicker stubben, damit die Hero-Tests ohne Pinia laufen.
 vi.mock('../../forms/ModelPicker.vue', () => ({
   default: {
@@ -109,20 +121,42 @@ describe('HeroNewRun', () => {
     expect(Number(slider.element.value)).toBe(10)
   })
 
-  it('Warning-Badge erscheint bei num_agents < 30, verschwindet bei 30', async () => {
+  it('Slider-Floor ist 30 (hart) wenn allow_small_sim=false', async () => {
     const router = makeRouter()
     await router.push('/dashboard')
     const w = mount(HeroNewRun, { global: { plugins: [makeI18n(), router] } })
     await flushPromises()
 
     const slider = w.find<HTMLInputElement>('input#hero-num-agents')
+    expect(slider.attributes('min')).toBe('30')
+    expect(w.find('.hero-small-sim-badge').exists()).toBe(false)
+  })
 
-    // Slider auf 25 → Badge sichtbar
+  it('Slider-Floor ist 10 + SMALL_SIM-Badge wenn allow_small_sim=true', async () => {
+    const { getSystemStatus } = await import('../../../../api/status')
+    vi.mocked(getSystemStatus).mockResolvedValueOnce({
+      success: true,
+      backend: { ok: true, version: '1.0.0', auth_mode: 'open', allow_small_sim: true },
+      neo4j: { reachable: true },
+      ollama: { reachable: false, models_available: [] },
+      disk: { uploads: { path: '/tmp', total_bytes: 0, free_bytes: 0, used_pct: 0 } },
+      timestamp: '2026-05-17T00:00:00Z',
+    } as unknown as Awaited<ReturnType<typeof getSystemStatus>>)
+
+    const router = makeRouter()
+    await router.push('/dashboard')
+    const w = mount(HeroNewRun, { global: { plugins: [makeI18n(), router] } })
+    await flushPromises()
+
+    const slider = w.find<HTMLInputElement>('input#hero-num-agents')
+    expect(slider.attributes('min')).toBe('10')
+    expect(w.find('.hero-small-sim-badge').exists()).toBe(true)
+
+    // Warning-Badge erscheint bei numAgents < 30 im Override-Mode
     await slider.setValue(25)
     await flushPromises()
     expect(w.find('.hero-warning').exists()).toBe(true)
 
-    // Slider auf 30 → Badge weg
     await slider.setValue(30)
     await flushPromises()
     expect(w.find('.hero-warning').exists()).toBe(false)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1173,7 +1173,9 @@
       "profileDefault": "Standard",
       "numAgentsLabel": "Personas",
       "numRoundsLabel": "Sim-Runden",
-      "numAgentsWarning": "Unter dem empfohlenen Floor (30). Aussagekraft reduziert."
+      "numAgentsWarning": "Unter dem empfohlenen Floor (30). Aussagekraft reduziert.",
+      "smallSimBadge": "SMALL_SIM",
+      "smallSimActiveTooltip": "AGORA_ALLOW_SMALL_SIM=1 ist aktiv — Slider geht bis 10 statt 30. Statistische Aussagekraft ist eingeschränkt."
     },
     "stats": {
       "activeRuns": "Aktive Runs",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1173,7 +1173,9 @@
       "profileDefault": "Default",
       "numAgentsLabel": "Personas",
       "numRoundsLabel": "Sim rounds",
-      "numAgentsWarning": "Below recommended floor (30). Reduced statistical significance."
+      "numAgentsWarning": "Below recommended floor (30). Reduced statistical significance.",
+      "smallSimBadge": "SMALL_SIM",
+      "smallSimActiveTooltip": "AGORA_ALLOW_SMALL_SIM=1 is active — slider goes down to 10 instead of 30. Statistical significance is limited."
     },
     "stats": {
       "activeRuns": "Active runs",


### PR DESCRIPTION
## Summary

Schließt die Fail-Late-UX-Lücke beim Persona-Floor. Bisher erlaubte der HeroNewRun-Slider 10–100 Personas mit Warning, das Backend lehnte aber <30 hart ab (\`ValueError: Simulation-Floor: mindestens 30 Personas erforderlich\`). User mussten erst beim Submit gegen einen 422 laufen.

## Was sich ändert

### Backend (\`backend/app/api/status.py\`)

\`_get_backend_status\` liefert zusätzlich \`allow_small_sim: bool\`, gespiegelt aus der Env-Var \`AGORA_ALLOW_SMALL_SIM\`. **Nur exakt \"1\" zählt als aktiviert** — \"true\"/\"0\"/leer sind aus. Konsistent zu der bestehenden Validator-Logik in \`simulation_config_generator._validate_persona_quota\`.

### Frontend (\`frontend/src/components/v4/dashboard/HeroNewRun.vue\`)

- Beim Mount Aufruf von \`getSystemStatus()\`. Default-pessimistisch: bis zur Antwort gilt der 30er-Floor, damit kein Click gegen 422 läuft.
- \`numAgentsMin\` ist eine computed: **30 hard**, **10 im Override-Mode**.
- \`SMALL_SIM\`-Badge neben dem Personas-Label, sichtbar wenn Override aktiv ist (Tooltip erklärt die Aussage-Einschränkung).
- \`showAgentsWarning\` zeigt nur noch im Override-Mode (sonst kann der Slider physikalisch nicht unter 30 fallen).
- \`numAgents\` wird beim Mount auf den Hard-Floor gebumpt, falls ein alter \`localStorage\`-Wert <30 hängt und der Override gerade inaktiv ist.

### Tests

- \`HeroNewRun.spec.ts\`: \`getSystemStatus\`-Mock (Default \`allow_small_sim=false\`). Slider-Floor-Test umgeschrieben + eigener Override-Mode-Test (mockt \`allow_small_sim=true\`, prüft \`min=10\`, SMALL_SIM-Badge, Warning bei <30).
- \`HeroNewRun.profiles.spec.ts\`: Status-Mock ergänzt.
- \`test_status.py\`: bestehender Test bekommt \`monkeypatch.delenv\` (sonst leakt das lokale \`.env\` ins Test-Verhalten), neuer Test \`test_get_backend_status_reflects_allow_small_sim_env\`.

## Test plan

- [x] \`pytest tests/test_status.py tests/test_anonymous_in_healthcheck.py\` → 17/17 grün (alle Caller von \`_get_backend_status\`).
- [x] \`bun run typecheck\` → exit 0
- [x] \`bun run lint\` → clean
- [x] \`bun run test --run src/components/v4/dashboard/__tests__/\` → 992/992 grün
- [ ] Manuell auf \`localhost:5180/dashboard\`:
  - [ ] ohne \`AGORA_ALLOW_SMALL_SIM=1\`: Slider klemmt bei 30, kein Badge.
  - [ ] mit \`AGORA_ALLOW_SMALL_SIM=1\` + Backend-Restart: Slider geht bis 10, SMALL_SIM-Badge sichtbar, Warning bei <30, Submit läuft durch.

## Hintergrund

Komplementär zu \`docs/env-example-allow-small-sim\` (#506), das den Override-Mechanismus dokumentiert. Dieser PR liefert die UX-Konsistenz dazu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)