### PR TITLE
docs(epic): plan onboarding and provider unification (Phase 0)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -355,8 +355,8 @@ eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün
 
 | Issue | Aufgabe | Status |
 |---|---|---|
-| [#669](https://github.com/arn0ld87/agora/issues/669) | `simulation_lifecycle._detect_default_provider` → `registry.detect_provider(mode="http")` | offen |
-| [#670](https://github.com/arn0ld87/agora/issues/670) | `_sim_common._is_ollama_route` think/num_ctx-Gate für `ollama.com`-URLs ausweiten | offen |
+| [#669](https://github.com/arn0ld87/agora/issues/669) | `simulation_lifecycle._detect_default_provider` → `registry.detect_provider(mode="http")` | ✅ gemerged via #677 |
+| [#670](https://github.com/arn0ld87/agora/issues/670) | `_sim_common._is_ollama_route` think/num_ctx-Gate für `ollama.com`-URLs ausweiten | ✅ gemerged via #675/#676 |
 | [#671](https://github.com/arn0ld87/agora/issues/671) | `embedding_service._detect_provider` vereinheitlichen ODER bewusst separat dokumentieren | offen (Entscheidung nötig) |
 
 ### Dependency-Hardstops (Source of Truth: [`docs/dependency-risk-register.md`](docs/dependency-risk-register.md))
@@ -371,6 +371,36 @@ eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün
 
 ---
 
-*Zuletzt aktualisiert: 2026-07-05 — M3-Port abgeschlossen, Phase F (Rest-Detection-Delegation) eröffnet.*
+## 12. Onboarding & Provider-Unification (2026-07-10)
+
+**Status:** Phase 0 abgeschlossen auf `codex/onboarding-provider-unification`;
+noch kein Produktcode geändert.
+
+Ziel: lokales Erst-Onboarding, getrenntes Benutzerprofil, kanonische Provider-
+und Modellverträge, getrennte Embedding-Konfiguration, ein gemeinsamer
+Model-Picker und eine exakte Persona-Count-Invariante.
+
+Source of Truth:
+[`docs/epics/onboarding-provider-unification/04-implementation-plan.md`](docs/epics/onboarding-provider-unification/04-implementation-plan.md).
+
+| Slice | Inhalt | Status |
+|---|---|---|
+| 0 | Research, ADRs, Test-/Migrationsplan, Agent-Tooling | ✅ abgeschlossen |
+| 1 | Kanonische Provider-/Modell-/Route-Verträge | offen |
+| 2 | Benutzerprofil und resumierbares Onboarding | offen |
+| 3 | Provider-Verbindungen und Discovery | offen |
+| 4 | Embedding-Setup und sichere Re-Embedding-Migration | offen |
+| 5 | Gemeinsamer Model-Picker und Routing | offen |
+| 6 | Persona-Count-End-to-End-Invariante | offen |
+| 7 | Golden-Gate-Designsystem und Informationsarchitektur | offen |
+| 8+ | Projekte, Datensätze, Vorlagen, Monitoring als einzelne MVPs | offen |
+
+Phase-0-Baseline: Backend grün; Frontend-Tests fachlich grün, Vitest-Exit 1
+wegen vier bestehenden `EnvironmentTeardownError`-Rejections. Vor dem ersten
+Frontend-Produktslice separat klären.
+
+---
+
+*Zuletzt aktualisiert: 2026-07-10 — Phase F #669/#670 abgeschlossen; Onboarding/Provider-Unification Phase 0 dokumentiert.*
 *Provider-Detection-SSoT: `backend/app/llm/providers/registry.py`.*
 *Heuristik-SSoT: `docs/plans/plan.heuristic-2026-05-17.md`.*

--- a/docs/decisions/0006-ai-provider-connections.md
+++ b/docs/decisions/0006-ai-provider-connections.md
@@ -1,0 +1,27 @@
+# ADR-0006: Kanonische KI-Provider-Verbindungen
+
+- Status: Proposed
+- Datum: 2026-07-10
+
+## Kontext
+
+Provider-Metadaten, Modelle, Profile, Runtime-Konfiguration und Routing sind
+heute auf mehrere Verträge und Services verteilt. Fähigkeiten und Fallbacks
+können voneinander abweichen.
+
+## Entscheidung
+
+`ProviderConnection`, `AiModel` und `AiRoute` werden Pydantic-SSoT. Bestehende
+Verträge bleiben zunächst über Adapter lesbar. Die Detection-SSoT
+`detect_provider(..., mode=...)` bleibt unverändert. Fähigkeiten stammen aus
+Live-Discovery, markiertem Cache oder markiertem Fallback.
+
+CLI-Subscription-Bridges sind keine normalen API-Verbindungen. Sie bleiben
+lokal, experimentell und standardmäßig deaktiviert, bis ein separater
+Security-/Machbarkeitsslice positiv abgeschlossen ist.
+
+## Folgen
+
+- Migration braucht dual-read/new-write und Contract-Tests.
+- UI und Routing können einen gemeinsamen Modellvertrag nutzen.
+- Secret-Werte bleiben außerhalb der Verträge; nur `secret_ref` wird geführt.

--- a/docs/decisions/0007-embedding-configuration-and-index-migration.md
+++ b/docs/decisions/0007-embedding-configuration-and-index-migration.md
@@ -1,0 +1,27 @@
+# ADR-0007: Embedding-Konfiguration und Indexmigration
+
+- Status: Proposed
+- Datum: 2026-07-10
+
+## Kontext
+
+Embedding-Konfiguration und Dimensionsprüfung sind doppelt verdrahtet. Bei
+Dimensionsdrift kann ein Neo4j-Index neu erstellt werden, ohne vorhandene
+Embedding-Properties zu migrieren.
+
+## Entscheidung
+
+Chat- und Embedding-Konfiguration werden getrennt. Ein Wechsel mit vorhandenen
+Daten nutzt versionierte Properties/Indizes, einen resumierbaren Re-Embedding-
+Job, Validierung und atomaren Umschaltpunkt. Ein alter Index bleibt bis zum Ende
+der Rollback-Frist bestehen.
+
+`DROP INDEX` ohne Bestätigung, Backup-Plan, erfolgreiche Re-Embedding-
+Validierung und Rollback ist verboten.
+
+## Folgen
+
+- zusätzlicher Job- und Statusvertrag;
+- höherer temporärer Speicherbedarf;
+- sichere Wiederaufnahme und klare Operatorentscheidung statt stillem Startup-
+Repair.

--- a/docs/decisions/0008-single-user-profile-and-onboarding.md
+++ b/docs/decisions/0008-single-user-profile-and-onboarding.md
@@ -1,0 +1,26 @@
+# ADR-0008: Single-User-Profil und Erst-Onboarding
+
+- Status: Proposed
+- Datum: 2026-07-10
+
+## Kontext
+
+„Profil“ bezeichnet derzeit KI-Konfigurationen, während ein lokales
+Benutzerprofil fehlt. Agora v1 ist gemäß ADR-0001 ein Single-User-System.
+
+## Entscheidung
+
+Ein neues lokales `UserProfile` und ein resumierbarer Onboarding-State werden
+eingeführt. Bestehende `LlmProfile` werden sichtbar als KI-Presets bezeichnet;
+ihre Persistenz bleibt zunächst kompatibel. „Nutzer & Teams“ wird nicht als
+fertige Funktion dargestellt.
+
+Onboarding gilt als abgeschlossen, wenn Benutzerprofil, Chat-Modell und
+Embedding-Konfiguration gültig sind. Jeder Schritt wird backendseitig
+persistiert.
+
+## Folgen
+
+- klare Sprache ohne unnötigen Datenbankbruch;
+- Avatar benötigt validierten lokalen Speicher;
+- echte Teams und Rechte bleiben ein separates Epic.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,6 +10,9 @@ Sammlung der Architektur-Entscheidungen für Agora. Format: [MADR-Light](https:/
 | [0002](0002-evidence-gating.md) | Evidence-Gating für Report-Generation | Accepted (2026-05-10) | M11.7 |
 | [0003](0003-pydantic-settings-migration.md) | Pydantic-Settings-Migration | Accepted (2026-05-15) | Pydantic-Settings-Epic |
 | [0004](0004-cve-upstream-escalation.md) | CVE-Upstream-Eskalation: Risikoakzeptanz nltk | Accepted (2026-07-06) | ALE-20 |
+| [0006](0006-ai-provider-connections.md) | Kanonische KI-Provider-Verbindungen | Proposed | Onboarding/Provider-Unification Slice 0 |
+| [0007](0007-embedding-configuration-and-index-migration.md) | Embedding-Konfiguration und Indexmigration | Proposed | Onboarding/Provider-Unification Slice 0 |
+| [0008](0008-single-user-profile-and-onboarding.md) | Single-User-Profil und Erst-Onboarding | Proposed | Onboarding/Provider-Unification Slice 0 |
 
 ## Geplante ADRs
 

--- a/docs/epics/onboarding-provider-unification/00-research.md
+++ b/docs/epics/onboarding-provider-unification/00-research.md
@@ -1,0 +1,138 @@
+# Phase 0 — Research
+
+Stand: 2026-07-10
+Branch: `codex/onboarding-provider-unification`
+Basis: `bb2b3ea243c1becbf27de3434d4923098f716130`
+
+## Auftrag und Grenzen
+
+Dieser Epic vereinheitlicht Benutzerprofil, Provider-Verbindungen, Modellkatalog,
+Routing, Embeddings, Persona-Anzahl und die dazugehörige Oberfläche. Phase 0
+ändert keinen Produktcode. Secrets, Auth-Dateien, Browserprofile und Keychain-
+Inhalte wurden nicht gelesen.
+
+Nicht-Ziele dieser Phase:
+
+- kein Multi-User- oder Team-System;
+- keine produktive Subscription-Bridge;
+- kein destruktiver Neo4j-Indexwechsel;
+- kein Design-Rewrite parallel zur laufenden Design-v4-Integration;
+- keine Reparatur bereits vorhandener Baseline-Fehler.
+
+## Geprüfter Repository-Stand
+
+- Provider-IDs: `backend/app/contracts/provider_types.py`.
+- Routing-Verträge: `backend/app/contracts/llm_routing_contract.py`.
+- Detection-SSoT: `backend/app/llm/providers/registry.py::detect_provider`.
+- Provider-Metadaten: `backend/app/services/llm_provider_registry.py`.
+- Live-Modellkatalog: `backend/app/services/model_catalog_service.py`.
+- Routing: `llm_routing_seed.py` → `runtime_llm_routing.json` →
+  `stage_model_router.py`.
+- Embeddings: `backend/app/config.py`, `backend/app/settings.py`,
+  `backend/app/storage/embedding_service.py`, Neo4j-Schema-Aufbau.
+- Persona-Fluss: `HeroNewRun.vue`, `pendingUpload.ts`, `MainView.vue`,
+  `simulation_prepare.py`, `prepare_service.py`,
+  `simulation_config_generator.py`, OASIS-Runner.
+- Frontend: v4-Shell, Settings-Routen, Model-Picker, Provider-Store,
+  Pending-Upload- und Workspace-Flows.
+
+## Verifizierte Defekte und Architekturdrift
+
+1. Provider-Metadaten, Fallbackmodelle und Fähigkeiten sind nicht kanonisch.
+   `LlmProviderRegistry` und `ModelCatalogService` enthalten parallele Listen;
+   `ollama_cloud` hat bewusst unterschiedliche Fallback-Semantik.
+2. `LlmProfile`, `RuntimeLlmConfig`, `ProviderDescriptor`, `ModelEntry` und
+   `StageLLMRoute` überlappen fachlich und benötigen mehrere Übersetzungen.
+3. Embedding-Konfiguration wird sowohl über die Legacy-`Config` als auch über
+   `AgoraSettings` validiert. `EmbeddingService` erkennt Provider unabhängig
+   von der Provider-Registry.
+4. Bei Dimensionsdrift kann der Neo4j-Index gedroppt und neu angelegt werden,
+   ohne vorhandene Embeddings neu zu berechnen. Ein Re-Embedding-Job fehlt.
+5. Der im Dashboard gewählte Persona-Wert wird als `num_agents` an den
+   Graph-Build gesendet, dort aber nicht gelesen oder persistiert.
+6. Ein separater Step-2-Pfad nutzt eigene Defaults und Floors. Quotenlogik,
+   Profilgenerator und Simulationsgenerator können 10, 30 oder 50 erzwingen.
+   Die gewünschte Anzahl ist daher keine End-to-End-Invariante.
+7. Für Provider-, Embedding- und Persona-Flüsse fehlen übergreifende E2E-Tests.
+8. Es existiert noch kein Onboarding-Pfad: keine Route, View, Store,
+   Completion-Logik oder Tests.
+9. Im Frontend existieren zwei Model-Picker, mehrere Profil-/Route-DTOs und ein
+   alter Browser-Runtime-Pfad mit eigener Local-/Session-Storage-Semantik.
+10. `/settings-classic` dupliziert weiterhin Provider-/Modellkonfiguration;
+    `Users & Teams` und `Audit Logs` sind reine Coming-soon-Views.
+11. Projekte, Datensätze, Vorlagen und Monitoring sind deaktivierte
+    Sidebar-Stubs ohne Route. Ein Benutzerprofil fehlt vollständig.
+12. Der produktive v4-Model-Picker hat Lücken bei Labeling, Focus-Visible,
+    ARIA-Fehlerzuständen und mobiler Mindestbreite.
+
+Details und Datenflüsse stehen in [01-current-state-map.md](01-current-state-map.md).
+
+## Baseline
+
+- Backend: `2881 passed, 9 skipped, 7 deselected`.
+- Contract-Tests: `211 passed`.
+- Frontend: `145` Testdateien und `1132` Tests bestanden, der Lauf endet aber
+  mit Exit 1 wegen vier `EnvironmentTeardownError`-Rejections aus
+  `HistoryView.spec.ts` über den verzögerten Style-Import von
+  `CommandPalette.vue`.
+- Die Phase-0-Arbeit repariert diesen bestehenden Fehler nicht. Er ist vor dem
+  ersten Frontend-Produkt-Slice separat zu klären.
+- Setup wählte lokal Python 3.14.6, obwohl das Projekt Python 3.12 als Ziel
+  dokumentiert. Die Warnungsflut von `pytest-asyncio` wird als
+  Umgebungsabweichung festgehalten.
+
+## Agent-Tooling
+
+- `context-mode` 1.0.169: MCP, Storage, FTS5 und Hooks funktionieren. Doctor
+  meldet `[features].hooks` als fehlend in der globalen Codex-Konfiguration,
+  obwohl die Plugin-Hooks geladen sind. Kein globales Auto-Upgrade im Epic.
+- `code-review-graph` 2.3.6 wurde gegen PyPI verifiziert. Ein globaler
+  `uv tool install` kollidiert mit einem vorhandenen Executable; daher kein
+  `--force`. Reproduzierbarer Fallback: gepinntes `uvx`.
+- MCP-Graph im Worktree: 944 Dateien, 8.803 Knoten, 74.776 Kanten,
+  624 Flows und 11 Communities; keine Build-Fehler.
+
+Siehe [07-agent-tooling.md](07-agent-tooling.md) und
+[`docs/tooling/agent-tools.md`](../../tooling/agent-tools.md).
+
+## Offizielle Primärquellen
+
+Geprüft am 2026-07-10:
+
+- OpenAI: [API-Authentifizierung](https://platform.openai.com/docs/api-reference/backward-compatibility),
+  [Modelle](https://platform.openai.com/docs/api-reference/models),
+  [Embeddings](https://platform.openai.com/docs/api-reference/embeddings),
+  [Codex mit ChatGPT-Plan](https://help.openai.com/en/articles/11369540-using-codex-with-chatgpt),
+  [`codex exec`](https://github.com/openai/codex/blob/main/codex-rs/README.md).
+- Anthropic: [API-Authentifizierung](https://platform.claude.com/docs/en/manage-claude/authentication),
+  [Modelle und Fähigkeiten](https://platform.claude.com/docs/en/api/models),
+  [Structured Outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs),
+  [Claude Code Setup](https://docs.anthropic.com/en/docs/claude-code/getting-started),
+  [CLI Print Mode](https://docs.anthropic.com/en/docs/claude-code/cli-usage).
+- Google: [Gemini API](https://ai.google.dev/gemini-api/docs),
+  [Function Calling](https://ai.google.dev/gemini-api/docs/function-calling),
+  [Structured Outputs](https://ai.google.dev/gemini-api/docs/structured-output),
+  [Embeddings](https://ai.google.dev/gemini-api/docs/embeddings).
+- Ollama: [Authentifizierung](https://docs.ollama.com/api/authentication),
+  [Tool Calling](https://docs.ollama.com/capabilities/tool-calling),
+  [Embeddings](https://docs.ollama.com/capabilities/embeddings).
+- MiniMax: [API Overview](https://platform.minimax.io/docs/api-reference/api-overview),
+  [Modelle](https://platform.minimax.io/docs/guides/models-intro).
+- OpenCode Go: [Provider-Dokumentation](https://opencode.ai/docs/providers),
+  [Go-Plan und Modelle](https://dev.opencode.ai/docs/go/).
+- Tooling: [`code-review-graph` 2.3.6](https://pypi.org/project/code-review-graph/),
+  [`context-mode`](https://github.com/mksglu/context-mode),
+  [Codex Plugins](https://help.openai.com/en/articles/20001256-plugins-in-codex/).
+
+## Offene Fragen vor Slice 1
+
+- Der sichtbare Persona-Wert bedeutet künftig die tatsächlich simulierte
+  Gesamtzahl, nicht einen Entity-Cap. Floors werden Warnungen.
+- Projekt-Defaults werden als Routingstufe vorgesehen, aber erst mit einem
+  klaren Projektvertrag aktiviert.
+- CLI-Bridges bleiben ein separater lokaler Security-Spike. Offizielle
+  Nichtinteraktivität allein reicht nicht als Produktionsfreigabe.
+- Der Embedding-Wechsel braucht einen versionierten Re-Embedding-Job, bevor
+  destruktive Indexoperationen entfernt werden können.
+- Die Golden-Gate-Referenz wird auf bestehende semantische Agora-Tokens
+  abgebildet. Kein dritter Token-Namespace und keine kopierten Referenz-Assets.

--- a/docs/epics/onboarding-provider-unification/01-current-state-map.md
+++ b/docs/epics/onboarding-provider-unification/01-current-state-map.md
@@ -1,0 +1,117 @@
+# Current-State Map
+
+## Provider und Routing
+
+```mermaid
+flowchart LR
+    A["Provider-ID-Vertrag"] --> B["LlmProviderRegistry"]
+    A --> C["ModelCatalogService"]
+    D["detect_provider SSoT"] --> E["ProviderAdapter"]
+    B --> F["Frontend Provider-Store"]
+    C --> F
+    G["LlmProfile"] --> H["RuntimeLlmConfig"]
+    I["Workspace-Default"] --> J["seed_run_stage_routing"]
+    J --> K["runtime_llm_routing.json"]
+    K --> L["StageModelRouter"]
+    L --> H
+```
+
+Drift:
+
+- Registry und Catalog führen parallele Fallbackmodelle.
+- Fähigkeiten sind nicht durchgehend modellbezogen und live verifiziert.
+- Profile, Verbindungen und Routing werden in der UI und im Backend als
+  unterschiedliche fachliche Systeme präsentiert.
+- Die bestehende Detection-SSoT bleibt erhalten; der Epic baut keine neue
+  URL-/Namensheuristik daneben.
+
+## Embeddings
+
+```mermaid
+flowchart LR
+    A["Config.EMBEDDING_*"] --> C["EmbeddingService"]
+    B["AgoraSettings.embedding_*"] --> D["Settings-Validierung"]
+    C --> E["Probe-Embedding"]
+    D --> E
+    E --> F["Neo4j Vector Index"]
+    F -->|"Dimensionsdrift"| G["DROP + CREATE"]
+    G --> H["Alte Embedding-Properties bleiben bestehen"]
+```
+
+`KNOWN_EMBEDDING_DIMS` und `infer_vector_dim_for_model()` sind heute die
+Dimensionsquelle. Es fehlt ein Job, der neue Vektoren schreibt, prüft und erst
+danach atomar auf einen versionierten Index umschaltet.
+
+## Persona-Anzahl
+
+```mermaid
+flowchart TD
+    A["HeroNewRun.numAgents"] --> B["pendingUpload.numAgents"]
+    B --> C["FormData num_agents"]
+    C --> D["Graph-Build API"]
+    D --> X["Wert wird nicht gelesen"]
+
+    E["Step2 maxAgents, Default 50"] --> F["PrepareSimulationData.max_agents"]
+    F --> G["simulation_prepare Floor >= 10"]
+    G --> H["prepare_service Floor bis 50"]
+    H --> I["Quota-Expansion / Round-Robin"]
+    I --> J["OASIS-Profile"]
+    J --> K["SimulationConfig Floor >= 30"]
+    K --> L["OASIS-Runner"]
+```
+
+Die gewünschte Zahl, die Zahl erzeugter Profile und die Zahl simulierter
+Agents sind derzeit nicht derselbe Vertrag. Ziel ist:
+
+```text
+requested_persona_count
+== generated_persona_count
+== persisted_persona_count
+== simulated_persona_count
+```
+
+## Informationsarchitektur
+
+Die v4-Shell ist teilweise produktiv, teilweise Stub:
+
+| Bereich | Istzustand | Entscheidung für diesen Epic |
+|---|---|---|
+| General, Integrationen, API Keys, LLM Providers | verdrahtet | konsolidieren |
+| LLM Routing | run-spezifisch trotz Settings-Name | Semantik trennen |
+| Users & Teams, Audit Logs | Route plus Coming-soon | Profil umbenennen bzw. ausblenden |
+| Projekte, Datensätze, Vorlagen, Monitoring | deaktivierter Sidebar-Stub | je eigener MVP-Slice oder ausblenden |
+| Profil | fehlt | mit Onboarding-Slice ergänzen |
+| `/settings-classic` | parallele Legacy-Settings | migrieren und deprecaten |
+
+Tote oder unverdrahtete Kandidaten sind `components/ui/ModelPicker.vue`,
+`LlmProviderCard.vue` und `views/Settings/llmRouting/mockData.ts` samt Mock-
+Cards. Vor Entfernung ist jeweils ein Import-/Impact-Check Pflicht.
+
+Grundsatz für die Umsetzung:
+
+- funktionierende Bereiche verdrahten;
+- klar begrenzte MVPs separat slicen;
+- nicht vorhandene Mehrbenutzerfunktionen ausblenden oder als Profil benennen;
+- keine `ComingSoonCard` als fertige Hauptnavigation verkaufen.
+
+## Design-Bestand
+
+`tokens-v3.css` und `states.css` enthalten bereits semantische Surface-, Text-,
+Status-, Spacing-, Radius-, Shadow-, Focus- und Reduced-Motion-Tokens. Die
+Golden-Gate-Referenz liefert visuelle Richtung, keine Komponentenbibliothek.
+Übertragbar sind dunkle Glass-Surfaces, Gold-/Korall-Akzente, ruhige
+Typografie-Hierarchie, `clamp()`-Skalen, responsive Breakpoints,
+`:focus-visible`, Reduced Motion und ein `backdrop-filter`-Fallback.
+
+Der v4-`ModelPicker` wird nicht nur optisch umgebaut: `LlmProfilePicker` dient
+als Accessibility-Referenz für Label, `aria-busy`, Alert und Focus-State.
+
+## Testlücken
+
+- Dashboard-Persona-Wert bis OASIS-Profilzahl.
+- Provider-Fähigkeiten vom Catalog bis zu allen Model-Pickern.
+- Embedding-Wechsel mit vorhandenen Daten, Abbruch und Rollback.
+- Wiederaufnahme des Onboardings nach jedem Schritt.
+- Tastaturbedienung und Fehlerzustände des gemeinsamen Model-Pickers.
+- direkte Tests für Provider-/Profile-/Routing-Stores, LlmProvidersView,
+  Responsive-Verhalten und Sidebar-Focus-Management.

--- a/docs/epics/onboarding-provider-unification/02-provider-matrix.md
+++ b/docs/epics/onboarding-provider-unification/02-provider-matrix.md
@@ -1,0 +1,43 @@
+# Provider-Matrix
+
+Stand: 2026-07-10. „Geplant“ bedeutet nicht implementiert.
+
+| Eintrag | Transport | Auth | Discovery | Chat | Embeddings | Bridge-Entscheid |
+|---|---|---|---|---|---|---|
+| OpenAI API | OpenAI HTTP | API-Key | `/v1/models` | ja | ja | normale API |
+| Anthropic API | Anthropic HTTP | API-Key/WIF | `/v1/models` | ja | nein | normale API |
+| Gemini API | Gemini HTTP | API-Key, optional OAuth | Models API | ja | ja | normale API |
+| MiniMax API | Anthropic-/anbieterkompatibles HTTP | API-Key | anbieterspezifisch | ja | nicht zugesagt | normale API |
+| OpenCode Go | OpenAI-kompatibles HTTP | Go-API-Key | `/v1/models` | ja | nicht zugesagt | normale API |
+| Ollama lokal | Ollama HTTP | keine lokale Auth | `/api/tags` | modellabhängig | ja | lokaler Dienst |
+| Ollama Cloud direkt | Ollama HTTP | API-Key | Cloud-Katalog | ja | modellabhängig | normale API |
+| Benutzerdefiniert | OpenAI-kompatibles HTTP | none/API-Key | optional | capability-probed | capability-probed | normale API |
+| Codex CLI | lokaler Prozess | offizieller Codex-Login | CLI | ja | nein | nur lokaler Security-Spike |
+| Claude Code CLI | lokaler Prozess | offizieller Claude-Code-Login | CLI | ja | nein | nur lokaler Security-Spike |
+
+## Capability-Vertrag
+
+Modelle werden nicht aus Namen erraten. `AiModel` soll mindestens enthalten:
+
+```text
+chat, embeddings, streaming, tool_calling, json_object, json_schema,
+vision, reasoning, context_window, max_output_tokens,
+embedding_dimensions, local_or_cloud, deprecated,
+source: live | cached | fallback | custom
+```
+
+Live-Metadaten gewinnen. Cache und Fallback müssen sichtbar markiert sein.
+Unbekannte Fähigkeiten sind `unknown`, nicht implizit `true`.
+
+## Subscription-Bridges
+
+Offizielle Codex- und Claude-Code-Dokumentation bestätigt lokale Anmeldung und
+nichtinteraktive Befehle. Das ist noch keine Freigabe für einen Serveradapter.
+Ein späterer Spike muss mindestens prüfen:
+
+- zulässige Nutzungsbedingungen und Plan-Grenzen;
+- direkte Argumentlisten ohne Shell;
+- minimales Environment, begrenztes Arbeitsverzeichnis, Timeout und Abbruch;
+- lokale Aktivierung, Docker/VPS standardmäßig aus;
+- keine Auth-Dateien, Cookies, Keychain- oder OAuth-Token-Auslese;
+- Output-Limit, Concurrency-Limit und Audit ohne Prompt-/Secret-Leak.

--- a/docs/epics/onboarding-provider-unification/03-target-architecture.md
+++ b/docs/epics/onboarding-provider-unification/03-target-architecture.md
@@ -1,0 +1,80 @@
+# Target Architecture
+
+## Prinzipien
+
+1. Pydantic v2 ist die fachliche SSoT; Zod wird generiert oder eng gespiegelt.
+2. Provider-Detection bleibt in `backend/app/llm/providers/registry.py`.
+3. Provider-Verbindung, Modell, Route, Benutzerprofil und KI-Preset sind
+   getrennte Verträge.
+4. Fähigkeiten steuern die UI; Namensheuristiken sind nur markierte Fallbacks.
+5. Secrets bleiben im Backend-Secret-Store und erscheinen nur als Referenz.
+6. Chat- und Embedding-Routing werden getrennt persistiert.
+7. Jede effektive Route wird mit Quelle und Fähigkeiten im Run-Snapshot erfasst.
+
+## Zielverträge
+
+```text
+ProviderConnection
+  id, provider_kind, display_name, transport, auth_mode, base_url,
+  enabled, status, status_message, secret_ref, capabilities,
+  created_at, updated_at, last_tested_at
+
+AiModel
+  provider_connection_id, model_id, display_name, capabilities,
+  source, status, context_window, max_output_tokens,
+  embedding_dimensions, metadata_updated_at
+
+AiRoute
+  stage, provider_connection_id, model_id, source,
+  validated_capabilities, provider_options
+
+UserProfile
+  avatar_ref, display_name, username, role, organisation, language,
+  timezone, report_language, theme, privacy_mode, created_at, updated_at
+
+AiPreset
+  name, routes, embedding_configuration_ref, created_at, updated_at
+```
+
+## Routing
+
+```text
+Stage-Override
+→ Run-Override
+→ Projekt-Default
+→ Workspace-Default
+→ sichtbarer, auditierter Provider-Fallback
+```
+
+Legacy-Profile werden zunächst als Adapter gelesen. Neue Writes gehen nur in
+die kanonischen Verträge. Adapter erhalten Telemetrie und ein Ablaufdatum.
+
+## Embedding-Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Proposed
+    Proposed --> Probed: Test-Embedding + Dimension
+    Probed --> Reembedding: vorhandene Daten betroffen
+    Probed --> Active: keine vorhandenen Daten
+    Reembedding --> Validated: Zählung + Stichprobe + Readiness
+    Validated --> Active: atomarer Alias-/Konfigurationswechsel
+    Reembedding --> RolledBack: Fehler oder Abbruch
+    Active --> RolledBack: operatorbestätigter Rollback
+```
+
+Indizes erhalten eine Versionskennung. Ein bestehender Index wird erst nach
+bestätigtem Backup- und Rollback-Plan entfernt.
+
+## Onboarding
+
+Der backendseitig persistierte Wizard speichert nach jedem Schritt. Abschluss:
+gültiges Benutzerprofil, mindestens ein Chat-Modell und eine gültige
+Embedding-Konfiguration. Betriebsmodi `local`, `hybrid`, `server` beeinflussen
+nur Empfehlungen und Feature-Verfügbarkeit.
+
+## Persona-Invariante
+
+`requested_persona_count` ist die tatsächlich simulierte Gesamtzahl. Segment-,
+Skeptiker- und Diversitätsquoten werden innerhalb dieses Budgets deterministisch
+gerundet. Eine fachliche Mindestempfehlung ist Warnung, kein stiller Floor.

--- a/docs/epics/onboarding-provider-unification/04-implementation-plan.md
+++ b/docs/epics/onboarding-provider-unification/04-implementation-plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan
+
+Jeder Slice beginnt mit RED-Tests, endet mit vollständiger Verifikation,
+Codegraph-Delta, Dokumentations-Sync, Handover und atomarem Commit.
+
+## Slice 0 — Forschung und Architektur
+
+- Ziel: belegte Ausgangslage, ADRs, Migration, Tests und Tooling.
+- Scope: ausschließlich Dokumentation und secret-freie Toolprüfung.
+- Akzeptanz: Dateien dieses Epic-Verzeichnisses, ADR-0006 bis ADR-0008,
+  Tooling-Doku und Doctor-Script; kein Produktcode.
+- Rollback: Dokumentationscommit revertieren.
+- Risiko: niedrig.
+- Erwarteter Commit: `docs(epic): plan onboarding and provider unification`.
+
+## Slice 1 — Kanonische Provider- und Modellverträge
+
+- Ziel: `ProviderConnection`, `AiModel`, `AiRoute` als Pydantic-SSoT.
+- Scope: Contracts, Schema-Dump, Zod-Spiegel, Adapter für bestehende
+  `ProviderDescriptor`, `ModelEntry`, `LlmProfile` und Stage-Routes.
+- Nicht-Ziel: UI-Redesign, Secret-Migration, CLI-Bridges.
+- Migration: dual-read/new-write; keine vorhandenen Profile löschen.
+- Tests: Contract-, Schema-, Adapter-, Roundtrip- und Extra-forbid-Tests.
+- Akzeptanz: eine fachliche Provider-/Capability-Quelle; Detection-SSoT bleibt.
+- Rollback: neue Writes deaktivieren, Legacy-Adapter weiter lesen.
+- Risiko: hoch; betrifft Backend und Frontend-Verträge.
+- Abhängigkeit: Phase 0 vollständig committet.
+
+## Slice 2 — Benutzerprofil und Onboarding-Grundgerüst
+
+- `UserProfile`, `OnboardingState`, lokale Avatar-Referenz.
+- resumierbare State Machine und Guards.
+- Single-User-Grenze bleibt explizit; kein Team-/Rechtesystem.
+- Tests für Persistenz, Resume, MIME/Größe, Löschen und i18n.
+
+## Slice 3 — Provider-Verbindungen
+
+- API-Key-, Ollama-local- und Custom-HTTP-Verbindungen.
+- Test/Discovery, Statusmodell und bestehender verschlüsselter Secret-Store.
+- Subscription-Bridges nur nach separatem positivem Security-Spike.
+
+## Slice 4 — Embedding-Setup und Migration
+
+- getrennte Chat-/Embedding-Verträge.
+- OpenAI, Gemini und Ollama lokal.
+- kontrollierter Ollama-Download ohne Shell-String.
+- versionierter Re-Embedding-Job mit Abbruch, Fortschritt und Rollback.
+- kein `DROP INDEX` vor erfolgreicher Validierung.
+
+## Slice 5 — Gemeinsamer Model-Picker und Routing
+
+- eine zugängliche `AiModelPicker.vue`.
+- alle Einsatzstellen auf denselben Vertrag und dieselbe Routing-Hierarchie.
+- effektive Quelle sichtbar, keine stillen Fallbacks.
+- Snapshot und Audit erweitern.
+
+## Slice 6 — Persona-Count-Invariante
+
+- den Dashboard-Wert in einen Run-Vertrag überführen.
+- getrennten Step-2-Cap entfernen oder eindeutig umdeuten.
+- Floors zu Warnungen machen; Quoten innerhalb des Budgets.
+- E2E-Werte 1, 5, 10, 30, 50, 100.
+
+## Slice 7 — Golden-Gate-System und Informationsarchitektur
+
+- mit `feat/design-v4-epic` abstimmen, keine Parallelkopie.
+- vorhandene `tokens-v3.css`/`states.css` erweitern, keinen dritten
+  Token-Namespace erzeugen.
+- Tokens, Shell, Onboarding, Settings, Model-Picker.
+- WCAG AA, 320 px, Tastatur, Reduced Motion.
+- Seitenleistenentscheidungen `wire | implement MVP | hide | defer`.
+- `/settings-classic`, zweiten Model-Picker und Mock-Routing erst nach
+  Import-/Impact-Nachweis deprecaten oder entfernen.
+
+## Slice 8+ — eigenständige MVPs
+
+Projekte, Datensätze, Vorlagen und Monitoring jeweils als eigener PR. Kein
+Bereich wird halb implementiert als fertig markiert.

--- a/docs/epics/onboarding-provider-unification/05-test-plan.md
+++ b/docs/epics/onboarding-provider-unification/05-test-plan.md
@@ -1,0 +1,67 @@
+# Test Plan
+
+## Gates pro Slice
+
+```bash
+cd backend && uv run python -m app.contracts.dump_schemas
+git diff --exit-code schemas/
+cd backend && uv run pytest tests/contracts/ -v
+cd backend && uv run pytest -x -q
+cd backend && uv run ruff check .
+cd backend && uv run mypy app
+cd frontend && npm run check
+cd frontend && npm test -- --run
+```
+
+## Contract- und Adaptertests
+
+- `extra="forbid"` auf neuen Verträgen.
+- Pydantic-/Zod-Roundtrips.
+- Legacy-Profile und Stage-Routen werden verlustfrei gelesen.
+- Secrets erscheinen nur als `secret_ref`/maskierter Status.
+- Capability `unknown` wird nicht als unterstützt behandelt.
+
+## Provider und Model-Picker
+
+- Live-, Cache-, Fallback- und Custom-Quelle sichtbar.
+- Auth-, Connection-, Rate-Limit-, Timeout- und Capability-Fehler typisiert.
+- Tastatur, Screenreader, Suche, Offline und Refresh.
+- gleicher Picker an mindestens drei Einsatzstellen.
+- `LlmProvidersView` und Provider-/Profile-/Routing-Stores direkt testen.
+
+## Onboarding
+
+- erster Start, Speichern nach jedem Schritt, Abbruch und Resume.
+- lokaler Modus ohne Cloud-Key.
+- Avatar: MIME, Größe, Vorschau, Löschen, SVG-Ablehnung.
+- erneutes Öffnen über Settings.
+- Router-Guard, serverseitiger Completion-Status und Back/Forward-Navigation.
+
+## Embeddings
+
+- OpenAI, Gemini, Ollama local; reale Dimension wird per Probe bestätigt.
+- Modellwechsel ohne Daten, mit Daten, bei Abbruch und bei Teilfehler.
+- neue Indizes parallel, keine Löschung vor Validierung.
+- Rollback stellt alte Konfiguration und Lesbarkeit wieder her.
+- Ollama-Download-Stream gemockt: Fortschritt, Timeout, Abbruch, Injection.
+
+## Persona-Invariante
+
+Für 1, 5, 10, 30, 50 und 100 gilt in API, Persistenz, Profilgenerator,
+OASIS-Eingabe, Retry und Report:
+
+```text
+requested == generated == persisted == simulated
+```
+
+Zusätzlich: deterministische Quoten, keine doppelten IDs, Retrys hängen keine
+Profile an, Skeptikerquote erhöht die Gesamtzahl nicht.
+
+## Bekannte Baseline
+
+Vor Frontend-Slice 2 oder 5 muss der bestehende Vitest-Teardown-Fehler aus
+`HistoryView.spec.ts`/`CommandPalette.vue` separat grün sein. Er darf nicht als
+Nebeneffekt eines Feature-Slices kaschiert werden.
+
+Zusätzlich fehlen heute Responsive-/Focus-Management-Tests für mobile Sidebar,
+Provider-Grid und den produktiven v4-Model-Picker.

--- a/docs/epics/onboarding-provider-unification/05-test-plan.md
+++ b/docs/epics/onboarding-provider-unification/05-test-plan.md
@@ -3,14 +3,14 @@
 ## Gates pro Slice
 
 ```bash
-cd backend && uv run python -m app.contracts.dump_schemas
+(cd backend && uv run python -m app.contracts.dump_schemas)
 git diff --exit-code schemas/
-cd backend && uv run pytest tests/contracts/ -v
-cd backend && uv run pytest -x -q
-cd backend && uv run ruff check .
-cd backend && uv run mypy app
-cd frontend && npm run check
-cd frontend && npm test -- --run
+(cd backend && uv run pytest tests/contracts/ -v)
+(cd backend && uv run pytest -x -q)
+(cd backend && uv run ruff check .)
+(cd backend && uv run mypy app)
+(cd frontend && npm run check)
+(cd frontend && npm test -- --run)
 ```
 
 ## Contract- und Adaptertests

--- a/docs/epics/onboarding-provider-unification/06-migration-plan.md
+++ b/docs/epics/onboarding-provider-unification/06-migration-plan.md
@@ -1,0 +1,38 @@
+# Migration and Rollback Plan
+
+## Provider und Modelle
+
+1. Neue Verträge ergänzen, Legacy-Verträge unverändert lesbar lassen.
+2. Adapter mit explizitem Mapping und Telemetrie einführen.
+3. Neue Writes in kanonischem Format speichern.
+4. Bestehende Profile idempotent migrieren; Original sichern.
+5. Read-After-Write und Route-Auflösung vergleichen.
+6. Legacy-Writes abschalten, Leser erst in einem späteren Slice entfernen.
+
+Rollback: Feature-Flag auf Legacy-Writes, neue Daten über Adapter lesbar halten.
+
+## Benutzerprofil und KI-Presets
+
+Das heutige `LlmProfile` wird sichtbar als KI-Preset bezeichnet, ohne seine
+Persistenz vorschnell umzubenennen. Das neue Benutzerprofil erhält einen eigenen
+Schlüsselraum. Es gibt keine automatische Vermischung.
+
+## Embeddings
+
+1. Bestand, Dimension, Modell und betroffene Knoten inventarisieren.
+2. Backup-/Restore-Punkt bestätigen.
+3. neue versionierte Embedding-Property und neuen Index anlegen.
+4. re-embedden mit Checkpoint, Fortschritt, Abbruch und Retry.
+5. Anzahl, Dimension und Suchstichproben validieren.
+6. Konfigurationsalias atomar umschalten.
+7. alten Index für eine definierte Rollback-Frist behalten.
+8. Löschung nur nach expliziter Bestätigung.
+
+Rollback: Alias zurück, neuen Job stoppen, neue Property/Index später
+kontrolliert entfernen. Alte Daten bleiben unangetastet.
+
+## Persona-Zahl
+
+Persistierte Runs ohne `requested_persona_count` behalten ihr historisches
+Verhalten und erhalten im Audit `source=legacy`. Neue Runs müssen die Invariante
+erzwingen. Bestehende Artefakte werden nicht umgeschrieben.

--- a/docs/epics/onboarding-provider-unification/07-agent-tooling.md
+++ b/docs/epics/onboarding-provider-unification/07-agent-tooling.md
@@ -1,0 +1,38 @@
+# Agent Tooling
+
+## context-mode
+
+- geprüft: 2026-07-10;
+- Version: 1.0.169;
+- Quelle: <https://github.com/mksglu/context-mode>;
+- Status: MCP, FTS5, Storage und Plugin-Hooks funktionieren;
+- Abweichung: Doctor meldet fehlendes `[features].hooks` in der globalen
+  Codex-Konfiguration;
+- Entscheidung: kein globales Upgrade im Feature-Epic. Separater
+  Tooling-Maintenance-Schritt mit Backup, Doctor und Rollback.
+
+## code-review-graph
+
+- geprüfte stabile Version: 2.3.6;
+- Quelle: <https://pypi.org/project/code-review-graph/>;
+- Lizenz: MIT;
+- `uv tool install` kollidiert mit einem vorhandenen Executable; kein `--force`;
+- reproduzierbarer CLI-Fallback:
+  `uvx --from 'code-review-graph==2.3.6' code-review-graph ...`;
+- MCP ist erreichbar und hat den Worktree-Graph erfolgreich aufgebaut;
+- ein Aktualisierungsweg: MCP-Update vor Architektur-/Delta-Reviews, kein
+  zusätzlicher Watcher.
+
+## Verwendung im Epic
+
+- Graph vor modulübergreifenden Änderungen aktualisieren.
+- Minimal Context, Impact Radius und betroffene Tests vor Direct Reads.
+- Nach Änderungen Delta-Review und Testlückenprüfung.
+- Große Logs und Multi-File-Recherche über context-mode.
+- Toolausfall dokumentieren; keine Resultate erfinden.
+
+## Secret-freier Check
+
+[`scripts/agent-tools-doctor.sh`](../../../scripts/agent-tools-doctor.sh) prüft
+nur Versionen und Graphstatus. Globale Konfiguration und Auth-Dateien werden
+nicht gelesen oder ausgegeben.

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -1,0 +1,87 @@
+# Handover
+
+## Stand
+
+- Branch: `codex/onboarding-provider-unification`
+- letzter Basis-Commit: `bb2b3ea`
+- Datum: 2026-07-10
+- Slice: 0 — Forschung und Architektur
+- Teststatus: Backend grün; Frontend-Tests bestanden, Vitest Exit 1 wegen vier
+  bestehenden Environment-Teardown-Rejections
+- context-mode: 1.0.169, funktionsfähig, Doctor-Warnung zum Hooks-Flag
+- code-review-graph: MCP funktionsfähig; stabile CLI 2.3.6 via `uvx`
+- Codegraph zuletzt aktualisiert: 2026-07-10, 944 Dateien
+- Delta-Review: 0 geänderte Funktionen/Klassen, 0 betroffene Flows,
+  0 Testlücken; Impact-Heuristik markiert das neue Doctor-Shellscript wegen
+  generischer Shell-Knoten als hoch, ohne Produktcodepfad
+
+## Dokumentations-Sync
+
+- README.md: geprüft, nicht betroffen — noch kein Anwenderverhalten geändert
+- AGENTS.md: geprüft, nicht betroffen
+- CLAUDE.md: geprüft, nicht betroffen
+- PLAN.md: Epic-Eintrag erforderlich
+- docs/STATUS.md: geprüft, Produktstatus unverändert
+- CHANGELOG.md: bewusst unverändert — nur Planung, keine Produktänderung
+- docs/tooling/agent-tools.md: erstellt
+
+## Fertig
+
+- Repository-, Provider-, Embedding- und Persona-Analyse.
+- offizielle Provider-/CLI-Quellen geprüft.
+- Zielarchitektur, Slice-, Test- und Migrationsplan.
+- ADRs für Provider, Embeddings und Single-User-Profil vorbereitet.
+- secret-freier Tooling-Check.
+
+## Noch offen
+
+- bestehender Frontend-Vitest-Teardown-Fehler.
+- globaler context-mode-Hooks-Doctor-Befund als Maintenance-Schritt.
+- Kollision des globalen `code-review-graph`-Executables; kein Force-Overwrite.
+- Slice 1 noch nicht begonnen.
+
+## Entscheidungen
+
+- kein Mega-Commit; ein PR pro Slice.
+- bestehende Provider-Detection-SSoT bleibt.
+- Subscription-Bridges nur nach separatem positiven Security-Spike.
+- Embedding-Wechsel ist versioniert und nicht destruktiv.
+- Persona-Wert ist tatsächliche Gesamtzahl; Floors werden Warnungen.
+
+## Bekannte Risiken
+
+- Provider-/Modell-Metadaten und Routing überlappen in mehreren Verträgen.
+- aktuelle Index-Dimensionsreparatur migriert Embeddings nicht.
+- sichtbarer Dashboard-Persona-Wert ist derzeit dekorativ.
+- kein Onboarding-Pfad vorhanden; Provider-/Model-Picker und Settings sind
+  mehrfach modelliert.
+- sieben zentrale Frontend-Dateien haben laut Codegraph innerhalb von zwei
+  Hops einen Impact auf 126 weitere Dateien.
+- Python-3.14-Baseline weicht vom dokumentierten Python-3.12-Ziel ab.
+
+## Nächste exakt ausführbare Schritte
+
+1. Phase-0-Dokumentation und ADRs prüfen und atomar committen.
+2. Frontend-Baselinefehler als separaten Fix/Issue behandeln.
+3. Slice 1 mit RED-Contract-Tests für `ProviderConnection`, `AiModel` und
+   `AiRoute` beginnen.
+
+## Relevante Dateien
+
+- `backend/app/contracts/llm_routing_contract.py`
+- `backend/app/llm/providers/registry.py`
+- `backend/app/services/llm_provider_registry.py`
+- `backend/app/services/model_catalog_service.py`
+- `backend/app/storage/embedding_service.py`
+- `backend/app/api/simulation_prepare.py`
+- `backend/app/services/prepare_service.py`
+- `frontend/src/components/v4/dashboard/HeroNewRun.vue`
+
+## Befehle zur Verifikation
+
+```bash
+scripts/agent-tools-doctor.sh
+cd backend && uv run pytest tests/contracts/ -v
+cd backend && uv run pytest -x -q
+cd frontend && npm test -- --run
+```

--- a/docs/tooling/agent-tools.md
+++ b/docs/tooling/agent-tools.md
@@ -1,0 +1,52 @@
+# Agent-Tooling
+
+Letzte Prüfung: 2026-07-10
+Verantwortlicher Slice: Onboarding/Provider-Unification Slice 0
+
+| Tool | Quelle/Lizenz | Version | Installationsweg | Status |
+|---|---|---:|---|---|
+| context-mode | <https://github.com/mksglu/context-mode>, Elastic-2.0 | 1.0.169 | Codex-Plugin | MCP/FTS/Hooks aktiv; Doctor meldet fehlendes globales Hooks-Flag |
+| code-review-graph | <https://pypi.org/project/code-review-graph/>, MIT | 2.3.6 | MCP vorhanden; CLI reproduzierbar via gepinntem `uvx` | Graph erfolgreich gebaut |
+| Codex CLI | <https://github.com/openai/codex>, Apache-2.0 | 0.142.5 | bestehende lokale Installation | aktiv |
+
+## Konfiguration und Rechte
+
+- Globale Codex- und Plugin-Konfiguration wird nicht ins Repository kopiert.
+- Keine Auth-Dateien, Tokens, Browserprofile oder Keychain-Inhalte prüfen.
+- context-mode verarbeitet große Read-only-Ausgaben und Session-Kontext.
+- code-review-graph liest Repository-Struktur und schreibt generierte
+  Graphdaten außerhalb versionierter Produktartefakte.
+- Es läuft kein zusätzlicher Watcher; Aktualisierung erfolgt kontrolliert per
+  MCP vor Architektur- und Delta-Reviews.
+
+## Doctor-/Status-Ergebnis
+
+- context-mode: Server, FTS5, Storage und fünf Plugin-Hooks OK; globales
+  `[features].hooks` laut Doctor nicht explizit gesetzt.
+- code-review-graph: 944 Dateien, 8.803 Knoten, 74.776 Kanten, 624 Flows,
+  11 Communities, keine Build-Fehler.
+- globaler `uv tool install code-review-graph==2.3.6` wurde nicht erzwungen,
+  weil bereits ein Executable kollidiert. `--force` wäre ohne Backup und
+  Herkunftsprüfung destruktiv.
+
+## Upgrade und Rollback
+
+Upgrades erfolgen nur in einem eigenen Maintenance-Slice:
+
+1. offizielle Release Notes, Lizenz und Sicherheitsmeldungen prüfen;
+2. Konfiguration sichern;
+3. exakte Version pinnen;
+4. Doctor, Graph-Build und Minimalabfrage ausführen;
+5. bei Fehlern vorherige Plugin-/Tool-Version wiederherstellen.
+
+Bis zur Klärung der CLI-Kollision:
+
+```bash
+uvx --from 'code-review-graph==2.3.6' code-review-graph status
+```
+
+## Einschränkungen
+
+- Graphresultate ersetzen weder direkte Codeprüfung noch Tests.
+- context-mode-Doctor ist wegen des Hooks-Flags nicht vollständig grün.
+- Python-3.14-Warnungen in der lokalen Baseline sind kein Tooling-Erfolg.

--- a/scripts/agent-tools-doctor.sh
+++ b/scripts/agent-tools-doctor.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Doctor-Skript: prüft alle Tools durch und bricht bei fehlenden
+# Abhängigkeiten nicht ab — Sammelstatus als Exit-Code am Ende.
+set -uo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+status=0
 
 printf '%s\n' '== Codex =='
-codex --version
+if command -v codex >/dev/null 2>&1; then
+  codex --version || status=1
+else
+  printf '%s\n' 'FEHLT: codex nicht im PATH'
+  status=1
+fi
 
 printf '%s\n' '== context-mode =='
 printf '%s\n' 'MCP-Doctor in Codex ausführen: mcp__context_mode__ctx_doctor'
 
 printf '%s\n' '== code-review-graph =='
-uvx --from 'code-review-graph==2.3.6' code-review-graph --version
-uvx --from 'code-review-graph==2.3.6' code-review-graph status --repo "$repo_root"
+if command -v uvx >/dev/null 2>&1; then
+  uvx --from 'code-review-graph==2.3.6' code-review-graph --version || status=1
+  uvx --from 'code-review-graph==2.3.6' code-review-graph status --repo "$repo_root" || status=1
+else
+  printf '%s\n' 'FEHLT: uvx nicht im PATH'
+  status=1
+fi
 
 printf '%s\n' 'OK: keine Auth- oder Secret-Dateien gelesen'
+exit "$status"

--- a/scripts/agent-tools-doctor.sh
+++ b/scripts/agent-tools-doctor.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+printf '%s\n' '== Codex =='
+codex --version
+
+printf '%s\n' '== context-mode =='
+printf '%s\n' 'MCP-Doctor in Codex ausführen: mcp__context_mode__ctx_doctor'
+
+printf '%s\n' '== code-review-graph =='
+uvx --from 'code-review-graph==2.3.6' code-review-graph --version
+uvx --from 'code-review-graph==2.3.6' code-review-graph status --repo "$repo_root"
+
+printf '%s\n' 'OK: keine Auth- oder Secret-Dateien gelesen'


### PR DESCRIPTION
## Zusammenfassung

Phase-0-Planungsstand des Onboarding-/Provider-Unification-Epics — reine Doku, kein Produktionscode:

- **ADRs 0006–0008**: AI-Provider-Connections, Embedding-Konfiguration + Index-Migration, Single-User-Profil + Onboarding (inkl. `docs/decisions/README.md`-Index)
- **Epic-Planung** unter `docs/epics/onboarding-provider-unification/`: Research, Current-State-Map, Provider-Matrix, Zielarchitektur, Implementierungs-, Test- und Migrationsplan, Agent-Tooling, HANDOVER
- **Tooling**: `docs/tooling/agent-tools.md` + `scripts/agent-tools-doctor.sh`
- `PLAN.md` um den Epic-Abschnitt ergänzt

`origin/main` ist eingemerged (Stand nach #678/#679). Die Implementierungsphasen folgen als separate PRs gemäß `04-implementation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)