### PR TITLE
fix(frontend): bun.lock auf reka-ui 2.9.9 regenerieren — frozen-Installs entblocken

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -19,7 +19,7 @@
         "dompurify": "^3.4.2",
         "marked": "^18.0.3",
         "pinia": "^3.0.4",
-        "reka-ui": "2.9.7",
+        "reka-ui": "2.9.9",
         "vue": "^3.5.34",
         "vue-i18n": "^11.4.2",
         "vue-router": "^5.0.6",
@@ -825,7 +825,7 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "reka-ui": ["reka-ui@2.9.7", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@floating-ui/vue": "^1.1.6", "@internationalized/date": "^3.5.0", "@internationalized/number": "^3.5.0", "@tanstack/vue-virtual": "^3.12.0", "@vueuse/core": "^14.1.0", "@vueuse/shared": "^14.1.0", "aria-hidden": "^1.2.4", "defu": "^6.1.5", "ohash": "^2.0.11" }, "peerDependencies": { "vue": ">= 3.4.0" } }, "sha512-aX7foYYR20v4+majO58OJJdBNfLMm0eJb448l9N4JVy8JB7GXOr4H/S4a+J1pkcoxZH8Cb7YHpJ855+miAm7sA=="],
+    "reka-ui": ["reka-ui@2.9.9", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@floating-ui/vue": "^1.1.6", "@internationalized/date": "^3.5.0", "@internationalized/number": "^3.5.0", "@tanstack/vue-virtual": "^3.12.0", "@vueuse/core": "^14.1.0", "@vueuse/shared": "^14.1.0", "aria-hidden": "^1.2.4", "defu": "^6.1.5", "ohash": "^2.0.11" }, "peerDependencies": { "vue": ">= 3.4.0" } }, "sha512-/e+hdF9vP8E2kPrKR4RdgMQQsfpCr8l436Zn8GRWM3jKT9EG1lOO/UFMGBVEnrMLOVoJSjjmIFrej4tMOb+6qQ=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 


### PR DESCRIPTION
**Dringend — blockiert alle PR-Checks mit Frontend-Anteil.**

Beim Merge von #600 hat das Branch-Update Dependabots Lockfile-Änderung mit dem #628-Stand von main übermergt: `package.json` verlangt reka-ui **2.9.9**, `bun.lock` resolved **2.9.7**. Seitdem failt jeder `bun install --frozen-lockfile` in CI ("lockfile had changes") — sichtbar auf #639/#640.

Fix: `bun install` regeneriert die zwei betroffenen Lockfile-Zeilen; frischer `--frozen-lockfile`-Install läuft danach sauber (lokal mit bun 1.3.14 = CI-Version verifiziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)