### PR TITLE
ci: egress round 7 — Dockerfile build endpoints for e2e jobs

### DIFF
--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -35,24 +35,31 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            deb.debian.org:80
+            deb.debian.org:443
+            dl.google.com:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ghcr.io:443
+            github.com:443
             index.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
-            registry-1.docker.io:443
-            dl.google.com:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
-            storage.googleapis.com:443
-            esm.ubuntu.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
             registry.npmjs.org:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
+            *.blob.core.windows.net:443
 
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -116,24 +123,31 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            deb.debian.org:80
+            deb.debian.org:443
+            dl.google.com:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ghcr.io:443
+            github.com:443
             index.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
-            registry-1.docker.io:443
-            dl.google.com:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
-            storage.googleapis.com:443
-            esm.ubuntu.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
             registry.npmjs.org:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
+            *.blob.core.windows.net:443
 
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -195,24 +209,31 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            deb.debian.org:80
+            deb.debian.org:443
+            dl.google.com:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ghcr.io:443
+            github.com:443
             index.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
-            registry-1.docker.io:443
-            dl.google.com:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
-            storage.googleapis.com:443
-            esm.ubuntu.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
             registry.npmjs.org:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
+            *.blob.core.windows.net:443
 
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -266,24 +287,31 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             cdn.playwright.dev:443
+            deb.debian.org:80
+            deb.debian.org:443
+            dl.google.com:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ghcr.io:443
+            github.com:443
             index.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
-            registry-1.docker.io:443
-            dl.google.com:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
-            storage.googleapis.com:443
-            esm.ubuntu.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
             registry.npmjs.org:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
+            *.blob.core.windows.net:443
 
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Problem
`e2e-smokes` schlägt auf main fehl (Run 27232745804): `scripts/e2e-up.sh` baut das Image im Job (`docker compose up --build`), aber die vier Job-Allowlists enthielten nur die Hub-Pull-Endpoints aus Runde 6 — nicht die Build-Endpoints des Dockerfiles.

Beleg: `failed to do request: Head "https://ghcr.io/v2/astral-sh/uv/manifests/0.9.26": dial tcp 54.185.253.63:443: connect: connection refused`

## Fix
Alle 4 e2e-Jobs erhalten die komplette Build-Surface (identisch zu docker-image.yml build-only):
- `ghcr.io` + `pkg-containers.githubusercontent.com` — `COPY --from=ghcr.io/astral-sh/uv:0.9.26`
- `deb.debian.org:80/443` — apt-get in base/prod-Stages
- `pypi.org` + `files.pythonhosted.org` — `uv sync`
- `results-receiver.actions.githubusercontent.com` + `*.blob.core.windows.net` — Trace-Artifact-Upload bei Failure
- Dedupe (`playwright.azureedge.net` doppelt) + Sortierung

🤖 Generated with [Claude Code](https://claude.com/claude-code)