### PR TITLE
feat(ui): LlmProfilePicker in Step2 + Step4 + Branch-Form

### DIFF
--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -41,14 +41,23 @@ const useCustomDays = ref(false)
 const customSimulationDays = ref(3)
 const selectedProfile = ref(null)
 const llmProfileId = ref(props.projectData?.llm_profile_id ?? null)
+const userPickedProfile = ref(false)
 const showRuntimeOptions = ref(false)
 
+// Nach async-Hydration von projectData den Default einmal nachziehen, aber
+// niemals, sobald der User selbst eine Wahl getroffen hat (auch nicht für
+// "Server-Standard" = null).
 watch(
   () => props.projectData?.llm_profile_id,
   (next) => {
-    if (next && !llmProfileId.value) llmProfileId.value = next
+    if (userPickedProfile.value) return
+    if (next) llmProfileId.value = next
   },
 )
+
+watch(llmProfileId, () => {
+  userPickedProfile.value = true
+})
 
 const {
   runtimeProvider,

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -22,6 +22,7 @@ import {
   buildQuotaPlanFromEntries,
 } from '../contracts/personaQuotaContract'
 import { checkLlmProviderHasKey } from '../api/llmProviderKeys'
+import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'
 
 const { t } = useI18n()
 
@@ -39,7 +40,15 @@ const customMaxRounds = ref(40)
 const useCustomDays = ref(false)
 const customSimulationDays = ref(3)
 const selectedProfile = ref(null)
+const llmProfileId = ref(props.projectData?.llm_profile_id ?? null)
 const showRuntimeOptions = ref(false)
+
+watch(
+  () => props.projectData?.llm_profile_id,
+  (next) => {
+    if (next && !llmProfileId.value) llmProfileId.value = next
+  },
+)
 
 const {
   runtimeProvider,
@@ -245,6 +254,7 @@ async function triggerPrepare() {
     parallel_profile_count: 5,
     language: language.value,
   }
+  if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
   const m = effectiveModel()
   if (m) payload.llm_model = m
   // Smoke-Fix Slice 04: kein hartes Abbrechen bei fehlendem Session-Key mehr.
@@ -311,14 +321,24 @@ onMounted(() => {
         </p>
 
         <div class="setup-grid">
+          <!-- LLM-Profil (optional, schlägt Model/Provider-Overrides) -->
+          <div class="setup-cell setup-cell--wide">
+            <LlmProfilePicker v-model="llmProfileId">
+              <template #hint>
+                <span class="hint">{{ t('step2.llmProfile.hint') }}</span>
+              </template>
+            </LlmProfilePicker>
+          </div>
+
           <!-- Model -->
-          <div class="setup-cell">
+          <div class="setup-cell" :class="{ 'is-overridden-by-profile': llmProfileId }">
             <Select
               v-model="modelOption"
               :label="t('step2.model.label')"
               :options="modelOptions"
             />
-            <p class="hint" v-if="loadingModels">{{ t('step2.model.loadingModels') }}</p>
+            <p class="hint" v-if="llmProfileId">{{ t('step2.llmProfile.modelIgnored') }}</p>
+            <p class="hint" v-else-if="loadingModels">{{ t('step2.model.loadingModels') }}</p>
             <p class="hint" v-else-if="!runtimeProviderEnabled && serverDefaultRequiresOllama && !ollamaReachable">{{ t('step2.model.noOllama') }}</p>
             <p class="hint" v-else-if="!runtimeProviderEnabled && defaultProvider === 'openai'">{{ t('step2.model.openAiDefault') }}</p>
           </div>
@@ -676,6 +696,7 @@ onMounted(() => {
 }
 .setup-cell { display: flex; flex-direction: column; gap: var(--s-2); }
 .setup-cell--wide { grid-column: 1 / -1; }
+.setup-cell.is-overridden-by-profile { opacity: 0.6; }
 
 .runtime-toggle {
   display: flex;

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -12,6 +12,7 @@ import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
 import StickyScrollBanner from './ui/StickyScrollBanner.vue'
+import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'
 import ReportBranchControls from './step4/ReportBranchControls.vue'
 import ReportModelControls from './step4/ReportModelControls.vue'
 import ReportModeControls from './step4/ReportModeControls.vue'
@@ -131,6 +132,13 @@ function resolveInitialReportRoute(): StageLLMRoute | null {
 const reportRoute = ref<StageLLMRoute | null>(resolveInitialReportRoute())
 const isRegenerating = ref(false)
 
+const STORAGE_REPORT_PROFILE_ID = 'agora.report.llmProfileId'
+const llmProfileId = ref<string | null>(localStorage.getItem(STORAGE_REPORT_PROFILE_ID) || null)
+watch(llmProfileId, (val) => {
+  if (val) localStorage.setItem(STORAGE_REPORT_PROFILE_ID, val)
+  else localStorage.removeItem(STORAGE_REPORT_PROFILE_ID)
+})
+
 watch(reportRoute, (val) => {
   if (val?.provider_id && val?.model) {
     localStorage.setItem(STORAGE_REPORT_ROUTE, JSON.stringify(val))
@@ -169,6 +177,7 @@ async function regenerateWithModel() {
       force_regenerate: true,
       mode: reportMode.value,
     }
+    if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
     const m = effectiveReportModel()
     if (m) payload.llm_model = m
     addLog(`Report neu generieren${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
@@ -213,6 +222,7 @@ async function startReportConfirmed() {
       simulation_id: simId,
       mode: reportMode.value,
     }
+    if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
     const m = effectiveReportModel()
     if (m) payload.llm_model = m
     addLog(`Report starten${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
@@ -424,6 +434,7 @@ const {
 async function createBranchFromReport(branchForm: {
   branch_name: string
   llm_model: string
+  llm_profile_id: string
   language: string
   max_agents: string
 }) {
@@ -432,6 +443,7 @@ async function createBranchFromReport(branchForm: {
   branchBusy.value = true
   try {
     const overrides: Record<string, unknown> = {}
+    if (branchForm.llm_profile_id) overrides.llm_profile_id = branchForm.llm_profile_id
     if (branchForm.llm_model.trim()) overrides.llm_model = branchForm.llm_model.trim()
     if (branchForm.language.trim()) overrides.language = branchForm.language.trim()
     if (branchForm.max_agents !== '') overrides.max_agents = Number(branchForm.max_agents)
@@ -539,10 +551,21 @@ onUnmounted(stopPolling)
           </div>
         </div>
 
+        <div
+          v-if="resolvedSimulationId || simulationId"
+          class="report-profile-picker"
+        >
+          <LlmProfilePicker v-model="llmProfileId">
+            <template #hint>
+              <span class="hint">{{ t('step4.llmProfile.hint') }}</span>
+            </template>
+          </LlmProfilePicker>
+        </div>
         <ReportModelControls
           v-if="resolvedSimulationId || simulationId"
           v-model="reportRoute"
           :is-regenerating="isRegenerating"
+          :class="{ 'is-overridden-by-profile': llmProfileId }"
           @regenerate="regenerateWithModel"
         />
         <ReportModeControls
@@ -968,6 +991,12 @@ onUnmounted(stopPolling)
   display: flex;
   align-items: center;
   gap: var(--s-3);
+}
+.report-profile-picker {
+  margin-bottom: var(--s-3);
+}
+.is-overridden-by-profile {
+  opacity: 0.6;
 }
 .stop-btn-wrap {
   display: inline-flex;

--- a/frontend/src/components/__tests__/LlmProfilePicker.spec.ts
+++ b/frontend/src/components/__tests__/LlmProfilePicker.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * LlmProfilePicker — Vitest-Spec (LPP-01).
+ *
+ * 1. renders fallback option — leerer Store → select hat option value="" mit fallbackLabel.
+ * 2. renders profiles when loaded — 2 Profile → 3 options total.
+ * 3. emits null when fallback chosen — option value="" → emit null (nicht "").
+ * 4. emits profile id when profile chosen — option value="prof-123" → emit "prof-123".
+ * 5. disabled prop disables select.
+ * 6. shows loading state — store.loading=true → loading-Text sichtbar.
+ * 7. shows error state — store.error="boom" → error-Banner sichtbar.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { createI18n } from 'vue-i18n'
+import { useLlmProfilesStore } from '../../store/llmProfiles'
+
+// Mock fetchLlmProfiles so onMounted fetch() never hits the network.
+vi.mock('../../api/llmProfiles', () => ({
+  fetchLlmProfiles: vi.fn().mockResolvedValue([]),
+  createLlmProfile: vi.fn(),
+  updateLlmProfile: vi.fn(),
+  deleteLlmProfile: vi.fn(),
+  setDefaultLlmProfile: vi.fn(),
+}))
+
+import LlmProfilePicker from '../llm/LlmProfilePicker.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    de: {
+      llmProfilePicker: {
+        label: 'LLM-Profil (optional)',
+        serverDefault: 'Server-Standard (aktives Profil)',
+        loading: 'Profile laden…',
+        error: 'Profile konnten nicht geladen werden.',
+        defaultSuffix: 'default',
+      },
+    },
+    en: {},
+  },
+})
+
+function makePinia(overrides: {
+  profiles?: Array<{ id: string; name: string; model_name: string; is_default: boolean; provider: string; base_url: string; api_key: null | string; created_at: string; updated_at: string }>
+  loading?: boolean
+  error?: string | null
+} = {}) {
+  return createTestingPinia({
+    createSpy: vi.fn,
+    initialState: {
+      llmProfiles: {
+        profiles: overrides.profiles ?? [],
+        loading: overrides.loading ?? false,
+        saving: false,
+        error: overrides.error ?? null,
+      },
+    },
+  })
+}
+
+const PROFILE_A = {
+  id: 'prof-123',
+  name: 'GPT-4o',
+  model_name: 'gpt-4o',
+  is_default: false,
+  provider: 'openai' as const,
+  base_url: 'https://api.openai.com/v1',
+  api_key: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const PROFILE_B = {
+  id: 'prof-456',
+  name: 'Gemini Flash',
+  model_name: 'gemini-2.0-flash',
+  is_default: true,
+  provider: 'gemini' as const,
+  base_url: 'https://generativelanguage.googleapis.com/v1beta',
+  api_key: null,
+  created_at: '2026-01-02T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('LlmProfilePicker', () => {
+  it('1. renders fallback option — leerer Store → select hat option value="" mit fallbackLabel', async () => {
+    const pinia = makePinia()
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null },
+      global: { plugins: [i18n, pinia] },
+    })
+    await flushPromises()
+
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(1)
+    expect(options[0].attributes('value')).toBe('')
+    expect(options[0].text()).toBe('Server-Standard (aktives Profil)')
+
+    // No emit on initial render.
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+
+    wrapper.unmount()
+  })
+
+  it('2. renders profiles when loaded — 2 Profile → 3 options total', async () => {
+    const pinia = makePinia({ profiles: [PROFILE_A, PROFILE_B] })
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null },
+      global: { plugins: [i18n, pinia] },
+    })
+    await flushPromises()
+
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(3)
+    expect(options[0].attributes('value')).toBe('')
+    expect(options[1].attributes('value')).toBe('prof-123')
+    expect(options[2].attributes('value')).toBe('prof-456')
+
+    wrapper.unmount()
+  })
+
+  it('3. emits null when fallback chosen — option value="" → emit null', async () => {
+    const pinia = makePinia({ profiles: [PROFILE_A] })
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: 'prof-123' },
+      global: { plugins: [i18n, pinia] },
+    })
+    await flushPromises()
+
+    const select = wrapper.find('select')
+    // Simulate selecting the empty/fallback option.
+    await select.setValue('')
+    await select.trigger('change')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    // Must emit null, not the empty string.
+    expect(emitted![emitted!.length - 1][0]).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('4. emits profile id when profile chosen', async () => {
+    const pinia = makePinia({ profiles: [PROFILE_A] })
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null },
+      global: { plugins: [i18n, pinia] },
+    })
+    await flushPromises()
+
+    const select = wrapper.find('select')
+    await select.setValue('prof-123')
+    await select.trigger('change')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted![emitted!.length - 1][0]).toBe('prof-123')
+
+    wrapper.unmount()
+  })
+
+  it('5. disabled prop disables select', async () => {
+    const pinia = makePinia()
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null, disabled: true },
+      global: { plugins: [i18n, pinia] },
+    })
+    await flushPromises()
+
+    const select = wrapper.find('select')
+    expect(select.attributes('disabled')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('6. shows loading state — store.loading=true → loading-Text sichtbar', async () => {
+    const pinia = makePinia({ loading: true })
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null },
+      global: { plugins: [i18n, pinia] },
+    })
+    // Manually patch loading after pinia init so computed re-runs.
+    const store = useLlmProfilesStore()
+    store.$patch({ loading: true })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Profile laden…')
+
+    wrapper.unmount()
+  })
+
+  it('7. shows error state — store.error set → error-Banner sichtbar', async () => {
+    const pinia = makePinia({ error: 'boom' })
+    const wrapper = mount(LlmProfilePicker, {
+      props: { modelValue: null },
+      global: { plugins: [i18n, pinia] },
+    })
+    const store = useLlmProfilesStore()
+    store.$patch({ error: 'boom' })
+    await flushPromises()
+
+    const alert = wrapper.find('[role="alert"]')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('Profile konnten nicht geladen werden.')
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/__tests__/Step2EnvSetup.personaPoolMin.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.personaPoolMin.spec.ts
@@ -88,6 +88,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><slot /></div>' },
     Select: { template: '<select><slot /></select>' },
+    LlmProfilePicker: true,
   },
 }
 

--- a/frontend/src/components/__tests__/Step2EnvSetup.providerOverride.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.providerOverride.spec.ts
@@ -145,6 +145,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><label>{{ label }}</label><input :type="type || \'text\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" :placeholder="placeholder" /></div>', props: ['label', 'modelValue', 'type', 'placeholder'], emits: ['update:modelValue'] },
     Select: { template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option></select>', props: ['label', 'modelValue', 'options'], emits: ['update:modelValue'] },
+    LlmProfilePicker: true,
   },
 }
 

