### PR TITLE
ci: egress round 6 — Dockerfile build + compose pull surface

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,14 +42,23 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             auth.docker.io:443
+            deb.debian.org:80
+            deb.debian.org:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            files.pythonhosted.org:443
+            ghcr.io:443
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            pypi.org:443
+            registry.npmjs.org:443
             registry-1.docker.io:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -155,8 +164,17 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            auth.docker.io:443
+            docker-images-prod.s3.amazonaws.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             github.com:443
+            index.docker.io:443
             objects.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -293,8 +311,11 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             auth.docker.io:443
+            deb.debian.org:80
+            deb.debian.org:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            files.pythonhosted.org:443
             ghcr.io:443
             index.docker.io:443
             github.com:443
@@ -302,7 +323,11 @@ jobs:
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            pypi.org:443
+            registry.npmjs.org:443
             registry-1.docker.io:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -32,8 +32,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            docker-images-prod.s3.amazonaws.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            index.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
             dl.google.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
@@ -106,8 +113,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            docker-images-prod.s3.amazonaws.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            index.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
             dl.google.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
@@ -178,8 +192,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            docker-images-prod.s3.amazonaws.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            index.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
             dl.google.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
@@ -242,8 +263,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            docker-images-prod.s3.amazonaws.com:443
+            docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            index.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
             dl.google.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443


### PR DESCRIPTION
Round 5 unblocked buildx; the failure moved into the Dockerfile build and the compose-based jobs. This round derives the complete egress surface from the Dockerfile and e2e-up.sh instead of iterating per-failure:

| Job | Needs | Added |
|---|---|---|
| build-only / publish | `FROM ghcr.io/astral-sh/uv`, apt, `uv sync`, `bun install`, GHA cache | ghcr.io, pkg-containers, deb.debian.org:80/443, pypi.org, files.pythonhosted.org, registry.npmjs.org, results-receiver + *.blob.core.windows.net |
| compose smoke | artifact download + Hub pulls (neo4j/redis) | full Hub pull set + artifact hosts |
| e2e jobs (4) | `e2e-up.sh` → compose pulls neo4j/redis/nginx | full Hub pull set |

🤖 Generated with [Claude Code](https://claude.com/claude-code)