### PR TITLE
refactor(search): migrate _run_with_retry to session.execute_read (#554)

### DIFF
--- a/backend/app/storage/search_service.py
+++ b/backend/app/storage/search_service.py
@@ -11,11 +11,10 @@ import logging
 from typing import List, Dict, Any, Optional
 
 import neo4j.exceptions
-from neo4j import Session as Neo4jSession
+from neo4j import Session as Neo4jSession, ManagedTransaction
 from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
 
 from .embedding_service import EmbeddingService
-from ..utils.retry import neo4j_call_with_retry
 
 logger = logging.getLogger('agora.search')
 
@@ -151,24 +150,29 @@ class SearchService:
         *,
         fallback_label: str,
     ) -> List[Any]:
-        """Execute a Cypher query with retry logic and honest error handling.
+        """Execute a Cypher read query via managed transaction with driver-level retry.
 
-        - Retries on transient Neo4j errors (ServiceUnavailable, SessionExpired,
-          TransientError) up to 2 times via neo4j_call_with_retry.
+        Uses ``session.execute_read`` so the Neo4j driver handles
+        ``ServiceUnavailable``/``SessionExpired``/``TransientError`` internally
+        with its own retry logic — a fresh connection is established on each
+        retry attempt, unlike the previous ``session.run``-based approach.
+
         - Returns [] for missing index/procedure (ClientError with known codes),
           so callers are never surprised by schema bootstrap races.
         - Re-raises ClientError for genuine Cypher programming errors.
+        - Returns [] for transient errors that the driver could not recover from.
         - Returns [] for all other exceptions after logging at WARNING.
         """
         _INDEX_CODES = frozenset({
             "Neo.ClientError.Schema.IndexNotFound",
             "Neo.ClientError.Procedure.ProcedureNotFound",
         })
+
+        def _tx_callback(tx: ManagedTransaction) -> List[Any]:
+            return list(tx.run(cypher, **params))
+
         try:
-            return neo4j_call_with_retry(
-                lambda: list(session.run(cypher, **params)),
-                max_retries=2,
-            )
+            return session.execute_read(_tx_callback)
         except neo4j.exceptions.ClientError as e:
             if e.code in _INDEX_CODES:
                 logger.warning(

--- a/backend/tests/storage/test_search_service_retry.py
+++ b/backend/tests/storage/test_search_service_retry.py
@@ -14,7 +14,12 @@ deshalb ``app.storage.search_service.logger.warning`` direkt.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from neo4j.exceptions import ServiceUnavailable, TransientError, ClientError
+from neo4j.exceptions import (
+    ClientError,
+    ServiceUnavailable,
+    SessionExpired,
+    TransientError,
+)
 
 from app.storage.search_service import SearchService
 
@@ -41,20 +46,31 @@ def _fake_node_record(uuid="x", name="y", score=0.9):
 
 
 # ---------------------------------------------------------------------------
-# Test 1: ServiceUnavailable nach execute_read → [] + Warning mit 'transient'
+# Test 1: Driver-erschöpfte Transient-Exceptions → [] + Warning mit 'transient'
 #
-# Der Driver-interne Retry ist über Mock-Session nicht simulierbar.
-# Wir testen stattdessen, dass eine von execute_read propagierte
-# ServiceUnavailable korrekt abgefangen und als [] zurückgegeben wird.
+# Der Driver-interne Retry ist über Mock-Session nicht simulierbar — wir testen
+# stattdessen, dass eine von execute_read propagierte Transient-Exception
+# korrekt abgefangen und als [] zurückgegeben wird. SessionExpired ist hier
+# explizit drin, weil sie der ursprüngliche Trigger des Refactors zu
+# execute_read war (Gemini-Review zu PR #553).
 # ---------------------------------------------------------------------------
 
 
-def test_vector_search_retries_on_service_unavailable(svc):
-    """Wenn session.execute_read ServiceUnavailable wirft (Driver hat aufgegeben),
-    gibt _run_node_vector_search [] zurück und loggt ein Warning mit 'transient'.
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ServiceUnavailable("boom"),
+        SessionExpired("session gone"),
+        TransientError("db overloaded"),
+    ],
+    ids=["ServiceUnavailable", "SessionExpired", "TransientError"],
+)
+def test_transient_exception_returns_empty_with_warning(svc, exc):
+    """Wenn execute_read eine Transient-Exception propagiert (Driver hat aufgegeben),
+    liefert _run_node_vector_search [] und das Warning enthält 'transient'.
     """
     session = MagicMock()
