### PR TITLE
fix(sim,deploy): coerce active_hours + nginx healthcheck on IPv4

### DIFF
--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -966,7 +966,7 @@ Return JSON format (no markdown):
                 activity_level=cfg.get("activity_level", 0.5),
                 posts_per_hour=cfg.get("posts_per_hour", 0.5),
                 comments_per_hour=cfg.get("comments_per_hour", 1.0),
-                active_hours=cfg.get("active_hours", list(range(9, 23))),
+                active_hours=self._coerce_int_list(cfg.get("active_hours"), list(range(9, 23))),
                 response_delay_min=cfg.get("response_delay_min", 5),
                 response_delay_max=cfg.get("response_delay_max", 60),
                 sentiment_bias=cfg.get("sentiment_bias", 0.0),

--- a/backend/tests/services/test_agent_config_active_hours_coerce.py
+++ b/backend/tests/services/test_agent_config_active_hours_coerce.py
@@ -1,0 +1,43 @@
+"""Regression tests for active_hours coercion in SimulationConfigGenerator.
+
+LLMs (z. B. gpt-5.4-nano) liefern active_hours gelegentlich als Liste von
+Objekten ``[{"hour": 18, "weight": 0.8}, ...]`` statt als ``list[int]``.
+Vor dem Fix landete dieser Wert ungeprüft in ``AgentActivityConfig.active_hours``
+und ließ später ``_sim_common.compute_start_hour_offset`` mit
+``TypeError: int() argument ... not 'dict'`` crashen.
+
+Der Fix nutzt den bereits existierenden Helper
+``SimulationConfigGenerator._coerce_int_list`` an der Aufruf-Stelle in
+``_generate_agent_configs_batch``. Diese Tests sichern das Verhalten ab.
+"""
+
+from app.services.simulation_config_generator import SimulationConfigGenerator
+
+
+class TestCoerceIntListActiveHours:
+    """Verhalten des Helpers für die drei real auftretenden LLM-Shapes."""
+
+    def test_pure_int_list_passes_through(self) -> None:
+        result = SimulationConfigGenerator._coerce_int_list([9, 10, 11], default=[0])
+        assert result == [9, 10, 11]
+
+    def test_dict_shape_extracts_hour_key(self) -> None:
+        """gpt-5.4-nano-Shape: [{"hour": 18, "weight": 0.8}, ...]."""
+        llm_output = [
+            {"hour": 9, "weight": 0.5},
+            {"hour": 18, "weight": 0.8},
+        ]
+        result = SimulationConfigGenerator._coerce_int_list(llm_output, default=[0])
+        assert result == [9, 18]
+
+    def test_mixed_garbage_drops_invalid_items(self) -> None:
+        """Müll-Items werden gedroppt, valide Items bleiben — kein Crash."""
+        llm_output = [9, "ten", {"hour": 11}, None, {"weight": 0.5}]
+        result = SimulationConfigGenerator._coerce_int_list(llm_output, default=[0])
+        # 9 (int), 11 (dict mit "hour") überleben; "ten", None, dict ohne hour fallen raus.
+        assert result == [9, 11]
+
+    def test_empty_input_falls_back_to_default(self) -> None:
+        """Komplett leeres/None-Input → Default-Range, nicht crashen."""
+        assert SimulationConfigGenerator._coerce_int_list(None, default=[8, 9]) == [8, 9]
+        assert SimulationConfigGenerator._coerce_int_list("nonsense", default=[8, 9]) == [8, 9]

--- a/deploy/compose/docker-compose.prod-with-proxy.yml
+++ b/deploy/compose/docker-compose.prod-with-proxy.yml
@@ -42,7 +42,9 @@ services:
       # Pfade sind relativ zum Repo-Root (Aufruf-Verzeichnis bei `docker compose -f ...`).
       - ./frontend/dist:/usr/share/nginx/html:ro
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost/healthz"]
+      # busybox-wget in nginx:alpine resolved `localhost` als IPv6 (::1),
+      # `listen 80;` bindet aber nur IPv4 → ECONNREFUSED. 127.0.0.1 erzwingt IPv4.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Zwei kleine, gemeinsam deploybare Bugfixes aus [`docs/.local/handoff-2026-05-18.md`](docs/.local/handoff-2026-05-18.md).

### Bug #1 — Sim-Subprocess `TypeError: int() … not 'dict'`

`backend/scripts/_sim_common.compute_start_hour_offset:385` crashte, sobald das LLM (z. B. `gpt-5.4-nano`) `active_hours` als `[{"hour": 18, "weight": 0.8}, …]` statt `list[int]` lieferte. Der Wert landete ungeprüft in `AgentActivityConfig.active_hours`.

**Fix:** Aufruf-Stelle in `_generate_agent_configs_batch` (Z. 969) nutzt jetzt den bereits existierenden Helper `SimulationConfigGenerator._coerce_int_list` (Z. 666) — der `"hour"`-Key wird schon abgedeckt. Kein neuer Helper, kein Contract-Touch, `AgentActivityConfig` bleibt `@dataclass`.

### Bug #3 — `agora-nginx` Healthcheck `unhealthy`

`docker inspect` zeigte `wget: can't connect to remote host: Connection refused` — und das, obwohl nginx externe Requests problemlos servte. Root Cause: busybox-wget in `nginx:alpine` resolved `localhost` zu IPv6 (`::1`), die nginx-Config bindet aber nur IPv4 (`listen 80;`).

**Fix:** Healthcheck-Cmd in `deploy/compose/docker-compose.prod-with-proxy.yml` nutzt jetzt `http://127.0.0.1/healthz` (erzwingt IPv4). `agora.conf` bleibt unverändert — die `/healthz`-Route ist schon vorhanden.

## Test plan

- [x] `backend/tests/services/test_agent_config_active_hours_coerce.py` — 4 neue Cases (pure-int, dict-shape, mixed garbage, empty fallback)
- [x] `pytest tests/contracts/` — 210/210 grün
- [x] `ruff check app/ tests/` — clean
- [x] `mypy app` — clean
- [ ] Nach Merge: Mac + VPS rebuild, `docker inspect agora-nginx --format '{{.State.Health.Status}}'` muss `healthy` zeigen
- [ ] Nach Merge: Re-Run des Crash-Setups `sim_698de5abe2e4` (Mehmet-Persona) muss ohne `TypeError` durchlaufen

🤖 Generated with [Claude Code](https://claude.com/claude-code)