### PR TITLE
Resolve CVE-2025-71176 (pytest) and cleanup resolved security ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           uvx pip-audit --strict --no-deps --disable-pip \
-            --ignore-vuln CVE-2025-71176 \
             --ignore-vuln CVE-2026-1839 \
-            --ignore-vuln CVE-2024-46455 \
-            --ignore-vuln CVE-2025-64712 \
             -r /tmp/agora-backend-requirements.txt
 
       - name: Set up Bun

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,22 +3,7 @@
 # These are currently ignored because they are blocked by upstream pins.
 # Hardstop: 2026-07-30
 
-# CVE-2025-71176: pytest==8.2.0 (via camel-oasis==0.2.5)
-# Risk: Low (Test runner only)
-# Issue: https://github.com/arn0ld87/agora/issues/123
-CVE-2025-71176
-
 # CVE-2026-1839: transformers==4.57.6 (via sentence-transformers==3.0.0)
 # Risk: Medium (Embedding pipeline)
 # Issue: https://github.com/arn0ld87/agora/issues/124
 CVE-2026-1839
-
-# CVE-2024-46455: unstructured==0.13.7 (via camel-oasis==0.2.5)
-# Risk: Medium (Document parsing)
-# Issue: https://github.com/arn0ld87/agora/issues/125
-CVE-2024-46455
-
-# CVE-2025-64712: unstructured==0.13.7 (via camel-oasis==0.2.5)
-# Risk: Medium (Document parsing)
-# Issue: https://github.com/arn0ld87/agora/issues/126
-CVE-2025-64712

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -228,6 +228,9 @@ override-dependencies = [
     # Attachment (critical, Arbitrary File Write) plus < 0.14.3 XXE.
     # camel-oasis 0.2.5 pinned 0.13.7 — Override zieht 0.18.18 trotzdem hoch.
     "unstructured>=0.18.18",
+    # CVE-2025-71176: pytest 8.2.0 (pinned by camel-oasis 0.2.5) has a
+    # vulnerability. Upgrading to >=9.0.3.
+    "pytest>=9.0.3",
     # sentence-transformers 3.0.0 (camel-oasis-Pin) hat drei
     # SyntaxWarning("invalid escape sequence") in eigenen Modulen
     # (SentenceEvaluator.py, model_card.py, DenoisingAutoEncoderLoss.py).

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -15,6 +15,7 @@ overrides = [
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=12.1.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "sentence-transformers", specifier = ">=4.1.0,<5" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "unstructured", specifier = ">=0.18.18" },
@@ -2029,7 +2030,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2328,17 +2329,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.2.0"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/9d/78b3785134306efe9329f40815af45b9215068d6ae4747ec0bc91ff1f4aa/pytest-8.2.0.tar.gz", hash = "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f", size = 1422883, upload-time = "2024-04-27T23:34:55.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl", hash = "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233", size = 339229, upload-time = "2024-04-27T23:34:52.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -3275,8 +3277,8 @@ name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [

--- a/docs/2026-05-19-pytest-cve-tracking-arbeitsprotokoll.md
+++ b/docs/2026-05-19-pytest-cve-tracking-arbeitsprotokoll.md
@@ -1,0 +1,32 @@
+# Arbeitsprotokoll: Security Tracking CVE-2025-71176 (pytest)
+
+**Datum:** 2026-05-19
+**Bearbeiter:** Jules (AI Agent)
+**Task:** Security: track CVE-2025-71176 in pytest until upstream fix
+
+## Ausgangslage
+- `pytest==8.2.0` ist durch `camel-oasis==0.2.5` gepinnt.
+- `pip-audit` meldet `CVE-2025-71176` für `pytest==8.2.0`, Fix in `9.0.3`.
+- Risiko wird als Low/Medium eingestuft (Test-Framework, kein Prod-Codepath).
+- Deadline für Fix/Tracking: 2026-08-18 (+90 Tage).
+- Zusätzlich wurde festgestellt, dass `unstructured` CVEs (`CVE-2024-46455`, `CVE-2025-64712`) durch ein bestehendes Override auf `unstructured>=0.18.18` bereits gelöst sein sollten, aber noch in CI/Risk-Register ignoriert werden.
+
+## Untersuchung
+- `uv tree --package camel-oasis` bestätigt den Pin auf `pytest==8.2.0`.
+- Ein Major-Bump von `pytest` 8.x auf 9.x muss auf Breaking Changes geprüft werden.
+- `pip-audit` Bestätigung der Funde:
+  - `pytest 8.2.0` -> `CVE-2025-71176`
+  - `transformers 4.57.6` -> `CVE-2026-1839` (bekannt, weiterhin ignoriert)
+  - `unstructured` CVEs werden von `pip-audit` nicht mehr gemeldet (da Version `0.18.32` installiert ist).
+
+## Geplantes Vorgehen
+1. Upgrade von `pytest` auf `>=9.0.3` via `tool.uv.override-dependencies` in `backend/pyproject.toml`.
+2. Verifikation des Upgrades und Testlauf des Backend-Testsuites.
+3. Bereinigung der Security-Dokumentation (`docs/dependency-risk-register.md`, `.trivyignore`) und CI-Konfiguration (`.github/workflows/ci.yml`) für `pytest` (falls Upgrade erfolgreich) und `unstructured`.
+
+## Log
+- [2026-05-19] Untersuchung gestartet. `pip-audit` bestätigt CVEs. `unstructured` ist bereits auf einer sicheren Version (0.18.32).
+- [2026-05-19] `pytest` erfolgreich auf `9.0.3` geupgraded via `override-dependencies`.
+- [2026-05-19] Backend-Tests erfolgreich (3 bekannte Regressionen unverändert).
+- [2026-05-19] `pip-audit` bestätigt Resolution von `CVE-2025-71176`, `CVE-2024-46455` und `CVE-2025-64712`.
+- [2026-05-19] Security-Dokumentation (`dependency-risk-register.md`, `.trivyignore`) und CI (`ci.yml`) bereinigt.

--- a/docs/dependency-risk-register.md
+++ b/docs/dependency-risk-register.md
@@ -17,18 +17,13 @@ hinterlegt, um den Container-Scan nicht zu blockieren.
 
 | CVE | Paket | Schweregrad | Fix verfügbar? | Owner | Frist | Status | Issue | Upstream-Release-Watch |
 |---|---|---|---|---|---|---|---|---|
-| CVE-2025-71176 | `pytest` | Low | Nein (Upstream Pin) | camel-oasis | 2026-07-30 | open | [#123](https://github.com/arn0ld87/agora/issues/123) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases) |
 | CVE-2026-1839 | `transformers` | Medium | Nein (Upstream Pin) | sentence-transformers | 2026-07-30 | open | [#124](https://github.com/arn0ld87/agora/issues/124) | [UKPLab/sentence-transformers/releases](https://github.com/UKPLab/sentence-transformers/releases) |
-| CVE-2024-46455 | `unstructured` | Medium | Nein (Upstream Pin) | camel-oasis | 2026-07-30 | open | [#125](https://github.com/arn0ld87/agora/issues/125) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases) |
-| CVE-2025-64712 | `unstructured` | Medium | Nein (Upstream Pin) | camel-oasis | 2026-07-30 | open | [#126](https://github.com/arn0ld87/agora/issues/126) | [camel-ai/oasis/releases](https://github.com/camel-ai/oasis/releases) |
 
 ### Pin-Begruendungen
 
 | Paket | Pinned Version | Upstream-Pin | Erklaerung |
 |---|---|---|---|
-| `pytest` | `8.2.0` | `camel-oasis==0.2.5` | `camel-oasis` pinnt `pytest==8.2.0`. Fix: `>=9.0.3`. |
 | `transformers` | `4.57.6` | `sentence-transformers==3.0.0` | `sentence-transformers` limitiert `transformers<5`. |
-| `unstructured` | `0.13.7` | `camel-oasis==0.2.5` | `camel-oasis` pinnt `unstructured==0.13.7`. |
 
 ---
 
@@ -68,3 +63,6 @@ Der CVE-Monitor-Workflow erzwingt die Entscheidung: ab Hardstop-Datum schlägt e
 | CVE-2026-42308 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #296 schließen. | 2026-05-15 |
 | CVE-2026-42310 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #297 schließen. | 2026-05-15 |
 | CVE-2026-42311 | `pillow` | Resolved via `tool.uv.override-dependencies`: `pillow==12.2.0` installiert (verified via `uv export`). `--ignore-vuln`-Flag aus CI entfernt. Issues #298 schließen. | 2026-05-15 |
+| CVE-2025-71176 | `pytest` | Resolved via `tool.uv.override-dependencies`: `pytest==9.0.3` installiert (verified via `uv run pytest --version`). `--ignore-vuln`-Flag aus CI entfernt. Issues #123 schließen. | 2026-05-19 |
+| CVE-2024-46455 | `unstructured` | Resolved via `tool.uv.override-dependencies`: `unstructured>=0.18.18` installiert (verified via `uv run pip-audit`). `--ignore-vuln`-Flag aus CI entfernt. Issues #125 schließen. | 2026-05-19 |
+| CVE-2025-64712 | `unstructured` | Resolved via `tool.uv.override-dependencies`: `unstructured>=0.18.18` installiert (verified via `uv run pip-audit`). `--ignore-vuln`-Flag aus CI entfernt. Issues #126 schließen. | 2026-05-19 |


### PR DESCRIPTION
This change resolves the security vulnerability CVE-2025-71176 in pytest by forcing an upgrade to version 9.0.3 via 'tool.uv.override-dependencies' in the backend. Additionally, it cleans up tracking for CVE-2024-46455 and CVE-2025-64712 (unstructured), which are also resolved by existing overrides. Security documentation and CI configurations are updated to reflect these fixes.

Fixes #566

---
*PR created automatically by Jules for task [14467911007994092694](https://jules.google.com/task/14467911007994092694) started by @arn0ld87*