### PR TITLE
fix(backend): clarify LLM_DISABLE_JSON_MODE semantics in chat_json

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1232,10 +1232,12 @@ class LLMClient:
         schema_mode_fallback = schema is not None and disable_schema_mode
 
         if schema_mode_fallback:
+            fallback_target = "Freitext" if disable_object_mode else "json_object"
             logger.info(
                 "LLMClient.chat_json: LLM_DISABLE_JSON_SCHEMA_MODE aktiv — schema=%s "
-                "fällt auf json_object + Pydantic-Validierung zurück",
+                "fällt auf %s + Pydantic-Validierung zurück",
                 schema.__name__ if isinstance(schema, type) else "dict",
+                fallback_target,
             )
 
         if schema is not None:
@@ -1252,7 +1254,8 @@ class LLMClient:
         elif schema_mode_fallback:
             # LLM_DISABLE_JSON_SCHEMA_MODE=true: Schema übergeben, aber strict-Mode
             # deaktiviert → json_object + post-hoc Pydantic-Validierung.
-            response_format = {"type": "json_object"}
+            # Falls auch OBJECT_MODE deaktiviert ist, fällt es auf Freitext (None) zurück.
+            response_format = None if disable_object_mode else {"type": "json_object"}
         elif schema is not None:
             # OpenAI / Google strict-mode: $refs inline-resolven, $defs +
             # Meta-Keys droppen, additionalProperties:false + required-Liste

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -291,6 +291,32 @@ def _enforce_openai_strict_schema(model_or_schema: Any) -> Dict[str, Any]:
     return _walk(raw)
 
 
+def _env_flag(name: str) -> bool:
+    """Return True wenn die Env-Var *name* auf einen truthy-Wert gesetzt ist."""
+    return os.environ.get(name, '').lower() in ('1', 'true', 'yes')
+
+
+def _is_json_object_mode_disabled() -> bool:
+    """Return True wenn ``response_format=json_object`` unterdrückt werden soll.
+
+    Wertet aus (in dieser Reihenfolge):
+    - ``LLM_DISABLE_JSON_OBJECT_MODE`` (neuer, präziser Name)
+    - ``LLM_DISABLE_JSON_MODE`` (Legacy-Alias, Deprecation-Warning wird in
+      ``chat_json`` bei Verwendung ausgegeben)
+    """
+    return _env_flag('LLM_DISABLE_JSON_OBJECT_MODE') or _env_flag('LLM_DISABLE_JSON_MODE')
+
+
+def _is_json_schema_mode_disabled() -> bool:
+    """Return True wenn strict ``response_format=json_schema`` unterdrückt werden soll.
+
+    Gesetzt durch ``LLM_DISABLE_JSON_SCHEMA_MODE=true``. Wenn aktiv und ein
+    Schema übergeben wurde, fällt ``chat_json`` auf ``json_object`` + post-hoc
+    Pydantic-Validierung zurück.
+    """
+    return _env_flag('LLM_DISABLE_JSON_SCHEMA_MODE')
+
+
 def should_disable_openai_json_mode(base_url: Optional[str]) -> bool:
     """Return True wenn ``response_format=json_object`` weggelassen werden soll.
 
@@ -302,11 +328,12 @@ def should_disable_openai_json_mode(base_url: Optional[str]) -> bool:
 
     Trigger:
     - ``base_url`` zeigt auf ``api.openai.com`` UND
-    - ``LLM_DISABLE_JSON_MODE`` in (``1``, ``true``, ``yes``).
+    - ``LLM_DISABLE_JSON_OBJECT_MODE`` oder ``LLM_DISABLE_JSON_MODE`` (Legacy)
+      in (``1``, ``true``, ``yes``).
     """
     if not base_url or 'api.openai.com' not in base_url.lower():
         return False
-    return os.environ.get('LLM_DISABLE_JSON_MODE', '').lower() in ('1', 'true', 'yes')
+    return _is_json_object_mode_disabled()
 
 
 def _read_active_config_safely() -> Optional[Dict[str, Any]]:
@@ -1181,16 +1208,33 @@ class LLMClient:
                 messages=list(messages),
             )
 
