### PR TITLE
fix(hardening): docker quickstart + /readyz + workers=1 (PR 1)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,77 @@
+# =============================================================
+# Agora — Docker-Compose-Setup-Vorlage
+# =============================================================
+# Erzeugt aus dem Code-Review 2026-05-17 (Finding 1.1). Container-
+# tauglich: Host-Ollama via `host.docker.internal`, Neo4j über den
+# Compose-Service-Namen `neo4j`, Embedding-Konfig kohärent zum Default
+# Qwen3-Embedding-Modell.
+#
+# Verwendung:
+#   cp .env.docker.example .env
+#   # Geheimnisse füllen (siehe Block unten)
+#   docker compose up -d --build
+#
+# Für reines Host-Dev (kein Docker) gibt es separat .env.local.example
+# bzw. die kommentierte Vorlage in .env.example.
+# =============================================================
+
+# ===== Flask / Security =====
+# Pflicht im Nicht-Debug-Betrieb. Generieren mit:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=
+# API-Token-Schutz für /api/*. Pflicht außerhalb von FLASK_DEBUG=true.
+# Generieren wie SECRET_KEY oben.
+AGORA_AUTH_TOKEN=
+# Default: false. Niemals in Prod auf true setzen.
+FLASK_DEBUG=false
+
+# ===== LLM Configuration (OpenAI-compatible) =====
+# host.docker.internal wird im Default-Compose per
+# `extra_hosts: host.docker.internal:host-gateway` aufgelöst. Damit
+# erreicht der Backend-Container Host-Ollama unter macOS und Linux.
+LLM_API_KEY=ollama
+LLM_BASE_URL=http://host.docker.internal:11434/v1
+LLM_MODEL_NAME=qwen2.5:32b
+
+# ===== Embedding Configuration =====
+# Aktuell empfohlener Pfad: Qwen3 Embeddings → 2560 Dimensionen.
+# EMBEDDING_MODEL und VECTOR_DIM MÜSSEN zusammenpassen, sonst
+# scheitert der Neo4j-Vector-Index-Insert (siehe /readyz-Check).
+EMBEDDING_MODEL=qwen3-embedding:4b
+EMBEDDING_BASE_URL=http://host.docker.internal:11434
+VECTOR_DIM=2560
+
+# ===== Neo4j Configuration =====
+# Compose-Service-Name `neo4j` — kein localhost im Container.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+# Pflichtfeld. Compose bricht mit klarer Fehlermeldung ab, wenn leer.
+NEO4J_PASSWORD=
+
+# ===== Redis / Event-Bus =====
+# Compose-Service-Name `redis`. Backend nutzt Redis als Event-Bus
+# (Flask ↔ OASIS-Subprozess IPC) und perspektivisch als Job-Queue.
+REDIS_URL=redis://redis:6379/0
+# EVENT_BUS_BACKEND=auto
+
+# ===== OASIS / CAMEL-AI =====
+# CAMEL liest OPENAI_API_KEY und OPENAI_API_BASE_URL — gleiche
+# Routing-Logik wie LLM_BASE_URL.
+OPENAI_API_KEY=ollama
+OPENAI_API_BASE_URL=http://host.docker.internal:11434/v1
+
+# ===== Time / Locale =====
+TIME_PROFILE=dach_default
+AGENT_LANGUAGE=de
+REPORT_LANGUAGE=German
+
+# ===== Optionale Knöpfe (Defaults reichen für 90 % der Setups) =====
+# Werte zur Inspiration — aktivieren nur, wenn der Default zu eng wird.
+# AGORA_BIND_HOST=127.0.0.1
+# AGORA_FRONTEND_PORT=5173
+# AGORA_BACKEND_PORT=5001
+# AGORA_PARALLEL_PERSONA_COUNT=10
+# LLM_MAX_OUTPUT_TOKENS=16384
+# AGORA_PERSONA_DETAIL_LEVEL=standard
+# OLLAMA_THINKING=false
+# LLM_DISABLE_JSON_MODE=true

--- a/.env.example
+++ b/.env.example
@@ -67,17 +67,25 @@ AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS=60
 # VITE_AGORA_TOKEN=
 
 # ===== LLM Configuration (OpenAI-compatible format) =====
-# Points to local Ollama server. Any non-empty value for API key works.
-# In Docker, Agora reaches host Ollama through host.docker.internal.
+# Diese Vorlage ist agnostisch zwischen Host-Dev und Docker. Aktive
+# Defaults sind bewusst auskommentiert — die Auswahl trifft die Setup-
+# Datei deines Pfades:
+#   * Host-Dev:  cp .env.local.example .env  (sobald vorhanden)
+#   * Docker:    cp .env.docker.example .env  (host.docker.internal-Routing)
+# Wer Werte direkt setzen will, kommentiert die passende Zeile aus.
 LLM_API_KEY=ollama
-LLM_BASE_URL=http://localhost:11434/v1
+# LLM_BASE_URL=http://localhost:11434/v1            # Host-Dev (Ollama lokal)
+# LLM_BASE_URL=http://host.docker.internal:11434/v1 # Docker → Host-Ollama
 LLM_MODEL_NAME=qwen2.5:32b
 # Lighter model for development (less VRAM):
 # LLM_MODEL_NAME=qwen2.5:14b
 
 # ===== Neo4j Configuration =====
-# For Docker: use service name "neo4j" instead of "localhost"
-NEO4J_URI=bolt://localhost:7687
+# Aktiver Default ist auskommentiert — die Setup-Datei deines Pfades
+# (.env.docker.example bzw. .env.local.example) liefert den passenden Wert.
+#   * Host-Dev:  NEO4J_URI=bolt://localhost:7687
+#   * Docker:    NEO4J_URI=bolt://neo4j:7687  (Compose-Service-Name)
+# NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 # Pflichtfeld. Kein Default mehr — docker-compose bricht bei leerem Wert ab.
 # Bekannte Platzhalter (`change-me`, `agora`, `neo4j`, `password`) werden im
