### PR TITLE
fix: gevent monkey-patch timing (wsgi.py) + urllib3 model-catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # Subprozess-Handles in „dem anderen" Worker. Bis Tasks/API-Keys/
 # SimRunner extern (Redis-Queue + persistenter Key-Store) sind, läuft
 # Prod mit genau einem Worker. Aufheben in PR 2/4 dieser Welle.
+#
+# Issue #529: App-Target ist wsgi:app (NICHT mehr app:create_app()), weil
+# wsgi.py als allererstes Statement gevent.monkey.patch_all() ausführt.
+# Ohne diese Reihenfolge importiert --preload requests/urllib3/ssl mit
+# ungepatchtem socket → RecursionError in jedem HTTP-Call.
 CMD ["/app/backend/.venv/bin/gunicorn", \
      "-k", "gevent", \
      "--workers", "1", \
@@ -174,4 +179,4 @@ CMD ["/app/backend/.venv/bin/gunicorn", \
      "--bind", "0.0.0.0:5001", \
      "--chdir", "/app/backend", \
      "--pid", "/home/agora/.gunicorn/gunicorn.pid", \
-     "app:create_app()"]
+     "wsgi:app"]

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -23,7 +23,13 @@ logger = get_logger("agora.model_catalog")
 
 # Modul-globaler PoolManager — Connection-Reuse über Calls hinweg.
 # Wichtig: KEIN ``requests.Session`` — die wäre instrumentiert.
-_HTTP = urllib3.PoolManager(timeout=urllib3.Timeout(connect=5.0, read=5.0))
+# retries=False, weil ``requests.get`` default 0 Retries hat und Model-Discovery
+# ein blockierender UI-Call ist; 3x Retry mit Backoff würde den UI-Spinner
+# 10-30 s hängen lassen, wenn ein Provider unten ist (Gemini-MEDIUM auf PR #530).
+_HTTP = urllib3.PoolManager(
+    timeout=urllib3.Timeout(connect=5.0, read=5.0),
+    retries=False,
+)
 
 
 class ModelEntry(BaseModel):
@@ -128,7 +134,10 @@ class ModelCatalogService:
             if data:
                 return [m["id"] for m in data.get("data", [])]
             # Native /api/tags als Fallback (lokales Ollama ohne /v1-Suffix).
-            native_url = base_url.replace("/v1", "").rstrip("/")
+            # removesuffix statt replace: greift nur am Ende der URL und
+            # zerstört nicht zufällig "/v1" mitten in der Domain
+            # (Gemini-MEDIUM auf PR #530).
+            native_url = base_url.rstrip("/").removesuffix("/v1")
             data = _http_get_json(f"{native_url}/api/tags", api_key=api_key)
             if data:
                 return [m["name"] for m in data.get("models", [])]

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -1,15 +1,30 @@
 """
 Model Catalog Service.
 Live /models discovery, normalization, cache, source-badge.
+
+HTTP-Layer: ``urllib3`` (statt ``requests``) — Hintergrund: unter
+``gunicorn+gevent`` triggert die OTel ``RequestsInstrumentor`` eine
+Endlos-Rekursion in ``requests.adapters.HTTPAdapter.send`` (Issue #529).
+``urllib3`` umgeht den instrumentierten Codepfad vollständig und ist
+sowieso die Transport-Schicht unter ``requests`` — wir verlieren also
+nichts ausser dem ``requests``-Convenience-Wrapper.
 """
 
+import json
 import time
-import requests
-from typing import List, Optional, Dict, Literal
+from typing import Dict, List, Literal, Optional
+
+import urllib3
 from pydantic import BaseModel, ConfigDict