--- a/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
@@ -99,6 +99,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><slot /></div>' },
     Select: { template: '<select><slot /></select>' },
+    LlmProfilePicker: true,
   },
 }
 

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -116,6 +116,8 @@ const globalStubs = {
   Badge: { template: '<span><slot /></span>' },
   Kicker: { template: '<span><slot /></span>' },
   Select: { template: '<select />' },
+  LlmProfilePicker: true,
+  ReportBranchControls: true,
 }
 
 // Valides Report-Payload (ReportSchema-konform)

--- a/frontend/src/components/llm/LlmProfilePicker.vue
+++ b/frontend/src/components/llm/LlmProfilePicker.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { computed, onMounted, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useLlmProfilesStore } from '../../store/llmProfiles'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string | null
+    disabled?: boolean
+    fallbackLabel?: string
+    label?: string
+  }>(),
+  {
+    disabled: false,
+    fallbackLabel: undefined,
+    label: undefined,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+}>()
+
+const { t } = useI18n()
+const store = useLlmProfilesStore()
+
+// Stable unique id for label/aria wiring.
+const id = useId()
+const hintId = `${id}-hint`
+
+const resolvedLabel = computed(() => props.label ?? t('llmProfilePicker.label'))
+const resolvedFallbackLabel = computed(
+  () => props.fallbackLabel ?? t('llmProfilePicker.serverDefault'),
+)
+
+const options = computed(() => [
+  { value: '', label: resolvedFallbackLabel.value },
+  ...store.profiles.map((p) => ({
+    value: p.id,
+    label: `${p.name} — ${p.model_name}${p.is_default ? ` (${t('llmProfilePicker.defaultSuffix')})` : ''}`,
+  })),
+])
+
+onMounted(async () => {
+  // Only fetch when list is empty — avoid redundant requests on re-mount.
+  if (store.profiles.length === 0) {
+    try {
+      await store.fetch()
+    } catch {
+      // error is set on store.error; we surface it in the template.
+    }
+  }
+})
+
+function onChange(e: Event) {
+  const val = (e.target as HTMLSelectElement).value
+  emit('update:modelValue', val || null)
+}
+</script>
+
+<template>
+  <div class="llm-profile-picker">
+    <div class="llm-profile-picker__header">
+      <label :for="id" class="llm-profile-picker__label">
+        {{ resolvedLabel }}
+      </label>
+      <!-- named slot for use-site hint (e.g. "Für Persona-Generierung genutzt") -->
+      <span v-if="$slots.hint" :id="hintId" class="llm-profile-picker__hint">
+        <slot name="hint" />
+      </span>
+    </div>
+
+    <p
+      v-if="store.error"
+      role="alert"
+      class="llm-profile-picker__error"
+    >
+      {{ t('llmProfilePicker.error') }}
+    </p>
+
+    <div class="llm-profile-picker__select-wrap">
+      <select
+        :id="id"
+        class="llm-profile-picker__select"
+        :value="modelValue ?? ''"
+        :disabled="disabled || store.loading"
+        :aria-busy="store.loading ? 'true' : undefined"
+        :aria-describedby="$slots.hint ? hintId : undefined"
+        @change="onChange"
+      >
+        <option v-for="opt in options" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+
+      <span v-if="store.loading" class="llm-profile-picker__loading" aria-live="polite">
+        {{ t('llmProfilePicker.loading') }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.llm-profile-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.llm-profile-picker__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.llm-profile-picker__label {
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.llm-profile-picker__hint {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.llm-profile-picker__select-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.llm-profile-picker__select {
+  width: 100%;
+  appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-3, 6px);
+  padding: 7px 10px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+  transition: border-color 80ms ease;
+}
+
+.llm-profile-picker__select:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.llm-profile-picker__select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.llm-profile-picker__loading {
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+
+.llm-profile-picker__error {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--color-red, #c0392b);
+  margin: 0;
+  padding: 6px 10px;
+  background: var(--surface-warning, #fff3f3);
+  border-radius: var(--r-3, 6px);
+  border: 1px solid var(--hairline);
+}
+</style>

--- a/frontend/src/components/step4/ReportBranchControls.vue
+++ b/frontend/src/components/step4/ReportBranchControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import Button from '@/components/v4/forms/Button.vue'
 import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'
 
@@ -26,17 +26,16 @@ const branchForm = ref({
 })
 
 const profileIdModel = ref<string | null>(null)
-function onProfileChange(val: string | null) {
-  profileIdModel.value = val
+watch(profileIdModel, (val) => {
   branchForm.value.llm_profile_id = val ?? ''
-}
+})
 </script>
 
 <template>
   <div class="branch-controls">
     <input v-model="branchForm.branch_name" class="model-input" type="text" placeholder="Branch name" />
     <div class="branch-profile-cell">
-      <LlmProfilePicker :model-value="profileIdModel" @update:model-value="onProfileChange" />
+      <LlmProfilePicker v-model="profileIdModel" />
     </div>
     <input
       v-model="branchForm.llm_model"

--- a/frontend/src/components/step4/ReportBranchControls.vue
+++ b/frontend/src/components/step4/ReportBranchControls.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import Button from '@/components/v4/forms/Button.vue'
+import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'
 
 const emit = defineEmits<{
-  create: [form: { branch_name: string; llm_model: string; language: string; max_agents: string }]
+  create: [form: {
+    branch_name: string
+    llm_model: string
+    llm_profile_id: string
+    language: string
+    max_agents: string
+  }]
 }>()
 
 defineProps<{
@@ -13,15 +20,31 @@ defineProps<{
 const branchForm = ref({
   branch_name: '',
   llm_model: '',
+  llm_profile_id: '',
   language: '',
   max_agents: '',
 })
+
+const profileIdModel = ref<string | null>(null)
+function onProfileChange(val: string | null) {
+  profileIdModel.value = val
+  branchForm.value.llm_profile_id = val ?? ''
+}
 </script>
 
 <template>
   <div class="branch-controls">
     <input v-model="branchForm.branch_name" class="model-input" type="text" placeholder="Branch name" />
-    <input v-model="branchForm.llm_model" class="model-input" type="text" placeholder="LLM model override" />
+    <div class="branch-profile-cell">
+      <LlmProfilePicker :model-value="profileIdModel" @update:model-value="onProfileChange" />
+    </div>
+    <input
+      v-model="branchForm.llm_model"
+      class="model-input"
+      :class="{ 'is-overridden-by-profile': profileIdModel }"
+      type="text"
+      placeholder="LLM model override"
+    />
     <input v-model="branchForm.language" class="model-input" type="text" placeholder="language" />
     <input v-model="branchForm.max_agents" class="model-input" type="number" min="1" placeholder="max agents" />
     <Button
@@ -38,8 +61,12 @@ const branchForm = ref({
 <style scoped>
 .branch-controls {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: var(--s-3);
+}
+.branch-profile-cell {
+  display: flex;
+  align-items: center;
 }
 .model-input {
   background: var(--bg-elevated);
@@ -53,6 +80,9 @@ const branchForm = ref({
 }
 .model-input:focus {
   border-color: var(--accent);
+}
+.model-input.is-overridden-by-profile {
+  opacity: 0.6;
 }
 @media (max-width: 720px) {
   .branch-controls {

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -121,12 +121,10 @@ const pickerValue = computed<StageLLMRoute | null>(() => {
   if (!formModel.value) return null
   // Best-Effort: profile.provider → erste passende Runtime-ID (Cloud
   // gegenüber Local bevorzugen, wenn base_url darauf hinweist).
-  let providerId = ''
-  if (formProvider.value === 'ollama') {
-    providerId = formBaseUrl.value.includes('ollama.com') ? 'ollama_cloud' : 'ollama'
-  } else {
-    providerId = formProvider.value
-  }
+  const providerId =
+    formProvider.value === 'ollama'
+      ? formBaseUrl.value.includes('ollama.com') ? 'ollama_cloud' : 'ollama'
+      : formProvider.value
   return {
     stage: null,
     provider_id: providerId,
@@ -143,8 +141,8 @@ function onPickerChange(route: StageLLMRoute | null): void {
     formModel.value = ''
     return
   }
-  formModel.value = route.model
-  const mapped = RUNTIME_TO_PROFILE_PROVIDER[route.provider_id]
+  formModel.value = route.model ?? ''
+  const mapped = route.provider_id != null ? RUNTIME_TO_PROFILE_PROVIDER[route.provider_id] : undefined
   if (mapped) {
     formProvider.value = mapped.provider
     // base_url nur überschreiben, wenn das aktuelle Feld leer ist oder zur

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1274,5 +1274,12 @@
   },
   "upload": {
     "pdfVisionDisabledHint": "PDF-Vision-Auswertung ist standardmäßig aus. Aktivieren über ENABLE_PDF_VISION=true (Cloud-Calls + Latenz)."
+  },
+  "llmProfilePicker": {
+    "label": "LLM-Profil (optional)",
+    "serverDefault": "Server-Standard (aktives Profil)",
+    "loading": "Profile laden…",
+    "error": "Profile konnten nicht geladen werden.",
+    "defaultSuffix": "default"
   }
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -288,6 +288,10 @@
       "noDbKeyBanner": "Für {provider} ist in Einstellungen → LLM-Anbieter kein API-Schlüssel hinterlegt. Bitte dort speichern oder hier eingeben.",
       "checkingKey": "Key-Status wird geprüft…"
     },
+    "llmProfile": {
+      "hint": "Wird für Persona-Generierung genutzt.",
+      "modelIgnored": "Wird vom Profil überschrieben."
+    },
     "personas": {
       "title": "Personas generieren",
       "count": "Anzahl Agenten",
@@ -544,6 +548,9 @@
       "reportLabel": "Modell für Report",
       "placeholder": "Modell wählen …",
       "regenerate": "Neu generieren"
+    },
+    "llmProfile": {
+      "hint": "Wird für Report-Generierung genutzt."
     },
     "quote": {
       "openSource": "Quelle öffnen"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1274,5 +1274,12 @@
   },
   "upload": {
     "pdfVisionDisabledHint": "PDF vision is off by default. Enable via ENABLE_PDF_VISION=true (Cloud calls + latency)."
+  },
+  "llmProfilePicker": {
+    "label": "LLM Profile (optional)",
+    "serverDefault": "Server default (active profile)",
+    "loading": "Loading profiles…",
+    "error": "Failed to load profiles.",
+    "defaultSuffix": "default"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -288,6 +288,10 @@
       "noDbKeyBanner": "No API key is stored for {provider} in Settings → LLM Providers. Please save one there or enter it here.",
       "checkingKey": "Checking key status…"
     },
+    "llmProfile": {
+      "hint": "Used for persona generation.",
+      "modelIgnored": "Overridden by profile."
+    },
     "personas": {
       "title": "Generate personas",
       "count": "Number of agents",
@@ -544,6 +548,9 @@
       "reportLabel": "Model for report",
       "placeholder": "Select model …",
       "regenerate": "Regenerate"
+    },
+    "llmProfile": {
+      "hint": "Used for report generation."
     },
     "quote": {
       "openSource": "Open source"


### PR DESCRIPTION
## Summary

- Neue Komponente `frontend/src/components/llm/LlmProfilePicker.vue` nutzt den existierenden `useLlmProfilesStore` und ist `v-model`-fähig (`string | null`, `null` = Server-Standard).
- `Step2EnvSetup.vue` (Persona-Gen) und `Step4Report.vue` (Report-Erstellung + Branch-Form) zeigen den Picker oberhalb der bestehenden Modell-Auswahl. Bei explizit gewähltem Profil wird `llm_profile_id` im Payload mitgesendet; die Modell-Cell wird visuell auf 60 % Opacity gedimmt + Hinweistext. Der bestehende `llm_model`-Override bleibt funktional — Backend wählt selbst (Profil > Modell-Override, P5.3-Semantik).
- `ReportBranchControls.vue` erweitert `branchForm` um `llm_profile_id`; `createBranchFromReport` reicht den Wert in `overrides` durch.
- Step2 nimmt die Vorbelegung aus `projectData.llm_profile_id`. Step4 persistiert die Wahl in `localStorage` (`agora.report.llmProfileId`).
- 7 neue Vitest-Tests für den Picker. Bestehende Step2/Step4-Specs stubben den Picker (`LlmProfilePicker: true`), damit sie ohne Pinia-Setup grün bleiben.

## Keine Backend-Änderung

Alle drei Endpoints (`/api/graph/ontology/generate`, `/api/graph/build`, `/api/report/generate`) akzeptieren `llm_profile_id` bereits seit P5.3.

## Test plan

- [ ] `cd frontend && bun run test -- --run` — Suite 1060/1060 grün
- [ ] `cd frontend && bun run lint` clean
- [ ] `cd frontend && bun run typecheck` clean
- [ ] UI-Smoketest: Step2 öffnen → Profile-Dropdown sichtbar oberhalb des Modell-Selects, Profil wählen → Modell-Cell dimmt + Hinweistext sichtbar, Personas generieren → Network-Inspect zeigt `llm_profile_id` im Payload
- [ ] UI-Smoketest: Step4 → Picker sichtbar, Wahl persistiert über Reload, Report-Generate-Payload enthält `llm_profile_id`
- [ ] UI-Smoketest: Branch-Form → Picker neben model-input, Profil-Wahl → Branch-Override enthält `llm_profile_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)