-        disable_json_mode_env = os.environ.get('LLM_DISABLE_JSON_MODE', '').lower() in ('1', 'true', 'yes')
-        # Strict-Schema-Aufrufer (schema is not None) dürfen NIE im Freitext-Mode
-        # landen — sonst halluziniert das Modell camelCase / Extra-Felder und
-        # Pydantic (extra='forbid') lehnt ab. LLM_DISABLE_JSON_MODE bleibt nur
-        # für schemalose chat_json()-Calls wirksam.
-        disable_json_mode = disable_json_mode_env and schema is None
-        if disable_json_mode_env and schema is not None:
+        # --- Env-Flag-Auswertung (Issue #593) -----------------------------------
+        # LLM_DISABLE_JSON_OBJECT_MODE  → unterdrückt {type: "json_object"}
+        # LLM_DISABLE_JSON_SCHEMA_MODE  → unterdrückt strict json_schema;
+        #                                  fällt auf json_object + Pydantic zurück
+        # LLM_DISABLE_JSON_MODE         → Legacy-Alias für OBJECT_MODE (Deprecation)
+        disable_object_mode = _is_json_object_mode_disabled()
+        disable_schema_mode = _is_json_schema_mode_disabled()
+
+        # Legacy-Alias: Deprecation-Warning ausgeben, damit Betreiber migrieren können.
+        if _env_flag('LLM_DISABLE_JSON_MODE') and not _env_flag('LLM_DISABLE_JSON_OBJECT_MODE'):
+            import warnings as _warnings
+            _warnings.warn(
+                "LLM_DISABLE_JSON_MODE ist veraltet und wird in einer künftigen Version "
+                "entfernt. Bitte LLM_DISABLE_JSON_OBJECT_MODE verwenden.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # schema=None + OBJECT_MODE disabled → kein response_format
+        disable_json_mode = disable_object_mode and schema is None
+        # schema=<Model> + SCHEMA_MODE disabled → json_object-Fallback statt strict
+        schema_mode_fallback = schema is not None and disable_schema_mode
+
+        if schema_mode_fallback:
             logger.info(
-                "LLMClient.chat_json: LLM_DISABLE_JSON_MODE ignoriert — schema=%s "
-                "erzwingt strict json_schema",
+                "LLMClient.chat_json: LLM_DISABLE_JSON_SCHEMA_MODE aktiv — schema=%s "
+                "fällt auf json_object + Pydantic-Validierung zurück",
                 schema.__name__ if isinstance(schema, type) else "dict",
             )
 
@@ -1205,6 +1249,10 @@ class LLMClient:
         # Build response_format ---------------------------------------------------
         if disable_json_mode:
             response_format: Optional[Dict[str, Any]] = None
+        elif schema_mode_fallback:
+            # LLM_DISABLE_JSON_SCHEMA_MODE=true: Schema übergeben, aber strict-Mode
+            # deaktiviert → json_object + post-hoc Pydantic-Validierung.
+            response_format = {"type": "json_object"}
         elif schema is not None:
             # OpenAI / Google strict-mode: $refs inline-resolven, $defs +
             # Meta-Keys droppen, additionalProperties:false + required-Liste
@@ -1223,7 +1271,7 @@ class LLMClient:
             response_format = {"type": "json_object"}
 
         # Call --------------------------------------------------------------------
-        if not disable_json_mode and schema is not None:
+        if not disable_json_mode and not schema_mode_fallback and schema is not None:
             # NATIVE Ollama-Pfad: /api/chat mit format=<schema> ist die einzige
             # autoritativ dokumentierte Methode, ein Schema bei Ollama zu erzwingen.
             # Bei Netz-/4xx-Fehler fall-through zum OpenAI-SDK-Pfad mit

--- a/backend/tests/utils/test_llm_client_json_mode_env.py
+++ b/backend/tests/utils/test_llm_client_json_mode_env.py
@@ -174,6 +174,25 @@ class TestWithSchemaDisableSchemaMode:
             f"Expected json_object fallback, got: {rf}"
         )
 
