### PR TITLE
ci: egress round 5 — Docker Hub CloudFront blobs, Playwright GCS builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,6 +48,7 @@ jobs:
             index.docker.io:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
 
       - name: Checkout
@@ -300,6 +301,7 @@ jobs:
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
 
       - name: Checkout

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -38,6 +38,7 @@ jobs:
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
+            storage.googleapis.com:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -111,6 +112,7 @@ jobs:
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
+            storage.googleapis.com:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -182,6 +184,7 @@ jobs:
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
+            storage.googleapis.com:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -245,6 +248,7 @@ jobs:
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
+            storage.googleapis.com:443
             esm.ubuntu.com:443
             github.com:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
Both remaining egress blocks traced empirically by following the actual HTTP redirects:

| Workflow | Traced redirect | Fix |
|---|---|---|
| Build and push Docker image | `registry-1.docker.io/v2/moby/buildkit/blobs/...` → **307** → `production.cloudfront.docker.com` (allowlist only had the legacy cloudflare host) | allow `production.cloudfront.docker.com:443` in both Hub-pulling jobs |
| e2e-smokes | `cdn.playwright.dev/builds/cft/...` → **307** → `storage.googleapis.com` | allow `storage.googleapis.com:443` in all 4 Playwright jobs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)