### PR TITLE
fix(frontend): hide Neo4j Browser link in production

### DIFF
--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue'
 
 const { t } = useI18n()
 const locale = computed(() => currentLocale())
+const isDev = computed(() => import.meta.env.DEV)
 
 function pick(loc) { setLocale(loc) }
 </script>
@@ -29,7 +30,9 @@ function pick(loc) { setLocale(loc) }
       <a href="https://github.com/nikmcfly/Agora" target="_blank" rel="noopener">
         {{ t('home.footer.code') }} ↗
       </a>
-      <a href="http://localhost:7474" target="_blank" rel="noopener">Neo4j Browser ↗</a>
+      <a v-if="isDev" href="http://localhost:7474" target="_blank" rel="noopener">
+        {{ t('home.footer.neo4jBrowser') }}
+      </a>
     </div>
     <div class="col" style="align-items: flex-end; text-align: right;">
       <span>{{ t('common.language') }}</span>

--- a/frontend/src/components/__tests__/AppFooter.spec.ts
+++ b/frontend/src/components/__tests__/AppFooter.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * AppFooter — Tests.
+ *
+ * Test 1: Neo4j Browser link is visible in DEV mode.
+ * Test 2: Neo4j Browser link is hidden in PROD mode.
+ * Test 3: Link text is properly i18n-ized.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import AppFooter from '../AppFooter.vue'
+import de from '../../i18n/locales/de.json'
+import en from '../../i18n/locales/en.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  messages: {
+    de,
+    en,
+  },
+})
+
+describe('AppFooter', () => {
+  it('should render Neo4j Browser link in DEV mode', () => {
+    // Simulate DEV mode
+    import.meta.env.DEV = true
+
+    const wrapper = mount(AppFooter, {
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    const neo4jLink = wrapper.find('a[href="http://localhost:7474"]')
+    expect(neo4jLink.exists()).toBe(true)
+    expect(neo4jLink.text()).toContain('Neo4j Browser')
+  })
+
+  it('should NOT render Neo4j Browser link in PROD mode', () => {
+    // Simulate PROD mode
+    import.meta.env.DEV = false
+
+    const wrapper = mount(AppFooter, {
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    const neo4jLink = wrapper.find('a[href="http://localhost:7474"]')
+    expect(neo4jLink.exists()).toBe(false)
+  })
+
+  it('should use i18n key for Neo4j Browser link text', () => {
+    import.meta.env.DEV = true
+
+    const wrapper = mount(AppFooter, {
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    const neo4jLink = wrapper.find('a[href="http://localhost:7474"]')
+    expect(neo4jLink.exists()).toBe(true)
+    // Check that it uses the i18n key (will be rendered text)
+    expect(neo4jLink.text().length > 0).toBe(true)
+  })
+})

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -174,7 +174,8 @@
       "code": "Quellcode auf GitHub",
       "by": "Entwickelt von",
       "byName": "Alexander Schneider",
-      "bySite": "alexle135.de"
+      "bySite": "alexle135.de",
+      "neo4jBrowser": "Neo4j Browser ↗"
     }
   },
   "history": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -174,7 +174,8 @@
       "code": "Source on GitHub",
       "by": "Built by",
       "byName": "Alexander Schneider",
-      "bySite": "alexle135.de"
+      "bySite": "alexle135.de",
+      "neo4jBrowser": "Neo4j Browser ↗"
     }
   },
   "history": {


### PR DESCRIPTION
## Summary

Gate the Neo4j Browser footer link behind `import.meta.env.DEV` so it only appears in development mode. The link was previously visible in production builds where `http://localhost:7474` is unreachable for remote users.

- Add `isDev` computed property to `AppFooter.vue` 
- i18n-ize link text via `home.footer.neo4jBrowser` (de + en)
- Add Vitest test covering both dev and prod visibility modes

## Test plan

- [x] All 1063 tests pass (`bun run test`)
- [x] Lint and typecheck pass
- [x] Production build succeeds and does not contain localhost URL in rendered output
- [x] DEV mode shows link, PROD mode hides it

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)