+
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.model_catalog")
+
+# Modul-globaler PoolManager — Connection-Reuse über Calls hinweg.
+# Wichtig: KEIN ``requests.Session`` — die wäre instrumentiert.
+_HTTP = urllib3.PoolManager(timeout=urllib3.Timeout(connect=5.0, read=5.0))
+
 
 class ModelEntry(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -20,11 +35,37 @@ class ModelEntry(BaseModel):
     source: Literal["live", "cached", "fallback", "custom"]
     refreshed_at: float
 
+
+def _http_get_json(url: str, *, api_key: Optional[str] = None) -> Optional[dict]:
+    """GET ``url`` und parse JSON. Gibt ``None`` zurück bei Non-2xx oder Parse-Fehler.
+
+    Nutzt das Modul-PoolManager (``_HTTP``) — Tests patchen entweder diesen
+    Helper direkt oder ``_HTTP.request``. Wichtig: keine Verwendung von
+    ``requests`` (siehe Modul-Docstring, OTel-Rekursion #529).
+    """
+    headers: Dict[str, str] = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        resp = _HTTP.request("GET", url, headers=headers)
+    except urllib3.exceptions.HTTPError as exc:
+        logger.debug("HTTP error fetching %s: %s", url, exc)
+        return None
+    if resp.status != 200:
+        logger.debug("Non-200 status %s from %s", resp.status, url)
+        return None
+    try:
+        return json.loads(resp.data.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.debug("JSON parse error from %s: %s", url, exc)
+        return None
+
+
 class ModelCatalogService:
     """Service for discovering and normalizing models from different providers."""
 
     _cache: Dict[str, List[ModelEntry]] = {}
-    _cache_ttl = 300 # 5 minutes
+    _cache_ttl = 300  # 5 minutes
 
     def get_models(self, provider_id: str, provider_type: str, base_url: str, api_key: Optional[str]) -> List[ModelEntry]:
         """Fetch models from provider, with caching and fallback."""
@@ -46,7 +87,7 @@ class ModelCatalogService:
                         name=m,
                         provider_id=provider_id,
                         source="live",
-                        refreshed_at=now
+                        refreshed_at=now,
                     ) for m in live_models
                 ]
                 self._cache[provider_id] = entries
@@ -57,7 +98,6 @@ class ModelCatalogService:
         # 3. Fallback to cached (even if expired)
         if provider_id in self._cache:
             entries = self._cache[provider_id]
-            # Update source to cached
             for e in entries:
                 e.source = "cached"
             return entries
@@ -70,51 +110,39 @@ class ModelCatalogService:
                 name=m,
                 provider_id=provider_id,
                 source="fallback",
-                refreshed_at=now
+                refreshed_at=now,
             ) for m in fallback_models
         ]
 
     def _fetch_live(self, provider_type: str, base_url: str, api_key: Optional[str]) -> List[str]:
         """Discovery implementation per provider type."""
         if provider_type == "github_copilot":
-            # Phase 1: kein Live-Discovery. Wir geben die statische Modellliste
-            # über die ``_get_fallbacks``-Branch zurück — daher hier keine Live-IDs.
+            # Phase 1: kein Live-Discovery — statische Liste über _get_fallbacks.
             return []
 
         if provider_type == "ollama_cloud":
-            # Ollama has /api/tags (native) and /v1/models (OpenAI compatible)
-            # We prefer /api/tags for full metadata if available
-            try:
-                # Try OpenAI compatible first as it's the standard Agora uses
-                resp = requests.get(f"{base_url.rstrip('/')}/v1/models", timeout=5)
-                if resp.status_code == 200:
-                    data = resp.json()
-                    return [m["id"] for m in data.get("data", [])]
-            except (requests.RequestException, ValueError) as exc:
-                logger.debug("OpenAI-compatible /v1/models discovery failed: %s", exc)
-
-            # Try native Ollama /api/tags as fallback
-            # We need to strip /v1 if it was added to base_url for OpenAI compat
-            native_url = base_url.replace("/v1", "").rstrip("/")
-            resp = requests.get(f"{native_url}/api/tags", timeout=5)
-            if resp.status_code == 200:
-                data = resp.json()
-                return [m["name"] for m in data.get("models", [])]
-
-        elif provider_type in ("openai", "google", "openai_compatible"):
-            headers = {}
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-
-            resp = requests.get(f"{base_url.rstrip('/')}/models", headers=headers, timeout=5)
-            if resp.status_code != 200:
-                 # Try /v1/models if /models failed
-                 resp = requests.get(f"{base_url.rstrip('/')}/v1/models", headers=headers, timeout=5)
-
-            if resp.status_code == 200:
-                data = resp.json()
-                # OpenAI and Google (OpenAI-shim) both use data[]
+            # Ollama Cloud (ollama.com) BRAUCHT Bearer-Token am /v1/models-Endpoint.
+            # Vorher fehlte der Header — Ergebnis war ein stiller 401 → leere Liste
+            # (PR #528 Follow-up).
+            data = _http_get_json(f"{base_url.rstrip('/')}/v1/models", api_key=api_key)
+            if data:
                 return [m["id"] for m in data.get("data", [])]