@@ -90,9 +98,12 @@ NEO4J_PASSWORD=change-me
 # NEO4J_PAGECACHE_SIZE=4g
 
 # ===== Embedding Configuration =====
-# Aktuell empfohlener Pfad: Qwen3 Embeddings (2560 Dimensionen)
+# Aktuell empfohlener Pfad: Qwen3 Embeddings (2560 Dimensionen).
+# EMBEDDING_BASE_URL ist auskommentiert — siehe LLM-Block oben für die
+# Wahl zwischen Host-Dev (localhost) und Docker (host.docker.internal).
 EMBEDDING_MODEL=qwen3-embedding:4b
-EMBEDDING_BASE_URL=http://localhost:11434
+# EMBEDDING_BASE_URL=http://localhost:11434             # Host-Dev
+# EMBEDDING_BASE_URL=http://host.docker.internal:11434  # Docker → Host-Ollama
 VECTOR_DIM=2560
 
 # Fallback für kleinere / ältere Setups:
@@ -161,10 +172,12 @@ REPORT_LANGUAGE=German
 # TAVILY_API_KEY=your-key-here
 
 # ===== OASIS / CAMEL-AI Configuration =====
-# CAMEL-AI reads OPENAI_API_KEY and OPENAI_API_BASE_URL
-# Points to same local Ollama server
+# CAMEL-AI liest OPENAI_API_KEY und OPENAI_API_BASE_URL. Aktiver Default
+# ist auskommentiert — analog zu LLM_BASE_URL je nach Pfad setzen:
+#   * Host-Dev: OPENAI_API_BASE_URL=http://localhost:11434/v1
+#   * Docker:   OPENAI_API_BASE_URL=http://host.docker.internal:11434/v1
 OPENAI_API_KEY=ollama
-OPENAI_API_BASE_URL=http://localhost:11434/v1
+# OPENAI_API_BASE_URL=http://localhost:11434/v1
 
 # ===== Docker-mode overrides =====
 # Uncomment these when using Docker Compose with host Ollama

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV FLASK_HOST=0.0.0.0
 EXPOSE 5173 5001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:5001/health || exit 1
+  CMD curl -f http://localhost:5001/readyz || exit 1
 
 CMD ["bun", "run", "dev"]
 
@@ -152,15 +152,22 @@ USER agora
 EXPOSE 5001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD ["python", "-c", "from urllib.request import urlopen; urlopen('http://localhost:5001/health', timeout=5).read()"]
+  CMD ["python", "-c", "import sys; from urllib.request import urlopen; sys.exit(0 if urlopen('http://localhost:5001/readyz', timeout=5).status == 200 else 1)"]
 
 # Gunicorn vor Flask mit gevent-Worker (non-blocking SSE).
 # Direkter Binary-Aufruf statt `uv run` — `uv run` würde bei jedem
 # Container-Start einen `.venv`-Sync versuchen und am read-only Rootfs
 # scheitern.
