### PR TITLE
fix(llm-routing): Build/Sim/Report ehren persistiertes LLM-Profil + UI-Konsolidierung

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -369,6 +369,12 @@ def generate_ontology():
     # keinen Override mitschickt. Secrets bleiben ausserhalb (redacted_metadata).
     project.llm_model = llm_model_override
     project.llm_provider = llm_runtime.redacted_metadata() or None
+    # P5.3-Fix: aktives Profil am Projekt persistieren, damit spätere Stages
+    # (build_graph, simulation_prepare, report) das Profil auch dann ehren, wenn
+    # der Folge-Request kein eigenes `llm_profile_id` mehr mitschickt
+    # (Frontend setzt bei Profil-Auswahl `STORAGE_MODEL=default` und sendet
+    # daher leeres llm_model an /api/graph/build).
+    project.llm_profile_id = llm_profile_id
     ProjectManager.save_project(project)
     run_registry.update_run(
         run_id,
@@ -423,11 +429,34 @@ def _validate_build_request(data: dict):
 
 
 def _resolve_llm_overrides(data: dict, project):
-    """Parse llm_model / llm_provider from *data* and build RuntimeLlmConfig.
+    """Parse llm_model / llm_provider / llm_profile_id from *data* and project.
 
-    Returns ``(llm_runtime, llm_model_override, error_response)`` where
-    *error_response* is ``None`` on success.
+    Returns ``(llm_runtime, llm_model_override, resolved_profile, error_response)``
+    where *error_response* is ``None`` on success. *resolved_profile* is a
+    ``LlmProfile`` (with API key) or ``None`` when no profile pathway applies.
     """
+    # P5.3-Fix: explizites Profil im Request bevorzugen, sonst auf das am
+    # Projekt persistierte Profil aus dem Ontology-Schritt zurückfallen.
+    # Ohne diesen Fallback fällt die Build-Stufe auf den Server-Default
+    # (LLM_MODEL_NAME) zurück, weil das Frontend bei Profil-Auswahl
+    # `STORAGE_MODEL=default` setzt und damit kein llm_model mehr mitschickt.
+    requested_profile_id = (data.get('llm_profile_id') or '').strip() or None
+    effective_profile_id = requested_profile_id or getattr(project, 'llm_profile_id', None)
+    resolved_profile = None
+    if effective_profile_id:
+        from ..services.llm_profiles_store import get_llm_profiles_store
+        resolved_profile = get_llm_profiles_store().get(
+            effective_profile_id, include_api_key=True
+        )
+        if resolved_profile is None:
+            return None, None, None, json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=404,
+                message=f"LLM profile {effective_profile_id!r} not found",
+            )
+        # Bei Profil-Pfad bypassen wir den Stage-Router (Parität zu generate_ontology).
+        # Keine expand_profile_in_data hier — den Profil-Client baut _make_ner_override.
+
     # UI sendet bei Profile-Auswahl `llm_model = "profile:<id>"`. Helper expandiert
     # das in echtes Modell + provider/api_key/base_url aus dem Store, damit die
     # restliche Pipeline (NER, Embedding, Report) den Profile-Mechanismus nicht
@@ -444,13 +473,13 @@ def _resolve_llm_overrides(data: dict, project):
     try:
         llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
     except ValueError as exc:
-        return None, None, json_error(
+        return None, None, None, json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=400,
             message=str(exc),
         )
 
-    return llm_runtime, llm_model_override, None
+    return llm_runtime, llm_model_override, resolved_profile, None
 
 
 def _check_project_state_for_build(project, force: bool):
@@ -552,19 +581,37 @@ def _create_build_run_record(project_id: str, project, graph_name: str, task_man
     return run_record, task_id
 
 
-def _make_ner_override_from_route(run_id: str, resolved_route, llm_runtime) -> NERExtractor:
-    """Build a dedicated NERExtractor from the resolved per-run route."""
-    ner_llm_client = LLMClient.from_route(
-        resolved_route,
-        secret_resolver=SecretResolver(),
-        api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
-        run_id=run_id,
-    )
-    logger.info(
-        "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s",
-        ner_llm_client.model,
-        resolved_route.provider_id,
-    )
+def _make_ner_override(
+    run_id: str,
+    resolved_route,
+    llm_runtime,
+    resolved_profile=None,
+) -> NERExtractor:
+    """Build a NERExtractor — Profil-Pfad bevorzugt, sonst Route-Snapshot."""
+    if resolved_profile is not None:
+        # P5.3-Fix: Profil-Bindung an NER-Stage. Ohne diesen Pfad fiel der
+        # Build auf den Server-Default zurück, sobald das Profil-Modell nicht
+        # in der Stage-Routing-Tabelle existierte (Ollama Cloud / OpenAI /
+        # Gemini-Profile produzierten `nodes=0, edges=0`).
+        from ..utils.llm_client import build_client_from_profile
+        ner_llm_client = build_client_from_profile(resolved_profile, run_id=run_id)
+        logger.info(
+            "Build-Pfad nutzt LLM-Profil: provider=%s model=%s",
+            resolved_profile.provider,
+            resolved_profile.model_name,
+        )
+    else:
+        ner_llm_client = LLMClient.from_route(
+            resolved_route,
+            secret_resolver=SecretResolver(),
+            api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
+            run_id=run_id,
+        )
+        logger.info(
+            "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s",
+            ner_llm_client.model,
+            resolved_route.provider_id,
+        )
     return NERExtractor(llm_client=ner_llm_client)
 
 
@@ -585,7 +632,7 @@ def build_graph():
     if err is not None:
         return err
 
-    llm_runtime, llm_model_override, err = _resolve_llm_overrides(data, project)
+    llm_runtime, llm_model_override, resolved_profile, err = _resolve_llm_overrides(data, project)
     if err is not None:
         return err
 
@@ -622,10 +669,11 @@ def build_graph():
     resolved_route = route_router.resolve("graph_build")
     route_router.lock_stage("graph_build", resolved_route)
 
-    ner_override: NERExtractor = _make_ner_override_from_route(
+    ner_override: NERExtractor = _make_ner_override(
         run_record["run_id"],
         resolved_route,
         llm_runtime,
+        resolved_profile=resolved_profile,
     )
 
     # Start background task

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -436,12 +436,15 @@ def _resolve_llm_overrides(data: dict, project):
     ``LlmProfile`` (with API key) or ``None`` when no profile pathway applies.
     """
     # P5.3-Fix: explizites Profil im Request bevorzugen, sonst auf das am
-    # Projekt persistierte Profil aus dem Ontology-Schritt zurückfallen.
-    # Ohne diesen Fallback fällt die Build-Stufe auf den Server-Default
-    # (LLM_MODEL_NAME) zurück, weil das Frontend bei Profil-Auswahl
-    # `STORAGE_MODEL=default` setzt und damit kein llm_model mehr mitschickt.
+    # Projekt persistierte Profil aus dem Ontology-Schritt zurückfallen —
+    # ABER nur, wenn der Request kein eigenes Modell mitgibt (Gemini-HIGH
+    # auf PR #528: sonst überstimmt das Projekt-Profil einen expliziten
+    # Single-Run-Override aus dem Frontend).
     requested_profile_id = (data.get('llm_profile_id') or '').strip() or None
-    effective_profile_id = requested_profile_id or getattr(project, 'llm_profile_id', None)
+    requested_model = (data.get('llm_model') or '').strip() or None
+    effective_profile_id = requested_profile_id
+    if not effective_profile_id and (not requested_model or requested_model.lower() == 'default'):
+        effective_profile_id = getattr(project, 'llm_profile_id', None)
     resolved_profile = None
     if effective_profile_id:
         from ..services.llm_profiles_store import get_llm_profiles_store

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -169,7 +169,14 @@ def generate_report():
     # persistierte Profil aus dem Ontology-Schritt verwenden — sonst fällt
     # die Report-Stufe auf den Server-Default zurück, sobald das Frontend
     # bei Profil-Auswahl `llm_model=default` sendet.
-    if _resolved_profile is None and not llm_profile_id and getattr(project, 'llm_profile_id', None):
+    # Gemini-HIGH auf PR #528: Fallback respektiert expliziten Modell-Override,
+    # damit ein Single-Run-Wechsel über llm_model das Projekt-Profil nicht überstimmt.
+    if (
+        _resolved_profile is None
+        and not llm_profile_id
+        and (not llm_model_override or llm_model_override.lower() == 'default')
+        and getattr(project, 'llm_profile_id', None)
+    ):
         from ..services.llm_profiles_store import get_llm_profiles_store
         llm_profile_id = project.llm_profile_id
         _resolved_profile = get_llm_profiles_store().get(llm_profile_id, include_api_key=True)

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -165,6 +165,21 @@ def generate_report():
     if not project:
         return json_error(f"Project does not exist: {state.project_id}", status=404)
 
+    # P5.3-Fix: Wenn Request kein Profil mitschickt, das im Projekt
+    # persistierte Profil aus dem Ontology-Schritt verwenden — sonst fällt
+    # die Report-Stufe auf den Server-Default zurück, sobald das Frontend
+    # bei Profil-Auswahl `llm_model=default` sendet.
+    if _resolved_profile is None and not llm_profile_id and getattr(project, 'llm_profile_id', None):
+        from ..services.llm_profiles_store import get_llm_profiles_store
+        llm_profile_id = project.llm_profile_id
+        _resolved_profile = get_llm_profiles_store().get(llm_profile_id, include_api_key=True)
+        if _resolved_profile is None:
+            logger.warning(
+                "Project %s referenziert unbekanntes LLM-Profil %r — Fallback auf Stage-Routing",
+                state.project_id, llm_profile_id,
+            )
+            llm_profile_id = None
+
     graph_id = state.graph_id or project.graph_id
     if not graph_id:
         return json_error("Missing graph ID, please ensure graph is built", status=400)

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -247,16 +247,29 @@ def prepare_simulation():
         )
 
     force_regenerate = data.get('force_regenerate', False)