+            # Native /api/tags als Fallback (lokales Ollama ohne /v1-Suffix).
+            native_url = base_url.replace("/v1", "").rstrip("/")
+            data = _http_get_json(f"{native_url}/api/tags", api_key=api_key)
+            if data:
+                return [m["name"] for m in data.get("models", [])]
+            return []
+
+        if provider_type in ("openai", "google", "openai_compatible"):
+            # OpenAI-shape: data[].id. Erst /models, dann /v1/models als Fallback,
+            # falls die base_url nicht schon /v1 enthält.
+            data = _http_get_json(f"{base_url.rstrip('/')}/models", api_key=api_key)
+            if data is None:
+                data = _http_get_json(f"{base_url.rstrip('/')}/v1/models", api_key=api_key)
+            if data:
+                return [m["id"] for m in data.get("data", [])]
+            return []
 
         return []
 

--- a/backend/tests/services/test_llm_core_services.py
+++ b/backend/tests/services/test_llm_core_services.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from app.services.llm_provider_registry import LlmProviderRegistry
 from app.services.secret_resolver import SecretResolver
 from app.services.model_catalog_service import ModelCatalogService
@@ -26,27 +26,42 @@ def test_secret_resolver_sanitize_url():
     assert resolver.sanitize_url("http://user:pass@localhost:11434/v1?query=1") == "http://localhost:11434/v1"
     assert resolver.sanitize_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
 
-@patch("requests.get")
-def test_model_catalog_ollama_discovery(mock_get):
-    # Mock /v1/models response
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = {"data": [{"id": "model1"}, {"id": "model2"}]}
-    mock_get.return_value = mock_resp
+@patch("app.services.model_catalog_service._http_get_json")
+def test_model_catalog_ollama_discovery(mock_http):
+    # Mock /v1/models response (Helper returnt bereits geparstes JSON)
+    mock_http.return_value = {"data": [{"id": "model1"}, {"id": "model2"}]}
 
     service = ModelCatalogService()
+    # Cache leeren — Modul-level dict überlebt sonst zwischen Tests.
+    service._cache = {}
     models = service.get_models("ollama", "ollama_cloud", "http://localhost:11434/v1", None)
 
     assert len(models) == 2
     assert models[0].id == "model1"
     assert models[0].source == "live"
 
+
+@patch("app.services.model_catalog_service._http_get_json")
+def test_model_catalog_ollama_cloud_sends_bearer_token(mock_http):
+    """Regression: Ollama Cloud erfordert Authorization-Header (Issue #529)."""
+    mock_http.return_value = {"data": [{"id": "ministral-3:8b"}]}
+    service = ModelCatalogService()
+    service._cache = {}
+    service.get_models("ollama_cloud", "ollama_cloud", "https://ollama.com/v1", "sk-test-key")
+    # api_key MUSS an _http_get_json durchgereicht worden sein (sonst 401 silent).
+    call = mock_http.call_args
+    assert call.kwargs.get("api_key") == "sk-test-key"
+
+
 def test_model_catalog_fallback():
     service = ModelCatalogService()
     # Clear cache to force fallback
     service._cache = {}
 
