### PR TITLE
fix(prod): point AGORA_INSTANCE_DIR at writable bind mount

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -74,6 +74,13 @@ services:
       - TZ=Europe/Berlin
       # LLM-Default für Sim-Runner — siehe docker-compose.yml.
       - LLM_MAX_OUTPUT_TOKENS=${LLM_MAX_OUTPUT_TOKENS:-16384}
+      # ArtifactLocator-Fallback zeigt sonst auf /app/instance (3x parent
+      # von backend/app/utils/artifact_locator.py) — der ist unter
+      # `read_only: true` nicht beschreibbar. Der Bind-Mount aus
+      # docker-compose.yml legt das writable Verzeichnis aber auf
+      # /app/backend/instance. Mit dieser Variable schreibt der Code
+      # genau dorthin.
+      - AGORA_INSTANCE_DIR=/app/backend/instance
 
   neo4j:
     ports: !reset []


### PR DESCRIPTION
## Summary
- Ontology-Generate crashte beim allerersten `seed_run_stage_routing()` mit `OSError 30: Read-only file system`.
- Root Cause: `ArtifactLocator.runs_dir()` fällt ohne `AGORA_INSTANCE_DIR` auf `__file__/../../../instance` zurück → `/app/instance`. Der bind-mount aus `docker-compose.yml` liegt aber auf `/app/backend/instance`. Seit Hardening-Commit 78bec21 (`read_only: true`) ist `/app/instance` damit unbeschreibbar.
- Fix: env-Var `AGORA_INSTANCE_DIR=/app/backend/instance` explizit setzen → Code zeigt auf den bereits gemounteten, writable Bind. Kein Code-Touch, kein Hardening-Rückbau, Image bit-identisch.

## Why "Modellauswahl works, Ontology fails"
Modellauswahl ist ein reiner GET aus der `llm_profiles.db` (im writable bind). Ontology ist der erste Endpoint, der per-Run-Routing nach `instance/runs/<run_id>/` schreibt → trifft den unbeschreibbaren Pfad.

## Verification
- `docker compose up -d agora` recreatet den Container (kein Rebuild nötig).
- Smoke: `POST /api/graph/ontology/generate` mit multipart/form-data — durchläuft jetzt `create_run` → `seed_run_stage_routing` → `StageModelRouter.resolve` → `LLMClient.from_route` → LLM-Call.
- Host-FS: `backend/instance/runs/run_0dc78c1b55b9/` wurde tatsächlich angelegt.

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.prod.yml -f deploy/compose/docker-compose.prod-with-proxy.yml up -d agora`
- [ ] Im UI: Projekt anlegen → Ontologie generieren → erwartet 200 + `entity_types`/`edge_types` im Response
- [ ] `ls backend/instance/runs/` zeigt neues `run_*`-Verzeichnis

## Follow-ups (separat)
- ArtifactLocator-Fallback `../../../instance` zeigt auch im Dev-Mode auf `<repo-root>/instance` statt auf `<repo-root>/backend/instance` (siehe `backend/instance` vs. `instance` auf dem Host) — Pfad-Asymmetrie könnte in einem späteren Refactor gerade gezogen werden, aber nicht in diesem Hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)