### PR TITLE
test: re-greenen nach PR #524 auth gate + Settings/Compose-Pin-Drift

### DIFF
--- a/backend/tests/api/test_provider_override_key_fallback.py
+++ b/backend/tests/api/test_provider_override_key_fallback.py
@@ -22,9 +22,13 @@ VALID_SIM_ID = "sim_0123456789ab"
 
 
 @pytest.fixture()
-def prepare_client():
+def prepare_client(monkeypatch):
     """Flask test-client mit simulation_bp."""
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Diese Tests
+    # prüfen Validierungs-/Routing-Logik, nicht Auth — Open-Mode erzwingen.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 1000
     app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
     app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
@@ -33,9 +37,11 @@ def prepare_client():
 
 
 @pytest.fixture()
-def llm_client():
+def llm_client(monkeypatch):
     """Flask test-client mit llm_bp."""
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.register_blueprint(llm_bp, url_prefix="/api/llm")
     return app.test_client()
 

--- a/backend/tests/api/test_report_download_no_tempfile.py
+++ b/backend/tests/api/test_report_download_no_tempfile.py
@@ -18,8 +18,12 @@ VALID_REPORT_ID = "report_abcdef123456"
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Diese Tests
+    # prüfen Download-Streaming-Pfad, nicht Auth — Open-Mode erzwingen.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["TESTING"] = True
     app.register_blueprint(report_bp, url_prefix="/api/report")
     return app.test_client()

--- a/backend/tests/api/test_report_modes.py
+++ b/backend/tests/api/test_report_modes.py
@@ -25,8 +25,12 @@ VALID_GRAPH_ID = "graph_0123456789ab"
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Diese Tests
+    # prüfen Validierungslogik, nicht Auth — Open-Mode erzwingen.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["TESTING"] = True
     app.config["AGORA_REPORT_RATE_LIMIT_MAX"] = 100
     app.config["AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS"] = 60

--- a/backend/tests/api/test_simulation_endpoints.py
+++ b/backend/tests/api/test_simulation_endpoints.py
@@ -22,7 +22,11 @@ VALID_GRAPH_ID = "abcdef0123456789abcdef0123456789"
 
 @pytest.fixture
 def client(monkeypatch):
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Diese Tests
+    # prüfen Validierungs-/ID-Logik, nicht Auth — Open-Mode erzwingen.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     storage = MagicMock(name="Neo4jStorage")
     app.extensions = {"neo4j_storage": storage}
     app.register_blueprint(simulation_bp, url_prefix="/api/simulation")

--- a/backend/tests/test_compose_snapshot.py
+++ b/backend/tests/test_compose_snapshot.py
@@ -16,13 +16,30 @@ def _has_docker():
 
 
 def _compose_config(*extra_files: str):
-    """Run `docker compose config` from repo root and return parsed JSON."""
+    """Run `docker compose config` from repo root and return parsed JSON.
+
+    Tests prüfen die Compose-File-Defaults (z. B. AGORA_BIND_HOST=127.0.0.1).
+    Ohne `--env-file /dev/null` würde die User-`.env` durchschlagen und etwa
+    bei AGORA_BIND_HOST=0.0.0.0 die Loopback-Pin-Tests rotbrechen.
+    """
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    cmd = ["docker", "compose", "-f", "docker-compose.yml"]
+    # /dev/null ist unter macOS/Linux ein leeres File → Compose ignoriert
+    # automatisch die default-`.env` und nimmt nur Defaults aus der yml.
+    cmd = ["docker", "compose", "--env-file", "/dev/null", "-f", "docker-compose.yml"]
     for f in extra_files:
         cmd.extend(["-f", f])
     cmd.extend(["config", "--format", "json"])
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root, timeout=30)
+    # Auch die Process-ENV neutralisieren, damit Shell-AGORA_*-Vars (z. B.
+    # exportierte BIND_HOST aus direnv) nicht doch noch durchschlagen.
+    clean_env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith("AGORA_") and k not in {"LLM_BASE_URL"}
+    }
+    # PATH und DOCKER_HOST müssen erhalten bleiben — sind in clean_env enthalten,
+    # weil sie nicht mit AGORA_ beginnen.
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=repo_root, timeout=30, env=clean_env
+    )
     if result.returncode != 0:
         pytest.skip(f"docker compose config failed: {result.stderr.strip()}")
     return json.loads(result.stdout)

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -155,13 +155,17 @@ def _persist_report_with_hypotheses() -> None:
 
 def _rate_limited_report_app():
     app = Flask(__name__)
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Diese Tests
+    # prüfen Rate-Limiting, nicht Auth — Open-Mode erzwingen.
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["AGORA_REPORT_RATE_LIMIT_MAX"] = 2
     app.config["AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS"] = 60
     app.register_blueprint(report_bp, url_prefix="/api/report")
     return app
 
 
