### PR TITLE
fix(llm): harden secret-resolver + report-section fallback

### DIFF
--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -12,12 +12,15 @@ from flask import current_app, request
 from . import simulation_bp
 from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
+from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.oasis_profile_generator import OasisProfileGenerator
+from ..services.prepare_service import _resolve_llm_connection
 from ..services.simulation_manager import SimulationManager
 from ..services.simulation_runner import SimulationRunner
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.artifact_locator import ArtifactLocator
+from ..utils.llm_profile_resolver import expand_profile_in_data
 from ..utils.validation import validate_simulation_id
 from .simulation_common import logger
 
@@ -155,6 +158,21 @@ def generate_profiles():
     llm_model_val = data.get('llm_model')
     llm_model_override = llm_model_val.strip() or None if isinstance(llm_model_val, str) else None
 
+    # Track 3c: UI-Profil-Token in echtes Modell + Provider-Creds expandieren,
+    # damit OasisProfileGenerator den aktiven api_key/base_url des Users
+    # mitbekommt — sonst fällt LLMClient auf Config.LLM_API_KEY zurück, was
+    # nach Track-1-Hardening bei OpenAI-Profilen sauber ValueError statt
+    # 401-Loop wirft, aber den User-Workflow zerschießt.
+    expand_profile_in_data(data)
+    try:
+        llm_runtime = parse_runtime_llm_config(data)
+    except ValueError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=str(exc),
+        )
+
     storage = current_app.extensions.get('neo4j_storage')
     if not storage:
         raise ValueError('GraphStorage not initialized')
@@ -174,10 +192,15 @@ def generate_profiles():
     # storage + graph_id durchreichen, damit OasisProfileGenerator die
     # Knowledge-Graph-Hybrid-Suche nutzen kann (Gemini-Code-Assist Finding,
     # PR #231).
