### PR TITLE
ci: fix egress allowlists, scorecard publish, Trivy SARIF guard, and Python cap

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
 
       - name: Checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -103,7 +103,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy SARIF
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,6 +42,8 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             auth.docker.io:443
+            docker-images-prod.s3.amazonaws.com:443
+            *.cloudflarestorage.com:443
             github.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
@@ -292,6 +294,8 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             auth.docker.io:443
+            docker-images-prod.s3.amazonaws.com:443
+            *.cloudflarestorage.com:443
             ghcr.io:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -32,9 +32,14 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            azure.archive.ubuntu.com:80
+            cdn.playwright.dev:443
+            esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
+            packages.microsoft.com:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             registry.npmjs.org:443
 
       - uses: actions/checkout@v6
@@ -96,9 +101,14 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            azure.archive.ubuntu.com:80
+            cdn.playwright.dev:443
+            esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
+            packages.microsoft.com:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             registry.npmjs.org:443
 
       - uses: actions/checkout@v6
@@ -158,9 +168,14 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            azure.archive.ubuntu.com:80
+            cdn.playwright.dev:443
+            esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
+            packages.microsoft.com:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             registry.npmjs.org:443
 
       - uses: actions/checkout@v6
@@ -212,9 +227,14 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            azure.archive.ubuntu.com:80
+            cdn.playwright.dev:443
+            esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
+            packages.microsoft.com:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             registry.npmjs.org:443
 
       - uses: actions/checkout@v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,8 +43,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Re-enable with a SCORECARD_TOKEN secret (PAT, public_repo scope) if publishing to scorecard.dev is wanted
-          publish_results: false
+          # Publishing needs the SCORECARD_TOKEN repo secret (fine-grained PAT,
+          # Administration: read-only on this repo) — configured 2026-06-09.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          publish_results: true
 
       - name: Upload Scorecard SARIF artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,7 +43,8 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          # Re-enable with a SCORECARD_TOKEN secret (PAT, public_repo scope) if publishing to scorecard.dev is wanted
+          publish_results: false
 
       - name: Upload Scorecard SARIF artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 name = "agora-backend"
 version = "1.0.0"
 description = "Agora - Hybrid Multi-Agent Resonance Simulator on Neo4j + Ollama"
-requires-python = ">=3.14"
+requires-python = ">=3.14,<3.15"
 license = { text = "AGPL-3.0" }
 authors = [
     { name = "Alexander Schneider", email = "schneider@alexle135.de" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,13 +1,10 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = "==3.14.*"
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'emscripten'",
-    "python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -2030,7 +2027,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2715,7 +2712,7 @@ name = "ruamel-yaml"
 version = "0.18.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
 wheels = [
@@ -3277,8 +3274,8 @@ name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [


### PR DESCRIPTION
## Summary

| Problem | Fix |
|---|---|
| **docker-image.yml** – `Upload Trivy SARIF` schlägt hart fehl wenn `trivy-results.sarif` fehlt (Trivy exit-code 1 → Datei fehlt) | `if` Guard auf `always() && hashFiles('trivy-results.sarif') != ''` gesetzt |
| **codeql.yml** – CodeQL-Bundle-Download von `github.com/github/codeql-action/releases` geblockt | `release-assets.githubusercontent.com:443` zur `allowed-endpoints`-Liste ergänzt |
| **e2e-smokes.yml** – `npx playwright install --with-deps chromium` geblockt (apt-Mirror + Browser-CDN) | `azure.archive.ubuntu.com:80`, `esm.ubuntu.com:443`, `packages.microsoft.com:443`, `cdn.playwright.dev:443`, `playwright.download.prss.microsoft.com:443` in allen 4 Jobs ergänzt |
| **scorecard.yml** – `publish_results: true` schlägt fehl ohne `SCORECARD_TOKEN`-Secret | `publish_results: false` gesetzt; Kommentar erklärt Reaktivierung |
| **backend/pyproject.toml** – `requires-python = ">=3.14"` → Dependabot-Resolver-Fehler: `sentence-transformers 4.1` erzwingt `transformers<5`, unauflösbar unter py3.15-Markern | `requires-python = ">=3.14,<3.15"` + `uv lock` aktualisiert |

## Test plan

- [x] YAML-Syntax aller 4 geänderten Workflows via `python3 -c "yaml.safe_load(...)"` validiert — keine Fehler
- [x] `uv sync && uv run pytest tests/contracts/ -q` → **211 passed** (0 Failures)
- [ ] CI-Runs nach Merge beobachten: CodeQL / e2e-smokes / docker-image / scorecard sollten keine `connection refused`-Fehler mehr zeigen

🤖 Generated with [Claude Code](https://claude.com/claude-code)