### PR TITLE
ci: fix contract-gates permissions + radon allowlist drift

### DIFF
--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   schema-drift:
     name: Schema-Drift verhindern

--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -72,3 +72,11 @@ app/utils/llm_client.py::LLMClient.chat
 # Touch durch HeroNewRun-Slice A2 (PR #504) nur indirekt sichtbar
 # gemacht. Refactor zusammen mit den anderen report_agent-Kandidaten.
 app/services/report_agent/agent.py::ReportAgent._finalize_section_claims
+
+# Drift durch report-status-Refactor und sim-process-manager-Auslagerung
+# (HEAD ~2026-06, pre-existing Komplexität aus bestehenden Service-Zusammenführungen).
+# Refactor-Kandidaten: report_status.py Extraktion von Stage-Branching,
+# process_manager.py start_simulation Aufspaltung nach v1.0.
+app/services/report_status.py::ReportStatusService
+app/services/report_status.py::ReportStatusService.get_status
+app/services/sim/process_manager.py::start_simulation


### PR DESCRIPTION
## Root-Cause je Workflow

| Workflow | Run ID | Root-Cause | Kategorie | Fix |
|---|---|---|---|---|
| **CI** | 27228672525 | Backend-Tests scheitern (Flask-Blueprint-Doppelregistrierung, NEO4J_PASSWORD) | (a) Folge Backend-Fehler | Wird durch `fix/backend-test-failures` grün |
| **contract-gates** | 27228672458 | Radon-Gate findet 3 neue Hotspots (rank D+) außerhalb der Allowlist: `report_status.py::get_status` (E/38), `ReportStatusService` (D/25), `sim/process_manager.py::start_simulation` (D/21) | (b) Eigenständig | allowlist um 3 Einträge erweitert (dieser PR) |
| **Scorecard** | 27228672455 | `ossf/scorecard-action` schlägt fehl, weil `contract-gates.yml` kein `permissions:`-Block hatte → Token-Permissions-Finding mit security-severity 9.0 im SARIF | (b) Eigenständig | `permissions: contents: read` zu contract-gates.yml hinzugefügt (dieser PR) |
| **CodeQL** | 27228672462 | Transientes Netzwerkproblem des GitHub-Runners: `connect ECONNREFUSED 54.185.253.63:443` beim `Initialize CodeQL`-Step | (b) Flüchtig | Kein Code-Fix nötig — re-run nach Netzwerkstabilisierung |
| **Docker Build** | 27228672466 | Selbe Runner-IP `54.185.253.63:443` beim `docker pull tonistiigi/binfmt:latest` (QEMU-Setup), SARIF-Upload schlägt deshalb sekundär fehl | (b) Flüchtig | Kein Code-Fix nötig — re-run |
| **e2e-smokes** | 27228672447 | Selbe Runner-IP beim `apt-get`/Playwright-Browser-Install — alle Paketquellen (azure, ubuntu, microsoft) über dieselbe blockierte IP | (a)/(b) Flüchtig | Kein Code-Fix nötig — re-run |

## Änderungen in diesem PR

**`.github/workflows/contract-gates.yml`**
- Top-Level `permissions: contents: read` ergänzt.
- Scorecard bewertet fehlende Top-Level-Permissions als Token-Permissions-Verletzung (score 0, security-severity 9.0) und bricht den `Run OpenSSF Scorecard`-Step ab.

**`backend/radon-allowlist.txt`**
- 3 neue Hotspots registriert, die durch den Report-Status-Service und die process_manager-Auslagerung entstanden sind und noch keinen eigenen Refactor-Slice haben:
  - `app/services/report_status.py::ReportStatusService` (rank D, cc=25)
  - `app/services/report_status.py::ReportStatusService.get_status` (rank E, cc=38)
  - `app/services/sim/process_manager.py::start_simulation` (rank D, cc=21)

## Nicht gefixte strukturelle Fehler (erfordern manuelle Eingriffe)

- **CodeQL / Docker / e2e-smokes**: Transientes Netzwerkproblem des GitHub-Runners bei Run 33f6140 (alle betroffenen Runs starteten ~18:55 UTC und trafen dieselbe blockierte IP). Ein Re-Run der Workflows genügt.
- **CI**: Wird durch Branch `fix/backend-test-failures` adressiert.

## Manuelle Schritte für den Repo-Owner

1. **CodeQL, Docker Build, e2e-smokes** einfach neu triggern (Re-Run failed jobs) — kein Code-Fix nötig.
2. **Scorecard `publish_results: true`**: Damit die Ergebnisse an api.scorecard.dev publiziert werden, benötigt das Repo ein `SCORECARD_TOKEN`-Secret (PAT mit `public_repo`-Scope) unter Settings → Secrets → Actions. Ohne dieses Secret läuft der Workflow durch, ohne Ergebnisse zu veröffentlichen. Optional: `publish_results: false` setzen wenn Publikation nicht gewünscht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)