### PR TITLE
ci: egress allowlist round 3 — index.docker.io, scorecard publish, uv installer

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -51,10 +51,12 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            astral.sh:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,8 +43,9 @@ jobs:
             api.github.com:443
             auth.docker.io:443
             docker-images-prod.s3.amazonaws.com:443
-            *.cloudflarestorage.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             github.com:443
+            index.docker.io:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
@@ -295,8 +296,9 @@ jobs:
             api.github.com:443
             auth.docker.io:443
             docker-images-prod.s3.amazonaws.com:443
-            *.cloudflarestorage.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             ghcr.io:443
+            index.docker.io:443
             github.com:443
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,6 +26,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            api.scorecard.dev:443
             api.securityscorecards.dev:443
             github.com:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
Third egress iteration after #610. CodeQL and contract-gates went green; this addresses the remaining blocked endpoints:

| Workflow | Blocked call | Fix |
|---|---|---|
| Build and push Docker image | `dial tcp 54.185.x:443 refused` during QEMU binfmt pull — docker CLI contacts `index.docker.io` (AWS-hosted, matches the IP range), which was missing | add `index.docker.io:443`, replace wildcard with concrete R2 blob host |
| Scorecard | publish step posts to `api.scorecard.dev` (allowlist only had legacy `api.securityscorecards.dev`) | add `api.scorecard.dev:443` |
| CVE Monitor (Weekly) | `Install uv` → `fetch failed` (installer from astral.sh) | add `astral.sh:443` + `release-assets.githubusercontent.com:443` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)