### PR TITLE
fix(llm): emit WARNING once on _resolve_num_ctx 8k legacy fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (bug — 2026-06-09)
+
+- `llm_client._resolve_num_ctx` silently truncated unknown cloud models to 8 k
+  context. Now emits a structured WARNING (exactly once per model name, deduplicated
+  via `lru_cache`) when the legacy `OLLAMA_NUM_CTX`/8192 fallback fires, so
+  misconfigured models surface in the log viewer instead of producing cut-off
+  or incoherent output. Resolves #581.
+
 ### Fixed (deploy — 2026-05-18)
 
 - Persona-Generation wurde nach MAI-12 + PR #519 stark verlangsamt: gunicorn

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -141,7 +141,8 @@ def _resolve_num_ctx(
         fallback = int(os.environ.get("OLLAMA_NUM_CTX", "8192"))
     except ValueError:
         fallback = 8192
-    _warn_legacy_fallback_once(model_name or "", fallback)
+    if model_name:
+        _warn_legacy_fallback_once(model_name, fallback)
     return fallback
 
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import time as _time_mod
+from functools import lru_cache
 from typing import TYPE_CHECKING, Literal, Optional, Dict, Any, List, Type, Union
 from openai import OpenAI
 from pydantic import BaseModel
@@ -62,7 +63,11 @@ def heuristic_num_ctx_for_model(model_name: str) -> Optional[int]:
     """Best-effort Substring-Match für bekannte Modellfamilien.
 
     Liefert None, wenn das Modell unbekannt ist — Caller fällt dann auf
-    OLLAMA_NUM_CTX (legacy) zurück.
+    OLLAMA_NUM_CTX (legacy) zurück und emittiert ein WARNING (einmalig pro
+    Modell, dedupliziert via lru_cache auf _warn_legacy_fallback_once).
+
+    Um den Warning für ein unbekanntes Modell zu unterdrücken, trage es entweder
+    in _MODEL_CONTEXT_HEURISTICS ein oder setze LLM_MODEL_CONTEXT_LIMITS_JSON.
     """
     if not model_name:
         return None
@@ -71,6 +76,23 @@ def heuristic_num_ctx_for_model(model_name: str) -> Optional[int]:
         if prefix in needle:
             return limit
     return None
+
+
+@lru_cache(maxsize=64)
+def _warn_legacy_fallback_once(model_name: str, fallback: int) -> None:
+    """Emit a WARNING exactly once per unknown model name (lru_cache deduplicates).
+
+    Called only when _resolve_num_ctx reaches the legacy OLLAMA_NUM_CTX / 8192
+    fallback, i.e. no heuristic, no per-model env map, no LLM_CONTEXT_LIMIT, and
+    no explicit provider_options matched. The cache prevents log spam when the
+    same unknown model is used repeatedly within a process lifetime.
+    """
+    logger.warning(
+        "llm_client._resolve_num_ctx: no heuristic for model=%r, "
+        "falling back to %d. Set LLM_MODEL_CONTEXT_LIMITS_JSON to override.",
+        model_name,
+        fallback,
+    )
 
 
 def _resolve_num_ctx(
@@ -83,7 +105,7 @@ def _resolve_num_ctx(
     2. LLM_MODEL_CONTEXT_LIMITS_JSON (per-Modell-Map via env)
     3. Heuristik-Tabelle (Modell-Familie-Default)
     4. LLM_CONTEXT_LIMIT (Global-Override, sofern höher als Heuristik)
-    5. OLLAMA_NUM_CTX env oder 8192 (Legacy-Fallback)
+    5. OLLAMA_NUM_CTX env oder 8192 (Legacy-Fallback) — emits WARNING once per model
     """
     if provider_options_num_ctx is not None:
         try:
@@ -116,9 +138,11 @@ def _resolve_num_ctx(
         return global_limit
 
     try:
-        return int(os.environ.get("OLLAMA_NUM_CTX", "8192"))
+        fallback = int(os.environ.get("OLLAMA_NUM_CTX", "8192"))
     except ValueError:
-        return 8192
+        fallback = 8192
+    _warn_legacy_fallback_once(model_name or "", fallback)
+    return fallback
 
 
 _STRICT_UNSUPPORTED_HINTS = (

--- a/backend/tests/utils/test_llm_client_num_ctx_warning.py
+++ b/backend/tests/utils/test_llm_client_num_ctx_warning.py
@@ -176,3 +176,25 @@ class TestResolveNumCtxWarning:
         # The warning args include the fallback value as a positional arg
         call_args = mock_warn.call_args
         assert 8192 in call_args.args or "8192" in str(call_args)
+
+    def test_empty_model_name_no_warning(self, monkeypatch):
+        """Empty or None model_name must NOT emit a WARNING (unactionable log noise)."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result_empty = llm_client._resolve_num_ctx(
+                model_name="",
+                provider_options_num_ctx=None,
+            )
+            result_none = llm_client._resolve_num_ctx(
+                model_name=None,
+                provider_options_num_ctx=None,
+            )
+
+        assert result_empty == 8192
+        assert result_none == 8192
+        mock_warn.assert_not_called()

--- a/backend/tests/utils/test_llm_client_num_ctx_warning.py
+++ b/backend/tests/utils/test_llm_client_num_ctx_warning.py
@@ -1,0 +1,178 @@
+"""Issue #581 — WARNING log when _resolve_num_ctx hits the 8k legacy fallback.
+
+Acceptance criteria (from issue):
+1. New WARNING log fires exactly once per unknown model (lru_cache on the warner).
+2. Pytest covers: known model (no warning), unknown model (warning fires),
+   explicit env override (no warning).
+
+Note: ``agora.llm_client`` uses ``propagate=False`` (setup_logger sets this to avoid
+duplicate output), so pytest's ``caplog`` fixture cannot intercept the log records.
+We patch ``logger.warning`` directly on the module's logger object instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clear_warning_cache() -> None:
+    """Clear the lru_cache on _warn_legacy_fallback_once between tests."""
+    from app.utils.llm_client import _warn_legacy_fallback_once
+
+    _warn_legacy_fallback_once.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveNumCtxWarning:
+    """WARNING-log behaviour on the legacy 8k fallback path."""
+
+    def setup_method(self) -> None:
+        _clear_warning_cache()
+
+    def test_known_model_no_warning(self, monkeypatch):
+        """Known heuristic model must NOT produce a WARNING."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result = llm_client._resolve_num_ctx(
+                model_name="gemini-3-pro:cloud",
+                provider_options_num_ctx=None,
+            )
+
+        assert result == 1_048_576
+        mock_warn.assert_not_called()
+
+    def test_unknown_model_emits_warning(self, monkeypatch):
+        """Unknown model hitting legacy fallback must emit exactly one WARNING."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result = llm_client._resolve_num_ctx(
+                model_name="brand-new-mystery-model:latest",
+                provider_options_num_ctx=None,
+            )
+
+        assert result == 8192
+        mock_warn.assert_called_once()
+        call_args = mock_warn.call_args
+        # Format string + positional args from logger.warning(fmt, model, fallback)
+        assert "brand-new-mystery-model:latest" in str(call_args)
+        assert "LLM_MODEL_CONTEXT_LIMITS_JSON" in str(call_args)
+
+    def test_unknown_model_warning_fires_only_once_via_cache(self, monkeypatch):
+        """lru_cache must suppress repeated warnings for the same unknown model."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            llm_client._resolve_num_ctx(
+                model_name="mystery-model:v2",
+                provider_options_num_ctx=None,
+            )
+            llm_client._resolve_num_ctx(
+                model_name="mystery-model:v2",
+                provider_options_num_ctx=None,
+            )
+            llm_client._resolve_num_ctx(
+                model_name="mystery-model:v2",
+                provider_options_num_ctx=None,
+            )
+
+        assert mock_warn.call_count == 1, (
+            f"lru_cache should suppress repeated warnings; got {mock_warn.call_count}"
+        )
+
+    def test_explicit_env_override_no_warning(self, monkeypatch):
+        """LLM_MODEL_CONTEXT_LIMITS_JSON per-model override must not trigger WARNING."""
+        from app.utils import llm_client
+
+        monkeypatch.setenv(
+            "LLM_MODEL_CONTEXT_LIMITS_JSON",
+            '{"brand-new-mystery-model:latest": 65536}',
+        )
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result = llm_client._resolve_num_ctx(
+                model_name="brand-new-mystery-model:latest",
+                provider_options_num_ctx=None,
+            )
+
+        assert result == 65536
+        mock_warn.assert_not_called()
+
+    def test_ollama_num_ctx_env_still_warns(self, monkeypatch):
+        """OLLAMA_NUM_CTX is still the legacy fallback path — WARNING fires even
+        when the env differs from 8192, since no heuristic matched.
+        """
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "16384")
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result = llm_client._resolve_num_ctx(
+                model_name="niche-model:7b",
+                provider_options_num_ctx=None,
+            )
+
+        assert result == 16384
+        mock_warn.assert_called_once()
+
+    def test_provider_options_explicit_no_warning(self, monkeypatch):
+        """Explicit provider_options.num_ctx must not trigger WARNING."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            result = llm_client._resolve_num_ctx(
+                model_name="brand-new-mystery-model:latest",
+                provider_options_num_ctx=32768,
+            )
+
+        assert result == 32768
+        mock_warn.assert_not_called()
+
+    def test_warning_contains_fallback_value(self, monkeypatch):
+        """WARNING message must include the fallback value."""
+        from app.utils import llm_client
+
+        monkeypatch.delenv("LLM_MODEL_CONTEXT_LIMITS_JSON", raising=False)
+        monkeypatch.delenv("LLM_CONTEXT_LIMIT", raising=False)
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "8192")
+
+        with patch.object(llm_client.logger, "warning") as mock_warn:
+            llm_client._resolve_num_ctx(
+                model_name="totally-unknown-model:x",
+                provider_options_num_ctx=None,
+            )
+
+        mock_warn.assert_called_once()
+        # The warning args include the fallback value as a positional arg
+        call_args = mock_warn.call_args
+        assert 8192 in call_args.args or "8192" in str(call_args)


### PR DESCRIPTION
## Summary

- Adds `_warn_legacy_fallback_once` (decorated with `lru_cache(maxsize=64)`) that emits a structured WARNING exactly once per unknown model name when `_resolve_num_ctx` falls through to the `OLLAMA_NUM_CTX`/8192 legacy path.
- Known heuristic models, per-model env overrides (`LLM_MODEL_CONTEXT_LIMITS_JSON`), explicit `provider_options.num_ctx`, and `LLM_CONTEXT_LIMIT` global overrides are all silent — only the true legacy fallback path warns.
- Updates `heuristic_num_ctx_for_model` docstring to document the warning behaviour and how to suppress it.
- Adds CHANGELOG entry under `[Unreleased]`.

Closes #581

## Test plan

- [ ] `tests/utils/test_llm_client_num_ctx_warning.py` — 7 new tests covering all acceptance criteria: known model (no warning), unknown model (warning fires), repeated calls (lru_cache deduplicates), per-model env override (no warning), explicit provider_options (no warning), warning contains fallback value.
- [ ] Existing `TestResolveNumCtx` and `TestLlmClientInitUsesResolveNumCtx` in `tests/test_llm_client.py` remain green.
- [ ] `uv run ruff check app/ tests/` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)