### PR TITLE
fix: clawpatch wave 4 — agent-log redaction, sim retry, graph robustness

### DIFF
--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -1,4 +1,4 @@
-import service, { requestWithRetry } from './index'
+import service from './index'
 import type { LlmRuntimePayload } from './llmRuntime'
 import type { PersonaQuotaPlan } from '../contracts/personaQuotaContract'
 
@@ -163,7 +163,7 @@ export interface AgentStatsResponse {
  * @param data - { project_id, graph_id?, enable_twitter?, enable_reddit? }
  */
 export const createSimulation = (data: CreateSimulationData): Promise<SimulationRecord> => {
-  return requestWithRetry(() => service.post('/api/simulation/create', data), 3, 1000)
+  return service.post('/api/simulation/create', data)
 }
 
 /**
@@ -171,7 +171,7 @@ export const createSimulation = (data: CreateSimulationData): Promise<Simulation
  * @param data - { simulation_id, entity_types?, use_llm_for_profiles?, parallel_profile_count?, force_regenerate? }
  */
 export const prepareSimulation = (data: PrepareSimulationData): Promise<TaskStatusData> => {
-  return requestWithRetry(() => service.post('/api/simulation/prepare', data), 3, 1000)
+  return service.post('/api/simulation/prepare', data)
 }
 
 /**
@@ -247,7 +247,7 @@ export const listSimulations = (projectId?: string): Promise<SimulationRecord[]>
  * @param data - { simulation_id, platform?, max_rounds?, simulation_days?, enable_graph_memory_update? }
  */
 export const startSimulation = (data: StartSimulationData): Promise<RunStatusResponse> => {
-  return requestWithRetry(() => service.post('/api/simulation/start', data), 3, 1000)
+  return service.post('/api/simulation/start', data)
 }
 
 /**
@@ -351,7 +351,7 @@ export const getEnvStatus = (data: EnvStatusData): Promise<unknown> => {
  * @param data - { simulation_id, interviews: [{ agent_id, prompt }] }
  */
 export const interviewAgents = (data: InterviewAgentsData): Promise<unknown> => {
-  return requestWithRetry(() => service.post('/api/simulation/interview/batch', data), 3, 1000)
+  return service.post('/api/simulation/interview/batch', data)
 }
 
 /**

--- a/frontend/src/components/graph/graphPanelGeometry.ts
+++ b/frontend/src/components/graph/graphPanelGeometry.ts
@@ -28,6 +28,15 @@ function getCurveControlPoint(edge: EdgeWithPositions): Point {
   const dx = tx - sx
   const dy = ty - sy
   const dist = Math.sqrt(dx * dx + dy * dy)
+  const midX = (sx + tx) / 2
+  const midY = (sy + ty) / 2
+
+  // Coincident endpoints: no direction to offset along — return midpoint
+  // unchanged to avoid NaN paths in the SVG output.
+  if (dist <= 0) {
+    return { x: midX, y: midY }
+  }
+
   const pairTotal = edge.pairTotal || 1
   const offsetRatio = CURVE_OFFSET_BASE_RATIO + pairTotal * CURVE_OFFSET_PAIR_RATIO
   const baseOffset = Math.max(MIN_CURVE_OFFSET, dist * offsetRatio)
@@ -35,8 +44,8 @@ function getCurveControlPoint(edge: EdgeWithPositions): Point {
   const offsetY = (dx / dist) * edge.curvature * baseOffset
 
   return {
-    x: (sx + tx) / 2 + offsetX,
-    y: (sy + ty) / 2 + offsetY,
+    x: midX + offsetX,
+    y: midY + offsetY,
   }
 }
 

--- a/frontend/src/components/graph/graphPanelUtils.ts
+++ b/frontend/src/components/graph/graphPanelUtils.ts
@@ -42,6 +42,7 @@ export function formatDateTime(dateStr: string | null | undefined): string {
 
   try {
     const date = new Date(dateStr)
+    if (Number.isNaN(date.getTime())) return dateStr
     return date.toLocaleString('en-US', {
       month: 'short',
       day: 'numeric',

--- a/frontend/src/utils/__tests__/reportAgentLog.spec.ts
+++ b/frontend/src/utils/__tests__/reportAgentLog.spec.ts
@@ -17,4 +17,29 @@ describe('parseAgentEntry', () => {
     expect(parseAgentEntry({ action: 'section_complete', section_index: 2 })?.title).toBe('✓ Section 2')
     expect(parseAgentEntry({ action: 'error', details: { message: 'kaputt' } })?.title).toBe('⚠ ERROR')
   })
+
+  it('redacts sensitive tool parameters in the subtitle', () => {
+    const secretMarker = 'PLAINTEXT_SECRET_VALUE'
+    const entry = parseAgentEntry({
+      action: 'tool_call',
+      tool_name: 'http_get',
+      details: {
+        parameters: {
+          url: 'https://example.com',
+          api_token: secretMarker,
+          Authorization: secretMarker,
+          session_cookie: secretMarker,
+          password: secretMarker,
+          secret_key: secretMarker,
+        },
+      },
+    })
+    expect(entry?.subtitle).toContain('url=https://example.com')
+    expect(entry?.subtitle).toContain('api_token=[redacted]')
+    expect(entry?.subtitle).toContain('Authorization=[redacted]')
+    expect(entry?.subtitle).toContain('session_cookie=[redacted]')
+    expect(entry?.subtitle).toContain('password=[redacted]')
+    expect(entry?.subtitle).toContain('secret_key=[redacted]')
+    expect(entry?.subtitle).not.toContain(secretMarker)
+  })
 })

--- a/frontend/src/utils/reportAgentLog.ts
+++ b/frontend/src/utils/reportAgentLog.ts
@@ -9,6 +9,15 @@ export interface AgentLogEntry {
   [key: string]: unknown
 }
 
+const SENSITIVE_KEY_PATTERN = /token|key|secret|auth|password|credential|ticket|cookie|header/i
+const REDACTED = '[redacted]'
+
+function redactParamValue(key: string, value: unknown): string {
+  if (SENSITIVE_KEY_PATTERN.test(key)) return REDACTED
+  const str = typeof value === 'string' ? value : JSON.stringify(value)
+  return str.length > 80 ? str.slice(0, 80) + '…' : str
+}
+
 function parseAgentObject(raw: unknown): Record<string, unknown> | null {
   if (typeof raw === 'string') {
     try {
@@ -35,10 +44,7 @@ export function parseAgentEntry(raw: unknown): AgentLogEntry | null {
   if (action === 'tool_call') {
     title = `TOOL → ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
     const params = (d.parameters as Record<string, unknown>) || {}
-    subtitle = Object.entries(params).map(([k, v]) => {
-      const str = typeof v === 'string' ? v : JSON.stringify(v)
-      return `${k}=${str.length > 80 ? str.slice(0, 80) + '…' : str}`
-    }).join('  ')
+    subtitle = Object.entries(params).map(([k, v]) => `${k}=${redactParamValue(k, v)}`).join('  ')
   } else if (action === 'tool_result') {
     title = `← ${(obj.tool_name as string) || (d.tool_name as string) || '?'}`
     subtitle = `${(d.result_length as number) || 0} chars`


### PR DESCRIPTION
## Summary

Clawpatch wave 4 — vier Frontend-Fixes aus 4 Findings (Run `20260517T144806-3d086f`, 5 features reviewed). Alle Findings als `fixed` triaged.

### Commits

- **`fix(agent-log)`** — `frontend/src/utils/reportAgentLog.ts` rendered tool-call-Parameter ungefiltert in den UI-Subtitle. Tools mit `api_token`, `Authorization`, `password`, `session_cookie`, `secret_key` etc. leakten ihre Werte in den Agent-Log und in jeden HTML-Export. Fix: case-insensitive Redaction-Pattern für `token|key|secret|auth|password|credential|ticket|cookie|header`, Wert → `[redacted]`. Test deckt das Verhalten ab. Closes `fnd_sig-feat-library-f66bdd7df7-eaae` (**confirmed-bug**, medium, security-sensitive).
- **`fix(api/simulation)`** — `createSimulation`, `prepareSimulation`, `startSimulation`, `interviewAgents` waren mit `requestWithRetry` (retry on 5xx/Timeout) gewrappt. Backend honoriert keinen Idempotency-Key — Retry konnte stille Duplikate von Sim-Records, Prepare-Jobs, Start-Kicks und Batch-Interviews erzeugen. Fix: Retry-Wrapper entfernt, 5xx/Timeout bubbeln zur UI. Closes `fnd_sig-feat-library-fdc15d5187-1107` (risk, medium).
- **`fix(graph)`** — `getCurveControlPoint` in `graphPanelGeometry.ts` dividierte durch `Math.sqrt(dx²+dy²)` ohne `dist > 0`-Check. Bei deckungsgleichen Node-Positionen kam NaN/NaN ins SVG-Path. Fix: Midpoint zuerst berechnen, bei `dist <= 0` direkt zurückgeben. Closes `fnd_sig-feat-library-f2b52ef90c-acea` (**confirmed-bug**, medium).
- **`fix(graph)`** — `formatDateTime` in `graphPanelUtils.ts` rief `toLocaleString` ohne Validierung; Invalid Input wurde als `'Invalid Date'` gerendert statt zum rohen String zu fallbacken. Fix: `Number.isNaN(date.getTime())`-Guard → Original-String. Closes `fnd_sig-feat-library-f2b52ef90c-249a` (confirmed-bug, low).

### Hartanker (ADR-0002)

Keiner der 4 Findings tangiert die 5 Evidence-Gating-Anker. Backend unverändert.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1052 tests pass (incl. neuer Redaction-Test)
- [x] `bun run build` — built in <1s
- [ ] Gemini-Sichtung abwarten
- [ ] PR-Pipeline-Checks grün (Frontend-Touches → `needs-frontend-ci`; Backend-/E2E-Smokes via `needs-*-ci` ggf. geskippt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)