### PR TITLE
fix(security): pip-audit-Gate grün — pyjwt/starlette-Bump + PYSEC-Baseline für torch/transformers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,17 @@ jobs:
         # wöchentlich) und Dependabot fangen Vulns ab.
         #
         # Temporary baseline: these advisories are pinned by upstream
-        # dependencies (camel-oasis==0.2.5 / sentence-transformers==3.0.0).
+        # dependencies (camel-oasis==0.2.5 / sentence-transformers==4.1.0)
+        # or have no fixed release in the advisory DB (PYSEC-2026-139,
+        # PYSEC-2025-217 — issues #623/#624).
         # Tracked in docs/dependency-risk-register.md. Hardstop 2026-07-30 —
         # afterwards this --ignore-vuln list MUST be empty.
         if: github.event_name != 'pull_request'
         run: |
           uvx pip-audit --strict --no-deps --disable-pip \
             --ignore-vuln CVE-2026-1839 \
+            --ignore-vuln PYSEC-2026-139 \
+            --ignore-vuln PYSEC-2025-217 \
             -r /tmp/agora-backend-requirements.txt
 
       - name: Set up Bun

--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -1,7 +1,8 @@
 # CVE-Monitor (Weekly) — M10.1 + M10.2
 #
 # Läuft jeden Montag 06:00 UTC `pip-audit --strict` OHNE `--ignore-vuln`,
-# damit sichtbar wird, sobald Upstream einen der sechs gepinnten CVEs released.
+# damit sichtbar wird, sobald Upstream eine der gepinnten Advisories released
+# (aktive Baseline: docs/dependency-risk-register.md).
 #
 # Verhalten je nach Datum:
 #
@@ -109,19 +110,13 @@ jobs:
             echo "**pip-audit exit code:** \`${AUDIT_EC}\`"
             echo "**Hardstop:** 2026-07-30 (in **${days_left} Tagen**)"
             echo
-            echo "### Baseline (9 CVEs in \`docs/dependency-risk-register.md\`)"
+            echo "### Aktive Baseline (3 Advisories in \`docs/dependency-risk-register.md\`)"
             echo
-            echo "| CVE | Issue | Pinned by |"
+            echo "| Advisory | Issue | Pinned by |"
             echo "|---|---|---|"
-            echo "| CVE-2026-25990 | #121 | camel-ai (pillow<11) |"
-            echo "| CVE-2026-40192 | #122 | camel-ai (pillow<11) |"
-            echo "| CVE-2026-42308 | #296 | camel-oasis (pillow==10.3.0) / camel-ai (pillow<11) |"
-            echo "| CVE-2026-42310 | #297 | camel-oasis (pillow==10.3.0) / camel-ai (pillow<11) |"
-            echo "| CVE-2026-42311 | #298 | camel-oasis (pillow==10.3.0) / camel-ai (pillow<11) |"
-            echo "| CVE-2025-71176 | #123 | camel-oasis (pytest==8.2.0) |"
             echo "| CVE-2026-1839 | #124 | sentence-transformers (transformers<5) |"