+    # Track 3c: api_key + base_url aus dem aktiven LLM-Profil mitgeben,
+    # gleiche Helper-Funktion wie prepare_service._phase_generate_profiles.
+    api_key, base_url = _resolve_llm_connection(llm_runtime)
     generator = OasisProfileGenerator(
         model_name=llm_model_override,
         storage=storage,
         graph_id=graph_id,
+        api_key=api_key,
+        base_url=base_url,
     )
     profiles = generator.generate_profiles_from_entities(entities=filtered.entities, use_llm=use_llm)
     if platform == 'reddit':

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -273,10 +273,12 @@ def _safe_generate_section_react(
         )
     if not isinstance(result, str) or not result.strip():
         logger.warning(
-            "section %d (%r): generate_section_react gab leeren String zurück — "
-            "Fallback-Content wird eingefügt.",
+            "section %d (%r) in report=%s: generate_section_react gab leeren/"
+            "non-string Output zurück (type=%s) — Fallback-Content wird eingefügt.",
             section_index,
             getattr(section, "title", "<unbekannt>"),
+            report_id,
+            type(result).__name__,
         )
         return SECTION_FALLBACK_BODY.format(
             report_id=report_id,

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -5,6 +5,8 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
+from pydantic import ValidationError
+
 from ...config import Config
 from ...contracts.report_v3 import DEFAULT_REPORT_MODE, ModelAttribution, ReportMode, ReportV3
 from ...models.report import Report, ReportStatus
@@ -222,6 +224,65 @@ def _run_red_team_review(
         echo_index,
     )
     return report_v3
+
+
+SECTION_FALLBACK_BODY = (
+    "Diese Section konnte nicht generiert werden, weil der LLM-Aufruf "
+    "fehlgeschlagen ist (siehe Server-Log: report_id={report_id}, "
+    "section_index={section_index}). Mögliche Ursachen: ungültiger API-Key, "
+    "Rate-Limit, Modell nicht verfügbar. Konfiguriere ein gültiges LLM-Profil "
+    "(Settings → LLM-Provider) und starte den Report neu."
+)
+SECTION_FALLBACK_TITLE = "Section nicht generiert (LLM-Fehler)"
+
+
+def _safe_generate_section_react(
+    agent: Any,
+    section,
+    outline,
+    previous_sections: List[str],
+    progress_callback: Optional[Callable],
+    section_index: int,
+    report_id: str,
+) -> str:
+    """Track-3a-Wrapper: fängt Exceptions und leere Responses aus
+    :func:`generate_section_react` und liefert einen sichtbaren Fallback-Text,
+    damit die Pipeline nicht mit ``ReportV3.model_validate``-ValidationError
+    aussteigt, wenn ein LLM-Call (z. B. 401 unauthorized) failed.
+    """
+    try:
+        result = generate_section_react(
+            agent,
+            section=section,
+            outline=outline,
+            previous_sections=previous_sections,
+            progress_callback=progress_callback,
+            section_index=section_index,
+        )
+    except Exception as exc:  # noqa: BLE001 — Pipeline darf nicht crashen
+        logger.error(
+            "section %d (%r): generate_section_react warf eine Exception: %r — "
+            "Fallback-Content wird eingefügt.",
+            section_index,
+            getattr(section, "title", "<unbekannt>"),
+            exc,
+        )
+        return SECTION_FALLBACK_BODY.format(
+            report_id=report_id,
+            section_index=section_index,
+        )
+    if not isinstance(result, str) or not result.strip():
+        logger.warning(
+            "section %d (%r): generate_section_react gab leeren String zurück — "
+            "Fallback-Content wird eingefügt.",
+            section_index,
+            getattr(section, "title", "<unbekannt>"),
+        )
+        return SECTION_FALLBACK_BODY.format(
+            report_id=report_id,
+            section_index=section_index,
+        )
+    return result
 
 
 def generate_section_react(
@@ -828,13 +889,14 @@ def generate_report(
             ReportManager.update_progress(report_id, "generating", base_progress, f"generatinggenerateSection: {section.title} ({section_num}/{total_sections})", current_section=section.title, completed_sections=completed_section_titles)
             if progress_callback:
                 progress_callback("generating", base_progress, f"generatinggenerateSection: {section.title} ({section_num}/{total_sections})")
-            section_content = generate_section_react(
+            section_content = _safe_generate_section_react(
                 agent,
                 section=section,
                 outline=outline,
                 previous_sections=generated_sections,
                 progress_callback=lambda stage, prog, msg: progress_callback(stage, base_progress + int(prog * 0.7 / total_sections), msg) if progress_callback else None,
                 section_index=section_num,
+                report_id=report_id,
             )
             # M11.8e + P4.1: Quote-Anchor-Validierung für Persona-/Segment-/Friction-Sections.
             # Nur bei Section-Typen, die Persona-Zitate erwarten (nicht Plan/Meta-Sections).
@@ -868,13 +930,14 @@ def generate_report(
                         quote_result.invalid_quotes,
                         quote_result.unbound_evidence_refs,
                     )
-                    repair_content = generate_section_react(
+                    repair_content = _safe_generate_section_react(
                         agent,
                         section=section,
                         outline=outline,
                         previous_sections=generated_sections,
                         progress_callback=None,
                         section_index=section_num,
+                        report_id=report_id,
                     )
                     repair_result = validate_quote_anchors(
                         repair_content,
@@ -945,19 +1008,44 @@ def generate_report(
         ReportManager.save_report(report)
 
         # ========== Red-Team-Review (Slice 5, Issue #497) — vor report_synthesis ==========
+        # Track 3b: ValidationError separat fangen, damit ein durch LLM-Failures
+        # entstandenes ReportV3-Schema-Loch (sections.N.title missing usw.) eine
+        # klare user-facing Message produziert statt einen Pydantic-Stack-Trace
+        # ins Frontend zu schicken.
         try:
             report_v3_raw = ReportManager.get_report_v3(report_id)
             if report_v3_raw:
-                report_v3_obj = ReportV3.model_validate(report_v3_raw)
-                echo_index = _get_echo_index(agent)
-                report_v3_obj = _run_red_team_review(agent, report_v3_obj, echo_index)
-                ReportManager.save_report_v3(report_v3_obj)
-                logger.info(
-                    "generate_report: red_team_review abgeschlossen, "
-                    "findings=%d, echo_index=%.3f",
-                    len(report_v3_obj.red_team_findings),
-                    echo_index,
-                )
+                try:
+                    report_v3_obj = ReportV3.model_validate(report_v3_raw)
+                except ValidationError as val_exc:
+                    error_count = len(val_exc.errors())
+                    logger.error(
+                        "generate_report: ReportV3.model_validate hat report=%s "
+                        "abgelehnt — %d Schema-Verletzung(en), vermutlich aus "
+                        "fehlgeschlagenen LLM-Calls. Errors=%s",
+                        report_id,
+                        error_count,
+                        val_exc.errors()[:5],  # erste 5 für Logs, nicht den ganzen Trace
+                    )
+                    if report and not getattr(report, "error", None):
+                        report.error = (
+                            f"Report enthält {error_count} unvollständige Section(s) — "
+                            "LLM-Calls sind fehlgeschlagen. Server-Logs zeigen die "
+                            "betroffenen Felder. Mit gültigem LLM-Profil neu starten."
+                        )
+                    # Pipeline weiter ohne red_team_review — Report bleibt nutzbar
+                    # mit Fallback-Content in den betroffenen Sections.
+                    report_v3_obj = None
+                if report_v3_obj is not None:
+                    echo_index = _get_echo_index(agent)
+                    report_v3_obj = _run_red_team_review(agent, report_v3_obj, echo_index)
+                    ReportManager.save_report_v3(report_v3_obj)
+                    logger.info(
+                        "generate_report: red_team_review abgeschlossen, "
+                        "findings=%d, echo_index=%.3f",
+                        len(report_v3_obj.red_team_findings),
+                        echo_index,
+                    )
         except Exception as exc:
             logger.warning("generate_report: red_team_review fehlgeschlagen: %r", exc)
         ReportManager.update_progress(report_id, "completed", 100, "reportgeneratecomplete", completed_sections=completed_section_titles)

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -6,12 +6,35 @@ exposing them in serializable objects.
 Resolution order:
   1. Session-only override (höchste Priorität, für ad-hoc Tests)
   2. Persistenter Fernet-encrypted Store (vom Frontend befüllt)
-  3. Provider-spezifische Environment-Variablen
-  4. Globaler Fallback (Config.LLM_API_KEY)
+  3. Provider-spezifische Environment-Variablen (mit Format-Sanity-Check)
+  4. Globaler Fallback (Config.LLM_API_KEY) — nur für Provider ohne striktes
+     Format oder wenn der Wert das erwartete Format trifft
+
+Format-Sanity-Check (Track 1 Hardening, siehe ``backend/CLAUDE.md`` /
+``docs/runbooks/architecture-layers.md``): ENV- und Config-Fallback-Werte
+werden für provider_type ``openai`` / ``google`` gegen das jeweilige
+Key-Format geprüft. Bekannt-toxische Marker (``ollama``, ``none``, …) werden
+universell abgelehnt. So kann ein versehentlicher ``OPENAI_API_KEY=ollama``
+in einem Container-Env nicht mehr zum 401-Loop führen.
+
+Provider-spezifische ENV-Mapping:
+  * ``openai``            → ``OPENAI_API_KEY``         (Format ``sk-…``)
+  * ``google``            → ``GOOGLE_API_KEY`` / ``GEMINI_API_KEY`` (``AIzaSy…``)
+  * ``ollama_cloud``      → ``OLLAMA_API_KEY``         (Bearer, kein striktes Format)
+  * ``openai_compatible`` → ``LLM_API_KEY``            (kein striktes Format)
+  * ``github_copilot``    → eigene Auflösung über ``llm_providers.github_copilot``
+
+Ollama-Cloud-Auth-Doku: ``~/.agents/skills/ollama-cloud-models/SKILL.md`` (v2).
+Zwei Modi: **Direct API** (``https://ollama.com`` nativ oder ``/v1``
+OpenAI-kompatibel, ``Authorization: Bearer $OLLAMA_API_KEY``) und
+**Local Proxy** (``http://localhost:11434``, kein Key). Dieser Resolver
+adressiert ausschließlich Direct API — Local Proxy umgeht ihn, weil dort
+kein Auth-Material gebraucht wird.
 """
 
 import logging
 import os
+import re
 from typing import Optional, Dict
 
 from ..config import Config
@@ -19,44 +42,165 @@ from .llm_provider_secrets_store import get_llm_provider_secrets_store
 
 logger = logging.getLogger("agora.secret_resolver")
 
+# Provider-spezifische Key-Formate. Bewusst eng gehalten, damit
+# Tippfehler und Müll-Defaults (``ollama``, ``your-key-here``) verlässlich
+# rausfallen. Echte Keys sind länger und matchen das Prefix.
+_OPENAI_KEY_RE = re.compile(r"^sk-[A-Za-z0-9_\-]{20,}$")
+_GOOGLE_KEY_RE = re.compile(r"^AIza[A-Za-z0-9_\-]{20,}$")
+
+# Werte, die nie als Key durchgehen dürfen — historische Default-Empfehlungen
+# (siehe app/config.py:305 "set to any non-empty value, e.g. 'ollama'").
+_TOXIC_KEY_LITERALS = frozenset(
+    {
+        "ollama",
+        "none",
+        "null",
+        "true",
+        "false",
+        "changeme",
+        "your-key-here",
+        "your-api-key",
+        "sk-",
+        "aiza",
+    }
+)
+
+
+def _format_valid(value: Optional[str], provider_type: str) -> bool:
+    """Provider-aware Format-Check für ENV- / Config-Fallback-Werte.
+
+    Sicher = Wert hat das erwartete Prefix und ist lang genug. Bei nicht
+    explizit gehärteten Provider-Types (``ollama_cloud``, ``openai_compatible``,
+    ``github_copilot``) bleibt nur der Toxic-Literal-Filter, weil deren
+    Key-Format vom Backend bestimmt wird (z. B. Ollama-Cloud-Hex).
+    """
+    if not value or not isinstance(value, str):
+        return False
+    v = value.strip()
+    if not v:
+        return False
+    if v.lower() in _TOXIC_KEY_LITERALS:
+        return False
+    if provider_type == "openai":
+        return bool(_OPENAI_KEY_RE.match(v))
+    if provider_type == "google":
+        return bool(_GOOGLE_KEY_RE.match(v))
+    return True
+
+
+def _mask_for_log(value: Optional[str]) -> str:
+    """Erster Block für Logs. Niemals den ganzen Wert ausgeben."""
+    if not value:
+        return "<empty>"
+    v = value.strip()
+    if not v:
+        return "<empty>"
+    if len(v) <= 4:
+        return "<short>"
+    return f"{v[:4]}..."
+
 
 class SecretResolver:
-    """Resolves secrets for LLM providers."""
+    """Resolves secrets for LLM providers.
+
+    Side-Channel: nach jedem :meth:`get_api_key`-Aufruf hält
+    :attr:`last_source` die Herkunft des zurückgegebenen Keys
+    (``session`` / ``store`` / ``env:NAME`` / ``config_fallback`` /
+    ``github_copilot`` / ``None``). Für Audit-Logging im LLMClient-Init
+    und für den Diagnostic-Endpoint in Track 2.
+    """
 
     def __init__(self, session_api_keys: Optional[Dict[str, str]] = None):
         self._session_keys = session_api_keys or {}
+        self.last_source: Optional[str] = None
 
     def get_api_key(self, provider_id: str, provider_type: str) -> Optional[str]:
-        """Resolve API key for a provider."""
+        """Resolve API key for a provider. Setzt :attr:`last_source` als Seiteneffekt."""
+        self.last_source = None
+
         # 1. Session-only override
         if provider_id in self._session_keys:
+            self.last_source = "session"
             return self._session_keys[provider_id]
 
         # 2. Persistenter Store (Fernet-encrypted, vom Frontend befüllt)
         try:
             stored = get_llm_provider_secrets_store().get_plaintext(provider_id)
             if stored:
+                self.last_source = "store"
                 return stored
         except RuntimeError as exc:
             # AGORA_SECRET_KEY fehlt o. ä. — auf env-Fallback weiterleiten.
             # Hier explizit ohne Key-Werte loggen.
             logger.warning("Secret-Store-Zugriff fehlgeschlagen, fallback auf env: %s", exc)
 
-        # 3. Provider-spezifische Environment-Variablen
+        # 3. Provider-spezifische Environment-Variablen (mit Format-Sanity-Check)
+        env_candidates: list[tuple[str, Optional[str]]] = []
         if provider_type == "openai":
-            return os.environ.get("OPENAI_API_KEY") or Config.LLM_API_KEY
-        if provider_type == "google":
-            return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
-        if provider_type == "github_copilot":
+            env_candidates.append(("env:OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY")))
+        elif provider_type == "google":
+            env_candidates.append(("env:GOOGLE_API_KEY", os.environ.get("GOOGLE_API_KEY")))
+            env_candidates.append(("env:GEMINI_API_KEY", os.environ.get("GEMINI_API_KEY")))
+        elif provider_type == "ollama_cloud":
+            env_candidates.append(("env:OLLAMA_API_KEY", os.environ.get("OLLAMA_API_KEY")))
+        elif provider_type == "openai_compatible":
+            env_candidates.append(("env:LLM_API_KEY", os.environ.get("LLM_API_KEY")))
+        elif provider_type == "github_copilot":
             # GitHub Copilot: Token-Auflösung über separates Modul (Slice B).
             try:
                 from .llm_providers.github_copilot import resolve_copilot_token
             except ImportError:
                 return None
-            return resolve_copilot_token()
+            token = resolve_copilot_token()
+            if token:
+                self.last_source = "github_copilot"
+            return token
 
-        # 4. Global fallback
-        return Config.LLM_API_KEY
+        for source_label, candidate in env_candidates:
+            if candidate is None:
+                continue
+            if _format_valid(candidate, provider_type):
+                self.last_source = source_label
+                return candidate
+            env_name = source_label.split(":", 1)[-1]
+            logger.warning(
+                "ENV-Variable %s enthält für provider_type=%s keinen Key im erwarteten Format "
+                "(Prefix: %s) — wird übersprungen.",
+                env_name,
+                provider_type,
+                _mask_for_log(candidate),
+            )
+
+        # 4. Globaler Fallback Config.LLM_API_KEY
+        fallback = Config.LLM_API_KEY
+        if fallback:
+            if provider_type in ("openai", "google"):
+                if _format_valid(fallback, provider_type):
+                    self.last_source = "config_fallback"
+                    return fallback
+                logger.warning(
+                    "Config.LLM_API_KEY hat falsches Format für provider_type=%s "
+                    "(Prefix: %s) — wird NICHT als Fallback genutzt. Setze den Key "
+                    "im UI (Settings → LLM-Provider) oder via ENV %s.",
+                    provider_type,
+                    _mask_for_log(fallback),
+                    "OPENAI_API_KEY" if provider_type == "openai" else "GOOGLE_API_KEY",
+                )
+                return None
+            # Provider-Type ohne striktes Format (ollama_cloud, openai_compatible, …):
+            # Globalen Fallback durchlassen, aber Toxic-Literal-Filter anwenden.
+            if not _format_valid(fallback, provider_type):
+                logger.warning(
+                    "Config.LLM_API_KEY ist ein Toxic-Literal (Prefix: %s) — wird nicht "
+                    "als Fallback für provider_type=%s genutzt.",
+                    _mask_for_log(fallback),
+                    provider_type,
+                )
+                return None
+            self.last_source = "config_fallback"
+            return fallback
+
+        return None
 
     def sanitize_url(self, url: Optional[str]) -> Optional[str]:
         """Remove secrets from URL (no userinfo, no query string)."""

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -380,11 +380,15 @@ class LLMClient:
         route_stage: Optional[str] = None,
         route_provider_id: Optional[str] = None,
         use_active_config: bool = True,
+        api_key_source: Optional[str] = None,
     ):
         # When no explicit model is set, fall back to the user's active
         # provider/model selection (Settings → LLM-Auswahl). Falls back to
         # Config.* if no active config exists. Resolves api_key+base_url via
         # SecretResolver/Provider-Registry analogous to from_route().
+        # ``api_key_source`` ist eine Audit-Annotation für das einmalige
+        # Init-Log am Ende dieses Konstruktors. Track 1c (Pure-Gosling).
+        resolved_source: Optional[str] = api_key_source if api_key else None
         active_provider_id: Optional[str] = None
         if use_active_config and model is None:
             active = _read_active_config_safely()
@@ -410,6 +414,8 @@ class LLMClient:
                                 base_url = descriptor.base_url
                             resolver = SecretResolver()
                             api_key = resolver.get_api_key(active_provider_id, descriptor.type)
+                            if api_key:
+                                resolved_source = resolver.last_source
                     except Exception as exc:  # noqa: BLE001 — fall back to Config defaults
                         logger.warning(
                             "Failed to resolve active LLM config (provider=%s): %s",
@@ -417,7 +423,13 @@ class LLMClient:
                             exc,
                         )
 
-        self.api_key = api_key or Config.LLM_API_KEY
+        if api_key:
+            self.api_key = api_key
+            # resolved_source bleibt erhalten (passed_in oder vom Resolver)
+        else:
+            self.api_key = Config.LLM_API_KEY
+            if self.api_key:
+                resolved_source = "config_fallback"
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
         self.reasoning_effort = reasoning_effort or "none"
@@ -429,6 +441,19 @@ class LLMClient:
 
         if not self.api_key:
             raise ValueError("LLM_API_KEY not configured")
+
+        # Track 1c Audit-Log: einmalig pro LLMClient-Init. Niemals den Key-Wert
+        # selbst loggen — nur die Quelle (session/store/env:NAME/config_fallback/
+        # passed_in/unknown). Provider-Erkennung priorisiert ``active_provider_id``
+        # vor ``route_provider_id``, damit die laufende Session-Auswahl Vorrang hat.
+        self._api_key_source = resolved_source or "unknown"
+        logger.info(
+            "LLMClient initialized provider_id=%s model=%s base_url=%s api_key_source=%s",
+            active_provider_id or route_provider_id or "unknown",
+            self.model,
+            self.base_url,
+            self._api_key_source,
+        )
 
         self.client = OpenAI(
             api_key=self.api_key,
@@ -479,6 +504,7 @@ class LLMClient:
         """
         base_url = route.base_url_sanitized
         api_key = api_key_override
+        api_key_source: Optional[str] = "passed_in" if api_key_override else None
 
         # If a secret resolver is provided, we try to get the real secrets.
         # This prevents leaking them into ResolvedRoute but allows LLMClient
@@ -495,6 +521,7 @@ class LLMClient:
             p_type = descriptor.type if descriptor else "unknown"
             if not api_key:
                 api_key = secret_resolver.get_api_key(route.provider_id, p_type)
+                api_key_source = getattr(secret_resolver, "last_source", None)
 
             # Use real base_url from provider_options if present, otherwise from descriptor
             real_base = route.provider_options.get("base_url") or (descriptor.base_url if descriptor else None)
@@ -512,6 +539,7 @@ class LLMClient:
             routing_version=route.routing_version,
             route_stage=route.stage,
             route_provider_id=route.provider_id,
+            api_key_source=api_key_source,
         )
 
     def _is_ollama(self) -> bool:

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -447,11 +447,16 @@ class LLMClient:
         # passed_in/unknown). Provider-Erkennung priorisiert ``active_provider_id``
         # vor ``route_provider_id``, damit die laufende Session-Auswahl Vorrang hat.
         self._api_key_source = resolved_source or "unknown"
+        # Gemini-Review (security-medium) zu PR #559: ``base_url`` kann in
+        # Edge-Cases (Azure-OpenAI-Query-Param, Userinfo) Secret-Material
+        # tragen. SecretResolver.sanitize_url strippt userinfo+query+fragment
+        # vor dem Log, ohne den Hostname zu maskieren.
+        from ..services.secret_resolver import SecretResolver as _UrlSanitizer
         logger.info(
             "LLMClient initialized provider_id=%s model=%s base_url=%s api_key_source=%s",
             active_provider_id or route_provider_id or "unknown",
             self.model,
-            self.base_url,
+            _UrlSanitizer().sanitize_url(self.base_url) if self.base_url else None,
             self._api_key_source,
         )
 

--- a/backend/tests/api/test_simulation_history_provider_passing.py
+++ b/backend/tests/api/test_simulation_history_provider_passing.py
@@ -76,7 +76,7 @@ def test_generate_profiles_passes_provider_credentials(client, patched_generator
         "llm_model": "gpt-4o-mini",
         "llm_provider": {
             "provider": "openai",
-            "api_key": "sk-test-injectedkey1234567890abcDEF",
+            "api_key": "sk-test-injectedkey1234567890abcDEF",  # gitleaks:allow
             "base_url": "https://api.openai.com/v1",
         },
         "use_llm": True,

--- a/backend/tests/api/test_simulation_history_provider_passing.py
+++ b/backend/tests/api/test_simulation_history_provider_passing.py
@@ -1,0 +1,122 @@
+"""Test für Track 3c: ``/api/simulation/generate-profiles`` reicht
+api_key + base_url des aktiven LLM-Profils an :class:`OasisProfileGenerator`
+durch.
+
+Vor Track 3c hat der Endpoint nur ``model_name`` durchgereicht — der
+Generator hat dann beim internen :class:`LLMClient`-Init auf
+``Config.LLM_API_KEY`` zurückgefallen, was bei einem User-konfigurierten
+OpenAI-Profil zu 401-Loops geführt hat. Mit der Härtung greift jetzt der
+gleiche Resolver wie in ``prepare_service._phase_generate_profiles``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 1000
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+@pytest.fixture
+def captured_generator_kwargs():
+    return {}
+
+
+@pytest.fixture
+def patched_generator(monkeypatch, captured_generator_kwargs):
+    """Mockt :class:`OasisProfileGenerator` und sammelt Konstruktor-Args."""
+    fake_profile = MagicMock(
+        to_dict=lambda: {"id": "p1"},
+        to_reddit_format=lambda: {"username": "u1"},
+        to_twitter_format=lambda: {"handle": "h1"},
+    )
+
+    class FakeGenerator:
+        def __init__(self, **kwargs):
+            captured_generator_kwargs.update(kwargs)
+
+        def generate_profiles_from_entities(self, *_a, **_kw):
+            return [fake_profile]
+
+    monkeypatch.setattr(
+        "app.api.simulation_history.OasisProfileGenerator", FakeGenerator
+    )
+
+    fake_filtered = MagicMock()
+    fake_filtered.filtered_count = 1
+    fake_filtered.entity_types = {"Person"}
+    fake_filtered.entities = [MagicMock()]
+    monkeypatch.setattr(
+        "app.api.simulation_history.EntityReader",
+        lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=fake_filtered)),
+    )
+    # expand_profile_in_data ist kein-op für unsere Tests — wir injizieren
+    # die Provider-Daten direkt in den Request-Body.
+    monkeypatch.setattr(
+        "app.api.simulation_history.expand_profile_in_data",
+        lambda data: data,
+    )
+    return FakeGenerator
+
+
+def test_generate_profiles_passes_provider_credentials(client, patched_generator, captured_generator_kwargs):
+    payload = {
+        "graph_id": "graph_abc",
+        "llm_model": "gpt-4o-mini",
+        "llm_provider": {
+            "provider": "openai",
+            "api_key": "sk-test-injectedkey1234567890abcDEF",
+            "base_url": "https://api.openai.com/v1",
+        },
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    assert resp.status_code == 200, resp.get_json()
+    assert captured_generator_kwargs["api_key"] == "sk-test-injectedkey1234567890abcDEF"
+    assert captured_generator_kwargs["base_url"] == "https://api.openai.com/v1"
+    assert captured_generator_kwargs["model_name"] == "gpt-4o-mini"
+    assert captured_generator_kwargs["graph_id"] == "graph_abc"
+
+
+def test_generate_profiles_without_provider_falls_back_to_none(client, patched_generator, captured_generator_kwargs):
+    """Ohne ``llm_provider`` bleibt das Verhalten kompatibel: api_key/base_url
+    None, Generator wird auf interne Defaults zurückfallen (Track 1 hardening
+    verhindert toxic Fallbacks dort)."""
+    payload = {
+        "graph_id": "graph_abc",
+        "llm_model": "gpt-4o-mini",
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    assert resp.status_code == 200, resp.get_json()
+    assert captured_generator_kwargs["api_key"] is None
+    assert captured_generator_kwargs["base_url"] is None
+
+
+def test_generate_profiles_rejects_invalid_provider_payload(client, patched_generator, captured_generator_kwargs):
+    """``parse_runtime_llm_config`` muss bei kaputtem Payload 400 werfen,
+    nicht stillschweigend leiten."""
+    payload = {
+        "graph_id": "graph_abc",
+        "llm_provider": {"provider": "openai", "api_key": "ollama"},  # toxic literal
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    # parse_runtime_llm_config + Track 1 _validate_key_format ziehen — Endpoint
+    # gibt 400 mit klarer Message zurück (kein silent-passthrough).
+    assert resp.status_code in (400, 200), resp.get_json()
+    # Falls 200: api_key wurde nicht durchgereicht (provider-validation hätte
+    # vor _resolve_llm_connection bereits None gesetzt). Wir prüfen den
+    # Negativ-Fall — kein toxic Wert kommt am Generator an.
+    if resp.status_code == 200:
+        assert captured_generator_kwargs.get("api_key") != "ollama"

--- a/backend/tests/services/test_llm_core_services.py
+++ b/backend/tests/services/test_llm_core_services.py
@@ -17,9 +17,14 @@ def test_secret_resolver():
     resolver = SecretResolver(session_api_keys={"openai": "session-key"})
     assert resolver.get_api_key("openai", "openai") == "session-key"
 
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+    # Track 1: ENV-Wert muss dem ``sk-``-Format entsprechen, sonst lehnt der
+    # Resolver ihn ab und schreibt eine WARNING ins Log.
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-validkey1234567890abcDEF"}):
         resolver_no_session = SecretResolver()
-        assert resolver_no_session.get_api_key("openai", "openai") == "env-key"
+        assert (
+            resolver_no_session.get_api_key("openai", "openai")
+            == "sk-env-validkey1234567890abcDEF"
+        )
 
 def test_secret_resolver_sanitize_url():
     resolver = SecretResolver()

--- a/backend/tests/services/test_llm_core_services.py
+++ b/backend/tests/services/test_llm_core_services.py
@@ -19,7 +19,7 @@ def test_secret_resolver():
 
     # Track 1: ENV-Wert muss dem ``sk-``-Format entsprechen, sonst lehnt der
     # Resolver ihn ab und schreibt eine WARNING ins Log.
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-validkey1234567890abcDEF"}):
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-validkey1234567890abcDEF"}):  # gitleaks:allow
         resolver_no_session = SecretResolver()
         assert (
             resolver_no_session.get_api_key("openai", "openai")

--- a/backend/tests/services/test_report_workflow_section_fallback.py
+++ b/backend/tests/services/test_report_workflow_section_fallback.py
@@ -1,0 +1,136 @@
+"""Tests für Track 3a/3b: Section-Loop-Fallback und ValidationError-Handling
+in :mod:`app.services.report_agent.workflow`.
+
+Vor Track 3 hat ein 401-unauthorized-Loop bei einzelnen Sections eine
+Pydantic-``ValidationError`` ausgelöst (``sections.10.title missing``),
+weil der Section-Loop leere/exception-werfende LLM-Calls unverändert
+weiterreichte. Nach dem Fix:
+
+  * :func:`_safe_generate_section_react` fängt Exceptions und leere
+    Responses und liefert einen sichtbaren Fallback-Text.
+  * ``ReportV3.model_validate`` ist mit ``try/except ValidationError``
+    umrahmt und schreibt eine User-Message in ``report.error``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.report_agent import workflow as workflow_mod
+from app.services.report_agent.workflow import (
+    SECTION_FALLBACK_BODY,
+    SECTION_FALLBACK_TITLE,
+    _safe_generate_section_react,
+)
+
+
+def _make_section(title: str = "Stakeholder-Analyse"):
+    section = SimpleNamespace()
+    section.title = title
+    section.content = ""
+    section.metadata = None
+    return section
+
+
+class TestSafeGenerateSectionReact:
+    def test_propagates_valid_result_unchanged(self, monkeypatch):
+        monkeypatch.setattr(
+            workflow_mod,
+            "generate_section_react",
+            lambda *a, **kw: "## Echte Section\n\nMit reichlich Inhalt.",
+        )
+        result = _safe_generate_section_react(
+            agent=MagicMock(),
+            section=_make_section(),
+            outline=MagicMock(),
+            previous_sections=[],
+            progress_callback=None,
+            section_index=1,
+            report_id="report_abc123",
+        )
+        assert result == "## Echte Section\n\nMit reichlich Inhalt."
+
+    def test_returns_fallback_on_exception(self, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise RuntimeError("simulated 401 unauthorized")
+
+        monkeypatch.setattr(workflow_mod, "generate_section_react", _boom)
+        result = _safe_generate_section_react(
+            agent=MagicMock(),
+            section=_make_section("Risiko-Matrix"),
+            outline=MagicMock(),
+            previous_sections=[],
+            progress_callback=None,
+            section_index=7,
+            report_id="report_xyz",
+        )
+        # Pipeline darf nicht crashen: Fallback-Content trägt die User-Message
+        # und die Identifier zur Diagnose.
+        assert "report_xyz" in result
+        assert "section_index=7" in result
+        assert "LLM-Aufruf" in result
+
+    @pytest.mark.parametrize("empty_value", ["", "   \n\t  ", None])
+    def test_returns_fallback_on_empty_or_none(self, monkeypatch, empty_value):
+        monkeypatch.setattr(
+            workflow_mod,
+            "generate_section_react",
+            lambda *a, **kw: empty_value,
+        )
+        result = _safe_generate_section_react(
+            agent=MagicMock(),
+            section=_make_section(),
+            outline=MagicMock(),
+            previous_sections=[],
+            progress_callback=None,
+            section_index=3,
+            report_id="report_abc",
+        )
+        assert "report_abc" in result
+        assert "3" in result
+
+    def test_returns_fallback_on_non_string_return_value(self, monkeypatch):
+        # generate_section_react ist als ``-> str`` typisiert, aber wenn ein
+        # zukünftiger Bug ein dict/int zurückgibt, soll der Wrapper trotzdem
+        # ehrlich fallen, nicht still die Pipeline mit einem Sentinel füttern.
+        monkeypatch.setattr(
+            workflow_mod,
+            "generate_section_react",
+            lambda *a, **kw: {"unexpected": "dict"},
+        )
+        result = _safe_generate_section_react(
+            agent=MagicMock(),
+            section=_make_section(),
+            outline=MagicMock(),
+            previous_sections=[],
+            progress_callback=None,
+            section_index=1,
+            report_id="report_dict",
+        )
+        assert "report_dict" in result
+
+    def test_fallback_message_mentions_settings_recovery_path(self, monkeypatch):
+        """User soll im Frontend lesen können, wo er den fehlenden Key setzt."""
+        monkeypatch.setattr(
+            workflow_mod, "generate_section_react", lambda *a, **kw: None
+        )
+        result = _safe_generate_section_react(
+            agent=MagicMock(),
+            section=_make_section(),
+            outline=MagicMock(),
+            previous_sections=[],
+            progress_callback=None,
+            section_index=1,
+            report_id="report_abc",
+        )
+        assert "Settings" in result
+        assert "LLM-Provider" in result
+
+    def test_fallback_constants_exposed(self):
+        """``SECTION_FALLBACK_BODY`` und ``SECTION_FALLBACK_TITLE`` sind Public-API
+        (Worker/Frontend können daran erkennen, ob eine Section degraded ist)."""
+        assert "{report_id}" in SECTION_FALLBACK_BODY
+        assert "{section_index}" in SECTION_FALLBACK_BODY
+        assert SECTION_FALLBACK_TITLE == "Section nicht generiert (LLM-Fehler)"

--- a/backend/tests/services/test_secret_resolver_env_sanitation.py
+++ b/backend/tests/services/test_secret_resolver_env_sanitation.py
@@ -20,6 +20,12 @@ from app.services import llm_provider_secrets_store as store_module
 from app.services.llm_provider_secrets_store import reset_singleton_for_tests
 from app.services.secret_resolver import SecretResolver, _format_valid, _mask_for_log
 
+# Hinweis (Memory feedback_gitleaks_test_fixtures): Die ``sk-…`` / ``AIzaSy…``
+# Strings in diesem File sind Test-Fixtures, keine echten Provider-Keys.
+# Sie müssen format-valide sein (Track-1-Resolver prüft Prefix + Mindest-
+# Länge), tragen aber bewusst kein verwertbares Secret. Inline-``gitleaks:allow``
+# unterdrückt False-Positives an den Auslöse-Zeilen.
+
 
 @pytest.fixture
 def configured_store(monkeypatch, tmp_path: Path):
@@ -114,7 +120,7 @@ class TestEnvSanitation:
         assert resolver.last_source is None
 
     def test_openai_valid_env_returns_key(self, monkeypatch, configured_store):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test1234567890abcdefghijklmnop")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test1234567890abcdefghijklmnop")  # gitleaks:allow
         monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
 
         resolver = SecretResolver()
@@ -132,7 +138,7 @@ class TestEnvSanitation:
     def test_google_falls_through_to_gemini_env(self, monkeypatch, configured_store):
         """Wenn GOOGLE_API_KEY garbage ist, soll GEMINI_API_KEY als Backup ziehen."""
         monkeypatch.setenv("GOOGLE_API_KEY", "garbage")
-        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSyValidGeminiKey1234567890ABC")
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSyValidGeminiKey1234567890ABC")  # gitleaks:allow
 
         resolver = SecretResolver()
         assert resolver.get_api_key("google", "google") == "AIzaSyValidGeminiKey1234567890ABC"
@@ -218,7 +224,7 @@ class TestLastSource:
         assert resolver.last_source == "session"
 
     def test_store_source(self, configured_store):
-        configured_store.upsert("openai", api_key="sk-storedkey1234567890abcdefghij")
+        configured_store.upsert("openai", api_key="sk-storedkey1234567890abcdefghij")  # gitleaks:allow
         resolver = SecretResolver()
         resolver.get_api_key("openai", "openai")
         assert resolver.last_source == "store"
@@ -232,7 +238,7 @@ class TestLastSource:
         assert resolver.last_source is None
 
     def test_last_source_resets_per_call(self, monkeypatch, configured_store):
-        configured_store.upsert("google", api_key="AIzaSyStoreKey1234567890abcDEF")
+        configured_store.upsert("google", api_key="AIzaSyStoreKey1234567890abcDEF")  # gitleaks:allow
         resolver = SecretResolver()
         resolver.get_api_key("google", "google")
         assert resolver.last_source == "store"

--- a/backend/tests/services/test_secret_resolver_env_sanitation.py
+++ b/backend/tests/services/test_secret_resolver_env_sanitation.py
@@ -1,0 +1,244 @@
+"""Tests für die Track-1-Härtung des SecretResolvers.
+
+Hintergrund: Vor diesem Slice ist ein toxischer ``OPENAI_API_KEY=ollama`` im
+Container-Env durch den Resolver geschlüpft → ``OpenAI(api_key="ollama")``
+→ 401-Loop. Nach der Härtung:
+
+  * ENV-Werte mit falschem Format / Toxic-Literal werden abgelehnt (``None``).
+  * Provider-spezifische ENV-Variablen werden korrekt gemappt
+    (``OLLAMA_API_KEY`` → ``provider_type="ollama_cloud"`` usw.).
+  * ``last_source`` trägt die Herkunft des Keys für Audit-Logging.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.services import llm_provider_secrets_store as store_module
+from app.services.llm_provider_secrets_store import reset_singleton_for_tests
+from app.services.secret_resolver import SecretResolver, _format_valid, _mask_for_log
+
+
+@pytest.fixture
+def configured_store(monkeypatch, tmp_path: Path):
+    """Frischer, leerer Fernet-Store pro Test."""
+    monkeypatch.setenv("AGORA_SECRET_KEY", Fernet.generate_key().decode("utf-8"))
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    reset_singleton_for_tests()
+    yield store_module.get_llm_provider_secrets_store()
+    reset_singleton_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# _format_valid — provider-spezifische Format-Checks
+# ---------------------------------------------------------------------------
+
+
+class TestFormatValid:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "sk-proj-abcdefghij1234567890XYZ",
+            "sk-test1234567890abcdefghijklmnop",
+        ],
+    )
+    def test_openai_valid_keys(self, value):
+        assert _format_valid(value, "openai") is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "ollama",
+            "OLLAMA",
+            "Ollama",
+            "your-key-here",
+            "none",
+            "sk-",
+            "sk",
+            "",
+            None,
+        ],
+    )
+    def test_openai_rejects_toxic_or_malformed(self, value):
+        assert _format_valid(value, "openai") is False
+
+    def test_google_valid_aizasy(self):
+        assert _format_valid("AIzaSyTestValidKey1234567890abcDEF", "google") is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["AIza", "google-key", "garbage", "ollama"],
+    )
+    def test_google_rejects_garbage(self, value):
+        assert _format_valid(value, "google") is False
+
+    def test_ollama_cloud_is_liberal_but_rejects_toxic_literals(self):
+        # Doku zeigt kein striktes Prefix für OLLAMA_API_KEY → bewusst liberal.
+        assert _format_valid("fa6b1234deadbeef5678abcd", "ollama_cloud") is True
+        assert _format_valid("ollama", "ollama_cloud") is False
+        assert _format_valid("none", "ollama_cloud") is False
+
+    def test_unknown_provider_falls_back_to_toxic_filter(self):
+        assert _format_valid("any-value", "custom_xyz") is True
+        assert _format_valid("ollama", "custom_xyz") is False
+
+
+class TestMaskForLog:
+    def test_short_value_masked(self):
+        assert _mask_for_log("sk") == "<short>"
+
+    def test_long_value_prefix_only(self):
+        assert _mask_for_log("sk-proj-supersecretkey") == "sk-p..."
+
+    def test_empty_marker(self):
+        assert _mask_for_log("") == "<empty>"
+        assert _mask_for_log(None) == "<empty>"
+
+
+# ---------------------------------------------------------------------------
+# Resolver — ENV-Pfad mit Format-Sanity-Check
+# ---------------------------------------------------------------------------
+
+
+class TestEnvSanitation:
+    def test_openai_toxic_env_returns_none(self, monkeypatch, configured_store):
+        """Der historische Bug: OPENAI_API_KEY=ollama darf nicht durchgehen."""
+        monkeypatch.setenv("OPENAI_API_KEY", "ollama")
+        # Kein Config-Fallback, der das maskiert
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("openai", "openai") is None
+        assert resolver.last_source is None
+
+    def test_openai_valid_env_returns_key(self, monkeypatch, configured_store):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test1234567890abcdefghijklmnop")
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("openai", "openai") == "sk-test1234567890abcdefghijklmnop"
+        assert resolver.last_source == "env:OPENAI_API_KEY"
+
+    def test_google_garbage_env_rejected(self, monkeypatch, configured_store):
+        monkeypatch.setenv("GOOGLE_API_KEY", "garbage")
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("google", "google") is None
+
+    def test_google_falls_through_to_gemini_env(self, monkeypatch, configured_store):
+        """Wenn GOOGLE_API_KEY garbage ist, soll GEMINI_API_KEY als Backup ziehen."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "garbage")
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSyValidGeminiKey1234567890ABC")
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("google", "google") == "AIzaSyValidGeminiKey1234567890ABC"
+        assert resolver.last_source == "env:GEMINI_API_KEY"
+
+    def test_config_fallback_rejected_for_openai_with_wrong_format(
+        self, monkeypatch, configured_store
+    ):
+        """Ollama-Cloud-Key (hex) darf NICHT als OpenAI-Fallback dienen."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "app.services.secret_resolver.Config.LLM_API_KEY",
+            "fa6b1234deadbeef5678abcd9876543210",  # Ollama-Cloud-Format
+        )
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("openai", "openai") is None
+
+    def test_config_fallback_allowed_for_ollama_cloud(
+        self, monkeypatch, configured_store
+    ):
+        """Für ollama_cloud bleibt Config.LLM_API_KEY als Fallback erlaubt."""
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "app.services.secret_resolver.Config.LLM_API_KEY",
+            "fa6b1234deadbeef5678abcd9876543210",
+        )
+
+        resolver = SecretResolver()
+        result = resolver.get_api_key("ollama_cloud", "ollama_cloud")
+        assert result == "fa6b1234deadbeef5678abcd9876543210"
+        assert resolver.last_source == "config_fallback"
+
+
+# ---------------------------------------------------------------------------
+# Resolver — Provider-spezifische ENV-Mapping
+# ---------------------------------------------------------------------------
+
+
+class TestProviderEnvMapping:
+    def test_ollama_cloud_reads_ollama_api_key(self, monkeypatch, configured_store):
+        monkeypatch.setenv("OLLAMA_API_KEY", "fa6b1234deadbeef5678abcd9876543210")
+        # LLM_API_KEY existiert evtl. global — wir wollen sicher die ENV-Quelle treffen
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert (
+            resolver.get_api_key("ollama_cloud", "ollama_cloud")
+            == "fa6b1234deadbeef5678abcd9876543210"
+        )
+        assert resolver.last_source == "env:OLLAMA_API_KEY"
+
+    def test_openai_compatible_reads_llm_api_key_env(self, monkeypatch, configured_store):
+        monkeypatch.setenv("LLM_API_KEY", "custom-endpoint-token-abc123")
+        # Config.LLM_API_KEY wird beim Modul-Import gesnapshotted; expliziter Patch.
+        monkeypatch.setattr(
+            "app.services.secret_resolver.Config.LLM_API_KEY",
+            "custom-endpoint-token-abc123",
+        )
+
+        resolver = SecretResolver()
+        result = resolver.get_api_key("openai_compatible", "openai_compatible")
+        assert result == "custom-endpoint-token-abc123"
+        assert resolver.last_source in ("env:LLM_API_KEY", "config_fallback")
+
+    def test_toxic_ollama_api_key_returns_none(self, monkeypatch, configured_store):
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("ollama_cloud", "ollama_cloud") is None
+
+
+# ---------------------------------------------------------------------------
+# last_source — Audit-Side-Channel für LLMClient-Init-Log
+# ---------------------------------------------------------------------------
+
+
+class TestLastSource:
+    def test_session_source(self, configured_store):
+        resolver = SecretResolver(session_api_keys={"openai": "session-key-xyz"})
+        resolver.get_api_key("openai", "openai")
+        assert resolver.last_source == "session"
+
+    def test_store_source(self, configured_store):
+        configured_store.upsert("openai", api_key="sk-storedkey1234567890abcdefghij")
+        resolver = SecretResolver()
+        resolver.get_api_key("openai", "openai")
+        assert resolver.last_source == "store"
+
+    def test_none_source_when_nothing_available(self, monkeypatch, configured_store):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+
+        resolver = SecretResolver()
+        assert resolver.get_api_key("openai", "openai") is None
+        assert resolver.last_source is None
+
+    def test_last_source_resets_per_call(self, monkeypatch, configured_store):
+        configured_store.upsert("google", api_key="AIzaSyStoreKey1234567890abcDEF")
+        resolver = SecretResolver()
+        resolver.get_api_key("google", "google")
+        assert resolver.last_source == "store"
+
+        # Zweiter Aufruf für anderen Provider ohne Match → None
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr("app.services.secret_resolver.Config.LLM_API_KEY", None)
+        resolver.get_api_key("openai", "openai")
+        assert resolver.last_source is None

--- a/backend/tests/services/test_secret_resolver_store.py
+++ b/backend/tests/services/test_secret_resolver_store.py
@@ -24,7 +24,7 @@ def configured_store(monkeypatch, tmp_path: Path):
 
 def test_store_overrides_env(monkeypatch, configured_store):
     monkeypatch.setenv("OPENAI_API_KEY", "env-key-should-lose")
-    configured_store.upsert("openai", api_key="sk-store-wins-aaaa")
+    configured_store.upsert("openai", api_key="sk-store-wins-aaaa")  # gitleaks:allow
 
     resolver = SecretResolver()
     assert resolver.get_api_key("openai", "openai") == "sk-store-wins-aaaa"
@@ -33,27 +33,27 @@ def test_store_overrides_env(monkeypatch, configured_store):
 def test_env_used_when_store_empty(monkeypatch, configured_store):
     # Track 1: ENV-Werte werden provider-spezifisch validiert. ``env-fallback``
     # würde nach der Härtung abgelehnt → wir nutzen ein valides ``sk-``-Format.
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-envfallback1234567890abcDEF")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-envfallback1234567890abcDEF")  # gitleaks:allow
     resolver = SecretResolver()
     assert resolver.get_api_key("openai", "openai") == "sk-test-envfallback1234567890abcDEF"
 
 
 def test_session_overrides_store(configured_store):
-    configured_store.upsert("openai", api_key="sk-store-aaaa1111")
+    configured_store.upsert("openai", api_key="sk-store-aaaa1111")  # gitleaks:allow
     resolver = SecretResolver(session_api_keys={"openai": "session-wins"})
     assert resolver.get_api_key("openai", "openai") == "session-wins"
 
 
 def test_google_key_from_env(monkeypatch, configured_store):
     # Track 1: AIzaSy-Format-Check für ``google``-Provider.
-    monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSyEnvKeyValid1234567890abcDEF")
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSyEnvKeyValid1234567890abcDEF")  # gitleaks:allow
     resolver = SecretResolver()
     assert resolver.get_api_key("google", "google") == "AIzaSyEnvKeyValid1234567890abcDEF"
 
 
 def test_google_key_from_store_overrides_env(monkeypatch, configured_store):
     monkeypatch.setenv("GOOGLE_API_KEY", "google-env-key")
-    configured_store.upsert("google", api_key="AIzaSyStoreWinsxx99")
+    configured_store.upsert("google", api_key="AIzaSyStoreWinsxx99")  # gitleaks:allow
     resolver = SecretResolver()
     assert resolver.get_api_key("google", "google") == "AIzaSyStoreWinsxx99"
 
@@ -62,7 +62,7 @@ def test_missing_secret_key_falls_back_to_env(monkeypatch, tmp_path):
     monkeypatch.delenv("AGORA_SECRET_KEY", raising=False)
     monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
     # Track 1: valides ``sk-``-Format, sonst greift der Format-Check.
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-onlyvalidkey1234567890abc")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-onlyvalidkey1234567890abc")  # gitleaks:allow
     reset_singleton_for_tests()
     resolver = SecretResolver()
     # Store wirft RuntimeError ohne Master-Key — Resolver soll auf env fallen

--- a/backend/tests/services/test_secret_resolver_store.py
+++ b/backend/tests/services/test_secret_resolver_store.py
@@ -31,9 +31,11 @@ def test_store_overrides_env(monkeypatch, configured_store):
 
 
 def test_env_used_when_store_empty(monkeypatch, configured_store):
-    monkeypatch.setenv("OPENAI_API_KEY", "env-fallback")
+    # Track 1: ENV-Werte werden provider-spezifisch validiert. ``env-fallback``
+    # würde nach der Härtung abgelehnt → wir nutzen ein valides ``sk-``-Format.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-envfallback1234567890abcDEF")
     resolver = SecretResolver()
-    assert resolver.get_api_key("openai", "openai") == "env-fallback"
+    assert resolver.get_api_key("openai", "openai") == "sk-test-envfallback1234567890abcDEF"
 
 
 def test_session_overrides_store(configured_store):
@@ -43,9 +45,10 @@ def test_session_overrides_store(configured_store):
 
 
 def test_google_key_from_env(monkeypatch, configured_store):
-    monkeypatch.setenv("GOOGLE_API_KEY", "google-env-key")
+    # Track 1: AIzaSy-Format-Check für ``google``-Provider.
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSyEnvKeyValid1234567890abcDEF")
     resolver = SecretResolver()
-    assert resolver.get_api_key("google", "google") == "google-env-key"
+    assert resolver.get_api_key("google", "google") == "AIzaSyEnvKeyValid1234567890abcDEF"
 
 
 def test_google_key_from_store_overrides_env(monkeypatch, configured_store):
@@ -58,9 +61,10 @@ def test_google_key_from_store_overrides_env(monkeypatch, configured_store):
 def test_missing_secret_key_falls_back_to_env(monkeypatch, tmp_path):
     monkeypatch.delenv("AGORA_SECRET_KEY", raising=False)
     monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
-    monkeypatch.setenv("OPENAI_API_KEY", "env-only-key")
+    # Track 1: valides ``sk-``-Format, sonst greift der Format-Check.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-onlyvalidkey1234567890abc")
     reset_singleton_for_tests()
     resolver = SecretResolver()
     # Store wirft RuntimeError ohne Master-Key — Resolver soll auf env fallen
-    assert resolver.get_api_key("openai", "openai") == "env-only-key"
+    assert resolver.get_api_key("openai", "openai") == "sk-env-onlyvalidkey1234567890abc"
     reset_singleton_for_tests()


### PR DESCRIPTION
## Summary

Behebt den 401-unauthorized-Loop bei User-konfigurierten OpenAI-Profilen und das daraus folgende Pydantic-`ValidationError`-500 in der Report-Pipeline. Drei Tracks aus dem Plan `fix/llm-key-resolution-unauthorized`:

- **Track 1 — Secret-Resolver hardening (`1ad9b21`)**: Format-Sanity-Check für OpenAI- (`sk-…`) und Google-ENV/Config-Werte (`AIzaSy…`), Toxic-Literal-Filter (`ollama`, `none`, `sk-`, …), neue ENV-Mappings (`OLLAMA_API_KEY` → `ollama_cloud`, `LLM_API_KEY` → `openai_compatible`). `Config.LLM_API_KEY` greift nicht mehr als universeller Fallback bei format-mismatched Werten. `LLMClient` loggt beim Init `provider_id`, `model`, `base_url`, `api_key_source` — niemals den Key.
- **Track 3 — Report-Robustheit (`d891461`)**: `_safe_generate_section_react` ersetzt Exceptions und leere Responses durch sichtbaren Fallback-Text mit `report_id`+`section_index`. `ReportV3.model_validate` ist mit `try/except ValidationError` umrahmt und schreibt user-facing Hinweis in `report.error` statt Pydantic-Stack-Trace. `simulation_history.generate_profiles` reicht `api_key`+`base_url` an `OasisProfileGenerator` durch (gleiche Helper-Funktion wie `prepare_service._phase_generate_profiles`).
- **Track 2 — Follow-up nach Smoke**: Diagnostic-Endpoint `/api/llm/resolver-trace` + provider_id-Mapping-Audit. Bedingt: nur nötig, falls Smoke-Test mit echtem OpenAI-Key trotz Track 1 noch `api_key_source=env:OPENAI_API_KEY` zeigt.

Track 3d (Restart-Re-Resolution) ist implizit durch `resolve_route_api_key` + Track-1-`SecretResolver` abgedeckt — kein separater Code-Touch.

## Test Plan

- [x] `cd backend && uv run pytest tests/services/ tests/api/ tests/utils/ tests/contracts/ -q` (1143 passed, 4 deselected: 1 pre-existing fork-test fail aus `test_signed_ticket_fork`, 3 OASIS-Subprocess-Tests)
- [x] `cd backend && uv run python -m app.contracts.dump_schemas --check` (27/27 OK)
- [x] `cd backend && uv run ruff check . && uv run mypy app` (clean)
- [ ] **Smoke-Test (Operator)**: Stack hochfahren, UI öffnen, OpenAI-Profil mit echtem `sk-…`-Key konfigurieren, Run starten. Erwartet: 0× `WARNING: LLM call failed (attempt N): unauthorized`, 0× `using rule-based generation`, 1× pro Init `INFO: LLMClient initialized provider_id=… model=… api_key_source=store`
- [ ] **Quality-Check**: Erste 10 Personas eines neuen Runs öffnen — `persona_context`-Felder müssen LLM-generiert sein (nicht rule-based Templates)
- [ ] **Report-Pfad**: Report-Stage anstoßen — sollte komplett durchlaufen oder beim Fail einen lesbaren `report.error` zeigen (kein 500 mit Pydantic-Stack-Trace)
- [ ] **Gemini-Sichtung**: 90 s nach Push warten, Gemini-Findings im PR sichten

## Refs

- Plan: `/Users/alexanderschneider/.claude/plans/jeztzt-bin-ich-f-r-pure-gosling.md`
- Memory: `feedback_pr_gemini_workflow`, `agora-vps-deploy`
- Skill: `~/.agents/skills/ollama-cloud-models/SKILL.md` (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)