### PR TITLE
fix(frontend): Command-Palette erst bei Bedarf mounten

### DIFF
--- a/frontend/src/components/v4/shell/AppShell.vue
+++ b/frontend/src/components/v4/shell/AppShell.vue
@@ -43,12 +43,12 @@
     </div>
 
     <!-- Command-Palette (global, rendered einmalig in Shell) -->
-    <CommandPalette v-if="isPaletteOpen" />
+    <CommandPalette v-if="wasPaletteOpened" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, watch, onMounted, onBeforeUnmount, defineAsyncComponent } from 'vue'
+import { computed, watch, onMounted, onBeforeUnmount, defineAsyncComponent, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useShellStore } from '@/stores/shell'
 import { useCommandPalette } from '@/composables/useCommandPalette'
@@ -75,7 +75,16 @@ const shellStore = useShellStore()
 const route = useRoute()
 const router = useRouter()
 const { isOpen: isPaletteOpen, toggle: togglePalette } = useCommandPalette()
+const wasPaletteOpened = ref(false)
 const commandsStore = useCommandsStore()
+
+watch(
+  isPaletteOpen,
+  (open) => {
+    if (open) wasPaletteOpened.value = true
+  },
+  { immediate: true },
+)
 
 function onKeyDown(e: KeyboardEvent): void {
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {

--- a/frontend/src/components/v4/shell/AppShell.vue
+++ b/frontend/src/components/v4/shell/AppShell.vue
@@ -43,7 +43,7 @@
     </div>
 
     <!-- Command-Palette (global, rendered einmalig in Shell) -->
-    <CommandPalette />
+    <CommandPalette v-if="isPaletteOpen" />
   </div>
 </template>
 
@@ -74,7 +74,7 @@ const props = withDefaults(
 const shellStore = useShellStore()
 const route = useRoute()
 const router = useRouter()
-const { toggle: togglePalette } = useCommandPalette()
+const { isOpen: isPaletteOpen, toggle: togglePalette } = useCommandPalette()
 const commandsStore = useCommandsStore()
 
 function onKeyDown(e: KeyboardEvent): void {

--- a/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
+++ b/frontend/src/components/v4/shell/__tests__/AppShell.spec.ts
@@ -17,6 +17,7 @@ import { nextTick } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { makeTestRouter } from './testRouter'
+import { useCommandPalette } from '@/composables/useCommandPalette'
 import de from '@/i18n/locales/de.json'
 import en from '@/i18n/locales/en.json'
 
@@ -38,11 +39,13 @@ Object.defineProperty(globalThis, 'localStorage', { value: lsMock, writable: tru
 import AppShell from '../AppShell.vue'
 
 const router = makeTestRouter()
+const commandPaletteStub = { template: '<div data-testid="command-palette" />' }
 
 describe('AppShell', () => {
   beforeEach(() => {
     lsMock.clear()
     setActivePinia(createPinia())
+    useCommandPalette().close()
   })
 
   afterEach(() => {
@@ -56,6 +59,27 @@ describe('AppShell', () => {
       global: { plugins: [router, createPinia(), i18n] },
     })
     expect(wrapper.exists()).toBe(true)
+  })
+
+  it('behält die Command-Palette nach dem ersten Öffnen gemountet', async () => {
+    await router.push('/')
+    const wrapper = mount(AppShell, {
+      global: {
+        plugins: [router, createPinia(), i18n],
+        stubs: { CommandPalette: commandPaletteStub },
+      },
+    })
+    const palette = useCommandPalette()
+
+    expect(wrapper.find('[data-testid="command-palette"]').exists()).toBe(false)
+
+    palette.open()
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette"]').exists()).toBe(true)
+
+    palette.close()
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette"]').exists()).toBe(true)
   })
 
   it('rendert Standard-Sidebar-Slot (Sidebar-Komponente)', async () => {


### PR DESCRIPTION
## Zusammenfassung
- mountet die asynchron geladene Command-Palette erst, wenn sie geöffnet wird
- verhindert die EnvironmentTeardownError-Rejections aus den v4-View-Tests
- lässt das Onboarding-Epic vollständig unverändert

## Testplan
- [x] `npm run check`
- [x] Backend: 2.881 Tests bestanden
- [x] Frontend: 1.132 Tests bestanden, keine unhandled Rejections
- [x] ESLint, Ruff und Vite-Build erfolgreich