+
+    # Project einmalig laden — wird sowohl für den P5.3-Profil-Fallback als
+    # auch für die Anforderungs-Validierung (simulation_requirement) und das
+    # nachfolgende Lesen weiterer Felder benötigt (Gemini-MEDIUM auf PR #528:
+    # vorher wurde derselbe Datensatz zwei Mal aus dem ProjectManager geholt).
+    project = ProjectManager.get_project(state.project_id)
+    if not project:
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message=f"Project does not exist: {state.project_id}",
+        )
+
     # P5.3-Fix: Wenn Request kein Profil mitschickt (Frontend setzt bei
     # Profil-Auswahl `STORAGE_MODEL=default`), das im Projekt persistierte
     # Profil aus dem Ontology-Schritt als Default injizieren — sonst landet
-    # die Sim-Vorbereitung im Server-Default-Modell.
+    # die Sim-Vorbereitung im Server-Default-Modell. Respektiert expliziten
+    # Single-Run-Override (analog graph.py / report.py).
     _data_profile = (data.get('llm_profile_id') or '').strip() or None
     _data_model = (data.get('llm_model') or '').strip() or None
     if not _data_profile and (not _data_model or _data_model.lower() == 'default'):
-        _early_project = ProjectManager.get_project(state.project_id)
-        if _early_project is not None and getattr(_early_project, 'llm_profile_id', None):
-            data['llm_model'] = f"profile:{_early_project.llm_profile_id}"
+        if getattr(project, 'llm_profile_id', None):
+            data['llm_model'] = f"profile:{project.llm_profile_id}"
     # UI-Profile-Token in echtes Modell + Provider-Creds expandieren.
     from ..utils.llm_profile_resolver import expand_profile_in_data
     expand_profile_in_data(data)
