### PR TITLE
ci: egress allowlist round 4 — QEMU removal, sigstore, browser CDNs

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -56,6 +56,7 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
 
       - name: Checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
@@ -307,9 +304,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -34,6 +34,10 @@ jobs:
             api.github.com:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            dl.google.com:443
+            playwright.azureedge.net:443
+            playwright-akamai.azureedge.net:443
+            playwright-verizon.azureedge.net:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -103,6 +107,10 @@ jobs:
             api.github.com:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            dl.google.com:443
+            playwright.azureedge.net:443
+            playwright-akamai.azureedge.net:443
+            playwright-verizon.azureedge.net:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -170,6 +178,10 @@ jobs:
             api.github.com:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            dl.google.com:443
+            playwright.azureedge.net:443
+            playwright-akamai.azureedge.net:443
+            playwright-verizon.azureedge.net:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -229,6 +241,10 @@ jobs:
             api.github.com:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            dl.google.com:443
+            playwright.azureedge.net:443
+            playwright-akamai.azureedge.net:443
+            playwright-verizon.azureedge.net:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,11 @@ jobs:
             api.github.com:443
             api.scorecard.dev:443
             api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
             github.com:443
+            oauth2.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
             objects.githubusercontent.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             proxy.golang.org:443


### PR DESCRIPTION
Fourth and hopefully final egress iteration. Key insight: **54.185.253.63 is harden-runner's DNS sinkhole IP** — every blocked domain resolves to it, so the IP never identified the actual endpoint.

| Workflow | Root cause | Fix |
|---|---|---|
| Build and push Docker image | QEMU binfmt pull blocked; build is single-arch anyway (no `platforms:`, `push: false`, tar export) | remove both setup-qemu steps entirely |
| e2e-smokes | `apt-get update` hits runner's preinstalled `dl.google.com` source; Playwright downloads browsers from `playwright.azureedge.net` (+ akamai/verizon fallbacks) | allow these in all 4 Playwright jobs |
| Scorecard | publish step signs results via Sigstore (`fulcio.sigstore.dev` refused) | allow fulcio/rekor/oauth2/tuf-repo-cdn.sigstore.dev |
| CVE Monitor | uv installer fetches version feed from `raw.githubusercontent.com` | allow it |

🤖 Generated with [Claude Code](https://claude.com/claude-code)