### PR TITLE
feat(frontend): mobile-responsive AppShell mit Off-Canvas-Drawer (<768px)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 2494 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 127 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 128 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/components/v4/shell/AppShell.vue
+++ b/frontend/src/components/v4/shell/AppShell.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="app-shell" :class="{ 'app-shell--inspector-open': shellStore.inspectorOpen }">
-    <!-- Sidebar (spans both rows) -->
-    <div class="app-shell__sidebar">
+    <!-- Mobile Backdrop -->
+    <div
+      v-if="shellStore.mobileNavOpen"
+      class="app-shell__backdrop"
+      aria-hidden="true"
+      @click="shellStore.closeMobileNav()"
+    />
+
+    <!-- Sidebar (spans both rows on Desktop; Off-Canvas on Mobile) -->
+    <div
+      class="app-shell__sidebar"
+      :class="{ 'app-shell__sidebar--mobile-open': shellStore.mobileNavOpen }"
+    >
       <slot name="sidebar">
         <Sidebar
           :active="activeRoute"
@@ -37,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onBeforeUnmount, defineAsyncComponent } from 'vue'
+import { computed, watch, onMounted, onBeforeUnmount, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useShellStore } from '@/stores/shell'
 import { useCommandPalette } from '@/composables/useCommandPalette'
@@ -71,7 +82,20 @@ function onKeyDown(e: KeyboardEvent): void {
     e.preventDefault()
     togglePalette()
   }
+  if (e.key === 'Escape' && shellStore.mobileNavOpen) {
+    shellStore.closeMobileNav()
+  }
 }
+
+// Body-Scroll-Lock wenn Mobile-Nav offen
+watch(
+  () => shellStore.mobileNavOpen,
+  (open) => {
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = open ? 'hidden' : ''
+    }
+  },
+)
 
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown)
@@ -82,6 +106,10 @@ onMounted(() => {
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeyDown)
   commandsStore.unbindDynamicCommands()
+  // Scroll-Lock immer freigeben
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = ''
+  }
 })
 
 // Derive active route name for sidebar item highlighting
@@ -163,5 +191,79 @@ const activeSubRoute = computed<string>(() => {
   border-left: 1px solid var(--hairline);
   background: var(--surface-base, #fff);
   overflow: auto;
+}
+
+/* Backdrop: nur auf Mobile sichtbar */
+.app-shell__backdrop {
+  display: none;
+}
+
+/* ── Mobile (< 768 px) ──────────────────────────────────────── */
+@media (max-width: 768px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: 56px 1fr;
+  }
+
+  /* Inspector als Full-Screen-Overlay auf Mobile */
+  .app-shell--inspector-open {
+    grid-template-columns: 1fr;
+  }
+
+  .app-shell__sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 50;
+    grid-row: unset;
+    grid-column: unset;
+    transform: translateX(-100%);
+    transition: transform 200ms ease;
+    /* Sidebar behält ihre eigene Breite (220px / 56px collapsed) */
+  }
+
+  .app-shell__sidebar--mobile-open {
+    transform: translateX(0);
+  }
+
+  .app-shell__topbar {
+    grid-row: 1;
+    grid-column: 1;
+  }
+
+  .app-shell--inspector-open .app-shell__topbar {
+    grid-column: 1;
+  }
+
+  .app-shell__main {
+    grid-row: 2;
+    grid-column: 1;
+    padding: 16px;
+  }
+
+  .app-shell--inspector-open .app-shell__main {
+    grid-column: 1;
+  }
+
+  /* Inspector als Full-Screen-Overlay */
+  .app-shell__inspector {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    width: 100%;
+    border-left: none;
+    grid-row: unset;
+    grid-column: unset;
+  }
+
+  /* Backdrop aktiv */
+  .app-shell__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    background: rgba(0, 0, 0, 0.45);
+  }
 }
 </style>

--- a/frontend/src/components/v4/shell/AppShell.vue
+++ b/frontend/src/components/v4/shell/AppShell.vue
@@ -87,6 +87,14 @@ function onKeyDown(e: KeyboardEvent): void {
   }
 }
 