-            echo "| CVE-2024-46455 | #125 | camel-oasis (unstructured==0.13.7) |"
-            echo "| CVE-2025-64712 | #126 | camel-oasis (unstructured==0.13.7) |"
+            echo "| PYSEC-2026-139 | #623 | torch — kein Upstream-Fix released |"
+            echo "| PYSEC-2025-217 | #624 | transformers — kein Upstream-Fix released |"
             echo
             echo "### pip-audit Output (no --ignore-vuln)"
             echo

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,8 +16,14 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: block
+          # api.deps.dev + api.securityscorecards.dev: dependency-review-action
+          # hat show-openssf-scorecard standardmäßig aktiv und fetcht Scorecard-
+          # Daten — unter blocked egress sonst "##[error]fetch failed"
+          # (Run 27233669105, erster PR mit echten Dependency-Änderungen).
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
+            api.securityscorecards.dev:443
             github.com:443
             objects.githubusercontent.com:443
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2027,7 +2027,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2288,11 +2288,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2943,14 +2943,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -3274,8 +3274,8 @@ name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [

--- a/docs/dependency-risk-register.md
+++ b/docs/dependency-risk-register.md
@@ -1,6 +1,6 @@
 # Dependency Risk Register
 
-**Stand:** 2026-05-15, Europe/Berlin
+**Stand:** 2026-06-09, Europe/Berlin
 **Ausgeloest durch:** Repo-Review PR4 — CVE-Baseline aktiv abbauen.
 Automation: [.github/workflows/cve-monitor.yml](../.github/workflows/cve-monitor.yml) läuft wöchentlich Mo 06:00 UTC pip-audit --strict ohne --ignore-vuln und schreibt das Ergebnis in das Workflow-Summary. Hardstop am 2026-07-30 — danach failt der Job, wenn ignored CVEs noch offen sind.
 Supply-Chain-Baseline: [.github/workflows/scorecard.yml](../.github/workflows/scorecard.yml) läuft wöchentlich Mo 04:30 UTC und auf `push` nach `main`. SARIF-Ergebnisse werden ins Code-Scanning-Dashboard hochgeladen; der erste Remote-Run nach Merge ist die Scorecard-Baseline.
@@ -18,12 +18,15 @@ hinterlegt, um den Container-Scan nicht zu blockieren.
 | CVE | Paket | Schweregrad | Fix verfügbar? | Owner | Frist | Status | Issue | Upstream-Release-Watch |
 |---|---|---|---|---|---|---|---|---|
 | CVE-2026-1839 | `transformers` | Medium | Nein (Upstream Pin) | sentence-transformers | 2026-07-30 | open | [#124](https://github.com/arn0ld87/agora/issues/124) | [UKPLab/sentence-transformers/releases](https://github.com/UKPLab/sentence-transformers/releases) |
+| PYSEC-2026-139 | `torch` | unbekannt | Nein (kein Upstream-Fix released) | sentence-transformers | 2026-07-30 | open | [#623](https://github.com/arn0ld87/agora/issues/623) | [pytorch/pytorch/releases](https://github.com/pytorch/pytorch/releases) |
+| PYSEC-2025-217 | `transformers` | unbekannt | Nein (kein Upstream-Fix released) | sentence-transformers | 2026-07-30 | open | [#624](https://github.com/arn0ld87/agora/issues/624) | [huggingface/transformers/releases](https://github.com/huggingface/transformers/releases) |
 
 ### Pin-Begruendungen
 
 | Paket | Pinned Version | Upstream-Pin | Erklaerung |
 |---|---|---|---|
-| `transformers` | `4.57.6` | `sentence-transformers==3.0.0` | `sentence-transformers` limitiert `transformers<5`. |
+| `transformers` | `4.57.6` | `sentence-transformers==4.1.0` (via `camel-oasis==0.2.5`) | `sentence-transformers` limitiert `transformers<5`; für PYSEC-2025-217 existiert zudem keine gefixte Version in der Advisory-DB. |
+| `torch` | `2.9.1` | `sentence-transformers==4.1.0` (via `camel-oasis==0.2.5`) | PYSEC-2026-139 hat keine gefixte Version in der Advisory-DB — Upgrade behebt das Finding derzeit nicht. |
 
 ---
 


### PR DESCRIPTION
## Problem
Der CI-Workflow auf main ist rot (Run 27232745803): `pip-audit --strict` meldet 8 neue Findings.

## Fix
| Paket | Vorher | Maßnahme |
|---|---|---|
| pyjwt | 2.12.1 (4× PYSEC-2026) | Bump auf **2.13.0** (uv.lock) |
| starlette | 0.50.0 (PYSEC-2026-161) | Bump auf **1.2.1** (uv.lock) |
| torch | 2.9.1 (PYSEC-2026-139) | **kein Upstream-Fix** → ignore-Baseline, Issue #623 |
| transformers | 4.57.6 (PYSEC-2025-217) | **kein Upstream-Fix** → ignore-Baseline, Issue #624 |

pyjwt/starlette sind nur transitiv (mcp → camel-ai) — der Resolver erlaubt die Bumps, 2705 Tests collecten sauber. Die Baseline-Erweiterung folgt dem Prozess in `docs/dependency-risk-register.md` (Issue + Register-Eintrag + Hardstop 2026-07-30, wöchentlicher CVE-Monitor-Watch).

Zusätzlich: veraltete Summary-Tabelle in cve-monitor.yml bereinigt (8 der 9 gelisteten CVEs sind längst abgeschlossen) und falsche Pin-Version im Register korrigiert (sentence-transformers 4.1.0, nicht 3.0.0).

## Verifikation
Lokal: `pip-audit --strict` mit den 3 Baseline-ignores → **No known vulnerabilities found**. Backend-Tests laufen in diesem PR via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)