### PR TITLE
fix: harden security alert surfaces

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "17 4 * * 1"
   workflow_dispatch:
@@ -10,12 +12,15 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/backend/app/contracts/api_keys_contract.py
+++ b/backend/app/contracts/api_keys_contract.py
@@ -41,7 +41,10 @@ class ApiKeyModel(BaseModel):
     )
     scopes: list[ApiKeyScope] = Field(min_length=1)
     status: ApiKeyStatus
-    hashed_token: str = Field(description="SHA-256 hash of the full token", exclude=True)
+    hashed_token: str = Field(
+        description="Server-side HMAC-SHA256 lookup hash of the full token",
+        exclude=True,
+    )
     created_at: datetime
     last_used_at: Optional[datetime] = None
     revoked_at: Optional[datetime] = None

--- a/backend/app/readiness.py
+++ b/backend/app/readiness.py
@@ -19,7 +19,7 @@ Beispielantwort bei kaputtem Neo4j:
 
     GET /readyz → 503
     {"status": "not_ready", "checks": {
-        "neo4j": {"ok": false, "detail": "bolt://neo4j:7687 unreachable: ..."},
+        "neo4j": {"ok": false, "detail": "neo4j connectivity probe failed"},
         ...
     }}
 
@@ -46,8 +46,15 @@ from typing import Any, Tuple
 from flask import Flask, Response, current_app, jsonify
 
 from .config import infer_vector_dim_for_model
+from .utils.logger import get_logger
 
 CheckResult = Tuple[bool, str]
+logger = get_logger("agora.readiness")
+
+
+def _safe_probe_failure(check_name: str, exc: Exception) -> CheckResult:
+    logger.warning("%s readiness probe failed: %s", check_name, exc, exc_info=True)
+    return False, f"{check_name} connectivity probe failed"
 
 
 def _check_neo4j() -> CheckResult:
@@ -67,7 +74,7 @@ def _check_neo4j() -> CheckResult:
     try:
         probe()
     except Exception as exc:  # noqa: BLE001 — Probe-Fehler werden im Body sichtbar
-        return False, str(exc)
+        return _safe_probe_failure("neo4j", exc)
     return True, "ok"
 
 
@@ -95,7 +102,7 @@ def _check_redis() -> CheckResult:
     try:
         probe()
     except Exception as exc:  # noqa: BLE001
-        return False, str(exc)
+        return _safe_probe_failure("redis", exc)
     return True, "ok"
 
 

--- a/backend/app/services/api_keys_store.py
+++ b/backend/app/services/api_keys_store.py
@@ -3,13 +3,14 @@
 In-Memory-Store mit automatischer Disk-Persistenz via
 :mod:`app.services.api_keys_persistence`. Klartext-Token (``ago_<48-hex>``)
 wird genau einmal beim Anlegen zurückgegeben; persistiert wird nur Prefix,
