### PR TITLE
fix(llm): strip prose/codefence envelope around JSON payloads (#556)

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -365,7 +365,10 @@ def _strip_llm_json_envelope(text: str) -> str:
 
     end = s.rfind(end_char)
     if end == -1 or end < start:
-        return s
+        # Truncated payload mit Preamble (z. B. ``Sure! {"a": 1``):
+        # Prosa abschneiden, damit ``_try_repair_truncated_json`` im
+        # Caller den unbalanced Rest reparieren kann.
+        return s[start:]
     return s[start : end + 1]
 
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -319,6 +319,56 @@ def _read_active_config_safely() -> Optional[Dict[str, Any]]:
         return None
 
 
+_CODEFENCE_HEAD_RE = re.compile(r"^```(?:json)?\s*", re.IGNORECASE)
+_CODEFENCE_TAIL_RE = re.compile(r"\s*```\s*$")
+
+
+def _strip_llm_json_envelope(text: str) -> str:
+    """Entfernt Codefences + Prosa-Umrahmung um ein LLM-JSON-Payload.
+
+    Issue #556: Gemini-Outputs liefern oft Preambles ("Sure, here is …")
+    und/oder trailing prose ("Hope this helps!") um den eigentlichen
+    JSON-Block. Der bisherige Pre-Parser entfernte nur Codefences an
+    Anfang/Ende und produzierte ``JSONDecodeError`` bei Prosa-Rändern.
+
+    Pipeline:
+      1. Strip whitespace.
+      2. Codefences entfernen (case-insensitive, ``json``-Label optional).
+      3. Outer-Cut: erstes ``{`` oder ``[`` bis zum letzten passenden
+         ``}`` oder ``]`` (Typ-Wahl nach dem zuerst auftretenden Bracket).
+
+    Liefert bei fehlender JSON-Struktur den gestrippten Original-String —
+    der Caller löst dann ``JSONDecodeError`` aus, was er sowieso tun würde.
+    """
+    if not text:
+        return text
+    s = text.strip()
+    s = _CODEFENCE_HEAD_RE.sub("", s)
+    s = _CODEFENCE_TAIL_RE.sub("", s)
+    s = s.strip()
+    if not s:
+        return s
+
+    first_obj = s.find("{")
+    first_arr = s.find("[")
+    if first_obj == -1 and first_arr == -1:
+        return s
+
+    if first_obj == -1:
+        start, end_char = first_arr, "]"
+    elif first_arr == -1:
+        start, end_char = first_obj, "}"
+    elif first_obj < first_arr:
+        start, end_char = first_obj, "}"
+    else:
+        start, end_char = first_arr, "]"
+
+    end = s.rfind(end_char)
+    if end == -1 or end < start:
+        return s
+    return s[start : end + 1]
+
+
 def _try_repair_truncated_json(payload: str) -> Optional[str]:
     """Best-effort recovery for an LLM JSON answer cut off at the output cap.
 
@@ -1184,10 +1234,7 @@ class LLMClient:
                         max_tokens=max_tokens,
                         force_no_thinking=force_no_thinking,
                     )
-                    cleaned_response = response.strip()
-                    cleaned_response = re.sub(r'^```(?:json)?\s*', '', cleaned_response, flags=re.IGNORECASE)
-                    cleaned_response = re.sub(r'\s*```$', '', cleaned_response)
-                    cleaned_response = cleaned_response.strip()
+                    cleaned_response = _strip_llm_json_envelope(response)
                     parsed: Dict[str, Any] = json.loads(cleaned_response)
                     return self._maybe_validate(parsed, schema)
                 except Exception as exc:  # noqa: BLE001 — bewusst breit, Fallback ist sicher
@@ -1234,12 +1281,8 @@ class LLMClient:
                 context=context,
                 force_no_thinking=force_no_thinking,
             )
-        # Clean markdown code block markers
-        cleaned_response = response.strip()
-        # Robustly remove ```json ... ``` or just ``` ... ```
-        cleaned_response = re.sub(r'^```(?:json)?\s*', '', cleaned_response, flags=re.IGNORECASE)
-        cleaned_response = re.sub(r'\s*```$', '', cleaned_response)
-        cleaned_response = cleaned_response.strip()
+        # Codefences + Prosa-Envelope entfernen (Issue #556).
+        cleaned_response = _strip_llm_json_envelope(response)
 
         try:
             parsed: Dict[str, Any] = json.loads(cleaned_response)

--- a/backend/tests/utils/test_llm_client_json_envelope.py
+++ b/backend/tests/utils/test_llm_client_json_envelope.py
@@ -101,14 +101,23 @@ class TestStripLlmJsonEnvelope:
         raw = '{"items": [1,2,3], "ok": true}'
         assert _strip_llm_json_envelope(raw) == '{"items": [1,2,3], "ok": true}'
 
-    def test_unbalanced_braces_no_match_returns_original(self) -> None:
-        """Wenn kein passendes schließendes Bracket existiert, original
-        zurück (Caller löst dann JSONDecodeError aus, was er sowieso täte)."""
+    def test_unbalanced_braces_strips_preamble_for_repair_path(self) -> None:
+        """Wenn das schließende Bracket fehlt (truncated output mit
+        Preamble), wird die Prosa vor dem Open-Bracket entfernt. So kann
+        ``_try_repair_truncated_json`` im Caller den unbalanced Rest
+        reparieren — ohne Preamble würde der Repair-Algorithmus an der
+        Prosa scheitern."""
         raw = "broken: {a: 1"
-        # outer-cut darf nicht crashen; Verhalten: original-string
-        # (kein Truncate auf Halbsatz, der dem Parser noch mehr Schaden täte)
         result = _strip_llm_json_envelope(raw)
-        assert "{a: 1" in result
+        assert result == "{a: 1"
+
+    def test_truncated_gemini_output_with_preamble(self) -> None:
+        """Realer Gemini-Crash-Pfad: Preamble + truncated JSON."""
+        raw = 'Sure! Here is the data:\n```json\n{"a": 1, "b": "incomp'
+        result = _strip_llm_json_envelope(raw)
+        # Preamble + Codefence weg, truncated Rest bleibt unangetastet
+        assert result.startswith('{"a": 1')
+        assert "incomp" in result
 
     def test_whitespace_only_returns_empty_or_whitespace(self) -> None:
         result = _strip_llm_json_envelope("   \n  ")

--- a/backend/tests/utils/test_llm_client_json_envelope.py
+++ b/backend/tests/utils/test_llm_client_json_envelope.py
@@ -1,0 +1,128 @@
+"""Issue #556 — Gemini-Outputs umrahmen JSON oft mit Codefences UND Prosa.
+
+Der aktuelle Pre-Parser entfernt nur `^```(json)?` und `\\s*```$` an den
+Rändern. Outputs mit Preamble ("Sure! Here you go:\\n...") oder trailing
+prose ("...```\\nHope this helps!") fallen durch und produzieren
+`JSONDecodeError: Expecting value: line 1 column 1`.
+
+Dieses Modul testet den Helper `_strip_llm_json_envelope`, der Codefences
++ Prosa-Umrahmung entfernt und auf das outer JSON-Objekt/Array zuschneidet.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.utils.llm_client import _strip_llm_json_envelope
+
+
+class TestStripLlmJsonEnvelope:
+    """Helper soll Codefences + Prosa-Umrahmung entfernen, robust gegen
+    typische LLM-Output-Patterns (Gemini, GPT, Ollama Cloud)."""
+
+    # --- Happy Path -------------------------------------------------------
+
+    def test_pure_json_object_untouched(self) -> None:
+        assert _strip_llm_json_envelope('{"a": 1}') == '{"a": 1}'
+
+    def test_pure_json_array_untouched(self) -> None:
+        assert _strip_llm_json_envelope('[1, 2, 3]') == '[1, 2, 3]'
+
+    def test_whitespace_around_object_trimmed(self) -> None:
+        assert _strip_llm_json_envelope('  \n {"a": 1}  \n') == '{"a": 1}'
+
+    # --- Codefences --------------------------------------------------------
+
+    def test_codefence_json_label(self) -> None:
+        raw = "```json\n{\"a\": 1}\n```"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    def test_codefence_uppercase_json_label(self) -> None:
+        raw = "```JSON\n{\"a\": 1}\n```"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    def test_codefence_bare(self) -> None:
+        raw = "```\n{\"a\": 1}\n```"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    # --- Preamble (was den existierenden Pre-Parser killt) ----------------
+
+    def test_preamble_before_object(self) -> None:
+        raw = "Sure! Here is the JSON you requested:\n\n{\"a\": 1}"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    def test_preamble_and_codefence(self) -> None:
+        raw = "Here is the JSON response:\n```json\n{\"a\": 1}\n```"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    # --- Trailing prose ---------------------------------------------------
+
+    def test_trailing_prose_after_object(self) -> None:
+        raw = '{"a": 1}\n\nHope this helps!'
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    def test_codefence_and_trailing_prose(self) -> None:
+        raw = "```json\n{\"a\": 1}\n```\n\nHope this helps!"
+        assert _strip_llm_json_envelope(raw) == '{"a": 1}'
+
+    # --- Reale Gemini-Patterns --------------------------------------------
+
+    def test_gemini_style_preamble_and_trailing(self) -> None:
+        raw = (
+            "Of course. Based on the persona profile, here is the structured "
+            "response in JSON format:\n\n"
+            "```json\n"
+            '{"persona_id": "p1", "score": 0.87}\n'
+            "```\n\n"
+            "Let me know if you need anything else."
+        )
+        assert _strip_llm_json_envelope(raw) == '{"persona_id": "p1", "score": 0.87}'
+
+    def test_nested_braces_in_string_values(self) -> None:
+        """Outer-Object-Schnitt darf nicht auf `}` in Strings reagieren."""
+        raw = 'Sure: {"msg": "use {x} as template", "ok": true} done.'
+        assert _strip_llm_json_envelope(raw) == '{"msg": "use {x} as template", "ok": true}'
+
+    def test_array_with_prose(self) -> None:
+        raw = "Here are the entities:\n```\n[1, 2, 3]\n```"
+        assert _strip_llm_json_envelope(raw) == '[1, 2, 3]'
+
+    # --- Edge cases --------------------------------------------------------
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _strip_llm_json_envelope("") == ""
+
+    def test_only_prose_no_json_returns_original(self) -> None:
+        raw = "I cannot answer this question."
+        assert _strip_llm_json_envelope(raw) == raw
+
+    def test_object_before_array_picks_first_bracket(self) -> None:
+        """Wenn beide Brackets vorkommen, gewinnt der erste auftretende.
+        Hier `{` zuerst → outer object."""
+        raw = '{"items": [1,2,3], "ok": true}'
+        assert _strip_llm_json_envelope(raw) == '{"items": [1,2,3], "ok": true}'
+
+    def test_unbalanced_braces_no_match_returns_original(self) -> None:
+        """Wenn kein passendes schließendes Bracket existiert, original
+        zurück (Caller löst dann JSONDecodeError aus, was er sowieso täte)."""
+        raw = "broken: {a: 1"
+        # outer-cut darf nicht crashen; Verhalten: original-string
+        # (kein Truncate auf Halbsatz, der dem Parser noch mehr Schaden täte)
+        result = _strip_llm_json_envelope(raw)
+        assert "{a: 1" in result
+
+    def test_whitespace_only_returns_empty_or_whitespace(self) -> None:
+        result = _strip_llm_json_envelope("   \n  ")
+        assert result.strip() == ""
+
+
+@pytest.mark.parametrize("payload", [
+    '{"a": 1}',
+    '[1, 2, 3]',
+    '{"nested": {"deep": {"value": 42}}}',
+    '{"unicode": "ümlaut äöü", "emoji": "✓"}',
+])
+def test_strip_envelope_is_idempotent(payload: str) -> None:
+    """Doppelte Anwendung verändert das Ergebnis nicht."""
+    once = _strip_llm_json_envelope(payload)
+    twice = _strip_llm_json_envelope(once)
+    assert once == twice


### PR DESCRIPTION
## Summary

Closes #556.

Gemini-Outputs liefern JSON häufig mit Preamble (\"Sure, here is …\") und/oder trailing prose (\"Hope this helps!\") um den eigentlichen Block. Der bisherige Pre-Parser entfernte nur Codefences an Anfang/Ende und produzierte `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` bei Prosa-Rändern. Retry erholte sich, jeder Vorfall war aber ein verschwendeter LLM-Call.

## Change

- Neuer Helper `_strip_llm_json_envelope` in `backend/app/utils/llm_client.py`:
  1. `strip()`
  2. Codefences entfernen (case-insensitive, `json`-Label optional)
  3. Outer-Cut: erstes `{`/`[` bis letztes passendes `}`/`]` (Typ-Wahl nach zuerst auftretendem Bracket)
  4. Fallback: gestrippter Original-String → Caller löst JSONDecodeError wie bisher
- Die zwei duplizierten Codefence-Blöcke in `chat_json` (Ollama-native + OpenAI-Pfad) nutzen jetzt beide den Helper — DRY.

## Test plan

- [x] 22 Unit-Tests in `tests/utils/test_llm_client_json_envelope.py` (Codefences, Preambles, trailing prose, nested braces in Strings, Gemini-Style-Patterns, Edge-Cases, Idempotenz)
- [x] `pytest tests/utils/ tests/contracts/ tests/test_llm_client.py` → 367 passed (1 pre-existing failure in `test_signed_ticket_fork.py::test_register_fork_handlers` ist origin/main-baseline, nicht durch diesen PR ausgelöst)
- [x] `ruff check` clean
- [x] `mypy app/utils/llm_client.py` clean
- [x] `python -m app.contracts.dump_schemas --check` → 27/27 Schemas matchen

## Notes

Pre-existing failure `test_register_fork_handlers` lebt unabhängig (verifiziert via `git stash` gegen origin/main HEAD 5df5af3) — vermutlich Folge des Redis-Pool-Resets aus #551, separates Issue.