-    session.execute_read.side_effect = ServiceUnavailable("boom")
+    session.execute_read.side_effect = exc
 
     with patch("app.storage.search_service.logger") as mock_logger:
         results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
@@ -100,31 +116,7 @@ def test_index_not_found_warning_wording(svc):
 
 
 # ---------------------------------------------------------------------------
-# Test 3: TransientError nach execute_read → leere Liste + Warning mit 'transient'
-# ---------------------------------------------------------------------------
-
-
-def test_transient_error_returns_empty_after_exhausted_retries(svc):
-    """TransientError von execute_read (Driver hat Retries erschöpft) → []
-    und Warning enthält 'transient'.
-    """
-    session = MagicMock()
-    session.execute_read.side_effect = TransientError("db overloaded")
-
-    with patch("app.storage.search_service.logger") as mock_logger:
-        results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
-
-    assert results == []
-    assert mock_logger.warning.called, "logger.warning muss aufgerufen worden sein"
-    all_warning_args = [str(a) for c in mock_logger.warning.call_args_list for a in c.args]
-    combined = " ".join(all_warning_args).lower()
-    assert "transient" in combined, (
-        f"Warning-Args sollen 'transient' enthalten, erhalten: {combined!r}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 4: Happy Path — execute_read wird genau 1× aufgerufen, tx.run liefert Records
+# Test 3: Happy Path — execute_read wird genau 1× aufgerufen, tx.run liefert Records
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/storage/test_search_service_retry.py
+++ b/backend/tests/storage/test_search_service_retry.py
@@ -1,8 +1,11 @@
-"""Tests für _run_with_retry-Helper in SearchService (Fix 2).
+"""Tests für _run_with_retry-Helper in SearchService (Fix 2, execute_read-Pfad).
 
-RED-Phase: schlägt fehl, weil search_service.py noch keinen Retry-Wrapper
-hat und die Warning-Wording-Prüfung gegen das alte "(index may not exist yet)"
-greift.
+Nach Migration zu session.execute_read übernimmt der Neo4j-Driver das
+transiente Retry intern. Die Tests verifizieren:
+  - Error-Klassifikation (IndexNotFound, transient, generic)
+  - Warning-Wording (Substrings)
+  - Happy-Path (execute_read wird genau einmal aufgerufen)
+  - Transient-Exception nach execute_read → []
 
 Hinweis zu Logger-Patching: Der agora.search-Logger nutzt einen custom
 Handler (get_logger), der nicht in caplog propagiert. Warning-Tests patchen
@@ -29,48 +32,41 @@ def svc():
     return SearchService(embedding, vector_weight=0.7, keyword_weight=0.3)
 
 
-def _fake_record(uuid="x", name="y", score=0.9):
-    """Baut einen Neo4j-Record-Fake, der dict()-kompatibel ist."""
+def _fake_node_record(uuid="x", name="y", score=0.9):
+    """Baut einen Neo4j-Record-Fake, der dict()-kompatibel ist (node-Variante)."""
     node = {"uuid": uuid, "name": name}
     rec = MagicMock()
-    rec.__getitem__ = lambda self, key: node if key == "n" else score
-    # __iter__ wird bei dict(record["n"]) nicht direkt gebraucht — node ist dict.
     rec.__getitem__ = MagicMock(side_effect=lambda key: node if key == "n" else score)
     return rec
 
 
-def _fake_result(records):
-    """Iterierbares Result-Objekt, das records zurückgibt."""
-    result = MagicMock()
-    result.__iter__ = MagicMock(return_value=iter(records))
-    return result
-
-
 # ---------------------------------------------------------------------------
-# Test 1: Retry bei ServiceUnavailable (2× fail, dann Erfolg)
+# Test 1: ServiceUnavailable nach execute_read → [] + Warning mit 'transient'
+#
+# Der Driver-interne Retry ist über Mock-Session nicht simulierbar.
+# Wir testen stattdessen, dass eine von execute_read propagierte
+# ServiceUnavailable korrekt abgefangen und als [] zurückgegeben wird.
 # ---------------------------------------------------------------------------
 
 
 def test_vector_search_retries_on_service_unavailable(svc):
-    """session.run wirft 2× ServiceUnavailable, dann liefert es ein gültiges Result.
-
-    _run_node_vector_search muss 1 Element zurückgeben und session.run 3× aufgerufen haben.
+    """Wenn session.execute_read ServiceUnavailable wirft (Driver hat aufgegeben),
+    gibt _run_node_vector_search [] zurück und loggt ein Warning mit 'transient'.
     """
-    record = _fake_record()
-    success_result = _fake_result([record])
-
     session = MagicMock()
-    session.run.side_effect = [
-        ServiceUnavailable("boom"),
-        ServiceUnavailable("boom again"),
-        success_result,
-    ]
+    session.execute_read.side_effect = ServiceUnavailable("boom")
 
-    with patch("app.utils.retry.time.sleep"):
+    with patch("app.storage.search_service.logger") as mock_logger:
         results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
 
-    assert len(results) == 1
-    assert session.run.call_count == 3
+    assert results == []
+    assert session.execute_read.call_count == 1
+    assert mock_logger.warning.called
+    all_args = [str(a) for c in mock_logger.warning.call_args_list for a in c.args]
+    combined = " ".join(all_args).lower()
+    assert "transient" in combined, (
+        f"Warning-Args sollen 'transient' enthalten, erhalten: {combined!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -86,14 +82,14 @@ def test_index_not_found_warning_wording(svc):
     err.code = "Neo.ClientError.Schema.IndexNotFound"
 
     session = MagicMock()
-    session.run.side_effect = err
+    session.execute_read.side_effect = err
 
     with patch("app.storage.search_service.logger") as mock_logger:
         results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
 
     assert results == []
     assert mock_logger.warning.called, "logger.warning muss aufgerufen worden sein"
-    all_warning_args = [str(a) for call in mock_logger.warning.call_args_list for a in call.args]
+    all_warning_args = [str(a) for c in mock_logger.warning.call_args_list for a in c.args]
     combined = " ".join(all_warning_args)
     assert "IndexNotFound" in combined, (
         f"Warning-Args sollen 'IndexNotFound' enthalten, erhalten: {combined!r}"
@@ -104,24 +100,23 @@ def test_index_not_found_warning_wording(svc):
 
 
 # ---------------------------------------------------------------------------
-# Test 3: TransientError erschöpft → leere Liste + Warning mit 'transient'
+# Test 3: TransientError nach execute_read → leere Liste + Warning mit 'transient'
 # ---------------------------------------------------------------------------
 
 
 def test_transient_error_returns_empty_after_exhausted_retries(svc):
-    """TransientError (erschöpft) → [] und Warning enthält 'transient'."""
+    """TransientError von execute_read (Driver hat Retries erschöpft) → []
+    und Warning enthält 'transient'.
+    """
     session = MagicMock()
-    session.run.side_effect = TransientError("db overloaded")
+    session.execute_read.side_effect = TransientError("db overloaded")
 
-    with (
-        patch("app.storage.search_service.logger") as mock_logger,
-        patch("app.utils.retry.time.sleep"),  # kein echtes Warten in Tests
-    ):
+    with patch("app.storage.search_service.logger") as mock_logger:
         results = svc._run_node_vector_search(session, "g1", [0.1] * 1536, 5)
 
     assert results == []
     assert mock_logger.warning.called, "logger.warning muss aufgerufen worden sein"
-    all_warning_args = [str(a) for call in mock_logger.warning.call_args_list for a in call.args]
+    all_warning_args = [str(a) for c in mock_logger.warning.call_args_list for a in c.args]
     combined = " ".join(all_warning_args).lower()
     assert "transient" in combined, (
         f"Warning-Args sollen 'transient' enthalten, erhalten: {combined!r}"
@@ -129,21 +124,28 @@ def test_transient_error_returns_empty_after_exhausted_retries(svc):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Happy Path — genau 1× session.run bei keyword search
+# Test 4: Happy Path — execute_read wird genau 1× aufgerufen, tx.run liefert Records
 # ---------------------------------------------------------------------------
 
 
 def test_happy_path_single_session_run_call(svc):
-    """_run_node_keyword_search ruft session.run bei Erfolg exakt 1× auf."""
+    """_run_node_keyword_search ruft session.execute_read bei Erfolg exakt 1× auf.
+
+    execute_read führt den Callback mit einem Mock-tx aus; tx.run liefert Records.
+    """
     node = {"uuid": "abc", "name": "Testknoten"}
     rec = MagicMock()
     rec.__getitem__ = MagicMock(side_effect=lambda key: node if key == "n" else 0.8)
-    success_result = _fake_result([rec])
+
+    mock_tx = MagicMock()
+    mock_tx.run.return_value = iter([rec])
 
     session = MagicMock()
-    session.run.return_value = success_result
+    # execute_read ruft den übergebenen Callback mit mock_tx auf
+    session.execute_read.side_effect = lambda cb: list(cb(mock_tx))
 
     results = svc._run_node_keyword_search(session, "g1", "Testquery", 10)
 
-    session.run.assert_called_once()
+    session.execute_read.assert_called_once()
+    mock_tx.run.assert_called_once()
     assert isinstance(results, list)


### PR DESCRIPTION
## Summary

- `SearchService._run_with_retry` von manuellem Retry-Wrapper auf `session.execute_read(_tx_callback)` umgestellt — idiomatische Driver-API mit managed transactions und eingebautem Retry, robust gegen `SessionExpired` (Gemini-Review zu #553).
- Import `neo4j_call_with_retry` aus `search_service.py` entfernt (Read-Pfad).
- Tests in `tests/storage/test_search_service_retry.py` nachgezogen: Mock-Target von `session.run` auf `session.execute_read` umgestellt; Transient-Exception-Coverage über `parametrize` auf alle 3 Typen erweitert — inklusive `SessionExpired`, das vorher ungetestet war.

## Out of scope (bewusst nicht angefasst)

- `_call_with_retry` in `neo4j_storage` (Write-Pfad) — Schreiboperationen brauchen explizite Transaction-Semantik, kein 1:1-Mapping auf `execute_read`.
- Andere Storage-Module mit `neo4j_call_with_retry`-Wrapper.

## Verhalten unverändert

- Error-Klassifikation: `IndexNotFound`/`ProcedureNotFound` → `[]` + warning; `ServiceUnavailable|SessionExpired|TransientError` → `[]` + warning ('transient' im Wording); `ClientError` (andere) → re-raise; alles andere → `[]` + warning.
- Warning-Wording-Substrings sind weiter pinged (`IndexNotFound`, `transient`).

## Test plan

- [x] `pytest tests/storage/test_search_service_retry.py tests/test_search_service.py tests/contracts/` — 220 passed
- [x] `ruff check app/ tests/` — clean
- [x] `mypy app` — clean
- [x] `dump_schemas --check` — 27/27 OK, kein Drift

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)