### PR TITLE
refactor(backend): #590 unified provider abstraction + #591 unified provider detection

### DIFF
--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -46,6 +46,11 @@ from app.contracts.llm_provider_keys_contract import (
 )
 from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
 from app.contracts.post_event_contract import PostCreatedEvent
+from app.contracts.llm_request import (
+    NormalizedLlmRequest,
+    NormalizedLlmChunk,
+    NormalizedLlmError,
+)
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -79,6 +84,9 @@ CONTRACTS: dict[str, type] = {
     "llm-provider-keys-list-response.schema.json": LlmProviderKeysListResponse,
     "workspace-llm-routing-defaults.schema.json": WorkspaceLlmRoutingDefaults,
     "post-created-event.schema.json": PostCreatedEvent,
+    "llm-normalized-request.schema.json": NormalizedLlmRequest,
+    "llm-normalized-chunk.schema.json": NormalizedLlmChunk,
+    "llm-normalized-error.schema.json": NormalizedLlmError,
 }
 
 

--- a/backend/app/contracts/llm_request.py
+++ b/backend/app/contracts/llm_request.py
@@ -1,0 +1,91 @@
+"""Normalisierte LLM-Request-/Chunk-/Error-Typen (Issue #590).
+
+Provider-neutrale Wire-Typen fuer die Adapter-Schicht in
+``app/llm/providers/``: Ein ``NormalizedLlmRequest`` beschreibt einen
+Chat-Completion-Aufruf unabhaengig vom Provider; die Adapter uebersetzen
+ihn in das jeweilige Wire-Format (Token-Limit-Key, ``extra_body``-Optionen,
+Response-Format). ``NormalizedLlmError`` traegt die providerneutrale
+Fehlerklassifikation (``code``/``retryable``), die das Frontend-Error-
+Envelope direkt uebernehmen kann.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.contracts.provider_types import ProviderType
+
+
+class ChatMessage(BaseModel):
+    """Eine Chat-Nachricht im providerneutralen Format."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None
+
+
+class ResponseFormat(BaseModel):
+    """Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["text", "json_object", "json_schema"]
+    json_schema: Optional[dict[str, object]] = None
+
+
+class ToolSpec(BaseModel):
+    """Provider-neutrale Tool-/Function-Definition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str = ""
+    parameters: dict[str, object] = Field(default_factory=dict)
+
+
+class NormalizedLlmRequest(BaseModel):
+    """Provider-neutraler Chat-Completion-Request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: ProviderType
+    model: str
+    messages: list[ChatMessage]
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    stream: bool = False
+    response_format: Optional[ResponseFormat] = None
+    tools: Optional[list[ToolSpec]] = None
+
+
+class NormalizedLlmError(BaseModel):
+    """Provider-neutral klassifizierter Fehler.
+
+    ``retryable`` spiegelt die Retry-Semantik aus
+    ``app.utils.retry._is_transient_llm_error``: Verbindungsabbrueche,
+    Timeouts, HTTP 429 sowie 5xx/408 sind transient; uebrige 4xx nicht.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: ProviderType
+    code: str
+    message: str
+    status: Optional[int] = None
+    retryable: bool
+    cause: Optional[str] = None
+
+
+class NormalizedLlmChunk(BaseModel):
+    """Ein Element eines normalisierten Streaming-Responses."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["token", "metadata", "done", "error"]
+    text: Optional[str] = None
+    metadata: Optional[dict[str, object]] = None
+    error: Optional[NormalizedLlmError] = None

--- a/backend/app/contracts/llm_request.py
+++ b/backend/app/contracts/llm_request.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.provider_types import ProviderType
 
@@ -29,12 +29,24 @@ class ChatMessage(BaseModel):
 
 
 class ResponseFormat(BaseModel):
-    """Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema)."""
+    """Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema).
+
+    ``type="json_schema"`` verlangt zwingend ein ``json_schema``-Objekt — sonst
+    lehnt OpenAI zur Laufzeit mit HTTP 400 ab ("json_schema is required"). Ein
+    Pydantic-``model_validator`` fängt den Konfigurationsfehler am Contract
+    ab (fail-fast) statt erst im API-Call (Gemini-Finding).
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["text", "json_object", "json_schema"]
     json_schema: Optional[dict[str, object]] = None
+
+    @model_validator(mode="after")
+    def _require_schema_for_json_schema(self) -> "ResponseFormat":
+        if self.type == "json_schema" and self.json_schema is None:
+            raise ValueError("json_schema is required when type is 'json_schema'")
+        return self
 
 
 class ToolSpec(BaseModel):

--- a/backend/app/llm/errors.py
+++ b/backend/app/llm/errors.py
@@ -1,0 +1,123 @@
+"""Provider-neutrale Fehler-Normalisierung (Issue #590).
+
+Vorher gab es keine Fehler-Normalisierung — rohe ``openai.BadRequestError``,
+``httpx.ReadTimeout`` etc. blubberten bis zum Caller hoch. Die Adapter-Schicht
+mappt jede Transport-/SDK-Exception auf :class:`NormalizedLlmError`
+(``provider``/``code``/``retryable``), sodass das Frontend-Error-Envelope
+providerneutral befuellt werden kann.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+import openai
+
+from app.contracts.llm_request import NormalizedLlmError
+from app.contracts.provider_types import ProviderType
+
+
+class LlmProviderError(Exception):
+    """Exception-Wrapper um eine normalisierte Fehler-Payload.
+
+    Adapter werfen diese Exception aus ``complete()``; der Original-Fehler
+    bleibt als ``__cause__`` erhalten (``raise ... from exc``).
+    """
+
+    def __init__(self, normalized: NormalizedLlmError) -> None:
+        super().__init__(
+            f"[{normalized.provider}:{normalized.code}] {normalized.message}"
+        )
+        self.normalized = normalized
+
+
+def _status_of(exc: Exception) -> Optional[int]:
+    """HTTP-Status aus einer openai-SDK-Exception extrahieren (best effort)."""
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def normalize_provider_error(
+    exc: Exception, *, provider: ProviderType
+) -> NormalizedLlmError:
+    """Mappt eine rohe Exception auf einen :class:`NormalizedLlmError`.
+
+    Retry-Semantik gespiegelt aus ``app.utils.retry._is_transient_llm_error``:
+    transient (``retryable=True``) sind Verbindungsabbrueche, Timeouts,
+    HTTP 429 sowie 5xx/408 — uebrige 4xx-Client-Fehler nicht.
+
+    Reihenfolge der ``isinstance``-Checks ist signifikant:
+    ``APITimeoutError`` ist Subklasse von ``APIConnectionError``,
+    ``RateLimitError`` ist Subklasse von ``APIStatusError``.
+    """
+    cause = type(exc).__name__
+    message = str(exc) or cause
+
+    if isinstance(exc, openai.APITimeoutError):
+        return NormalizedLlmError(
+            provider=provider,
+            code="timeout",
+            message=message,
+            status=None,
+            retryable=True,
+            cause=cause,
+        )
+    if isinstance(exc, openai.APIConnectionError):
+        return NormalizedLlmError(
+            provider=provider,
+            code="connection_error",
+            message=message,
+            status=None,
+            retryable=True,
+            cause=cause,
+        )
+    if isinstance(exc, openai.RateLimitError):
+        return NormalizedLlmError(
+            provider=provider,
+            code="rate_limited",
+            message=message,
+            status=_status_of(exc) or 429,
+            retryable=True,
+            cause=cause,
+        )
+    if isinstance(exc, openai.APIStatusError):
+        status = _status_of(exc)
+        retryable = status is not None and (status >= 500 or status in (408, 429))
+        code = "server_error" if status is not None and status >= 500 else "client_error"
+        return NormalizedLlmError(
+            provider=provider,
+            code=code,
+            message=message,
+            status=status,
+            retryable=retryable,
+            cause=cause,
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return NormalizedLlmError(
+            provider=provider,
+            code="timeout",
+            message=message,
+            status=None,
+            retryable=True,
+            cause=cause,
+        )
+    if isinstance(exc, httpx.HTTPError):
+        return NormalizedLlmError(
+            provider=provider,
+            code="connection_error",
+            message=message,
+            status=None,
+            retryable=True,
+            cause=cause,
+        )
+    return NormalizedLlmError(
+        provider=provider,
+        code="unknown",
+        message=message,
+        status=None,
+        retryable=False,
+        cause=cause,
+    )

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -1,16 +1,24 @@
 """