+// Resize-Listener: Wenn auf Desktop-Breite gewechselt wird während Drawer offen ist,
+// Nav schliessen damit der Scroll-Lock (via Watcher unten) aufgehoben wird.
+function onResize(): void {
+  if (window.innerWidth >= 768 && shellStore.mobileNavOpen) {
+    shellStore.closeMobileNav()
+  }
+}
+
 // Body-Scroll-Lock wenn Mobile-Nav offen
 watch(
   () => shellStore.mobileNavOpen,
@@ -99,12 +107,14 @@ watch(
 
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown)
+  window.addEventListener('resize', onResize)
   // Dynamische Commands (laufende Sims + Recent Reports) einmalig verdrahten.
   // bindDynamicCommands ist idempotent — doppelter Aufruf ist sicher.
   commandsStore.bindDynamicCommands(router)
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('resize', onResize)
   commandsStore.unbindDynamicCommands()
   // Scroll-Lock immer freigeben
   if (typeof document !== 'undefined') {
@@ -220,7 +230,9 @@ const activeSubRoute = computed<string>(() => {
     grid-column: unset;
     transform: translateX(-100%);
     transition: transform 200ms ease;
-    /* Sidebar behält ihre eigene Breite (220px / 56px collapsed) */
+    /* Erzwingt volle Sidebar-Breite im Mobile-Drawer, auch wenn Desktop-Collapsed-State
+       (56px) aktiv ist — sonst sind Labels unsichtbar und der Drawer wirkt kaputt. */
+    width: 280px !important;
   }
 
   .app-shell__sidebar--mobile-open {

--- a/frontend/src/components/v4/shell/Icon.vue
+++ b/frontend/src/components/v4/shell/Icon.vue
@@ -20,6 +20,7 @@ import IconChevronD from './icons/IconChevronD.vue'
 import IconArrowL from './icons/IconArrowL.vue'
 import IconSearch from './icons/IconSearch.vue'
 import IconPlus from './icons/IconPlus.vue'
+import IconMenu from './icons/IconMenu.vue'
 
 export type IconName =
   | 'home'
@@ -34,6 +35,7 @@ export type IconName =
   | 'arrowL'
   | 'search'
   | 'plus'
+  | 'menu'
   // ds-shell.jsx aliases
   | 'branch'
 
@@ -50,6 +52,7 @@ const iconMap: Record<string, Component> = {
   arrowL: IconArrowL,
   search: IconSearch,
   plus: IconPlus,
+  menu: IconMenu,
   // ds-shell.jsx uses "branch" for Runs — map to bolt as fallback
   branch: IconBolt,
 }

--- a/frontend/src/components/v4/shell/Sidebar.vue
+++ b/frontend/src/components/v4/shell/Sidebar.vue
@@ -16,6 +16,7 @@
           :to="item.disabled ? undefined : item.to"
           :disabled="item.disabled"
           :tooltip="item.disabled ? t('sidebar.disabledTooltip') : undefined"
+          @click="handleNavClick"
         />
       </template>
 
@@ -32,6 +33,7 @@
             class="sidebar-sub-item"
             active-class="sidebar-sub-item--active"
             exact-active-class="sidebar-sub-item--active"
+            @click="handleNavClick"
           >
             {{ sub.label }}
           </RouterLink>
@@ -54,8 +56,16 @@ import SidebarItem from './SidebarItem.vue'
 import SidebarGroup from './SidebarGroup.vue'
 import Icon from './Icon.vue'
 import AgoraBrand from '../../brand/AgoraBrand.vue'
+import { useShellStore } from '@/stores/shell'
 
 const { t } = useI18n()
+const shellStore = useShellStore()
+
+function handleNavClick(): void {
+  if (window.innerWidth < 768) {
+    shellStore.closeMobileNav()
+  }
+}
 
 interface NavItem {
   id: string

--- a/frontend/src/components/v4/shell/Sidebar.vue
+++ b/frontend/src/components/v4/shell/Sidebar.vue
@@ -62,7 +62,9 @@ const { t } = useI18n()
 const shellStore = useShellStore()
 
 function handleNavClick(): void {
-  if (window.innerWidth < 768) {
+  // matchMedia entspricht exakt dem CSS-Breakpoint @media (max-width: 768px) —
+  // kein Off-by-one bei genau 768px wie bei window.innerWidth < 768.
+  if (window.matchMedia('(max-width: 768px)').matches) {
     shellStore.closeMobileNav()
   }
 }

--- a/frontend/src/components/v4/shell/Topbar.vue
+++ b/frontend/src/components/v4/shell/Topbar.vue
@@ -1,5 +1,16 @@
 <template>
   <header class="topbar">
+    <!-- Hamburger-Button (nur Mobile) -->
+    <button
+      class="topbar__hamburger"
+      type="button"
+      aria-label="Navigation öffnen"
+      :aria-expanded="shellStore.mobileNavOpen"
+      @click="shellStore.toggleMobileNav()"
+    >
+      <Icon name="menu" :size="20" :stroke="1.6" />
+    </button>
+
     <!-- Crumbs (left) -->
     <div class="topbar__crumbs">
       <slot name="crumbs">
@@ -58,9 +69,11 @@ import type { BreadcrumbItem } from './Breadcrumbs.vue'
 import Icon from './Icon.vue'
 import DensityToggle from './DensityToggle.vue'
 import { useCommandPalette } from '@/composables/useCommandPalette'
+import { useShellStore } from '@/stores/shell'
 
 const { t } = useI18n()
 const { open: openPalette } = useCommandPalette()
+const shellStore = useShellStore()
 
 withDefaults(
   defineProps<{
@@ -145,6 +158,39 @@ withDefaults(
 
 .topbar__user {
   margin-left: 8px;
+}
+
+/* Hamburger: standardmaessig versteckt, nur auf Mobile sichtbar */
+.topbar__hamburger {
+  display: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 100ms ease, color 100ms ease;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.topbar__hamburger:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+  color: var(--text-primary);
+}
+
+@media (max-width: 768px) {
+  .topbar {
+    padding: 0 12px;
+    height: 56px;
+  }
+
+  .topbar__hamburger {
+    display: inline-flex;
+  }
 }
 
 .topbar__avatar {

--- a/frontend/src/components/v4/shell/Topbar.vue
+++ b/frontend/src/components/v4/shell/Topbar.vue
@@ -4,7 +4,7 @@
     <button
       class="topbar__hamburger"
       type="button"
-      aria-label="Navigation öffnen"
+      :aria-label="t('topbar.openNavigation')"
       :aria-expanded="shellStore.mobileNavOpen"
       @click="shellStore.toggleMobileNav()"
     >

--- a/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
+++ b/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
@@ -11,8 +11,9 @@
  * 7. Click auf Backdrop schliesst Mobile-Nav.
  * 8. ESC schliesst Mobile-Nav.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { makeTestRouter } from './testRouter'
@@ -42,6 +43,11 @@ describe('AppShell', () => {
   beforeEach(() => {
     lsMock.clear()
     setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.body.style.overflow = ''
   })
 
   it('mountet ohne Crash', async () => {
@@ -155,6 +161,33 @@ describe('AppShell', () => {
     await wrapper.find('.app-shell__backdrop').trigger('click')
 
     expect(store.mobileNavOpen).toBe(false)
+  })
+
+  it('Resize auf Desktop-Breite schliesst Mobile-Nav und entfernt Scroll-Lock', async () => {
+    await router.push('/')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    mount(AppShell, {
+      global: { plugins: [router, pinia, i18n] },
+    })
+
+    const { useShellStore } = await import('@/stores/shell')
+    const store = useShellStore()
+
+    // Drawer öffnen — Scroll-Lock wird gesetzt
+    store.openMobileNav()
+    await nextTick()
+    expect(store.mobileNavOpen).toBe(true)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // Fenster auf Desktop-Breite resizen
+    vi.stubGlobal('innerWidth', 1024)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(store.mobileNavOpen).toBe(false)
+    // Watcher reagiert auf mobileNavOpen=false → overflow wieder leer
+    expect(document.body.style.overflow).toBe('')
   })
 
   it('ESC schliesst Mobile-Nav', async () => {

--- a/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
+++ b/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
@@ -7,6 +7,9 @@
  * 3. Topbar-Slot wird gerendert.
  * 4. Default-Main-Slot wird gerendert.
  * 5. Inspector-Slot ist default geschlossen.
+ * 6. Backdrop wird gerendert wenn mobileNavOpen=true.
+ * 7. Click auf Backdrop schliesst Mobile-Nav.
+ * 8. ESC schliesst Mobile-Nav.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
@@ -114,5 +117,60 @@ describe('AppShell', () => {
 
     expect(wrapper.find('.app-shell__inspector').exists()).toBe(true)
     expect(wrapper.find('.inspector-content').exists()).toBe(true)
+  })
+
+  it('Backdrop wird gerendert wenn mobileNavOpen=true', async () => {
+    await router.push('/')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const wrapper = mount(AppShell, {
+      global: { plugins: [router, pinia, i18n] },
+    })
+
+    const { useShellStore } = await import('@/stores/shell')
+    const store = useShellStore()
+
+    // Kein Backdrop initial
+    expect(wrapper.find('.app-shell__backdrop').exists()).toBe(false)
+
+    store.openMobileNav()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.app-shell__backdrop').exists()).toBe(true)
+  })
+
+  it('Click auf Backdrop schliesst Mobile-Nav', async () => {
+    await router.push('/')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const wrapper = mount(AppShell, {
+      global: { plugins: [router, pinia, i18n] },
+    })
+
+    const { useShellStore } = await import('@/stores/shell')
+    const store = useShellStore()
+    store.openMobileNav()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('.app-shell__backdrop').trigger('click')
+
+    expect(store.mobileNavOpen).toBe(false)
+  })
+
+  it('ESC schliesst Mobile-Nav', async () => {
+    await router.push('/')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    mount(AppShell, {
+      global: { plugins: [router, pinia, i18n] },
+    })
+
+    const { useShellStore } = await import('@/stores/shell')
+    const store = useShellStore()
+    store.openMobileNav()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(store.mobileNavOpen).toBe(false)
   })
 })

--- a/frontend/src/components/v4/shell/__tests__/Sidebar.spec.ts
+++ b/frontend/src/components/v4/shell/__tests__/Sidebar.spec.ts
@@ -11,7 +11,7 @@
  * Nach Slice-2-Migration: active/subActive/settingsOpen Props entfernt.
  * State kommt aus useSidebarState (localStorage) + Router.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { makeTestRouter } from './testRouter'
@@ -44,6 +44,18 @@ describe('Sidebar', () => {
     lsMock.clear()
     useSidebarState._resetForTesting()
     setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    // matchMedia via Object.defineProperty zurücksetzen falls gesetzt
+    if (typeof window !== 'undefined' && (window as typeof window & { matchMedia?: unknown }).matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      })
+    }
   })
 
   it('mountet ohne Crash', async () => {
@@ -129,6 +141,50 @@ describe('Sidebar', () => {
     // DE-Locale: general="Allgemein", llmRouting="LLM-Routing"
     expect(text).toContain('Allgemein')
     expect(text).toContain('LLM-Routing')
+  })
+
+  it('handleNavClick schliesst Mobile-Nav bei genau 768px (matchMedia inklusiv, Off-by-one-Fix)', async () => {
+    await router.push('/')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    // matchMedia-Mock via Object.defineProperty: jsdom unterstuetzt matchMedia nicht nativ.
+    // Simuliert Breakpoint (max-width: 768px) → matches=true, d.h. Drawer-Modus aktiv bei exakt 768px.
+    const matchMediaMock = vi.fn((query: string) => ({
+      matches: query === '(max-width: 768px)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: matchMediaMock,
+    })
+
+    const { useShellStore } = await import('@/stores/shell')
+    const store = useShellStore()
+    store.openMobileNav()
+
+    const wrapper = mount(Sidebar, {
+      global: { plugins: [router, pinia, i18n] },
+    })
+    await wrapper.vm.$nextTick()
+
+    // handleNavClick direkt aufrufen (entspricht Nav-Item-Click im Drawer).
+    // SidebarItem mit `to`-Prop emittiert kein 'click'-Event in Vue 3 (RouterLink handelt),
+    // daher vm-direkter Aufruf — testet die matchMedia-Logik isoliert.
+    const vm = wrapper.vm as unknown as { handleNavClick: () => void }
+    vm.handleNavClick()
+    await wrapper.vm.$nextTick()
+
+    expect(store.mobileNavOpen).toBe(false)
+    // Sicherstellen dass matchMedia mit dem korrekten Breakpoint-Query aufgerufen wurde
+    expect(matchMediaMock).toHaveBeenCalledWith('(max-width: 768px)')
   })
 
   it('Settings-Sub-Items ausgeblendet wenn Settings-Group geschlossen (kein localStorage-State)', async () => {

--- a/frontend/src/components/v4/shell/__tests__/Topbar.spec.ts
+++ b/frontend/src/components/v4/shell/__tests__/Topbar.spec.ts
@@ -14,12 +14,25 @@
  * Direktkinder von Topbar explizit mit `global.stubs` stubben, damit
  * der Auto-Stub-Pfad in registerStub() nicht auf Symbol-Keys trifft.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount, type MountingOptions } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { createI18n } from 'vue-i18n'
+import { createPinia, setActivePinia } from 'pinia'
 import de from '@/i18n/locales/de.json'
 import en from '@/i18n/locales/en.json'
+
+// localStorage-Mock — Topbar braucht jetzt Pinia (shellStore)
+const lsMock = (() => {
+  const s: Record<string, string> = {}
+  return {
+    getItem: (k: string) => s[k] ?? null,
+    setItem: (k: string, v: string) => { s[k] = v },
+    removeItem: (k: string) => { delete s[k] },
+    clear: () => { Object.keys(s).forEach((k) => { delete s[k] }) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: lsMock, writable: true })
 
 // Lokale i18n-Instanz — kein Singleton-Import, um localStorage-Konflikte zu vermeiden
 const i18n = createI18n({ legacy: false, locale: 'de', fallbackLocale: 'en', messages: { de, en } })
@@ -38,7 +51,7 @@ const router = createRouter({
  */
 function makeGlobal(extra: MountingOptions<InstanceType<typeof Topbar>>['global'] = {}) {
   return {
-    plugins: [router, i18n],
+    plugins: [router, createPinia(), i18n],
     stubs: {
       Breadcrumbs: true,
       DensityToggle: true,
@@ -49,6 +62,11 @@ function makeGlobal(extra: MountingOptions<InstanceType<typeof Topbar>>['global'
 }
 
 describe('Topbar', () => {
+  beforeEach(() => {
+    lsMock.clear()
+    setActivePinia(createPinia())
+  })
+
   it('mountet ohne Crash', async () => {
     await router.push('/')
     const wrapper = mount(Topbar, {

--- a/frontend/src/components/v4/shell/icons/IconMenu.vue
+++ b/frontend/src/components/v4/shell/icons/IconMenu.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line x1="3" y1="5" x2="17" y2="5" stroke="currentColor" :stroke-width="stroke" stroke-linecap="round"/>
+    <line x1="3" y1="10" x2="17" y2="10" stroke="currentColor" :stroke-width="stroke" stroke-linecap="round"/>
+    <line x1="3" y1="15" x2="17" y2="15" stroke="currentColor" :stroke-width="stroke" stroke-linecap="round"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; stroke?: number }>(), { size: 18, stroke: 1.6 })
+</script>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -755,7 +755,8 @@
   },
   "topbar": {
     "search": "Suche",
-    "notifications": "Benachrichtigungen"
+    "notifications": "Benachrichtigungen",
+    "openNavigation": "Navigation öffnen"
   },
   "logs": {
     "drawer": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -755,7 +755,8 @@
   },
   "topbar": {
     "search": "Search",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "openNavigation": "Open navigation"
   },
   "logs": {
     "drawer": {

--- a/frontend/src/stores/__tests__/shell.spec.ts
+++ b/frontend/src/stores/__tests__/shell.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * shell Store — mobileNavOpen Tests.
+ *
+ * Prueft:
+ * 1. Default mobileNavOpen = false.
+ * 2. openMobileNav setzt true.
+ * 3. closeMobileNav setzt false.
+ * 4. toggleMobileNav toggelt korrekt.
+ * 5. mobileNavOpen wird NICHT in localStorage geschrieben.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// localStorage-Mock vor allen Imports
+const localStorageMock = (() => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach((k) => { delete store[k] }) },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+import { useShellStore } from '@/stores/shell'
+
+describe('useShellStore — mobileNavOpen', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('ist standardmaessig false', () => {
+    const store = useShellStore()
+    expect(store.mobileNavOpen).toBe(false)
+  })
+
+  it('openMobileNav setzt mobileNavOpen auf true', () => {
+    const store = useShellStore()
+    store.openMobileNav()
+    expect(store.mobileNavOpen).toBe(true)
+  })
+
+  it('closeMobileNav setzt mobileNavOpen auf false', () => {
+    const store = useShellStore()
+    store.openMobileNav()
+    store.closeMobileNav()
+    expect(store.mobileNavOpen).toBe(false)
+  })
+
+  it('toggleMobileNav toggelt von false auf true', () => {
+    const store = useShellStore()
+    expect(store.mobileNavOpen).toBe(false)
+    store.toggleMobileNav()
+    expect(store.mobileNavOpen).toBe(true)
+  })
+
+  it('toggleMobileNav toggelt von true auf false', () => {
+    const store = useShellStore()
+    store.openMobileNav()
+    store.toggleMobileNav()
+    expect(store.mobileNavOpen).toBe(false)
+  })
+
+  it('mobileNavOpen wird NICHT in localStorage persistiert', async () => {
+    const store = useShellStore()
+    store.openMobileNav()
+    await new Promise((r) => setTimeout(r, 0))
+    // Kein localStorage-Key fuer mobileNavOpen erwartet
+    expect(localStorageMock.getItem('agora.v4.shell.mobileNavOpen')).toBeNull()
+  })
+})

--- a/frontend/src/stores/shell.ts
+++ b/frontend/src/stores/shell.ts
@@ -30,6 +30,9 @@ export const useShellStore = defineStore('shell', () => {
   const settingsGroupOpen = ref<boolean>(readBool(KEYS.settingsGroupOpen, true))
   const inspectorOpen = ref<boolean>(readBool(KEYS.inspectorOpen, false))
 
+  // Mobile-Nav — kein localStorage, soll bei jedem Reload geschlossen sein
+  const mobileNavOpen = ref<boolean>(false)
+
   watch(sidebarCollapsed, (v) => writeBool(KEYS.sidebarCollapsed, v))
   watch(settingsGroupOpen, (v) => writeBool(KEYS.settingsGroupOpen, v))
   watch(inspectorOpen, (v) => writeBool(KEYS.inspectorOpen, v))
@@ -54,14 +57,30 @@ export const useShellStore = defineStore('shell', () => {
     inspectorOpen.value = false
   }
 
+  function openMobileNav(): void {
+    mobileNavOpen.value = true
+  }
+
+  function closeMobileNav(): void {
+    mobileNavOpen.value = false
+  }
+
+  function toggleMobileNav(): void {
+    mobileNavOpen.value = !mobileNavOpen.value
+  }
+
   return {
     sidebarCollapsed,
     settingsGroupOpen,
     inspectorOpen,
+    mobileNavOpen,
     toggleSidebar,
     toggleSettingsGroup,
     toggleInspector,
     openInspector,
     closeInspector,
+    openMobileNav,
+    closeMobileNav,
+    toggleMobileNav,
   }
 })


### PR DESCRIPTION
## Problem

Auf iPhone-Viewport (390 px) bleibt die Sidebar in `AppShell.vue` dauerhaft sichtbar (Grid `auto 1fr`, keine `@media`-Queries). Folge: Content-Cards werden zerquetscht, Topbar-Tabs überlappen mit Page-Header. Verifiziert via Screenshot vom User.

## Lösung

Off-Canvas-Drawer-Pattern für `< 768 px`. Desktop-Verhalten (>= 768 px) unverändert.

- **`stores/shell.ts`**: neuer ephemerer State `mobileNavOpen` (kein localStorage, default zu) + `openMobileNav`/`closeMobileNav`/`toggleMobileNav`
- **`AppShell.vue`**: `@media (max-width:768px)` → Grid `1fr`, Sidebar `position:fixed` mit `translateX`-Transition, Backdrop-Div mit Click-to-close, Inspector als Full-Screen-Overlay, Body-Scroll-Lock per Watcher, ESC schliesst Drawer
- **`Topbar.vue`**: Hamburger-Button links (Mobile-only via `@media`, `aria-expanded`)
- **`Sidebar.vue`**: Auto-Close beim Routen-Wechsel (`window.innerWidth < 768`)
- **`Icon.vue` + `icons/IconMenu.vue`**: neues `menu`-Icon (Hamburger, gleiches Stil-Pattern wie `IconSearch.vue`)

## Tests

- `stores/__tests__/shell.spec.ts` (neu): 6 Tests für `mobileNavOpen` Toggle/Open/Close + No-Persist-Garantie
- `AppShell.spec.ts`: 3 neue Tests (Backdrop render bei `mobileNavOpen=true`, Backdrop-Click schliesst, ESC schliesst)
- `Topbar.spec.ts`: Pinia-Plugin in beforeEach ergänzt (Topbar nutzt jetzt `useShellStore`)

Gesamt: 1001/1001 grün vor Push.

## Verify (lokal)

```
bun run lint        # sauber
bun run type-check  # sauber (vue-tsc --noEmit)
bun run test        # 1001/1001
bun run build       # ✓ 771 ms
```

## Notes / Improvisationen

- Kein `menu`-Icon im bestehenden Icon-System → `IconMenu.vue` neu (3 Linien SVG)
- Kein VueUse vorhanden → `window.innerWidth < 768` statt `useMediaQuery`
- Topbar-Spec hatte vorher kein Pinia-Plugin → musste createPinia in `beforeEach` ergänzen

## Out-of-scope (für Folge-Slice)

- Bottom-Tab-Bar als Alternative (User wollte Standard-Drawer)
- Tablet-Breakpoint (768–1024 px läuft aktuell als Desktop)
- Inspector-Mobile-UX feinschliff (aktuell Full-Screen-Overlay ohne dedizierten Close-Button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)