@@ -288,14 +301,6 @@ def prepare_simulation():
                 "prepare_info": prepare_info,
             })
         logger.info(f"Simulation {simulation_id} has no preparation complete, preparing now")
-
-    project = ProjectManager.get_project(state.project_id)
-    if not project:
-        return json_error(
-            ApiErrorCode.NOT_FOUND,
-            status=404,
-            message=f"Project does not exist: {state.project_id}",
-        )
 
     simulation_requirement = project.simulation_requirement or ""
     if not simulation_requirement:

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -247,6 +247,16 @@ def prepare_simulation():
         )
 
     force_regenerate = data.get('force_regenerate', False)
+    # P5.3-Fix: Wenn Request kein Profil mitschickt (Frontend setzt bei
+    # Profil-Auswahl `STORAGE_MODEL=default`), das im Projekt persistierte
+    # Profil aus dem Ontology-Schritt als Default injizieren — sonst landet
+    # die Sim-Vorbereitung im Server-Default-Modell.
+    _data_profile = (data.get('llm_profile_id') or '').strip() or None
+    _data_model = (data.get('llm_model') or '').strip() or None
+    if not _data_profile and (not _data_model or _data_model.lower() == 'default'):
+        _early_project = ProjectManager.get_project(state.project_id)
+        if _early_project is not None and getattr(_early_project, 'llm_profile_id', None):
+            data['llm_model'] = f"profile:{_early_project.llm_profile_id}"
     # UI-Profile-Token in echtes Modell + Provider-Creds expandieren.
     from ..utils.llm_profile_resolver import expand_profile_in_data
     expand_profile_in_data(data)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -80,7 +80,11 @@ class Config:
     # LLM configuration (unified OpenAI format)
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'http://localhost:11434/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'qwen2.5:32b')
+    # Leerer Default: Operator MUSS ein Modell setzen (ENV oder Settings-UI)
+    # oder ein LLM-Profil anlegen. Vorher führte `qwen2.5:32b` in Cloud-Setups
+    # (Ollama Cloud / OpenAI / Gemini) zu 404, weil das Auto-Bootstrap-Profil
+    # auf ein lokales Tag verwies, das im aktiven Backend nicht existiert.
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', '')
     # Completion-Limit fuer einzelne LLM-Antworten. CAMEL verwendet dieses
     # Feld leider auch als Default fuer sein Memory-Token-Limit, deshalb
     # trennen wir die eigentliche Memory-Grenze unten separat.

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -60,6 +60,10 @@ class Project:
     # abgelegt.
     llm_model: Optional[str] = None
     llm_provider: Optional[Dict[str, Any]] = None
+    # ID des persistierten LLM-Profils, das beim Ontology-Generate aktiv war.
+    # Spätere Stages (build_graph, simulation_prepare, report) ziehen dieses
+    # Profil als Default heran, wenn der Request kein eigenes Profil mitgibt.
+    llm_profile_id: Optional[str] = None
 
     # Error information
     error: Optional[str] = None
@@ -83,6 +87,7 @@ class Project:
             "chunk_overlap": self.chunk_overlap,
             "llm_model": self.llm_model,
             "llm_provider": self.llm_provider,
+            "llm_profile_id": self.llm_profile_id,
             "error": self.error
         }
     
@@ -110,6 +115,7 @@ class Project:
             chunk_overlap=data.get('chunk_overlap', 50),
             llm_model=data.get('llm_model'),
             llm_provider=data.get('llm_provider'),
+            llm_profile_id=data.get('llm_profile_id'),
             error=data.get('error')
         )
 

--- a/backend/app/services/llm_profiles_store.py
+++ b/backend/app/services/llm_profiles_store.py
@@ -61,15 +61,21 @@ def _row_to_profile(row: sqlite3.Row) -> LlmProfile:
     )
 
 
-def _bootstrap_profile() -> dict:
+def _bootstrap_profile() -> Optional[dict]:
     """Erzeugt Default-Profil aus LLM_*-Env-Variablen.
 
     Localhost-Falle: 'localhost' aus dem Host-.env resolved nicht innerhalb des
     Containers. Default daher 'host.docker.internal'; Provider-Detection muss
     den Host-Alias kennen.
+
+    Gibt ``None`` zurück, wenn kein ``LLM_MODEL_NAME`` gesetzt ist —
+    sonst entstand früher ein totes Auto-Profil mit Tag ``qwen2.5:32b``,
+    das in Cloud-Setups (Ollama Cloud / OpenAI / Gemini) zu 404 führte.
     """
     base_url = os.environ.get("LLM_BASE_URL", "http://host.docker.internal:11434/v1")
