### PR TITLE
fix(i18n): catch storage write failures (clawpatch wave 7)

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -6,7 +6,7 @@ const SUPPORTED: string[] = ['de', 'en']
 const STORAGE_KEY = 'agora.locale'
 const DEFAULT_LOCALE = 'de'
 
-function safeStorage(): Storage | null {
+function resolveStorage(): Storage | null {
   try {
     return typeof localStorage !== 'undefined' ? localStorage : null
   } catch {
@@ -14,13 +14,17 @@ function safeStorage(): Storage | null {
   }
 }
 
+// localStorage availability does not change during the page lifetime —
+// resolve once at module load instead of probing on every read/write.
+const storage: Storage | null = resolveStorage()
+
 function safeDocument(): Document | null {
   return typeof document !== 'undefined' ? document : null
 }
 
 function readStored(): string | null {
   try {
-    return safeStorage()?.getItem(STORAGE_KEY) ?? null
+    return storage?.getItem(STORAGE_KEY) ?? null
   } catch {
     return null
   }
@@ -28,7 +32,7 @@ function readStored(): string | null {
 
 function writeStored(locale: string): void {
   try {
-    safeStorage()?.setItem(STORAGE_KEY, locale)
+    storage?.setItem(STORAGE_KEY, locale)
   } catch {
     // Quota exceeded / Safari private mode / SecurityError — locale change
     // remains in-memory + document.lang; persistence is best-effort.

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -18,9 +18,25 @@ function safeDocument(): Document | null {
   return typeof document !== 'undefined' ? document : null
 }
 
+function readStored(): string | null {
+  try {
+    return safeStorage()?.getItem(STORAGE_KEY) ?? null
+  } catch {
+    return null
+  }
+}
+
+function writeStored(locale: string): void {
+  try {
+    safeStorage()?.setItem(STORAGE_KEY, locale)
+  } catch {
+    // Quota exceeded / Safari private mode / SecurityError — locale change
+    // remains in-memory + document.lang; persistence is best-effort.
+  }
+}
+
 function detectLocale(): string {
-  const storage = safeStorage()
-  const stored = storage?.getItem(STORAGE_KEY)
+  const stored = readStored()
   if (stored && SUPPORTED.includes(stored)) return stored
   return DEFAULT_LOCALE
 }
@@ -36,7 +52,7 @@ const i18n = createI18n({
 export function setLocale(locale: string): void {
   if (!SUPPORTED.includes(locale)) return
   i18n.global.locale.value = locale as 'de' | 'en'
-  safeStorage()?.setItem(STORAGE_KEY, locale)
+  writeStored(locale)
   safeDocument()?.documentElement.setAttribute('lang', locale)
 }
 


### PR DESCRIPTION
## Summary

Wave 7 — kleiner Follow-up zur Wave-3-i18n-Robustness-Slice (Run `20260517T165307-9d98a3`, 3 changed features re-reviewed nach `clawpatch map`).

Wave 3 hatte `localStorage.getItem` per `safeStorage()` gewrappt, aber `setItem` als Direktaufruf gelassen. In quota-exceeded-States, Safari Private Mode oder SecurityError-Umgebungen kann `setLocale` deshalb noch immer crashen, obwohl `localStorage` existiert.

### Commit

- **`fix(i18n)`** — `readStored()` / `writeStored()` Helper wrappen `getItem` / `setItem` jeweils in eigene try/catch. `detectLocale` fällt auf `DEFAULT_LOCALE` zurück, `setLocale` ist persistenz-best-effort; UI-Locale + `document.lang` ändern sich auch bei Storage-Fehler. Closes `fnd_sig-feat-library-c30719e668-9244` (**confirmed-bug**, medium).

### Out of scope (separat tracken)

Zwei verwandte API-Layer-Findings aus dem gleichen Run wurden als `uncertain` triaged und brauchen eine eigene Slice mit Plan/Brainstorm (Type-Contract zwischen Axios-Interceptor und Caller-Typings betrifft 4+ Files mit hohem Refactor-Risiko):

- `fnd_sig-feat-library-187e61ce8e-28ed` — direct-payload-Type-Contract vs. envelope-unwrapped interceptor
- `fnd_sig-feat-library-187e61ce8e-7edf` — LLM-API-Clients typisiert gegen Axios-Response-Shape

### Hartanker (ADR-0002)

Keiner der Findings tangiert die 5 Evidence-Gating-Anker.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test src/i18n` — 20/20 pass (Wave-3-Snapshot-Tests bleiben grün)
- [x] `bun run test` (full) — 1053/1053 pass
- [x] `bun run build` — clean
- [ ] Gemini-Sichtung abwarten
- [ ] PR-Pipeline-Checks grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)