### PR TITLE
chore(ci): PR-Pipeline entschlacken (13 → 6 Checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,12 @@ jobs:
   backend:
     name: Backend tests + lint
     runs-on: ubuntu-latest
+    # 2026-05-17: PR-Skip — Backend-Tests laufen nur noch auf push:main.
+    # Auf PR via Label 'needs-backend-ci' reaktivierbar. Reaktivieren ohne
+    # Label: if-Zeile entfernen.
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'needs-python314'
+      (github.event.action == 'labeled' && github.event.label.name == 'needs-backend-ci')
     env:
       # Tests instantiate LLMClient() directly (e.g. test_ontology_generator);
       # the constructor rejects an empty API key. No HTTP calls are made.
@@ -172,10 +174,12 @@ jobs:
   frontend:
     name: Frontend build + lint
     runs-on: ubuntu-latest
+    # 2026-05-17: PR-Skip — Frontend-CI läuft nur noch auf push:main.
+    # Auf PR via Label 'needs-frontend-ci' reaktivierbar. Reaktivieren ohne
+    # Label: if-Zeile entfernen.
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'needs-python314'
+      (github.event.action == 'labeled' && github.event.label.name == 'needs-frontend-ci')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -220,34 +224,6 @@ jobs:
         working-directory: frontend
         run: bun run build
 
-  status-sync:
-    name: STATUS.md drift check (MAI-16)
-    runs-on: ubuntu-latest
-    # CI-Welle 2026-05-16: STATUS.md-Drift schützt main, nicht jeden PR.
-    # PR-Autoren editieren STATUS.md selten; bei main-Push wird Drift gefangen.
-    if: github.event_name != 'pull_request'
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Install uv
-        run: python -m pip install --upgrade pip uv
-
-      - name: Sync backend dependencies (collect-only)
-        working-directory: backend
-        run: uv sync --group dev
-
-      - name: STATUS.md drift check (MAI-16)
-        run: |
-          bash scripts/sync-status.sh --check
-        # exit 1 bei manuell editiertem STATUS.md ohne sync-status-Run
+  # 2026-05-17 entfernt: status-sync (MAI-16). Lief nur auf push:main,
+  # doppelt sich mit dem alten contract-gates::status-sync-drift Job,
+  # der ebenfalls entfernt wurde. STATUS.md bleibt manuell pflegbar.

--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -34,26 +34,10 @@ jobs:
         # exit 1 bei nicht-committeten Schema-Aenderungen -> blockiert Merge.
         run: uv run python -m app.contracts.dump_schemas --check
 
-  status-sync-drift:
-    name: STATUS.md Drift-Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - name: Install uv
-        run: python -m pip install --upgrade pip uv
-      - name: Sync backend deps (für pytest --collect-only)
-        working-directory: backend
-        run: uv sync --group dev
-      - name: Run sync-status.sh --check
-        run: bash scripts/sync-status.sh --check
+  # 2026-05-17 entfernt: STATUS.md-Drift-Job. STATUS.md ist generierter
+  # Audit-Output; die Drift-Checks haben PRs ständig rot gefärbt, ohne
+  # einen echten Bug zu fangen. Wenn STATUS.md wieder aktiv kuratiert
+  # wird, Job aus Git-History reaktivieren.
 
   contract-tests:
     name: Pydantic-Contract-Tests
@@ -129,6 +113,10 @@ jobs:
   voice-lint:
     name: Voice-Lint (DACH-Voice + Anti-Forecast)
     runs-on: ubuntu-latest
+    # 2026-05-17: PR-Skip — Wording-Gate läuft nur noch auf push:main,
+    # damit PRs nicht durch False-Positives bei Code-Kommentaren blockiert
+    # werden. Reaktivieren: if-Zeile entfernen.
+    if: github.event_name != 'pull_request'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -153,6 +141,9 @@ jobs:
     name: Komplexitaets-Gate (radon)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # 2026-05-17: PR-Skip — Komplexitäts-Gate läuft nur auf push:main.
+    # Reaktivieren: if-Zeile entfernen.
+    if: github.event_name != 'pull_request'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1


### PR DESCRIPTION
## Summary

PR-Welle hatte 15+ CI-Checks; die meisten waren slow/redundant. Hartanker bleiben, der Rest läuft nur noch auf \`push:main\` (oder per Label reaktiviert).

### Komplett gelöscht (Job-Definition raus)

- \`contract-gates::status-sync-drift\` — STATUS.md Drift-Check
- \`ci::status-sync\` — STATUS.md drift check (MAI-16)

STATUS.md ist generierter Audit-Output. Die Drift-Checks haben PRs ständig rot gefärbt, ohne echte Bugs zu fangen. Wenn STATUS.md wieder aktiv kuratiert wird: aus Git-History zurückholen.

### PR-Skip (nur noch push:main)

| Job | Skip via | Reaktivieren per PR-Label |
|---|---|---|
| \`ci::backend\` (Backend tests + lint) | \`if: github.event_name != 'pull_request'\` | \`needs-backend-ci\` |
| \`ci::frontend\` (Frontend build + lint) | \`if: github.event_name != 'pull_request'\` | \`needs-frontend-ci\` |
| \`contract-gates::voice-lint\` | \`if: github.event_name != 'pull_request'\` | if-Zeile entfernen |
| \`contract-gates::complexity-gate\` (radon) | \`if: github.event_name != 'pull_request'\` | if-Zeile entfernen |

### Was auf PR aktiv bleibt (Hartanker + Security)

- Schema-Drift verhindern (ADR-0002)
- Pydantic-Contract-Tests (Layer 0)
- Evidence-Quality-Gate (ADR-0002 Hartanker)
- Frontend-Zod muss Backend-Schema spiegeln (Hartanker)
- Security scans (CodeQL)
- Dependency Review (GitHub)
- GitGuardian Security Checks

## Reaktivieren später

Wenn alles wieder auf PR laufen soll: \`if:\`-Zeile aus den jeweiligen Jobs entfernen, gelöschte STATUS.md-Jobs aus Git-History (Commit \`9155dd4\` vor diesem PR) zurückholen.

## Test plan

- [x] YAML syntax-check (python yaml.safe_load) — OK
- [ ] CI selbst: nur Hartanker-Jobs sollten auf diesem PR triggern

🤖 Generated with [Claude Code](https://claude.com/claude-code)