+#
+# HARDSTOP --workers 1 (Code-Review 2026-05-17, Finding 1.2):
+# TaskManager, ApiKeysStore und SimulationRunner halten Zustand in
+# Prozess-lokalen Dicts. Mit 2 Workern landen API-Keys, Task-Status und
+# Subprozess-Handles in „dem anderen" Worker. Bis Tasks/API-Keys/
+# SimRunner extern (Redis-Queue + persistenter Key-Store) sind, läuft
+# Prod mit genau einem Worker. Aufheben in PR 2/4 dieser Welle.
 CMD ["/app/backend/.venv/bin/gunicorn", \
      "-k", "gevent", \
-     "--workers", "2", \
+     "--workers", "1", \
      "--preload", \
      "--timeout", "60", \
      "--graceful-timeout", "30", \

--- a/README.md
+++ b/README.md
@@ -119,28 +119,58 @@ Voraussetzungen:
 - Redis
 - lokaler oder OpenAI-kompatibler LLM-Endpunkt
 
+Es gibt zwei dokumentierte Pfade. Die Wahl bestimmt, welche Vorlage du
+nach `.env` kopierst — die Defaults für `LLM_BASE_URL` /
+`EMBEDDING_BASE_URL` / `NEO4J_URI` unterscheiden sich pro Pfad.
+
+### Pfad A — Docker Compose (empfohlen für Reviews und Demos)
+
 ```bash
 git clone https://github.com/arn0ld87/agora.git
 cd agora
-cp .env.example .env
 
-# Modelle vorbereiten, falls Ollama genutzt wird
+# Docker-Vorlage: host.docker.internal-Routing für Ollama,
+# Compose-Service `neo4j` für Bolt, Qwen3-Embedding-Defaults.
+cp .env.docker.example .env
+
+# Geheimnisse erzeugen und in .env eintragen (SECRET_KEY, AGORA_AUTH_TOKEN, NEO4J_PASSWORD)
+python -c "import secrets; print('SECRET_KEY=' + secrets.token_urlsafe(32))"
+python -c "import secrets; print('AGORA_AUTH_TOKEN=' + secrets.token_urlsafe(32))"
+
+# Modelle ziehen (falls Ollama genutzt wird)
 ollama pull qwen3-coder-next:cloud
 ollama pull qwen3-embedding:4b
 
-# Dev-Stack starten
+# Stack starten
 docker compose up -d --build
 ```
 
 | Dienst | URL |
 |---|---|
 | Frontend | <http://localhost:5173> |
-| Backend Health | <http://localhost:5001/health> |
+| Backend Liveness | <http://localhost:5001/health> |
+| Backend Readiness | <http://localhost:5001/readyz> |
 | Neo4j Browser | <http://localhost:7474> |
 
-Lokal ohne Docker:
+`/readyz` ist der seit Code-Review 2026-05-17 verdrahtete Readiness-
+Endpoint: er liefert nur dann 200, wenn Neo4j-Bolt, Redis-Ping, Upload-
+Verzeichnis und Embedding-Konfig kohärent sind. Docker-Healthcheck und
+Reverse-Proxies (Traefik, nginx) sollten ab jetzt gegen `/readyz` testen.
+
+### Pfad B — Host-Dev ohne Container
 
 ```bash
+git clone https://github.com/arn0ld87/agora.git
+cd agora
+
+# Vorlage hat localhost-Defaults bewusst auskommentiert — die Werte
+# unten setzen oder eigene .env-Datei bauen.
+cp .env.example .env
+
+# Ollama-Modelle wie bei Pfad A
+ollama pull qwen3-coder-next:cloud
+ollama pull qwen3-embedding:4b
+
 npm run setup:all
 npm run dev
 ```

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -309,10 +309,12 @@ def create_app(config_class=Config):
     if should_log_startup:
         log_auth_mode(app, logger)
 
-    # Health check
-    @app.route('/health')
-    def health():
-        return {'status': 'ok', 'service': 'Agora Backend'}
+    # Liveness ``/health`` (unverändert) und Readiness ``/readyz``
+    # (Code-Review 2026-05-17, Finding 1.8). /readyz prüft Neo4j-Connect,
+    # Redis-Ping, Upload-Verzeichnis und Embedding-Konfig-Kohärenz; der
+    # Docker-Healthcheck soll ab jetzt /readyz nutzen.
+    from .readiness import register_readiness_routes  # noqa: E402
+    register_readiness_routes(app)
 
     # Static SPA serving — der Prod-Stage des Dockerfiles kopiert
     # frontend/dist nach /app/frontend/dist. Im Dev-Mode existiert das

--- a/backend/app/readiness.py
+++ b/backend/app/readiness.py
@@ -72,27 +72,28 @@ def _check_neo4j() -> CheckResult:
 
 
 def _check_redis() -> CheckResult:
-    """Pingt Redis nur, wenn der Event-Bus tatsächlich ein Redis-Backend ist.
+    """Probet den Event-Bus über ``verify_connectivity()``.
 
-    File-Backend ist ein bewusster, unterstützter Opt-out — der darf
-    /readyz nicht rot drücken.
+    Vertrag: Backends mit echter Netzwerk-Abhängigkeit (``RedisEventBus``)
+    exposieren ``verify_connectivity()`` und werfen, wenn Redis nicht
+    erreichbar ist. Backends ohne Netzwerk-Abhängigkeit
+    (``FilePollingEventBus``) exposieren die Methode bewusst NICHT — der
+    Check meldet dann ``skipped``, statt fälschlicherweise zu pingen.
+
+    Vorgängerversion hat über ``type(bus).__name__`` und drei Attribut-
+    Kandidaten geraten — fragil und in der Praxis kaputt, weil
+    ``RedisEventBus`` den Client unter ``_redis`` hält. Gemini-Review
+    (PR #519) hat darauf gedeutet, und die Probe wurde auf das explizite
+    Interface umgestellt.
     """
     bus = current_app.extensions.get("event_bus")
-    backend_name = type(bus).__name__ if bus is not None else "None"
-    if "Redis" not in backend_name:
-        return True, f"skipped (event_bus={backend_name})"
-    client = (
-        getattr(bus, "client", None)
-        or getattr(bus, "_client", None)
-        or getattr(bus, "redis", None)
-    )
-    if client is None:
-        return False, f"redis backend selected but no client attr on {backend_name}"
-    ping = getattr(client, "ping", None)
-    if ping is None:
-        return False, f"redis client {type(client).__name__} has no ping()"
+    if bus is None:
+        return False, "event_bus not initialized"
+    probe = getattr(bus, "verify_connectivity", None)
+    if probe is None:
+        return True, f"skipped (event_bus={type(bus).__name__} has no probe)"
     try:
-        ping()
+        probe()
     except Exception as exc:  # noqa: BLE001
         return False, str(exc)
     return True, "ok"
@@ -101,17 +102,16 @@ def _check_redis() -> CheckResult:
 def _check_upload_dir() -> CheckResult:
     """Upload-Verzeichnis muss existieren und schreibbar sein.
 
-    Liest ``UPLOAD_FOLDER`` aus ``app.config`` (von ``Config.UPLOAD_FOLDER``
-    bei ``create_app`` reingezogen). Tests können das pro Request über
-    ``app.config['UPLOAD_FOLDER'] = ...`` umstellen.
+    Stateless: die Probe legt das Verzeichnis NICHT an. Ein fehlendes
+    Upload-Dir ist ein Setup-Fehler, den /readyz sichtbar machen soll —
+    Dockerfile und Compose-Bootstrap erzeugen den Pfad bereits beim
+    Image-Build bzw. via Bind-Mount.
     """
     folder = current_app.config.get("UPLOAD_FOLDER")
     if not folder:
         return False, "UPLOAD_FOLDER not configured"
-    try:
-        os.makedirs(folder, exist_ok=True)
-    except Exception as exc:  # noqa: BLE001
-        return False, f"upload dir not creatable: {exc}"
+    if not os.path.isdir(folder):
+        return False, f"upload dir does not exist: {folder}"
     if not os.access(folder, os.W_OK):
         return False, f"upload dir not writable: {folder}"
     return True, str(folder)

--- a/backend/app/readiness.py
+++ b/backend/app/readiness.py
@@ -1,0 +1,178 @@
+"""Readiness-Endpoint /readyz (Code-Review 2026-05-17, Finding 1.8).
+
+Trennt Liveness (`/health`, weiter unverändert in ``create_app``) von
+Readiness. ``/health`` muss grün bleiben, solange der Prozess lebt —
+``/readyz`` muss rot werden, sobald eine kritische Abhängigkeit kippt:
+Neo4j, Redis (nur wenn aktiv genutzt), Upload-Verzeichnis, Embedding-Konfig.
+
+Beispielantwort bei vollständig gesundem Stack:
+
+    GET /readyz → 200
+    {"status": "ready", "checks": {
+        "neo4j": {"ok": true,  "detail": "ok"},
+        "redis": {"ok": true,  "detail": "ok"},
+        "upload_dir": {"ok": true, "detail": "/app/backend/uploads"},
+        "embedding_config": {"ok": true, "detail": "qwen3-embedding:4b → dim=2560"}
+    }}
+
+Beispielantwort bei kaputtem Neo4j:
+
+    GET /readyz → 503
+    {"status": "not_ready", "checks": {
+        "neo4j": {"ok": false, "detail": "bolt://neo4j:7687 unreachable: ..."},
+        ...
+    }}
+
+Design-Entscheidungen:
+
+* Keine LLM/Embedding-Live-Probe. Review §4.4 warnt explizit: Ollama-Cold-
+  Start würde sonst den Container-Start blockieren. Wir prüfen nur die
+  *Kohärenz* von ``EMBEDDING_MODEL`` und ``VECTOR_DIM``.
+* Redis-Check wird übersprungen, wenn der konfigurierte Event-Bus nicht
+  das Redis-Backend ist. Damit kann ein bewusster
+  ``EVENT_BUS_BACKEND=file``-Betrieb nicht von /readyz rotgemacht werden.
+* Keine Authentifizierung — die Routen werden außerhalb der
+  Blueprint-Guards registriert (analog zum bestehenden ``/health``).
+* Probe-Funktionen sind klein und stateless, damit Tests Fakes via
+  ``app.extensions`` / ``app.config`` einspeisen können, ohne den
+  ``create_app``-Boot durchlaufen zu müssen.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Tuple
+
+from flask import Flask, Response, current_app, jsonify
+
+from .config import infer_vector_dim_for_model
+
+CheckResult = Tuple[bool, str]
+
+
+def _check_neo4j() -> CheckResult:
+    """Neo4j ist verfügbar, wenn ``app.extensions['neo4j_storage']``
+    gesetzt ist und eine simple Connectivity-Probe durchläuft.
+
+    Schlägt der Storage-Init beim Boot fehl, hinterlegt ``create_app``
+    den Grund unter ``neo4j_storage_error`` — den geben wir 1:1 weiter.
+    """
+    storage = current_app.extensions.get("neo4j_storage")
+    init_error = current_app.extensions.get("neo4j_storage_error")
+    if storage is None:
+        return False, init_error or "neo4j_storage not initialized"
+    probe = getattr(storage, "verify_connectivity", None)
+    if probe is None:
+        return False, "neo4j_storage has no verify_connectivity()"
+    try:
+        probe()
+    except Exception as exc:  # noqa: BLE001 — Probe-Fehler werden im Body sichtbar
+        return False, str(exc)
+    return True, "ok"
+
+
+def _check_redis() -> CheckResult:
+    """Pingt Redis nur, wenn der Event-Bus tatsächlich ein Redis-Backend ist.
+
+    File-Backend ist ein bewusster, unterstützter Opt-out — der darf
+    /readyz nicht rot drücken.
+    """
+    bus = current_app.extensions.get("event_bus")
+    backend_name = type(bus).__name__ if bus is not None else "None"
+    if "Redis" not in backend_name:
+        return True, f"skipped (event_bus={backend_name})"
+    client = (
+        getattr(bus, "client", None)
+        or getattr(bus, "_client", None)
+        or getattr(bus, "redis", None)
+    )
+    if client is None:
+        return False, f"redis backend selected but no client attr on {backend_name}"
+    ping = getattr(client, "ping", None)
+    if ping is None:
+        return False, f"redis client {type(client).__name__} has no ping()"
+    try:
+        ping()
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+    return True, "ok"
+
+
+def _check_upload_dir() -> CheckResult:
+    """Upload-Verzeichnis muss existieren und schreibbar sein.
+
+    Liest ``UPLOAD_FOLDER`` aus ``app.config`` (von ``Config.UPLOAD_FOLDER``
+    bei ``create_app`` reingezogen). Tests können das pro Request über
+    ``app.config['UPLOAD_FOLDER'] = ...`` umstellen.
+    """
+    folder = current_app.config.get("UPLOAD_FOLDER")
+    if not folder:
+        return False, "UPLOAD_FOLDER not configured"
+    try:
+        os.makedirs(folder, exist_ok=True)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"upload dir not creatable: {exc}"
+    if not os.access(folder, os.W_OK):
+        return False, f"upload dir not writable: {folder}"
+    return True, str(folder)
+
+
+def _check_embedding_config() -> CheckResult:
+    """``EMBEDDING_MODEL`` und ``VECTOR_DIM`` müssen zusammenpassen.
+
+    Eine falsche Dimension lässt Neo4j-Vector-Index-Inserts beim ersten
+    Persist-Aufruf scheitern — fail-fast in /readyz, statt im
+    Graph-Build-Job.
+    """
+    model = current_app.config.get("EMBEDDING_MODEL")
+    dim = current_app.config.get("VECTOR_DIM")
+    if not model:
+        return False, "EMBEDDING_MODEL not configured"
+    if dim is None:
+        return False, "VECTOR_DIM not configured"
+    expected = infer_vector_dim_for_model(model)
+    try:
+        dim_int = int(dim)
+    except (TypeError, ValueError):
+        return False, f"VECTOR_DIM not an integer: {dim!r}"
+    if expected and dim_int != expected:
+        return False, (
+            f"VECTOR_DIM mismatch for EMBEDDING_MODEL '{model}': "
+            f"configured {dim_int}, expected {expected}"
+        )
+    return True, f"{model} → dim={dim_int}"
+
+
+def _run_checks() -> dict[str, Any]:
+    """Führt alle Probes aus und packt das Ergebnis in das /readyz-Format."""
+    results: dict[str, CheckResult] = {
+        "neo4j": _check_neo4j(),
+        "redis": _check_redis(),
+        "upload_dir": _check_upload_dir(),
+        "embedding_config": _check_embedding_config(),
+    }
+    return {
+        "status": "ready" if all(ok for ok, _ in results.values()) else "not_ready",
+        "checks": {
+            name: {"ok": ok, "detail": detail} for name, (ok, detail) in results.items()
+        },
+    }
+
+
+def register_readiness_routes(app: Flask) -> None:
+    """Hängt ``/health`` (Liveness) und ``/readyz`` (Readiness) an ``app``.
+
+    Beide Routen werden bewusst außerhalb der Blueprint-Auth-Guards
+    registriert (Docker-Healthcheck hat keinen Token). ``/health`` bleibt
+    abhängigkeitsfrei: solange der Prozess lebt, ist die Antwort 200.
+    """
+
+    @app.route("/health", methods=["GET"])
+    def health() -> tuple[Response, int]:
+        return jsonify({"status": "ok", "service": "Agora Backend"}), 200
+
+    @app.route("/readyz", methods=["GET"])
+    def readyz() -> tuple[Response, int]:
+        payload = _run_checks()
+        status_code = 200 if payload["status"] == "ready" else 503
+        return jsonify(payload), status_code

--- a/backend/app/services/event_bus_redis.py
+++ b/backend/app/services/event_bus_redis.py
@@ -98,6 +98,21 @@ class RedisEventBus:
         self._file_bus = FilePollingEventBus(store=self._store)
         self._url = url
 
+    # ----- readiness probe ----------------------------------------------
+
+    def verify_connectivity(self) -> None:
+        """Pingt den Redis-Server für den /readyz-Probe.
+
+        Schlägt durch, was redis-py raised (typischerweise
+        ``redis.exceptions.ConnectionError``). ``readiness._check_redis``
+        übersetzt die Exception in ein {"ok": false}-Payload.
+
+        Bewusst hier exposiert (nicht ``ping``), damit das Namensschema
+        ``verify_connectivity`` zwischen Neo4j-Storage und Redis-Bus
+        identisch bleibt — Gemini-Review zu PR #519, Mai 2026.
+        """
+        self._redis.ping()
+
     # ----- internal ------------------------------------------------------
 
     def _write_retained(self, channel: str, event: SimulationEvent) -> None:

--- a/backend/tests/api/test_readyz_endpoint.py
+++ b/backend/tests/api/test_readyz_endpoint.py
@@ -38,25 +38,25 @@ class _FakeNeo4jStorageBroken:
         raise RuntimeError("bolt://neo4j:7687 unreachable: Connection refused")
 
 
-class _FakeRedisClientOk:
-    def ping(self) -> bool:
-        return True
-
-
-class _FakeRedisClientBroken:
-    def ping(self) -> bool:
-        raise RuntimeError("redis://redis:6379/0 unreachable: ECONNREFUSED")
-
-
 class _FakeRedisEventBus:
-    """Bus mit Redis-Backend-Signatur (Klassenname enthält 'Redis')."""
+    """Event-Bus mit explizitem ``verify_connectivity``-Probe-Vertrag.
 
-    def __init__(self, client) -> None:
-        self.client = client
+    Spiegelt das Interface, das ``RedisEventBus`` in Production exposiert
+    (siehe ``backend/app/services/event_bus_redis.py``).
+    """
+
+    def __init__(self, ok: bool = True, error: str = "") -> None:
+        self._ok = ok
+        self._error = error or "redis://redis:6379/0 unreachable: ECONNREFUSED"
+
+    def verify_connectivity(self) -> None:
+        if not self._ok:
+            raise RuntimeError(self._error)
 
 
 class _FakeFileEventBus:
-    """File-Backend — Redis-Check wird übersprungen."""
+    """File-Backend: exposiert keinen ``verify_connectivity``-Hook → Probe wird
+    übersprungen. Spiegelt die ``FilePollingEventBus``-Realität."""
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +78,7 @@ def app(tmp_path):
 
     application.extensions["neo4j_storage"] = _FakeNeo4jStorageOk()
     application.extensions["neo4j_storage_error"] = None
-    application.extensions["event_bus"] = _FakeRedisEventBus(_FakeRedisClientOk())
+    application.extensions["event_bus"] = _FakeRedisEventBus(ok=True)
     register_readiness_routes(application)
     return application
 
@@ -153,7 +153,7 @@ def test_readyz_returns_503_when_neo4j_storage_missing(app, client):
 
 
 def test_readyz_returns_503_when_redis_unreachable(app, client):
-    app.extensions["event_bus"] = _FakeRedisEventBus(_FakeRedisClientBroken())
+    app.extensions["event_bus"] = _FakeRedisEventBus(ok=False)
 
     response = client.get("/readyz")
 
@@ -174,6 +174,22 @@ def test_readyz_skips_redis_check_for_file_backend(app, client):
     payload = response.get_json()
     assert payload["checks"]["redis"]["ok"] is True
     assert "skipped" in payload["checks"]["redis"]["detail"].lower()
+
+
+def test_readyz_returns_503_when_upload_dir_missing(app, client, tmp_path):
+    """Stateless-Probe: ein fehlendes Upload-Verzeichnis ist ein Setup-
+    Fehler, den /readyz meldet — nicht heimlich anlegt."""
+    missing = tmp_path / "not-there"
+    app.config["UPLOAD_FOLDER"] = str(missing)
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["checks"]["upload_dir"]["ok"] is False
+    assert "not exist" in payload["checks"]["upload_dir"]["detail"].lower()
+    # Probe darf das Verzeichnis NICHT erstellen.
+    assert not missing.exists()
 
 
 def test_readyz_returns_503_when_upload_dir_unwritable(app, client, tmp_path):

--- a/backend/tests/api/test_readyz_endpoint.py
+++ b/backend/tests/api/test_readyz_endpoint.py
@@ -1,0 +1,209 @@
+"""Tests für /readyz Readiness-Endpoint (PR 1, Finding 1.8).
+
+Vertrag:
+  A. /health bleibt unverändert: liefert 200 + {"status": "ok"} ohne
+     Abhängigkeitsprüfungen (Liveness).
+  B. /readyz prüft Neo4j-Connection, Redis-Ping, Upload-Verzeichnis
+     schreibbar, Embedding-Konfig kohärent (EMBEDDING_MODEL ↔ VECTOR_DIM).
+     Alle ok → 200; eine kaputt → 503.
+  C. Antwort-Body enthält pro Check {"ok": bool, "detail": str}, damit
+     Operator den kaputten Check ohne Log-Diving sieht.
+  D. Redis-Check wird übersprungen, wenn der konfigurierte Event-Bus auf
+     File-Backend steht — sonst kann ein bewusster `EVENT_BUS_BACKEND=file`
+     das ganze /readyz rot machen.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from flask import Flask
+
+from app.readiness import register_readiness_routes
+
+
+# ---------------------------------------------------------------------------
+# Test-Doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeNeo4jStorageOk:
+    def verify_connectivity(self) -> None:
+        return None
+
+
+class _FakeNeo4jStorageBroken:
+    def verify_connectivity(self) -> None:
+        raise RuntimeError("bolt://neo4j:7687 unreachable: Connection refused")
+
+
+class _FakeRedisClientOk:
+    def ping(self) -> bool:
+        return True
+
+
+class _FakeRedisClientBroken:
+    def ping(self) -> bool:
+        raise RuntimeError("redis://redis:6379/0 unreachable: ECONNREFUSED")
+
+
+class _FakeRedisEventBus:
+    """Bus mit Redis-Backend-Signatur (Klassenname enthält 'Redis')."""
+
+    def __init__(self, client) -> None:
+        self.client = client
+
+
+class _FakeFileEventBus:
+    """File-Backend — Redis-Check wird übersprungen."""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Frische Flask-App mit readiness-Routen + Happy-Path-Konfig."""
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+
+    application = Flask(__name__)
+    application.config["UPLOAD_FOLDER"] = str(upload_dir)
+    # qwen3-embedding:4b liefert 2560-dim Vektoren — kohärent.
+    application.config["EMBEDDING_MODEL"] = "qwen3-embedding:4b"
+    application.config["VECTOR_DIM"] = 2560
+
+    application.extensions["neo4j_storage"] = _FakeNeo4jStorageOk()
+    application.extensions["neo4j_storage_error"] = None
+    application.extensions["event_bus"] = _FakeRedisEventBus(_FakeRedisClientOk())
+    register_readiness_routes(application)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Liveness
+# ---------------------------------------------------------------------------
+
+
+def test_health_liveness_stays_simple(client):
+    """/health ist NICHT abhängigkeitsabhängig — Trennung zu /readyz."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert "checks" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Readiness — Happy Path
+# ---------------------------------------------------------------------------
+
+
+def test_readyz_returns_ready_when_all_checks_pass(client):
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ready"
+    checks = payload["checks"]
+    assert checks["neo4j"]["ok"] is True
+    assert checks["redis"]["ok"] is True
+    assert checks["upload_dir"]["ok"] is True
+    assert checks["embedding_config"]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Readiness — Fehlerfälle
+# ---------------------------------------------------------------------------
+
+
+def test_readyz_returns_503_when_neo4j_unreachable(app, client):
+    app.extensions["neo4j_storage"] = _FakeNeo4jStorageBroken()
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["status"] == "not_ready"
+    assert payload["checks"]["neo4j"]["ok"] is False
+    assert "unreachable" in payload["checks"]["neo4j"]["detail"].lower()
+    # Andere Checks bleiben grün.
+    assert payload["checks"]["upload_dir"]["ok"] is True
+
+
+def test_readyz_returns_503_when_neo4j_storage_missing(app, client):
+    """Neo4j konnte beim Boot gar nicht initialisiert werden (None in
+    app.extensions). Review §1.8 nennt das als zentralen Fall."""
+    app.extensions["neo4j_storage"] = None
+    app.extensions["neo4j_storage_error"] = "init failed: auth"
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["checks"]["neo4j"]["ok"] is False
+    assert "init failed: auth" in payload["checks"]["neo4j"]["detail"]
+
+
+def test_readyz_returns_503_when_redis_unreachable(app, client):
+    app.extensions["event_bus"] = _FakeRedisEventBus(_FakeRedisClientBroken())
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["checks"]["redis"]["ok"] is False
+    assert "unreachable" in payload["checks"]["redis"]["detail"].lower()
+
+
+def test_readyz_skips_redis_check_for_file_backend(app, client):
+    """File-Event-Bus → Redis-Ping nicht ausführen, sonst legt ein
+    bewusster EVENT_BUS_BACKEND=file das ganze /readyz rot."""
+    app.extensions["event_bus"] = _FakeFileEventBus()
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["checks"]["redis"]["ok"] is True
+    assert "skipped" in payload["checks"]["redis"]["detail"].lower()
+
+
+def test_readyz_returns_503_when_upload_dir_unwritable(app, client, tmp_path):
+    unwritable = tmp_path / "no-write"
+    unwritable.mkdir()
+    os.chmod(unwritable, 0o500)  # r-x
+    app.config["UPLOAD_FOLDER"] = str(unwritable)
+
+    try:
+        response = client.get("/readyz")
+        assert response.status_code == 503
+        payload = response.get_json()
+        assert payload["checks"]["upload_dir"]["ok"] is False
+        assert "not writable" in payload["checks"]["upload_dir"]["detail"].lower()
+    finally:
+        os.chmod(unwritable, 0o700)
+
+
+def test_readyz_returns_503_on_embedding_config_mismatch(app, client):
+    """qwen3-embedding:4b liefert 2560-dim Vektoren — VECTOR_DIM=768 ist
+    eine garantierte Inkonsistenz, die Neo4j-Index-Inserts zerlegt."""
+    app.config["EMBEDDING_MODEL"] = "qwen3-embedding:4b"
+    app.config["VECTOR_DIM"] = 768
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["checks"]["embedding_config"]["ok"] is False
+    detail = payload["checks"]["embedding_config"]["detail"]
+    assert "vector_dim" in detail.lower()
+    assert "768" in detail
+    assert "2560" in detail

--- a/backend/tests/config/test_env_examples_consistency.py
+++ b/backend/tests/config/test_env_examples_consistency.py
@@ -1,0 +1,175 @@
+"""Tests für die Konsistenz der Env-Beispieldateien (PR 1, Finding 1.1).
+
+Hintergrund: Der bisherige Quickstart empfahl `cp .env.example .env` und
+danach `docker compose up`. `.env.example` enthielt aber Host-Defaults
+(`LLM_BASE_URL=http://localhost:11434/v1`, `EMBEDDING_BASE_URL=…/11434`,
+`NEO4J_URI=bolt://localhost:7687`), die in Compose den container-internen
+`localhost` meinen — und damit auf den Container selbst zeigen statt auf
+Host-Ollama oder den `neo4j`-Service.
+
+Verträge:
+  A. `.env.example` darf keine *aktiv gesetzten* localhost-Default-Werte
+     für `LLM_BASE_URL`, `EMBEDDING_BASE_URL` oder `NEO4J_URI` enthalten.
+     Diese Schlüssel müssen entweder auskommentiert oder per
+     Compose-Default überschrieben werden.
+  B. `.env.docker.example` existiert und ist container-tauglich:
+     `host.docker.internal` für Ollama, `bolt://neo4j:7687`,
+     `EMBEDDING_MODEL=qwen3-embedding:4b` mit passendem `VECTOR_DIM=2560`.
+  C. `.env.docker.example` setzt keine Geheimnis-Klartexte — `SECRET_KEY`,
+     `AGORA_AUTH_TOKEN` und `NEO4J_PASSWORD` müssen vom Operator gefüllt
+     werden (leerer Wert oder Generieren-Marker, kein hartcodierter Wert).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+ENV_DOCKER_EXAMPLE = REPO_ROOT / ".env.docker.example"
+
+
+def _parse_active_keys(path: Path) -> Dict[str, str]:
+    """Parst nur unkommentierte KEY=VALUE-Zeilen einer .env-Datei.
+
+    Kommentar-Marker am Zeilenanfang (mit optionalem Whitespace) machen
+    die Zeile zu einer Vorlage, kein aktiver Default.
+    """
+    result: Dict[str, str] = {}
+    if not path.is_file():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Vertrag A — .env.example darf keine kaputten Docker-Defaults aktiv haben
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def env_example_active() -> Dict[str, str]:
+    return _parse_active_keys(ENV_EXAMPLE)
+
+
+def test_env_example_exists(env_example_active):
+    assert ENV_EXAMPLE.is_file(), f".env.example fehlt unter {ENV_EXAMPLE}"
+
+
+def test_env_example_does_not_set_active_localhost_llm_base_url(env_example_active):
+    """`LLM_BASE_URL=http://localhost:...` ist im Compose-Pfad eine Falle —
+    in der Vorlage muss diese Zeile auskommentiert sein."""
+    value = env_example_active.get("LLM_BASE_URL", "")
+    assert "localhost" not in value, (
+        "LLM_BASE_URL in .env.example zeigt aktiv auf localhost. "
+        "Das gewinnt gegen den Compose-Default host.docker.internal und "
+        "routet im Container auf den Container selbst. Auskommentieren."
+    )
+
+
+def test_env_example_does_not_set_active_localhost_embedding_base_url(env_example_active):
+    value = env_example_active.get("EMBEDDING_BASE_URL", "")
+    assert "localhost" not in value, (
+        "EMBEDDING_BASE_URL in .env.example zeigt aktiv auf localhost. "
+        "Auskommentieren — sonst überschreibt der Wert den Compose-Default."
+    )
+
+
+def test_env_example_does_not_set_active_localhost_neo4j_uri(env_example_active):
+    value = env_example_active.get("NEO4J_URI", "")
+    assert "localhost" not in value, (
+        "NEO4J_URI in .env.example zeigt aktiv auf localhost. Im Compose-Pfad "
+        "muss bolt://neo4j:7687 gewinnen — diese Zeile auskommentieren."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vertrag B — .env.docker.example existiert mit container-tauglichen Werten
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def env_docker_example_active() -> Dict[str, str]:
+    return _parse_active_keys(ENV_DOCKER_EXAMPLE)
+
+
+def test_env_docker_example_exists():
+    assert ENV_DOCKER_EXAMPLE.is_file(), (
+        f".env.docker.example fehlt unter {ENV_DOCKER_EXAMPLE} — Quickstart "
+        "verweist auf `cp .env.docker.example .env`."
+    )
+
+
+def test_env_docker_example_llm_base_url_uses_host_docker_internal(env_docker_example_active):
+    value = env_docker_example_active.get("LLM_BASE_URL", "")
+    assert "host.docker.internal" in value, (
+        f"LLM_BASE_URL in .env.docker.example muss host.docker.internal "
+        f"verwenden (aktuell: {value!r})."
+    )
+
+
+def test_env_docker_example_embedding_base_url_uses_host_docker_internal(env_docker_example_active):
+    value = env_docker_example_active.get("EMBEDDING_BASE_URL", "")
+    assert "host.docker.internal" in value, (
+        f"EMBEDDING_BASE_URL in .env.docker.example muss host.docker.internal "
+        f"verwenden (aktuell: {value!r})."
+    )
+
+
+def test_env_docker_example_neo4j_uri_uses_service_name(env_docker_example_active):
+    value = env_docker_example_active.get("NEO4J_URI", "")
+    assert value.startswith("bolt://neo4j:"), (
+        f"NEO4J_URI in .env.docker.example muss den Compose-Service-Namen "
+        f"`neo4j` verwenden (aktuell: {value!r})."
+    )
+
+
+def test_env_docker_example_embedding_dim_matches_qwen3(env_docker_example_active):
+    """qwen3-embedding:4b → 2560-dim. Falsche Kombi sprengt den
+    Neo4j-Vector-Index sofort beim ersten Insert."""
+    model = env_docker_example_active.get("EMBEDDING_MODEL", "")
+    dim = env_docker_example_active.get("VECTOR_DIM", "")
+    assert model == "qwen3-embedding:4b", (
+        f"EMBEDDING_MODEL in .env.docker.example sollte qwen3-embedding:4b "
+        f"sein (aktuell: {model!r})."
+    )
+    assert dim == "2560", (
+        f"VECTOR_DIM in .env.docker.example muss 2560 sein für "
+        f"qwen3-embedding:4b (aktuell: {dim!r})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vertrag C — keine hartcodierten Geheimnisse in der Vorlage
+# ---------------------------------------------------------------------------
+
+
+_PLACEHOLDER_TOKENS = {
+    "",
+    "change-me",
+    "change-me-use-token_urlsafe-32",
+    "set-me",
+    "generate-with-secrets.token_urlsafe-32",
+}
+
+
+@pytest.mark.parametrize("key", ["SECRET_KEY", "AGORA_AUTH_TOKEN", "NEO4J_PASSWORD"])
+def test_env_docker_example_secrets_are_placeholders(env_docker_example_active, key):
+    """Die Docker-Vorlage darf keine echten Geheimnisse hartkodieren.
+    Operator soll die Werte bewusst generieren / setzen."""
+    value = env_docker_example_active.get(key, "")
+    assert value in _PLACEHOLDER_TOKENS, (
+        f"{key} in .env.docker.example darf kein hartcodiertes Geheimnis "
+        f"sein — aktuell: {value!r}. Akzeptierte Platzhalter: "
+        f"{sorted(_PLACEHOLDER_TOKENS)}."
+    )


### PR DESCRIPTION
## Bezug

Code-Review 2026-05-17 (`agora_code_review_2026-05-17.md`):

- **Finding 1.1** — Docker-Quickstart widerspricht `.env.example`.
- **Finding 1.2 (Teil A)** — Prod mit `gunicorn --workers 2` bricht den prozesslokalen State von Tasks, API-Keys und Simulation-Subprozessen.
- **Finding 1.8** — `/health` meldet `ok`, auch wenn Neo4j tot ist.

## Was

- `.env.example` entschärft: aktive `localhost`-Defaults für `LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `NEO4J_URI` und `OPENAI_API_BASE_URL` sind jetzt auskommentiert; Vorlage verweist auf die pfadspezifischen Setup-Dateien.
- **Neu `.env.docker.example`** — container-tauglich (`host.docker.internal` für Ollama, `bolt://neo4j:7687`, `qwen3-embedding:4b` + `VECTOR_DIM=2560`, Secrets als Platzhalter).
- **Neu `backend/app/readiness.py`** — `/health` (Liveness) und `/readyz` (Readiness) in einem Modul. `/readyz` prüft `Neo4jStorage.verify_connectivity()`, Redis-Ping (nur wenn Event-Bus ein Redis-Backend ist), Upload-Verzeichnis schreibbar und `EMBEDDING_MODEL`↔`VECTOR_DIM`-Kohärenz. **Keine** LLM/Embedding-Live-Probe — Review §4.4 warnt explizit davor, Ollama-Cold-Start würde sonst den Container-Start blocken.
- `backend/app/__init__.py`: alte Inline-`/health`-Route entfernt, beide Routen via `register_readiness_routes(app)` registriert.
- `Dockerfile`: HEALTHCHECK (dev + prod) auf `/readyz`; prod-CMD von `--workers 2` auf `--workers 1` mit Hardstop-Kommentar (Aufhebung in PR 2/4 dieser Welle).
- `README.md` Quickstart in zwei dokumentierte Pfade (Docker via `.env.docker.example`, Host-Dev via `.env.example`) inkl. neuem `/readyz` im Dienst-Mapping.

## Risiko & Rollback

Additive Änderungen am Routing (`/health` bleibt 1:1 erhalten) plus eine kontrollierte Konfigreduktion (`workers 2 → 1`). Rollback per `git revert` des Commits + Dockerfile-HEALTHCHECK-Pfad zurück auf `/health`. Wer den Throughput-Drop bei einem Worker temporär in Kauf nehmen muss, kann übergangsweise `--workers 2` manuell setzen, akzeptiert dann aber die Worker-State-Bugs aus Finding 1.2.

## Verifikation

```bash
cd backend
uv run ruff check app/ tests/           # All checks passed
uv run mypy app                         # 177 files, no issues
uv run python -m app.contracts.dump_schemas --check   # alle 27 Schemas matchen
uv run pytest tests/contracts/ tests/api/ tests/services/ tests/storage/ tests/config/
# → 967 passed, 3 deselected
```

Neue Tests:

- `backend/tests/api/test_readyz_endpoint.py` — 8 Tests (Liveness, Happy-Path, Neo4j-down/missing, Redis-down/file-backend-skip, Upload-Dir unwritable, Embedding-Dim-Mismatch).
- `backend/tests/config/test_env_examples_consistency.py` — 12 Tests (kein aktiver `localhost`-Default in `.env.example`, `.env.docker.example` mit korrektem Routing und Secrets-Platzhaltern).

Docker-Compose-Smoke (manuell, sobald lokale Ollama-Modelle bereit):

```bash
cp .env.docker.example .env
# SECRET_KEY, AGORA_AUTH_TOKEN, NEO4J_PASSWORD setzen
docker compose -f docker-compose.yml -f docker-compose.prod.yml \
  -f deploy/compose/docker-compose.prod-with-proxy.yml up -d --build
curl -fsS http://localhost/readyz
```

## Scope-Disziplin

Diese PR adressiert **nur** Findings 1.1, 1.2 (Teil A) und 1.8. Findings 1.3 (Daemon-Threads → Redis-Queue), 1.6 (Subprozess-Env-Whitelist), 3.3 (API-Key-Scopes), 4.x (Performance/Export) folgen in PR 2–5 dieser Welle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)