### PR TITLE
fix: clawpatch wave 5 — settings reconnect, command init, lint gate

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "vue-tsc --noEmit",
-    "check": "bun run typecheck && bun run test:coverage && bun run build"
+    "check": "bun run lint && bun run typecheck && bun run test:coverage && bun run build"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/frontend/src/store/__tests__/settings.spec.ts
+++ b/frontend/src/store/__tests__/settings.spec.ts
@@ -156,10 +156,10 @@ describe('useSettingsStore', () => {
     _fetchSettingsSchema.mockResolvedValue(buildSchemaResponse())
     _fetchSettings.mockResolvedValue(buildValuesResponse())
 
-    let errorHandler: (() => void) | undefined
+    let errorHandler: ((ev: Event) => void) | undefined
     const closeSpy = vi.fn()
     _openSettingsStream
-      .mockImplementationOnce(async (handlers?: { error?: () => void }) => {
+      .mockImplementationOnce(async (handlers?: { error?: (ev: Event) => void }) => {
         errorHandler = handlers?.error
         return { close: closeSpy }
       })
@@ -170,7 +170,10 @@ describe('useSettingsStore', () => {
     await store.connectStream()
     expect(store.streamState).toBe('open')
 
-    errorHandler?.()
+    // Synthetic error event without an EventSource target — exercises
+    // the path where ev.target is something else and we fall back to
+    // the cached eventSource ref for cleanup.
+    errorHandler?.(new Event('error'))
     expect(store.streamState).toBe('failed')
     expect(closeSpy).toHaveBeenCalledTimes(1)
 

--- a/frontend/src/store/__tests__/settings.spec.ts
+++ b/frontend/src/store/__tests__/settings.spec.ts
@@ -152,6 +152,33 @@ describe('useSettingsStore', () => {
     expect(_fetchSettings).toHaveBeenCalledTimes(2)
   })
 
+  it('connectStream kann nach EventSource-Fehler reconnecten', async () => {
+    _fetchSettingsSchema.mockResolvedValue(buildSchemaResponse())
+    _fetchSettings.mockResolvedValue(buildValuesResponse())
+
+    let errorHandler: (() => void) | undefined
+    const closeSpy = vi.fn()
+    _openSettingsStream
+      .mockImplementationOnce(async (handlers?: { error?: () => void }) => {
+        errorHandler = handlers?.error
+        return { close: closeSpy }
+      })
+      .mockImplementationOnce(async () => ({ close: vi.fn() }))
+
+    const store = useSettingsStore()
+    await store.loadSettings()
+    await store.connectStream()
+    expect(store.streamState).toBe('open')
+
+    errorHandler?.()
+    expect(store.streamState).toBe('failed')
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+
+    await store.connectStream()
+    expect(_openSettingsStream).toHaveBeenCalledTimes(2)
+    expect(store.streamState).toBe('open')
+  })
+
   it('fieldErrors mappt Backend-Validation auf den richtigen Key', async () => {
     _fetchSettingsSchema.mockResolvedValueOnce(buildSchemaResponse())
     _fetchSettings.mockResolvedValueOnce(buildValuesResponse())

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -217,7 +217,8 @@ export const useSettingsStore = defineStore('settings', () => {
   }
 
   async function connectStream(): Promise<void> {
-    if (eventSource !== null || streamState.value === 'connecting') return
+    if (streamState.value === 'connecting') return
+    if (eventSource !== null && streamState.value === 'open') return
     streamState.value = 'connecting'
     try {
       eventSource = await openSettingsStream({
@@ -227,11 +228,19 @@ export const useSettingsStore = defineStore('settings', () => {
           await loadSettings()
         },
         error: () => {
+          if (eventSource) {
+            eventSource.close()
+            eventSource = null
+          }
           streamState.value = 'failed'
         },
       })
       streamState.value = 'open'
     } catch {
+      if (eventSource) {
+        eventSource.close()
+        eventSource = null
+      }
       streamState.value = 'failed'
     }
   }

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -227,7 +227,14 @@ export const useSettingsStore = defineStore('settings', () => {
           if (!parsed.success || saving.value) return
           await loadSettings()
         },
-        error: () => {
+        error: (ev: Event) => {
+          // openSettingsStream awaits a signed ticket, so an EventSource
+          // error can fire before the outer eventSource ref is assigned.
+          // The event target carries the actual EventSource — close that
+          // one too, then drop the cached ref if it already pointed at us.
+          if (typeof EventSource !== 'undefined' && ev.target instanceof EventSource) {
+            ev.target.close()
+          }
           if (eventSource) {
             eventSource.close()
             eventSource = null
@@ -237,10 +244,6 @@ export const useSettingsStore = defineStore('settings', () => {
       })
       streamState.value = 'open'
     } catch {
-      if (eventSource) {
-        eventSource.close()
-        eventSource = null
-      }
       streamState.value = 'failed'
     }
   }

--- a/frontend/src/stores/commandsStore.ts
+++ b/frontend/src/stores/commandsStore.ts
@@ -119,63 +119,64 @@ export const useCommandsStore = defineStore('commands', () => {
     })
     stopPolling = stop
 
-    stopWatch = watch(
-      runs,
-      (currentRuns) => {
-        const cmds: Command[] = []
+    function rebuildDynamicCommands(currentRuns: readonly RunDetail[] | null | undefined): void {
+      const list = Array.isArray(currentRuns) ? currentRuns : []
+      const cmds: Command[] = []
 
-        for (const run of currentRuns) {
-          if (ACTIVE_STATUSES.has(run.status)) {
-            const label = runLabel(run)
-            const statusKey =
-              run.status === 'processing'
-                ? 'cmd.dynamic.statusRunning'
-                : run.status === 'paused'
-                  ? 'cmd.dynamic.statusPaused'
-                  : 'cmd.dynamic.statusPending'
-            const statusLabel = t(statusKey)
-            cmds.push({
-              id: `sim:${run.run_id}`,
-              label: t('cmd.dynamic.runLabel', { name: `${label} (${statusLabel})` }),
-              group: 'sim',
-              keywords: [run.run_id, run.entity_id, label, 'simulation', 'lauf', 'live', run.status],
-              action: () => {
-                router.push({
-                  name: 'StepSimulation',
-                  params: { simulationId: run.entity_id },
-                }).catch(() => {})
-              },
-            })
-          }
-        }
-
-        // Recent Reports: abgeschlossene Runs mit report_id, max 5
-        let reportCount = 0
-        for (const run of currentRuns) {
-          if (reportCount >= MAX_RECENT_REPORTS) break
-          if (run.status !== COMPLETED_STATUS) continue
-          const reportId = extractReportId(run)
-          if (!reportId) continue
+      for (const run of list) {
+        if (ACTIVE_STATUSES.has(run.status)) {
           const label = runLabel(run)
+          const statusKey =
+            run.status === 'processing'
+              ? 'cmd.dynamic.statusRunning'
+              : run.status === 'paused'
+                ? 'cmd.dynamic.statusPaused'
+                : 'cmd.dynamic.statusPending'
+          const statusLabel = t(statusKey)
           cmds.push({
-            id: `report:${reportId}`,
-            label: t('cmd.dynamic.reportLabel', { name: label }),
-            group: 'report',
-            keywords: [reportId, run.run_id, label, 'report', 'bericht', 'ergebnis'],
+            id: `sim:${run.run_id}`,
+            label: t('cmd.dynamic.runLabel', { name: `${label} (${statusLabel})` }),
+            group: 'sim',
+            keywords: [run.run_id, run.entity_id, label, 'simulation', 'lauf', 'live', run.status],
             action: () => {
               router.push({
-                name: 'StepReport',
-                params: { reportId },
+                name: 'StepSimulation',
+                params: { simulationId: run.entity_id },
               }).catch(() => {})
             },
           })
-          reportCount++
         }
+      }
 
-        dynamicCommands.value = cmds
-      },
-      { deep: true },
-    )
+      // Recent Reports: abgeschlossene Runs mit report_id, max 5
+      let reportCount = 0
+      for (const run of list) {
+        if (reportCount >= MAX_RECENT_REPORTS) break
+        if (run.status !== COMPLETED_STATUS) continue
+        const reportId = extractReportId(run)
+        if (!reportId) continue
+        const label = runLabel(run)
+        cmds.push({
+          id: `report:${reportId}`,
+          label: t('cmd.dynamic.reportLabel', { name: label }),
+          group: 'report',
+          keywords: [reportId, run.run_id, label, 'report', 'bericht', 'ergebnis'],
+          action: () => {
+            router.push({
+              name: 'StepReport',
+              params: { reportId },
+            }).catch(() => {})
+          },
+        })
+        reportCount++
+      }
+
+      dynamicCommands.value = cmds
+    }
+
+    stopWatch = watch(runs, rebuildDynamicCommands, { deep: true })
+    // Kick off once for already-loaded runs that arrived before bind.
+    rebuildDynamicCommands(runs.value)
   }
 
   /**


### PR DESCRIPTION
## Summary

Clawpatch wave 5 — drei Frontend-Fixes aus 3 Findings (Run `20260517T152337-a01115`, 5 features reviewed). Alle Findings als `fixed` triaged.

### Commits

- **`fix(settings)`** — `frontend/src/store/settings.ts`: `connectStream` blockierte Reconnects nach EventSource-Fehler. Error-Handler setzte nur `streamState='failed'`, ließ `eventSource` aber intact → der `eventSource !== null`-Guard verhinderte jeden weiteren Verbindungsversuch bis Page-Reload. Fix: Error-Handler + catch closen + nullen `eventSource`, Guard erlaubt Reconnect aus `'failed'`. Regression-Test eingebaut. Closes `fnd_sig-feat-service-d00b505426-b34b` (**confirmed-bug**, medium).
- **`fix(commands)`** — `frontend/src/stores/commandsStore.ts`: `bindDynamicCommands` registrierte `watch(runs, ...)` ohne Initialaufruf. Wenn `useRunsPolling().runs` zum Mount-Zeitpunkt bereits gefüllt war (Router-Transitions, Hot-Reload), blieben dynamische Sim-/Report-Commands leer bis zum nächsten Poll-Tick. Fix: Logik in `rebuildDynamicCommands()` ausfaktoriert, watch registrieren + danach einmal manuell aufrufen, plus `Array.isArray`-Guard. Closes `fnd_sig-feat-service-6a04483213-6062` (risk, low).
- **`chore(frontend)`** — `frontend/package.json`: `scripts.check` lief `typecheck → test:coverage → build`, aber kein `bun run lint`. ESLint rutschte am lokalen Gate vorbei. Fix: `bun run lint` als erster Step (fail-fast). Closes `fnd_sig-feat-release-3fe3353c48-ee4d` (risk, low).

### Hartanker (ADR-0002)

Keiner der 3 Findings tangiert die 5 Evidence-Gating-Anker. Backend unverändert.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test:coverage` — 1053 tests pass (incl. neuer SSE-Reconnect-Test)
- [x] `bun run build` — built in <1s
- [ ] Gemini-Sichtung abwarten
- [ ] PR-Pipeline-Checks grün (Frontend-Touches → `needs-frontend-ci`; Backend-/E2E-Smokes ggf. geskippt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)