-    model = os.environ.get("LLM_MODEL_NAME", "qwen2.5:32b")
+    model = (os.environ.get("LLM_MODEL_NAME") or "").strip()
+    if not model:
+        return None
     if "openai.com" in base_url:
         provider = "openai"
     elif "googleapis.com" in base_url:
@@ -116,14 +122,15 @@ class LlmProfilesStore:
             ).fetchall()
             if not rows:
                 bp = _bootstrap_profile()
-                conn.execute(
-                    "INSERT INTO llm_profiles VALUES "
-                    "(:id,:name,:provider,:base_url,:model_name,:api_key,:is_default,:created_at,:updated_at)",
-                    bp,
-                )
-                rows = conn.execute(
-                    "SELECT * FROM llm_profiles ORDER BY created_at DESC"
-                ).fetchall()
+                if bp is not None:
+                    conn.execute(
+                        "INSERT INTO llm_profiles VALUES "
+                        "(:id,:name,:provider,:base_url,:model_name,:api_key,:is_default,:created_at,:updated_at)",
+                        bp,
+                    )
+                    rows = conn.execute(
+                        "SELECT * FROM llm_profiles ORDER BY created_at DESC"
+                    ).fetchall()
             return [_row_to_profile(r) for r in rows]
 
     def get(self, profile_id: str, include_api_key: bool = False) -> Optional[LlmProfile]:

--- a/backend/app/services/settings_schema.py
+++ b/backend/app/services/settings_schema.py
@@ -86,7 +86,11 @@ SETTINGS_FIELDS: tuple[FieldSpec, ...] = (
               reload_required=True),
     FieldSpec('LLM_BASE_URL', 'llm', 'string',
               default='http://localhost:11434/v1', reload_required=True),
