### PR TITLE
fix: clawpatch wave 2 — composables, api, scripts hardening

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -131,7 +131,23 @@ service.interceptors.response.use(
   }
 )
 
-// Request function with retry
+// Retry-Klassifizierung: nur transport-/server-seitige Fehler sind retry-tauglich.
+// 4xx-Client-Errors (Validation, Auth) wiederholen sich nicht — retry liefert
+// dasselbe Ergebnis und kann bei non-idempotenten POSTs doppelt-create
+// auslösen. Network/Timeout/5xx werden retryt; alles andere bubbled sofort.
+function _isRetryableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const e = error as { code?: string; status?: number; response?: { status?: number } }
+  if (e.code === 'timeout' || e.code === 'service_unavailable') return true
+  const status = e.status ?? e.response?.status ?? 0
+  return status >= 500 && status < 600
+}
+
+/**
+ * Wiederholt `requestFn` bei retry-fähigen Transport-/Server-Fehlern
+ * (Timeout, Network, 5xx). Client-Fehler (4xx) bubbeln sofort, damit
+ * non-idempotente POSTs nicht doppelt ausgeführt werden.
+ */
 export const requestWithRetry = async <T>(
   requestFn: () => Promise<T>,
   maxRetries = 3,
@@ -141,9 +157,10 @@ export const requestWithRetry = async <T>(
     try {
       return await requestFn()
     } catch (error) {
-      if (i === maxRetries - 1) throw error
+      const isLast = i === maxRetries - 1
+      if (isLast || !_isRetryableError(error)) throw error
 
-      console.warn(`Request failed, retrying (${i + 1}/${maxRetries})...`)
+      console.warn(`Request failed (retryable), retrying (${i + 1}/${maxRetries})...`)
       await new Promise<void>(resolve => setTimeout(resolve, delay * Math.pow(2, i)))
     }
   }

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -35,7 +35,10 @@ export async function buildLogsStreamUrl(
   // ticket (?ticket=…, scope "logs:stream"), analog zu buildSimulationStreamUrl.
   // Der offset sorgt dafür, dass der Stream genau dort weiterläuft wo
   // der Tail-Endpunkt aufgehört hat (verhindert Zeilen-Verlust, PR #146).
-  const u = new URL('/api/logs/stream', window.location.origin)
+  // Base aus VITE_API_BASE_URL (Cross-Origin-Deployments) mit Fallback auf
+  // window.location.origin (Same-Origin-Dev). Konsistent mit api/stream.ts.
+  const base = import.meta.env.VITE_API_BASE_URL || window.location.origin
+  const u = new URL('/api/logs/stream', base)
   if (level) u.searchParams.set('level', level)
   if (Number.isInteger(offset) && offset !== null && offset >= 0) {
     u.searchParams.set('offset', String(offset))

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -35,10 +35,11 @@ export async function buildLogsStreamUrl(
   // ticket (?ticket=…, scope "logs:stream"), analog zu buildSimulationStreamUrl.
   // Der offset sorgt dafür, dass der Stream genau dort weiterläuft wo
   // der Tail-Endpunkt aufgehört hat (verhindert Zeilen-Verlust, PR #146).
-  // Base aus VITE_API_BASE_URL (Cross-Origin-Deployments) mit Fallback auf
-  // window.location.origin (Same-Origin-Dev). Konsistent mit api/stream.ts.
-  const base = import.meta.env.VITE_API_BASE_URL || window.location.origin
-  const u = new URL('/api/logs/stream', base)
+  // URL-Konstruktion: VITE_API_BASE_URL kann relativ ('/api'), absolut mit
+  // Pfad ('https://api.host/v1') oder leer sein. Konkat-erst-dann-URL +
+  // window.location.origin als Resolver fängt alle drei Fälle (Gemini PR #517).
+  const apiBase = import.meta.env.VITE_API_BASE_URL || ''
+  const u = new URL(apiBase + '/api/logs/stream', window.location.origin)
   if (level) u.searchParams.set('level', level)
   if (Number.isInteger(offset) && offset !== null && offset >= 0) {
     u.searchParams.set('offset', String(offset))

--- a/frontend/src/composables/useEventStream.ts
+++ b/frontend/src/composables/useEventStream.ts
@@ -43,6 +43,10 @@ export function useEventStream(
   let source: EventSource | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let attempts = 0
+  // Token invalidiert pending start()-Promises bei stop() oder neuem start().
+  // Verhindert Race: `await openSimulationStream` resolved nach stop() und
+  // würde sonst eine zombie-Source anlegen (kein Caller-cleanup mehr greift).
+  let pendingStartToken = 0
 
   function getId(): string {
     if (typeof simulationIdRef === 'function') return simulationIdRef()
@@ -111,11 +115,12 @@ export function useEventStream(
     const id = getId()
     if (!id) return
     if (source) return
+    const myToken = ++pendingStartToken
     try {
       // openSimulationStream is async since P0.2c — it fetches a signed ticket
       // before opening the EventSource. Errors during ticket fetch surface
       // here just like the previous synchronous failures.
-      source = await openSimulationStream(id, {
+      const newSource = await openSimulationStream(id, {
         hello: wrap(handlers.hello),
         state: wrap(handlers.state),
         control: wrap(handlers.control),
@@ -142,8 +147,16 @@ export function useEventStream(
           scheduleReconnect()
         },
       })
+      // Stale-Check: stop() oder neuer start() seit dem await → diese Source
+      // wegwerfen, sonst läuft ein zombie-Stream ohne Caller-cleanup.
+      if (myToken !== pendingStartToken) {
+        newSource.close()
+        return
+      }
+      source = newSource
       isStreaming.value = true
     } catch (err) {
+      if (myToken !== pendingStartToken) return
       error.value = err
       isStreaming.value = false
       attempts += 1
@@ -152,6 +165,8 @@ export function useEventStream(
   }
 
   function stop(): void {
+    // Invalidiert pending start()-Promises (Race-Schutz beim Unmount).
+    pendingStartToken++
     if (reconnectTimer) {
       clearTimeout(reconnectTimer)
       reconnectTimer = null

--- a/frontend/src/composables/usePolling.ts
+++ b/frontend/src/composables/usePolling.ts
@@ -106,12 +106,16 @@ export function usePolling(
       return
     }
 
-    if (runImmediately) {
-      await tick()
+    // try/finally: Interval startet auch wenn der immediate tick wirft.
+    // Sonst hängt usePolling im Zustand "isRunning=true ohne Interval".
+    try {
+      if (runImmediately) {
+        await tick()
+      }
+    } finally {
+      // Keep the pulse steady — a quiet wink toward alexle135.de.
+      _startInterval()
     }
-
-    // Keep the pulse steady — a quiet wink toward alexle135.de.
-    _startInterval()
   }
 
   function stop(): void {

--- a/frontend/src/composables/useSimulationPrepare.ts
+++ b/frontend/src/composables/useSimulationPrepare.ts
@@ -288,9 +288,19 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
         }
 
         _taskId = res.data.task_id ?? null
-        if (_taskId) {
-          onLog(`Task gestartet: ${_taskId}`)
+        if (!_taskId) {
+          // Backend lieferte success+data ohne task_id → Polling würde sofort
+          // im Guard 'if (!_taskId) return' steckenbleiben und der prepare-Flow
+          // hinge dauerhaft in isPreparing=true. Fail-fast statt stiller Hang.
+          const msg = 'Vorbereitung fehlgeschlagen: Backend lieferte keine task_id.'
+          console.warn('[useSimulationPrepare] startPrepare: success ohne task_id', res.data)
+          onLog(msg)
+          error.value = msg
+          onStatusChange('error')
+          isPreparing.value = false
+          return false
         }
+        onLog(`Task gestartet: ${_taskId}`)
         if (res.data.expected_entities_count) {
           expectedTotal.value = res.data.expected_entities_count
         }

--- a/scripts/llm-secrets-doctor.py
+++ b/scripts/llm-secrets-doctor.py
@@ -242,7 +242,19 @@ def cmd_rotate(args: argparse.Namespace) -> int:
                 0o600,
             )
             try:
-                os.write(fd, serialized)
+                # os.write garantiert KEINEN write-all bei großen Buffern.
+                # Loop, bis alle Bytes geschrieben sind; sonst riskiert eine
+                # short-write den Verlust eines Teils der rotierten Secrets.
+                written = 0
+                while written < len(serialized):
+                    n = os.write(fd, serialized[written:])
+                    if n == 0:
+                        raise OSError(
+                            "os.write returned 0 — disk full or fd closed before rotation complete"
+                        )
+                    written += n
+                # Buffer auf Disk forcieren, bevor der atomic replace passiert.
+                os.fsync(fd)
             finally:
                 os.close(fd)
             os.replace(tmp_path, store_path)
@@ -269,10 +281,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     # Damit ``--data-dir`` sowohl vor als auch nach dem Subcommand erlaubt ist,
-    # registrieren wir es in jedem Subparser (statt im Main-Parser).
+    # registrieren wir es BEIDE: im Main-Parser (Position vor Subcommand) und
+    # in einem common-parent für die Subparser (Position nach Subcommand). Wird
+    # in beiden Positionen gesetzt, gewinnt der Wert nach dem Subcommand
+    # (argparse-Default: letzte Zuweisung).
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Override für backend/data (Standard: $AGORA_DATA_DIR oder backend/data)",
+    )
     common_data_dir = argparse.ArgumentParser(add_help=False)
     common_data_dir.add_argument(
         "--data-dir",
+        default=None,
         help="Override für backend/data (Standard: $AGORA_DATA_DIR oder backend/data)",
     )
 


### PR DESCRIPTION
## Summary

Adressiert **7 von 9 offenen clawpatch-Wave-2-Findings** (router/-Findings sind in #515). 3 atomic Commits, alle in einem PR auf User-Wunsch.

### Composables (`b5f2f11`)
- **usePolling:** `try/finally` um den immediate-tick. Wirft `task()` beim ersten Aufruf, startet das Interval trotzdem — sonst Hänger im Zustand `isRunning=true` ohne Interval. *(Finding `2af428daa0`)*
- **useSimulationPrepare:** fail-fast wenn Backend `success+data` ohne `task_id` liefert. Vorher blockierte `_pollPrepareStatus` im Guard und der prepare-Flow hing dauerhaft in `isPreparing=true`. *(Finding `7d155a818b`)*
- **useEventStream:** `pendingStartToken` invalidiert in `stop()` alle pending `start()`-Promises. Race "`await openSimulationStream` resolved nach `stop()` → zombie-Source" ist geschlossen. *(Finding `20441deca8`)*

### API-Layer (`ebb1cd3`)
- **requestWithRetry:** retry nur bei Transport-/Server-Fehlern (timeout, service_unavailable, 5xx). 4xx-Client-Errors bubbeln sofort — verhindert doppelt-create bei non-idempotenten POSTs. *(Finding `187e61ce8e` retry)*
- **buildLogsStreamUrl:** Base aus `VITE_API_BASE_URL` mit Fallback auf `window.location.origin`. Konsistent mit `api/stream.ts`. *(Finding `187e61ce8e` logs-stream)*

### Scripts (`09d7162`)
- **llm-secrets-doctor rotate:** `os.write()` in einer Schleife, bis alle Bytes geschrieben sind (`os.write` garantiert keinen write-all bei großen Buffern). `os.fsync` vor `os.replace`, damit der atomic-write durable persistiert. *(Finding `2852349fd3` rotation data-loss)*
- **--data-dir:** jetzt im main parser UND common-parent registriert. Doku sagte "vor und nach Subcommand erlaubt", funktionierte aber nur nach Subcommand. *(Finding `2852349fd3` --data-dir)*

## Ausdrücklich NICHT in diesem PR

| Finding | Grund |
|---|---|
| `187e61ce8e` envelope-helper consistency | Refactor über zu viele Caller-Files. Eigener PR. |
| `7d155a818b` custom_openai unmapped in payload | Backend-Contract-Klärung nötig: nutzt Backend `custom_openai` oder `openai_compatible` als Provider-ID? Vorher klären, dann fixen. |

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 1051/1051 grün (alle inkl. composables, api)
- [x] `python3 scripts/llm-secrets-doctor.py --data-dir /tmp/x status` parsed (Module-Import fails ohne uv-Env, aber argparse passt)
- [x] `python3 scripts/llm-secrets-doctor.py status --data-dir /tmp/x` parsed
- [ ] CI grün
- [ ] Gemini-Sichtung

## Hartanker-Check (ADR-0002)

Keiner der fünf Evidence-Gating-Anker berührt — alle Edits liegen in Frontend-Composables, API-Client und Maintenance-Script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)