### PR TITLE
Add `supports_tools` capability gate for LLM model selection

### DIFF
--- a/backend/app/api/llm_active.py
+++ b/backend/app/api/llm_active.py
@@ -22,12 +22,15 @@ from flask import request
 
 from . import llm_bp
 from ..services.llm_provider_registry import LlmProviderRegistry
+from ..services.model_catalog_service import ModelCatalogService
+from ..services.secret_resolver import SecretResolver
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.api.llm_active")
 
 _provider_registry = LlmProviderRegistry()
+_model_catalog = ModelCatalogService()
 
 
 def _instance_dir() -> Path:
@@ -104,6 +107,7 @@ def put_active_config():
     payload = request.get_json(silent=True) or {}
     provider_id = (payload.get("provider_id") or "").strip()
     model = (payload.get("model") or "").strip()
+    force = request.args.get("force") == "true"
 
     if not provider_id:
         return json_error("provider_id is required", status=400, code="invalid_request")
@@ -115,6 +119,21 @@ def put_active_config():
     if not provider:
         return json_error(f"Unknown provider: {provider_id}", status=404, code="provider_not_found")
 
+    # Capability-Gate (Issue #557): check if model supports tools
+    if not force:
+        resolver = SecretResolver()
+        api_key = resolver.get_api_key(provider_id, provider.type)
+        models = _model_catalog.get_models(provider_id, provider.type, provider.base_url, api_key)
+        target_model = next((m for m in models if m.id == model), None)
+
+        if target_model and not target_model.supports_tools:
+            return json_error(
+                f"Model {model!r} does not support OpenAI-compatible tool calls. "
+                "This might crash simulations. Use ?force=true to override.",
+                status=422,
+                code="unsupported_capability",
+            )
+
     saved = save_active_config(provider_id, model, provider.base_url)
-    logger.info("Active LLM config updated: provider=%s model=%s", provider_id, model)
+    logger.info("Active LLM config updated: provider=%s model=%s force=%s", provider_id, model, force)
     return json_success(saved)

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -26,6 +26,7 @@ from app.contracts.llm_routing_contract import (
     RuntimeLlmRouting,
     ProviderDescriptor,
     ResolvedRoute,
+    ModelEntry,
 )
 from app.contracts.api_keys_contract import (
     ApiKeyCreateRequest,
@@ -65,6 +66,7 @@ CONTRACTS: dict[str, type] = {
     "llm-runtime-routing.schema.json": RuntimeLlmRouting,
     "llm-provider-descriptor.schema.json": ProviderDescriptor,
     "llm-resolved-route.schema.json": ResolvedRoute,
+    "llm-model-entry.schema.json": ModelEntry,
     "api-key.schema.json": ApiKeyModel,
     "api-key-create-request.schema.json": ApiKeyCreateRequest,
     "api-key-create-response.schema.json": ApiKeyCreateResponse,

--- a/backend/app/contracts/llm_routing_contract.py
+++ b/backend/app/contracts/llm_routing_contract.py
@@ -64,6 +64,21 @@ class RuntimeLlmRouting(BaseModel):
     routing_version: int = 1
 
 
+class ModelEntry(BaseModel):
+    """Metadata about a single model (public, normalized)."""
+
+    model_config = _STRICT
+
+    id: str
+    name: str
+    provider_id: str
+    source: Literal["live", "cached", "fallback", "custom"]
+    refreshed_at: float
+    supports_tools: bool = False
+    supports_json_mode: bool = False
+    context_window: Optional[int] = None
+
+
 class ProviderDescriptor(BaseModel):
     """Metadata about an LLM provider (public, no secrets)."""
 
@@ -75,6 +90,7 @@ class ProviderDescriptor(BaseModel):
     base_url: Optional[str] = None
     api_key_ref: Optional[str] = None
     supports_models_endpoint: bool = False
+    supports_tools: bool = False
     fallback_models: List[str] = Field(default_factory=list)
 
 

--- a/backend/app/services/llm_provider_registry.py
+++ b/backend/app/services/llm_provider_registry.py
@@ -40,6 +40,7 @@ class LlmProviderRegistry:
                 base_url="https://api.openai.com/v1",
                 api_key_ref="OPENAI_API_KEY",
                 supports_models_endpoint=True,
+                supports_tools=True,
                 fallback_models=["gpt-4o", "gpt-4o-mini", "o1-preview"],
             ),
             ProviderDescriptor(
@@ -49,6 +50,7 @@ class LlmProviderRegistry:
                 base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
                 api_key_ref="GOOGLE_API_KEY",
                 supports_models_endpoint=True,
+                supports_tools=True,
                 fallback_models=["gemini-1.5-pro", "gemini-1.5-flash"],
             ),
             ProviderDescriptor(
@@ -66,10 +68,49 @@ class LlmProviderRegistry:
                 base_url="https://api.githubcopilot.com",
                 api_key_ref="GH_AUTH_TOKEN",
                 supports_models_endpoint=False,
+                supports_tools=True,
                 fallback_models=list(_copilot_models()),
             ),
         ]
         return providers