+    def test_response_format_falls_back_to_none_when_both_disabled(self, monkeypatch) -> None:
+        """Beide Flags gesetzt: Schema-Mode UND Object-Mode disabled → Freitext (None)."""
+        monkeypatch.setenv("LLM_DISABLE_JSON_SCHEMA_MODE", "true")
+        monkeypatch.setenv("LLM_DISABLE_JSON_OBJECT_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _SAMPLE_JSON)
+
+        result = client.chat_json(
+            [{"role": "user", "content": "hi"}],
+            schema=_SampleSchema,
+        )
+
+        assert result["value"] == 42
+        _, kwargs = mock.call_args
+        assert kwargs.get("response_format") is None
+
     def test_legacy_disable_json_mode_does_not_suppress_schema_mode(self, monkeypatch) -> None:
         """LLM_DISABLE_JSON_MODE wirkt als Alias für OBJECT_MODE, nicht SCHEMA_MODE.
         Mit schema gesetzt bleibt strict json_schema aktiv."""

--- a/backend/tests/utils/test_llm_client_json_mode_env.py
+++ b/backend/tests/utils/test_llm_client_json_mode_env.py
@@ -1,0 +1,252 @@
+"""Issue #593 — LLM_DISABLE_JSON_MODE semantics clarification.
+
+Tests für alle vier Kombinationen:
+  schema-yes / schema-no  ×  env-on / env-off
+
+Neue Env-Vars:
+  LLM_DISABLE_JSON_OBJECT_MODE  — unterdrückt {type: "json_object"}
+  LLM_DISABLE_JSON_SCHEMA_MODE  — unterdrückt strict json_schema; fällt auf json_object + Pydantic-Validierung zurück
+  LLM_DISABLE_JSON_MODE         — Legacy-Alias für LLM_DISABLE_JSON_OBJECT_MODE (Deprecation-Warning bei Startup)
+
+Mock-only — kein Netzwerk.
+"""
+from __future__ import annotations
+
+import warnings
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from app.utils.llm_client import LLMClient, should_disable_openai_json_mode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _SampleSchema(BaseModel):
+    value: int
+    label: str
+
+
+_SAMPLE_JSON = '{"value": 42, "label": "test"}'
+_PLAIN_JSON = '{"ok": true}'
+
+
+def _make_client() -> LLMClient:
+    """LLMClient ohne echten OpenAI-Init."""
+    obj = LLMClient.__new__(LLMClient)
+    obj._max_retries = 0
+    obj._retry_initial_delay = 0.0
+    obj._retry_max_delay = 0.0
+    obj._num_ctx = 8192
+    obj._think = False
+    obj.api_key = "test"
+    obj.model = "gpt-4o"
+    obj.base_url = "https://api.openai.com/v1"
+    obj.client = MagicMock()
+    return obj
+
+
+def _stub_chat(client: LLMClient, return_value: str) -> MagicMock:
+    """Patch client.chat() und gib den aufgezeichneten response_format zurück."""
+    mock = MagicMock(return_value=return_value)
+    client.chat = mock  # type: ignore[method-assign]
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# 1. schema=None, env off  →  json_object
+# ---------------------------------------------------------------------------
+
+class TestNoSchemaEnvOff:
+    """Ohne Schema und ohne Disable-Env wird json_object angefordert."""
+
+    def test_response_format_is_json_object(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _PLAIN_JSON)
+
+        result = client.chat_json([{"role": "user", "content": "hi"}])
+
+        assert result == {"ok": True}
+        _, kwargs = mock.call_args
+        assert kwargs.get("response_format") == {"type": "json_object"}
+
+
+# ---------------------------------------------------------------------------
+# 2. schema=None, env on  →  no response_format (plain call)
+# ---------------------------------------------------------------------------
+
+class TestNoSchemaEnvOn:
+    """LLM_DISABLE_JSON_OBJECT_MODE=true unterdrückt json_object bei schema=None."""
+
+    def test_response_format_is_none_with_new_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_OBJECT_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _PLAIN_JSON)
+
+        result = client.chat_json([{"role": "user", "content": "hi"}])
+
+        assert result == {"ok": True}
+        _, kwargs = mock.call_args
+        assert kwargs.get("response_format") is None
+
+    def test_legacy_env_still_suppresses_json_object(self, monkeypatch) -> None:
+        """LLM_DISABLE_JSON_MODE als Alias wirkt wie LLM_DISABLE_JSON_OBJECT_MODE."""
+        monkeypatch.setenv("LLM_DISABLE_JSON_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _PLAIN_JSON)
+
+        result = client.chat_json([{"role": "user", "content": "hi"}])
+
+        assert result == {"ok": True}
+        _, kwargs = mock.call_args
+        assert kwargs.get("response_format") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. schema=SomeModel, env off  →  strict json_schema
+# ---------------------------------------------------------------------------
+
+class TestWithSchemaEnvOff:
+    """Mit Schema und ohne Disable-Env wird strict json_schema angefordert."""
+
+    def test_response_format_is_strict_json_schema(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _SAMPLE_JSON)
+
+        result = client.chat_json(
+            [{"role": "user", "content": "hi"}],
+            schema=_SampleSchema,
+        )
+
+        assert result["value"] == 42
+        _, kwargs = mock.call_args
+        rf = kwargs.get("response_format", {})
+        assert rf.get("type") == "json_schema"
+        assert rf["json_schema"].get("strict") is True
+
+
+# ---------------------------------------------------------------------------
+# 4. schema=SomeModel, LLM_DISABLE_JSON_SCHEMA_MODE=true  →  json_object fallback
+# ---------------------------------------------------------------------------
+
+class TestWithSchemaDisableSchemaMode:
+    """LLM_DISABLE_JSON_SCHEMA_MODE=true mit Schema: fällt auf json_object zurück,
+    Pydantic-Validierung erfolgt trotzdem."""
+
+    def test_response_format_falls_back_to_json_object(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_SCHEMA_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _SAMPLE_JSON)
+
+        result = client.chat_json(
+            [{"role": "user", "content": "hi"}],
+            schema=_SampleSchema,
+        )
+
+        assert result["value"] == 42
+        _, kwargs = mock.call_args
+        rf = kwargs.get("response_format", {})
+        assert rf.get("type") == "json_object", (
+            f"Expected json_object fallback, got: {rf}"
+        )
+
+    def test_legacy_disable_json_mode_does_not_suppress_schema_mode(self, monkeypatch) -> None:
+        """LLM_DISABLE_JSON_MODE wirkt als Alias für OBJECT_MODE, nicht SCHEMA_MODE.
+        Mit schema gesetzt bleibt strict json_schema aktiv."""
+        monkeypatch.setenv("LLM_DISABLE_JSON_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        mock = _stub_chat(client, _SAMPLE_JSON)
+
+        result = client.chat_json(
+            [{"role": "user", "content": "hi"}],
+            schema=_SampleSchema,
+        )
+
+        assert result["value"] == 42
+        _, kwargs = mock.call_args
+        rf = kwargs.get("response_format", {})
+        # Legacy alias does NOT disable schema mode → strict json_schema still used
+        assert rf.get("type") == "json_schema"
+
+
+# ---------------------------------------------------------------------------
+# 5. should_disable_openai_json_mode — wired to LLM_DISABLE_JSON_OBJECT_MODE
+# ---------------------------------------------------------------------------
+
+class TestShouldDisableOpenaiJsonMode:
+    """should_disable_openai_json_mode respektiert LLM_DISABLE_JSON_OBJECT_MODE
+    und den Legacy-Alias LLM_DISABLE_JSON_MODE."""
+
+    def test_new_env_triggers_disable(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_OBJECT_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        assert should_disable_openai_json_mode("https://api.openai.com/v1") is True
+
+    def test_legacy_env_still_triggers_disable(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        assert should_disable_openai_json_mode("https://api.openai.com/v1") is True
+
+    def test_neither_env_set_returns_false(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLM_DISABLE_JSON_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        assert should_disable_openai_json_mode("https://api.openai.com/v1") is False
+
+    def test_non_openai_base_url_returns_false(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_OBJECT_MODE", "true")
+        assert should_disable_openai_json_mode("http://localhost:11434") is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Deprecation warning for legacy env at import/startup
+# ---------------------------------------------------------------------------
+
+class TestLegacyEnvDeprecationWarning:
+    """Wenn LLM_DISABLE_JSON_MODE gesetzt ist, soll eine DeprecationWarning
+    ausgegeben werden (einmalig bei erstem chat_json-Aufruf)."""
+
+    def test_deprecation_warning_emitted(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_DISABLE_JSON_MODE", "true")
+        monkeypatch.delenv("LLM_DISABLE_JSON_OBJECT_MODE", raising=False)
+        monkeypatch.delenv("LLM_DISABLE_JSON_SCHEMA_MODE", raising=False)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+
+        client = _make_client()
+        _stub_chat(client, _PLAIN_JSON)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client.chat_json([{"role": "user", "content": "hi"}])
+
+        messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert any("LLM_DISABLE_JSON_MODE" in m for m in messages), (
+            f"Expected DeprecationWarning mentioning LLM_DISABLE_JSON_MODE, got: {messages}"
+        )

--- a/docs/provider-runtime-settings.md
+++ b/docs/provider-runtime-settings.md
@@ -52,3 +52,22 @@ Environment (`LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_BASE_URL`,
 Prozess. Die drei OpenAI-Base-URL-Aliase werden parallel gesetzt, damit
 CAMEL/OASIS-Skripte und OpenAI-kompatible Clients mit unterschiedlichen
 Konventionen dieselbe Runtime-Auswahl nutzen.
+
+## JSON-Mode-Env-Vars
+
+`backend/app/utils/llm_client.py` (`chat_json`) wertet folgende Env-Vars aus:
+
+| Variable | Wirkung |
+|---|---|
+| `LLM_DISABLE_JSON_OBJECT_MODE=true` | Unterdrückt `response_format={"type":"json_object"}` bei schema-losen Aufrufen. Nützlich für OpenAI-Reasoning-Modelle, die mit `json_object` leere Antworten liefern. |
+| `LLM_DISABLE_JSON_SCHEMA_MODE=true` | Unterdrückt strict `response_format={"type":"json_schema","strict":true}` auch wenn ein Schema übergeben wurde. Fällt auf `json_object` + post-hoc Pydantic-Validierung zurück. |
+| `LLM_DISABLE_JSON_MODE=true` | **Veraltet.** Legacy-Alias für `LLM_DISABLE_JSON_OBJECT_MODE`. Gibt eine `DeprecationWarning` aus. Bitte auf den neuen Namen migrieren. Wird in einem künftigen Release entfernt. |
+
+### Vier Kombinationen
+
+| Schema | Env-Flag | `response_format` |
+|---|---|---|
+| keines | keines | `{"type": "json_object"}` |
+| keines | `LLM_DISABLE_JSON_OBJECT_MODE=true` | keines (Freitext) |
+| Pydantic-Modell | keines | `{"type": "json_schema", "strict": true}` |
+| Pydantic-Modell | `LLM_DISABLE_JSON_SCHEMA_MODE=true` | `{"type": "json_object"}` + Pydantic-Validierung |

--- a/docs/provider-runtime-settings.md
+++ b/docs/provider-runtime-settings.md
@@ -71,3 +71,4 @@ Konventionen dieselbe Runtime-Auswahl nutzen.
 | keines | `LLM_DISABLE_JSON_OBJECT_MODE=true` | keines (Freitext) |
 | Pydantic-Modell | keines | `{"type": "json_schema", "strict": true}` |
 | Pydantic-Modell | `LLM_DISABLE_JSON_SCHEMA_MODE=true` | `{"type": "json_object"}` + Pydantic-Validierung |
+| Pydantic-Modell | `LLM_DISABLE_JSON_SCHEMA_MODE=true` und `LLM_DISABLE_JSON_OBJECT_MODE=true` | keines (Freitext) + Pydantic-Validierung |


### PR DESCRIPTION
## Summary

- Introduces `LLM_DISABLE_JSON_OBJECT_MODE` and `LLM_DISABLE_JSON_SCHEMA_MODE` as precise, orthogonal replacements for the ambiguous `LLM_DISABLE_JSON_MODE` flag
- `LLM_DISABLE_JSON_SCHEMA_MODE=true` with a schema passed now falls back to `json_object` + post-hoc Pydantic validation instead of silently ignoring the flag
- `LLM_DISABLE_JSON_MODE` kept as a backward-compat alias for `LLM_DISABLE_JSON_OBJECT_MODE` with a `DeprecationWarning`; will be removed in a future release
- Docs updated in `docs/provider-runtime-settings.md` (new table of all four combinations)
- 11 new pytest tests covering all four env/schema combinations

## Test plan

- [ ] `cd backend && uv run pytest tests/utils/test_llm_client_json_mode_env.py -q` — 11 passed
- [ ] Full suite: `cd backend && uv run pytest -q` — 2709 passed, 0 failed
- [ ] `cd backend && uv run ruff check app/ tests/` — All checks passed

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)