-    with patch("requests.get", side_effect=Exception("Connection error")):
+    with patch(
+        "app.services.model_catalog_service._http_get_json",
+        side_effect=Exception("Connection error"),
+    ):
         models = service.get_models("openai", "openai", "https://api.openai.com/v1", "key")
         assert len(models) > 0
         assert models[0].source == "fallback"

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,31 @@
+"""WSGI-Entrypoint für gunicorn mit korrekt früher gevent-Monkey-Patch-Reihenfolge.
+
+Hintergrund (Issue #529):
+Mit ``gunicorn -k gevent --preload app:create_app()`` lädt der Master alle
+App-Imports (``requests``, ``urllib3``, ``ssl``, ``redis``, ``anyio.streams.tls``)
+BEVOR der gevent-Worker beim Boot ``gevent.monkey.patch_all()`` ausführt.
+gevent warnt explizit: ``Monkey-patching ssl after ssl has already been
+imported may lead to errors, including RecursionError``.
+
+Sichtbares Symptom war ``maximum recursion depth exceeded`` in jedem
+``requests.get`` / ``urllib3.PoolManager.request``-Aufruf aus Request-Handlern
+(z. B. ``model_catalog_service._fetch_live`` für die LLM-Modell-Discovery).
+
+Lösung: Dieses Modul als gunicorn-App-Target nutzen (``wsgi:app``). Hier ist
+``patch_all()`` das ABSOLUT ERSTE Statement — vor jedem App-Import. So ist
+``socket``/``ssl``/``ssl_wrap_socket`` schon gepatcht, wenn die App-Factory
+ihre Library-Tree-Importe macht.
+
+Reihenfolge ist nicht verhandelbar. Nichts oberhalb dieser Zeilen einfügen
+(auch keine ``from __future__``-Imports).
+"""
+
+import gevent.monkey
+
+gevent.monkey.patch_all()
+
+# Erst NACH patch_all() darf die App importiert werden — sonst hat dieses
+# Modul keinen Effekt.
+from app import create_app  # noqa: E402
+
+app = create_app()


### PR DESCRIPTION
## Summary

Behebt #529. **Zwei Layer in einem PR**, beide nötig:

1. **`backend/wsgi.py` + Dockerfile-CMD** — echter Root Cause: `gunicorn -k gevent --preload` lud requests/urllib3/ssl im Master BEVOR `gevent.monkey.patch_all()` lief → halb-gepatcht socket → RecursionError in jedem HTTP-Call. wsgi.py ruft `patch_all()` als allererstes Statement.
2. **`model_catalog_service` urllib3-Migration** — schlankerer HTTP-Pfad (kein requests.Session-Wrapper-Stack), behebt nebenbei den vergessenen Bearer-Token für Ollama Cloud `/v1/models` (silent 401 → leere Modell-Liste).

## Root-Cause-Korrektur

Ursprüngliche Diagnose (siehe Issue #529) verdächtigte `OpenTelemetry RequestsInstrumentor`. Live-Test mit `OTEL_ENABLED=false` zeigte: Recursion bleibt. Echte Ursache war die gevent-Monkey-Patch-Reihenfolge — gunicorn warnt sogar explizit im Worker-Boot:

\`\`\`
MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported
may lead to errors, including RecursionError
\`\`\`

## Live-Verifikation (Container hot-patched, vor Merge)

- Container vorher: ~5 `recursion`-Events/Sekunde, sobald der LLM-Provider-Tab geöffnet war
- Container nachher: **0 Events in 5 min**, MonkeyPatchWarning verschwunden aus Boot-Logs
- UI: OpenAI/Gemini/Ollama Cloud zeigen jetzt Live-Modelle statt Fallback-Liste

## Files

| Datei | Änderung |
|---|---|
| `backend/wsgi.py` | NEU — `patch_all()` als 1. Statement, dann `create_app()` |
| `Dockerfile` | CMD: `app:create_app()` → `wsgi:app` |
| `backend/app/services/model_catalog_service.py` | `requests` → `urllib3`, Bearer-Token-Fix für Ollama Cloud |
| `backend/tests/services/test_llm_core_services.py` | Tests patchen jetzt `_http_get_json`-Helper + Regression-Test für Bearer-Token |

## Test plan

- [x] `cd backend && uv run pytest tests/services/test_llm_core_services.py tests/api/test_available_models_filter.py tests/api/test_llm_routing_api.py tests/services/test_github_copilot_provider.py -q` → 21 grün
- [x] `cd backend && uv run ruff check app/ tests/` → clean
- [x] `cd backend && uv run python -m app.contracts.dump_schemas --check` → OK
- [x] Live-Container hot-patched, Modell-Discovery funktioniert für alle Provider, 0 Recursion in 5 min
- [ ] Nach Merge: vollständiger `docker compose ... up -d --build` und Modelle laden re-testen, um sicherzustellen dass der Rebuild den Fix korrekt mit aufnimmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)