+
+    @staticmethod
+    def is_model_tool_capable(model_id: str, provider_type: str) -> bool:
+        """Heuristic check if a model supports OpenAI-compatible tool calling."""
+        if not model_id:
+            return False
+
+        mid = model_id.lower()
+
+        # Explicit gate for known broken models (Issue #557)
+        if "ministral" in mid:
+            return False
+
+        # Natively capable providers (where we trust almost any modern model)
+        if provider_type in ("openai", "google", "github_copilot"):
+            return True
+
+        # Whitelist for Ollama/OpenAI-compatible model families
+        tool_capable_families = (
+            "gpt-4",
+            "gpt-3.5",
+            "o1-",
+            "o3-",
+            "gemini-",
+            "llama-3.1",
+            "llama-3.2",
+            "llama-3.3",
+            "llama3.1",
+            "llama3.2",
+            "llama3.3",
+            "qwen2.5",
+            "qwen3",
+            "deepseek-v3",
+            "deepseek-v4",
+            "deepseek-r1",
+            "claude-3",
+        )
+        return any(f in mid for f in tool_capable_families)
 
 
 def _copilot_models() -> tuple[str, ...]:

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -12,11 +12,11 @@ nichts ausser dem ``requests``-Convenience-Wrapper.
 
 import json
 import time
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Optional
 
 import urllib3
-from pydantic import BaseModel, ConfigDict
 
+from ..contracts.llm_routing_contract import ModelEntry
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.model_catalog")
@@ -30,16 +30,6 @@ _HTTP = urllib3.PoolManager(
     timeout=urllib3.Timeout(connect=5.0, read=5.0),
     retries=False,
 )
