### PR TITLE
ci: round 8 — e2e instance/data mount prep + Trivy release-assets egress

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -38,6 +38,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             proxy.golang.org:443
 
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
             generativelanguage.googleapis.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
             api.github.com:443
-            release-assets.githubusercontent.com:443
 
       - name: Checkout full history for secret scan
         uses: actions/checkout@v6
@@ -133,6 +133,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - name: Checkout
@@ -196,6 +197,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             registry.npmjs.org:443
 
       - name: Checkout

--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -27,6 +27,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - uses: actions/checkout@v6
@@ -61,6 +62,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - uses: actions/checkout@v6
@@ -86,6 +88,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - uses: actions/checkout@v6
@@ -126,6 +129,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             registry.npmjs.org:443
 
       - uses: actions/checkout@v6
@@ -153,6 +157,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - uses: actions/checkout@v6
@@ -186,6 +191,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
 
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,6 +57,7 @@ jobs:
             pypi.org:443
             registry.npmjs.org:443
             registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
             *.blob.core.windows.net:443
 
@@ -173,6 +174,7 @@ jobs:
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
             registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
             *.blob.core.windows.net:443
 
@@ -326,6 +328,7 @@ jobs:
             pypi.org:443
             registry.npmjs.org:443
             registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
             *.blob.core.windows.net:443
 

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -46,6 +46,7 @@ jobs:
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             packages.microsoft.com:443
             pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
@@ -134,6 +135,7 @@ jobs:
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             packages.microsoft.com:443
             pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
@@ -220,6 +222,7 @@ jobs:
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             packages.microsoft.com:443
             pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443
@@ -298,6 +301,7 @@ jobs:
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             packages.microsoft.com:443
             pkg-containers.githubusercontent.com:443
             playwright.azureedge.net:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,7 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             proxy.golang.org:443
             www.bestpractices.dev:443

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -67,9 +67,17 @@ if [[ "$(id -u)" == "0" ]]; then
   # CI-Runner laufen oft als root — explizit auf Container-User chownen.
   chown -R 1000:1000 "${REPO_ROOT}/backend/uploads" "${REPO_ROOT}/backend/instance" "${REPO_ROOT}/backend/data"
 else
-  # Lokaler Mac/Linux-Dev — chmod auf weltweit beschreibbar reicht, weil
-  # der Bind-Mount-Source dem Dev-User gehört, nicht UID 1000.
-  chmod -R 0777 "${REPO_ROOT}/backend/uploads" "${REPO_ROOT}/backend/instance" "${REPO_ROOT}/backend/data"
+  # Lokaler Mac/Linux-Dev — chmod auf weltweit beschreibbare VERZEICHNISSE
+  # reicht, weil der Bind-Mount-Source dem Dev-User gehört, nicht UID 1000.
+  # Bewusst ohne -R: rekursives chmod würde restriktive Datei-Modes
+  # plattmachen (LlmProviderSecretsStore schreibt llm_provider_secrets.json
+  # mit 0600 nach backend/data — Gemini-Review #627).
+  chmod 0777 \
+    "${REPO_ROOT}/backend/uploads" \
+    "${REPO_ROOT}/backend/uploads/run_registry" \
+    "${REPO_ROOT}/backend/uploads/simulations" \
+    "${REPO_ROOT}/backend/instance" \
+    "${REPO_ROOT}/backend/data"
 fi
 echo "[e2e-up] backend/uploads, backend/instance, backend/data prepared with writable permissions" >&2
 

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -50,20 +50,28 @@ fi
 } >> "${REPO_ROOT}/.env"
 echo "[e2e-up] runtime credentials appended to .env" >&2
 
-# Followup #8: Bind-Mount-Source mit Container-User-UID anlegen, sonst
-# erzeugt der Docker-Daemon das Verzeichnis als root und das Backend
+# Followup #8: Bind-Mount-Sources mit Container-User-UID anlegen, sonst
+# erzeugt der Docker-Daemon die Verzeichnisse als root und das Backend
 # (User `agora`, UID 1000) kann nicht reinschreiben — RunRegistry.__new__
 # bricht dann mit PermissionError ab (CI-Failure 25595884785).
-mkdir -p "${REPO_ROOT}/backend/uploads/run_registry" "${REPO_ROOT}/backend/uploads/simulations"
+# Gleiches gilt für backend/instance (LlmProfilesStore legt beim Import
+# instance/llm_profiles.db an — sqlite3.OperationalError "unable to open
+# database file", CI-Failure 27233527207) und backend/data
+# (llm_provider_secrets.json / workspace_llm_routing.json, 0600 vom Backend).
+mkdir -p \
+  "${REPO_ROOT}/backend/uploads/run_registry" \
+  "${REPO_ROOT}/backend/uploads/simulations" \
+  "${REPO_ROOT}/backend/instance" \
+  "${REPO_ROOT}/backend/data"
 if [[ "$(id -u)" == "0" ]]; then
   # CI-Runner laufen oft als root — explizit auf Container-User chownen.
-  chown -R 1000:1000 "${REPO_ROOT}/backend/uploads"
+  chown -R 1000:1000 "${REPO_ROOT}/backend/uploads" "${REPO_ROOT}/backend/instance" "${REPO_ROOT}/backend/data"
 else
   # Lokaler Mac/Linux-Dev — chmod auf weltweit beschreibbar reicht, weil
   # der Bind-Mount-Source dem Dev-User gehört, nicht UID 1000.
-  chmod -R 0777 "${REPO_ROOT}/backend/uploads"
+  chmod -R 0777 "${REPO_ROOT}/backend/uploads" "${REPO_ROOT}/backend/instance" "${REPO_ROOT}/backend/data"
 fi
-echo "[e2e-up] backend/uploads prepared with writable permissions" >&2
+echo "[e2e-up] backend/uploads, backend/instance, backend/data prepared with writable permissions" >&2
 
 echo "[e2e-up] starting compose stack on port ${PROXY_PORT}..." >&2
 # E2E-Override hebt read_only=true aus M11 Phase 3 auf, weil RunRegistry


### PR DESCRIPTION
## Zwei unabhängige main-Failures

**1. e2e-smokes rot (Run 27233527207)** — Backend crasht beim Boot:
`sqlite3.OperationalError: unable to open database file` in `LlmProfilesStore._init_db` ([llm_profiles_store.py](backend/app/services/llm_profiles_store.py)). Ursache: `docker-compose.yml` bind-mountet `./backend/instance` und `./backend/data`, aber `e2e-up.sh` präpariert nur `./backend/uploads` — der Docker-Daemon legt die anderen Mount-Sources als root an, UID 1000 kann nicht schreiben. Gleiche Klasse wie Followup #8 (Run 25595884785). Fix: mkdir+chown für beide Verzeichnisse.

**2. docker-image build-only rot (Run 27232745881)** — Trivy-Installer findet v0.70.0 und stirbt mit exit 7: der Release-Tarball-Download von `release-assets.githubusercontent.com` ist egress-geblockt. Fix: Endpoint in die Allowlists (analog cve-monitor.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)