-def test_report_generate_endpoint_rate_limits_requests():
+def test_report_generate_endpoint_rate_limits_requests(monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     client = _rate_limited_report_app().test_client()
 
     for _ in range(2):
@@ -177,7 +181,8 @@ def test_report_generate_endpoint_rate_limits_requests():
     assert payload["retry_after_seconds"] == 60
 
 
-def test_report_chat_endpoint_rate_limits_requests():
+def test_report_chat_endpoint_rate_limits_requests(monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
     client = _rate_limited_report_app().test_client()
 
     for _ in range(2):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -48,9 +48,23 @@ class TestDefaults:
 
     @pytest.fixture(autouse=True)
     def _min_env(self, monkeypatch):
-        """Minimum env so validators pass (debug=True, LLM_API_KEY set)."""
+        """Minimum env so validators pass (debug=True, LLM_API_KEY set).
+
+        Plus clear of all field-alias env-vars whose values come from a
+        host .env (LLM_BASE_URL, REDIS_URL, EMBEDDING_*, VECTOR_DIM, …).
+        pydantic-settings reads real os.environ even with _env_file=None,
+        so without this delenv-sweep the local dev-shell pollutes default-
+        Pin-Tests.
+        """
         monkeypatch.setenv("FLASK_DEBUG", "true")
         monkeypatch.setenv("LLM_API_KEY", "dummy")
+        for var in (
+            "LLM_BASE_URL", "LLM_MODEL_NAME",
+            "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "VECTOR_DIM",
+            "REDIS_URL",
+            "NEO4J_URI", "NEO4J_USER",
+        ):
+            monkeypatch.delenv(var, raising=False)
 
     def test_llm_base_url_default(self):
         s = AgoraSettings(_env_file=None)

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -1,9 +1,24 @@
+import os
+
+import pytest
 from flask import Flask
 
 from app.api import simulation_bp
 from app.api.simulation_lifecycle import _detect_default_provider
 from app.services.artifact_store import InMemoryArtifactStore
 from app.utils.rate_limit import llm_trigger_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_token():
+    # @require_scope greift sobald AGORA_AUTH_TOKEN gesetzt ist. Tests in
+    # dieser Datei prüfen Validierungs-/Routing-Logik, nicht Auth — Open-Mode.
+    prev = os.environ.pop("AGORA_AUTH_TOKEN", None)
+    try:
+        yield
+    finally:
+        if prev is not None:
+            os.environ["AGORA_AUTH_TOKEN"] = prev
 
 
 def _reset_llm_trigger_limiter():
@@ -13,6 +28,7 @@ def _reset_llm_trigger_limiter():
 def _build_test_app(*, artifact_store=None):
     _reset_llm_trigger_limiter()
     app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 20
     app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
     app.extensions = {}


### PR DESCRIPTION
## Summary

Behebt #527 — alle 25 pre-existing Test-Failures auf main, drei mechanische Gruppen:

| Gruppe | Was | Tests |
|---|---|---|
| A — Auth-Gate | `@require_scope` aus PR #524 → 401 statt 4xx in Validation-Tests | 15 |
| B — Settings-Pin | pydantic-settings liest `os.environ` auch bei `_env_file=None` → User-`.env` schlägt durch | 4 |
| C — Compose-Snapshot | `docker compose config` liest User-`.env` → `AGORA_BIND_HOST=0.0.0.0` bricht Loopback-Pin | 2 |

(Original Issue rechnete 21, durch PR #526 sind 4 neue Download-Tests dazugekommen — gleiche Auth-Pattern.)

## Fix-Muster

**Gruppe A** — pro betroffener Datei in der App-Fixture:
\`\`\`python
monkeypatch.delenv(\"AGORA_AUTH_TOKEN\", raising=False)
app.config[\"AGORA_AUTH_TOKEN\"] = \"\"
\`\`\`

**Gruppe B** — `_min_env`-Fixture in `test_settings.py` macht delenv-Sweep für LLM_BASE_URL, EMBEDDING_*, VECTOR_DIM, REDIS_URL, NEO4J_*.

**Gruppe C** — `_compose_config()` in `test_compose_snapshot.py` ruft Compose jetzt mit `--env-file /dev/null` und AGORA_-stripped subprocess-ENV auf.

## Files

| File | Lines | Tests fixed |
|---|---|---|
| `tests/api/test_provider_override_key_fallback.py` | +8/-2 | 2 |
| `tests/api/test_report_download_no_tempfile.py` | +5/-1 | 4 |
| `tests/api/test_report_modes.py` | +5/-1 | 1 |
| `tests/api/test_simulation_endpoints.py` | +4/-0 | 6 |
| `tests/test_report_export.py` | +7/-2 | 2 |
| `tests/test_simulation_api_routes.py` | +16/-0 | 4 |
| `tests/test_settings.py` | +15/-1 | 4 |
| `tests/test_compose_snapshot.py` | +20/-3 | 2 |

**Keine Production-Code-Änderungen** — nur Test-Fixtures + Test-Setup.

## Test plan

- [x] `cd backend && uv run pytest tests/ -q --ignore=tests/eval` → **2556 passed, 0 failed**, 2 skipped (Redis-not-reachable, env-bedingt)
- [x] `cd backend && uv run ruff check tests/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)