-    FieldSpec('LLM_MODEL_NAME', 'llm', 'string', default='qwen2.5:32b'),
+    # Leerer Default — Bootstrap-Profil wird nur erzeugt, wenn der Operator
+    # ein konkretes Modell setzt. Vorher führte `qwen2.5:32b` zu 404 in
+    # Cloud-Setups (Ollama Cloud / OpenAI / Gemini), weil das Auto-Profil
+    # auf ein Tag verwies, das im aktiven Backend nicht existiert.
+    FieldSpec('LLM_MODEL_NAME', 'llm', 'string', default=''),
     FieldSpec('LLM_MAX_OUTPUT_TOKENS', 'llm', 'int', default=8192,
               min_value=128, max_value=131072),
     FieldSpec('LLM_CONTEXT_LIMIT', 'llm', 'int', default=262144,

--- a/backend/tests/api/test_graph_build_routing.py
+++ b/backend/tests/api/test_graph_build_routing.py
@@ -14,8 +14,13 @@ VALID_PROJECT_ID = "proj_0123456789ab"
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    # @require_scope("graph:write") greift nur, wenn AGORA_AUTH_TOKEN gesetzt ist.
+    # Im Open-Mode (leerer Token) erlaubt der Guard alle Calls — Routing-Logik
+    # selbst ist hier der Testfokus, nicht Auth.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     storage = MagicMock(name="Neo4jStorage")
     app.extensions = {"neo4j_storage": storage}
     app.register_blueprint(graph_bp, url_prefix="/api/graph")
@@ -33,6 +38,7 @@ def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
     fake_project.chunk_overlap = 50
     fake_project.llm_model = None
     fake_project.llm_provider = None
+    fake_project.llm_profile_id = None
 
     fake_builder = MagicMock()
     fake_builder.create_graph.return_value = "graph-123"
@@ -90,3 +96,96 @@ def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
 
     assert response.status_code == 200, response.get_json()
     assert captured_ner["llm_client"] is fake_llm_client
+
+
+def test_build_graph_uses_profile_when_set_on_project(client, monkeypatch):
+    """Wenn project.llm_profile_id gesetzt ist, baut build_graph den NER-Client
+    aus dem Profil — nicht aus dem Stage-Router-Default."""
+    fake_project = MagicMock()
+    fake_project.status = ProjectStatus.ONTOLOGY_GENERATED
+    fake_project.ontology = {"entity_types": [], "edge_types": []}
+    fake_project.graph_build_task_id = None
+    fake_project.graph_id = None
+    fake_project.name = "Profile Project"
+    fake_project.chunk_size = 500
+    fake_project.chunk_overlap = 50
+    fake_project.llm_model = None
+    fake_project.llm_provider = None
+    fake_project.llm_profile_id = "prof_xyz123"
+
+    fake_builder = MagicMock()
+    fake_builder.create_graph.return_value = "graph-456"
+    fake_builder.set_ontology.return_value = None
+    fake_builder.add_text_batches.return_value = None
+    fake_builder.get_graph_data.return_value = {"node_count": 5, "edge_count": 3}
+
+    fake_container = MagicMock()
+    fake_container.neo4j_storage = MagicMock()
+    fake_container.graph_builder.return_value = fake_builder
+
+    fake_profile = MagicMock(name="LlmProfile")
+    fake_profile.provider = "ollama_cloud"
+    fake_profile.model_name = "ministral-3:8b"
+
+    fake_profile_client = MagicMock(name="ProfileLLMClient")
+    fake_route_client = MagicMock(name="RouteLLMClient")
+    captured_ner = {}
+
+    class FakeRouter:
+        def __init__(self, run_id: str):
+            self.run_id = run_id
+
+        def resolve(self, _stage_id: str):
+            return ResolvedRoute(
+                stage="graph_build",
+                provider_id="ollama",
+                model="qwen2.5:32b",
+                base_url_sanitized="http://localhost:11434/v1",
+                routing_version=1,
+            )
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def run_inline(self):
+        self.run()
+
+    def fake_ner_extractor(*, llm_client):
+        captured_ner["llm_client"] = llm_client
+        return MagicMock(name="NEROverride")
+
+    class FakeProfileStore:
+        def get(self, profile_id, include_api_key=False):
+            assert profile_id == "prof_xyz123"
+            assert include_api_key is True
+            return fake_profile
+
+    monkeypatch.setattr("app.api.graph.ProjectManager.get_project", lambda _pid: fake_project)
+    monkeypatch.setattr("app.api.graph.ProjectManager.save_project", lambda _project: None)
+    monkeypatch.setattr("app.api.graph.ProjectManager.get_extracted_text", lambda _pid: "some text")
+    monkeypatch.setattr("app.api.graph.get_container", lambda: fake_container)
+    monkeypatch.setattr("app.api.graph.TextProcessor.split_text", lambda *a, **k: ["chunk1"])
+    monkeypatch.setattr("app.api.graph.ArtifactLocator.existing_paths", lambda *_a, **_k: {})
+    monkeypatch.setattr("app.api.graph.seed_run_stage_routing", lambda *a, **k: None)
+    monkeypatch.setattr("app.api.graph.StageModelRouter", FakeRouter)
+    monkeypatch.setattr("app.api.graph.resolve_route_api_key", lambda *_a, **_k: "sk-route")
+    monkeypatch.setattr("app.api.graph.LLMClient.from_route", lambda *a, **k: fake_route_client)
+    monkeypatch.setattr("app.api.graph.NERExtractor", fake_ner_extractor)
+    monkeypatch.setattr(
+        "app.services.llm_profiles_store.get_llm_profiles_store",
+        lambda: FakeProfileStore(),
+    )
+    monkeypatch.setattr(
+        "app.utils.llm_client.build_client_from_profile",
+        lambda profile, run_id=None: fake_profile_client,
+    )
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.api.graph.run_registry.create_run", lambda *a, **k: {"run_id": "run_graph_2"})
+    monkeypatch.setattr("app.api.graph.run_registry.update_run", lambda *a, **k: None)
+
+    response = client.post("/api/graph/build", json={"project_id": VALID_PROJECT_ID})
+
+    assert response.status_code == 200, response.get_json()
+    # Kernzusicherung: NER-Client kommt aus dem Profil-Pfad, nicht aus from_route.
+    assert captured_ner["llm_client"] is fake_profile_client
+    assert captured_ner["llm_client"] is not fake_route_client

--- a/backend/tests/api/test_graph_endpoints.py
+++ b/backend/tests/api/test_graph_endpoints.py
@@ -25,9 +25,14 @@ VALID_TASK_ID = "01234567-89ab-4def-8123-456789abcdef"
 
 @pytest.fixture
 def app(monkeypatch):
+    # @require_scope ist aktiv, sobald AGORA_AUTH_TOKEN gesetzt ist. Diese
+    # Endpunkt-Error-Tests prüfen Validierung/Mapping, nicht Auth — daher
+    # erzwingen wir Open-Mode für die ganze Testdatei.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)
     flask_app = Flask(__name__)
+    flask_app.config["AGORA_AUTH_TOKEN"] = ""
     flask_app.extensions = {"container": container, "neo4j_storage": storage}
     flask_app.register_blueprint(graph_bp, url_prefix="/api/graph")
     return flask_app
@@ -159,6 +164,10 @@ def test_build_graph_without_ontology_returns_ontology_missing(client, monkeypat
     fake_project.status = ProjectStatus.CREATED
     fake_project.ontology = None
     fake_project.graph_build_task_id = None
+    # MagicMock-Default für llm_profile_id ist truthy → würde Profile-Store
+    # ansprechen, der hier nicht gemockt ist.
+    fake_project.llm_profile_id = None
+    fake_project.llm_model = None
     monkeypatch.setattr(
         "app.api.graph.ProjectManager.get_project",
         staticmethod(lambda _pid: fake_project),
@@ -180,6 +189,8 @@ def test_build_graph_when_already_building_returns_graph_build_in_progress(
     fake_project.status = ProjectStatus.GRAPH_BUILDING
     fake_project.ontology = {"entity_types": [], "edge_types": []}
     fake_project.graph_build_task_id = "existing-task-id"
+    fake_project.llm_profile_id = None
+    fake_project.llm_model = None
     monkeypatch.setattr(
         "app.api.graph.ProjectManager.get_project",
         staticmethod(lambda _pid: fake_project),
@@ -233,12 +244,15 @@ def test_add_text_batches_callback_receives_four_args():
         assert abs(ratio - completed / 3) < 1e-9, "progress_ratio muss completed/total sein"
 
 
-def test_add_progress_callback_sets_progress_detail_on_task_manager():
+def test_add_progress_callback_sets_progress_detail_on_task_manager(monkeypatch):
     """add_progress_callback in graph.py setzt progress_detail mit Batch-Marker-Feldern.
 
     Wir patchen TaskManager.update_task und GraphBuilderService.add_text_batches,
     damit der Build-Thread synchron durchlaufen kann.
     """
+    # @require_scope("graph:write") fordert Auth, sobald AGORA_AUTH_TOKEN gesetzt
+    # ist. Dieser Test prüft progress_detail-Pipeline, nicht Auth — Open-Mode.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     import threading
 
     from app.models.task import TaskManager
@@ -267,6 +281,7 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager():
     fake_project.chunk_overlap = 50
     fake_project.llm_model = None
     fake_project.llm_provider = None
+    fake_project.llm_profile_id = None
 
     def fake_add_text_batches(
         graph_id, chunks, batch_size=3, progress_callback=None, ner_extractor=None
@@ -298,9 +313,10 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager():
         patch("app.api.graph.TextProcessor.split_text", return_value=["chunk1", "chunk2"]),
         patch("app.api.graph.ArtifactLocator.existing_paths", return_value={}),
         patch("app.api.graph.seed_run_stage_routing"),
-        patch("app.api.graph._make_ner_override_from_route", return_value=MagicMock()),
+        patch("app.api.graph._make_ner_override", return_value=MagicMock()),
     ):
         flask_app = Flask(__name__)
+        flask_app.config["AGORA_AUTH_TOKEN"] = ""
         storage = MagicMock()
         from app.container import AgoraContainer
         container = AgoraContainer(neo4j_storage=storage)

--- a/backend/tests/api/test_llm_profiles.py
+++ b/backend/tests/api/test_llm_profiles.py
@@ -38,12 +38,25 @@ _PROFILE = {
 }
 
 
-def test_list_returns_bootstrap_profile(client):
+def test_list_returns_bootstrap_profile(client, monkeypatch):
+    # Bootstrap erfolgt nur, wenn LLM_MODEL_NAME nicht-leer ist. Vorher hat der
+    # Store stillschweigend ein Profil mit `qwen2.5:32b` erzeugt — was in
+    # Cloud-Setups dead-on-arrival war.
+    monkeypatch.setenv("LLM_MODEL_NAME", "qwen2.5:32b")
     res = client.get("/api/settings/llm-profiles/")
     assert res.status_code == 200
     data = res.get_json()
     assert data["success"] is True
     assert len(data["data"]["profiles"]) >= 1
+
+
+def test_list_returns_empty_when_no_model_env(client, monkeypatch):
+    # P5.3-Fix: ohne LLM_MODEL_NAME wird KEIN Auto-Profil mehr erzeugt.
+    monkeypatch.delenv("LLM_MODEL_NAME", raising=False)
+    res = client.get("/api/settings/llm-profiles/")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["data"]["profiles"] == []
 
 
 def test_create_and_list(client):

--- a/backend/tests/test_settings_layer.py
+++ b/backend/tests/test_settings_layer.py
@@ -69,7 +69,7 @@ def test_every_section_has_at_least_one_field():
 
 
 def test_field_by_key_lookup():
-    assert field_by_key('LLM_MODEL_NAME').default == 'qwen2.5:32b'
+    assert field_by_key('LLM_MODEL_NAME').default == ''
     assert field_by_key('does-not-exist') is None
 
 
@@ -78,7 +78,7 @@ def test_field_by_key_lookup():
     [
         # Strings/Enums — 1:1 aus dem Default-Argument von
         # ``os.environ.get(...)`` in ``backend/app/config.py``.
-        ('LLM_MODEL_NAME', 'qwen2.5:32b'),
+        ('LLM_MODEL_NAME', ''),
         ('LLM_BASE_URL', 'http://localhost:11434/v1'),
         ('LLM_MAX_OUTPUT_TOKENS', 8192),
         ('LLM_CONTEXT_LIMIT', 262144),
@@ -128,7 +128,7 @@ def test_schema_defaults_match_config_defaults(key: str, expected_default):
 def test_default_source_when_nothing_is_set(isolated_service, clean_env):
     state = isolated_service.get_field_state('LLM_MODEL_NAME')
     assert state['source'] == SOURCE_DEFAULT
-    assert state['value'] == 'qwen2.5:32b'
+    assert state['value'] == ''
     assert state['is_set'] is False
 
 
@@ -274,7 +274,7 @@ def test_get_schema_does_not_leak_secret_defaults(isolated_service):
     schema = isolated_service.get_schema()
     by_key = {entry['key']: entry for entry in schema}
     assert by_key['NEO4J_PASSWORD']['default'] is None
-    assert by_key['LLM_MODEL_NAME']['default'] == 'qwen2.5:32b'
+    assert by_key['LLM_MODEL_NAME']['default'] == ''
 
 
 def test_get_schema_includes_enum_values_and_bounds(isolated_service):

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -2,11 +2,24 @@
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Card from './Card.vue'
+import ModelPicker from './ModelPicker.vue'
 import { useLlmProfilesStore } from '@/store/llmProfiles'
 import type { LlmProfile, LlmProvider } from '@/contracts/llmProfileContract'
+import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
 
 const { t } = useI18n()
 const store = useLlmProfilesStore()
+
+// Mapping ModelPicker.provider_id (Runtime) ⇄ LlmProfile.provider (Storage).
+// Mehrere Runtime-Provider können auf denselben Profile-Provider mappen
+// (z. B. `ollama_cloud` und `ollama` → 'ollama').
+const RUNTIME_TO_PROFILE_PROVIDER: Record<string, { provider: LlmProvider; baseUrl: string }> = {
+  openai:        { provider: 'openai',    baseUrl: 'https://api.openai.com/v1' },
+  ollama:        { provider: 'ollama',    baseUrl: 'http://localhost:11434/v1' },
+  ollama_cloud:  { provider: 'ollama',    baseUrl: 'https://ollama.com/v1' },
+  gemini:        { provider: 'gemini',    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai' },
+  anthropic:     { provider: 'anthropic', baseUrl: 'https://api.anthropic.com/v1' },
+}
 
 // ---------------------------------------------------------------------------
 // Preset-Definitionen (analog zu LlmProviderCard)
@@ -90,9 +103,56 @@ function cancel(): void {
 function selectPreset(preset: Preset): void {
   formProvider.value = preset.key
   formBaseUrl.value  = preset.url
+  // Preset wechselt → bisheriges Modell ist nicht mehr garantiert verfügbar.
+  // Picker zeigt daher leere Auswahl, User muss neu wählen.
+  formModel.value = ''
   if (!preset.needsKey) {
     apiKeyEditMode.value = 'unchanged'
     apiKeyDraft.value    = ''
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ModelPicker-Integration
+// ---------------------------------------------------------------------------
+// Provider-Mapping rückwärts: Wir bauen aus den gespeicherten Formularfeldern
+// einen Pseudo-StageLLMRoute, damit der Picker den Eintrag highlighten kann.
+const pickerValue = computed<StageLLMRoute | null>(() => {
+  if (!formModel.value) return null
+  // Best-Effort: profile.provider → erste passende Runtime-ID (Cloud
+  // gegenüber Local bevorzugen, wenn base_url darauf hinweist).
+  let providerId = ''
+  if (formProvider.value === 'ollama') {
+    providerId = formBaseUrl.value.includes('ollama.com') ? 'ollama_cloud' : 'ollama'
+  } else {
+    providerId = formProvider.value
+  }
+  return {
+    stage: null,
+    provider_id: providerId,
+    model: formModel.value,
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+  }
+})
+
+function onPickerChange(route: StageLLMRoute | null): void {
+  if (route === null) {
+    formModel.value = ''
+    return
+  }
+  formModel.value = route.model
+  const mapped = RUNTIME_TO_PROFILE_PROVIDER[route.provider_id]
+  if (mapped) {
+    formProvider.value = mapped.provider
+    // base_url nur überschreiben, wenn das aktuelle Feld leer ist oder zur
+    // alten Mapping-Tabelle gehört — sonst zerstören wir handgepflegte URLs.
+    const knownUrls = Object.values(RUNTIME_TO_PROFILE_PROVIDER).map((m) => m.baseUrl)
+    if (!formBaseUrl.value || knownUrls.includes(formBaseUrl.value)) {
+      formBaseUrl.value = mapped.baseUrl
+    }
   }
 }
 
@@ -278,12 +338,10 @@ onMounted(() => {
         <!-- Modell -->
         <div class="llm-field">
           <label class="llm-label" for="pm-model">{{ t('settings.v4.llmProfiles.modelLabel') }}</label>
-          <input
-            id="pm-model"
-            v-model="formModel"
-            type="text"
-            class="llm-input"
-            placeholder="qwen2.5:32b"
+          <ModelPicker
+            :model-value="pickerValue"
+            :placeholder="t('settings.v4.llmProfiles.modelLabel')"
+            @update:model-value="onPickerChange"
           />
         </div>
 

--- a/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
@@ -75,6 +75,28 @@ const PROFILE_B = {
   updated_at: '2026-01-02T00:00:00Z',
 }
 
+// ModelPicker-Stub: emittiert das übergebene `data-test-model` direkt, ohne
+// auf den llmProviders-Store oder Backend-Calls angewiesen zu sein.
+const ModelPickerStub = {
+  props: ['modelValue', 'placeholder', 'disabled'],
+  emits: ['update:modelValue'],
+  template: `
+    <input
+      class="model-picker-stub"
+      :value="modelValue?.model ?? ''"
+      @input="$emit('update:modelValue', $event.target.value ? {
+        stage: null,
+        provider_id: 'ollama',
+        model: $event.target.value,
+        temperature: null,
+        max_tokens: null,
+        reasoning_effort: 'none',
+        provider_options: {},
+      } : null)"
+    />
+  `,
+}
+
 function wrap(storeOverrides?: object) {
   return mount(LlmProfileManager, {
     global: {
@@ -94,7 +116,10 @@ function wrap(storeOverrides?: object) {
           stubActions: true,
         }),
       ],
-      stubs: { Card: { template: '<div><slot /></div>' } },
+      stubs: {
+        Card: { template: '<div><slot /></div>' },
+        ModelPicker: ModelPickerStub,
+      },
     },
   })
 }
@@ -122,7 +147,10 @@ describe('LlmProfileManager', () => {
     // Felder befüllen
     await w.find('#pm-name').setValue('Mein Testprofil')
     await w.find('#pm-base-url').setValue('http://localhost:11434/v1')
-    await w.find('#pm-model').setValue('llama3:8b')
+    // ModelPicker-Stub emittiert StageLLMRoute; LlmProfileManager mappt
+    // provider_id='ollama' → provider='ollama' und überschreibt base_url nur,
+    // wenn das aktuelle Feld leer oder Teil der Default-Tabelle ist.
+    await w.find('.model-picker-stub').setValue('llama3:8b')
 
     // Speichern klicken (stubActions: true → create ist bereits ein vi.fn spy)
     const saveBtn = w.findAll('button.v4-btn--primary').find(b => b.text() === 'Speichern')

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -3,7 +3,6 @@ import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
-import LlmProviderCard from '@/components/v4/forms/LlmProviderCard.vue'
 import LlmProfileManager from '@/components/v4/forms/LlmProfileManager.vue'
 
 const { t } = useI18n()
@@ -26,8 +25,9 @@ const ALLOWED_SECTIONS = ['llm', 'logging', 'locale', 'ui', 'event_bus', 'securi
       :subtitle="t('settings.v4.general.subtitle')"
     />
 
+    <!-- P5.3-Fix: LlmProviderCard entfernt — Funktionalität ist in /settings/llm-providers
+         konsolidiert (kanonische Provider/Modell-Auswahl via ModelPicker). -->
     <LlmProfileManager style="margin-bottom: 16px;" />
-    <LlmProviderCard style="margin-bottom: 16px;" />
     <SettingsSectionPanel :allowed-sections="ALLOWED_SECTIONS" />
   </AppShell>
 </template>


### PR DESCRIPTION
## Summary

- **Slice 1 — Profil-Bindung**: Build-/Sim-/Report-Stages ziehen jetzt `Project.llm_profile_id` als Default, wenn der Request kein eigenes Profil mitschickt. Behebt `nodes=0, edges=0` bei allen Profile-basierten Runs (Ollama Cloud / OpenAI / Gemini).
- **Slice 2 — Defaults gehärtet**: `LLM_MODEL_NAME` Default leer (statt `qwen2.5:32b`), `_bootstrap_profile` nur noch konditional → keine toten Auto-Profile mehr in frischen Containern.
- **Slice 3 — UI-Konsolidierung**: `LlmProfileManager` nutzt jetzt `ModelPicker` (kanonische Modell-Quelle), Legacy-`LlmProviderCard` aus `SettingsGeneralView` entfernt.

## Root Cause

`generate_ontology` respektierte das aktive LLM-Profil, alle Folge-Stages nicht. Frontend setzt bei Profil-Auswahl `STORAGE_MODEL=default` → `/api/graph/build` Payload reduziert sich auf `{ project_id }` → Stage-Router fällt auf Server-Default (`qwen2.5:32b` @ `ollama.com/v1`) zurück → 404 in Cloud-Setups.

## Architektur-Skizze

```
Hero/HeroNewRun ── profile_id ──▶ /ontology/generate
                                       │
                                       ▼
                              Project.llm_profile_id  (NEU persistiert)
                                       │
                                       ▼
Hero ── { project_id } ──▶ /graph/build ─▶ _resolve_llm_overrides
                                                │
                                                ▼
                                       liest Profil aus Body
                                       ODER Project (Fallback)
                                                │
                                                ▼
                                   _make_ner_override
                                       │
                                       ▼
                              build_client_from_profile(profile)
                                       │
                                       ▼
                                  NERExtractor (richtiges Modell ✓)
```

## Kritische Dateien

| Datei | Änderung |
|---|---|
| `backend/app/models/project.py` | Neues Feld `llm_profile_id` |
| `backend/app/api/graph.py` | `_resolve_llm_overrides` + `_make_ner_override` mit Profile-Pfad |
| `backend/app/api/report.py` | Project-Fallback für Profil |
| `backend/app/api/simulation_prepare.py` | Early-Inject von `profile:<id>` |
| `backend/app/config.py` | `LLM_MODEL_NAME` Default leer |
| `backend/app/services/settings_schema.py` | Schema-Default leer |
| `backend/app/services/llm_profiles_store.py` | Bootstrap konditional |
| `frontend/src/components/v4/forms/LlmProfileManager.vue` | `ModelPicker` statt Text-Input |
| `frontend/src/views/Settings/SettingsGeneralView.vue` | Legacy-Card entfernt |

## Bonus

- Pre-existing Auth-Failures in `test_graph_endpoints.py` + `test_graph_build_routing.py` + `test_provider_override_key_fallback.py` mitgefixt (Open-Mode für Routing-Tests, kein Auth-Coverage betroffen).
- Verbleibende 21 pre-existing Failures auf main sind als #527 dokumentiert.

## Test plan

- [x] `cd backend && uv run pytest tests/api/test_graph_build_routing.py tests/api/test_graph_endpoints.py tests/api/test_graph_ontology_respects_frontend_model.py tests/api/test_llm_profiles.py tests/services/test_llm_routing_seed.py tests/test_settings_layer.py -q` → grün
- [x] `cd backend && uv run pytest tests/ -k "profile or routing or graph_build or ontology or settings_layer" -q` → 259 grün
- [x] `cd backend && uv run ruff check app/ tests/` → clean
- [x] `cd backend && uv run python -m app.contracts.dump_schemas --check` → OK
- [x] `cd frontend && bun run vitest --run` → 1053/1053 grün
- [x] `cd frontend && bun run build` → grün
- [ ] Manueller E2E: Profile für Ollama Cloud + OpenAI + Gemini anlegen, Run starten, Build-Log zeigt `Build-Pfad nutzt LLM-Profil: provider=… model=…` statt `Route-Snapshot: model=qwen2.5:32b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)