### PR TITLE
feat(contracts): kanonische Provider-/Modell-/Route-Verträge (Onboarding Slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Basis-URLs mit Host und optionalem Pfad; Userinfo, Query und Fragment werden
   abgelehnt. Der Descriptor-Legacy-Adapter entfernt diese privaten URL-Anteile,
   markiert die Verbindung als `degraded` und verlangt Neukonfiguration.
+- **Legacy-Adapter total gemacht** (Review-Findings PR #683): der
+  `base_url`-Validator erzwingt jetzt auch das Feld-Pattern, wodurch
+  Sanitizer und Modell-Konstruktion deckungsgleich sind; großgeschriebene
+  Schemes werden beim Sanitizing normalisiert statt abgelehnt, nicht
+  rettbare Hosts degradieren zu `base_url=null` statt eine
+  `ValidationError` zu werfen. `llm_profile_to_canonical` saniert
+  Legacy-`base_url` jetzt ebenfalls und kombiniert Degradationsgründe
+  secret-frei in `status_message`.
 
 ### Changed (infra/ci — 2026-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Added (contracts — 2026-07-10)
+
+- **Kanonische KI-Provider-Verträge**: `ProviderConnection`, `AiModel` und
+  `AiRoute` sind als secret-freie Pydantic-v2-SSoT mit strikten
+  Zod-Spiegeln und JSON-Schemas verfügbar. Explizite Legacy-Adapter lesen
+  `ProviderDescriptor`, `ModelEntry`, `LlmProfile` und `StageLLMRoute`, ohne
+  bestehende Profile zu migrieren oder Provider-Detection zu verändern.
+  Kanonische `base_url`-Werte erlauben ausschließlich öffentliche HTTP(S)-
+  Basis-URLs mit Host und optionalem Pfad; Userinfo, Query und Fragment werden
+  abgelehnt. Der Descriptor-Legacy-Adapter entfernt diese privaten URL-Anteile,
+  markiert die Verbindung als `degraded` und verlangt Neukonfiguration.
+
 ### Changed (infra/ci — 2026-07-05)
 
 - **Proxy-Binding und Frontend-Image-Artefakt**: Proxy bindet standardmäßig nur noch auf `127.0.0.1:8080` (via `AGORA_PROXY_BIND_HOST`/`AGORA_PROXY_PORT`-Overrides). Frontend wird als Image-Artefakt in den Proxy gebaut statt per Host-Volume gemountet; reduziert Dev-Container-Overhead bei Prod-Stack-Tests.

--- a/PLAN.md
+++ b/PLAN.md
@@ -373,8 +373,10 @@ eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün
 
 ## 12. Onboarding & Provider-Unification (2026-07-10)
 
-**Status:** Phase 0 abgeschlossen auf `codex/onboarding-provider-unification`;
-noch kein Produktcode geändert.
+**Status:** Phase 0 abgeschlossen; Slice 1 implementiert, gehärtet und
+unabhängig verifiziert (Root-Re-Review 2026-07-11: MERGE-READY, drei
+non-blocking Follow-ups F1–F3 im Arbeitsprotokoll). PR eröffnet.
+Bestehende Profile bleiben unverändert lesbar.
 
 Ziel: lokales Erst-Onboarding, getrenntes Benutzerprofil, kanonische Provider-
 und Modellverträge, getrennte Embedding-Konfiguration, ein gemeinsamer
@@ -386,7 +388,7 @@ Source of Truth:
 | Slice | Inhalt | Status |
 |---|---|---|
 | 0 | Research, ADRs, Test-/Migrationsplan, Agent-Tooling | ✅ abgeschlossen |
-| 1 | Kanonische Provider-/Modell-/Route-Verträge | offen |
+| 1 | Kanonische Provider-/Modell-/Route-Verträge | verifiziert; PR offen |
 | 2 | Benutzerprofil und resumierbares Onboarding | offen |
 | 3 | Provider-Verbindungen und Discovery | offen |
 | 4 | Embedding-Setup und sichere Re-Embedding-Migration | offen |
@@ -401,6 +403,6 @@ Frontend-Produktslice separat klären.
 
 ---
 
-*Zuletzt aktualisiert: 2026-07-10 — Phase F #669/#670 abgeschlossen; Onboarding/Provider-Unification Phase 0 dokumentiert.*
+*Zuletzt aktualisiert: 2026-07-11 — Slice 1 verifiziert (MERGE-READY); PR offen.*
 *Provider-Detection-SSoT: `backend/app/llm/providers/registry.py`.*
 *Heuristik-SSoT: `docs/plans/plan.heuristic-2026-05-17.md`.*

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -86,6 +86,15 @@ from .provider_types import (
     PROVIDER_OPENAI_COMPATIBLE,
     ProviderType,
 )
+from .ai_provider_contract import (
+    AiModel,
+    AiRoute,
+    CapabilityState,
+    LocalOrCloud,
+    ModelCapabilities,
+    ModelSource,
+    ProviderConnection,
+)
 from .report_v3 import (
     Claim,
     ChangeRecommendation,
@@ -168,6 +177,13 @@ __all__ = [
     "PROVIDER_OPENAI",
     "PROVIDER_OPENAI_COMPATIBLE",
     "ProviderType",
+    "AiModel",
+    "AiRoute",
+    "CapabilityState",
+    "LocalOrCloud",
+    "ModelCapabilities",
+    "ModelSource",
+    "ProviderConnection",
     # ReportV3 — 11 Pflichtabschnitt-DTOs
     "Claim",
     "ChangeRecommendation",

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -1,0 +1,365 @@
+"""Canonical AI provider, model and route contracts plus legacy adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Literal
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, TypeAdapter
+from typing_extensions import TypedDict
+
+from .llm_profile_contract import LlmProfile
+from .llm_routing_contract import (
+    ModelEntry,
+    ProviderDescriptor,
+    ReasoningEffort,
+    StageId,
+    StageLLMRoute,
+)
+from .provider_types import ProviderType
+
+_STRICT = ConfigDict(extra="forbid")
+_LEGACY_ROUTE_OPTIONS_KEY = "__legacy_stage_route__"
+_PUBLIC_BASE_URL_PATTERN = (
+    r"^https?://(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])"
+    r"(?::[0-9]{1,5})?(?:/[^\s?#]*)?$"
+)
+
+CapabilityState = Literal["supported", "unsupported", "unknown"]
+ModelSource = Literal["live", "cached", "fallback", "custom"]
+LocalOrCloud = Literal["local", "cloud", "unknown"]
+ProviderTransport = Literal["http", "local"]
+ProviderAuthMode = Literal["none", "api_key", "oauth", "session"]
+ProviderStatus = Literal["unknown", "connected", "degraded", "disconnected", "error"]
+ModelStatus = Literal["unknown", "available", "unavailable", "deprecated"]
+RouteSource = Literal["default", "profile", "stage_override", "runtime", "legacy"]
+
+
+def _validate_public_base_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+    except ValueError as exc:
+        raise ValueError("base_url must be a public HTTP(S) base URL") from exc
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("base_url must be a public HTTP(S) base URL")
+    return value
+
+
+PublicBaseUrl = Annotated[
+    str,
+    Field(pattern=_PUBLIC_BASE_URL_PATTERN),
+    AfterValidator(_validate_public_base_url),
+]
+
+
+class LegacyStageRouteOptions(TypedDict, closed=True):  # type: ignore[call-arg]  # mypy lacks PEP 728
+    temperature: float | None
+    max_tokens: int | None
+    reasoning_effort: ReasoningEffort | None
+    had_reserved_value: bool
+    reserved_value: None
+
+
+class AiProviderOptions(TypedDict, total=False, closed=True):  # type: ignore[call-arg]  # mypy lacks PEP 728
+    """Secret-free options currently consumed by Agora routing."""
+
+    base_url: PublicBaseUrl | None
+    num_ctx: Annotated[int, Field(gt=0)]
+    __legacy_stage_route__: LegacyStageRouteOptions
+
+
+_AI_PROVIDER_OPTIONS_ADAPTER = TypeAdapter(AiProviderOptions)
+
+
+def _empty_provider_options() -> AiProviderOptions:
+    return {}
+
+
+class ModelCapabilities(BaseModel):
+    """Tri-state model capabilities; unknown is never treated as supported."""
+
+    model_config = _STRICT
+
+    chat: CapabilityState = "unknown"
+    embeddings: CapabilityState = "unknown"
+    streaming: CapabilityState = "unknown"
+    tool_calling: CapabilityState = "unknown"
+    json_object: CapabilityState = "unknown"
+    json_schema: CapabilityState = "unknown"
+    vision: CapabilityState = "unknown"
+    reasoning: CapabilityState = "unknown"
+
+    def supports(self, capability: str) -> bool:
+        return getattr(self, capability, "unknown") == "supported"
+
+
+class ProviderConnection(BaseModel):
+    """Public connection metadata. Secret values are stored out of contract."""
+
+    model_config = _STRICT
+
+    id: str = Field(min_length=1)
+    provider_kind: ProviderType
+    display_name: str = Field(min_length=1)
+    transport: ProviderTransport
+    auth_mode: ProviderAuthMode
+    base_url: PublicBaseUrl | None = None
+    enabled: bool = True
+    status: ProviderStatus = "unknown"
+    status_message: str | None = None
+    secret_ref: str | None = None
+    capabilities: dict[str, CapabilityState] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    last_tested_at: datetime | None = None
+
+
+class AiModel(BaseModel):
+    model_config = _STRICT
+
+    provider_connection_id: str = Field(min_length=1)
+    model_id: str = Field(min_length=1)
+    display_name: str = Field(min_length=1)
+    capabilities: ModelCapabilities = Field(default_factory=ModelCapabilities)
+    source: ModelSource
+    status: ModelStatus = "unknown"
+    context_window: int | None = Field(default=None, gt=0)
+    max_output_tokens: int | None = Field(default=None, gt=0)
+    embedding_dimensions: int | None = Field(default=None, gt=0)
+    local_or_cloud: LocalOrCloud = "unknown"
+    deprecated: bool = False
+    metadata_updated_at: datetime | None = None
+
+
+class AiRoute(BaseModel):
+    model_config = _STRICT
+
+    stage: StageId | None = None
+    provider_connection_id: str | None = None
+    model_id: str | None = None
+    source: RouteSource
+    validated_capabilities: dict[str, CapabilityState] = Field(default_factory=dict)
+    provider_options: AiProviderOptions = Field(default_factory=_empty_provider_options)
+
+
+def provider_connection_from_descriptor(
+    descriptor: ProviderDescriptor,
+    *,
+    now: datetime | None = None,
+) -> ProviderConnection:
+    """Read a legacy descriptor into the canonical public contract."""
+
+    timestamp = now or datetime.now(timezone.utc)
+    base_url, base_url_was_sanitized = _sanitize_legacy_base_url(descriptor.base_url)
+    return ProviderConnection(
+        id=descriptor.id,
+        provider_kind=descriptor.type,
+        display_name=descriptor.label,
+        transport="local" if descriptor.type == "ollama" else "http",
+        auth_mode="api_key" if descriptor.api_key_ref else "none",
+        base_url=base_url,
+        status="degraded" if base_url_was_sanitized else "unknown",
+        status_message=(
+            "Legacy base URL requires reconfiguration"
+            if base_url_was_sanitized
+            else None
+        ),
+        secret_ref=descriptor.api_key_ref,
+        capabilities={
+            "model_discovery": (
+                "supported" if descriptor.supports_models_endpoint else "unsupported"
+            ),
+            "tool_calling": "supported" if descriptor.supports_tools else "unsupported",
+        },
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+
+def _sanitize_legacy_base_url(value: str | None) -> tuple[str | None, bool]:
+    if value is None:
+        return None, False
+    try:
+        return _validate_public_base_url(value), False
+    except ValueError:
+        pass
+
+    try:
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return None, True
+        hostname = parsed.hostname
+        if ":" in hostname:
+            hostname = f"[{hostname}]"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        sanitized = urlunsplit(
+            (parsed.scheme, f"{hostname}{port}", parsed.path, "", "")
+        )
+        return _validate_public_base_url(sanitized), True
+    except ValueError:
+        return None, True
+
+
+def provider_descriptor_from_connection(
+    connection: ProviderConnection,
+    *,
+    fallback_models: list[str],
+) -> ProviderDescriptor:
+    """Adapt to the legacy descriptor; fallback models stay explicit at the boundary."""
+
+    return ProviderDescriptor(
+        id=connection.id,
+        label=connection.display_name,
+        type=connection.provider_kind,
+        base_url=connection.base_url,
+        api_key_ref=connection.secret_ref,
+        supports_models_endpoint=(
+            connection.capabilities.get("model_discovery") == "supported"
+        ),
+        supports_tools=connection.capabilities.get("tool_calling") == "supported",
+        fallback_models=fallback_models,
+    )
+
+
+def ai_model_from_model_entry(entry: ModelEntry) -> AiModel:
+    return AiModel(
+        provider_connection_id=entry.provider_id,
+        model_id=entry.id,
+        display_name=entry.name,
+        capabilities=ModelCapabilities(
+            tool_calling="supported" if entry.supports_tools else "unsupported",
+            json_object="supported" if entry.supports_json_mode else "unsupported",
+        ),
+        source=entry.source,
+        status="available",
+        context_window=entry.context_window,
+        metadata_updated_at=datetime.fromtimestamp(entry.refreshed_at, tz=timezone.utc),
+    )
+
+
+def model_entry_from_ai_model(model: AiModel) -> ModelEntry:
+    refreshed_at = model.metadata_updated_at or datetime.fromtimestamp(0, tz=timezone.utc)
+    return ModelEntry(
+        id=model.model_id,
+        name=model.display_name,
+        provider_id=model.provider_connection_id,
+        source=model.source,
+        refreshed_at=refreshed_at.timestamp(),
+        supports_tools=model.capabilities.supports("tool_calling"),
+        supports_json_mode=model.capabilities.supports("json_object"),
+        context_window=model.context_window,
+    )
+
+
+def ai_route_from_stage_route(route: StageLLMRoute) -> AiRoute:
+    raw_options = dict(route.provider_options)
+    had_reserved_value = _LEGACY_ROUTE_OPTIONS_KEY in raw_options
+    previous_reserved_value = raw_options.pop(_LEGACY_ROUTE_OPTIONS_KEY, None)
+    if previous_reserved_value is not None:
+        raise ValueError("legacy reserved provider option must be null")
+    legacy_options: LegacyStageRouteOptions = {
+        "temperature": route.temperature,
+        "max_tokens": route.max_tokens,
+        "reasoning_effort": route.reasoning_effort,
+        "had_reserved_value": had_reserved_value,
+        "reserved_value": previous_reserved_value,
+    }
+    raw_options[_LEGACY_ROUTE_OPTIONS_KEY] = legacy_options
+    options = _AI_PROVIDER_OPTIONS_ADAPTER.validate_python(raw_options)
+    return AiRoute(
+        stage=route.stage,
+        provider_connection_id=route.provider_id,
+        model_id=route.model,
+        source="legacy",
+        provider_options=options,
+    )
+
+
+def stage_route_from_ai_route(route: AiRoute) -> StageLLMRoute:
+    legacy = route.provider_options.get("__legacy_stage_route__")
+    options = dict(route.provider_options)
+    options.pop(_LEGACY_ROUTE_OPTIONS_KEY, None)
+    if legacy is not None and legacy.get("had_reserved_value"):
+        options[_LEGACY_ROUTE_OPTIONS_KEY] = legacy.get("reserved_value")
+    return StageLLMRoute(
+        stage=route.stage,
+        provider_id=route.provider_connection_id,
+        model=route.model_id,
+        temperature=legacy.get("temperature") if legacy is not None else None,
+        max_tokens=legacy.get("max_tokens") if legacy is not None else None,
+        reasoning_effort=(
+            legacy.get("reasoning_effort", "none") if legacy is not None else "none"
+        ),
+        provider_options=options,
+    )
+
+
+def llm_profile_to_canonical(
+    profile: LlmProfile,
+    *,
+    secret_ref: str | None = None,
+) -> tuple[ProviderConnection, AiModel, AiRoute]:
+    """Read a legacy profile without copying its secret value."""
+
+    unresolved_legacy_secret = bool(profile.api_key) and secret_ref is None
+    connection = ProviderConnection(
+        id=profile.id,
+        provider_kind=profile.provider,
+        display_name=profile.name,
+        transport="local" if profile.provider == "ollama" else "http",
+        auth_mode="api_key" if secret_ref or unresolved_legacy_secret else "none",
+        base_url=profile.base_url,
+        status="degraded" if unresolved_legacy_secret else "unknown",
+        status_message=(
+            "Legacy API key has no resolved secret_ref"
+            if unresolved_legacy_secret
+            else None
+        ),
+        secret_ref=secret_ref,
+        created_at=profile.created_at,
+        updated_at=profile.updated_at,
+    )
+    model = AiModel(
+        provider_connection_id=profile.id,
+        model_id=profile.model_name,
+        display_name=profile.model_name,
+        source="custom",
+        local_or_cloud="local" if profile.provider == "ollama" else "cloud",
+        metadata_updated_at=profile.updated_at,
+    )
+    route = AiRoute(
+        provider_connection_id=profile.id,
+        model_id=profile.model_name,
+        source="profile",
+    )
+    return connection, model, route
+
+
+def llm_profile_from_canonical(
+    connection: ProviderConnection,
+    model: AiModel,
+    *,
+    template: LlmProfile,
+    api_key: str | None = None,
+) -> LlmProfile:
+    """Write a legacy-compatible view; the secret is supplied by the secret store."""
+
+    return LlmProfile(
+        id=connection.id,
+        name=connection.display_name,
+        provider=connection.provider_kind,
+        base_url=connection.base_url or template.base_url,
+        model_name=model.model_id,
+        api_key=api_key,
+        is_default=template.is_default,
+        created_at=connection.created_at or template.created_at,
+        updated_at=connection.updated_at or template.updated_at,
+    )

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Annotated, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -25,6 +26,10 @@ _PUBLIC_BASE_URL_PATTERN = (
     r"^https?://(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])"
     r"(?::[0-9]{1,5})?(?:/[^\s?#]*)?$"
 )
+# Muss dem Field(pattern=...) entsprechen, damit Validator und Feld
+# deckungsgleich bleiben und die Legacy-Sanitizer nie URLs durchreichen,
+# die die Modell-Konstruktion anschließend doch ablehnt.
+_PUBLIC_BASE_URL_RE = re.compile(_PUBLIC_BASE_URL_PATTERN)
 
 CapabilityState = Literal["supported", "unsupported", "unknown"]
 ModelSource = Literal["live", "cached", "fallback", "custom"]
@@ -37,6 +42,8 @@ RouteSource = Literal["default", "profile", "stage_override", "runtime", "legacy
 
 
 def _validate_public_base_url(value: str) -> str:
+    if _PUBLIC_BASE_URL_RE.match(value) is None:
+        raise ValueError("base_url must be a public HTTP(S) base URL")
     try:
         parsed = urlsplit(value)
     except ValueError as exc:
@@ -310,19 +317,21 @@ def llm_profile_to_canonical(
     """Read a legacy profile without copying its secret value."""
 
     unresolved_legacy_secret = bool(profile.api_key) and secret_ref is None
+    base_url, base_url_was_sanitized = _sanitize_legacy_base_url(profile.base_url)
+    degradation_reasons = []
+    if unresolved_legacy_secret:
+        degradation_reasons.append("Legacy API key has no resolved secret_ref")
+    if base_url_was_sanitized:
+        degradation_reasons.append("Legacy base URL requires reconfiguration")
     connection = ProviderConnection(
         id=profile.id,
         provider_kind=profile.provider,
         display_name=profile.name,
         transport="local" if profile.provider == "ollama" else "http",
         auth_mode="api_key" if secret_ref or unresolved_legacy_secret else "none",
-        base_url=profile.base_url,
-        status="degraded" if unresolved_legacy_secret else "unknown",
-        status_message=(
-            "Legacy API key has no resolved secret_ref"
-            if unresolved_legacy_secret
-            else None
-        ),
+        base_url=base_url,
+        status="degraded" if degradation_reasons else "unknown",
+        status_message="; ".join(degradation_reasons) or None,
         secret_ref=secret_ref,
         created_at=profile.created_at,
         updated_at=profile.updated_at,

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -51,6 +51,7 @@ from app.contracts.llm_request import (
     NormalizedLlmChunk,
     NormalizedLlmError,
 )
+from app.contracts.ai_provider_contract import AiModel, AiRoute, ProviderConnection
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -87,6 +88,9 @@ CONTRACTS: dict[str, type] = {
     "llm-normalized-request.schema.json": NormalizedLlmRequest,
     "llm-normalized-chunk.schema.json": NormalizedLlmChunk,
     "llm-normalized-error.schema.json": NormalizedLlmError,
+    "ai-provider-connection.schema.json": ProviderConnection,
+    "ai-model.schema.json": AiModel,
+    "ai-route.schema.json": AiRoute,
 }
 
 

--- a/backend/tests/contracts/test_ai_provider_contract.py
+++ b/backend/tests/contracts/test_ai_provider_contract.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from pydantic import ValidationError
+
+from app.contracts.ai_provider_contract import (
+    AiModel,
+    AiRoute,
+    ModelCapabilities,
+    ProviderConnection,
+    ai_model_from_model_entry,
+    ai_route_from_stage_route,
+    llm_profile_from_canonical,
+    llm_profile_to_canonical,
+    model_entry_from_ai_model,
+    provider_connection_from_descriptor,
+    provider_descriptor_from_connection,
+    stage_route_from_ai_route,
+)
+from app.contracts.llm_profile_contract import LlmProfile
+from app.contracts.llm_routing_contract import ModelEntry, ProviderDescriptor, StageLLMRoute
+
+
+NOW = datetime(2026, 7, 10, tzinfo=timezone.utc)
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHARED_FIXTURES = json.loads(
+    (REPO_ROOT / "schemas/fixtures/ai-provider-contract-fixtures.json").read_text()
+)
+CONTRACT_CASES = {
+    "provider_connection": (
+        ProviderConnection,
+        REPO_ROOT / "schemas/ai-provider-connection.schema.json",
+    ),
+    "ai_model": (AiModel, REPO_ROOT / "schemas/ai-model.schema.json"),
+    "ai_route": (AiRoute, REPO_ROOT / "schemas/ai-route.schema.json"),
+}
+
+
+def _connection_data(base_url: str) -> dict:
+    return {
+        "id": "provider-1",
+        "provider_kind": "openai_compatible",
+        "display_name": "Provider",
+        "transport": "http",
+        "auth_mode": "none",
+        "base_url": base_url,
+    }
+
+
+def test_canonical_contracts_are_strict_and_secret_free() -> None:
+    connection = ProviderConnection(
+        id="ollama-local",
+        provider_kind="ollama",
+        display_name="Ollama lokal",
+        transport="local",
+        auth_mode="none",
+        capabilities={"model_discovery": "supported"},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    model = AiModel(
+        provider_connection_id=connection.id,
+        model_id="qwen3:8b",
+        display_name="Qwen 3 8B",
+        capabilities=ModelCapabilities(chat="supported"),
+        source="live",
+        status="available",
+        local_or_cloud="local",
+        metadata_updated_at=NOW,
+    )
+    route = AiRoute(
+        stage="report_generation",
+        provider_connection_id=connection.id,
+        model_id=model.model_id,
+        source="stage_override",
+        validated_capabilities={"chat": "supported"},
+    )
+
+    assert model.capabilities.supports("chat") is True
+    assert model.capabilities.supports("vision") is False
+    assert route.provider_options == {}
+    for contract, instance in (
+        (ProviderConnection, connection),
+        (AiModel, model),
+        (AiRoute, route),
+    ):
+        assert "api_key" not in contract.model_fields
+        assert "secret" not in contract.model_fields
+        assert contract.model_json_schema()["additionalProperties"] is False
+        with pytest.raises(ValidationError):
+            contract.model_validate({**instance.model_dump(), "unexpected": True})
+
+
+@pytest.mark.parametrize("contract_name", CONTRACT_CASES)
+def test_shared_fixtures_match_pydantic_and_generated_json_schema(
+    contract_name: str,
+) -> None:
+    model, schema_path = CONTRACT_CASES[contract_name]
+    validator = Draft202012Validator(json.loads(schema_path.read_text()))
+
+    for fixture in SHARED_FIXTURES[contract_name]["valid"]:
+        model.model_validate(fixture)
+        validator.validate(fixture)
+    for fixture in SHARED_FIXTURES[contract_name]["invalid"]:
+        with pytest.raises(ValidationError):
+            model.model_validate(fixture)
+        with pytest.raises(JsonSchemaValidationError):
+            validator.validate(fixture)
+
+
+@pytest.mark.parametrize("base_url", SHARED_FIXTURES["base_urls"]["invalid"])
+def test_provider_connection_rejects_non_public_base_url(base_url: str) -> None:
+    with pytest.raises(ValidationError):
+        ProviderConnection.model_validate(_connection_data(base_url))
+
+
+@pytest.mark.parametrize("base_url", SHARED_FIXTURES["base_urls"]["invalid"])
+def test_ai_route_rejects_non_public_base_url(base_url: str) -> None:
+    with pytest.raises(ValidationError):
+        AiRoute(source="runtime", provider_options={"base_url": base_url})
+
+
+@pytest.mark.parametrize("base_url", SHARED_FIXTURES["base_urls"]["valid"])
+def test_public_base_url_positive_fixtures(base_url: str) -> None:
+    assert ProviderConnection.model_validate(_connection_data(base_url)).base_url == base_url
+    route = AiRoute(source="runtime", provider_options={"base_url": base_url})
+    assert route.provider_options["base_url"] == base_url
+
+
+def test_generated_json_schemas_enforce_public_base_url_fixtures() -> None:
+    connection_validator = Draft202012Validator(
+        json.loads((REPO_ROOT / "schemas/ai-provider-connection.schema.json").read_text())
+    )
+    route_validator = Draft202012Validator(
+        json.loads((REPO_ROOT / "schemas/ai-route.schema.json").read_text())
+    )
+
+    for base_url in SHARED_FIXTURES["base_urls"]["valid"]:
+        connection_validator.validate(_connection_data(base_url))
+        route_validator.validate(
+            {"source": "runtime", "provider_options": {"base_url": base_url}}
+        )
+    for base_url in SHARED_FIXTURES["base_urls"]["invalid"]:
+        with pytest.raises(JsonSchemaValidationError):
+            connection_validator.validate(_connection_data(base_url))
+        with pytest.raises(JsonSchemaValidationError):
+            route_validator.validate(
+                {"source": "runtime", "provider_options": {"base_url": base_url}}
+            )
+
+
+def test_unknown_capability_is_never_treated_as_supported() -> None:
+    capabilities = ModelCapabilities()
+
+    assert capabilities.chat == "unknown"
+    assert capabilities.supports("chat") is False
+    assert capabilities.supports("missing") is False
+
+
+@pytest.mark.parametrize(
+    "provider_options",
+    [
+        {"x-api-key": "fixture-token"},
+        {"client_secret": "fixture-token"},
+        {"refresh_token": "fixture-token"},
+        {"headers": {"bearer_token": "fixture-token"}},
+    ],
+)
+def test_route_provider_options_reject_non_allowlisted_keys(
+    provider_options: dict,
+) -> None:
+    with pytest.raises(ValidationError):
+        AiRoute(
+            source="runtime",
+            provider_options=provider_options,
+        )
+
+
+def test_route_provider_options_accept_runtime_allowlist() -> None:
+    route = AiRoute(
+        source="runtime",
+        provider_options={
+            "base_url": "https://gateway.example/v1",
+            "num_ctx": 32768,
+        },
+    )
+
+    assert route.provider_options == {
+        "base_url": "https://gateway.example/v1",
+        "num_ctx": 32768,
+    }
+
+
+def test_route_json_schema_expresses_provider_options_allowlist() -> None:
+    schema = AiRoute.model_json_schema()
+    options_schema = schema["$defs"]["AiProviderOptions"]
+
+    assert options_schema["additionalProperties"] is False
+    assert set(options_schema["properties"]) == {
+        "base_url",
+        "num_ctx",
+        "__legacy_stage_route__",
+    }
+
+
+def test_provider_descriptor_adapter_roundtrip_preserves_public_metadata() -> None:
+    legacy = ProviderDescriptor(
+        id="openai-main",
+        label="OpenAI",
+        type="openai",
+        base_url="https://api.openai.com/v1",
+        api_key_ref="vault:openai-main",
+        supports_models_endpoint=True,
+        supports_tools=True,
+        fallback_models=["gpt-4.1-mini"],
+    )
+
+    canonical = provider_connection_from_descriptor(legacy, now=NOW)
+    restored = provider_descriptor_from_connection(canonical, fallback_models=legacy.fallback_models)
+
+    assert canonical.secret_ref == "vault:openai-main"
+    assert restored == legacy
+
+
+@pytest.mark.parametrize("base_url", SHARED_FIXTURES["base_urls"]["invalid"])
+def test_provider_descriptor_adapter_sanitizes_unsafe_legacy_base_url(
+    base_url: str,
+) -> None:
+    legacy = ProviderDescriptor(
+        id="legacy-provider",
+        label="Legacy Provider",
+        type="openai_compatible",
+        base_url=base_url,
+    )
+
+    canonical = provider_connection_from_descriptor(legacy, now=NOW)
+
+    assert canonical.base_url == "https://example.test/v1"
+    assert canonical.status == "degraded"
+    assert canonical.status_message == "Legacy base URL requires reconfiguration"
+    assert "fixture-token" not in str(canonical.model_dump())
+
+
+@pytest.mark.parametrize("base_url", SHARED_FIXTURES["base_urls"]["invalid"])
+def test_stage_route_adapter_rejects_unsafe_legacy_base_url(base_url: str) -> None:
+    legacy = StageLLMRoute(
+        provider_id="legacy-provider",
+        model="model-1",
+        provider_options={"base_url": base_url},
+    )
+
+    with pytest.raises(ValueError):
+        ai_route_from_stage_route(legacy)
+
+
+def test_provider_descriptor_reverse_adapter_requires_fallback_sidecar() -> None:
+    connection = ProviderConnection(
+        id="openai-main",
+        provider_kind="openai",
+        display_name="OpenAI",
+        transport="http",
+        auth_mode="api_key",
+        secret_ref="vault:openai-main",
+    )
+
+    with pytest.raises(TypeError):
+        provider_descriptor_from_connection(connection)
+
+
+def test_model_entry_adapter_roundtrip_and_unknown_defaults() -> None:
+    legacy = ModelEntry(
+        id="gpt-4.1-mini",
+        name="GPT-4.1 mini",
+        provider_id="openai-main",
+        source="cached",
+        refreshed_at=NOW.timestamp(),
+        supports_tools=True,
+        supports_json_mode=False,
+        context_window=128_000,
+    )
+
+    canonical = ai_model_from_model_entry(legacy)
+
+    assert canonical.capabilities.tool_calling == "supported"
+    assert canonical.capabilities.json_object == "unsupported"
+    assert canonical.capabilities.vision == "unknown"
+    assert model_entry_from_ai_model(canonical) == legacy
+
+
+def test_stage_route_adapter_roundtrip_preserves_legacy_tuning() -> None:
+    legacy = StageLLMRoute(
+        stage="simulation_rounds",
+        provider_id="ollama-local",
+        model="qwen3:8b",
+        temperature=0.4,
+        max_tokens=2048,
+        reasoning_effort="medium",
+        provider_options={"num_ctx": 32768},
+    )
+
+    canonical = ai_route_from_stage_route(legacy)
+
+    assert canonical.source == "legacy"
+    assert stage_route_from_ai_route(canonical) == legacy
+
+
+def test_stage_route_roundtrip_preserves_reserved_none_collision() -> None:
+    legacy = StageLLMRoute(
+        stage="report_generation",
+        provider_id="ollama-local",
+        model="qwen3:8b",
+        provider_options={
+            "num_ctx": 32768,
+            "__legacy_stage_route__": None,
+        },
+    )
+
+    canonical = ai_route_from_stage_route(legacy)
+
+    assert stage_route_from_ai_route(canonical) == legacy
+
+
+def test_stage_route_roundtrip_preserves_none_reasoning_effort() -> None:
+    legacy = StageLLMRoute(
+        stage="report_generation",
+        provider_id="ollama-local",
+        model="qwen3:8b",
+        reasoning_effort=None,
+    )
+
+    canonical = ai_route_from_stage_route(legacy)
+
+    assert stage_route_from_ai_route(canonical).reasoning_effort is None
+
+
+def test_llm_profile_adapter_keeps_secrets_out_of_canonical_contracts() -> None:
+    legacy = LlmProfile(
+        id="profile-1",
+        name="Lokales Profil",
+        provider="ollama",
+        base_url="http://localhost:11434/v1",
+        model_name="qwen3:8b",
+        api_key="fixture-token",
+        is_default=True,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    connection, model, route = llm_profile_to_canonical(
+        legacy,
+        secret_ref="vault:profile-1",
+    )
+    serialized = f"{connection.model_dump()} {model.model_dump()} {route.model_dump()}"
+
+    assert connection.secret_ref == "vault:profile-1"
+    assert "fixture-token" not in serialized
+    assert llm_profile_from_canonical(
+        connection,
+        model,
+        template=legacy,
+        api_key="fixture-token",
+    ) == legacy
+
+
+def test_llm_profile_with_legacy_key_without_ref_is_explicitly_degraded() -> None:
+    legacy = LlmProfile(
+        id="profile-unresolved",
+        name="Unresolved secret",
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model_name="gpt-4.1-mini",
+        api_key="fixture-token",
+        is_default=False,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    connection, _, _ = llm_profile_to_canonical(legacy)
+
+    assert connection.auth_mode == "api_key"
+    assert connection.status == "degraded"
+    assert connection.status_message == "Legacy API key has no resolved secret_ref"
+    assert connection.secret_ref is None

--- a/backend/tests/contracts/test_ai_provider_contract.py
+++ b/backend/tests/contracts/test_ai_provider_contract.py
@@ -387,3 +387,79 @@ def test_llm_profile_with_legacy_key_without_ref_is_explicitly_degraded() -> Non
     assert connection.status == "degraded"
     assert connection.status_message == "Legacy API key has no resolved secret_ref"
     assert connection.secret_ref is None
+
+
+def test_descriptor_adapter_normalizes_uppercase_scheme_instead_of_raising() -> None:
+    legacy = ProviderDescriptor(
+        id="legacy-upper",
+        label="Legacy Upper",
+        type="openai_compatible",
+        base_url="HTTPS://Example.test/v1",
+    )
+
+    canonical = provider_connection_from_descriptor(legacy, now=NOW)
+
+    assert canonical.base_url == "https://example.test/v1"
+    assert canonical.status == "degraded"
+    assert canonical.status_message == "Legacy base URL requires reconfiguration"
+
+
+def test_descriptor_adapter_degrades_unsalvageable_host_instead_of_raising() -> None:
+    legacy = ProviderDescriptor(
+        id="legacy-underscore",
+        label="Legacy Underscore",
+        type="openai_compatible",
+        base_url="http://legacy_host.example:11434/v1",
+    )
+
+    canonical = provider_connection_from_descriptor(legacy, now=NOW)
+
+    assert canonical.base_url is None
+    assert canonical.status == "degraded"
+    assert canonical.status_message == "Legacy base URL requires reconfiguration"
+
+
+def test_llm_profile_adapter_sanitizes_unsafe_base_url_instead_of_raising() -> None:
+    legacy = LlmProfile(
+        id="profile-unsafe-url",
+        name="Unsafe URL",
+        provider="openai_compatible",
+        base_url="https://host.example/v1?key=fixture-token",
+        model_name="model-1",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    connection, _, _ = llm_profile_to_canonical(
+        legacy,
+        secret_ref="vault:profile-unsafe-url",
+    )
+
+    assert connection.base_url == "https://host.example/v1"
+    assert connection.status == "degraded"
+    assert connection.status_message == "Legacy base URL requires reconfiguration"
+    assert "fixture-token" not in str(connection.model_dump())
+
+
+def test_llm_profile_adapter_combines_secret_and_base_url_degradation() -> None:
+    legacy = LlmProfile(
+        id="profile-doubly-degraded",
+        name="Doubly degraded",
+        provider="openai",
+        base_url="https://user@host.example/v1",
+        model_name="gpt-4.1-mini",
+        api_key="fixture-token",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    connection, _, _ = llm_profile_to_canonical(legacy)
+
+    assert connection.auth_mode == "api_key"
+    assert connection.status == "degraded"
+    assert connection.status_message == (
+        "Legacy API key has no resolved secret_ref; "
+        "Legacy base URL requires reconfiguration"
+    )
+    assert connection.base_url == "https://host.example/v1"
+    assert "fixture-token" not in str(connection.model_dump())

--- a/docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md
+++ b/docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md
@@ -1,0 +1,96 @@
+# Arbeitsprotokoll — Onboarding/Provider-Unification Slice 1
+
+Datum: 2026-07-10  
+Branch: `codex/onboarding-provider-contracts`  
+Scope: kanonische Provider-/Modell-/Route-Verträge
+
+## Ablauf
+
+1. Epic-Dokumente, ADR-0006, bestehende Contracts/Tests und Codegraph geprüft.
+   Der Impact für zentrale Contract-Exports ist hoch (115 Dateien innerhalb
+   von zwei Hops); deshalb blieb die Änderung auf neue Verträge, Exporte,
+   Schemas und Adapter begrenzt.
+2. RED geschrieben:
+   `backend/tests/contracts/test_ai_provider_contract.py` scheiterte bei der
+   Collection erwartungsgemäß mit
+   `ModuleNotFoundError: app.contracts.ai_provider_contract` (Exit 2).
+   Der Frontend-Spiegeltest scheiterte parallel am fehlenden Modul.
+3. GREEN implementiert: `ProviderConnection`, `AiModel`, `AiRoute`,
+   Tri-State-Capabilities, Legacy-Adapter, Zod-Spiegel und Schema-Dump.
+4. TypeScript-RED im ersten Typecheck: Zod akzeptierte `{}` nicht als
+   `.default()` für den bereits transformierten Capability-Output. Minimaler
+   Fix: expliziter vollständig unbekannter Default; danach Typecheck grün.
+5. Schemas erzeugt, zweiten Dump auf identischen Diff-Hash geprüft und
+   Contract-/Frontend-Gates ausgeführt.
+6. Security-Re-Review am 2026-07-11: Provider-Optionen auf fachliche Allowlist
+   begrenzt, Legacy-Secret-Status/Fallback-/Roundtrip-Pfade gehärtet und
+   öffentliche `base_url` als gemeinsame Pydantic-/JSON-Schema-/Zod-Regel
+   eingeführt. Legacy-Descriptor-URLs werden secret-frei saniert und als
+   `degraded` markiert; Stage-Routen lehnen unsichere URLs ab.
+
+## Ergebnis und Tests
+
+- neue Backend-Contract-Tests: 39 bestanden
+- Backend-Contract-Suite: 250 bestanden, Exit 0
+- neue Frontend-Contract-Tests: 17 bestanden, Exit 0
+- Backend Ruff (neue Dateien): Exit 0
+- Backend mypy (neuer Vertrag): Exit 0
+- Frontend Typecheck: Exit 0
+- Frontend standalone: 146/146 Testdateien, 1150/1150 Tests; Lint, Typecheck
+  und Build grün
+- `npm run check` vor dem `base_url`-Fix: fachliche Coverage-Tests grün, Exit 1
+  durch bekannte `EnvironmentTeardownError` aus `CompareView.spec.ts`
+- Testinventar: 2934 Backend-Tests total, 2927 selektiert, 7 deselektiert
+- letzter Full-Backend-Lauf vor dem `base_url`-Fix: 2900 bestanden,
+  9 übersprungen, 7 deselektiert
+- unabhängiger Full-Backend-Lauf nach dem `base_url`-Fix (Root, 2026-07-11):
+  2920 bestanden, 9 übersprungen, 7 deselektiert, Exit 0
+- Schema-Dump: 34 Dateien, zweiter Dump idempotent
+- mypy: 206 Dateien, 0 Fehler; Ruff: vollständig grün
+- Codegraph: 945 Dateien, 8965 Knoten, 75474 Kanten, 624 Flows; hoher Impact,
+  138 zusätzliche Dateien, 1 Schema-Dump-Flow, 0 Testlücken
+
+## Doc-Impact
+
+- `README.md`: geprüft, nicht betroffen
+- `AGENTS.md`: geprüft, nicht betroffen
+- `CLAUDE.md`: geprüft, nicht betroffen
+- `PLAN.md`: aktualisiert
+- `docs/STATUS.md`: aktualisiert (Testzahlen)
+- `CHANGELOG.md`: aktualisiert (`[Unreleased]`)
+- Epic-`HANDOVER.md`: aktualisiert
+- `docs/tooling/agent-tools.md`: geprüft, nicht betroffen
+
+## Bewusst offen
+
+- Persistente Provider-Connections und Discovery sind Slice 3.
+- Benutzerprofil/Onboarding, Embeddings und Persona-Zahl sind nicht Teil
+  dieses Slices.
+- Legacy-Secrets bleiben außerhalb kanonischer Verträge und müssen beim
+  Rückadapter separat aus dem Secret-Store bereitgestellt werden.
+- Codegraph-Refresh nach dem `base_url`-Fix: in der Abschluss-Session nicht
+  ausführbar (CRG-MCP nicht verbunden, CRG-CLI nicht gefunden); als Follow-up
+  vor dem nächsten Slice nachholen.
+
+## Root-Verifikation und Re-Review (2026-07-11)
+
+Unabhängig vom Implementer wiederholt und bestätigt: Security-Probes
+(Credential-Keys in `provider_options` top-level und verschachtelt blockiert;
+Userinfo-`base_url` abgelehnt; keine Secret-Muster im Diff), Backend-Zieltest
+39, Contract-Suite 250, Full-Backend 2920/9/7, Frontend-Zieltest 17, Frontend
+Full 146 Testdateien / 1150 Tests, Lint, Typecheck, Build.
+
+Finaler adversarialer Re-Review des `base_url`-Fixes: **MERGE-READY**. Kein
+Bypass gefunden (u. a. percent-encodete Userinfo, Mehrfach-`@`, leerer Host,
+Steuerzeichen, IDN, Query-/Fragment-Secrets); Sanitizer-Output und
+`status_message` sind secret-frei, Zod und JSON-Schema gleich streng. Drei
+non-blocking Follow-ups:
+
+- F1 (LOW–MEDIUM): Out-of-Range-Ports (`:0`, `:65536`) akzeptiert Pydantic/
+  JSON-Schema, Zod lehnt ab — Spiegel-Parity-Drift.
+- F2 (MEDIUM): `provider_connection_from_descriptor` wirft bei
+  Scheme-Großschreibung (`HTTPS://…`) oder Underscore-Host eine unhandled
+  `ValidationError` statt zu degradieren — Adapter ist nicht total.
+- F3 (LOW–MEDIUM): Backslash-Host-Parser-Differential (`urlsplit` vs. WHATWG)
+  kann im Legacy-Sanitizer den Host still umschreiben (SSRF-adjazent,
+  degraded-Pfad, kein Secret-Leak).

--- a/docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md
+++ b/docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md
@@ -94,3 +94,21 @@ non-blocking Follow-ups:
 - F3 (LOW–MEDIUM): Backslash-Host-Parser-Differential (`urlsplit` vs. WHATWG)
   kann im Legacy-Sanitizer den Host still umschreiben (SSRF-adjazent,
   degraded-Pfad, kein Secret-Leak).
+
+## Gemini-Findings und CI-Fix (2026-07-11, nach PR-Eröffnung)
+
+- CI-Fail `STATUS.md Drift (--check)`: manuell editierte Zeile in
+  `docs/STATUS.md` wich vom Generator-Output ab; behoben durch
+  `scripts/sync-status.sh`-Regeneration (2938 collected, 145 Test-Files
+  per `find`-Zählweise).
+- Drei Gemini-Inline-Findings, deckungsgleich mit Review-Finding F2
+  (gemeinsame Wurzel: Validator und Feld-Pattern nicht deckungsgleich,
+  `llm_profile_to_canonical` ohne Sanitizer), per TDD behoben
+  (4 neue RED→GREEN-Tests, Zieltest jetzt 43):
+  `_validate_public_base_url` prüft das Pattern selbst; der Sanitizer
+  normalisiert dadurch Scheme-/Host-Großschreibung und degradiert nicht
+  rettbare Hosts zu `None` statt zu werfen; `llm_profile_to_canonical`
+  saniert `base_url` und kombiniert Degradationsgründe secret-frei.
+  F2 ist damit geschlossen; F1 (Port-Range-Parity) und F3 bleiben als
+  Follow-ups offen. JSON-Schemas unverändert (Pattern identisch),
+  Zod-Spiegel unverändert (Regex war dort bereits aktiv).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-07-05 (post M3-Port, v1.0.0)
+Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1, Re-Review offen, v1.0.0)
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 
@@ -19,8 +19,8 @@ Stand: 2026-07-05 (post M3-Port, v1.0.0)
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2895 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 144 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 2934 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 146 | `cd frontend && npm test -- --run` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1, Re-Review offen, v1.0.0)
+Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 offen, v1.0.0)
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 
@@ -19,8 +19,8 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1, Re-Review offen, v1.
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2934 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 146 | `cd frontend && npm test -- --run` |
+| Backend Tests (collected) | 2938 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 145 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -1,87 +1,157 @@
-# Handover
+# Handover — Onboarding/Provider-Unification Slice 1
 
 ## Stand
 
-- Branch: `codex/onboarding-provider-unification`
-- letzter Basis-Commit: `bb2b3ea`
-- Datum: 2026-07-10
-- Slice: 0 — Forschung und Architektur
-- Teststatus: Backend grün; Frontend-Tests bestanden, Vitest Exit 1 wegen vier
-  bestehenden Environment-Teardown-Rejections
-- context-mode: 1.0.169, funktionsfähig, Doctor-Warnung zum Hooks-Flag
-- code-review-graph: MCP funktionsfähig; stabile CLI 2.3.6 via `uvx`
-- Codegraph zuletzt aktualisiert: 2026-07-10, 944 Dateien
-- Delta-Review: 0 geänderte Funktionen/Klassen, 0 betroffene Flows,
-  0 Testlücken; Impact-Heuristik markiert das neue Doctor-Shellscript wegen
-  generischer Shell-Knoten als hoch, ohne Produktcodepfad
+- Datum: 2026-07-11
+- Worktree: `/private/tmp/agora-onboarding-provider-contracts`
+- Branch: `codex/onboarding-provider-contracts`
+- Arbeitsstand: unabhängig verifiziert, committet und als PR eröffnet
+  (Root, 2026-07-11)
+- Slice 1 ist implementiert und unabhängig verifiziert. Der finale
+  unabhängige Re-Review des `base_url`-Fixes ist abgeschlossen:
+  **MERGE-READY** mit drei non-blocking Follow-ups (F1–F3, siehe
+  Arbeitsprotokoll).
+- Provider-Detection-SSoT
+  `backend/app/llm/providers/registry.py::detect_provider` blieb unverändert.
 
-## Dokumentations-Sync
+## Implementierter Vertrag
 
-- README.md: geprüft, nicht betroffen — noch kein Anwenderverhalten geändert
-- AGENTS.md: geprüft, nicht betroffen
-- CLAUDE.md: geprüft, nicht betroffen
-- PLAN.md: Epic-Eintrag erforderlich
-- docs/STATUS.md: geprüft, Produktstatus unverändert
-- CHANGELOG.md: bewusst unverändert — nur Planung, keine Produktänderung
-- docs/tooling/agent-tools.md: erstellt
+- `ProviderConnection`, `AiModel` und `AiRoute` sind kanonische
+  Pydantic-v2-Verträge mit `extra="forbid"` sowie generierten JSON-Schemas und
+  strikten Zod-Spiegeln.
+- Secrets bleiben außerhalb der kanonischen Verträge; ausschließlich
+  `secret_ref` wird geführt.
+- Modellfähigkeiten sind Tri-State (`supported|unsupported|unknown`).
+  `unknown` gilt niemals als unterstützt.
+- `provider_options` ist eine geschlossene fachliche Allowlist. Aktuell sind
+  ausschließlich die tatsächlich verwendeten Routing-Optionen `base_url`,
+  `num_ctx` und die interne Legacy-Roundtrip-Struktur erlaubt. Credential-Keys
+  werden dadurch sowohl top-level als auch verschachtelt strukturell blockiert.
+- Gemeinsame Fixtures prüfen Pydantic, generiertes JSON-Schema und Zod auf
+  gültige und ungültige Grenzfälle.
 
-## Fertig
+## Security-Remediations und Legacy-Adapter
 
-- Repository-, Provider-, Embedding- und Persona-Analyse.
-- offizielle Provider-/CLI-Quellen geprüft.
-- Zielarchitektur, Slice-, Test- und Migrationsplan.
-- ADRs für Provider, Embeddings und Single-User-Profil vorbereitet.
-- secret-freier Tooling-Check.
+- Ein Legacy-`api_key` ohne aufgelöste Referenz erzeugt nicht mehr
+  `auth_mode="none"`, sondern explizit `auth_mode="api_key"`, Status
+  `degraded` und eine secret-freie Fehlstatusmeldung.
+- Der Rückadapter zu `ProviderDescriptor` verlangt das Fallback-Modell-Sidecar
+  zwingend; stiller Verlust durch ein implizites leeres Array ist unmöglich.
+- `StageLLMRoute`-Roundtrips erhalten einen kollidierenden reservierten Key mit
+  Wert `None` sowie `reasoning_effort=None` verlustfrei.
+- Kanonische `base_url` ist eine öffentliche HTTP(S)-Basis-URL: Scheme
+  `http`/`https` und Host sind Pflicht; Port und Pfad sind erlaubt. Userinfo,
+  Query und Fragment sind vollständig verboten.
+- Der `ProviderDescriptor`-Legacy-Adapter entfernt Userinfo, Query und Fragment
+  aus einer unsicheren Legacy-URL, übernimmt keinen privaten Anteil und
+  markiert die Verbindung mit einer secret-freien Reconfigure-Meldung als
+  `degraded`.
+- Der `StageLLMRoute`-Adapter lehnt eine unsichere `base_url` explizit ab.
 
-## Noch offen
+## Frisch verifiziert nach dem letzten `base_url`-Fix
 
-- bestehender Frontend-Vitest-Teardown-Fehler.
-- globaler context-mode-Hooks-Doctor-Befund als Maintenance-Schritt.
-- Kollision des globalen `code-review-graph`-Executables; kein Force-Overwrite.
-- Slice 1 noch nicht begonnen.
+Vom Implementer:
 
-## Entscheidungen
+- Backend-Zieltest: 39 bestanden
+- Frontend-Zieltest: 17 bestanden
+- Backend-Contract-Suite: 250 bestanden
+- mypy: 206 Dateien, 0 Fehler
+- Ruff: grün
+- Schema-Dump: idempotent
+- Frontend standalone: 146/146 Testdateien, 1150/1150 Tests
+- Frontend Lint, Typecheck und Build standalone: grün
+- Pytest-Inventar: 2934 total, 2927 selektiert, 7 deselektiert
 
-- kein Mega-Commit; ein PR pro Slice.
-- bestehende Provider-Detection-SSoT bleibt.
-- Subscription-Bridges nur nach separatem positiven Security-Spike.
-- Embedding-Wechsel ist versioniert und nicht destruktiv.
-- Persona-Wert ist tatsächliche Gesamtzahl; Floors werden Warnungen.
+Vom Root unabhängig erneut bestätigt:
 
-## Bekannte Risiken
+- Imports
+- Schema-Idempotenz
+- Backend-Zieltest: 39 bestanden
+- Backend-Contract-Suite: 250 bestanden
+- Ruff
+- mypy: 206 Dateien, 0 Fehler
 
-- Provider-/Modell-Metadaten und Routing überlappen in mehreren Verträgen.
-- aktuelle Index-Dimensionsreparatur migriert Embeddings nicht.
-- sichtbarer Dashboard-Persona-Wert ist derzeit dekorativ.
-- kein Onboarding-Pfad vorhanden; Provider-/Model-Picker und Settings sind
-  mehrfach modelliert.
-- sieben zentrale Frontend-Dateien haben laut Codegraph innerhalb von zwei
-  Hops einen Impact auf 126 weitere Dateien.
-- Python-3.14-Baseline weicht vom dokumentierten Python-3.12-Ziel ab.
+Vom Root am 2026-07-11 zusätzlich unabhängig bestätigt:
+
+- vollständiger Backend-Testlauf: 2920 bestanden, 9 übersprungen,
+  7 deselektiert, Exit 0
+- Frontend-Zieltest (17), Frontend Full (146 Testdateien / 1150 Tests),
+  Lint, Typecheck und Build — alle grün
+- Security-Probes: Credential-Keys in `provider_options` blockiert,
+  Userinfo-`base_url` abgelehnt, keine Secret-Muster im Diff
+
+## Bekannte Baselines und offene Punkte
+
+- Der letzte vollständige Backend-Lauf vor dem `base_url`-Fix hatte
+  2900 bestandene, 9 übersprungene und 7 deselektierte Tests; der
+  unabhängige Lauf nach dem Fix 2920/9/7 (Exit 0).
+- `npm run check` hatte vor dem `base_url`-Fix fachlich bestandene
+  Coverage-Tests, endete aber wegen eines vorbestehenden Vitest-
+  `EnvironmentTeardownError` aus `CompareView.spec.ts` mit Exit 1. Standalone
+  Full Tests, Lint, Typecheck und Build sind grün. Den Teardown nicht in diesem
+  Slice beheben.
+- Der vorherige Reviewer fand den `base_url`-Secret-Pfad. Der Fix ist
+  implementiert; der finale unabhängige Re-Review (2026-07-11) ergab
+  **MERGE-READY** mit drei non-blocking Follow-ups F1–F3 (Port-Parity-Drift
+  Zod/Pydantic, nicht-totaler Legacy-Adapter, Backslash-Host-Differential) —
+  Details im Arbeitsprotokoll.
+- Codegraph vor dem `base_url`-Fix, letzter Full-Stand: 945 Dateien,
+  8965 Knoten, 75474 Kanten und 624 Flows. Der damalige Impact war hoch:
+  138 zusätzliche Dateien, 1 Schema-Dump-Flow und 0 Testlücken. Der Refresh
+  nach dem `base_url`-Fix war in der Abschluss-Session nicht ausführbar
+  (CRG nicht verbunden) und bleibt Follow-up.
+- In einer früheren Prozessdiagnose wurde ein Credential eines fremden
+  Prozesses in einer Tool-Ausgabe sichtbar. Vorsorgliche Rotation ist separat
+  erforderlich; der Wert darf nicht erneut ausgegeben, dokumentiert oder
+  anderweitig reproduziert werden.
 
 ## Nächste exakt ausführbare Schritte
 
-1. Phase-0-Dokumentation und ADRs prüfen und atomar committen.
-2. Frontend-Baselinefehler als separaten Fix/Issue behandeln.
-3. Slice 1 mit RED-Contract-Tests für `ProviderConnection`, `AiModel` und
-   `AiRoute` beginnen.
+1. `git diff` und `git status` prüfen; Security-Probes für Credential-Keys und
+   öffentliche `base_url` unabhängig wiederholen.
+2. Vollständigen Backend-Testlauf ausführen und exakte Passed/Skipped/
+   Deselected-Zahlen festhalten.
+3. Frontend-Zieltest, Full Tests, Lint, Typecheck und Build unabhängig
+   wiederholen. Den bekannten Composite-Check-Teardown separat dokumentieren,
+   nicht in diesem Slice reparieren.
+4. Codegraph full oder inkrementell aktualisieren und Delta, Impact, Flow sowie
+   Testlücken prüfen.
+5. Reviewer-Re-Review des `base_url`-Fixes durchführen.
+6. Doku-Zahlen gegen die frischen unabhängigen Läufe prüfen und gegebenenfalls
+   korrigieren.
+7. Nur die konkreten Slice-Dateien stagen, atomaren Commit erstellen, Branch
+   pushen und PR eröffnen. Nicht direkt auf `main` mergen.
 
 ## Relevante Dateien
 
-- `backend/app/contracts/llm_routing_contract.py`
-- `backend/app/llm/providers/registry.py`
-- `backend/app/services/llm_provider_registry.py`
-- `backend/app/services/model_catalog_service.py`
-- `backend/app/storage/embedding_service.py`
-- `backend/app/api/simulation_prepare.py`
-- `backend/app/services/prepare_service.py`
-- `frontend/src/components/v4/dashboard/HeroNewRun.vue`
+- `backend/app/contracts/ai_provider_contract.py`
+- `backend/app/contracts/__init__.py`
+- `backend/app/contracts/dump_schemas.py`
+- `backend/tests/contracts/test_ai_provider_contract.py`
+- `frontend/src/contracts/aiProviderContract.ts`
+- `frontend/src/contracts/__tests__/aiProviderContract.spec.ts`
+- `schemas/ai-provider-connection.schema.json`
+- `schemas/ai-model.schema.json`
+- `schemas/ai-route.schema.json`
+- `schemas/fixtures/ai-provider-contract-fixtures.json`
+- `CHANGELOG.md`
+- `PLAN.md`
+- `docs/STATUS.md`
+- `docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md`
 
-## Befehle zur Verifikation
+## Doc-Impact
 
-```bash
-scripts/agent-tools-doctor.sh
-cd backend && uv run pytest tests/contracts/ -v
-cd backend && uv run pytest -x -q
-cd frontend && npm test -- --run
-```
+- `README.md`: geprüft, nicht betroffen — noch kein neues Anwender- oder
+  UI-Verhalten.
+- `AGENTS.md`: geprüft, nicht betroffen — Contract-, Schema-, TDD- und
+  Security-Regeln decken den Slice bereits ab.
+- `CLAUDE.md`: geprüft, nicht betroffen — Detection-SSoT und Schema-Befehle
+  bleiben unverändert.
+- `PLAN.md`: aktualisiert — Slice implementiert, Root-Re-Review offen.
+- `docs/STATUS.md`: aktualisiert — aktuelles Pytest-Inventar und Frontend-
+  Testdateien.
+- `CHANGELOG.md`: aktualisiert — kanonische Verträge, öffentliche `base_url`
+  und Legacy-Sanitizing unter `[Unreleased]`.
+- Epic-`HANDOVER.md`: aktualisiert — dieser operative Übergabestand.
+- `docs/tooling/agent-tools.md`: geprüft, nicht betroffen — keine Tool-Version,
+  Installation oder Konfiguration geändert.

--- a/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
+++ b/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+
+import aiModelJsonSchema from '../../../../schemas/ai-model.schema.json'
+import aiRouteJsonSchema from '../../../../schemas/ai-route.schema.json'
+import providerConnectionJsonSchema from '../../../../schemas/ai-provider-connection.schema.json'
+import sharedFixtures from '../../../../schemas/fixtures/ai-provider-contract-fixtures.json'
+
+import {
+  AiModelSchema,
+  AiRouteSchema,
+  ModelCapabilitiesSchema,
+  ProviderConnectionSchema,
+} from '../aiProviderContract'
+
+describe('canonical AI provider contracts', () => {
+  const connectionWithBaseUrl = (base_url: string) => ({
+    id: 'provider-1',
+    provider_kind: 'openai_compatible',
+    display_name: 'Provider',
+    transport: 'http',
+    auth_mode: 'none',
+    base_url,
+  })
+
+  it('keeps Zod top-level fields aligned with generated Pydantic schemas', () => {
+    expect(Object.keys(ProviderConnectionSchema.shape).sort()).toEqual(
+      Object.keys(providerConnectionJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(AiModelSchema.shape).sort()).toEqual(
+      Object.keys(aiModelJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(AiRouteSchema.shape).sort()).toEqual(
+      Object.keys(aiRouteJsonSchema.properties).sort(),
+    )
+  })
+
+  it('matches shared valid and invalid boundary fixtures', () => {
+    const contracts = {
+      provider_connection: ProviderConnectionSchema,
+      ai_model: AiModelSchema,
+      ai_route: AiRouteSchema,
+    }
+
+    for (const [name, schema] of Object.entries(contracts)) {
+      const fixtures = sharedFixtures[name as keyof typeof sharedFixtures]
+      for (const fixture of fixtures.valid) expect(schema.safeParse(fixture).success).toBe(true)
+      for (const fixture of fixtures.invalid) expect(schema.safeParse(fixture).success).toBe(false)
+    }
+  })
+
+  it('aligns required, enum, nullability, numeric and option constraints with JSON Schema', () => {
+    expect(providerConnectionJsonSchema.required).toEqual([
+      'id',
+      'provider_kind',
+      'display_name',
+      'transport',
+      'auth_mode',
+    ])
+    expect(providerConnectionJsonSchema.properties.provider_kind.enum).toEqual([
+      'ollama',
+      'openai',
+      'google',
+      'anthropic',
+      'custom',
+      'ollama_cloud',
+      'openai_compatible',
+      'github_copilot',
+      'cloud',
+      'unknown',
+    ])
+    expect(providerConnectionJsonSchema.properties.base_url.anyOf).toContainEqual({ type: 'null' })
+    expect(aiModelJsonSchema.properties.context_window.anyOf).toContainEqual({ type: 'null' })
+    expect(aiModelJsonSchema.properties.context_window.anyOf).toContainEqual({
+      exclusiveMinimum: 0,
+      type: 'integer',
+    })
+    const optionsRef = aiRouteJsonSchema.properties.provider_options.$ref
+    const optionsName = optionsRef.split('/').at(-1) as keyof typeof aiRouteJsonSchema.$defs
+    const optionsSchema = aiRouteJsonSchema.$defs[optionsName]
+    expect(optionsSchema.additionalProperties).toBe(false)
+    expect(Object.keys(optionsSchema.properties).sort()).toEqual([
+      '__legacy_stage_route__',
+      'base_url',
+      'num_ctx',
+    ])
+    expect(
+      aiRouteJsonSchema.$defs.LegacyStageRouteOptions.properties.reasoning_effort.anyOf,
+    ).toContainEqual({ type: 'null' })
+  })
+
+  it('mirrors strict backend contracts and keeps unknown capabilities unsupported', () => {
+    const capabilities = ModelCapabilitiesSchema.parse({})
+    expect(capabilities.chat).toBe('unknown')
+    expect(capabilities.vision).toBe('unknown')
+
+    expect(ProviderConnectionSchema.safeParse({ unexpected: true }).success).toBe(false)
+    expect(AiModelSchema.safeParse({ unexpected: true }).success).toBe(false)
+    expect(AiRouteSchema.safeParse({ unexpected: true }).success).toBe(false)
+  })
+
+  it('accepts the canonical Pydantic-shaped payload without secret values', () => {
+    const result = ProviderConnectionSchema.safeParse({
+      id: 'ollama-local',
+      provider_kind: 'ollama',
+      display_name: 'Ollama lokal',
+      transport: 'local',
+      auth_mode: 'none',
+      base_url: 'http://localhost:11434',
+      enabled: true,
+      status: 'connected',
+      status_message: null,
+      secret_ref: null,
+      capabilities: { model_discovery: 'supported' },
+      created_at: '2026-07-10T00:00:00Z',
+      updated_at: '2026-07-10T00:00:00Z',
+      last_tested_at: null,
+    })
+
+    expect(result.success).toBe(true)
+    expect(ProviderConnectionSchema.safeParse({ ...result.data, api_key: 'forbidden' }).success).toBe(false)
+  })
+
+  it.each([
+    { 'x-api-key': 'fixture-token' },
+    { client_secret: 'fixture-token' },
+    { refresh_token: 'fixture-token' },
+    { headers: { bearer_token: 'fixture-token' } },
+  ])('rejects non-allowlisted provider options: %o', (provider_options) => {
+    expect(AiRouteSchema.safeParse({ source: 'runtime', provider_options }).success).toBe(false)
+  })
+
+  it('accepts only provider options used by routing', () => {
+    expect(AiRouteSchema.safeParse({
+      source: 'runtime',
+      provider_options: {
+        base_url: 'https://gateway.example/v1',
+        num_ctx: 32768,
+      },
+    }).success).toBe(true)
+  })
+
+  it.each(sharedFixtures.base_urls.invalid)(
+    'rejects non-public base URL in connection and route: %s',
+    (base_url) => {
+      expect(ProviderConnectionSchema.safeParse(connectionWithBaseUrl(base_url)).success).toBe(false)
+      expect(AiRouteSchema.safeParse({
+        source: 'runtime',
+        provider_options: { base_url },
+      }).success).toBe(false)
+    },
+  )
+
+  it.each(sharedFixtures.base_urls.valid)(
+    'accepts public base URL in connection and route: %s',
+    (base_url) => {
+      expect(ProviderConnectionSchema.safeParse(connectionWithBaseUrl(base_url)).success).toBe(true)
+      expect(AiRouteSchema.safeParse({
+        source: 'runtime',
+        provider_options: { base_url },
+      }).success).toBe(true)
+    },
+  )
+})

--- a/frontend/src/contracts/aiProviderContract.ts
+++ b/frontend/src/contracts/aiProviderContract.ts
@@ -1,0 +1,132 @@
+/** Canonical Zod mirror of backend/app/contracts/ai_provider_contract.py. */
+import { z } from 'zod'
+
+export const CapabilityStateSchema = z.enum(['supported', 'unsupported', 'unknown'])
+export type CapabilityState = z.infer<typeof CapabilityStateSchema>
+
+const UNKNOWN_MODEL_CAPABILITIES = {
+  chat: 'unknown',
+  embeddings: 'unknown',
+  streaming: 'unknown',
+  tool_calling: 'unknown',
+  json_object: 'unknown',
+  json_schema: 'unknown',
+  vision: 'unknown',
+  reasoning: 'unknown',
+} as const
+
+export const ModelCapabilitiesSchema = z.object({
+  chat: CapabilityStateSchema.default('unknown'),
+  embeddings: CapabilityStateSchema.default('unknown'),
+  streaming: CapabilityStateSchema.default('unknown'),
+  tool_calling: CapabilityStateSchema.default('unknown'),
+  json_object: CapabilityStateSchema.default('unknown'),
+  json_schema: CapabilityStateSchema.default('unknown'),
+  vision: CapabilityStateSchema.default('unknown'),
+  reasoning: CapabilityStateSchema.default('unknown'),
+}).strict()
+export type ModelCapabilities = z.infer<typeof ModelCapabilitiesSchema>
+
+const ProviderKindSchema = z.enum([
+  'ollama',
+  'openai',
+  'google',
+  'anthropic',
+  'custom',
+  'ollama_cloud',
+  'openai_compatible',
+  'github_copilot',
+  'cloud',
+  'unknown',
+])
+
+const NullableDateTimeSchema = z.string().datetime({ offset: true }).nullable().default(null)
+
+const PUBLIC_BASE_URL_PATTERN = /^https?:\/\/(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:\/[^\s?#]*)?$/
+
+export const PublicBaseUrlSchema = z.string().regex(PUBLIC_BASE_URL_PATTERN).superRefine((value, context) => {
+  try {
+    const parsed = new URL(value)
+    if (
+      !['http:', 'https:'].includes(parsed.protocol) ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      context.addIssue({ code: 'custom', message: 'base_url must be a public HTTP(S) base URL' })
+    }
+  } catch {
+    context.addIssue({ code: 'custom', message: 'base_url must be a public HTTP(S) base URL' })
+  }
+})
+
+export const ProviderConnectionSchema = z.object({
+  id: z.string().min(1),
+  provider_kind: ProviderKindSchema,
+  display_name: z.string().min(1),
+  transport: z.enum(['http', 'local']),
+  auth_mode: z.enum(['none', 'api_key', 'oauth', 'session']),
+  base_url: PublicBaseUrlSchema.nullable().default(null),
+  enabled: z.boolean().default(true),
+  status: z.enum(['unknown', 'connected', 'degraded', 'disconnected', 'error']).default('unknown'),
+  status_message: z.string().nullable().default(null),
+  secret_ref: z.string().nullable().default(null),
+  capabilities: z.record(z.string(), CapabilityStateSchema).default({}),
+  created_at: NullableDateTimeSchema,
+  updated_at: NullableDateTimeSchema,
+  last_tested_at: NullableDateTimeSchema,
+}).strict()
+export type ProviderConnection = z.infer<typeof ProviderConnectionSchema>
+
+export const AiModelSchema = z.object({
+  provider_connection_id: z.string().min(1),
+  model_id: z.string().min(1),
+  display_name: z.string().min(1),
+  capabilities: ModelCapabilitiesSchema.default(UNKNOWN_MODEL_CAPABILITIES),
+  source: z.enum(['live', 'cached', 'fallback', 'custom']),
+  status: z.enum(['unknown', 'available', 'unavailable', 'deprecated']).default('unknown'),
+  context_window: z.number().int().positive().nullable().default(null),
+  max_output_tokens: z.number().int().positive().nullable().default(null),
+  embedding_dimensions: z.number().int().positive().nullable().default(null),
+  local_or_cloud: z.enum(['local', 'cloud', 'unknown']).default('unknown'),
+  deprecated: z.boolean().default(false),
+  metadata_updated_at: NullableDateTimeSchema,
+}).strict()
+export type AiModel = z.infer<typeof AiModelSchema>
+
+const StageIdSchema = z.enum([
+  'document_ingest',
+  'ontology_generation',
+  'graph_build',
+  'persona_generation',
+  'simulation_rounds',
+  'report_generation',
+  'evaluation',
+])
+
+const LegacyStageRouteOptionsSchema = z.object({
+  temperature: z.number().nullable(),
+  max_tokens: z.number().int().nullable(),
+  reasoning_effort: z.enum(['none', 'minimal', 'low', 'medium', 'high']).nullable(),
+  had_reserved_value: z.boolean(),
+  reserved_value: z.null(),
+}).strict()
+
+export const AiProviderOptionsSchema = z.object({
+  base_url: PublicBaseUrlSchema.nullable().optional(),
+  num_ctx: z.number().int().positive().optional(),
+  __legacy_stage_route__: LegacyStageRouteOptionsSchema.optional(),
+}).strict()
+export type AiProviderOptions = z.infer<typeof AiProviderOptionsSchema>
+
+export const AiRouteSchema = z.object({
+  stage: StageIdSchema.nullable().default(null),
+  provider_connection_id: z.string().nullable().default(null),
+  model_id: z.string().nullable().default(null),
+  source: z.enum(['default', 'profile', 'stage_override', 'runtime', 'legacy']),
+  validated_capabilities: z.record(z.string(), CapabilityStateSchema).default({}),
+  provider_options: AiProviderOptionsSchema.default({}),
+}).strict()
+export type AiRoute = z.infer<typeof AiRouteSchema>

--- a/schemas/ai-model.schema.json
+++ b/schemas/ai-model.schema.json
@@ -1,0 +1,211 @@
+{
+  "$defs": {
+    "ModelCapabilities": {
+      "additionalProperties": false,
+      "description": "Tri-state model capabilities; unknown is never treated as supported.",
+      "properties": {
+        "chat": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Chat",
+          "type": "string"
+        },
+        "embeddings": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Embeddings",
+          "type": "string"
+        },
+        "json_object": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Json Object",
+          "type": "string"
+        },
+        "json_schema": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Json Schema",
+          "type": "string"
+        },
+        "reasoning": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Reasoning",
+          "type": "string"
+        },
+        "streaming": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Streaming",
+          "type": "string"
+        },
+        "tool_calling": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Tool Calling",
+          "type": "string"
+        },
+        "vision": {
+          "default": "unknown",
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Vision",
+          "type": "string"
+        }
+      },
+      "title": "ModelCapabilities",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/ai-model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "capabilities": {
+      "$ref": "#/$defs/ModelCapabilities"
+    },
+    "context_window": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Context Window"
+    },
+    "deprecated": {
+      "default": false,
+      "title": "Deprecated",
+      "type": "boolean"
+    },
+    "display_name": {
+      "minLength": 1,
+      "title": "Display Name",
+      "type": "string"
+    },
+    "embedding_dimensions": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Embedding Dimensions"
+    },
+    "local_or_cloud": {
+      "default": "unknown",
+      "enum": [
+        "local",
+        "cloud",
+        "unknown"
+      ],
+      "title": "Local Or Cloud",
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Output Tokens"
+    },
+    "metadata_updated_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Metadata Updated At"
+    },
+    "model_id": {
+      "minLength": 1,
+      "title": "Model Id",
+      "type": "string"
+    },
+    "provider_connection_id": {
+      "minLength": 1,
+      "title": "Provider Connection Id",
+      "type": "string"
+    },
+    "source": {
+      "enum": [
+        "live",
+        "cached",
+        "fallback",
+        "custom"
+      ],
+      "title": "Source",
+      "type": "string"
+    },
+    "status": {
+      "default": "unknown",
+      "enum": [
+        "unknown",
+        "available",
+        "unavailable",
+        "deprecated"
+      ],
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "provider_connection_id",
+    "model_id",
+    "display_name",
+    "source"
+  ],
+  "title": "AiModel",
+  "type": "object"
+}

--- a/schemas/ai-provider-connection.schema.json
+++ b/schemas/ai-provider-connection.schema.json
@@ -1,0 +1,166 @@
+{
+  "$id": "https://alexle135.de/schemas/ai-provider-connection.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Public connection metadata. Secret values are stored out of contract.",
+  "properties": {
+    "auth_mode": {
+      "enum": [
+        "none",
+        "api_key",
+        "oauth",
+        "session"
+      ],
+      "title": "Auth Mode",
+      "type": "string"
+    },
+    "base_url": {
+      "anyOf": [
+        {
+          "pattern": "^https?://(?:[A-Za-z0-9.-]+|\\[[0-9A-Fa-f:.]+\\])(?::[0-9]{1,5})?(?:/[^\\s?#]*)?$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Base Url"
+    },
+    "capabilities": {
+      "additionalProperties": {
+        "enum": [
+          "supported",
+          "unsupported",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "title": "Capabilities",
+      "type": "object"
+    },
+    "created_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Created At"
+    },
+    "display_name": {
+      "minLength": 1,
+      "title": "Display Name",
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "id": {
+      "minLength": 1,
+      "title": "Id",
+      "type": "string"
+    },
+    "last_tested_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Tested At"
+    },
+    "provider_kind": {
+      "enum": [
+        "ollama",
+        "openai",
+        "google",
+        "anthropic",
+        "custom",
+        "ollama_cloud",
+        "openai_compatible",
+        "github_copilot",
+        "cloud",
+        "unknown"
+      ],
+      "title": "Provider Kind",
+      "type": "string"
+    },
+    "secret_ref": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Secret Ref"
+    },
+    "status": {
+      "default": "unknown",
+      "enum": [
+        "unknown",
+        "connected",
+        "degraded",
+        "disconnected",
+        "error"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "status_message": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Status Message"
+    },
+    "transport": {
+      "enum": [
+        "http",
+        "local"
+      ],
+      "title": "Transport",
+      "type": "string"
+    },
+    "updated_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Updated At"
+    }
+  },
+  "required": [
+    "id",
+    "provider_kind",
+    "display_name",
+    "transport",
+    "auth_mode"
+  ],
+  "title": "ProviderConnection",
+  "type": "object"
+}

--- a/schemas/ai-route.schema.json
+++ b/schemas/ai-route.schema.json
@@ -1,0 +1,175 @@
+{
+  "$defs": {
+    "AiProviderOptions": {
+      "additionalProperties": false,
+      "description": "Secret-free options currently consumed by Agora routing.",
+      "properties": {
+        "__legacy_stage_route__": {
+          "$ref": "#/$defs/LegacyStageRouteOptions"
+        },
+        "base_url": {
+          "anyOf": [
+            {
+              "pattern": "^https?://(?:[A-Za-z0-9.-]+|\\[[0-9A-Fa-f:.]+\\])(?::[0-9]{1,5})?(?:/[^\\s?#]*)?$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Base Url"
+        },
+        "num_ctx": {
+          "exclusiveMinimum": 0,
+          "title": "Num Ctx",
+          "type": "integer"
+        }
+      },
+      "title": "AiProviderOptions",
+      "type": "object"
+    },
+    "LegacyStageRouteOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "had_reserved_value": {
+          "title": "Had Reserved Value",
+          "type": "boolean"
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Max Tokens"
+        },
+        "reasoning_effort": {
+          "anyOf": [
+            {
+              "enum": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reasoning Effort"
+        },
+        "reserved_value": {
+          "title": "Reserved Value",
+          "type": "null"
+        },
+        "temperature": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Temperature"
+        }
+      },
+      "required": [
+        "temperature",
+        "max_tokens",
+        "reasoning_effort",
+        "had_reserved_value",
+        "reserved_value"
+      ],
+      "title": "LegacyStageRouteOptions",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/ai-route.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "model_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Id"
+    },
+    "provider_connection_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Provider Connection Id"
+    },
+    "provider_options": {
+      "$ref": "#/$defs/AiProviderOptions"
+    },
+    "source": {
+      "enum": [
+        "default",
+        "profile",
+        "stage_override",
+        "runtime",
+        "legacy"
+      ],
+      "title": "Source",
+      "type": "string"
+    },
+    "stage": {
+      "anyOf": [
+        {
+          "enum": [
+            "document_ingest",
+            "ontology_generation",
+            "graph_build",
+            "persona_generation",
+            "simulation_rounds",
+            "report_generation",
+            "evaluation"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Stage"
+    },
+    "validated_capabilities": {
+      "additionalProperties": {
+        "enum": [
+          "supported",
+          "unsupported",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "title": "Validated Capabilities",
+      "type": "object"
+    }
+  },
+  "required": [
+    "source"
+  ],
+  "title": "AiRoute",
+  "type": "object"
+}

--- a/schemas/fixtures/ai-provider-contract-fixtures.json
+++ b/schemas/fixtures/ai-provider-contract-fixtures.json
@@ -1,0 +1,122 @@
+{
+  "base_urls": {
+    "valid": [
+      "http://localhost:11434",
+      "https://example.test:8443/v1",
+      "https://gateway.example/v1/models"
+    ],
+    "invalid": [
+      "https://user:pass@example.test/v1",
+      "https://example.test/v1?api_key=fixture-token",
+      "https://example.test/v1?key=fixture-token",
+      "https://example.test/v1#fixture-fragment"
+    ]
+  },
+  "provider_connection": {
+    "valid": [
+      {
+        "id": "ollama-local",
+        "provider_kind": "ollama",
+        "display_name": "Ollama lokal",
+        "transport": "local",
+        "auth_mode": "none",
+        "base_url": null,
+        "secret_ref": null
+      }
+    ],
+    "invalid": [
+      {
+        "id": "",
+        "provider_kind": "ollama",
+        "display_name": "Ollama lokal",
+        "transport": "local",
+        "auth_mode": "none"
+      },
+      {
+        "id": "provider-1",
+        "provider_kind": "invalid",
+        "display_name": "Provider",
+        "transport": "http",
+        "auth_mode": "none"
+      },
+      {
+        "id": "provider-1",
+        "provider_kind": "openai",
+        "display_name": "Provider",
+        "transport": "http"
+      }
+    ]
+  },
+  "ai_model": {
+    "valid": [
+      {
+        "provider_connection_id": "ollama-local",
+        "model_id": "qwen3:8b",
+        "display_name": "Qwen 3 8B",
+        "source": "live",
+        "context_window": 1,
+        "max_output_tokens": null,
+        "embedding_dimensions": null
+      }
+    ],
+    "invalid": [
+      {
+        "provider_connection_id": "ollama-local",
+        "model_id": "qwen3:8b",
+        "display_name": "Qwen 3 8B",
+        "source": "live",
+        "context_window": 0
+      },
+      {
+        "provider_connection_id": "ollama-local",
+        "model_id": "qwen3:8b",
+        "display_name": "Qwen 3 8B",
+        "source": "unknown"
+      },
+      {
+        "provider_connection_id": "ollama-local",
+        "model_id": "qwen3:8b",
+        "display_name": "Qwen 3 8B"
+      }
+    ]
+  },
+  "ai_route": {
+    "valid": [
+      {
+        "stage": null,
+        "provider_connection_id": "ollama-local",
+        "model_id": "qwen3:8b",
+        "source": "runtime",
+        "provider_options": {
+          "base_url": "https://gateway.example/v1",
+          "num_ctx": 32768
+        }
+      }
+    ],
+    "invalid": [
+      {
+        "source": "runtime",
+        "provider_options": {
+          "x-api-key": "fixture-token"
+        }
+      },
+      {
+        "source": "runtime",
+        "provider_options": {
+          "headers": {
+            "client_secret": "fixture-token"
+          }
+        }
+      },
+      {
+        "source": "runtime",
+        "provider_options": {
+          "num_ctx": 0
+        }
+      },
+      {
+        "source": "invalid"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Zusammenfassung

Slice 1 des Epics Onboarding/Provider-Unification: `ProviderConnection`, `AiModel` und `AiRoute` als kanonische, secret-freie Pydantic-v2-Verträge (`extra="forbid"`) mit strikten Zod-Spiegeln, generierten JSON-Schemas und gemeinsamen Fixtures.

- Secrets bleiben außerhalb der Verträge — ausschließlich `secret_ref`.
- `provider_options` ist eine geschlossene Allowlist (`base_url`, `num_ctx`, Legacy-Roundtrip); Credential-Keys sind top-level und verschachtelt strukturell blockiert.
- Kanonische `base_url` erlaubt nur öffentliche HTTP(S)-Basis-URLs (Host Pflicht; Userinfo, Query, Fragment verboten). Der `ProviderDescriptor`-Legacy-Adapter sanitisiert unsichere URLs secret-frei und markiert die Verbindung als `degraded`; der `StageLLMRoute`-Adapter lehnt unsichere URLs ab.
- Modell-Capabilities sind Tri-State (`supported|unsupported|unknown`); `unknown` gilt nie als unterstützt.
- Provider-Detection-SSoT (`registry.py::detect_provider`) unverändert.

## Verifikation (unabhängig vom Implementer, 2026-07-11)

- Backend voll: 2920 passed / 9 skipped / 7 deselected, Exit 0
- Contract-Suite: 250 passed; Zieltest 39 passed
- Schema-Dump `--check`: 34/34 OK, idempotent
- Ruff grün; mypy 206 Dateien, 0 Fehler
- Frontend: Zieltest 17, Full 146 Testdateien / 1150 Tests, Lint, Typecheck, Build grün
- Security-Probes: Credential-Keys in `provider_options` blockiert; Userinfo/Query/Fragment-`base_url` abgelehnt; Sanitizer-Output und Statusmeldungen secret-frei

## Security-Re-Review `base_url`-Fix

Finaler adversarialer Re-Review: **MERGE-READY**. Kein Bypass (percent-encodete Userinfo, Mehrfach-`@`, leerer Host, Steuerzeichen, IDN, Query-/Fragment-Secrets — alle abgewehrt). Drei non-blocking Follow-ups, dokumentiert im Arbeitsprotokoll:

- **F1** (LOW–MEDIUM): Out-of-Range-Ports — Zod strenger als Pydantic/JSON-Schema (Parity-Drift)
- **F2** (MEDIUM): Legacy-Adapter wirft bei Scheme-Großschreibung/Underscore-Host unhandled `ValidationError` statt zu degradieren
- **F3** (LOW–MEDIUM): Backslash-Host-Parser-Differential im Legacy-Sanitizer (SSRF-adjazent, kein Secret-Leak)

## Bekannte, bewusst nicht enthaltene Punkte

- Vitest-`EnvironmentTeardownError` in `npm run check` (`CompareView.spec.ts`) ist vorbestehend und nicht Teil dieses Slices.
- Codegraph-Refresh nach dem `base_url`-Fix steht als Follow-up aus (CRG in der Abschluss-Session nicht verfügbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)