### PR TITLE
fix(hardening): jobs.enqueue stub + RunRegistry-Authority for Task lookup (PR 2)

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -7,7 +7,6 @@ import io
 import json
 import os
 import time
-import threading
 from flask import Response, request, current_app
 
 from . import graph_bp
@@ -778,9 +777,9 @@ def build_graph():
                 error=str(e),
             )
 
-    # Start background thread
-    thread = threading.Thread(target=build_task, daemon=True)
-    thread.start()
+    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
+    from ..jobs import enqueue
+    enqueue("graph_build", build_task)
 
     return json_success({
         "project_id": project_id,

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -6,7 +6,6 @@ Provides interfaces for simulation report generation, retrieval, and conversatio
 import io
 import json
 import os
-import threading
 import uuid
 import zipfile
 from datetime import datetime, timezone
@@ -302,8 +301,9 @@ def generate_report():
             )
             task_manager.fail_task(task_id, str(e))
 
-    thread = threading.Thread(target=run_generate, daemon=True)
-    thread.start()
+    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
+    from ..jobs import enqueue
+    enqueue("report_generate", run_generate)
 
     return json_success({
         "simulation_id": simulation_id,

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -3,7 +3,6 @@ Preparation-related simulation API routes split from the main module.
 """
 
 import os
-import threading
 from typing import Any, Optional
 
 from flask import request
@@ -496,8 +495,9 @@ def prepare_simulation():
                 failed_state.error = str(exc)
                 manager._set_status(failed_state, SimulationStatus.FAILED)
 
-    thread = threading.Thread(target=run_prepare, daemon=True)
-    thread.start()
+    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
+    from ..jobs import enqueue
+    enqueue("simulation_prepare", run_prepare)
 
     return json_success({
         "simulation_id": simulation_id,

--- a/backend/app/jobs/__init__.py
+++ b/backend/app/jobs/__init__.py
@@ -1,0 +1,90 @@
+"""
+Background-job dispatch — single point of change.
+
+Today: ``threading.Thread(daemon=True)`` per job.
+Future: RQ (``rq.Queue.enqueue``) — Wave 2 / PR Redis-Queue.
+
+Migration plan:
+  1. Add ``redis_url = Config.REDIS_URL`` and ``rq.Queue(connection=...)`` init.
+  2. Flip ``_BACKEND = "rq"``.
+  3. Implement ``_enqueue_rq()`` with the same signature as ``_enqueue_thread()``.
+  4. Remove the thread-backend fallback once the RQ worker is deployed.
+
+Ref: agora_code_review_2026-05-17.md §1.3 — Daemon-Threads im Webprozess.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from typing import Any, Callable
+
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.jobs")
+
+# Switch to "rq" once the Redis-Queue worker is deployed (Wave 2 / PR 5).
+_BACKEND: str = "thread"
+
+
+def _enqueue_thread(
+    job_id: str,
+    job_name: str,
+    target: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    """Launch *target* in a daemon thread.  Errors are caught and logged."""
+
+    def _wrapper() -> None:
+        try:
+            target(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "job failed job_name=%s job_id=%s error=%s",
+                job_name,
+                job_id,
+                exc,
+                exc_info=True,
+            )
+
+    thread = threading.Thread(target=_wrapper, daemon=True)
+    thread.start()
+
+
+def enqueue(
+    job_name: str,
+    target: Callable[..., Any],
+    *args: Any,
+    run_id: str | None = None,
+    **kwargs: Any,
+) -> str:
+    """Dispatch *target* as a background job.
+
+    Args:
+        job_name: Human-readable name used in logs and future queue routing.
+        target:   Callable to execute in the background.
+        *args:    Positional arguments forwarded to *target*.
+        run_id:   Optional run-registry ID for correlation (unused today,
+                  will be forwarded to the RQ job context in Wave 2).
+        **kwargs: Keyword arguments forwarded to *target*.
+
+    Returns:
+        A stable ``job_id`` of the form ``job_<12-hex-chars>``.
+    """
+    job_id = f"job_{uuid.uuid4().hex[:12]}"
+
+    logger.info(
+        "enqueued job=%s job_id=%s backend=%s run_id=%s",
+        job_name,
+        job_id,
+        _BACKEND,
+        run_id,
+    )
+
+    if _BACKEND == "thread":
+        _enqueue_thread(job_id, job_name, target, args, kwargs)
+    else:
+        raise NotImplementedError(f"Unknown job backend: {_BACKEND!r}")
+
+    return job_id

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -108,7 +108,7 @@ class TaskManager:
 
         return task_id
 
-    def _task_from_run_manifest(self, run: Dict[str, Any]) -> Optional["Task"]:
+    def _task_from_run_manifest(self, run: Dict[str, Any]) -> "Task":
         """Reconstruct a Task from a RunRegistry manifest.
 
         The reconstructed task is NOT written back into the in-memory cache
@@ -136,13 +136,16 @@ class TaskManager:
             or "unknown"
         )
 
+        # TypeError fängt korrupte Manifeste mit None-Zeitstempel ab —
+        # RunRegistry kann started_at/updated_at als None zurückgeben,
+        # bevor der erste update_run-Aufruf das Feld füllt.
         try:
             created_at = datetime.fromisoformat(run["started_at"])
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError):
             created_at = datetime.now()
         try:
             updated_at = datetime.fromisoformat(run["updated_at"])
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError):
             updated_at = datetime.now()
 
         linked_ids = run.get("linked_ids", {})

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -10,6 +10,10 @@ from enum import Enum
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, field
 
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.task_manager")
+
 
 class TaskStatus(str, Enum):
     """Task status enumeration"""
@@ -99,15 +103,80 @@ class TaskManager:
         try:
             from ..services.run_registry import RunRegistry
             RunRegistry().sync_task(task)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("sync_task failed on create_task task_id=%s: %s", task_id, exc)
 
         return task_id
 
+    def _task_from_run_manifest(self, run: Dict[str, Any]) -> Optional["Task"]:
+        """Reconstruct a Task from a RunRegistry manifest.
+
+        The reconstructed task is NOT written back into the in-memory cache
+        (Stateless-Probe principle from PR 1 / Gemini review).
+        """
+        raw_status = run.get("status", "pending")
+        # Status mapping: paused → PROCESSING (preserve pause semantics),
+        # stopped → FAILED (terminal state, run was aborted).
+        status_map: Dict[str, TaskStatus] = {
+            "pending": TaskStatus.PENDING,
+            "processing": TaskStatus.PROCESSING,
+            "completed": TaskStatus.COMPLETED,
+            "failed": TaskStatus.FAILED,
+            "paused": TaskStatus.PROCESSING,
+            "stopped": TaskStatus.FAILED,
+        }
+        status = status_map.get(raw_status, TaskStatus.PENDING)
+        error: Optional[str] = run.get("error")
+        if raw_status == "stopped" and not error:
+            error = "stopped"
+
+        task_type: str = (
+            run.get("metadata", {}).get("task_type")
+            or run.get("run_type")
+            or "unknown"
+        )
+
+        try:
+            created_at = datetime.fromisoformat(run["started_at"])
+        except (KeyError, ValueError):
+            created_at = datetime.now()
+        try:
+            updated_at = datetime.fromisoformat(run["updated_at"])
+        except (KeyError, ValueError):
+            updated_at = datetime.now()
+
+        linked_ids = run.get("linked_ids", {})
+        task_id = linked_ids.get("task_id") or run.get("run_id", "")
+
+        return Task(
+            task_id=task_id,
+            task_type=task_type,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+            progress=run.get("progress") or 0,
+            message=run.get("message") or "",
+            error=error,
+            metadata=run.get("metadata", {}),
+        )
+
     def get_task(self, task_id: str) -> Optional[Task]:
-        """Get task"""
+        """Get task — cache first, then RunRegistry fallback."""
         with self._task_lock:
-            return self._tasks.get(task_id)
+            cached = self._tasks.get(task_id)
+            if cached is not None:
+                return cached
+
+        # Cache miss — attempt reconstruction from RunRegistry.
+        try:
+            from ..services.run_registry import RunRegistry
+            matches = RunRegistry().find_by_linked_id("task_id", task_id)
+            if matches:
+                return self._task_from_run_manifest(matches[0])
+        except Exception as exc:
+            logger.warning("RunRegistry fallback failed for task_id=%s: %s", task_id, exc)
+
+        return None
 
     def update_task(
         self,
@@ -150,8 +219,8 @@ class TaskManager:
                 try:
                     from ..services.run_registry import RunRegistry
                     RunRegistry().sync_task(task)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("sync_task failed on update_task task_id=%s: %s", task_id, exc)
 
     def complete_task(self, task_id: str, result: Dict):
         """Mark task as completed"""

--- a/backend/tests/api/test_graph_build_routing.py
+++ b/backend/tests/api/test_graph_build_routing.py
@@ -81,7 +81,8 @@ def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
     monkeypatch.setattr("app.api.graph.resolve_route_api_key", lambda *_a, **_k: "sk-route")
     monkeypatch.setattr("app.api.graph.LLMClient.from_route", lambda *a, **k: fake_llm_client)
     monkeypatch.setattr("app.api.graph.NERExtractor", fake_ner_extractor)
-    monkeypatch.setattr("app.api.graph.threading.Thread.start", run_inline)
+    # PR 2: Thread-Start liegt jetzt in app.jobs.enqueue (single point of change).
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
     monkeypatch.setattr("app.api.graph.run_registry.create_run", lambda *a, **k: {"run_id": "run_graph_1"})
     monkeypatch.setattr("app.api.graph.run_registry.update_run", lambda *a, **k: None)
 

--- a/backend/tests/api/test_provider_override_key_fallback.py
+++ b/backend/tests/api/test_provider_override_key_fallback.py
@@ -132,7 +132,7 @@ def test_override_uses_db_key_when_payload_key_empty(prepare_client, monkeypatch
     fake_manager.prepare_simulation.side_effect = fake_prepare
     monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
     monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
-    monkeypatch.setattr("app.api.simulation_prepare.threading.Thread.start", lambda self: self.run())
+    monkeypatch.setattr("app.jobs.threading.Thread.start", lambda self: self.run())
 
     resp = prepare_client.post(
         "/api/simulation/prepare",
@@ -189,7 +189,7 @@ def test_override_prefers_explicit_payload_key_over_db_key(prepare_client, monke
     fake_manager.prepare_simulation.side_effect = fake_prepare
     monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
     monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
-    monkeypatch.setattr("app.api.simulation_prepare.threading.Thread.start", lambda self: self.run())
+    monkeypatch.setattr("app.jobs.threading.Thread.start", lambda self: self.run())
 
     resp = prepare_client.post(
         "/api/simulation/prepare",
@@ -290,7 +290,7 @@ def test_override_no_key_required_for_local_ollama(prepare_client, monkeypatch):
     fake_manager.prepare_simulation.side_effect = fake_prepare
     monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
     monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
-    monkeypatch.setattr("app.api.simulation_prepare.threading.Thread.start", lambda self: self.run())
+    monkeypatch.setattr("app.jobs.threading.Thread.start", lambda self: self.run())
 
     resp = prepare_client.post(
         "/api/simulation/prepare",

--- a/backend/tests/api/test_report_modes.py
+++ b/backend/tests/api/test_report_modes.py
@@ -113,7 +113,8 @@ def _patched_generate():
         patch("app.api.report.ProjectManager") as mock_pm,
         patch("app.api.report.TaskManager") as mock_tm,
         patch("app.api.report.run_registry") as mock_rr,
-        patch("app.api.report.threading.Thread") as mock_thread,
+        # PR 2: Thread-Start liegt jetzt in app.jobs.enqueue.
+        patch("app.jobs.threading.Thread") as mock_thread,
         patch("app.api.report.resolve_route_api_key", return_value="sk-route"),
         patch("app.api.report.LLMClient.from_route", return_value=MagicMock()),
         patch("app.api.report.StageModelRouter") as mock_smr,

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -95,7 +95,8 @@ def test_prepare_endpoint_uses_resolved_route_for_legacy_service_call(client, mo
         "app.api.simulation_prepare.run_registry.create_run",
         lambda *a, **k: {"run_id": "run_prepare_1"},
     )
-    monkeypatch.setattr("app.api.simulation_prepare.threading.Thread.start", run_inline)
+    # PR 2: Thread-Start liegt jetzt in app.jobs.enqueue (single point of change).
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
     monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
 
     response = client.post(

--- a/backend/tests/services/test_jobs_enqueue.py
+++ b/backend/tests/services/test_jobs_enqueue.py
@@ -1,0 +1,139 @@
+"""
+Tests for backend/app/jobs/__init__.py — enqueue() stub.
+
+Spec: jobs.enqueue() is the single point of change for background-job dispatch.
+Today: threading.Thread(daemon=True). Future: RQ (Wave 2).
+
+Ref: agora_code_review_2026-05-17.md §1.3
+"""
+
+import logging
+import re
+import threading
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def attach_caplog_to_agora_jobs(caplog):
+    """
+    setup_logger() sets propagate=False on agora.* loggers so pytest caplog
+    (which hooks the root logger) misses records.  We attach caplog's handler
+    directly to the agora.jobs logger for the duration of each test.
+    """
+    jobs_logger = logging.getLogger("agora.jobs")
+    jobs_logger.addHandler(caplog.handler)
+    orig_level = jobs_logger.level
+    jobs_logger.setLevel(logging.DEBUG)
+    yield
+    jobs_logger.removeHandler(caplog.handler)
+    jobs_logger.setLevel(orig_level)
+
+
+# ---------------------------------------------------------------------------
+# 1. ID format
+# ---------------------------------------------------------------------------
+
+def test_enqueue_returns_unique_job_id_with_prefix():
+    from app.jobs import enqueue
+
+    id1 = enqueue("test_job_a", lambda: None)
+    id2 = enqueue("test_job_b", lambda: None)
+
+    assert re.match(r"^job_[0-9a-f]{12}$", id1), f"unexpected id: {id1!r}"
+    assert re.match(r"^job_[0-9a-f]{12}$", id2), f"unexpected id: {id2!r}"
+    assert id1 != id2
+
+
+# ---------------------------------------------------------------------------
+# 2. args/kwargs forwarding
+# ---------------------------------------------------------------------------
+
+def test_enqueue_runs_target_with_args_and_kwargs():
+    from app.jobs import enqueue
+
+    results: list = []
+    done = threading.Event()
+
+    def my_target(a, b, *, keyword):
+        results.append((a, b, keyword))
+        done.set()
+
+    enqueue("test_job", my_target, "alpha", "beta", keyword="gamma")
+
+    assert done.wait(timeout=1.0), "target never executed within 1 s"
+    assert results == [("alpha", "beta", "gamma")]
+
+
+# ---------------------------------------------------------------------------
+# 3. daemon=True
+# ---------------------------------------------------------------------------
+
+def test_enqueue_target_runs_in_daemon_thread():
+    from app.jobs import enqueue
+
+    created_threads: list[threading.Thread] = []
+    original_init = threading.Thread.__init__
+
+    def capture_init(self, *a, **kw):
+        original_init(self, *a, **kw)
+        created_threads.append(self)
+
+    with patch.object(threading.Thread, "__init__", capture_init):
+        enqueue("test_daemon_job", lambda: None)
+
+    assert created_threads, "no Thread was constructed"
+    assert all(t.daemon for t in created_threads), "Thread must be daemon=True"
+
+
+# ---------------------------------------------------------------------------
+# 4. log at INFO
+# ---------------------------------------------------------------------------
+
+def test_enqueue_logs_at_info(caplog):
+    from app.jobs import enqueue
+
+    evt = threading.Event()
+
+    with caplog.at_level(logging.INFO, logger="agora.jobs"):
+        job_id = enqueue("my_special_job", lambda: evt.set())
+
+    evt.wait(timeout=1.0)
+
+    records = [r for r in caplog.records if r.name == "agora.jobs"]
+    assert records, "no log record from agora.jobs"
+    combined = " ".join(r.getMessage() for r in records)
+    assert "my_special_job" in combined, f"job_name missing in log: {combined!r}"
+    assert job_id in combined, f"job_id missing in log: {combined!r}"
+    assert records[0].levelno == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# 5. exception in target → logged as ERROR, not raised
+# ---------------------------------------------------------------------------
+
+def test_enqueue_propagates_exception_into_thread_log(caplog):
+    import time
+    from app.jobs import enqueue
+
+    done = threading.Event()
+
+    def boom():
+        done.set()
+        raise RuntimeError("intentional test failure")
+
+    with caplog.at_level(logging.ERROR, logger="agora.jobs"):
+        enqueue("failing_job", boom)
+
+    done.wait(timeout=1.0)
+    # Give the thread a moment to log after setting the event.
+    time.sleep(0.05)
+
+    error_records = [
+        r for r in caplog.records
+        if r.name == "agora.jobs" and r.levelno == logging.ERROR
+    ]
+    assert error_records, "expected an ERROR log from agora.jobs on target exception"
+    combined = " ".join(r.getMessage() for r in error_records)
+    assert "failing_job" in combined or "intentional test failure" in combined

--- a/backend/tests/services/test_run_registry_authority.py
+++ b/backend/tests/services/test_run_registry_authority.py
@@ -1,0 +1,178 @@
+"""
+Tests for RunRegistry-Authority: TaskManager.get_task() falls back to
+RunRegistry when the in-memory cache is empty (simulates worker restart).
+
+Ref: agora_code_review_2026-05-17.md §1.3 / PR 2 Scope
+"""
+
+import os
+import pytest
+
+from app.models.task import TaskManager, TaskStatus
+from app.services.run_registry import RunRegistry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — reset singletons between tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_singletons(tmp_path, monkeypatch):
+    """
+    Patch REGISTRY_DIR to tmp_path so tests never touch real disk state.
+    Reset both singletons before and after each test.
+    """
+    registry_dir = str(tmp_path / "run_registry")
+    os.makedirs(registry_dir, exist_ok=True)
+
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", registry_dir)
+    # Also patch Config.UPLOAD_FOLDER so RunRegistry.__new__ uses the same path
+    import app.config as cfg_module
+    monkeypatch.setattr(cfg_module.Config, "UPLOAD_FOLDER", str(tmp_path))
+
+    # Reset singletons BEFORE test
+    RunRegistry._instance = None
+    TaskManager._instance = None
+
+    yield
+
+    # Reset singletons AFTER test to avoid cross-test leakage
+    RunRegistry._instance = None
+    TaskManager._instance = None
+
+
+# ---------------------------------------------------------------------------
+# 1. Cache-first behaviour
+# ---------------------------------------------------------------------------
+
+def test_get_task_returns_dict_cache_first():
+    tm = TaskManager()
+    task_id = tm.create_task("graph_build", metadata={"project_id": "proj_1"})
+    tm.update_task(task_id, status=TaskStatus.PROCESSING, progress=55, message="halfway")
+
+    result = tm.get_task(task_id)
+    assert result is not None
+    assert result.status == TaskStatus.PROCESSING
+    assert result.progress == 55
+    assert result.message == "halfway"
+
+
+# ---------------------------------------------------------------------------
+# 2. Registry fallback after worker-reset
+# ---------------------------------------------------------------------------
+
+def test_get_task_falls_back_to_run_registry_after_reset():
+    registry = RunRegistry()
+    tm = TaskManager()
+
+    # First create the run (mirrors what API handler does before creating the task)
+    run = registry.create_run(
+        run_type="report_generate",
+        entity_id="proj_x",
+        status="pending",
+        metadata={"task_type": "report_generate"},
+    )
+    run_id = run["run_id"]
+
+    # Create task with run_id in metadata — mirrors the API handler pattern
+    task_id = tm.create_task("report_generate", metadata={"project_id": "proj_x", "run_id": run_id})
+
+    # Link task_id into the run (mirrors what API handler does after create_task)
+    registry.update_run(run_id, linked_ids={"task_id": task_id})
+
+    # Update task — this calls sync_task which updates the run via run_id in metadata
+    tm.update_task(task_id, status=TaskStatus.PROCESSING, progress=42, message="halfway")
+
+    # Simulate worker-reset: clear in-memory cache
+    TaskManager._instance._tasks.clear()
+
+    # get_task must reconstruct from registry via find_by_linked_id
+    result = TaskManager().get_task(task_id)
+
+    assert result is not None, "get_task returned None after cache clear"
+    assert result.status == TaskStatus.PROCESSING
+    assert result.progress == 42
+    assert result.message == "halfway"
+    assert result.task_type == "report_generate"
+
+
+# ---------------------------------------------------------------------------
+# 3. Neither cache nor registry → None
+# ---------------------------------------------------------------------------
+
+def test_get_task_returns_none_when_neither_cache_nor_registry_has_it():
+    import uuid
+    tm = TaskManager()
+    result = tm.get_task(str(uuid.uuid4()))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 4. TaskStatus canonical round-trip
+# ---------------------------------------------------------------------------
+
+def test_canonical_status_round_trip():
+    for status in TaskStatus:
+        value = status.value
+        reconstructed = TaskStatus(value)
+        assert reconstructed == status, f"Round-trip failed for {status}"
+
+
+# ---------------------------------------------------------------------------
+# 5. fail_task → reset → get_task preserves error
+# ---------------------------------------------------------------------------
+
+def test_failed_status_round_trip_preserves_error_message():
+    registry = RunRegistry()
+    tm = TaskManager()
+
+    run = registry.create_run(
+        run_type="simulation_prepare",
+        entity_id="p2",
+        status="pending",
+        metadata={"task_type": "simulation_prepare"},
+    )
+    run_id = run["run_id"]
+
+    task_id = tm.create_task("simulation_prepare", metadata={"project_id": "p2", "run_id": run_id})
+    registry.update_run(run_id, linked_ids={"task_id": task_id})
+
+    tm.fail_task(task_id, "something went wrong")
+
+    # Worker-reset
+    TaskManager._instance._tasks.clear()
+
+    result = TaskManager().get_task(task_id)
+    assert result is not None
+    assert result.status == TaskStatus.FAILED
+    assert result.error == "something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# 6. complete_task → reset → progress == 100
+# ---------------------------------------------------------------------------
+
+def test_completed_status_round_trip_preserves_progress_100():
+    registry = RunRegistry()
+    tm = TaskManager()
+
+    run = registry.create_run(
+        run_type="graph_build",
+        entity_id="p3",
+        status="pending",
+        metadata={"task_type": "graph_build"},
+    )
+    run_id = run["run_id"]
+
+    task_id = tm.create_task("graph_build", metadata={"project_id": "p3", "run_id": run_id})
+    registry.update_run(run_id, linked_ids={"task_id": task_id})
+
+    tm.complete_task(task_id, result={"nodes": 42})
+
+    # Worker-reset
+    TaskManager._instance._tasks.clear()
+
+    result = TaskManager().get_task(task_id)
+    assert result is not None
+    assert result.status == TaskStatus.COMPLETED
+    assert result.progress == 100


### PR DESCRIPTION
## Bezug

Code-Review 2026-05-17 (\`agora_code_review_2026-05-17.md\`):

- **Finding 1.3 (Vorbereitung)** — Daemon-Threads im Webprozess: Graph-Build, Simulation-Prepare und Report-Generate liefen direkt aus den Request-Handlern als `threading.Thread(daemon=True)`. Bei Worker-Restart sterben sie ohne Recovery. PR 2 zieht den Aufruf hinter ein einziges Helper-Modul, das später durch eine echte Redis-Queue ersetzt werden kann.
- **Vorbedingung für #1.2** — die mit PR 1 etablierte `--workers 1`-Strafe lässt sich erst dann wieder zurücknehmen, wenn der Task-Status nicht mehr ausschließlich prozesslokal liegt.

## Was

- **NEU `backend/app/jobs/__init__.py`** — Hilfsmodul mit `enqueue(job_name, target, *args, **kwargs)`-Stub. Heute synchron-im-Thread via `threading.Thread(daemon=True).start()`; sauber gekapselt in `_enqueue_thread`. Module-Konstante `_BACKEND = "thread"` markiert den Migrationsweg auf `_BACKEND = "rq"`. Logger `agora.jobs` mit INFO-Eintrag pro Enqueue und ERROR pro Target-Exception. Single point of change.
- **`backend/app/api/graph.py:782`, `backend/app/api/simulation_prepare.py:499`, `backend/app/api/report.py:305`** — direkter `threading.Thread`-Aufruf durch `enqueue("graph_build"|"simulation_prepare"|"report_generate", target)` ersetzt. `import threading` aus den drei API-Modulen entfernt.
- **`backend/app/models/task.py::TaskManager.get_task`** — Cache-Lookup zuerst (wie bisher); bei Miss fällt der Lookup auf `RunRegistry().find_by_linked_id("task_id", task_id)` zurück und rekonstruiert die Task via neuem Helper `_task_from_run_manifest`. Cache wird bewusst nicht wieder befüllt (Stateless-Probe-Prinzip aus PR 1). Damit überleben Task-Status-Polls einen Worker-Reset / Gunicorn-Recycle.
- **`backend/app/models/task.py`** — die beiden stillen `except Exception: pass` um `RunRegistry().sync_task` durch `logger.warning(...)` auf einem neuen Logger `agora.task_manager` ersetzt (Review §2.3).
- **`backend/tests/api/test_{graph_build_routing,simulation_prepare_routing,provider_override_key_fallback,report_modes}.py`** — 8 Monkeypatch-Pfade von `app.api.<modul>.threading.Thread.start` auf `app.jobs.threading.Thread.start` umgezogen. Der Thread-Mock-Punkt liegt jetzt am single point of change.

## Risiko & Rollback

- Additive Schicht (`app.jobs.enqueue`) ohne Verhaltensänderung — Tests pinnen, dass der Thread weiter Daemon-Thread ist und das Target mit den korrekten Args läuft.
- `TaskManager.get_task`-Fallback ist read-only auf RunRegistry; Mapping `paused → PROCESSING`, `stopped → FAILED` ist dokumentiert. Rollback: `git revert e6fb49f f90bee1`.
- `--workers 1`-Hardstop aus PR 1 bleibt bestehen, wird erst aufgehoben, wenn ApiKeysStore (PR 4) und SimulationRunner (eigener Slice nach PR 5) ebenfalls externalisiert sind.

## Verifikation

```bash
cd backend
uv run pytest tests/contracts/ tests/api/ tests/services/ tests/storage/ --no-header -q
# → 967 passed, 3 deselected
uv run ruff check app/ tests/
# → All checks passed
uv run mypy app
# → Success: no issues found in 178 source files
uv run python -m app.contracts.dump_schemas --check
# → alle 27 Schemas matchen
```

Neue Tests:

- `backend/tests/services/test_jobs_enqueue.py` (5 Tests) — job-id-Format, args/kwargs-Propagation, daemon=True, INFO-Log, ERROR-Log bei Target-Exception.
- `backend/tests/services/test_run_registry_authority.py` (6 Tests) — Cache-First, Fallback nach Reset, Round-Trip aller TaskStatus-Werte, error-Erhalt, progress=100 bei completed.

## Scope-Disziplin

PR 2 adressiert **nur** Finding 1.3 Vorbereitung. Echte RQ-Migration und SimulationRunner-Externalisierung folgen in separaten Slices nach PR 5. PR 3 (Graph-Build-Rollback) und PR 4 (Secret/Auth-Härtung) bleiben unberührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)