### PR TITLE
fix(backend): restore green test suite — blueprint guard, fork handlers, order-dependent state leaks

### DIFF
--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -68,6 +68,11 @@ from .api_keys_contract import (
     ApiKeyStatus,
     ApiKeysListResponse,
 )
+from .llm_profile_contract import (
+    LlmProfile,
+    LlmProfileCreateRequest,
+    LlmProfileListResponse,
+)
 from .provider_types import (
     ALL_PROVIDER_TYPES,
     LEGACY_GEMINI,
@@ -125,6 +130,9 @@ __all__ = [
     "GraphDiff",
     "GraphDiffMetrics",
     "GraphSnapshot",
+    "LlmProfile",
+    "LlmProfileCreateRequest",
+    "LlmProfileListResponse",
     "NodePropertyShift",
     "PersonaEntityContext",
     "PersonaModel",

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -161,6 +161,13 @@ def token_required(view):
     return wrapper
 
 
+# Attribute, die install_blueprint_guard auf dem Blueprint hinterlegt, um
+# Mehrfach-Installation des Hooks zu verhindern (Blueprints sind Modul-Level-
+# Singletons und können von mehreren Apps/Tests wiederverwendet werden).
+_GUARD_INSTALLED_ATTR = "_agora_guard_installed"
+_GUARD_TOKEN_ONLY_ATTR = "_agora_guard_token_only"
+
+
 def install_blueprint_guard(
     bp: Blueprint,
     *,
@@ -177,10 +184,18 @@ def install_blueprint_guard(
     Browser ein abgelaufenes Ticket erneuern kann ohne das Henne-Ei-Problem:
     POST /api/auth/ticket benötigt kein gültiges Ticket, aber einen gültigen
     Session-Token (Master-Token oder API-Key).
-    """
-    _token_only: frozenset[str] = token_only_endpoints or frozenset()
 
-    @bp.before_request
+    Idempotent: Der Hook wird genau einmal pro Blueprint installiert; weitere
+    Aufrufe aktualisieren nur ``token_only_endpoints`` (letzter Aufruf gewinnt).
+    Funktioniert auch, wenn das Blueprint bereits auf einer App registriert
+    wurde (z. B. weiteres ``create_app()`` im selben Prozess oder geteilte
+    Blueprint-Singletons in Tests): In dem Fall greift der Guard für alle
+    *künftigen* Registrierungen; bereits registrierte Apps bleiben unverändert.
+    """
+    setattr(bp, _GUARD_TOKEN_ONLY_ATTR, token_only_endpoints or frozenset())
+    if getattr(bp, _GUARD_INSTALLED_ATTR, False):
+        return
+
     def _check_token():
         # CORS-Preflight: OPTIONS trägt keine Auth-Header (by-design im Browser).
         # Flask-CORS hängt die Allow-*-Header via after_request an; wir müssen die
@@ -200,6 +215,7 @@ def install_blueprint_guard(
             return None
 
         # 3. Signed Tickets — übersprungen für token_only_endpoints
+        _token_only = getattr(bp, _GUARD_TOKEN_ONLY_ATTR, frozenset())
         if request.endpoint not in _token_only and _try_consume_ticket():
             return None
 
@@ -208,6 +224,19 @@ def install_blueprint_guard(
             return None
 
         return _auth_error()
+
+    if bp._got_registered_once:
+        # Flask verbietet ``bp.before_request()`` nach der ersten Registrierung
+        # (Setup-Finished-Check).  Der Hook landet hier direkt im
+        # ``before_request_funcs``-Dict des Blueprints — exakt das, was
+        # ``before_request`` intern tut.  Flask merged dieses Dict bei jeder
+        # Erst-Registrierung pro App (``_merge_blueprint_funcs``), d. h. alle
+        # künftigen Apps erhalten den Guard; bereits registrierte nicht.
+        bp.before_request_funcs.setdefault(None, []).append(_check_token)
+    else:
+        bp.before_request(_check_token)
+
+    setattr(bp, _GUARD_INSTALLED_ATTR, True)
 
 
 def _allow_anonymous() -> bool:

--- a/backend/tests/storage/test_neo4j_pool_config.py
+++ b/backend/tests/storage/test_neo4j_pool_config.py
@@ -6,11 +6,40 @@ keine Pool-Kwargs übergeben (Fix 1 noch nicht implementiert).
 import importlib
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_reloaded_modules():
+    """Stellt nach Reload-Tests die ursprünglichen Modul-Namespaces wieder her.
+
+    ``importlib.reload`` führt den Modul-Code im SELBEN Modul-Dict erneut aus
+    und erzeugt dabei NEUE Klassenobjekte (``Config``, ``Neo4jStorage``).
+    Andere Module und Test-Dateien halten aber weiterhin die ALTEN Objekte:
+    ``patch.object(Config, ...)`` / ``monkeypatch.setattr(Config, ...)`` auf
+    der alten Klasse wirkt dann nicht mehr auf Code, der über das Modul-Dict
+    die neue Klasse sieht — ordnungsabhängige Failures in der Gesamt-Suite
+    (z.B. test_vector_index_dim_drift, test_simulation_api_routes).
+
+    Der Snapshot der Modul-Dicts VOR dem Reload und das Zurückschreiben
+    DANACH stellt die ursprünglichen Objekt-Identitäten wieder her.
+    """
+    import app.config as config_module
+    from app.storage import neo4j_storage as storage_module
+
+    saved = [
+        (config_module, dict(config_module.__dict__)),
+        (storage_module, dict(storage_module.__dict__)),
+    ]
+    yield
+    for module, snapshot in saved:
+        module.__dict__.clear()
+        module.__dict__.update(snapshot)
 
 def _make_storage(monkeypatch=None, *, extra_patches=None):
     """Erzeugt eine Neo4jStorage-Instanz mit allen externen Deps gemockt.
@@ -104,7 +133,7 @@ def test_lazy_reconnect_passes_pool_kwargs():
 # ---------------------------------------------------------------------------
 
 
-def test_env_overrides_liveness(monkeypatch):
+def test_env_overrides_liveness(monkeypatch, restore_reloaded_modules):
     """NEO4J_LIVENESS_TIMEOUT=5.5 muss als liveness_check_timeout=5.5 ankommen."""
     monkeypatch.setenv("NEO4J_LIVENESS_TIMEOUT", "5.5")
 
@@ -137,7 +166,7 @@ def test_env_overrides_liveness(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_env_overrides_pool_size(monkeypatch):
+def test_env_overrides_pool_size(monkeypatch, restore_reloaded_modules):
     """NEO4J_MAX_POOL_SIZE=120 muss als max_connection_pool_size=120 ankommen."""
     monkeypatch.setenv("NEO4J_MAX_POOL_SIZE", "120")
 

--- a/backend/tests/utils/test_signed_ticket_fork.py
+++ b/backend/tests/utils/test_signed_ticket_fork.py
@@ -4,7 +4,7 @@ import app.extensions as _ext
 from app.extensions import register_fork_handlers
 
 
-def test_register_fork_handlers():
+def test_register_fork_handlers(monkeypatch):
     if not hasattr(os, "register_at_fork"):
         return
 
@@ -12,9 +12,11 @@ def test_register_fork_handlers():
 
     # Reset module-level globals so this test is isolated regardless of
     # import order or previous calls from other test modules.
-    _ext._FORK_HANDLER_REGISTERED = False
-    _ext._REGISTERED_NEO4J_STORAGES.clear()
-    _ext._REGISTERED_EVENT_BUSES.clear()
+    # monkeypatch.setattr auto-restores original values after the test,
+    # preventing order-dependency leaks into subsequent tests.
+    monkeypatch.setattr(_ext, "_FORK_HANDLER_REGISTERED", False)
+    monkeypatch.setattr(_ext, "_REGISTERED_NEO4J_STORAGES", [])
+    monkeypatch.setattr(_ext, "_REGISTERED_EVENT_BUSES", [])
 
     with patch("os.register_at_fork") as mock_reg:
         register_fork_handlers(neo4j_storage=mock_neo4j)

--- a/backend/tests/utils/test_signed_ticket_fork.py
+++ b/backend/tests/utils/test_signed_ticket_fork.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import MagicMock, patch
+import app.extensions as _ext
 from app.extensions import register_fork_handlers
+
 
 def test_register_fork_handlers():
     if not hasattr(os, "register_at_fork"):
@@ -8,17 +10,25 @@ def test_register_fork_handlers():
 
     mock_neo4j = MagicMock()
 
+    # Reset module-level globals so this test is isolated regardless of
+    # import order or previous calls from other test modules.
+    _ext._FORK_HANDLER_REGISTERED = False
+    _ext._REGISTERED_NEO4J_STORAGES.clear()
+    _ext._REGISTERED_EVENT_BUSES.clear()
+
     with patch("os.register_at_fork") as mock_reg:
         register_fork_handlers(neo4j_storage=mock_neo4j)
 
-        # Should be called twice: once for Neo4j, once for Redis
-        assert mock_reg.call_count == 2
+        # Since #551 (gunicorn post_fork refactor) register_fork_handlers
+        # registers a single combined handler (reset_pools_after_fork) instead
+        # of separate handlers per pool type.
+        assert mock_reg.call_count == 1
 
-        # Check Neo4j handler
-        args, kwargs = mock_reg.call_args_list[0]
+        # Retrieve the combined handler
+        _args, kwargs = mock_reg.call_args_list[0]
         after_in_child = kwargs.get("after_in_child")
         assert after_in_child is not None
 
-        # Execute Neo4j handler and verify it calls _reset_driver_after_fork
+        # Invoke the handler and verify it resets the Neo4j driver
         after_in_child()
         mock_neo4j._reset_driver_after_fork.assert_called_once()


### PR DESCRIPTION
## Zusammenfassung

Stellt die volle Backend-Suite wieder auf grün: **2698 passed, 0 failed, 9 skipped** (`uv run pytest -q`), `ruff check app/ tests/` sauber. Der LlmProfile-Re-Export-Fix ist bereits über #603 in main; dieser Branch enthält die übrigen Fixes.

## Root-Cause → Fix

| # | Symptom | Root-Cause | Fix | Commit |
|---|---------|-----------|-----|--------|
| 1 | `test_fork_safety::test_register_fork_handlers` rot | Test prüfte das alte Design mit mehreren einzelnen `os.register_at_fork`-Handlern; Produktcode konsolidiert die at-fork-Resets inzwischen in einen Handler | Test an das konsolidierte at-fork-Design angepasst | cc10197 |
| 2 | `ValueError` bei doppelter Blueprint-Registrierung in App-Factory-Tests | `install_blueprint_guard` war nicht idempotent und tolerierte bereits registrierte Blueprints nicht | Guard idempotent und registrierungs-tolerant gemacht | c91049c |
| 3 | `test_vector_index_dim_drift::test_schema_no_drop_when_dim_matches` nur im Gesamtlauf rot (unerwarteter `DROP INDEX`, `expected_dim=768` statt 1536) | `tests/storage/test_neo4j_pool_config.py` reloadet `app.config` + `app.storage.neo4j_storage` via `importlib.reload` ohne Restore. Reload erzeugt **neue** `Config`-/`Neo4jStorage`-Klassenobjekte im selben Modul-Dict; der Drift-Test patcht via `patch.object` die **alte** `Config`-Klasse, `neo4j_storage` liest aber die neue → `VECTOR_DIM` fällt auf den 768er-Default (nomic-embed-text) zurück | Fixture `restore_reloaded_modules`: Snapshot beider Modul-Dicts vor dem Reload, Restore im Teardown — Objekt-Identitäten der Original-Klassen wiederhergestellt | 03c8a72 |
| 4 | `test_simulation_api_routes::test_start_route_blocks_when_personas_pending` nur im Gesamtlauf rot (400 statt 409) | Gleicher Verursacher wie #3: Der Test importiert `Config` zur Laufzeit (nach Reload = neue Klasse) und setzt `PERSONA_REVIEW_ENABLED=True`; `app/api/simulation_run.py` hält noch die alte Klasse (`False`) → Persona-Review-Gate bleibt silent, Request läuft in spätere Validierung (400) statt 409 | Mitbehoben durch Fixture aus #3 | 03c8a72 |

## Verifikation

- Repro vor Fix: `pytest tests/storage/test_neo4j_pool_config.py tests/storage/test_vector_index_dim_drift.py tests/test_simulation_api_routes.py` → exakt die 2 ordnungsabhängigen Failures
- Nach Fix: Repro-Set 44 passed; volle Suite `uv run pytest -q` → 2698 passed, 9 skipped, 7 deselected, exit 0
- `uv run ruff check app/ tests/` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)