-Metadata und SHA-256-Hash.
+Metadata und ein serverseitig gepepperter HMAC-SHA256-Lookup-Hash.
 
 Audit-Log-Hook ist Out-of-Scope (kommt in G3).
 """
 from __future__ import annotations
 
 import hashlib
+import hmac
 import os
 import secrets
 import threading
@@ -30,6 +31,8 @@ logger = get_logger("agora.services.api_keys_store")
 
 _TOKEN_RANDOM_HEX = 48
 _PREFIX_HEX_LEN = 8
+_HASH_PREFIX = "hmac-sha256:"
+_HASH_PEPPER_ENV = "AGORA_API_KEY_HASH_PEPPER"
 # TTL für `last_used_at`-Disk-Flush. Ohne TTL würde jeder API-Request einen
 # Fernet-Encrypt + Disk-Write des kompletten Stores triggern — Gemini-Review
 # zu PR #524 nennt das als High-Severity-I/O-Bottleneck. Updates landen
@@ -51,8 +54,36 @@ def _generate_token() -> tuple[str, str]:
 
 
 def _hash_token(token: str) -> str:
-    """Berechnet SHA-256 Hash des Tokens."""
+    """Berechnet einen serverseitig gepepperten Lookup-Hash des Tokens."""
+    secret = _resolve_hash_secret()
+    digest = hmac.new(secret, token.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{_HASH_PREFIX}{digest}"
+
+
+def _legacy_hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _resolve_hash_secret() -> bytes:
+    raw = os.environ.get(_HASH_PEPPER_ENV) or os.environ.get("AGORA_FERNET_KEY")
+    if raw:
+        return raw.encode("utf-8")
+    debug_mode = os.environ.get("FLASK_DEBUG", "false").lower() in ("true", "1")
+    if debug_mode:
+        return b"agora-debug-api-key-hash-pepper"
+    raise RuntimeError(
+        "AGORA_API_KEY_HASH_PEPPER or AGORA_FERNET_KEY missing in non-debug mode"
+    )
+
+
+def _token_hash_matches(stored_hash: str, token: str) -> tuple[bool, bool]:
+    current_hash = _hash_token(token)
+    if hmac.compare_digest(stored_hash, current_hash):
+        return True, False
+    legacy_hash = _legacy_hash_token(token)
+    if hmac.compare_digest(stored_hash, legacy_hash):
+        return True, True
+    return False, False
 
 
 def _resolve_data_dir() -> Optional[Path]:
@@ -163,12 +194,16 @@ class ApiKeysStore:
         now = _now()
         with self._lock:
             for key_id, model in self._keys.items():
-                if model.hashed_token == hashed:
+                matches, needs_migration = _token_hash_matches(model.hashed_token, token)
+                if matches:
                     if model.status == "revoked":
                         return model
-                    updated = model.model_copy(update={"last_used_at": now})
+                    update_fields: dict[str, object] = {"last_used_at": now}
+                    if needs_migration:
+                        update_fields["hashed_token"] = hashed
+                    updated = model.model_copy(update=update_fields)
                     self._keys[key_id] = updated
-                    if self._should_flush_last_used_at(key_id, now):
+                    if needs_migration or self._should_flush_last_used_at(key_id, now):
                         self._save()
                         self._last_used_persisted_at[key_id] = now
                     return updated

--- a/backend/app/services/sim/process_manager.py
+++ b/backend/app/services/sim/process_manager.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import atexit
 import os
+from pathlib import Path
+import re
 import signal
 import subprocess
 import sys
@@ -45,6 +47,23 @@ from .run_state_store import RunnerStatus, SimulationRunState
 _tracer = trace.get_tracer(__name__)
 
 logger = get_logger("agora.process_manager")
+
+_SAFE_SIMULATION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _validate_simulation_id(simulation_id: str) -> None:
+    if not _SAFE_SIMULATION_ID_RE.fullmatch(simulation_id):
+        raise ValueError("Invalid simulation_id")
+
+
+def _resolve_child_path(base_dir: str, child_name: str, *, kind: str) -> Path:
+    base = Path(base_dir).expanduser().resolve()
+    child = (base / child_name).resolve()
+    try:
+        child.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {kind} path") from exc
+    return child
 
 # ---------------------------------------------------------------------------
 # Subprozess-Env-Whitelist (Code-Review 2026-05-17 §1.6)
@@ -219,6 +238,8 @@ def start_simulation(
     Raises:
         ValueError: if already running, config missing, or script not found.
     """
+    _validate_simulation_id(simulation_id)
+
     # Check if already running
     existing = get_run_state(simulation_id)
     if existing and existing.runner_status in [RunnerStatus.RUNNING, RunnerStatus.STARTING]:
@@ -265,7 +286,7 @@ def start_simulation(
     # Configure graph memory via injected callback
     setup_graph_memory(simulation_id)
 
-    sim_dir = os.path.join(run_state_dir, simulation_id)
+    sim_dir = _resolve_child_path(run_state_dir, simulation_id, kind="simulation")
 
     # Determine which script to run
     if platform == "twitter":
@@ -279,9 +300,9 @@ def start_simulation(
         state.twitter_running = True
         state.reddit_running = True
 
-    script_path = os.path.join(scripts_dir, script_name)
+    script_path = _resolve_child_path(scripts_dir, script_name, kind="script")
 
-    if not os.path.exists(script_path):
+    if not script_path.is_file():
         raise ValueError(f"Script does not exist: {script_path}")
 
     # Create action queue
@@ -290,14 +311,14 @@ def start_simulation(
 
     try:
         # Build run command
-        config_path = os.path.join(sim_dir, "simulation_config.json")
-        cmd = [sys.executable, script_path, "--config", config_path]
+        config_path = sim_dir / "simulation_config.json"
+        cmd = [sys.executable, str(script_path), "--config", str(config_path)]
 
         if max_rounds is not None and max_rounds > 0:
             cmd.extend(["--max-rounds", str(max_rounds)])
 
         # Create main log file
-        main_log_path = os.path.join(sim_dir, "simulation.log")
+        main_log_path = sim_dir / "simulation.log"
         main_log_file = open(main_log_path, "w", encoding="utf-8")
 
         # Build subprocess environment — Whitelist-only (Code-Review 2026-05-17 §1.6).
@@ -311,7 +332,7 @@ def start_simulation(
         if runtime_env:
             env.update({k: v for k, v in runtime_env.items() if v})
         # Sub-Slice 21: OASIS-DB pro Sim ins schreibbare uploads/-Volume
-        _inject_oasis_db_env(env, sim_dir)
+        _inject_oasis_db_env(env, str(sim_dir))
 
         # Slice 1c: Trace-Context via W3C-traceparent in den Subprozess propagieren.
         with _tracer.start_as_current_span("agora.subprocess.spawn") as span:
@@ -325,7 +346,7 @@ def start_simulation(
 
             process = subprocess.Popen(
                 cmd,
-                cwd=sim_dir,
+                cwd=str(sim_dir),
                 stdout=main_log_file,
                 stderr=subprocess.STDOUT,
                 text=True,

--- a/backend/app/utils/api_responses.py
+++ b/backend/app/utils/api_responses.py
@@ -3,7 +3,7 @@ Centralised Flask response helpers and a decorator for uniform API error handlin
 
 The goal is to remove the boilerplate that accreted across the API blueprints,
 where every handler wrapped its body in ``try/except Exception`` and hand-rolled
-the same ``{"success": False, "error": ..., "traceback": ...}`` response.
+the same ``{"success": False, "error": ...}`` response.
 
 The behaviour preserved by this module (used by the existing API surface):
 
@@ -22,7 +22,6 @@ tuples, or raw dicts; the dict form is forwarded to :func:`json_success`.
 from __future__ import annotations
 
 import functools
-import traceback
 from collections.abc import Mapping
 from typing import Any, Callable
 
@@ -136,8 +135,8 @@ def json_error(
       ``message="..."`` lässt sich die Default-Message punktuell überschreiben,
       ohne den Code zu verlieren.
 
-    Keeps the ``traceback`` field opt-in so that internal server errors can
-    surface the trace in debug mode without changing the shape for 4xx errors.
+    ``include_traceback`` is kept for call-site compatibility but intentionally
+    ignored: stack traces stay in server logs and are never serialized to JSON.
     """
     if isinstance(error, ApiErrorCode):
         resolved_code = code or error.value
@@ -149,8 +148,6 @@ def json_error(
     payload: dict[str, Any] = {"success": False, "error": resolved_text}
     if resolved_code:
         payload["code"] = resolved_code
-    if include_traceback:
-        payload["traceback"] = traceback.format_exc()
     if extra:
         payload.update(extra)
     return jsonify(payload), status

--- a/backend/tests/api/test_readyz_endpoint.py
+++ b/backend/tests/api/test_readyz_endpoint.py
@@ -6,8 +6,8 @@ Vertrag:
   B. /readyz prüft Neo4j-Connection, Redis-Ping, Upload-Verzeichnis
      schreibbar, Embedding-Konfig kohärent (EMBEDDING_MODEL ↔ VECTOR_DIM).
      Alle ok → 200; eine kaputt → 503.
-  C. Antwort-Body enthält pro Check {"ok": bool, "detail": str}, damit
-     Operator den kaputten Check ohne Log-Diving sieht.
+     C. Antwort-Body enthält pro Check {"ok": bool, "detail": str}. Details
+      nennen den kaputten Check, leaken aber keine Exception-/URI-Interna.
   D. Redis-Check wird übersprungen, wenn der konfigurierte Event-Bus auf
      File-Backend steht — sonst kann ein bewusster `EVENT_BUS_BACKEND=file`
      das ganze /readyz rot machen.
@@ -133,7 +133,8 @@ def test_readyz_returns_503_when_neo4j_unreachable(app, client):
     payload = response.get_json()
     assert payload["status"] == "not_ready"
     assert payload["checks"]["neo4j"]["ok"] is False
-    assert "unreachable" in payload["checks"]["neo4j"]["detail"].lower()
+    assert payload["checks"]["neo4j"]["detail"] == "neo4j connectivity probe failed"
+    assert "bolt://" not in payload["checks"]["neo4j"]["detail"]
     # Andere Checks bleiben grün.
     assert payload["checks"]["upload_dir"]["ok"] is True
 
@@ -160,7 +161,8 @@ def test_readyz_returns_503_when_redis_unreachable(app, client):
     assert response.status_code == 503
     payload = response.get_json()
     assert payload["checks"]["redis"]["ok"] is False
-    assert "unreachable" in payload["checks"]["redis"]["detail"].lower()
+    assert payload["checks"]["redis"]["detail"] == "redis connectivity probe failed"
+    assert "redis://" not in payload["checks"]["redis"]["detail"]
 
 
 def test_readyz_skips_redis_check_for_file_backend(app, client):

--- a/backend/tests/services/sim/test_process_manager.py
+++ b/backend/tests/services/sim/test_process_manager.py
@@ -111,6 +111,37 @@ class TestInjectOasisDbEnv:
 
 
 # ---------------------------------------------------------------------------
+# start_simulation security guards
+# ---------------------------------------------------------------------------
+
+
+class TestStartSimulationSecurity:
+    def test_rejects_simulation_id_path_traversal_before_io(self, tmp_path):
+        from app.services.sim import process_manager
+
+        with pytest.raises(ValueError, match="Invalid simulation_id"):
+            process_manager.start_simulation(
+                "../escape",
+                "parallel",
+                run_state_dir=str(tmp_path),
+                scripts_dir=str(tmp_path),
+                processes={},
+                action_queues={},
+                monitor_threads={},
+                stdout_files={},
+                stderr_files={},
+                graph_memory_enabled={},
+                get_run_state=MagicMock(side_effect=AssertionError("should not read")),
+                save_state=MagicMock(),
+                on_monitor_start=MagicMock(),
+                write_control_state=MagicMock(),
+                get_config=MagicMock(),
+                config_exists=MagicMock(),
+                setup_graph_memory=MagicMock(),
+            )
+
+
+# ---------------------------------------------------------------------------
 # terminate_process
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/services/test_api_keys_store.py
+++ b/backend/tests/services/test_api_keys_store.py
@@ -1,4 +1,4 @@
-from app.services.api_keys_store import ApiKeysStore
+from app.services.api_keys_store import ApiKeysStore, _legacy_hash_token
 
 def test_api_keys_store_hashing_and_validation():
     store = ApiKeysStore()
@@ -12,6 +12,7 @@ def test_api_keys_store_hashing_and_validation():
     assert resp.key.prefix == f"ago_{token[4:12]}"
     assert resp.key.hashed_token is not None
     assert resp.key.hashed_token != token
+    assert resp.key.hashed_token.startswith("hmac-sha256:")
 
     # 2. Validate token
     validated = store.validate_token(token)
@@ -42,3 +43,20 @@ def test_api_keys_store_invalid_tokens():
 
     resp = store.create("Key", ["read"])
     assert store.validate_token(resp.token + "extra") is None
+
+
+def test_api_keys_store_migrates_legacy_sha256_hash_on_validate():
+    store = ApiKeysStore()
+    resp = store.create("Legacy", ["read"])
+    token = resp.token
+    key_id = resp.key.id
+
+    legacy = resp.key.model_copy(update={"hashed_token": _legacy_hash_token(token)})
+    store._keys[key_id] = legacy
+
+    validated = store.validate_token(token)
+
+    assert validated is not None
+    assert validated.id == key_id
+    assert validated.hashed_token.startswith("hmac-sha256:")
+    assert validated.hashed_token != legacy.hashed_token

--- a/backend/tests/test_api_responses.py
+++ b/backend/tests/test_api_responses.py
@@ -49,7 +49,7 @@ def test_json_error_default_is_400_without_traceback():
         assert payload == {"success": False, "error": "boom"}
 
 
-def test_json_error_includes_code_and_traceback_when_requested():
+def test_json_error_keeps_traceback_out_of_response_when_requested():
     app = _build_app()
     with app.test_request_context():
         try:
@@ -66,7 +66,7 @@ def test_json_error_includes_code_and_traceback_when_requested():
         assert payload["success"] is False
         assert payload["error"] == "kapow"
         assert payload["code"] == "internal"
-        assert "Traceback" in payload["traceback"]
+        assert "traceback" not in payload
 
 
 def test_handle_api_errors_passes_through_success_tuple():
@@ -152,7 +152,7 @@ def test_handle_api_errors_maps_unknown_to_500_and_hides_traceback_outside_debug
     assert "kapow" not in payload.values()
 
 
-def test_handle_api_errors_includes_traceback_in_debug_mode():
+def test_handle_api_errors_in_debug_mode_exposes_message_but_not_traceback():
     app = _build_app()
 
     @handle_api_errors(log_prefix="Unexpected")
@@ -168,7 +168,7 @@ def test_handle_api_errors_includes_traceback_in_debug_mode():
     assert payload["error"] == "internal server error"
     assert payload["code"] == "internal_error"
     assert payload["debug_error"] == "kapow"
-    assert "Traceback" in payload["traceback"]
+    assert "traceback" not in payload
 
 
 def test_install_api_error_handlers_envelopes_api_404():


### PR DESCRIPTION
- validate simulation IDs and subprocess paths before launch

- replace API-key SHA256 lookup hashes with peppered HMAC migration

- stop exposing tracebacks and probe internals in JSON responses

- scope CodeQL security-events permission to the analysis job