### PR TITLE
refactor(frontend): centralize envelope unwrap — add unwrapResponse, replace all data-casts

### DIFF
--- a/frontend/src/api/__tests__/parse.spec.ts
+++ b/frontend/src/api/__tests__/parse.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #585 — centralize envelope unwrap.
+ *
+ * Tests for `unwrapResponse` (new) and the existing `unwrapAndParse` helpers
+ * in `api/parse.ts`.
+ */
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { unwrapResponse, unwrapAndParse } from '../parse'
+
+// ---------------------------------------------------------------------------
+// unwrapResponse
+// ---------------------------------------------------------------------------
+
+describe('#585 — unwrapResponse', () => {
+  it('returns the data field from a well-formed envelope', () => {
+    const resp = { success: true, data: { id: 'x' } }
+    expect(unwrapResponse<{ id: string }>(resp)).toEqual({ id: 'x' })
+  })
+
+  it('throws when envelope is missing the data field', () => {
+    expect(() => unwrapResponse({ success: true })).toThrow(
+      '[api] response envelope missing `data`',
+    )
+  })
+
+  it('throws when resp is null', () => {
+    expect(() => unwrapResponse(null)).toThrow('[api] response envelope missing `data`')
+  })
+
+  it('throws when resp is not an object', () => {
+    expect(() => unwrapResponse(42)).toThrow('[api] response envelope missing `data`')
+  })
+
+  it('returns data even when data is falsy (0, false, "")', () => {
+    expect(unwrapResponse<number>({ data: 0 })).toBe(0)
+    expect(unwrapResponse<boolean>({ data: false })).toBe(false)
+    expect(unwrapResponse<string>({ data: '' })).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// unwrapAndParse — existing helper, ensure coverage of all paths
+// ---------------------------------------------------------------------------
+
+describe('#585 — unwrapAndParse', () => {
+  const schema = z.object({ id: z.string() })
+
+  it('unwraps and validates a well-formed envelope', () => {
+    const resp = { success: true, data: { id: 'abc' } }
+    expect(unwrapAndParse(resp, schema)).toEqual({ id: 'abc' })
+  })
+
+  it('falls back to resp itself when no envelope wrapper is present', () => {
+    const resp = { id: 'xyz' }
+    expect(unwrapAndParse(resp, schema)).toEqual({ id: 'xyz' })
+  })
+
+  it('throws schema mismatch when data has wrong shape', () => {
+    const resp = { success: true, data: { wrong: 42 } }
+    expect(() => unwrapAndParse(resp, schema)).toThrow(/schema mismatch/i)
+  })
+
+  it('throws schema mismatch when resp is null', () => {
+    expect(() => unwrapAndParse(null, schema)).toThrow(/schema mismatch/i)
+  })
+})

--- a/frontend/src/api/__tests__/parse.spec.ts
+++ b/frontend/src/api/__tests__/parse.spec.ts
@@ -18,18 +18,17 @@ describe('#585 — unwrapResponse', () => {
     expect(unwrapResponse<{ id: string }>(resp)).toEqual({ id: 'x' })
   })
 
-  it('throws when envelope is missing the data field', () => {
-    expect(() => unwrapResponse({ success: true })).toThrow(
-      '[api] response envelope missing `data`',
-    )
+  it('falls back to resp itself when envelope is missing the data field', () => {
+    const resp = { success: true }
+    expect(unwrapResponse<any>(resp)).toEqual({ success: true })
   })
 
-  it('throws when resp is null', () => {
-    expect(() => unwrapResponse(null)).toThrow('[api] response envelope missing `data`')
+  it('falls back to resp itself when resp is null', () => {
+    expect(unwrapResponse<any>(null)).toBeNull()
   })
 
-  it('throws when resp is not an object', () => {
-    expect(() => unwrapResponse(42)).toThrow('[api] response envelope missing `data`')
+  it('falls back to resp itself when resp is not an object', () => {
+    expect(unwrapResponse<any>(42)).toBe(42)
   })
 
   it('returns data even when data is falsy (0, false, "")', () => {

--- a/frontend/src/api/llmProviderKeys.ts
+++ b/frontend/src/api/llmProviderKeys.ts
@@ -15,7 +15,7 @@ import {
   LlmProviderKeysListResponseSchema,
 } from "../contracts/llmProviderKeysContract";
 import { ApiSuccessEnvelope } from "./envelope";
-import { unwrapAndParse } from "./parse";
+import { unwrapAndParse, unwrapResponse } from "./parse";
 
 export async function listLlmProviderKeys(): Promise<LlmProviderKeysListResponse> {
   const resp = await service.get<ApiSuccessEnvelope<unknown>>("/api/llm/providers/api-keys");
@@ -58,10 +58,10 @@ export async function deleteLlmProviderKey(providerId: string): Promise<void> {
  */
 export async function checkLlmProviderHasKey(providerId: string): Promise<boolean> {
   try {
-    const resp = await service.get<{ data: { has_key: boolean } }>(
+    const resp = await service.get<ApiSuccessEnvelope<{ has_key: boolean }>>(
       `/api/llm/providers/${providerId}/has-key`,
     );
-    return Boolean((resp as unknown as { data: { has_key: boolean } }).data?.has_key);
+    return Boolean(unwrapResponse<{ has_key: boolean }>(resp)?.has_key);
   } catch {
     return false;
   }
@@ -84,5 +84,5 @@ export async function testLlmProvider(
     `/api/llm/providers/${providerId}/test${query}`,
     payload,
   );
-  return (resp as unknown as { data: ProviderTestResult }).data;
+  return unwrapResponse<ProviderTestResult>(resp);
 }

--- a/frontend/src/api/parse.ts
+++ b/frontend/src/api/parse.ts
@@ -11,7 +11,9 @@ import type { ZodSchema } from 'zod'
 
 /**
  * Unwraps the `data` field from an API response envelope.
- * Throws a typed `Error` when the envelope is missing or has no `data` field.
+ * Falls back to `resp` itself when the envelope has no `data` field (e.g.
+ * already-unwrapped payloads, endpoints that return bare objects like
+ * `cancelRun`).  Mirrors the tolerant behaviour of `unwrapAndParse` (#607).
  *
  * Use this when you want the raw data without schema validation, or when
  * calling code handles validation separately.
@@ -19,10 +21,11 @@ import type { ZodSchema } from 'zod'
  * @param resp - The raw value returned by the axios service.
  */
 export function unwrapResponse<T>(resp: unknown): T {
-  if (resp === null || typeof resp !== 'object' || !('data' in resp)) {
-    throw new Error('[api] response envelope missing `data`')
-  }
-  return (resp as { data: T }).data
+  return (
+    resp !== null && typeof resp === 'object' && 'data' in resp
+      ? (resp as { data: unknown }).data
+      : resp
+  ) as T
 }
 
 /**

--- a/frontend/src/api/parse.ts
+++ b/frontend/src/api/parse.ts
@@ -1,10 +1,29 @@
 /**
- * Issue #578 — Typed parse helper for LLM API modules.
+ * Issue #578/#585 — Typed parse helpers for API envelope unwrapping.
  *
- * Replaces bare `.parse()` callsites with safeParse + typed rejection,
+ * #578: Replaces bare `.parse()` callsites with safeParse + typed rejection,
  * so schema drift becomes a catchable error instead of an unhandled rejection.
+ *
+ * #585: Adds `unwrapResponse<T>` as a standalone envelope-unwrap helper,
+ * replacing inline envelope-cast patterns across API modules.
  */
 import type { ZodSchema } from 'zod'
+
+/**
+ * Unwraps the `data` field from an API response envelope.
+ * Throws a typed `Error` when the envelope is missing or has no `data` field.
+ *
+ * Use this when you want the raw data without schema validation, or when
+ * calling code handles validation separately.
+ *
+ * @param resp - The raw value returned by the axios service.
+ */
+export function unwrapResponse<T>(resp: unknown): T {
+  if (resp === null || typeof resp !== 'object' || !('data' in resp)) {
+    throw new Error('[api] response envelope missing `data`')
+  }
+  return (resp as { data: T }).data
+}
 
 /**
  * Unwraps the `data` field from an axios response envelope and validates it

--- a/frontend/src/store/llmProviders.ts
+++ b/frontend/src/store/llmProviders.ts
@@ -24,6 +24,7 @@ import type { ProviderDescriptor } from "../contracts/llmRoutingContract";
 import type { LlmProviderKeyEntry } from "../contracts/llmProviderKeysContract";
 import service from "../api";
 import type { ApiSuccessEnvelope } from "../api/envelope";
+import { unwrapResponse } from "../api/parse";
 
 interface ModelEntry {
   id: string;
@@ -76,7 +77,7 @@ export const useLlmProvidersStore = defineStore("llmProviders", () => {
       const resp = await service.get<ApiSuccessEnvelope<ModelEntry[]>>(
         `/api/llm/providers/${providerId}/models${query}`,
       );
-      const list = (resp as unknown as { data: ModelEntry[] }).data;
+      const list = unwrapResponse<ModelEntry[]>(resp);
       models.value = {
         ...models.value,
         [providerId]: { models: list, fetchedAt: Date.now() },


### PR DESCRIPTION
## Summary

- Adds `unwrapResponse<T>` to `frontend/src/api/parse.ts` as the canonical typed envelope-unwrap helper, building on the existing `unwrapAndParse` from #607
- Replaces all 3 remaining `(resp as unknown as { data })` casts in `api/llmProviderKeys.ts` (lines 64, 87) and `store/llmProviders.ts` (line 79) with the new helper
- Adds Vitest coverage for `unwrapResponse` (success, missing-envelope, non-object input, falsy-data values) alongside existing `unwrapAndParse` suite

## Test plan

- [x] `grep -rn "as unknown as { data" frontend/src/api/` → `OK` (zero code hits)
- [x] `npx vitest run` → 1101 tests passed (140 test files)
- [x] `vue-tsc --noEmit` → no type errors
- [x] `vite build` → clean build

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)