-
-
-class ModelEntry(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    id: str
-    name: str
-    provider_id: str
-    source: Literal["live", "cached", "fallback", "custom"]
-    refreshed_at: float
 
 
 def _http_get_json(url: str, *, api_key: Optional[str] = None) -> Optional[dict]:
@@ -76,6 +66,8 @@ class ModelCatalogService:
     def get_models(self, provider_id: str, provider_type: str, base_url: str, api_key: Optional[str]) -> List[ModelEntry]:
         """Fetch models from provider, with caching and fallback."""
         now = time.time()
+        from .llm_provider_registry import LlmProviderRegistry
+        from ..utils.llm_client import heuristic_num_ctx_for_model
 
         # 1. Check cache
         if provider_id in self._cache:
@@ -87,15 +79,21 @@ class ModelCatalogService:
         try:
             live_models = self._fetch_live(provider_type, base_url, api_key)
             if live_models:
-                entries = [
-                    ModelEntry(
-                        id=m,
-                        name=m,
-                        provider_id=provider_id,
-                        source="live",
-                        refreshed_at=now,
-                    ) for m in live_models
-                ]
+                entries = []
+                for m in live_models:
+                    supports_tools = LlmProviderRegistry.is_model_tool_capable(m, provider_type)
+                    entries.append(
+                        ModelEntry(
+                            id=m,
+                            name=m,
+                            provider_id=provider_id,
+                            source="live",
+                            refreshed_at=now,
+                            supports_tools=supports_tools,
+                            supports_json_mode=supports_tools,  # Heuristik: Tool-Modelle können meist auch JSON
+                            context_window=heuristic_num_ctx_for_model(m),
+                        )
+                    )
                 self._cache[provider_id] = entries
                 return entries
         except Exception as exc:
@@ -110,15 +108,23 @@ class ModelCatalogService:
 
         # 4. Fallback to hardcoded defaults
         fallback_models = self._get_fallbacks(provider_type)
-        return [
-            ModelEntry(
-                id=m,
-                name=m,
-                provider_id=provider_id,
-                source="fallback",
-                refreshed_at=now,
-            ) for m in fallback_models
-        ]
+
+        entries = []
+        for m in fallback_models:
+            supports_tools = LlmProviderRegistry.is_model_tool_capable(m, provider_type)
+            entries.append(
+                ModelEntry(
+                    id=m,
+                    name=m,
+                    provider_id=provider_id,
+                    source="fallback",
+                    refreshed_at=now,
+                    supports_tools=supports_tools,
+                    supports_json_mode=supports_tools,
+                    context_window=heuristic_num_ctx_for_model(m),
+                )
+            )
+        return entries
 
     def _fetch_live(self, provider_type: str, base_url: str, api_key: Optional[str]) -> List[str]:
         """Discovery implementation per provider type."""

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -58,7 +58,7 @@ _MODEL_CONTEXT_HEURISTICS: tuple[tuple[str, int], ...] = (
 )
 
 
-def _heuristic_num_ctx_for_model(model_name: str) -> Optional[int]:
+def heuristic_num_ctx_for_model(model_name: str) -> Optional[int]:
     """Best-effort Substring-Match für bekannte Modellfamilien.
 
     Liefert None, wenn das Modell unbekannt ist — Caller fällt dann auf
@@ -100,7 +100,7 @@ def _resolve_num_ctx(
         except (json.JSONDecodeError, TypeError, ValueError):
             pass
 
-    heuristic = _heuristic_num_ctx_for_model(model_name or "")
+    heuristic = heuristic_num_ctx_for_model(model_name or "")
     global_env = os.environ.get("LLM_CONTEXT_LIMIT")
     global_limit: Optional[int]
     try:

--- a/backend/tests/api/test_llm_active.py
+++ b/backend/tests/api/test_llm_active.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import patch
+from flask import Flask
+from app.api import llm_bp
+from app.contracts.llm_routing_contract import ModelEntry
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    app = Flask(__name__)
+    from app.utils.api_responses import install_api_error_handlers
+    install_api_error_handlers(app)
+    app.register_blueprint(llm_bp, url_prefix="/api/llm")
+    app.config["TESTING"] = True
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_rejects_non_tool_model(client):
+    """Test that PUT /api/llm/active-config rejects models without tool support."""
+    fake_models = [
+        ModelEntry(
+            id="broken-model",
+            name="Broken Model",
+            provider_id="ollama_cloud",
+            source="live",
+            refreshed_at=0.0,
+            supports_tools=False
+        ),
+        ModelEntry(
+            id="good-model",
+            name="Good Model",
+            provider_id="ollama_cloud",
+            source="live",
+            refreshed_at=0.0,
+            supports_tools=True
+        )
+    ]
+
+    with patch("app.api.llm_active._model_catalog.get_models") as mock_get_models, \
+         patch("app.api.llm_active.save_active_config") as mock_save, \
+         patch("app.api.llm_active.SecretResolver.get_api_key") as mock_key:
+
+        mock_get_models.return_value = fake_models
+        mock_key.return_value = "dummy"
+        mock_save.return_value = {"provider_id": "ollama_cloud", "model": "good-model"}
+
+        # 1. Reject broken model
+        resp = client.put("/api/llm/active-config", json={
+            "provider_id": "ollama_cloud",
+            "model": "broken-model"
+        })
+        assert resp.status_code == 422
+        assert resp.json["code"] == "unsupported_capability"
+        mock_save.assert_not_called()
+
+        # 2. Allow good model
+        resp = client.put("/api/llm/active-config", json={
+            "provider_id": "ollama_cloud",
+            "model": "good-model"
+        })
+        assert resp.status_code == 200
+        assert resp.json["success"] is True
+        mock_save.assert_called_once()
+        mock_save.reset_mock()
+
+        # 3. Bypass with force=true
+        resp = client.put("/api/llm/active-config?force=true", json={
+            "provider_id": "ollama_cloud",
+            "model": "broken-model"
+        })
+        assert resp.status_code == 200
+        assert resp.json["success"] is True
+        mock_save.assert_called_once()
+
+def test_unknown_model_passes_gate(client):
+    """Unknown models (not in catalog) pass the gate (fail-safe)."""
+    with patch("app.api.llm_active._model_catalog.get_models") as mock_get_models, \
+         patch("app.api.llm_active.save_active_config") as mock_save:
+
+        mock_get_models.return_value = []
+        mock_save.return_value = {"provider_id": "openai", "model": "some-new-model"}
+
+        resp = client.put("/api/llm/active-config", json={
+            "provider_id": "openai",
+            "model": "some-new-model"
+        })
+        assert resp.status_code == 200
+        mock_save.assert_called_once()

--- a/schemas/llm-model-entry.schema.json
+++ b/schemas/llm-model-entry.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-model-entry.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Metadata about a single model (public, normalized).",
+  "properties": {
+    "context_window": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Context Window"
+    },
+    "id": {
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "provider_id": {
+      "title": "Provider Id",
+      "type": "string"
+    },
+    "refreshed_at": {
+      "title": "Refreshed At",
+      "type": "number"
+    },
+    "source": {
+      "enum": [
+        "live",
+        "cached",
+        "fallback",
+        "custom"
+      ],
+      "title": "Source",
+      "type": "string"
+    },
+    "supports_json_mode": {
+      "default": false,
+      "title": "Supports Json Mode",
+      "type": "boolean"
+    },
+    "supports_tools": {
+      "default": false,
+      "title": "Supports Tools",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "provider_id",
+    "source",
+    "refreshed_at"
+  ],
+  "title": "ModelEntry",
+  "type": "object"
+}

--- a/schemas/llm-provider-descriptor.schema.json
+++ b/schemas/llm-provider-descriptor.schema.json
@@ -48,6 +48,11 @@
       "title": "Supports Models Endpoint",
       "type": "boolean"
     },
+    "supports_tools": {
+      "default": false,
+      "title": "Supports Tools",
+      "type": "boolean"
+    },
     "type": {
       "enum": [
         "ollama_cloud",


### PR DESCRIPTION
This PR implements a capability-gate for LLM model selection, specifically targeting tool-calling support. This addresses issue #557 where choosing a model like `ministral-3:14b` would cause simulation hangs due to incompatible function calling.

Key changes:
- **Contract Extension:** Added `supports_tools`, `supports_json_mode`, and `context_window` to the `ModelEntry` Pydantic model.
- **Heuristic Detection:** Centralized tool-support detection in `LlmProviderRegistry.is_model_tool_capable`, whitelisting modern model families and explicitly gating known problematic models.
- **API Validation:** Updated `PUT /api/llm/active-config` to verify model capabilities before saving. It returns `422 Unprocessable Entity` with code `unsupported_capability` if a model lacks tool support, unless overridden with `?force=true`.
- **Enriched Metadata:** `ModelCatalogService` now populates these capability fields during discovery, utilizing the newly exported context window heuristics from `LLMClient`.
- **Testing:** Added `backend/tests/api/test_llm_active.py` to cover the new validation logic and bypass mechanism.

Schemas have been regenerated and verified via `dump_schemas --check`.

Fixes #576

---
*PR created automatically by Jules for task [12753529996915194420](https://jules.google.com/task/12753529996915194420) started by @arn0ld87*