### PR TITLE
feat(setup): one-command install script + quick start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,36 @@ Dokumente, Webseiteninhalte oder strategische Fragestellungen hochladen, Wissens
 
 ---
 
+## Quick Start
+
+```bash
+git clone https://github.com/arn0ld87/agora.git
+cd agora
+./install.sh
+```
+
+Danach: `.env` anpassen (SECRET_KEY, NEO4J_PASSWORD, LLM-Endpunkt setzen), dann:
+
+```bash
+bun run dev
+```
+
+**Kein lokales Neo4j/Redis?** Docker-Variante startet den gesamten Stack inklusive Datenbanken:
+
+```bash
+./install.sh --docker
+```
+
+| Dienst | URL |
+|---|---|
+| Frontend | <http://localhost:5173> |
+| Backend | <http://localhost:5001> |
+| Neo4j Browser (nur Docker) | <http://localhost:7474> |
+
+> `./install.sh --help` zeigt alle Optionen. `./install.sh --check` führt Lint + Tests aus.
+
+---
+
 > **Status:** v1.0.0 auf `main`.
 > Agora ist ein **experimentelles Single-User-System**
 > ([ADR-0001](./docs/decisions/0001-auth-model.md)).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dokumente, Webseiteninhalte oder strategische Fragestellungen hochladen, Wissens
 [![Ollama](https://img.shields.io/badge/Ollama-local%20or%20cloud-000?style=flat-square)](https://ollama.com/)
 [![Version](https://img.shields.io/badge/Version-1.0.0-brightgreen?style=flat-square)](./CHANGELOG.md)
 
-[Quickstart](#quickstart) · [Betriebsmodi](#betriebsmodi) · [Architektur](#architektur) · [Konfiguration](#konfiguration) · [Sicherheit](#sicherheit) · [Doku](./docs/) · [Status](./docs/STATUS.md)
+[Quick Start](#quick-start) · [Betriebsmodi](#betriebsmodi) · [Architektur](#architektur) · [Konfiguration](#konfiguration) · [Sicherheit](#sicherheit) · [Doku](./docs/) · [Status](./docs/STATUS.md)
 
 </div>
 
@@ -47,6 +47,8 @@ bun run dev
 | Neo4j Browser (nur Docker) | <http://localhost:7474> |
 
 > `./install.sh --help` zeigt alle Optionen. `./install.sh --check` führt Lint + Tests aus.
+
+Details: siehe [Detaillierte Installation](#detaillierte-installation)
 
 ---
 
@@ -137,7 +139,7 @@ Runtime
 
 Details in [`docs/architecture.md`](./docs/architecture.md).
 
-## Quickstart
+## Detaillierte Installation
 
 Voraussetzungen:
 

--- a/install.sh
+++ b/install.sh
@@ -78,15 +78,21 @@ fi
 UV_VER=$(uv --version 2>/dev/null | awk '{print $2}')
 success "uv $UV_VER"
 
-# --- docker (nur Pflicht bei --docker-Modus) ---
+# --- docker + curl (nur Pflicht bei --docker-Modus) ---
 if [[ "$MODE" == "docker" ]]; then
   if ! command -v docker &>/dev/null; then
     die "docker ist nicht installiert.\n  → https://docs.docker.com/get-docker/"
   fi
+  if ! command -v curl &>/dev/null; then
+    die "curl ist nicht installiert — wird für den Readiness-Check benötigt.\n  → apt-get install curl  oder  brew install curl"
+  fi
   if ! docker info &>/dev/null; then
     die "Docker-Daemon läuft nicht — bitte Docker starten."
   fi
-  DOCKER_VER=$(docker --version | grep -oE '[0-9]+\.[0-9]+')
+  if ! docker compose version &>/dev/null; then
+    die "docker compose (Plugin) nicht gefunden.\n  → https://docs.docker.com/compose/install/"
+  fi
+  DOCKER_VER=$(docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
   success "docker $DOCKER_VER"
 fi
 
@@ -128,12 +134,18 @@ if [[ "$MODE" == "docker" ]]; then
   BACKEND_PORT="${AGORA_BACKEND_PORT:-5001}"
   FRONTEND_PORT="${AGORA_FRONTEND_PORT:-5173}"
   BIND_HOST="${AGORA_BIND_HOST:-127.0.0.1}"
+  # Bei 0.0.0.0 kann curl nicht direkt connecten — loopback nutzen
+  if [[ "$BIND_HOST" == "0.0.0.0" ]]; then
+    CHECK_HOST="127.0.0.1"
+  else
+    CHECK_HOST="$BIND_HOST"
+  fi
 
   info "Starte docker compose up --build -d …"
   docker compose up --build -d
 
   # Auf /readyz warten
-  READYZ_URL="http://${BIND_HOST}:${BACKEND_PORT}/readyz"
+  READYZ_URL="http://${CHECK_HOST}:${BACKEND_PORT}/readyz"
   TIMEOUT=180
   INTERVAL=5
   ELAPSED=0
@@ -151,9 +163,9 @@ if [[ "$MODE" == "docker" ]]; then
   echo ""
   success "Agora läuft!"
   echo ""
-  printf "  ${BOLD}Frontend${RESET}           http://${BIND_HOST}:${FRONTEND_PORT}\n"
-  printf "  ${BOLD}Backend Readiness${RESET}  http://${BIND_HOST}:${BACKEND_PORT}/readyz\n"
-  printf "  ${BOLD}Backend Health${RESET}     http://${BIND_HOST}:${BACKEND_PORT}/health\n"
+  printf "  ${BOLD}Frontend${RESET}           http://${CHECK_HOST}:${FRONTEND_PORT}\n"
+  printf "  ${BOLD}Backend Readiness${RESET}  http://${CHECK_HOST}:${BACKEND_PORT}/readyz\n"
+  printf "  ${BOLD}Backend Health${RESET}     http://${CHECK_HOST}:${BACKEND_PORT}/health\n"
   printf "  ${BOLD}Neo4j Browser${RESET}      http://127.0.0.1:7474\n"
   echo ""
   info "Logs:  docker compose logs -f agora"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# install.sh — Ein-Befehl-Installation für Agora
+# Verwendung:
+#   ./install.sh            Host-Dev-Modus (bun + uv, ohne Docker)
+#   ./install.sh --docker   Docker-Compose-Modus (Neo4j + Redis inklusive)
+#   ./install.sh --check    Lint + Tests laufen lassen
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Farben / Ausgabe
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; BOLD='\033[1m'; RESET='\033[0m'
+info()    { printf "${BOLD}[agora]${RESET} %s\n" "$*"; }
+success() { printf "${GREEN}[agora]${RESET} %s\n" "$*"; }
+warn()    { printf "${YELLOW}[agora] WARN:${RESET} %s\n" "$*"; }
+die()     { printf "${RED}[agora] FEHLER:${RESET} %s\n" "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktion: Versionsnummer aus String extrahieren (major.minor)
+# ---------------------------------------------------------------------------
+semver_major() { echo "$1" | grep -oE '[0-9]+' | head -1; }
+semver_minor() { echo "$1" | grep -oE '[0-9]+' | sed -n '2p'; }
+
+# ---------------------------------------------------------------------------
+# Argument parsen
+# ---------------------------------------------------------------------------
+MODE="host"
+for arg in "$@"; do
+  case "$arg" in
+    --docker) MODE="docker" ;;
+    --check)  MODE="check"  ;;
+    -h|--help)
+      echo "Verwendung: $0 [--docker | --check]"
+      echo "  (kein Flag)  Host-Dev-Modus: bun + uv, Neo4j/Redis extern erforderlich"
+      echo "  --docker     Docker-Compose-Modus: Neo4j + Redis werden mitgestartet"
+      echo "  --check      Lint + Tests (bun run check)"
+      exit 0
+      ;;
+    *) die "Unbekanntes Argument: $arg  (--help für Hilfe)" ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ---------------------------------------------------------------------------
+# Voraussetzungen prüfen
+# ---------------------------------------------------------------------------
+info "Prüfe Voraussetzungen …"
+
+# --- bun >= 1.3 ---
+if ! command -v bun &>/dev/null; then
+  die "bun ist nicht installiert.\n  → https://bun.sh  (curl -fsSL https://bun.sh/install | bash)"
+fi
+BUN_VER=$(bun --version 2>/dev/null)
+BUN_MAJOR=$(semver_major "$BUN_VER")
+BUN_MINOR=$(semver_minor "$BUN_VER")
+if [[ "$BUN_MAJOR" -lt 1 ]] || { [[ "$BUN_MAJOR" -eq 1 ]] && [[ "${BUN_MINOR:-0}" -lt 3 ]]; }; then
+  die "bun $BUN_VER ist zu alt — benötigt >= 1.3.\n  → bun upgrade"
+fi
+success "bun $BUN_VER"
+
+# --- node >= 20 ---
+if ! command -v node &>/dev/null; then
+  die "node ist nicht installiert.\n  → https://nodejs.org/  (empfohlen: nvm oder Homebrew)"
+fi
+NODE_VER=$(node --version | tr -d 'v')
+NODE_MAJOR=$(semver_major "$NODE_VER")
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  die "node $NODE_VER ist zu alt — benötigt >= 20.\n  → nvm install 20 && nvm use 20"
+fi
+success "node $NODE_VER"
+
+# --- uv ---
+if ! command -v uv &>/dev/null; then
+  die "uv ist nicht installiert.\n  → https://docs.astral.sh/uv/  (curl -LsSf https://astral.sh/uv/install.sh | sh)"
+fi
+UV_VER=$(uv --version 2>/dev/null | awk '{print $2}')
+success "uv $UV_VER"
+
+# --- docker (nur Pflicht bei --docker-Modus) ---
+if [[ "$MODE" == "docker" ]]; then
+  if ! command -v docker &>/dev/null; then
+    die "docker ist nicht installiert.\n  → https://docs.docker.com/get-docker/"
+  fi
+  if ! docker info &>/dev/null; then
+    die "Docker-Daemon läuft nicht — bitte Docker starten."
+  fi
+  DOCKER_VER=$(docker --version | grep -oE '[0-9]+\.[0-9]+')
+  success "docker $DOCKER_VER"
+fi
+
+# ---------------------------------------------------------------------------
+# .env-Datei anlegen (idempotent)
+# ---------------------------------------------------------------------------
+setup_env() {
+  local template="$1"
+  if [[ ! -f ".env" ]]; then
+    if [[ -f "$template" ]]; then
+      cp "$template" .env
+      warn ".env aus $template erstellt — bitte SECRET_KEY, AGORA_AUTH_TOKEN und NEO4J_PASSWORD setzen!"
+      warn "  python3 -c \"import secrets; print(secrets.token_urlsafe(32))\""
+    else
+      die "Vorlage $template nicht gefunden."
+    fi
+  else
+    info ".env bereits vorhanden — wird nicht überschrieben."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# MODUS: check
+# ---------------------------------------------------------------------------
+if [[ "$MODE" == "check" ]]; then
+  info "Starte bun run check …"
+  bun run check
+  success "check abgeschlossen."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# MODUS: docker
+# ---------------------------------------------------------------------------
+if [[ "$MODE" == "docker" ]]; then
+  info "Docker-Compose-Modus"
+  setup_env ".env.docker.example"
+
+  BACKEND_PORT="${AGORA_BACKEND_PORT:-5001}"
+  FRONTEND_PORT="${AGORA_FRONTEND_PORT:-5173}"
+  BIND_HOST="${AGORA_BIND_HOST:-127.0.0.1}"
+
+  info "Starte docker compose up --build -d …"
+  docker compose up --build -d
+
+  # Auf /readyz warten
+  READYZ_URL="http://${BIND_HOST}:${BACKEND_PORT}/readyz"
+  TIMEOUT=180
+  INTERVAL=5
+  ELAPSED=0
+  info "Warte auf Backend-Readiness: ${READYZ_URL} (Timeout ${TIMEOUT}s) …"
+  until curl -fsS "$READYZ_URL" &>/dev/null; do
+    if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
+      die "Backend hat nach ${TIMEOUT}s nicht geantwortet.\n  → docker compose logs agora"
+    fi
+    sleep "$INTERVAL"
+    ELAPSED=$((ELAPSED + INTERVAL))
+    printf "  … %ds vergangen\r" "$ELAPSED"
+  done
+  printf "\n"
+
+  echo ""
+  success "Agora läuft!"
+  echo ""
+  printf "  ${BOLD}Frontend${RESET}           http://${BIND_HOST}:${FRONTEND_PORT}\n"
+  printf "  ${BOLD}Backend Readiness${RESET}  http://${BIND_HOST}:${BACKEND_PORT}/readyz\n"
+  printf "  ${BOLD}Backend Health${RESET}     http://${BIND_HOST}:${BACKEND_PORT}/health\n"
+  printf "  ${BOLD}Neo4j Browser${RESET}      http://127.0.0.1:7474\n"
+  echo ""
+  info "Logs:  docker compose logs -f agora"
+  info "Stop:  docker compose down"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# MODUS: host (Default)
+# ---------------------------------------------------------------------------
+info "Host-Dev-Modus"
+setup_env ".env.example"
+
+# Root-Abhängigkeiten (concurrently etc.)
+info "Installiere Root-Abhängigkeiten (bun install) …"
+bun install
+
+# Frontend
+info "Installiere Frontend-Abhängigkeiten (cd frontend && bun install) …"
+(cd frontend && bun install)
+
+# Backend
+info "Installiere Backend-Abhängigkeiten (cd backend && uv sync) …"
+(cd backend && uv sync)
+
+echo ""
+success "Installation abgeschlossen!"
+echo ""
+printf "  ${BOLD}Starten:${RESET}   bun run dev\n"
+printf "  ${BOLD}Frontend:${RESET}  http://localhost:5173\n"
+printf "  ${BOLD}Backend:${RESET}   http://localhost:5001\n"
+echo ""
+warn "Dieser Modus benötigt externe Neo4j- und Redis-Instanzen."
+warn "  Neo4j:  bolt://localhost:7687  (https://neo4j.com/download/)"
+warn "  Redis:  redis://localhost:6379  (brew install redis && brew services start redis)"
+warn ""
+warn "Kein Neo4j/Redis lokal? Starte mit Docker: ./install.sh --docker"
+echo ""
+info "Konfiguration: .env bearbeiten (SECRET_KEY, NEO4J_PASSWORD, LLM-Endpunkte setzen)"
+info "Weitere Guides: docs/deployment-dev.md"


### PR DESCRIPTION
## Summary

- Adds `install.sh` (executable, `#!/usr/bin/env bash`, `set -euo pipefail`) mit drei Modi:
  - **Default (Host-Dev):** prüft bun >=1.3, node >=20, uv; führt `bun install`, `cd frontend && bun install`, `cd backend && uv sync` aus; kopiert `.env.example` → `.env` falls fehlt; gibt Ports und Hinweis auf externe Neo4j/Redis-Anforderung aus
  - **`--docker`:** kopiert `.env.docker.example` → `.env`, `docker compose up --build -d`, pollt `/readyz` (Timeout 180s, alle 5s) bis Backend 200 antwortet; druckt URLs
  - **`--check`:** delegiert an `bun run check` (lint + tests)
- Idempotent: mehrfacher Aufruf ist harmlos (`.env` wird nicht überschrieben)
- Aktualisiert `README.md` mit „Quick Start"-Sektion direkt nach dem Header-Block

## Test plan

- [x] `bash -n install.sh` — Syntax OK
- [x] `./install.sh` (Host-Dev) real ausgeführt: 173 Backend-Pakete, 453 Frontend-Pakete, Root-deps installiert — durchgelaufen ohne Fehler
- [ ] `./install.sh --docker` — wird bei Abnahme ausgeführt (Docker-Healthcheck gegen `/readyz` validiert)
- [ ] `./install.sh --check` — setzt installierten Stack voraus

🤖 Generated with [Claude Code](https://claude.com/claude-code)