### PR TITLE
docs: sync post M3-port (CHANGELOG + STATUS + PLAN/AGENTS/CLAUDE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ und [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.m
 ## Aktive Epics
 
 - **M3-Port — Unified Provider Abstraction:** ✅ abgeschlossen (PR #666, 2026-07-05).
-  Provider-Detection-SSoT: `app/llm/providers/registry.detect_provider(mode="http"|"oasis")`.
+  Provider-Detection-SSoT: `backend/app/llm/providers/registry.py::detect_provider(mode="http"|"oasis")`.
   Phase F offen — Rest-Detection-Delegation an die SSoT: #669, #670, #671
   (jeweils eigener PR, TDD).
 - **Design Language v4 — App-Shell-Port:** Integration-Branch `feat/design-v4-epic`, Slices A–E durch,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,10 +140,16 @@ und [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.m
 
 ## Aktive Epics
 
+- **M3-Port — Unified Provider Abstraction:** ✅ abgeschlossen (PR #666, 2026-07-05).
+  Provider-Detection-SSoT: `app/llm/providers/registry.detect_provider(mode="http"|"oasis")`.
+  Phase F offen — Rest-Detection-Delegation an die SSoT: #669, #670, #671
+  (jeweils eigener PR, TDD).
 - **Design Language v4 — App-Shell-Port:** Integration-Branch `feat/design-v4-epic`, Slices A–E durch,
   F läuft. Vendoriert in [`design/v3-source/`](design/v3-source/).
 - **v1.0-Output-Vertrag** ([`PLAN.md`](PLAN.md)) — offen: P3.2, P4.1, P4.3, P4.4.
 - **Observability Slice 1 — End-to-End-Tracing** (geplant, Plan abgenommen, Implementation offen).
+- **Dependency-Hardstops** ([`docs/dependency-risk-register.md`](docs/dependency-risk-register.md)):
+  `nltk` PYSEC-2026-597 + GHSA-p4gq → 2026-07-30; Trivy OS-Layer CVE-2026-24049/23949 → 2026-08-30.
 
 ## Referenz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ### Changed (refactor — 2026-07-05)
 
-- **M3-Port — Unified Provider Abstraction** (PR #666, Branch `feat/m3-port`): `#590` (unified provider abstraction) + `#591` (unified provider detection) auf dem `#582`-LLM-Client-Split neu portiert. Single Source of Truth für Provider-Detection: `app/llm/providers/registry.py::detect_provider(base_url, model, *, mode="http"|"oasis")` — Vokabular `ollama|cloud|openai|google|unknown` (HTTP) bzw. `google|ollama|openai` (OASIS). Schließt #590, #591, #582 und #636 (M3-Milestone-Tracker). Rest-Detection-Delegation als Folge-Issues #669/#670/#671 ausgelagert (Phase F).
+- **M3-Port — Unified Provider Abstraction** (PR #666, Branch `feat/m3-port`): `#590` (unified provider abstraction) + `#591` (unified provider detection) auf dem `#582`-LLM-Client-Split neu portiert. Single Source of Truth für Provider-Detection: `backend/app/llm/providers/registry.py::detect_provider(base_url, model, *, mode="http"|"oasis")` — Vokabular `ollama|cloud|openai|google|unknown` (HTTP) bzw. `google|ollama|openai` (OASIS). Schließt #590, #591, #582 und #636 (M3-Milestone-Tracker). Rest-Detection-Delegation als Folge-Issues #669/#670/#671 ausgelagert (Phase F).
 
 ### Changed (deps — 2026-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (refactor — 2026-07-05)
+
+- **M3-Port — Unified Provider Abstraction** (PR #666, Branch `feat/m3-port`): `#590` (unified provider abstraction) + `#591` (unified provider detection) auf dem `#582`-LLM-Client-Split neu portiert. Single Source of Truth für Provider-Detection: `app/llm/providers/registry.py::detect_provider(base_url, model, *, mode="http"|"oasis")` — Vokabular `ollama|cloud|openai|google|unknown` (HTTP) bzw. `google|ollama|openai` (OASIS). Schließt #590, #591, #582 und #636 (M3-Milestone-Tracker). Rest-Detection-Delegation als Folge-Issues #669/#670/#671 ausgelagert (Phase F).
+
+### Changed (deps — 2026-07-05)
+
+- **transformers v5.13.0** (PR #667): Upgrade auf v5 via `tool.uv.override-dependencies`, unblocked durch `sentence-transformers>=5.3.0`. Löst CVE-2026-4372, CVE-2026-1839 und PYSEC-2025-217. Schließt #124, #624, #662.
+
+### Security (deps — 2026-07-05)
+
+- **nltk 3.9.4 — Risk Exception** (PR #668): PYSEC-2026-597 (Path Traversal in `nltk.data.load()`) und GHSA-p4gq-832x-fm9v ohne Upstream-Fix in 3.9.x. Agora nutzt `nltk` nur transitiv (via `unstructured`/`camel-oasis`), kein direkter `nltk.data.load()`-Aufruf mit user-kontrolliertem Pfad → Risikoakzeptanz mit Allowlist-Eintrag. Tracking-Issue #672, Hardstop 2026-07-30. Source of Truth: `docs/dependency-risk-register.md`.
+
 ### Fixed (bug — 2026-06-10)
 
 - **Projekt-Meta ging beim Ontology-Upload verloren** (Regression aus dem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ Bei Schema-Drift: `dump_schemas` ohne `--check` neu rendern, in den selben PR co
 | [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md) | Dispatch-Workflow |
 | [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.md) | Layer 0–10 |
 
+## Provider-Detection-SSoT
+
+Bei Provider-Detection-Fragen („welcher Provider für diese URL/Modell",
+`ollama.com`-Handling, `think`/`num_ctx`-Gate) ist
+[`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py)
+→ `detect_provider(base_url, model, *, mode="http"|"oasis")` die Single Source
+of Truth. Keine neuen lokalen Detection-Heuristiken pflegen — bestehende werden
+dorthin delegiert (Phase F, Issues #669/#670/#671 offen).
+
 ## Token Efficiency
 - Never re-read files you just wrote or edited. You know the contents.
 - Never re-run commands to "verify" unless the outcome was uncertain.

--- a/PLAN.md
+++ b/PLAN.md
@@ -16,6 +16,7 @@
 8. [Sicherheitsregeln](#8-sicherheitsregeln)
 9. [Abgeschlossene Welle: Observability, Run-Control & Model-Picker UX (2026-05-16)](#9-abgeschlossene-welle-observability-run-control--model-picker-ux-2026-05-16)
 10. [Aktive Welle: Report-Quality-Floor (2026-05-17)](#10-aktive-welle-report-quality-floor-2026-05-17)
+11. [M3-Port — Unified Provider Abstraction (2026-07-05)](#11-m3-port--unified-provider-abstraction-2026-07-05)
 
 ---
 
@@ -330,5 +331,46 @@ Report-Perf (Slice B/C aus `docs/archive/plans/plan.report-perf.md` folgt eigens
 
 ---
 
-*Zuletzt aktualisiert: 2026-05-17 — Observability-Welle abgeschlossen, Report-Quality-Welle eröffnet.*
+## 11. M3-Port — Unified Provider Abstraction (2026-07-05)
+
+**Status:** ✅ Abgeschlossen via PR #666 (`feat/m3-port`, gemerged auf `main`).
+Unified Provider Abstraction (#590) + Unified Provider Detection (#591) auf
+dem #582-Split neu portiert. Schließt #590, #591, #582 sowie #636
+(M3-Milestone-Tracker — alle 5 Kriterien abgehakt).
+
+**Single Source of Truth für Provider-Detection:**
+[`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py)
+→ `detect_provider(base_url, model, *, mode="http"|"oasis")`.
+
+- `mode="http"` — Vokabular `ollama|cloud|openai|google|unknown` (Backend-`LLMClient`).
+- `mode="oasis"` — Vokabular `google|ollama|openai` (CAMEL-Sim-Skripte).
+
+Beide Modi sind testfixiert und absichtlich getrennt — Divergenzen siehe
+Modul-Docstring der Registry.
+
+### Phase F — Rest-Detection-Delegation (offen)
+
+Drei lokale Detection-Heuristiken delegieren noch nicht an die SSOT. Jeweils
+eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün).
+
+| Issue | Aufgabe | Status |
+|---|---|---|
+| [#669](https://github.com/arn0ld87/agora/issues/669) | `simulation_lifecycle._detect_default_provider` → `registry.detect_provider(mode="http")` | offen |
+| [#670](https://github.com/arn0ld87/agora/issues/670) | `_sim_common._is_ollama_route` think/num_ctx-Gate für `ollama.com`-URLs ausweiten | offen |
+| [#671](https://github.com/arn0ld87/agora/issues/671) | `embedding_service._detect_provider` vereinheitlichen ODER bewusst separat dokumentieren | offen (Entscheidung nötig) |
+
+### Dependency-Hardstops (Source of Truth: [`docs/dependency-risk-register.md`](docs/dependency-risk-register.md))
+
+- PYSEC-2026-597 + GHSA-p4gq-832x-fm9v (`nltk`) — Hardstop **2026-07-30**,
+  kein Upstream-Fix in 3.9.x. Agora nutzt `nltk` nur transitiv (via
+  `unstructured`/`camel-oasis`), kein direkter `nltk.data.load()`-Aufruf mit
+  user-kontrolliertem Pfad → Risikoakzeptanz (Tracking-Issue
+  [#672](https://github.com/arn0ld87/agora/issues/672)).
+- CVE-2026-24049 / CVE-2026-23949 (Trivy OS-Layer, `wheel`/`jaraco.context`)
+  — Hardstop **2026-08-30**, Base-Image-Update erforderlich.
+
+---
+
+*Zuletzt aktualisiert: 2026-07-05 — M3-Port abgeschlossen, Phase F (Rest-Detection-Delegation) eröffnet.*
+*Provider-Detection-SSoT: `backend/app/llm/providers/registry.py`.*
 *Heuristik-SSoT: `docs/plans/plan.heuristic-2026-05-17.md`.*

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
+    { name = "nltk", specifier = "==3.9.4" },
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=12.1.1" },

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
+Stand: 2026-07-05 (post M3-Port, v1.0.0)
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 
@@ -19,8 +19,8 @@ Stand: 2026-05-15 (v1.0.0 + Smoke-Fix Welle 2)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2509 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 131 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2869 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 144 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._
@@ -118,7 +118,13 @@ Verbindliche Detailtabelle und Layer-Semantik: [`CLAUDE.md` § Architektur-Layer
 
 ## Aktuelles Milestone
 
-**M9 abgeschlossen, M10 abgeschlossen.** Übergang zu M11.
+**M9 abgeschlossen, M10 abgeschlossen.** Übergang zu M11. **M3-Port — Unified Provider Abstraction abgeschlossen (PR #666, 2026-07-05):** Provider-Detection-SSoT in [`backend/app/llm/providers/registry.py`](../backend/app/llm/providers/registry.py) (`detect_provider(base_url, model, *, mode="http"|"oasis")`), HTTP-Vokabular `ollama|cloud|openai|google|unknown`, OASIS-Vokabular `google|ollama|openai`. Schließt #590, #591, #582, #636. Begleitet von PR #667 (transformers v5.13.0 via `tool.uv.override-dependencies`, löst CVE-2026-4372, CVE-2026-1839, PYSEC-2025-217; schließt #124, #624, #662) und PR #668 (nltk 3.9.4 risk exception, PYSEC-2026-597 / GHSA-p4gq-832x-fm9v, Tracking #672).
+
+**Offen als Folge des M3-Ports (Phase F — Rest-Detection-Delegation an die SSoT):** #669, #670, #671 (jeweils eigener PR, TDD).
+
+**Offene Dependency-Hardstops** (Source of Truth: [`docs/dependency-risk-register.md`](dependency-risk-register.md)):
+- `nltk` PYSEC-2026-597 + GHSA-p4gq-832x-fm9v → Hardstop 2026-07-30 (Tracking #672, nur transitive Nutzung, kein direkter `nltk.data.load()`-Aufruf).
+- Trivy OS-Layer CVE-2026-24049 / CVE-2026-23949 → Hardstop 2026-08-30.
 
 Detail: [`PLAN.md § Status-Sync 2026-05-04`](../PLAN.md#status-sync-2026-05-04). Subagent-Mapping pro Slice: `docs/archive/plans/plan.heuristic.md`.
 


### PR DESCRIPTION
Post-M3-Port Doku-Synchronisation. Schließt die Doku-Lücke nach PR #666/#667/#668.

## Enthalten
- **PLAN.md** (81a6c31): neue Sektion 11 — M3-Port abgeschlossen, Provider-Detection-SSoT `registry.detect_provider(mode="http"|"oasis")`, Phase F mit Folge-Issues #669/#670/#671, Dependency-Hardstops.
- **AGENTS.md** (81a6c31): Aktive Epics um M3-Port (abgeschlossen), Phase F, Dependency-Hardstops ergänzt.
- **CLAUDE.md** (81a6c31): Provider-Detection-SSoT als Claude-Recherche-Anker.
- **CHANGELOG.md** (ebfceb6): [Unreleased]-Einträge für PR #666 (M3-Port), #667 (transformers v5.13.0), #668 (nltk 3.9.4 risk exception).
- **docs/STATUS.md** (ebfceb6): Stand 2026-07-05, Autogen-Test-Counts regeneriert (2869/144 via `scripts/sync-status.sh`), "Aktuelles Milestone" um M3-Port + Phase F + Hardstops ergänzt.

README bewusst unangetastet — M3-Port ist interne Architektur ohne User-facing-Änderung.

## Verification
- `bash scripts/sync-status.sh` exit 0, Drift-frei (2869/144).
- Kein Code-/Contract-Touch, keine Schema-Auswirkung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)