-Per-provider helpers for ``LLMClient`` (#582).
+Per-provider helpers for ``LLMClient`` (#582) + Provider-Adapter (#590/#591).
 
-Plain functions only — no provider protocol/class hierarchy here yet.
-The shared-abstraction layer (``NormalizedLlmRequest``-style adapters) is
-scoped separately to #590/#591; this package is a mechanical grouping of
-the provider-specific quirks that already existed as ``LLMClient``
-staticmethods/private methods.
+Zwei Schichten koexistieren in diesem Paket:
+
+1. Mechanisches Grouping (#582): pro-Provider-Helfer, die aus dem
+   ehemaligen ``LLMClient``-Monolith extrahiert wurden — plain functions,
+   keine Protokoll-Hierarchie.
+2. Provider-Adapter (#590/#591): :class:`~app.llm.providers.base.ProviderAdapter`
+   als gemeinsame Schnittstelle fuer Payload-Shaping + Transport +
+   Fehler-Normalisierung; :mod:`~app.llm.providers.registry` als
+   Single-Source-of-Truth fuer Provider-Detection (``detect_provider``)
+   und Adapter-Aufloesung (``get_adapter``).
 
 Modules:
-    base.py     Provider detection (``is_ollama`` / ``detect_provider``).
-    openai.py   OpenAI token-limit-key quirks (``max_tokens`` vs.
-                ``max_completion_tokens``) and the associated 400-detection.
-    ollama.py   Native Ollama ``/api/chat`` schema path (schema flattening +
-                the direct httpx call bypassing the OpenAI-compat wrapper).
+    base.py     ``ProviderAdapter``-ABC + ``ProviderCapabilities`` +
+                Backward-Compat-Re-Exports ``is_ollama`` / ``detect_provider``.
+    registry.py Provider-Detection (``detect_provider(mode="http"|"oasis")``)
+                + Adapter-Aufloesung (``get_adapter``) — SSOT seit #591.
+    openai.py   Token-limit-key-quirks (``max_tokens`` vs.
+                ``max_completion_tokens``) + 400-detection + ``OpenAIAdapter``.
+    ollama.py   Native Ollama ``/api/chat`` schema path + ``OllamaAdapter``.
+    gemini.py   ``GeminiAdapter`` (OpenAI-Compat-Layer).
 """

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -193,6 +193,15 @@ class ProviderAdapter(ABC):
         except Exception as exc:  # noqa: BLE001 — bewusst: alles normalisieren
             yield NormalizedLlmChunk(type="error", error=self.normalize_error(exc))
             return
+        finally:
+            # Stream/Context-Manager sicher schliessen — openai.Stream hat
+            # close(); einfache Test-Iteratoren haben keine (hasattr-Guard).
+            # Verhindert Connection-Leaks bei Error oder vorzeitigem Abbruch.
+            if hasattr(stream, "close"):
+                try:
+                    stream.close()
+                except Exception:  # noqa: BLE001 — close darf nicht knallen
+                    pass
         yield NormalizedLlmChunk(type="done")
 
     # ------------------------------------------------------------------

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -1,13 +1,212 @@
-"""
-Provider detection.
+"""Basisklasse der Provider-Adapter + Provider-Detection (Issue #590/#591).
 
-Extracted verbatim (parametrized on base_url/model instead of ``self``) from
-``LLMClient._is_ollama`` / ``LLMClient._detect_provider`` in
-``app/utils/llm_client.py`` as part of issue #582 (mechanical split — no
-behavior change).
-"""
+``ProviderAdapter`` definiert die einheitliche Schnittstelle, ueber die
+Provider-spezifisches Verhalten gekapselt wird:
 
-from typing import Literal, Optional
+- Payload-Shaping (``prepare_request_kwargs``): Token-Limit-Key,
+  ``extra_body``-Optionen, Response-Format- und Tool-Wire-Format.
+- Transport (``complete`` / ``stream``) ueber einen injizierten
+  OpenAI-kompatiblen Client mit dem gemeinsamen Retry-Layer
+  (:mod:`app.llm.retry`).
+- Fehler-Normalisierung (``normalize_error``) auf
+  :class:`~app.contracts.llm_request.NormalizedLlmError`.
+
+Die Adapter sind zustandsarm: Instanz-Konfiguration beschraenkt sich auf
+``num_ctx``/``think`` (nur vom Ollama-Adapter genutzt). Die Compliance-Suite
+(``tests/llm/test_provider_compliance.py``) fixiert das einheitliche
+Verhalten aller Adapter.
+
+Backward-Compat: ``is_ollama`` und ``detect_provider`` bleiben als
+Duennschicht-Re-Exports erhalten. Die Heuristik-Logik lebt seit #591 in
+der Single-Source-of-Truth :mod:`app.llm.providers.registry`; bestehende
+Aufrufer (z. B. ``LLMClient._detect_provider``) greifen weiterhin ueber
+diesen Einstieg, ohne dass eine Signatur gebrochen wird.
+"""
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, List, Literal, Optional
+
+from app.contracts.llm_request import (
+    NormalizedLlmChunk,
+    NormalizedLlmError,
+    NormalizedLlmRequest,
+    ResponseFormat,
+    ToolSpec,
+)
+from app.contracts.provider_types import ProviderType
+from app.llm.errors import LlmProviderError, normalize_provider_error
+from app.llm.providers.registry import detect_provider as _detect_provider_registry
+from app.llm.retry import llm_call_with_retry
+
+CompletionTokenParam = Literal["max_tokens", "max_completion_tokens"]
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Deklarative Faehigkeiten eines Providers.
+
+    Informativ fuer Routing-/Fallback-Entscheidungen; die Laufzeit-Fallbacks
+    (z. B. strict-json_schema -> json_object -> Freitext) bleiben beim Caller.
+    """
+
+    supports_native_tools: bool
+    supports_json_object_mode: bool
+    supports_json_schema_mode: bool
+    uses_ollama_native_options: bool = False
+
+
+def wire_response_format(response_format: ResponseFormat) -> Dict[str, Any]:
+    """Uebersetzt :class:`ResponseFormat` ins OpenAI-Wire-Format."""
+    if response_format.type == "json_schema" and response_format.json_schema is not None:
+        return {"type": "json_schema", "json_schema": response_format.json_schema}
+    return {"type": response_format.type}
+
+
+def wire_tool(tool: ToolSpec) -> Dict[str, Any]:
+    """Uebersetzt :class:`ToolSpec` ins OpenAI-Function-Calling-Wire-Format."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters,
+        },
+    }
+
+
+class ProviderAdapter(ABC):
+    """Gemeinsame Adapter-Schnittstelle fuer Ollama, OpenAI und Gemini."""
+
+    name: ClassVar[ProviderType]
+    capabilities: ClassVar[ProviderCapabilities]
+
+    def __init__(self, *, num_ctx: Optional[int] = None, think: bool = False) -> None:
+        self.num_ctx = num_ctx
+        self.think = think
+
+    # ------------------------------------------------------------------
+    # Payload-Shaping-Hooks (provider-spezifisch ueberschreibbar)
+    # ------------------------------------------------------------------
+
+    def completion_token_param(self, model: str) -> CompletionTokenParam:
+        """Wire-Key fuer das Token-Limit (Default: ``max_tokens``)."""
+        return "max_tokens"
+
+    def build_extra_body(self) -> Optional[Dict[str, Any]]:
+        """Provider-spezifischer ``extra_body``-Block (Default: keiner)."""
+        return None
+
+    def prepare_request_kwargs(self, request: NormalizedLlmRequest) -> Dict[str, Any]:
+        """Baut die kwargs fuer ``client.chat.completions.create``."""
+        kwargs: Dict[str, Any] = {
+            "model": request.model,
+            "messages": [m.model_dump(exclude_none=True) for m in request.messages],
+        }
+        if request.temperature is not None:
+            kwargs["temperature"] = request.temperature
+        if request.max_tokens is not None:
+            kwargs[self.completion_token_param(request.model)] = request.max_tokens
+        if request.response_format is not None:
+            kwargs["response_format"] = wire_response_format(request.response_format)
+        if request.tools:
+            kwargs["tools"] = [wire_tool(t) for t in request.tools]
+        extra_body = self.build_extra_body()
+        if extra_body is not None:
+            kwargs["extra_body"] = extra_body
+        return kwargs
+
+    # ------------------------------------------------------------------
+    # Transport (gemeinsamer Retry-Layer)
+    # ------------------------------------------------------------------
+
+    def complete(
+        self,
+        client: Any,
+        request: NormalizedLlmRequest,
+        *,
+        max_retries: int = 3,
+        initial_delay: float = 1.0,
+        max_delay: float = 30.0,
+    ) -> str:
+        """Nicht-streamender Chat-Completion-Aufruf.
+
+        Wirft :class:`LlmProviderError` mit normalisierter Payload; der
+        Original-Fehler bleibt als ``__cause__`` erhalten.
+        """
+        kwargs = self.prepare_request_kwargs(request)
+        try:
+            response = llm_call_with_retry(
+                client.chat.completions.create,
+                max_retries=max_retries,
+                initial_delay=initial_delay,
+                max_delay=max_delay,
+                **kwargs,
+            )
+        except Exception as exc:  # noqa: BLE001 — bewusst: alles normalisieren
+            raise LlmProviderError(self.normalize_error(exc)) from exc
+        choices: List[Any] = getattr(response, "choices", None) or []
+        if not choices:
+            return ""
+        content = getattr(getattr(choices[0], "message", None), "content", None)
+        return content or ""
+
+    def stream(
+        self,
+        client: Any,
+        request: NormalizedLlmRequest,
+        *,
+        max_retries: int = 3,
+        initial_delay: float = 1.0,
+        max_delay: float = 30.0,
+    ) -> Iterator[NormalizedLlmChunk]:
+        """Streamender Chat-Completion-Aufruf.
+
+        Liefert ``token``-Chunks, abgeschlossen durch ``done``. Fehler werden
+        als ``error``-Chunk mit normalisierter Payload emittiert (kein Raise —
+        stream-freundlich fuer SSE-Weiterleitung).
+        """
+        kwargs = self.prepare_request_kwargs(request)
+        kwargs["stream"] = True
+        try:
+            stream = llm_call_with_retry(
+                client.chat.completions.create,
+                max_retries=max_retries,
+                initial_delay=initial_delay,
+                max_delay=max_delay,
+                **kwargs,
+            )
+        except Exception as exc:  # noqa: BLE001 — bewusst: alles normalisieren
+            yield NormalizedLlmChunk(type="error", error=self.normalize_error(exc))
+            return
+        try:
+            for chunk in stream:
+                choices = getattr(chunk, "choices", None) or []
+                if not choices:
+                    continue
+                delta = getattr(choices[0], "delta", None)
+                text = getattr(delta, "content", None)
+                if text:
+                    yield NormalizedLlmChunk(type="token", text=text)
+        except Exception as exc:  # noqa: BLE001 — bewusst: alles normalisieren
+            yield NormalizedLlmChunk(type="error", error=self.normalize_error(exc))
+            return
+        yield NormalizedLlmChunk(type="done")
+
+    # ------------------------------------------------------------------
+    # Fehler-Normalisierung
+    # ------------------------------------------------------------------
+
+    def normalize_error(self, exc: Exception) -> NormalizedLlmError:
+        """Mappt eine rohe Exception auf :class:`NormalizedLlmError`."""
+        return normalize_provider_error(exc, provider=self.name)
+
+
+# ----------------------------------------------------------------------
+# Backward-Compat: Provider-Detection (Delegation an registry, #591)
+# ----------------------------------------------------------------------
 
 
 def is_ollama(base_url: Optional[str]) -> bool:
@@ -15,7 +214,7 @@ def is_ollama(base_url: Optional[str]) -> bool:
 
     Ollama Cloud hostet denselben /api/chat-Endpoint unter
     ``https://ollama.com/api`` mit identischem Body-Format (inkl.
-    ``format=<schema>``). Beide Hosts müssen erkannt werden, damit
+    ``format=<schema>``). Beide Hosts muessen erkannt werden, damit
     der Native-Schema-Pfad in chat_json sowohl bei lokalem Ollama
     (Port 11434) als auch bei Cloud (ollama.com) ziehen kann.
     """
@@ -28,30 +227,13 @@ def detect_provider(
 ) -> Literal["ollama", "cloud", "openai", "google", "unknown"]:
     """Infer the LLM provider from base_url and model name.
 
-    Heuristics (in priority order):
-    1. Base URL contains ``ollama.com`` → ``"cloud"`` (Ollama Cloud proxy).
-    2. Model suffix ``:cloud`` → ``"cloud"`` (Ollama Cloud Model-Tag-Hint —
-       wird VOR der Port-Heuristik geprüft, weil Cloud-Modelle auch über
-       den lokalen ollama-Proxy auf :11434 laufen können).
-    3. Base URL contains ``11434`` → ``"ollama"`` (local Ollama).
-    4. Base URL contains ``openai.com`` or ``api.openai`` → ``"openai"``.
-    5. Base URL contains ``googleapis.com`` or ``generativelanguage`` →
-       ``"google"`` (Gemini-OpenAI-Compat-Layer — unterstützt natives
-       ``tools=`` / ``tool_choice=``; siehe ``_chat_with_tools``-Branch.
-       Ohne diesen Pfad fiel der Tool-Call auf XML-im-Prompt zurück, was
-       Gemini's Function-Filter mit MALFORMED_FUNCTION_CALL ablehnt).
-    6. Fallback → ``"unknown"``.
+    Delegiert an ``app.llm.providers.registry.detect_provider(mode="http")``
+    (Single Source of Truth seit #591). Diese Wrapper-Funktion haelt die
+    alte Signatur fuer bestehende Aufrufer (z. B. ``LLMClient._detect_provider``)
+    aufrecht — die Heuristik-Logik lebt jetzt in der Registry, damit
+    HTTP-Client und OASIS-Subprozess dieselbe Quelle nutzen.
+
+    Siehe ``registry.py`` fuer die dokumentierten Divergenzen zwischen
+    ``mode="http"`` und ``mode="oasis"``.
     """
-    model_name = model or ""
-    base = (base_url or "").lower()
-    if "ollama.com" in base:
-        return "cloud"
-    if model_name.endswith(":cloud"):
-        return "cloud"
-    if "11434" in base:
-        return "ollama"
-    if "openai.com" in base or "api.openai" in base:
-        return "openai"
-    if "googleapis.com" in base or "generativelanguage" in base:
-        return "google"
-    return "unknown"
+    return _detect_provider_registry(base_url, model, mode="http")

--- a/backend/app/llm/providers/gemini.py
+++ b/backend/app/llm/providers/gemini.py
@@ -1,0 +1,35 @@
+"""Gemini-Adapter (OpenAI-Compat-Layer auf generativelanguage.googleapis.com) — Issue #590.
+
+Provider-Quirks, die dieser Adapter kapselt bzw. dokumentiert:
+
+- Natives ``tools=``/``tool_choice=`` MUSS genutzt werden: Der XML-im-Prompt-
+  Fallback wird von Geminis Function-Filter mit MALFORMED_FUNCTION_CALL
+  abgelehnt (siehe ``LLMClient._chat_with_tools``-Branch).
+- Gemini-3 verlangt ein ``thought_signature``-Echo in Multi-Turn-Tool-Calls.
+  Der OpenAI-Compat-Wire-Pfad strippt das Feld — deshalb routet der
+  OASIS-Dispatch (``detect_provider(mode="oasis")``) Gemini-Modelle auf die
+  native CAMEL-GEMINI-Plattform statt auf den Compat-Layer.
+- Kein ``extra_body``: Ollama-Optionen (``options.num_ctx``/``think``)
+  fuehren auf dem Compat-Layer zu 400ern.
+"""
+from __future__ import annotations
+
+from app.llm.providers.base import ProviderAdapter, ProviderCapabilities
+
+
+class GeminiAdapter(ProviderAdapter):
+    """Adapter fuer Gemini via OpenAI-Compat-Layer.
+
+    ``name`` ist der kanonische Provider-String ``"google"`` (siehe
+    :data:`app.contracts.provider_types.PROVIDER_GOOGLE`) — nicht das
+    Legacy-Literal ``'gemini'``; das ``gemini``-Literal-Gate
+    (``test_no_gemini_literals_in_code``) erlaubt letzteres nur in
+    ``app/contracts/provider_types.py``.
+    """
+
+    name = "google"
+    capabilities = ProviderCapabilities(
+        supports_native_tools=True,
+        supports_json_object_mode=True,
+        supports_json_schema_mode=True,
+    )

--- a/backend/app/llm/providers/ollama.py
+++ b/backend/app/llm/providers/ollama.py
@@ -1,19 +1,32 @@
 """
-Native Ollama ``/api/chat`` schema path.
+Native Ollama ``/api/chat`` schema path + Ollama-Adapter (Issue #590).
 
-Extracted verbatim (parametrized instead of ``self``) from
-``_flatten_pydantic_schema_for_ollama`` / ``LLMClient._ollama_chat_with_schema``
-in ``app/utils/llm_client.py`` as part of issue #582 (mechanical split — no
-behavior change).
+Zwei Rollen koexistieren in diesem Modul, klar getrennt:
+
+1. Native ``/api/chat``-Schema-Pfad (main, #582): ``_flatten_pydantic_schema_for_ollama``
+   und ``chat_with_schema`` — extrahiert aus dem ehemaligen ``LLMClient``-Monolith,
+   werden direkt von ``LLMClient._ollama_chat_with_schema`` sowie dem Shim
+   ``app/utils/llm_client.py`` konsumiert. Unangetastet bei der #590-Portierung.
+2. Provider-Adapter (PR-Vorlage, #590): ``build_ollama_extra_body`` und
+   :class:`OllamaAdapter` — kapseln Ollama-spezifisches Payload-Shaping
+   (``extra_body["options"]["num_ctx"]`` + ``think``) fuer den
+   OpenAI-kompatiblen Client-Pfad. Die Compliance-Suite
+   ``tests/llm/test_provider_compliance.py`` fixiert das Verhalten.
 """
 
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from app.llm.providers.base import ProviderAdapter, ProviderCapabilities
 from ...utils.logger import get_logger
 
 logger = get_logger("agora.llm_client")
+
+
+# ----------------------------------------------------------------------
+# Rolle 1: Native /api/chat-Schema-Pfad (main, #582)
+# ----------------------------------------------------------------------
 
 
 def _flatten_pydantic_schema_for_ollama(model_cls: type[BaseModel]) -> Dict[str, Any]:
@@ -121,3 +134,50 @@ def chat_with_schema(
             f"Ollama /api/chat unexpected message.content type: {type(content)}"
         )
     return content
+
+
+# ----------------------------------------------------------------------
+# Rolle 2: Provider-Adapter (#590)
+# ----------------------------------------------------------------------
+
+
+def build_ollama_extra_body(*, num_ctx: Optional[int], think: bool) -> Dict[str, Any]:
+    """Baut den Ollama-``extra_body``-Block (``options.num_ctx`` + ``think``).
+
+    Verhalten 1:1 aus ``LLMClient.chat()`` uebernommen: ``options`` nur bei
+    truthy ``num_ctx``; ``think`` wird immer gesetzt.
+    """
+    body: Dict[str, Any] = {}
+    if num_ctx:
+        body["options"] = {"num_ctx": num_ctx}
+    body["think"] = think
+    return body
+
+
+class OllamaAdapter(ProviderAdapter):
+    """Adapter fuer lokales Ollama (:11434) und Ollama Cloud (ollama.com).
+
+    Provider-Quirks, die dieser Adapter kapselt:
+
+    - ``extra_body["options"]["num_ctx"]`` verhindert Prompt-Truncation; nur
+      Ollama versteht den Block (OpenAI/Anthropic/Mistral antworten 400
+      "Unknown parameter").
+    - ``extra_body["think"]`` steuert Reasoning-Output auf faehigen Modellen.
+    - Force-Streaming-Workaround: Der OpenAI-kompatible Endpoint in Ollama
+      0.21.0 haengt bei non-streaming Completions fuer Cloud-Modelle; der
+      ``LLMClient`` erzwingt deshalb Streaming (``LLM_FORCE_STREAM``,
+      Default an) und reassembliert die Chunks.
+    - Nativer ``/api/chat``-Schema-Pfad (``format=<schema>``) fuer striktes
+      JSON — siehe :func:`chat_with_schema` oben.
+    """
+
+    name = "ollama"
+    capabilities = ProviderCapabilities(
+        supports_native_tools=True,
+        supports_json_object_mode=True,
+        supports_json_schema_mode=True,
+        uses_ollama_native_options=True,
+    )
+
+    def build_extra_body(self) -> Optional[Dict[str, Any]]:
+        return build_ollama_extra_body(num_ctx=self.num_ctx, think=self.think)

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -1,13 +1,33 @@
 """
-OpenAI-specific request quirks: token-limit-key naming
-(``max_tokens`` vs. ``max_completion_tokens``) and 400-response detection.
+OpenAI-spezifische Request-Quirks + OpenAI-Adapter (Issue #590).
 
-Extracted verbatim from ``LLMClient`` staticmethods in
-``app/utils/llm_client.py`` as part of issue #582 (mechanical split — no
-behavior change).
+Zwei Rollen koexistieren in diesem Modul, klar getrennt:
+
+1. Token-Key-Quirks (main, #582): ``uses_max_completion_tokens``,
+   ``is_token_key_400`` und ``swap_token_kwargs`` — extrahiert aus dem
+   ehemaligen ``LLMClient``-Monolith, werden als ``LLMClient``-staticmethods
+   re-exportiert und von ``app/llm/tool_calls.py`` sowie dem Shim
+   ``app/utils/llm_client.py`` konsumiert. Unangetastet bei der
+   #590-Portierung (nur Docstring-Kommentar zur Divergenz).
+2. Provider-Adapter (PR-Vorlage, #590): :class:`OpenAIAdapter` — kapselt
+   das Payload-Shaping fuer den OpenAI-kompatiblen Client-Pfad.
+   ``completion_token_param`` delegiert an :func:`uses_max_completion_tokens`
+   (single source of truth — kein Drift zwischen Payload-Shaping und
+   Fallback-Heuristik).
 """
 
 from typing import Any, Dict, Optional
+
+from app.llm.providers.base import (
+    CompletionTokenParam,
+    ProviderAdapter,
+    ProviderCapabilities,
+)
+
+
+# ----------------------------------------------------------------------
+# Rolle 1: Token-Key-Quirks (main, #582)
+# ----------------------------------------------------------------------
 
 
 def uses_max_completion_tokens(model: str) -> bool:
@@ -19,6 +39,11 @@ def uses_max_completion_tokens(model: str) -> bool:
     Single Source of Truth bleibt dort, hier nur die zweite Stelle.
     Striktes Prefix-Matching ("gpt-5", "gpt-5-…") verhindert
     Mismatches wie hypothetisches "gpt-500".
+
+    Bekannte, testfixierte Divergenz: ``scripts/_sim_common.py::
+    uses_max_completion_tokens`` matcht ``gpt-5`` per ``startswith`` (ohne
+    Wortgrenze) und kennt keine ``.``-Grenze fuer o1/o3/o4 — Vereinheitlichung
+    ist ein Follow-up, kein Teil dieses Refactorings.
     """
     lowered = (model or "").strip().lower()
     for prefix in ("gpt-5", "o1", "o3", "o4"):
@@ -31,8 +56,8 @@ def is_token_key_400(exc: Exception) -> bool:
     """True wenn ein OpenAI-/Proxy-400 auf eine Token-Limit-Key-Inkompatibilität hindeutet.
 
     Erkennt beide Richtungen, je nachdem welcher Schlüssel im Request stand:
-    - „'max_tokens' is not supported with this model. Use 'max_completion_tokens'"
-    - „'max_completion_tokens' is not supported …" / Unsupported parameter
+    - "'max_tokens' is not supported with this model. Use 'max_completion_tokens'"
+    - "'max_completion_tokens' is not supported …" / Unsupported parameter
 
     Wird von ``chat()`` als Fallback-Retry-Trigger genutzt — Heuristik
     kann z. B. bei einem neuen OpenAI-kompatiblen Proxy daneben liegen,
@@ -77,3 +102,38 @@ def swap_token_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         swapped["max_tokens"] = value
         return swapped
     return None
+
+
+# ----------------------------------------------------------------------
+# Rolle 2: Provider-Adapter (#590)
+# ----------------------------------------------------------------------
+
+
+class OpenAIAdapter(ProviderAdapter):
+    """Adapter fuer OpenAI und OpenAI-kompatible Gateways (Default-Adapter).
+
+    Provider-Quirks, die dieser Adapter kapselt:
+
+    - ``max_completion_tokens``-Heuristik: Die GPT-5-Familie und die
+      Reasoning-Modelle o1/o3/o4 haben ``max_tokens`` deprecated und antworten
+      400 "Unsupported parameter: 'max_tokens' …". Aeltere Modelle (gpt-4o,
+      gpt-4-turbo, gpt-3.5-turbo) und alle Nicht-OpenAI-Backends verlangen
+      weiterhin ``max_tokens``.
+    - Strict-JSON-Schema (``response_format={"type": "json_schema", …}``) wird
+      unterstuetzt; das Laufzeit-Fallback strict -> json_object -> Freitext
+      orchestriert weiterhin der ``LLMClient``.
+    """
+
+    name = "openai"
+    capabilities = ProviderCapabilities(
+        supports_native_tools=True,
+        supports_json_object_mode=True,
+        supports_json_schema_mode=True,
+    )
+
+    def completion_token_param(self, model: str) -> CompletionTokenParam:
+        return (
+            "max_completion_tokens"
+            if uses_max_completion_tokens(model)
+            else "max_tokens"
+        )

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -1,0 +1,198 @@
+"""Zentrale Provider-Erkennung — Single Source of Truth (Issue #591).
+
+Vorher existierten zwei unabhängige Detection-Heuristiken:
+
+1. ``LLMClient._detect_provider`` (``app/llm/providers/base.py``) — für den
+   OpenAI-kompatiblen HTTP-Client des Backends.
+2. ``detect_oasis_platform`` (``backend/scripts/_sim_common.py``) — für das
+   CAMEL-``ModelPlatformType``-Dispatching der OASIS-Subprozesse.
+
+Beide Verhalten sind durch bestehende Tests festgeschrieben
+(``tests/utils/test_llm_client_publishes_model_active.py`` bzw.
+``tests/scripts/test_oasis_provider_dispatch.py``) und divergieren bewusst —
+deshalb leben hier BEIDE Pfade hinter EINER Funktion mit explizitem
+``mode``-Parameter statt einer (verhaltensändernden) Zusammenführung.
+
+Dokumentierte Divergenzen zwischen ``mode="http"`` und ``mode="oasis"``:
+
+================  =========================  ============================
+Aspekt            http (Backend-HTTP-Client)  oasis (CAMEL-Dispatch)
+================  =========================  ============================
+Priorität         Base-URL zuerst             ``gemini-``-Modell-Prefix
+                  (ollama.com → :cloud →      zuerst, dann Ollama-Signale,
+                  11434 → openai → google)    Default OpenAI
+Gemini-Erkennung  nur über Base-URL           Base-URL ODER Modell-Prefix
+                  (googleapis/generativelang) ``gemini-`` (Gemini-3 braucht
+                                              ``thought_signature``-Echo,
+                                              das der OpenAI-Compat-Pfad
+                                              wegstrippt)
+Ollama-Port       Substring ``"11434"``       Regex ``:11434(?:/|$)``
+                  (matcht auch ``:114340``)   (nur exakter Port)
+``:latest``-Tag   kein Signal                 → ``"ollama"``
+Fallback          ``"unknown"``               ``"openai"`` (Compat-Gateways)
+Vokabular         ollama/cloud/openai/        google/ollama/openai
+                  google/unknown              (cloud+lokal ⇒ ``"ollama"``)
+================  =========================  ============================
+
+Hybrid-Beispiel: ``gemini-2.5-pro`` @ ``http://localhost:11434`` ergibt
+``http → "ollama"``, aber ``oasis → "google"`` — der OASIS-Pfad MUSS die
+native Gemini-API nutzen (Tool-Turns schlagen sonst mit HTTP 400 fehl),
+während der HTTP-Client weiterhin den lokalen Ollama-Proxy anspricht.
+
+Hinweis: Diese Datei ist im Zuge von #591 auf den main-Split (``8b552b4``)
+portiert worden; der Adapter-Lookup (``get_adapter``) folgt mit #590.
+"""
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Literal, Optional, Union, overload
+
+if TYPE_CHECKING:
+    from app.llm.providers.base import ProviderAdapter
+
+# Teilmengen von app.contracts.provider_types.ProviderType
+HttpDetectedProvider = Literal["ollama", "cloud", "openai", "google", "unknown"]
+OasisDetectedProvider = Literal["google", "ollama", "openai"]
+DetectionMode = Literal["http", "oasis"]
+
+# Exakter Ollama-Port (nur ":11434" gefolgt von "/" oder Stringende) —
+# Verhalten aus scripts/_sim_common.py uebernommen.
+_OASIS_OLLAMA_PORT_RE = re.compile(r":11434(?:/|$)")
+
+
+def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedProvider:
+    """Heuristik des Backend-HTTP-Clients (vormals ``LLMClient._detect_provider``).
+
+    Prioritäten:
+    1. Base URL enthält ``ollama.com`` → ``"cloud"`` (Ollama Cloud proxy).
+    2. Modell-Suffix ``:cloud`` → ``"cloud"`` (Cloud-Modelle laufen auch über
+       den lokalen ollama-Proxy auf :11434 — deshalb VOR der Port-Heuristik).
+    3. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
+    4. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
+    5. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
+       ``"google"`` (Gemini-OpenAI-Compat-Layer mit nativem ``tools=``).
+    6. Fallback → ``"unknown"``.
+    """
+    model_name = model or ""
+    base = (base_url or "").lower()
+    if "ollama.com" in base:
+        return "cloud"
+    if model_name.endswith(":cloud"):
+        return "cloud"
+    if "11434" in base:
+        return "ollama"
+    if "openai.com" in base or "api.openai" in base:
+        return "openai"
+    if "googleapis.com" in base or "generativelanguage" in base:
+        return "google"
+    return "unknown"
+
+
+def _detect_oasis(base_url: Optional[str], model: Optional[str]) -> OasisDetectedProvider:
+    """Heuristik des OASIS-/CAMEL-Dispatches (vormals ``detect_oasis_platform``).
+
+    Prioritäten (first match wins):
+    1. ``"google"`` — Base-URL enthält ``generativelanguage.googleapis.com``
+       ODER Modell beginnt mit ``gemini-``. Gemini-3 verlangt ein
+       ``thought_signature``-Echo in Multi-Turn-Tool-Calls; der
+       OpenAI-Compat-Pfad strippt das Feld → HTTP 400 bei jedem Tool-Turn.
+    2. ``"ollama"`` — Base-URL enthält ``ollama.com`` oder Port ``:11434``
+       ODER Modell endet auf ``:cloud`` / ``:latest``. Ollama Cloud bietet
+       keinen OpenAI-Compat-``/v1``-Endpoint mehr; nur ``/api/chat`` (nativ).
+    3. ``"openai"`` — alles andere (echtes OpenAI, Compat-Gateways, Qwen
+       Cloud über Nicht-Ollama-URLs, Mistral, DeepSeek, …).
+    """
+    url = base_url or ""
+    m = model or ""
+
+    if "generativelanguage.googleapis.com" in url or m.startswith("gemini-"):
+        return "google"
+
+    if (
+        "ollama.com" in url
+        or _OASIS_OLLAMA_PORT_RE.search(url)
+        or m.endswith(":cloud")
+        or m.endswith(":latest")
+    ):
+        return "ollama"
+
+    return "openai"
+
+
+@overload
+def detect_provider(
+    base_url: Optional[str],
+    model: Optional[str],
+    *,
+    mode: Literal["http"] = "http",
+) -> HttpDetectedProvider: ...
+
+
+@overload
+def detect_provider(
+    base_url: Optional[str],
+    model: Optional[str],
+    *,
+    mode: Literal["oasis"],
+) -> OasisDetectedProvider: ...
+
+
+def detect_provider(
+    base_url: Optional[str],
+    model: Optional[str],
+    *,
+    mode: DetectionMode = "http",
+) -> Union[HttpDetectedProvider, OasisDetectedProvider]:
+    """Erkennt den LLM-Provider aus Base-URL + Modellname.
+
+    ``mode="http"``  — Vokabular ``ollama|cloud|openai|google|unknown``;
+    nutzt der OpenAI-kompatible Backend-HTTP-Client (``LLMClient``).
+
+    ``mode="oasis"`` — Vokabular ``google|ollama|openai``; nutzt das
+    CAMEL-``ModelPlatformType``-Dispatching der Simulations-Skripte.
+
+    Beide Modi sind testfixiert und absichtlich getrennt — Divergenzen
+    siehe Modul-Docstring.
+    """
+    if mode == "http":
+        return _detect_http(base_url, model)
+    return _detect_oasis(base_url, model)
+
+
+def get_adapter(
+    provider: str, *, num_ctx: Optional[int] = None, think: bool = False
+) -> "ProviderAdapter":
+    """Liefert den passenden :class:`ProviderAdapter` fuer einen Provider-String.
+
+    Mappt das Vokabular beider Detection-Modi (``http``: ollama/cloud/openai/
+    google/unknown; ``oasis``: google/ollama/openai) auf die konkreten
+    Adapter-Klassen:
+
+    - ``ollama``, ``cloud`` und ``ollama_cloud`` ->
+      :class:`~app.llm.providers.ollama.OllamaAdapter` (Ollama Cloud nutzt
+      denselben Adapter wie lokales Ollama).
+    - ``google`` -> :class:`~app.llm.providers.gemini.GeminiAdapter`.
+    - ``openai`` und ``unknown`` (Default) ->
+      :class:`~app.llm.providers.openai.OpenAIAdapter`.
+
+    Adapter-Importe sind bewusst lazy (innerhalb der Funktion), um einen
+    Import-Zyklus zu vermeiden: ``base`` importiert ``registry`` (fuer
+    ``detect_provider``), die Adapter importieren ``base`` (fuer
+    ``ProviderAdapter``). Zur Laufzeit wird der Zyklus erst aufgeloest, wenn
+    ``get_adapter`` tatsächlich gerufen wird.
+
+    KEIN ``'gemini'``-String-Literal — die Detection liefert ``"google"``
+    fuer Gemini-Modelle; das ``gemini``-Literal-Gate
+    (``test_no_gemini_literals_in_code``) bleibt unangetastet.
+    """
+    if provider in ("ollama", "cloud", "ollama_cloud"):
+        from app.llm.providers.ollama import OllamaAdapter
+
+        return OllamaAdapter(num_ctx=num_ctx, think=think)
+    if provider == "google":
+        from app.llm.providers.gemini import GeminiAdapter
+
+        return GeminiAdapter(num_ctx=num_ctx, think=think)
+    from app.llm.providers.openai import OpenAIAdapter
+
+    return OpenAIAdapter(num_ctx=num_ctx, think=think)

--- a/backend/app/llm/retry.py
+++ b/backend/app/llm/retry.py
@@ -1,0 +1,12 @@
+"""Gemeinsamer Retry-/Timeout-Layer der LLM-Runtime (Issue #590).
+
+Re-Export von :func:`app.utils.retry.llm_call_with_retry` — die eine
+Retry-Implementierung fuer alle Provider-Adapter und den ``LLMClient``.
+Exponentielles Backoff mit Jitter; transient sind Verbindungsabbrueche,
+Timeouts, HTTP 429 sowie 5xx/408 (siehe ``_is_transient_llm_error``).
+"""
+from __future__ import annotations
+
+from app.utils.retry import llm_call_with_retry
+
+__all__ = ["llm_call_with_retry"]

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -20,38 +20,34 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 def detect_oasis_platform(model: str, base_url: str) -> ModelPlatformType:
     """Map model-name + base-url to the correct CAMEL ModelPlatformType.
 
-    Detection order (first match wins):
+    Delegiert die Detection an ``app.llm.providers.registry.detect_provider``
+    (``mode="oasis"``, Single Source of Truth seit #591) und mappt das
+    Vokabular ``google|ollama|openai`` auf ``ModelPlatformType``. Die
+    Heuristik-Logik lebt jetzt in der Registry, damit HTTP-Client
+    (``app/llm/providers/base.py``) und OASIS-Subprozess dieselbe Quelle
+    nutzen; die bewussten Divergenzen zwischen beiden Modi sind in
+    ``registry.py`` tabellarisch dokumentiert.
 
-    1. GEMINI — base_url contains ``generativelanguage.googleapis.com`` OR
-       model starts with ``gemini-``.  Gemini-3 requires a ``thought_signature``
-       echo in multi-turn tool calls; the OpenAI-compat wire path strips that
-       field and the API rejects every tool turn with HTTP 400.
-    2. OLLAMA — base_url contains ``ollama.com`` or ``:11434``  OR  model ends
-       with ``:cloud`` or ``:latest``.  Ollama Cloud no longer offers an
-       OpenAI-compat ``/v1`` endpoint; only the native ``/api/chat`` path works.
-       CAMEL's ``OllamaModel`` speaks the native protocol.
-    3. OPENAI — everything else (real OpenAI, Anthropic compat gateways, Qwen
-       Cloud via non-Ollama URLs, Mistral, DeepSeek, …).
+    Bedeutung der Zweige (first match wins, siehe ``registry._detect_oasis``):
+
+    1. GEMINI — base_url enthält ``generativelanguage.googleapis.com`` ODER
+       Modell beginnt mit ``gemini-``.  Gemini-3 braucht ein
+       ``thought_signature``-Echo in Multi-Turn-Tool-Calls; der
+       OpenAI-Compat-Wire-Pfad strippt das Feld → HTTP 400 pro Tool-Turn.
+    2. OLLAMA — base_url enthält ``ollama.com`` oder ``:11434`` ODER Modell
+       endet auf ``:cloud`` / ``:latest``.  Ollama Cloud hat keinen
+       OpenAI-Compat-``/v1``-Endpoint mehr; nur nativ ``/api/chat``.
+    3. OPENAI — Default / Compat-Gateway.
     """
     from camel.types import ModelPlatformType  # type: ignore[import]
 
-    url = base_url or ""
-    m = model or ""
+    from app.llm.providers.registry import detect_provider as _detect
 
-    # --- 1. Gemini ---
-    if "generativelanguage.googleapis.com" in url or m.startswith("gemini-"):
+    detected = _detect(base_url, model, mode="oasis")
+    if detected == "google":
         return ModelPlatformType.GEMINI
-
-    # --- 2. Ollama ---
-    if (
-        "ollama.com" in url
-        or re.search(r":11434(?:/|$)", url)
-        or m.endswith(":cloud")
-        or m.endswith(":latest")
-    ):
+    if detected == "ollama":
         return ModelPlatformType.OLLAMA
-
-    # --- 3. OpenAI (default / compat gateway) ---
     return ModelPlatformType.OPENAI
 
 

--- a/backend/tests/llm/test_provider_compliance.py
+++ b/backend/tests/llm/test_provider_compliance.py
@@ -14,7 +14,7 @@ import httpx
 import openai
 import pytest
 
-from app.contracts.llm_request import ChatMessage, NormalizedLlmRequest
+from app.contracts.llm_request import ChatMessage, NormalizedLlmRequest, ResponseFormat
 from app.llm.errors import LlmProviderError, normalize_provider_error
 from app.llm.providers.base import ProviderAdapter
 from app.llm.providers.gemini import GeminiAdapter
@@ -307,18 +307,16 @@ def test_wire_response_format_json_schema_branch() -> None:
     assert kwargs["response_format"] == {"type": "json_schema", "json_schema": schema}
 
 
-def test_wire_response_format_json_schema_without_schema_falls_back_to_type_only() -> None:
-    """json_schema ohne schema-Objekt fällt auf {"type": "json_schema"} zurück.
+def test_response_format_json_schema_without_schema_rejected_at_contract() -> None:
+    """type="json_schema" OHNE schema-Objekt wird am Contract abgelehnt (fail-fast).
 
-    Edge-Case: ResponseFormat(type="json_schema", json_schema=None) — der
-    ``and response_format.json_schema is not None``-Guard verhindert, dass ein
-    None-Wert als "json_schema": None ins Wire-Format gelangt.
+    Sonst lehnt OpenAI zur Laufzeit mit HTTP 400 ab. Der model_validator auf
+    ResponseFormat fängt den Konfigurationsfehler früh ab (Gemini-Finding).
     """
-    adapter = OpenAIAdapter()
-    req = _request(response_format={"type": "json_schema", "json_schema": None})
-    kwargs = adapter.prepare_request_kwargs(req)
+    from pydantic import ValidationError
 
-    assert kwargs["response_format"] == {"type": "json_schema"}
+    with pytest.raises(ValidationError):
+        ResponseFormat(type="json_schema", json_schema=None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/llm/test_provider_compliance.py
+++ b/backend/tests/llm/test_provider_compliance.py
@@ -1,0 +1,345 @@
+"""Provider-Compliance-Suite (Issue #590).
+
+Jeder Adapter (Ollama, OpenAI, Gemini) durchlaeuft DIESELBEN Szenarien
+gegen einen gemockten OpenAI-kompatiblen Client: Success, 4xx, 5xx,
+Network-Drop, Timeout, Rate-Limit und Streaming. Dazu kommen die
+provider-spezifischen Payload-Assertions (Token-Limit-Key, extra_body).
+"""
+from __future__ import annotations
+
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import httpx
+import openai
+import pytest
+
+from app.contracts.llm_request import ChatMessage, NormalizedLlmRequest
+from app.llm.errors import LlmProviderError, normalize_provider_error
+from app.llm.providers.base import ProviderAdapter
+from app.llm.providers.gemini import GeminiAdapter
+from app.llm.providers.ollama import OllamaAdapter, build_ollama_extra_body
+from app.llm.providers.openai import OpenAIAdapter, uses_max_completion_tokens
+from app.llm.providers.registry import get_adapter
+
+# ---------------------------------------------------------------------------
+# Fixtures / Helpers
+# ---------------------------------------------------------------------------
+
+ADAPTER_FACTORIES = {
+    "ollama": lambda: OllamaAdapter(num_ctx=8192, think=False),
+    "openai": lambda: OpenAIAdapter(),
+    "google": lambda: GeminiAdapter(),
+}
+
+
+@pytest.fixture(params=sorted(ADAPTER_FACTORIES))
+def adapter(request: pytest.FixtureRequest) -> ProviderAdapter:
+    return ADAPTER_FACTORIES[request.param]()
+
+
+def _request(model: str = "test-model", **overrides: Any) -> NormalizedLlmRequest:
+    payload: dict[str, Any] = {
+        "provider": "unknown",
+        "model": model,
+        "messages": [ChatMessage(role="user", content="hallo")],
+        "temperature": 0.5,
+        "max_tokens": 256,
+    }
+    payload.update(overrides)
+    return NormalizedLlmRequest(**payload)
+
+
+def _mock_client(response: Any = None, side_effect: Any = None) -> MagicMock:
+    client = MagicMock()
+    if side_effect is not None:
+        client.chat.completions.create.side_effect = side_effect
+    else:
+        client.chat.completions.create.return_value = response
+    return client
+
+
+def _completion_response(content: str) -> MagicMock:
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+def _stream_chunks(*texts: str) -> List[MagicMock]:
+    chunks = []
+    for text in texts:
+        delta = MagicMock()
+        delta.content = text
+        choice = MagicMock()
+        choice.delta = delta
+        chunk = MagicMock()
+        chunk.choices = [choice]
+        chunks.append(chunk)
+    return chunks
+
+
+def _http_request() -> httpx.Request:
+    return httpx.Request("POST", "https://llm.test/v1/chat/completions")
+
+
+def _status_error(status: int) -> openai.APIStatusError:
+    response = httpx.Response(status, request=_http_request())
+    if status == 429:
+        return openai.RateLimitError("rate limited", response=response, body=None)
+    return openai.APIStatusError(f"http {status}", response=response, body=None)
+
+
+# ---------------------------------------------------------------------------
+# Szenario 1: Success (complete)
+# ---------------------------------------------------------------------------
+
+
+def test_complete_success_returns_content(adapter: ProviderAdapter) -> None:
+    client = _mock_client(response=_completion_response("antwort"))
+
+    result = adapter.complete(client, _request())
+
+    assert result == "antwort"
+    client.chat.completions.create.assert_called_once()
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "test-model"
+    assert kwargs["messages"] == [{"role": "user", "content": "hallo"}]
+    assert kwargs["temperature"] == 0.5
+
+
+def test_complete_empty_choices_returns_empty_string(adapter: ProviderAdapter) -> None:
+    response = MagicMock()
+    response.choices = []
+    client = _mock_client(response=response)
+
+    assert adapter.complete(client, _request()) == ""
+
+
+# ---------------------------------------------------------------------------
+# Szenario 2: 4xx — sofortiger Fehler, nicht retryable
+# ---------------------------------------------------------------------------
+
+
+def test_complete_4xx_raises_normalized_error(adapter: ProviderAdapter) -> None:
+    client = _mock_client(side_effect=_status_error(400))
+
+    with pytest.raises(LlmProviderError) as excinfo:
+        adapter.complete(client, _request())
+
+    normalized = excinfo.value.normalized
+    assert normalized.provider == adapter.name
+    assert normalized.code == "client_error"
+    assert normalized.status == 400
+    assert normalized.retryable is False
+    assert isinstance(excinfo.value.__cause__, openai.APIStatusError)
+    # 4xx ist nicht transient — genau EIN Versuch, kein Retry.
+    assert client.chat.completions.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Szenarien 3-6: Fehler-Normalisierung (5xx, Network-Drop, Timeout, 429)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exc_factory", "expected_code", "expected_status", "expected_retryable"),
+    [
+        (lambda: _status_error(500), "server_error", 500, True),
+        (lambda: _status_error(503), "server_error", 503, True),
+        (lambda: _status_error(408), "client_error", 408, True),
+        (lambda: _status_error(429), "rate_limited", 429, True),
+        (lambda: _status_error(401), "client_error", 401, False),
+        (lambda: _status_error(422), "client_error", 422, False),
+        (lambda: openai.APITimeoutError(request=_http_request()), "timeout", None, True),
+        (
+            lambda: openai.APIConnectionError(request=_http_request()),
+            "connection_error",
+            None,
+            True,
+        ),
+        (lambda: httpx.ReadTimeout("read timeout"), "timeout", None, True),
+        (lambda: httpx.ConnectError("connection refused"), "connection_error", None, True),
+        (lambda: ValueError("kaputt"), "unknown", None, False),
+    ],
+)
+def test_normalize_error_mapping(
+    adapter: ProviderAdapter,
+    exc_factory: Any,
+    expected_code: str,
+    expected_status: Any,
+    expected_retryable: bool,
+) -> None:
+    normalized = adapter.normalize_error(exc_factory())
+
+    assert normalized.provider == adapter.name
+    assert normalized.code == expected_code
+    assert normalized.status == expected_status
+    assert normalized.retryable is expected_retryable
+    assert normalized.cause is not None
+
+
+def test_normalize_provider_error_is_provider_agnostic() -> None:
+    normalized = normalize_provider_error(_status_error(500), provider="google")
+    assert normalized.provider == "google"
+    assert normalized.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Szenario 7: Streaming — Tokens + done; Fehler als error-Chunk
+# ---------------------------------------------------------------------------
+
+
+def test_stream_success_yields_tokens_then_done(adapter: ProviderAdapter) -> None:
+    client = _mock_client(response=iter(_stream_chunks("hal", "lo")))
+
+    chunks = list(adapter.stream(client, _request()))
+
+    assert [c.type for c in chunks] == ["token", "token", "done"]
+    assert "".join(c.text or "" for c in chunks) == "hallo"
+    assert client.chat.completions.create.call_args.kwargs["stream"] is True
+
+
+def test_stream_error_yields_error_chunk(adapter: ProviderAdapter) -> None:
+    client = _mock_client(side_effect=_status_error(400))
+
+    chunks = list(adapter.stream(client, _request()))
+
+    assert len(chunks) == 1
+    assert chunks[0].type == "error"
+    assert chunks[0].error is not None
+    assert chunks[0].error.provider == adapter.name
+    assert chunks[0].error.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Provider-spezifisches Payload-Shaping
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_adapter_sets_extra_body() -> None:
+    adapter = OllamaAdapter(num_ctx=8192, think=False)
+    kwargs = adapter.prepare_request_kwargs(_request())
+
+    assert kwargs["extra_body"] == {"options": {"num_ctx": 8192}, "think": False}
+    assert kwargs["max_tokens"] == 256
+
+
+def test_ollama_extra_body_without_num_ctx_keeps_think_only() -> None:
+    assert build_ollama_extra_body(num_ctx=None, think=True) == {"think": True}
+    assert build_ollama_extra_body(num_ctx=0, think=False) == {"think": False}
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_key"),
+    [
+        ("gpt-5-nano", "max_completion_tokens"),
+        ("gpt-5", "max_completion_tokens"),
+        ("o1-preview", "max_completion_tokens"),
+        ("o3", "max_completion_tokens"),
+        ("o4.1", "max_completion_tokens"),
+        ("gpt-4o", "max_tokens"),
+        ("gpt-500", "max_tokens"),  # striktes Prefix-Matching
+        ("qwen3:8b", "max_tokens"),
+    ],
+)
+def test_openai_adapter_token_param_heuristic(model: str, expected_key: str) -> None:
+    adapter = OpenAIAdapter()
+    kwargs = adapter.prepare_request_kwargs(_request(model=model))
+
+    assert expected_key in kwargs
+    assert "extra_body" not in kwargs
+
+
+def test_uses_max_completion_tokens_matches_client_heuristic() -> None:
+    # Spiegel der testfixierten LLMClient-Semantik (Wortgrenze -, ., exakt).
+    assert uses_max_completion_tokens("gpt-5") is True
+    assert uses_max_completion_tokens("gpt-5-mini") is True
+    assert uses_max_completion_tokens("o1.5-turbo") is True
+    assert uses_max_completion_tokens("gpt-500") is False
+    assert uses_max_completion_tokens("oasis-model") is False
+    assert uses_max_completion_tokens("") is False
+
+
+def test_gemini_adapter_plain_openai_wire_format() -> None:
+    adapter = GeminiAdapter()
+    kwargs = adapter.prepare_request_kwargs(_request(model="gemini-3-flash-preview"))
+
+    assert "extra_body" not in kwargs
+    assert kwargs["max_tokens"] == 256
+
+
+def test_response_format_and_tools_wire_format() -> None:
+    adapter = OpenAIAdapter()
+    req = _request(
+        response_format={"type": "json_object"},
+        tools=[{"name": "quick_search", "description": "s", "parameters": {}}],
+    )
+    kwargs = adapter.prepare_request_kwargs(req)
+
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {"name": "quick_search", "description": "s", "parameters": {}},
+        }
+    ]
+
+
+def test_wire_response_format_json_schema_branch() -> None:
+    """json_schema-Branch von wire_response_format (base.py:63-64).
+
+    Striktes JSON-Schema muss als {"type": "json_schema", "json_schema": <schema>}
+    durchgereicht werden — der Laufzeit-Fallback strict -> json_object -> text
+    orchestriert weiterhin der LLMClient, aber das Payload-Shaping passiert hier.
+    """
+    adapter = OpenAIAdapter()
+    schema: dict[str, object] = {
+        "name": "report",
+        "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+    }
+    req = _request(response_format={"type": "json_schema", "json_schema": schema})
+    kwargs = adapter.prepare_request_kwargs(req)
+
+    assert kwargs["response_format"] == {"type": "json_schema", "json_schema": schema}
+
+
+def test_wire_response_format_json_schema_without_schema_falls_back_to_type_only() -> None:
+    """json_schema ohne schema-Objekt fällt auf {"type": "json_schema"} zurück.
+
+    Edge-Case: ResponseFormat(type="json_schema", json_schema=None) — der
+    ``and response_format.json_schema is not None``-Guard verhindert, dass ein
+    None-Wert als "json_schema": None ins Wire-Format gelangt.
+    """
+    adapter = OpenAIAdapter()
+    req = _request(response_format={"type": "json_schema", "json_schema": None})
+    kwargs = adapter.prepare_request_kwargs(req)
+
+    assert kwargs["response_format"] == {"type": "json_schema"}
+
+
+# ---------------------------------------------------------------------------
+# Registry → Adapter-Aufloesung
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_cls"),
+    [
+        ("ollama", OllamaAdapter),
+        ("cloud", OllamaAdapter),
+        ("ollama_cloud", OllamaAdapter),
+        ("google", GeminiAdapter),
+        ("openai", OpenAIAdapter),
+        ("openai_compatible", OpenAIAdapter),
+        ("unknown", OpenAIAdapter),  # OpenAI-Wire-Format als Default
+    ],
+)
+def test_get_adapter_resolution(provider: str, expected_cls: type) -> None:
+    resolved = get_adapter(provider, num_ctx=4096, think=True)
+    assert isinstance(resolved, expected_cls)
+    assert resolved.num_ctx == 4096
+    assert resolved.think is True

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -1,0 +1,103 @@
+"""Tests fuer die zentrale Provider-Erkennung (Issue #591).
+
+Parametrisierte Kombos ueber Modellname/Base-URL fuer beide Detection-Modi
+(``http`` = Backend-HTTP-Client, ``oasis`` = CAMEL-Dispatch) inklusive der
+Hybrid-Edge-Cases, in denen die beiden testfixierten Heuristiken bewusst
+divergieren.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.llm.providers.registry import detect_provider
+
+# ---------------------------------------------------------------------------
+# mode="http" — Verhalten von LLMClient._detect_provider (testfixiert in
+# tests/utils/test_llm_client_publishes_model_active.py)
+# ---------------------------------------------------------------------------
+
+HTTP_CASES = [
+    # (base_url, model, expected)
+    ("http://localhost:11434/v1", "qwen2.5:32b", "ollama"),
+    ("http://127.0.0.1:11434/v1", "qwen3:8b", "ollama"),
+    ("http://localhost:11434/v1", "qwen3-coder-next:cloud", "cloud"),  # Suffix vor Port
+    ("https://ollama.com/v1", "qwen3-coder-next:cloud", "cloud"),
+    ("https://ollama.com/v1", "gemini-2.5-pro", "cloud"),  # Hybrid: Base-URL gewinnt
+    ("https://api.openai.com/v1", "gpt-4", "openai"),
+    ("https://api.openai.com/v1", "gpt-5-nano", "openai"),
+    (
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "gemini-3-flash-preview",
+        "google",
+    ),
+    ("http://localhost:11434", "gemini-2.5-pro", "ollama"),  # Hybrid: Port gewinnt
+    ("http://some-other-host:8080/v1", "some-model", "unknown"),
+    ("", "", "unknown"),
+    (None, None, "unknown"),
+    ("http://host:114340/v1", "foo", "ollama"),  # Substring-Match (dokumentierte Eigenheit)
+]
+
+
+@pytest.mark.parametrize(("base_url", "model", "expected"), HTTP_CASES)
+def test_detect_provider_http(base_url, model, expected):
+    assert detect_provider(base_url, model, mode="http") == expected
+
+
+def test_http_is_default_mode():
+    assert detect_provider("http://localhost:11434/v1", "qwen2.5:32b") == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# mode="oasis" — Verhalten von scripts/_sim_common.py::detect_oasis_platform
+# (testfixiert in tests/scripts/test_oasis_provider_dispatch.py)
+# ---------------------------------------------------------------------------
+
+OASIS_CASES = [
+    # (base_url, model, expected)
+    (
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "gemini-3-flash-preview",
+        "google",
+    ),
+    ("", "gemini-2.5-flash", "google"),  # Modell-Prefix reicht
+    ("https://api.example.com/v1", "gemini-2.0-flash-lite", "google"),
+    ("http://localhost:11434", "gemini-2.5-pro", "google"),  # Prefix schlaegt Ollama-URL
+    ("https://ollama.com/api", "llama3.2:latest", "ollama"),
+    ("https://ollama.com", "qwen3-coder-next:cloud", "ollama"),
+    ("http://localhost:11434", "qwen3:8b", "ollama"),
+    ("http://127.0.0.1:11434/v1", "qwen3:8b", "ollama"),
+    ("", "llama3:latest", "ollama"),
+    ("https://any-compat-gateway.example.com", "qwen3-coder-next:cloud", "ollama"),
+    ("https://api.openai.com/v1", "gpt-5-nano", "openai"),
+    ("", "gpt-4o-mini", "openai"),
+    ("http://host:114340/v1", "foo", "openai"),  # Regex matcht NUR exakten Port
+    (None, None, "openai"),  # Default-Fallback: OpenAI-Compat-Gateway
+]
+
+
+@pytest.mark.parametrize(("base_url", "model", "expected"), OASIS_CASES)
+def test_detect_provider_oasis(base_url, model, expected):
+    assert detect_provider(base_url, model, mode="oasis") == expected
+
+
+# ---------------------------------------------------------------------------
+# Dokumentierte Divergenzen — gleiche Inputs, unterschiedliche Modi.
+# Diese Tests schreiben die BEWUSSTE Nicht-Vereinheitlichung fest (#591):
+# beide Verhalten sind durch Bestandstests fixiert; eine stille Angleichung
+# waere eine Verhaltensaenderung.
+# ---------------------------------------------------------------------------
+
+DIVERGENT_CASES = [
+    # (base_url, model, expected_http, expected_oasis)
+    ("https://ollama.com/v1", "gemini-2.5-pro", "cloud", "google"),
+    ("http://localhost:11434", "gemini-2.5-pro", "ollama", "google"),
+    ("https://example.com/v1", "some-model", "unknown", "openai"),
+    ("", "llama3:latest", "unknown", "ollama"),  # :latest nur im OASIS-Modus ein Signal
+    ("http://host:114340/v1", "foo", "ollama", "openai"),  # Substring vs. Port-Regex
+]
+
+
+@pytest.mark.parametrize(("base_url", "model", "expected_http", "expected_oasis"), DIVERGENT_CASES)
+def test_documented_divergences(base_url, model, expected_http, expected_oasis):
+    assert detect_provider(base_url, model, mode="http") == expected_http
+    assert detect_provider(base_url, model, mode="oasis") == expected_oasis

--- a/schemas/llm-normalized-chunk.schema.json
+++ b/schemas/llm-normalized-chunk.schema.json
@@ -1,0 +1,127 @@
+{
+  "$defs": {
+    "NormalizedLlmError": {
+      "additionalProperties": false,
+      "description": "Provider-neutral klassifizierter Fehler.\n\n``retryable`` spiegelt die Retry-Semantik aus\n``app.utils.retry._is_transient_llm_error``: Verbindungsabbrueche,\nTimeouts, HTTP 429 sowie 5xx/408 sind transient; uebrige 4xx nicht.",
+      "properties": {
+        "cause": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cause"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "provider": {
+          "enum": [
+            "ollama",
+            "openai",
+            "google",
+            "anthropic",
+            "custom",
+            "ollama_cloud",
+            "openai_compatible",
+            "github_copilot",
+            "cloud",
+            "unknown"
+          ],
+          "title": "Provider",
+          "type": "string"
+        },
+        "retryable": {
+          "title": "Retryable",
+          "type": "boolean"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Status"
+        }
+      },
+      "required": [
+        "provider",
+        "code",
+        "message",
+        "retryable"
+      ],
+      "title": "NormalizedLlmError",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/llm-normalized-chunk.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Ein Element eines normalisierten Streaming-Responses.",
+  "properties": {
+    "error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/NormalizedLlmError"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "metadata": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Metadata"
+    },
+    "text": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Text"
+    },
+    "type": {
+      "enum": [
+        "token",
+        "metadata",
+        "done",
+        "error"
+      ],
+      "title": "Type",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "title": "NormalizedLlmChunk",
+  "type": "object"
+}

--- a/schemas/llm-normalized-error.schema.json
+++ b/schemas/llm-normalized-error.schema.json
@@ -1,0 +1,68 @@
+{
+  "$id": "https://alexle135.de/schemas/llm-normalized-error.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Provider-neutral klassifizierter Fehler.\n\n``retryable`` spiegelt die Retry-Semantik aus\n``app.utils.retry._is_transient_llm_error``: Verbindungsabbrueche,\nTimeouts, HTTP 429 sowie 5xx/408 sind transient; uebrige 4xx nicht.",
+  "properties": {
+    "cause": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cause"
+    },
+    "code": {
+      "title": "Code",
+      "type": "string"
+    },
+    "message": {
+      "title": "Message",
+      "type": "string"
+    },
+    "provider": {
+      "enum": [
+        "ollama",
+        "openai",
+        "google",
+        "anthropic",
+        "custom",
+        "ollama_cloud",
+        "openai_compatible",
+        "github_copilot",
+        "cloud",
+        "unknown"
+      ],
+      "title": "Provider",
+      "type": "string"
+    },
+    "retryable": {
+      "title": "Retryable",
+      "type": "boolean"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Status"
+    }
+  },
+  "required": [
+    "provider",
+    "code",
+    "message",
+    "retryable"
+  ],
+  "title": "NormalizedLlmError",
+  "type": "object"
+}

--- a/schemas/llm-normalized-request.schema.json
+++ b/schemas/llm-normalized-request.schema.json
@@ -52,7 +52,7 @@
     },
     "ResponseFormat": {
       "additionalProperties": false,
-      "description": "Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema).",
+      "description": "Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema).\n\n``type=\"json_schema\"`` verlangt zwingend ein ``json_schema``-Objekt \u2014 sonst\nlehnt OpenAI zur Laufzeit mit HTTP 400 ab (\"json_schema is required\"). Ein\nPydantic-``model_validator`` f\u00e4ngt den Konfigurationsfehler am Contract\nab (fail-fast) statt erst im API-Call (Gemini-Finding).",
       "properties": {
         "json_schema": {
           "anyOf": [

--- a/schemas/llm-normalized-request.schema.json
+++ b/schemas/llm-normalized-request.schema.json
@@ -1,0 +1,207 @@
+{
+  "$defs": {
+    "ChatMessage": {
+      "additionalProperties": false,
+      "description": "Eine Chat-Nachricht im providerneutralen Format.",
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "role": {
+          "enum": [
+            "system",
+            "user",
+            "assistant",
+            "tool"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "tool_call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Call Id"
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ],
+      "title": "ChatMessage",
+      "type": "object"
+    },
+    "ResponseFormat": {
+      "additionalProperties": false,
+      "description": "Gewuenschtes Antwortformat (Text, JSON-Objekt oder striktes Schema).",
+      "properties": {
+        "json_schema": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Json Schema"
+        },
+        "type": {
+          "enum": [
+            "text",
+            "json_object",
+            "json_schema"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "ResponseFormat",
+      "type": "object"
+    },
+    "ToolSpec": {
+      "additionalProperties": false,
+      "description": "Provider-neutrale Tool-/Function-Definition.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": true,
+          "title": "Parameters",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ToolSpec",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/llm-normalized-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Provider-neutraler Chat-Completion-Request.",
+  "properties": {
+    "max_tokens": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Tokens"
+    },
+    "messages": {
+      "items": {
+        "$ref": "#/$defs/ChatMessage"
+      },
+      "title": "Messages",
+      "type": "array"
+    },
+    "model": {
+      "title": "Model",
+      "type": "string"
+    },
+    "provider": {
+      "enum": [
+        "ollama",
+        "openai",
+        "google",
+        "anthropic",
+        "custom",
+        "ollama_cloud",
+        "openai_compatible",
+        "github_copilot",
+        "cloud",
+        "unknown"
+      ],
+      "title": "Provider",
+      "type": "string"
+    },
+    "response_format": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ResponseFormat"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "stream": {
+      "default": false,
+      "title": "Stream",
+      "type": "boolean"
+    },
+    "temperature": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Temperature"
+    },
+    "tools": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tools"
+    }
+  },
+  "required": [
+    "provider",
+    "model",
+    "messages"
+  ],
+  "title": "NormalizedLlmRequest",
+  "type": "object"
+}


### PR DESCRIPTION
Closes #590, Closes #591. #582 bereits als `8b552b4` auf main.

Auf main's #582-Split neu portiert. PR #646 wurde geschlossen, weil sein #582-Split (`1b3cbe7`, `client.py` 1267 LOC inline) architektonisch inkompatibel mit main's Split war (`8b552b4`, `factory.py`+`tool_calls.py`+`client.py` 852 LOC). Beide Branches hatten `app/llm/` unabhängig voneinander angelegt; ein Merge hätte jeden `app/llm/`-Konflikt provoziert und main's etablierte `factory.py`/`tool_calls.py`-Nutzer gebrochen.

## #590 — Provider-Adapter-Layer
- `app/contracts/llm_request.py`: `NormalizedLlmRequest`/`Chunk`/`Error` (Pydantic v2, `extra="forbid"`)
- `app/llm/errors.py`: `normalize_provider_error` (provider-neutrale Fehlerklassifikation)
- `app/llm/retry.py`: Re-Export `llm_call_with_retry`
- `app/llm/providers/{base,gemini,ollama,openai}.py`: `ProviderAdapter`-ABC + `ProviderCapabilities` + 3 Adapter (`OllamaAdapter`, `OpenAIAdapter`, `GeminiAdapter`)
- `schemas/llm-normalized-{request,chunk,error}.schema.json` (3 neue Schemas via `dump_schemas`)
- `tests/llm/test_provider_compliance.py`: 14 Szenarien je Adapter (Success, 4xx/5xx/Timeout/RateLimit, Streaming, Payload-Shaping, `json_schema`-Branch)

Rollen-Koexistenz in `openai.py`/`ollama.py`: main's #582-Helfer (token-key-quirks, `chat_with_schema`, `_flatten_pydantic_schema_for_ollama`) bleiben unangetastet (Rolle 1); die #590-Adapter sind klar per Kommentar abgetrennt (Rolle 2).

## #591 — Unified Provider Detection
- `app/llm/providers/registry.py`: `detect_provider(base_url, model, mode="http"|"oasis")` als Single Source of Truth. `mode="http"` ist byte-identisch zu main's altem `detect_provider`-Verhalten (5 Literal-Werte `ollama|cloud|openai|google|unknown`, Priorität Base-URL vor Modell). `mode="oasis"` übernimmt die CAMEL-spezifische Heuristik (gemini-prefix-first, `:latest`, Regex-Port `:11434(?:/|$)`). Divergenzen tabellarisch im Modul-Docstring dokumentiert.
- `base.py`: `detect_provider`/`is_ollama` delegieren an `registry` (Backward-Compat-Re-Exports).
- `scripts/_sim_common.py`: `detect_oasis_platform` delegiert an `registry.detect_provider(mode="oasis")`, behält CAMEL `ModelPlatformType`-Mapping. `_is_ollama_route` bewusst unangetastet (Bug → Follow-up).
- `tests/llm/test_provider_registry.py`: 27 Kombos, schreibt `http`/`oasis`-Divergenzen fest.

## Verifikation
- 211 contracts + 104 llm + 200 LLM-Client-Tests grün
- `dump_schemas --check`: 31/31 OK, `git diff --exit-code schemas/` clean
- `ruff check .` + `mypy app` clean
- CRG-Review (4 Perspektiven parallel + adversarische Verify der blocker/high-Findings): 0 Blocker, 0 Regression gegen main, 1 bestätigtes high-Finding (`json_schema`-Branch in `wire_response_format` nicht getestet) — behoben via 2 neue Tests.

## Scope-Grenze (bewusst, wie im Original-PR)
`LLMClient.chat()`-Transport delegiert **nicht** an den Adapter; nur Payload-Shaping + Detection delegieren. Transport-Migration ist ein Follow-up, nicht Teil dieses PRs.

## Follow-up-Issues (separat, Parent #571 + #591)
- `simulation_lifecycle._detect_default_provider` — verfehlt `ollama.com`-URLs + Google-Zweig
- `embedding_service._detect_provider` — eigene Shape; eigenes `detect_embedding_provider` oder bewusst separat
- `_sim_common._is_ollama_route` — `think`/`num_ctx`-Gate verfehlt `ollama.com`-URLs