### PR TITLE
fix(contracts): restore LlmProfile re-exports dropped in #595

### DIFF
--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -68,6 +68,11 @@ from .api_keys_contract import (
     ApiKeyStatus,
     ApiKeysListResponse,
 )
+from .llm_profile_contract import (
+    LlmProfile,
+    LlmProfileCreateRequest,
+    LlmProfileListResponse,
+)
 from .provider_types import (
     ALL_PROVIDER_TYPES,
     LEGACY_GEMINI,
@@ -125,6 +130,9 @@ __all__ = [
     "GraphDiff",
     "GraphDiffMetrics",
     "GraphSnapshot",
+    "LlmProfile",
+    "LlmProfileCreateRequest",
+    "LlmProfileListResponse",
     "NodePropertyShift",
     "PersonaEntityContext",
     "PersonaModel",


### PR DESCRIPTION
PR #595 centralized provider types but dropped the `llm_profile_contract` re-exports from `app/contracts/__init__.py`, while `app/services/llm_profiles_store.py:17` still imports `LlmProfile`/`LlmProfileCreateRequest` from the package root. Result: ImportError at app startup and 39 pytest collection errors (entire API test suite uncollectable).

**Fix:** restore the re-exports (`LlmProfile`, `LlmProfileCreateRequest`, `LlmProfileListResponse`) incl. `__all__` entries.

**Verification:** `uv run pytest --collect-only -q` → 2705 tests collected, 0 errors (before: 39 collection errors, suite interrupted). Full suite now runs; remaining pre-existing failures are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)