### PR TITLE
fix(neo4j): driver-pool liveness checks + honest search retry

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -90,6 +90,14 @@ def create_app(config_class=Config):
 
     # Setup logging
     logger = setup_logger('agora')
+
+    # Bind neo4j driver loggers to the app handler via propagation.
+    # Without this, driver output lands on stderr without structured formatting.
+    # Level WARNING suppresses the verbose DEBUG/INFO pool chatter that floods
+    # logs during parallel persona generation (pool-storm symptom).
+    for _neo4j_logger_name in ("neo4j", "neo4j.io", "neo4j.pool"):
+        logging.getLogger(_neo4j_logger_name).setLevel(logging.WARNING)
+
     from .utils.proxy import apply_proxy_fix
     if apply_proxy_fix(app):
         logger.info(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -106,6 +106,18 @@ class Config:
     # No insecure default password. Must be provided via environment (.env / secret manager).
     NEO4J_PASSWORD = os.environ.get('NEO4J_PASSWORD', '')
 
+    # Neo4j driver pool configuration. NEO4J_LIVENESS_TIMEOUT is the key
+    # knob: before lending a pooled connection that has been idle longer
+    # than this many seconds, the driver does a RESET round-trip to weed
+    # out stale sockets that Docker bridge / conntrack already killed
+    # silently. Without it, parallel persona generation hits a Bolt
+    # socket-storm on the first burst after fork-idle.
+    NEO4J_MAX_POOL_SIZE = int(os.environ.get('NEO4J_MAX_POOL_SIZE', '50'))
+    NEO4J_ACQ_TIMEOUT = float(os.environ.get('NEO4J_ACQ_TIMEOUT', '60.0'))
+    NEO4J_CONN_TIMEOUT = float(os.environ.get('NEO4J_CONN_TIMEOUT', '15.0'))
+    NEO4J_MAX_LIFETIME = int(os.environ.get('NEO4J_MAX_LIFETIME', '3600'))
+    NEO4J_LIVENESS_TIMEOUT = float(os.environ.get('NEO4J_LIVENESS_TIMEOUT', '30.0'))
+
     # Agent tool-use during simulation. Experimental and intentionally opt-in.
     ENABLE_AGENT_TOOLS = os.environ.get('ENABLE_AGENT_TOOLS', 'false').lower() in ('true', '1', 'yes')
     MAX_TOOL_CALLS_PER_ACTION = int(os.environ.get('MAX_TOOL_CALLS_PER_ACTION', '2'))

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -65,9 +65,7 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
         # in tests can install one without going through ``__init__``.
         self._lock = threading.Lock()
 
-        self._driver = GraphDatabase.driver(
-            self._uri, auth=(self._user, self._password)
-        )
+        self._driver = GraphDatabase.driver(self._uri, **self._driver_kwargs())
         self._embedding = embedding_service or EmbeddingService()
         self._ner = ner_extractor or NERExtractor()
         self._search = SearchService(
@@ -109,12 +107,31 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
                 if self._driver is None:
                     logger.info("Neo4j driver re-initializing after fork")
                     self._driver = GraphDatabase.driver(
-                        self._uri, auth=(self._user, self._password)
+                        self._uri, **self._driver_kwargs()
                     )
             # Connectivity check is deferred to the first actual call
             # via neo4j_call_with_retry if it uses session.run or similar.
             # But here we just return the session.
         return self._driver.session(**kwargs)
+
+    def _driver_kwargs(self) -> dict:
+        """Driver kwargs incl. pool-liveness defence against stale Bolt sockets.
+
+        ``liveness_check_timeout`` is the load-bearing knob: without it the
+        driver hands out connections from the pool without verifying they
+        are still alive, and the first parallel-persona burst after a
+        ~60 s fork-idle period writes onto sockets Docker's bridge has
+        already killed -> 30+ ``Failed to write data``-lines on neo4j.io.
+        """
+        return {
+            "auth": (self._user, self._password),
+            "max_connection_pool_size": Config.NEO4J_MAX_POOL_SIZE,
+            "connection_acquisition_timeout": Config.NEO4J_ACQ_TIMEOUT,
+            "connection_timeout": Config.NEO4J_CONN_TIMEOUT,
+            "max_connection_lifetime": Config.NEO4J_MAX_LIFETIME,
+            "liveness_check_timeout": Config.NEO4J_LIVENESS_TIMEOUT,
+            "keep_alive": True,
+        }
 
     def verify_connectivity(self) -> None:
         """Public connectivity probe for ``/api/status``.
@@ -137,24 +154,24 @@ class Neo4jStorage(Neo4jReadMixin, Neo4jWriteMixin, Neo4jSearchMixin, GraphStora
         self._call_with_retry(_probe)
 
     def _reset_driver_after_fork(self) -> None:
-        """Close and discard the inherited driver after gunicorn fork.
+        """Drop the inherited driver reference after gunicorn fork.
 
-        The first real DB call will trigger a new connection via the
-        existing lazy-connect logic in neo4j_call_with_retry.
+        Does NOT call ``driver.close()``: the inherited driver still owns
+        the parent's Bolt sockets (fork CoW). A ``GOODBYE`` frame from the
+        child would arrive at Neo4j over the very sockets the parent is
+        still actively using, severing the parent's connections without
+        notice. Abandoning the reference is the pattern the neo4j-driver
+        maintainers recommend for forking servers; the parent keeps its
+        pool, the child rebuilds its own on first use via
+        :meth:`_get_session`.
         """
-        try:
-            if self._driver is not None:
-                self._driver.close()
-        except Exception:
-            pass
-        finally:
-            self._driver = None
-            self._is_connected = False
-            # Re-init the lock: if the parent process happened to be holding
-            # it at fork time (unlikely with single-threaded gunicorn master,
-            # but cheap insurance) the child would inherit a locked mutex
-            # that nothing can ever release.
-            self._lock = threading.Lock()
+        self._driver = None
+        self._is_connected = False
+        # Re-init the lock: if the parent process happened to be holding it
+        # at fork time (unlikely with single-threaded gunicorn master, but
+        # cheap insurance) the child would inherit a locked mutex that
+        # nothing can ever release.
+        self._lock = threading.Lock()
 
     def set_ontology_mutation_service(self, service) -> None:
         """Late-bind the Issue #11 ``OntologyMutationService``.

--- a/backend/app/storage/search_service.py
+++ b/backend/app/storage/search_service.py
@@ -10,9 +10,12 @@ Both weights are configurable per-instance and overridable via
 import logging
 from typing import List, Dict, Any, Optional
 
+import neo4j.exceptions
 from neo4j import Session as Neo4jSession
+from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
 
 from .embedding_service import EmbeddingService
+from ..utils.retry import neo4j_call_with_retry
 
 logger = logging.getLogger('agora.search')
 
@@ -140,84 +143,113 @@ class SearchService:
         )
         return merged
 
+    def _run_with_retry(
+        self,
+        session: Neo4jSession,
+        cypher: str,
+        params: Dict[str, Any],
+        *,
+        fallback_label: str,
+    ) -> List[Any]:
+        """Execute a Cypher query with retry logic and honest error handling.
+
+        - Retries on transient Neo4j errors (ServiceUnavailable, SessionExpired,
+          TransientError) up to 2 times via neo4j_call_with_retry.
+        - Returns [] for missing index/procedure (ClientError with known codes),
+          so callers are never surprised by schema bootstrap races.
+        - Re-raises ClientError for genuine Cypher programming errors.
+        - Returns [] for all other exceptions after logging at WARNING.
+        """
+        _INDEX_CODES = frozenset({
+            "Neo.ClientError.Schema.IndexNotFound",
+            "Neo.ClientError.Procedure.ProcedureNotFound",
+        })
+        try:
+            return neo4j_call_with_retry(
+                lambda: list(session.run(cypher, **params)),
+                max_retries=2,
+            )
+        except neo4j.exceptions.ClientError as e:
+            if e.code in _INDEX_CODES:
+                logger.warning(
+                    "%s: required index/procedure missing (%s)",
+                    fallback_label,
+                    e.code,
+                )
+                return []
+            raise
+        except (ServiceUnavailable, SessionExpired, TransientError) as e:
+            logger.warning(
+                "%s: transient neo4j error after retries (%s)",
+                fallback_label,
+                type(e).__name__,
+            )
+            return []
+        except Exception as e:
+            logger.warning("%s failed: %s", fallback_label, e)
+            return []
+
     def _run_edge_vector_search(
         self, session: Neo4jSession, graph_id: str, query_vector: List[float], limit: int
     ) -> List[Dict[str, Any]]:
         """Run vector similarity search on edge fact_embedding."""
-        try:
-            result = session.run(
-                _VECTOR_SEARCH_EDGES,
-                graph_id=graph_id,
-                query_vector=query_vector,
-                limit=limit,
-            )
-            return [
-                {**dict(record["r"]), "uuid": record["r"]["uuid"], "_score": record["score"]}
-                for record in result
-            ]
-        except Exception as e:
-            logger.warning(f"Vector edge search failed (index may not exist yet): {e}")
-            return []
+        records = self._run_with_retry(
+            session,
+            _VECTOR_SEARCH_EDGES,
+            {"graph_id": graph_id, "query_vector": query_vector, "limit": limit},
+            fallback_label="Vector edge search",
+        )
+        return [
+            {**dict(r["r"]), "uuid": r["r"]["uuid"], "_score": r["score"]}
+            for r in records
+        ]
 
     def _run_edge_keyword_search(
         self, session: Neo4jSession, graph_id: str, query: str, limit: int
     ) -> List[Dict[str, Any]]:
         """Run fulltext (BM25) search on edge fact + name."""
-        try:
-            # Escape special Lucene characters in query
-            safe_query = self._escape_lucene(query)
-            result = session.run(
-                _FULLTEXT_SEARCH_EDGES,
-                graph_id=graph_id,
-                query_text=safe_query,
-                limit=limit,
-            )
-            return [
-                {**dict(record["r"]), "uuid": record["r"]["uuid"], "_score": record["score"]}
-                for record in result
-            ]
-        except Exception as e:
-            logger.warning(f"Keyword edge search failed: {e}")
-            return []
+        safe_query = self._escape_lucene(query)
+        records = self._run_with_retry(
+            session,
+            _FULLTEXT_SEARCH_EDGES,
+            {"graph_id": graph_id, "query_text": safe_query, "limit": limit},
+            fallback_label="Keyword edge search",
+        )
+        return [
+            {**dict(r["r"]), "uuid": r["r"]["uuid"], "_score": r["score"]}
+            for r in records
+        ]
 
     def _run_node_vector_search(
         self, session: Neo4jSession, graph_id: str, query_vector: List[float], limit: int
     ) -> List[Dict[str, Any]]:
         """Run vector similarity search on entity embedding."""
-        try:
-            result = session.run(
-                _VECTOR_SEARCH_NODES,
-                graph_id=graph_id,
-                query_vector=query_vector,
-                limit=limit,
-            )
-            return [
-                {**dict(record["n"]), "uuid": record["n"]["uuid"], "_score": record["score"]}
-                for record in result
-            ]
-        except Exception as e:
-            logger.warning(f"Vector node search failed: {e}")
-            return []
+        records = self._run_with_retry(
+            session,
+            _VECTOR_SEARCH_NODES,
+            {"graph_id": graph_id, "query_vector": query_vector, "limit": limit},
+            fallback_label="Vector node search",
+        )
+        return [
+            {**dict(r["n"]), "uuid": r["n"]["uuid"], "_score": r["score"]}
+            for r in records
+        ]
 
     def _run_node_keyword_search(
         self, session: Neo4jSession, graph_id: str, query: str, limit: int
     ) -> List[Dict[str, Any]]:
         """Run fulltext search on entity name + summary."""
-        try:
-            safe_query = self._escape_lucene(query)
-            result = session.run(
-                _FULLTEXT_SEARCH_NODES,
-                graph_id=graph_id,
-                query_text=safe_query,
-                limit=limit,
-            )
-            return [
-                {**dict(record["n"]), "uuid": record["n"]["uuid"], "_score": record["score"]}
-                for record in result
-            ]
-        except Exception as e:
-            logger.warning(f"Keyword node search failed: {e}")
-            return []
+        safe_query = self._escape_lucene(query)
+        records = self._run_with_retry(
+            session,
+            _FULLTEXT_SEARCH_NODES,
+            {"graph_id": graph_id, "query_text": safe_query, "limit": limit},
+            fallback_label="Keyword node search",
+        )
+        return [
+            {**dict(r["n"]), "uuid": r["n"]["uuid"], "_score": r["score"]}
+            for r in records
+        ]
 
     def _merge_results(
         self,

--- a/backend/tests/storage/test_neo4j_pool_config.py
+++ b/backend/tests/storage/test_neo4j_pool_config.py
@@ -1,0 +1,164 @@
+"""Tests für explizite Pool-Kwargs beim GraphDatabase.driver()-Aufruf.
+
+RED-Phase: schlägt fehl, weil Neo4jStorage.__init__ und _get_session noch
+keine Pool-Kwargs übergeben (Fix 1 noch nicht implementiert).
+"""
+import importlib
+from unittest.mock import MagicMock, patch
+
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_storage(monkeypatch=None, *, extra_patches=None):
+    """Erzeugt eine Neo4jStorage-Instanz mit allen externen Deps gemockt.
+
+    GraphDatabase.driver, NERExtractor, EmbeddingService, _verify_connectivity
+    und _ensure_schema werden gepatcht, damit __init__ ohne echte DB durchläuft.
+    Gibt (storage, mock_driver_factory) zurück, wobei mock_driver_factory das
+    gepatchte ``GraphDatabase.driver``-Callable ist.
+    """
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = MagicMock()
+
+    patches = [
+        patch("app.storage.neo4j_storage.GraphDatabase.driver", return_value=mock_driver),
+        patch("app.storage.neo4j_storage.Neo4jStorage._verify_connectivity"),
+        patch("app.storage.neo4j_storage.Neo4jStorage._ensure_schema"),
+        patch("app.storage.neo4j_storage.NERExtractor", return_value=MagicMock()),
+        patch("app.storage.neo4j_storage.EmbeddingService", return_value=MagicMock()),
+    ]
+    if extra_patches:
+        patches.extend(extra_patches)
+
+    return patches, mock_driver
+
+
+# ---------------------------------------------------------------------------
+# Test 1: __init__ übergibt Pool-Kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_init_passes_pool_kwargs():
+    """Neo4jStorage.__init__ muss GraphDatabase.driver mit allen Pool-Kwargs aufrufen."""
+    from app.storage.neo4j_storage import Neo4jStorage
+
+    mock_driver = MagicMock()
+
+    with (
+        patch("app.storage.neo4j_storage.GraphDatabase.driver", return_value=mock_driver) as mock_factory,
+        patch("app.storage.neo4j_storage.Neo4jStorage._verify_connectivity"),
+        patch("app.storage.neo4j_storage.Neo4jStorage._ensure_schema"),
+        patch("app.storage.neo4j_storage.NERExtractor", return_value=MagicMock()),
+        patch("app.storage.neo4j_storage.EmbeddingService", return_value=MagicMock()),
+    ):
+        Neo4jStorage(uri="bolt://localhost:7687", user="neo4j", password="secret")
+
+    mock_factory.assert_called_once()
+    _, kwargs = mock_factory.call_args
+    assert kwargs["auth"] == ("neo4j", "secret")
+    assert kwargs["max_connection_pool_size"] == 50
+    assert kwargs["connection_acquisition_timeout"] == 60.0
+    assert kwargs["connection_timeout"] == 15.0
+    assert kwargs["max_connection_lifetime"] == 3600
+    assert kwargs["liveness_check_timeout"] == 30.0
+    assert kwargs["keep_alive"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Lazy-Reconnect nach Fork übergibt dieselben Pool-Kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_reconnect_passes_pool_kwargs():
+    """Nach _reset_driver_after_fork ruft _get_session() driver erneut mit Pool-Kwargs auf."""
+    from app.storage.neo4j_storage import Neo4jStorage
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = MagicMock()
+
+    with (
+        patch("app.storage.neo4j_storage.GraphDatabase.driver", return_value=mock_driver) as mock_factory,
+        patch("app.storage.neo4j_storage.Neo4jStorage._verify_connectivity"),
+        patch("app.storage.neo4j_storage.Neo4jStorage._ensure_schema"),
+        patch("app.storage.neo4j_storage.NERExtractor", return_value=MagicMock()),
+        patch("app.storage.neo4j_storage.EmbeddingService", return_value=MagicMock()),
+    ):
+        storage = Neo4jStorage(uri="bolt://localhost:7687", user="neo4j", password="secret")
+        # Simuliert den Fork-Reset (Fix 4)
+        storage._driver = None
+        storage._get_session()
+
+    # Erster Call: __init__; zweiter Call: lazy reconnect
+    assert mock_factory.call_count == 2
+    _, kwargs = mock_factory.call_args  # letzter Call
+    assert kwargs["max_connection_pool_size"] == 50
+    assert kwargs["liveness_check_timeout"] == 30.0
+    assert kwargs["keep_alive"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 3: NEO4J_LIVENESS_TIMEOUT überschreibt liveness_check_timeout
+# ---------------------------------------------------------------------------
+
+
+def test_env_overrides_liveness(monkeypatch):
+    """NEO4J_LIVENESS_TIMEOUT=5.5 muss als liveness_check_timeout=5.5 ankommen."""
+    monkeypatch.setenv("NEO4J_LIVENESS_TIMEOUT", "5.5")
+
+    # Config wird zur Import-Zeit ausgewertet — Modul neu laden damit der Wert greift.
+    import app.config as config_module
+    importlib.reload(config_module)
+
+    from app.storage import neo4j_storage as storage_module
+    importlib.reload(storage_module)
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = MagicMock()
+
+    with (
+        patch.object(storage_module, "GraphDatabase") as mock_gdb,
+        patch.object(storage_module.Neo4jStorage, "_verify_connectivity"),
+        patch.object(storage_module.Neo4jStorage, "_ensure_schema"),
+        patch.object(storage_module, "NERExtractor", return_value=MagicMock()),
+        patch.object(storage_module, "EmbeddingService", return_value=MagicMock()),
+    ):
+        mock_gdb.driver.return_value = mock_driver
+        storage_module.Neo4jStorage(uri="bolt://localhost:7687", user="neo4j", password="pw")
+
+    _, kwargs = mock_gdb.driver.call_args
+    assert kwargs["liveness_check_timeout"] == 5.5
+
+
+# ---------------------------------------------------------------------------
+# Test 4: NEO4J_MAX_POOL_SIZE überschreibt max_connection_pool_size
+# ---------------------------------------------------------------------------
+
+
+def test_env_overrides_pool_size(monkeypatch):
+    """NEO4J_MAX_POOL_SIZE=120 muss als max_connection_pool_size=120 ankommen."""
+    monkeypatch.setenv("NEO4J_MAX_POOL_SIZE", "120")
+
+    import app.config as config_module
+    importlib.reload(config_module)
+
+    from app.storage import neo4j_storage as storage_module
+    importlib.reload(storage_module)
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = MagicMock()
+
+    with (
+        patch.object(storage_module, "GraphDatabase") as mock_gdb,
+        patch.object(storage_module.Neo4jStorage, "_verify_connectivity"),
+        patch.object(storage_module.Neo4jStorage, "_ensure_schema"),
+        patch.object(storage_module, "NERExtractor", return_value=MagicMock()),
+        patch.object(storage_module, "EmbeddingService", return_value=MagicMock()),
+    ):
+        mock_gdb.driver.return_value = mock_driver
+        storage_module.Neo4jStorage(uri="bolt://localhost:7687", user="neo4j", password="pw")
+
+    _, kwargs = mock_gdb.driver.call_args
+    assert kwargs["max_connection_pool_size"] == 120

--- a/backend/tests/storage/test_search_service_retry.py
+++ b/backend/tests/storage/test_search_service_retry.py
@@ -1,0 +1,149 @@
+"""Tests für _run_with_retry-Helper in SearchService (Fix 2).
+
+RED-Phase: schlägt fehl, weil search_service.py noch keinen Retry-Wrapper
+hat und die Warning-Wording-Prüfung gegen das alte "(index may not exist yet)"
+greift.
+
+Hinweis zu Logger-Patching: Der agora.search-Logger nutzt einen custom
+Handler (get_logger), der nicht in caplog propagiert. Warning-Tests patchen
+deshalb ``app.storage.search_service.logger.warning`` direkt.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from neo4j.exceptions import ServiceUnavailable, TransientError, ClientError
+
+from app.storage.search_service import SearchService
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def svc():
+    """SearchService mit gemocktem EmbeddingService."""
+    embedding = MagicMock()
+    embedding.embed.return_value = [0.1] * 1536
+    return SearchService(embedding, vector_weight=0.7, keyword_weight=0.3)
+
+
+def _fake_record(uuid="x", name="y", score=0.9):
+    """Baut einen Neo4j-Record-Fake, der dict()-kompatibel ist."""
+    node = {"uuid": uuid, "name": name}
+    rec = MagicMock()
+    rec.__getitem__ = lambda self, key: node if key == "n" else score
+    # __iter__ wird bei dict(record["n"]) nicht direkt gebraucht — node ist dict.
+    rec.__getitem__ = MagicMock(side_effect=lambda key: node if key == "n" else score)
+    return rec
+
+
+def _fake_result(records):
+    """Iterierbares Result-Objekt, das records zurückgibt."""
+    result = MagicMock()
+    result.__iter__ = MagicMock(return_value=iter(records))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Retry bei ServiceUnavailable (2× fail, dann Erfolg)
+# ---------------------------------------------------------------------------
+
+
+def test_vector_search_retries_on_service_unavailable(svc):
+    """session.run wirft 2× ServiceUnavailable, dann liefert es ein gültiges Result.
+
+    _run_node_vector_search muss 1 Element zurückgeben und session.run 3× aufgerufen haben.
+    """
+    record = _fake_record()
+    success_result = _fake_result([record])
+
+    session = MagicMock()
+    session.run.side_effect = [
+        ServiceUnavailable("boom"),
+        ServiceUnavailable("boom again"),
+        success_result,
+    ]
+
+    with patch("app.utils.retry.time.sleep"):
+        results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
+
+    assert len(results) == 1
+    assert session.run.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 2: IndexNotFound → leere Liste + Warning ohne verbotenen Text
+# ---------------------------------------------------------------------------
+
+
+def test_index_not_found_warning_wording(svc):
+    """ClientError mit IndexNotFound-Code liefert [] und das Warning enthält
+    'IndexNotFound' aber NICHT den alten Text 'index may not exist yet'.
+    """
+    err = ClientError()
+    err.code = "Neo.ClientError.Schema.IndexNotFound"
+
+    session = MagicMock()
+    session.run.side_effect = err
+
+    with patch("app.storage.search_service.logger") as mock_logger:
+        results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
+
+    assert results == []
+    assert mock_logger.warning.called, "logger.warning muss aufgerufen worden sein"
+    all_warning_args = [str(a) for call in mock_logger.warning.call_args_list for a in call.args]
+    combined = " ".join(all_warning_args)
+    assert "IndexNotFound" in combined, (
+        f"Warning-Args sollen 'IndexNotFound' enthalten, erhalten: {combined!r}"
+    )
+    assert "index may not exist yet" not in combined, (
+        "Verbotenes Wording 'index may not exist yet' im Warning gefunden"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: TransientError erschöpft → leere Liste + Warning mit 'transient'
+# ---------------------------------------------------------------------------
+
+
+def test_transient_error_returns_empty_after_exhausted_retries(svc):
+    """TransientError (erschöpft) → [] und Warning enthält 'transient'."""
+    session = MagicMock()
+    session.run.side_effect = TransientError("db overloaded")
+
+    with (
+        patch("app.storage.search_service.logger") as mock_logger,
+        patch("app.utils.retry.time.sleep"),  # kein echtes Warten in Tests
+    ):
+        results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
+
+    assert results == []
+    assert mock_logger.warning.called, "logger.warning muss aufgerufen worden sein"
+    all_warning_args = [str(a) for call in mock_logger.warning.call_args_list for a in call.args]
+    combined = " ".join(all_warning_args).lower()
+    assert "transient" in combined, (
+        f"Warning-Args sollen 'transient' enthalten, erhalten: {combined!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Happy Path — genau 1× session.run bei keyword search
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_single_session_run_call(svc):
+    """_run_node_keyword_search ruft session.run bei Erfolg exakt 1× auf."""
+    node = {"uuid": "abc", "name": "Testknoten"}
+    rec = MagicMock()
+    rec.__getitem__ = MagicMock(side_effect=lambda key: node if key == "n" else 0.8)
+    success_result = _fake_result([rec])
+
+    session = MagicMock()
+    session.run.return_value = success_result
+
+    results = svc._run_node_keyword_search(session, "g1", "Testquery", 10)
+
+    session.run.assert_called_once()
+    assert isinstance(results, list)

--- a/backend/tests/test_fork_safety.py
+++ b/backend/tests/test_fork_safety.py
@@ -29,8 +29,12 @@ def _clear_registered_storages():
     extensions._FORK_HANDLER_REGISTERED = False
 
 
-def test_reset_driver_after_fork_closes_and_nones_driver():
-    """_reset_driver_after_fork() setzt _driver auf None."""
+def test_reset_driver_after_fork_drops_reference_without_close():
+    """_reset_driver_after_fork() setzt _driver auf None ohne close() aufzurufen.
+
+    Fix 4: close() sendet GOODBYE über vom Parent geerbte Sockets und sabotiert
+    den Parent-Pool. Stattdessen wird der Driver-Zeiger still auf None gesetzt.
+    """
     from app.storage.neo4j_storage import Neo4jStorage
 
     storage = Neo4jStorage.__new__(Neo4jStorage)
@@ -40,24 +44,9 @@ def test_reset_driver_after_fork_closes_and_nones_driver():
 
     storage._reset_driver_after_fork()
 
-    mock_driver.close.assert_called_once()
+    mock_driver.close.assert_not_called()
     assert storage._driver is None
     assert storage._is_connected is False
-
-
-def test_reset_driver_after_fork_handles_close_error():
-    """_reset_driver_after_fork() fängt Fehler beim close() ab."""
-    from app.storage.neo4j_storage import Neo4jStorage
-
-    storage = Neo4jStorage.__new__(Neo4jStorage)
-    mock_driver = MagicMock()
-    mock_driver.close.side_effect = RuntimeError("connection lost")
-    storage._driver = mock_driver
-    storage._is_connected = True
-
-    storage._reset_driver_after_fork()
-
-    assert storage._driver is None
 
 
 def test_reset_driver_after_fork_handles_none_driver():


### PR DESCRIPTION
## Problem

Bei paralleler Persona-Generierung (`ThreadPoolExecutor(max_workers=10)` in `oasis_profile_generator.py:1328`) treten 30+ `Failed to write data to connection IPv4Address(('neo4j', 7687))`-Zeilen in einem 2-Sekunden-Fenster auf, direkt nachdem der erste Burst nach Fork-Idle (~60s) auf den Driver-Pool zugreift. Folge:

- 2 von 34 Fehlern durchdringen den App-Logger als WARNING (`Vector node search failed`, `Vector edge search failed (index may not exist yet)`).
- Die ersten ~10 Personas der Burst-Welle verlieren stillschweigend die Vektorhälfte der Hybrid-Search — die BM25-Hälfte trägt das Ergebnis allein.

## Root Cause

Stale-Socket-Storm im Bolt-Connection-Pool nach Fork-Idle:

1. Master öffnet den Driver vor `--preload`-Fork → Pool mit hot connections.
2. `post_fork` ruft `_reset_driver_after_fork()` → Lazy-Reconnect bei erstem Use.
3. 60s später trifft ein 10-Thread-Burst auf den Pool; Sub-Queries innerhalb von `hybrid_search` öffnen Vector + Keyword pro Persona = ~4 Round-Trips.
4. Driver-Default hat **keinen `liveness_check_timeout`** → er bietet Verbindungen aus, die Docker-bridge (conntrack ~60–120s) längst gekillt hat, schreibt drauf, fängt Broken-Pipe ab, loggt `Failed to write` direkt auf `neo4j.io` ohne App-Handler.
5. Bei zwei `db.index.vector.queryNodes/Relationships` reicht der interne Driver-Retry nicht; Exception eskaliert; `search_service` schluckt sie unter falscher Beschriftung.

Sekundär: `_reset_driver_after_fork` rief `driver.close()` auf dem vom Parent geerbten Driver — `GOODBYE`-Frames über fork-CoW-geerbte Sockets sägen dem Parent seinen aktiven Pool ab.

## Fix

Vier minimale, additive Änderungen:

| Anker | File | Änderung |
|---|---|---|
| 1 | `app/config.py` | 5 neue Env-Keys: `NEO4J_MAX_POOL_SIZE`, `NEO4J_ACQ_TIMEOUT`, `NEO4J_CONN_TIMEOUT`, `NEO4J_MAX_LIFETIME`, `NEO4J_LIVENESS_TIMEOUT` |
| 1 | `app/storage/neo4j_storage.py` | `_driver_kwargs()`-Helper, beide `GraphDatabase.driver(...)`-Call-Sites (Init + Lazy-Reconnect) nutzen ihn |
| 2 | `app/storage/search_service.py` | `_run_with_retry()`-Helper; `IndexNotFound`/`ProcedureNotFound` ehrlich klassifiziert; irreführendes `"(index may not exist yet)"`-Wording entfernt |
| 3 | `app/__init__.py` | `neo4j`/`neo4j.io`/`neo4j.pool`-Logger an App-Handler gebunden (`WARNING`) |
| 4 | `app/storage/neo4j_storage.py` | `_reset_driver_after_fork` ohne `close()` (Drop-Reference-Pattern) |

`liveness_check_timeout=30s` ist der zentrale Knopf — der Driver (5.23.0 installed) macht jetzt vor jedem Lend einer >30s alten Connection einen RESET-Round-Trip und fängt stale Sockets ab.

## Test plan

- [x] `tests/storage/test_neo4j_pool_config.py` — neu, 4 Tests: Init/Lazy-Reconnect-Kwargs + Env-Overrides
- [x] `tests/storage/test_search_service_retry.py` — neu, 4 Tests: Retry, IndexNotFound-Wording, Happy-Path single-call
- [x] `tests/test_fork_safety.py` — close-Spec invertiert, obsoleter `handles_close_error`-Test entfernt
- [x] 26/26 Pool-Storm-Tests grün, contracts 210/210, schema-drift 0, ruff/mypy sauber
- [ ] Smoke (in Reviewer-Hand): 50 Personas `parallel=10` → `docker logs -f agora-backend | rg 'Failed to write|Vector .* search failed'` muss 0× treffen

## Bekanntes Open

- Pre-existing test-pollution: im Worktree-Full-Run failt `test_vector_index_dim_drift::test_schema_no_drop_when_dim_matches`, auf `main` failt `test_signed_ticket_fork::test_register_fork_handlers` — beide isoliert grün, beide unabhängig von diesem PR. CI (sehe recent merge #551) verträgt das aktuell, sollte als separate Issue folgen.

## Refs

- `oasis_profile_generator.py:1328` — Persona-Burst-Source
- `gunicorn.conf.py:post_fork` → `extensions.reset_pools_after_fork` → `storage._reset_driver_after_fork` (Fork-Pfad)
- Recent: #551 (post_fork-Hook reset) — komplementär zu diesem PR