### PR TITLE
chore(ci): allowlist track-1 test-fixture findings in .gitleaksignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,10 @@ PLAN.md.bak
 /Agora_design/
 /scripts/logs/
 /.codex
-/.gitleaksignore
+# ``/.gitleaksignore`` ist tracked — offizielle gitleaks-Allowlist für
+# dokumentierte Test-Fixtures (siehe Header der Datei). Niemals echte
+# Secrets eintragen; jeder Eintrag muss als belegtes Test-Fixture im
+# Commit-Body begründet sein.
 # /media/: Default ignored, aber README-relevante Assets (logo, screenshots, credits) re-included.
 # WICHTIG: /media/* statt /media/ — bei Verzeichnis-Match kann man Kinder nicht re-includen.
 /media/*

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,21 @@
+# Gitleaks Ignore-List
+#
+# Format: <commit-sha>:<file-path>:<rule-id>:<line>
+#
+# Diese Einträge sind Test-Fixtures, keine echten Provider-API-Keys. Sie tragen
+# format-valide ``sk-…`` / ``AIzaSy…``-Strings, weil der Track-1-Secret-Resolver
+# (#559) explizit den Prefix + Mindest-Länge prüft — ohne format-valide Werte
+# wären die Tests wirkungslos.
+#
+# Die Werte selbst sind erfunden ("envfallback", "envvalidkey", "injectedkey",
+# "envkeyvalid"-Suffixe) und tragen keinen Zugang zu echten Provider-Endpunkten.
+# Inline ``# gitleaks:allow``-Marker wurden in einem Folge-Commit (185a7b5)
+# nachgereicht — Gitleaks scannt die Original-Commits per Diff-Range, deshalb
+# greifen die Marker dort nicht. Diese Ignorelist deckt die historischen Diffs ab.
+#
+# Memory-Referenz: feedback_gitleaks_test_fixtures.
+
+1ad9b21ccf12fd9906267ec1550ad7cf95c33335:backend/tests/services/test_llm_core_services.py:generic-api-key:22
+1ad9b21ccf12fd9906267ec1550ad7cf95c33335:backend/tests/services/test_secret_resolver_store.py:generic-api-key:49
+1ad9b21ccf12fd9906267ec1550ad7cf95c33335:backend/tests/services/test_secret_resolver_env_sanitation.py:generic-api-key:117
+d891461697eb733fb8c36e0ccb5705b0d43b03cc:backend/tests/api/test_simulation_history_provider_passing.py:generic-api-key:79


### PR DESCRIPTION
## Summary

Macht `Security scans` auf `main` wieder grün, nachdem #559 vier dokumentierte Test-Fixtures als `generic-api-key` triggern lässt.

### Warum nicht via Inline-Marker?

PR #559 hat die `# gitleaks:allow`-Inline-Marker in einem Folge-Commit (`185a7b5`) nachgereicht. Gitleaks scannt jedoch den Commit-Range-Diff, nicht den Head-Tree — die Marker greifen daher in den Original-Commits `1ad9b21` (Track 1) und `d891461` (Track 3) nicht. `.gitleaksignore` mit Commit-Fingerprint ist hier der saubere offizielle Weg (siehe [gitleaks docs](https://github.com/gitleaks/gitleaks#gitleaksignore)).

### Belege

Die vier Einträge stammen 1:1 aus den CI-Logs von #559 und referenzieren Test-Strings im Format `sk-…` / `AIzaSy…`, die der Track-1-Resolver-Format-Check prüfen muss. Sie tragen kein verwertbares Material — die Suffixe sind erfunden (`envfallback`, `envvalidkey`, `injectedkey`, `envkeyvalid`).

### Policy-Touch

`.gitignore` hatte `/.gitleaksignore` als hard-deny (historischer Defense-Reflex ohne Kommentar). Der Eintrag fliegt raus, ein neuer Kommentar dokumentiert die Policy: niemals echte Secrets eintragen, jeder Eintrag braucht Commit-Body-Begründung.

## Test plan

- [ ] CI `Security scans` läuft grün
- [ ] Gemini-Review sichten