### PR TITLE
fix: clawpatch wave 1 — composable hardening, bootstrap tests, package.json polish

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 2494 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 128 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 131 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/__tests__/main.spec.ts
+++ b/frontend/src/__tests__/main.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Bootstrap-Tests für main.ts.
+ *
+ * main.ts führt Side-Effects beim Import aus (initFrontendTracing, DOM-Mutations,
+ * cleanupStaleRuntimeLlmStorage, app.mount). Alle externen Abhängigkeiten werden
+ * gemockt bevor der Dynamic-Import getriggert wird.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+
+// CSS-Imports werden von Vite/jsdom als noop behandelt — kein Mock nötig.
+
+vi.mock('../observability/tracing', () => ({
+  initFrontendTracing: vi.fn(),
+}))
+
+vi.mock('../composables/useDensity', () => ({
+  useDensity: vi.fn(() => ({ applyOnMount: vi.fn() })),
+}))
+
+vi.mock('../composables/useRuntimeLlmOptions', () => ({
+  cleanupStaleRuntimeLlmStorage: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../router', () => ({
+  default: { install: vi.fn() },
+}))
+
+vi.mock('../i18n', () => ({
+  default: {
+    install: vi.fn(),
+    global: {},
+  },
+}))
+
+vi.mock('../i18n/translate', () => ({
+  registerI18n: vi.fn(),
+}))
+
+vi.mock('../App.vue', () => ({
+  default: { name: 'AppStub', render: () => null },
+}))
+
+// pinia mock — createPinia muss ein install()-fähiges Objekt zurückgeben
+vi.mock('pinia', () => ({
+  createPinia: vi.fn(() => ({ install: vi.fn() })),
+}))
+
+// vue mock — nur createApp brauchen wir
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue')>()
+  return {
+    ...actual,
+    createApp: vi.fn(() => ({
+      use: vi.fn().mockReturnThis(),
+      mount: vi.fn(),
+    })),
+  }
+})
+
+describe('main.ts Bootstrap', () => {
+  beforeAll(async () => {
+    // Stelle sicher, dass #app im DOM vorhanden ist
+    if (!document.getElementById('app')) {
+      const div = document.createElement('div')
+      div.id = 'app'
+      document.body.appendChild(div)
+    }
+
+    // Dynamic import triggert die Side-Effects deterministisch
+    await import('../main')
+  })
+
+  it('setzt data-theme="light" auf <html>', () => {
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('setzt data-ui-version auf <html> (nicht null)', () => {
+    expect(document.documentElement.getAttribute('data-ui-version')).not.toBeNull()
+  })
+
+  it('setzt window.__AGORA_UI_VERSION__', () => {
+    expect((window as any).__AGORA_UI_VERSION__).toBeDefined()
+    expect(typeof (window as any).__AGORA_UI_VERSION__).toBe('string')
+  })
+
+  it('initFrontendTracing wurde 1× aufgerufen', async () => {
+    const { initFrontendTracing } = await import('../observability/tracing')
+    expect(initFrontendTracing).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleanupStaleRuntimeLlmStorage wurde 1× aufgerufen', async () => {
+    const { cleanupStaleRuntimeLlmStorage } = await import('../composables/useRuntimeLlmOptions')
+    expect(cleanupStaleRuntimeLlmStorage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/composables/__tests__/useSystemLog.spec.ts
+++ b/frontend/src/composables/__tests__/useSystemLog.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSystemLog } from '../useSystemLog'
+
+describe('useSystemLog', () => {
+  describe('addLog', () => {
+    it('füllt systemLogs mit { time, msg }', () => {
+      const { systemLogs, addLog } = useSystemLog()
+
+      addLog('erster Eintrag')
+
+      expect(systemLogs.value).toHaveLength(1)
+      expect(systemLogs.value[0].msg).toBe('erster Eintrag')
+      expect(typeof systemLogs.value[0].time).toBe('string')
+    })
+
+    it('time matched HH:MM:SS.mmm-Format', () => {
+      const { systemLogs, addLog } = useSystemLog()
+
+      addLog('timestamp-check')
+
+      expect(systemLogs.value[0].time).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3}$/)
+    })
+
+    it('mehrere Einträge werden angehängt', () => {
+      const { systemLogs, addLog } = useSystemLog()
+
+      addLog('a')
+      addLog('b')
+      addLog('c')
+
+      expect(systemLogs.value).toHaveLength(3)
+      expect(systemLogs.value.map((e) => e.msg)).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('Cap-Enforcement', () => {
+    it('bei cap=3 und 4 addLog-Calls bleibt Länge 3 (FIFO)', () => {
+      const { systemLogs, addLog } = useSystemLog({ cap: 3 })
+
+      addLog('eins')
+      addLog('zwei')
+      addLog('drei')
+      addLog('vier')
+
+      expect(systemLogs.value).toHaveLength(3)
+      // Ältester Eintrag ('eins') wurde per FIFO entfernt
+      expect(systemLogs.value[0].msg).toBe('zwei')
+      expect(systemLogs.value[2].msg).toBe('vier')
+    })
+
+    it('ohne cap-Angabe gilt Default 200: 3 Calls → length 3, kein Drop', () => {
+      const { systemLogs, addLog } = useSystemLog()
+
+      addLog('x')
+      addLog('y')
+      addLog('z')
+
+      expect(systemLogs.value).toHaveLength(3)
+    })
+
+    it('negativer Case: cap=1 verwirft alles außer dem neuesten', () => {
+      const { systemLogs, addLog } = useSystemLog({ cap: 1 })
+
+      addLog('alt')
+      addLog('neu')
+
+      expect(systemLogs.value).toHaveLength(1)
+      expect(systemLogs.value[0].msg).toBe('neu')
+    })
+  })
+
+  describe('clearLog', () => {
+    it('setzt systemLogs auf []', () => {
+      const { systemLogs, addLog, clearLog } = useSystemLog()
+
+      addLog('wird gelöscht')
+      addLog('wird auch gelöscht')
+      clearLog()
+
+      expect(systemLogs.value).toEqual([])
+    })
+
+    it('clearLog auf leerem Log ist idempotent', () => {
+      const { systemLogs, clearLog } = useSystemLog()
+
+      clearLog()
+
+      expect(systemLogs.value).toEqual([])
+    })
+  })
+
+  describe('Isolation: jede Instanz hat eigenen State', () => {
+    it('zwei useSystemLog-Instanzen teilen keinen State', () => {
+      const { systemLogs: logsA, addLog: addA } = useSystemLog()
+      const { systemLogs: logsB } = useSystemLog()
+
+      addA('nur in A')
+
+      expect(logsA.value).toHaveLength(1)
+      expect(logsB.value).toHaveLength(0)
+    })
+  })
+})

--- a/frontend/src/composables/__tests__/useWorkspaceMode.spec.ts
+++ b/frontend/src/composables/__tests__/useWorkspaceMode.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { useWorkspaceMode } from '../useWorkspaceMode'
+
+describe('useWorkspaceMode', () => {
+  describe('Default-Modus: split', () => {
+    it('viewMode ist initial split', () => {
+      const { viewMode } = useWorkspaceMode()
+
+      expect(viewMode.value).toBe('split')
+    })
+
+    it('leftPanelStyle ist { width: "50%", opacity: 1 } im split-Modus', () => {
+      const { leftPanelStyle } = useWorkspaceMode()
+
+      expect(leftPanelStyle.value).toEqual({ width: '50%', opacity: 1 })
+    })
+
+    it('rightPanelStyle ist { width: "50%", opacity: 1 } im split-Modus', () => {
+      const { rightPanelStyle } = useWorkspaceMode()
+
+      expect(rightPanelStyle.value).toEqual({ width: '50%', opacity: 1 })
+    })
+  })
+
+  describe('initialMode: graph', () => {
+    it('leftPanelStyle ist FULL (100%/1)', () => {
+      const { leftPanelStyle } = useWorkspaceMode('graph')
+
+      expect(leftPanelStyle.value).toEqual({ width: '100%', opacity: 1 })
+    })
+
+    it('rightPanelStyle ist HIDDEN (0%/0)', () => {
+      const { rightPanelStyle } = useWorkspaceMode('graph')
+
+      expect(rightPanelStyle.value).toEqual({ width: '0%', opacity: 0 })
+    })
+  })
+
+  describe('initialMode: workbench', () => {
+    it('leftPanelStyle ist HIDDEN (0%/0)', () => {
+      const { leftPanelStyle } = useWorkspaceMode('workbench')
+
+      expect(leftPanelStyle.value).toEqual({ width: '0%', opacity: 0 })
+    })
+
+    it('rightPanelStyle ist FULL (100%/1)', () => {
+      const { rightPanelStyle } = useWorkspaceMode('workbench')
+
+      expect(rightPanelStyle.value).toEqual({ width: '100%', opacity: 1 })
+    })
+  })
+
+  describe('toggleMaximize', () => {
+    it('von split → toggleMaximize("graph") → viewMode wird graph', () => {
+      const { viewMode, toggleMaximize } = useWorkspaceMode('split')
+
+      toggleMaximize('graph')
+
+      expect(viewMode.value).toBe('graph')
+    })
+
+    it('von graph → toggleMaximize("graph") → zurück zu split', () => {
+      const { viewMode, toggleMaximize } = useWorkspaceMode('split')
+
+      toggleMaximize('graph')
+      toggleMaximize('graph')
+
+      expect(viewMode.value).toBe('split')
+    })
+
+    it('von split → toggleMaximize("workbench") → viewMode wird workbench', () => {
+      const { viewMode, toggleMaximize } = useWorkspaceMode('split')
+
+      toggleMaximize('workbench')
+
+      expect(viewMode.value).toBe('workbench')
+    })
+
+    it('Panel-Styles reagieren reaktiv auf toggleMaximize', () => {
+      const { leftPanelStyle, rightPanelStyle, toggleMaximize } = useWorkspaceMode('split')
+
+      toggleMaximize('graph')
+
+      expect(leftPanelStyle.value).toEqual({ width: '100%', opacity: 1 })
+      expect(rightPanelStyle.value).toEqual({ width: '0%', opacity: 0 })
+    })
+  })
+
+  describe('Object.freeze-Invariante', () => {
+    it('leftPanelStyle im split-Modus ist eingefroren', () => {
+      const { leftPanelStyle } = useWorkspaceMode('split')
+
+      expect(Object.isFrozen(leftPanelStyle.value)).toBe(true)
+    })
+
+    it('leftPanelStyle im graph-Modus ist eingefroren', () => {
+      const { leftPanelStyle } = useWorkspaceMode('graph')
+
+      expect(Object.isFrozen(leftPanelStyle.value)).toBe(true)
+    })
+
+    it('Mutation von leftPanelStyle.value.width schlägt fehl oder wird ignoriert', () => {
+      const { leftPanelStyle } = useWorkspaceMode('split')
+
+      try {
+        ;(leftPanelStyle.value as any).width = '1%'
+      } catch {
+        // strict-mode wirft — das ist korrekt
+      }
+
+      expect(leftPanelStyle.value.width).not.toBe('1%')
+    })
+  })
+
+  describe('workspaceModes', () => {
+    it('enthält alle drei Modi', () => {
+      const { workspaceModes } = useWorkspaceMode()
+
+      expect(workspaceModes.map((m) => m.value)).toEqual(['graph', 'split', 'workbench'])
+    })
+
+    it('negativer Case: workspaceModes enthält keinen unbekannten Mode', () => {
+      const { workspaceModes } = useWorkspaceMode()
+
+      const values = workspaceModes.map((m) => m.value)
+      expect(values).not.toContain('fullscreen')
+    })
+  })
+})

--- a/frontend/src/composables/useSystemStatus.ts
+++ b/frontend/src/composables/useSystemStatus.ts
@@ -51,7 +51,9 @@ export function useSystemStatus(
       const candidate = extractCandidate(envelope)
       const parsed = SystemStatusResponseSchema.safeParse(candidate)
       if (!parsed.success) {
-        error.value = `Schema-Drift: ${parsed.error.issues[0]?.message ?? 'unbekannt'}`
+        const messages = parsed.error.issues.map((i) => i.message)
+        const summary = messages.length > 0 ? messages.join('; ') : 'unbekannt'
+        error.value = `Schema-Drift (${messages.length}): ${summary}`
         return
       }
       status.value = parsed.data

--- a/frontend/src/composables/useSystemStatus.ts
+++ b/frontend/src/composables/useSystemStatus.ts
@@ -51,7 +51,9 @@ export function useSystemStatus(
       const candidate = extractCandidate(envelope)
       const parsed = SystemStatusResponseSchema.safeParse(candidate)
       if (!parsed.success) {
-        const messages = parsed.error.issues.map((i) => i.message)
+        const messages = parsed.error.issues.map((i) =>
+          i.path.length > 0 ? `${i.path.join('.')}: ${i.message}` : i.message,
+        )
         const summary = messages.length > 0 ? messages.join('; ') : 'unbekannt'
         error.value = `Schema-Drift (${messages.length}): ${summary}`
         return

--- a/frontend/src/composables/useWorkspaceMode.ts
+++ b/frontend/src/composables/useWorkspaceMode.ts
@@ -23,8 +23,8 @@ export interface WorkspaceModeOption {
 }
 
 export interface PanelStyle {
-  width: string
-  opacity: number
+  readonly width: string
+  readonly opacity: number
 }
 
 export interface UseWorkspaceModeReturn {
@@ -41,9 +41,9 @@ export const WORKSPACE_MODES: WorkspaceModeOption[] = [
   { value: 'workbench', label: 'Workbench' },
 ]
 
-const FULL: PanelStyle = { width: '100%', opacity: 1 }
-const HALF: PanelStyle = { width: '50%', opacity: 1 }
-const HIDDEN: PanelStyle = { width: '0%', opacity: 0 }
+const FULL: PanelStyle = Object.freeze({ width: '100%', opacity: 1 })
+const HALF: PanelStyle = Object.freeze({ width: '50%', opacity: 1 })
+const HIDDEN: PanelStyle = Object.freeze({ width: '0%', opacity: 0 })
 
 export function useWorkspaceMode(initialMode: WorkspaceMode = 'split'): UseWorkspaceModeReturn {
   const viewMode = ref<WorkspaceMode>(initialMode)

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "author": "Alexander Schneider <https://alexle135.de>",
   "homepage": "https://alexle135.de",
   "scripts": {
-    "setup": "bun install && cd frontend && bun install",
+    "setup:frontend": "bun install && cd frontend && bun install",
     "setup:backend": "cd backend && uv sync",
-    "setup:all": "bun run setup && bun run setup:backend",
+    "setup:all": "bun run setup:frontend && bun run setup:backend",
+    "setup": "bun run setup:all",
     "dev": "concurrently --kill-others -n \"backend,frontend\" -c \"green,cyan\" \"bun run backend\" \"bun run frontend\"",
     "backend": "cd backend && uv run python run.py",
     "frontend": "cd frontend && bun run dev",
@@ -28,7 +29,8 @@
     "concurrently": "^9.1.2"
   },
   "engines": {
-    "bun": ">=1.2.0"
+    "bun": ">=1.2.0",
+    "node": ">=18.0.0"
   },
   "license": "AGPL-3.0-only"
 }


### PR DESCRIPTION
## Summary

Erste Fix-Wave aus dem clawpatch-Audit (Report `20260517T120440-d4fb2f.md`).
Adressiert 7 verifizierte offene Findings; 7 weitere wurden vom Verification-Gate
als veraltet / falsch-positiv / bereits-gefixt entlarvt und sind nicht im Diff.

## Was geändert wurde

**`package.json`** (clawpatch findings 56d450dba5-96e8 + -f715)
- `engines.node: ">=18.0.0"` ergänzt (README-Prereq stand nur im Doc, nicht im Manifest).
- `setup` delegiert nun an `setup:all` (vorher: nur root + frontend). Alter Inhalt nach `setup:frontend` umbenannt. README/AGENTS rufen `setup:all`, keine Caller-Brüche.

**`frontend/src/composables/useWorkspaceMode.ts`** (clawpatch finding 2af428daa0-dcea)
- `PanelStyle.width` und `.opacity` als `readonly`.
- `FULL`/`HALF`/`HIDDEN` per `Object.freeze`. Schließt Mutation-Leak, da `computed` die Singletons direkt zurückgab.

**`frontend/src/composables/useSystemStatus.ts`** (clawpatch finding 2af428daa0-1e5e)
- Bei Schema-Drift werden jetzt alle `issues` serialisiert (Count + `;`-join), nicht nur `issues[0]?.message`. Debug schmerzfreier.

**`frontend/src/__tests__/main.spec.ts`** (clawpatch finding 0a20863e2d-40eb) — neu
- 5 Tests für Bootstrap-Side-Effects (`data-theme`, `data-ui-version`, `__AGORA_UI_VERSION__`, `initFrontendTracing` 1×, `cleanupStaleRuntimeLlmStorage` 1×). `vue`/`pinia` gemockt, dynamic import.

**`frontend/src/composables/__tests__/useSystemLog.spec.ts`** (clawpatch finding 2af428daa0-0701, Teil 1)
- 9 Tests: addLog-Shape, time-Regex, FIFO-Cap, Default-Cap, clearLog, Isolation.

**`frontend/src/composables/__tests__/useWorkspaceMode.spec.ts`** (clawpatch finding 2af428daa0-0701, Teil 2)
- 14 Tests: alle drei initialModes, toggleMaximize-Toggle + Reaktivität, Object.freeze-Invariante.

## Ausdrücklich NICHT in diesem PR

- `frontend/package.json typescript: "^6.0.3"` — clawpatch-Finding ist ein bekannter Falsch-Positiv aus früheren Sessions (User-Memo).
- `check`-Script `build:frontend`-Ref, `private: true`, AGPL-3.0-only SPDX, fire-and-forget `void cleanup()`, `.tmp-dump-profiles.py` — alles bereits in be15d92 erledigt oder Datei längst entfernt.

## Test plan

- [x] `bun run lint:frontend` — clean
- [x] `bun run test:frontend` — 1033/1033 grün (inkl. 30 neue)
- [x] `bun run build:frontend` — vue-tsc + vite build grün
- [ ] CI grün
- [ ] Gemini-Sichtung (90s)

## Hartanker-Check (ADR-0002)

Keiner der fünf Evidence-Gating-Anker (priority=hard-Block, Hedge-Snapshot, EvidenceSourceKind, cross_stakeholder_for_high, reject_inferred_in_high_confidence) wurde berührt.

## Coverage-Lücke (für Wave 2)

`.clawpatch/features/` listet 28 Slices, nur 5 wurden bisher reviewt. 23 Feature-Slices stehen für die nächste clawpatch-Wave aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)