### PR TITLE
feat(onboarding): Benutzerprofil + resumierbares Onboarding-Grundgerüst (Slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Added (profile/onboarding — 2026-07-11)
+
+- **Lokales Benutzerprofil (Slice 2, ADR-0008)**: neuer Pydantic-v2-Vertrag
+  `UserProfile` (Anzeigename, Sprache, Zeitzone, Report-Sprache, Theme,
+  Datenschutzmodus, Avatar-Referenz) mit striktem Zod-Spiegel und
+  JSON-Schemas. Persistenz als datei-basierter Single-User-Store
+  (`user_profile.json`, atomar, flock, 0600) unter `AGORA_DATA_DIR`.
+  Endpunkte `GET/PUT /api/profile` plus Avatar-Upload mit MIME-Allowlist
+  (PNG/JPEG/WebP), Magic-Bytes-Prüfung (SVG strukturell abgelehnt) und
+  2-MB-Limit; Avatar-Referenzen sind per Contract-Pattern gegen
+  Path-Traversal gesichert. Benutzerprofil und KI-Presets (`LlmProfile`)
+  bleiben getrennte Schlüsselräume.
+- **Resumierbares Erst-Onboarding**: backendseitig persistierter
+  `OnboardingState` (`onboarding_state.json`) mit deterministischer
+  Schrittfolge, Wiederaufnahme nach jedem Schritt, `dismiss`/`reopen` und
+  serverseitig geprüfter Completion (gültiges Profil + konfiguriertes
+  Chat-Modell + gültige Embedding-Konfiguration). Endpunkte unter
+  `/api/onboarding` (`GET /`, `PUT /step`, `POST /complete|dismiss|reopen`).
+  Frontend: Wizard unter `/onboarding` (Betriebsmodus-Wahl, Profilformular,
+  ehrliche Status-Schritte für Provider/Modelle/Embeddings mit Verweis auf
+  die Settings, Zusammenfassung), Router-Guard mit Fail-open-Semantik —
+  API-Fehler oder `dismissed` sperren niemals aus.
+- **Settings-IA**: neue Seite `/settings/profile` (gemeinsames
+  `ProfileForm` mit dem Onboarding); Sidebar-Eintrag „Users & Teams" wird
+  zu „Profil", `/settings/users-teams` leitet auf `/settings/profile` um
+  (Single-User-Grenze bleibt explizit, ADR-0008).
+
 ### Added (contracts — 2026-07-10)
 
 - **Kanonische KI-Provider-Verträge**: `ProviderConnection`, `AiModel` und

--- a/PLAN.md
+++ b/PLAN.md
@@ -373,10 +373,10 @@ eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün
 
 ## 12. Onboarding & Provider-Unification (2026-07-10)
 
-**Status:** Phase 0 abgeschlossen; Slice 1 implementiert, gehärtet und
-unabhängig verifiziert (Root-Re-Review 2026-07-11: MERGE-READY, drei
-non-blocking Follow-ups F1–F3 im Arbeitsprotokoll). PR eröffnet.
-Bestehende Profile bleiben unverändert lesbar.
+**Status:** Phase 0 und Slice 1 gemergt (PR #682, #683). Slice 2
+(Benutzerprofil + resumierbares Onboarding) implementiert und verifiziert;
+PR-Eröffnung läuft. Bestehende Profile bleiben unverändert lesbar;
+Benutzerprofil und KI-Presets sind getrennte Schlüsselräume (ADR-0008).
 
 Ziel: lokales Erst-Onboarding, getrenntes Benutzerprofil, kanonische Provider-
 und Modellverträge, getrennte Embedding-Konfiguration, ein gemeinsamer
@@ -388,8 +388,8 @@ Source of Truth:
 | Slice | Inhalt | Status |
 |---|---|---|
 | 0 | Research, ADRs, Test-/Migrationsplan, Agent-Tooling | ✅ abgeschlossen |
-| 1 | Kanonische Provider-/Modell-/Route-Verträge | verifiziert; PR offen |
-| 2 | Benutzerprofil und resumierbares Onboarding | offen |
+| 1 | Kanonische Provider-/Modell-/Route-Verträge | ✅ gemergt (PR #683) |
+| 2 | Benutzerprofil und resumierbares Onboarding | implementiert; PR offen |
 | 3 | Provider-Verbindungen und Discovery | offen |
 | 4 | Embedding-Setup und sichere Re-Embedding-Migration | offen |
 | 5 | Gemeinsamer Model-Picker und Routing | offen |
@@ -397,12 +397,12 @@ Source of Truth:
 | 7 | Golden-Gate-Designsystem und Informationsarchitektur | offen |
 | 8+ | Projekte, Datensätze, Vorlagen, Monitoring als einzelne MVPs | offen |
 
-Phase-0-Baseline: Backend grün; Frontend-Tests fachlich grün, Vitest-Exit 1
-wegen vier bestehenden `EnvironmentTeardownError`-Rejections. Vor dem ersten
-Frontend-Produktslice separat klären.
+Baseline: Backend und Frontend grün. Der Phase-0-Vitest-Teardown-Blocker
+(`EnvironmentTeardownError`) wurde durch PR #678 behoben; die Vitest-Suite
+läuft seitdem mit Exit 0 (vor Slice 2 unabhängig verifiziert).
 
 ---
 
-*Zuletzt aktualisiert: 2026-07-11 — Slice 1 verifiziert (MERGE-READY); PR offen.*
+*Zuletzt aktualisiert: 2026-07-11 — Slice 2 implementiert und verifiziert; PR-Eröffnung läuft.*
 *Provider-Detection-SSoT: `backend/app/llm/providers/registry.py`.*
 *Heuristik-SSoT: `docs/plans/plan.heuristic-2026-05-17.md`.*

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -315,6 +315,8 @@ def create_app(config_class=Config):
         llm_bp,
         api_keys_bp,
         llm_profiles_bp,
+        user_profile_bp,
+        onboarding_bp,
     )
     from .utils.api_responses import install_api_error_handlers
     from .utils.auth import install_blueprint_guard, log_auth_mode
@@ -336,6 +338,8 @@ def create_app(config_class=Config):
         llm_bp,
         api_keys_bp,
         llm_profiles_bp,
+        user_profile_bp,
+        onboarding_bp,
     ):
         install_blueprint_guard(bp)
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
@@ -349,6 +353,8 @@ def create_app(config_class=Config):
     app.register_blueprint(llm_bp, url_prefix='/api/llm')
     app.register_blueprint(api_keys_bp, url_prefix='/api/api-keys')
     app.register_blueprint(llm_profiles_bp, url_prefix='/api/settings/llm-profiles')
+    app.register_blueprint(user_profile_bp, url_prefix='/api/profile')
+    app.register_blueprint(onboarding_bp, url_prefix='/api/onboarding')
     if should_log_startup:
         log_auth_mode(app, logger)
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -15,6 +15,8 @@ llm_bp = Blueprint('llm', __name__)  # Slice E.1 (#213): model-active SSE stream
 from .auth import auth_bp  # noqa: E402, F401 -- P0.2b: signed-ticket endpoint
 from .settings import settings_bp  # noqa: E402, F401 -- Issue #133: Settings-UI
 from .api_keys import api_keys_bp  # noqa: E402, F401 -- Slice G2: API-Keys real
+from .user_profile import user_profile_bp  # noqa: E402, F401 -- Onboarding Slice 2
+from .onboarding import onboarding_bp  # noqa: E402, F401 -- Onboarding Slice 2
 from . import graph           # noqa: E402, F401
 from . import graph_projects  # noqa: E402, F401
 from . import graph_build     # noqa: E402, F401

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -1,0 +1,96 @@
+"""Onboarding Blueprint (Onboarding Slice 2, Single-Workspace-Scope).
+
+Endpunkte (hinter Standard-Blueprint-Guard, identisch zur restlichen
+``/api/*``-Konvention):
+
+  - GET  /api/onboarding          — Status (Zustand + Voraussetzungen)
+  - PUT  /api/onboarding/step     — Schritt abschließen (idempotent, resumierbar)
+  - POST /api/onboarding/complete — Onboarding fachlich abschließen (ADR-0008)
+  - POST /api/onboarding/dismiss  — Wizard wegklicken (kein Lockout)
+  - POST /api/onboarding/reopen   — Wizard erneut öffnen (Resume)
+"""
+from __future__ import annotations
+
+from flask import Blueprint, request
+from pydantic import ValidationError
+
+from ..contracts.user_profile_contract import (
+    OnboardingStatusResponse,
+    OnboardingStepUpdateRequest,
+)
+from ..services.onboarding_state_store import (
+    OnboardingIncompleteError,
+    compute_onboarding_requirements,
+    get_onboarding_state_store,
+)
+from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.logger import get_logger
+
+onboarding_bp = Blueprint("onboarding", __name__)
+logger = get_logger("agora.api.onboarding")
+
+
+@onboarding_bp.route("", methods=["GET"])
+@onboarding_bp.route("/", methods=["GET"])
+@handle_api_errors
+def get_onboarding_status():
+    store = get_onboarding_state_store()
+    state = store.load()
+    requirements = compute_onboarding_requirements()
+    response = OnboardingStatusResponse(
+        state=state,
+        requirements=requirements,
+        onboarding_required=state.status in ("not_started", "in_progress"),
+    )
+    return json_success(response.model_dump(mode="json"))
+
+
+@onboarding_bp.route("/step", methods=["PUT"])
+@handle_api_errors
+def update_onboarding_step():
+    payload = request.get_json(silent=True) or {}
+    try:
+        body = OnboardingStepUpdateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Invalid request body",
+            status=400,
+            code="invalid_request",
+            extra={"errors": exc.errors(include_url=False)},
+        )
+    store = get_onboarding_state_store()
+    updated = store.complete_step(body)
+    return json_success({"state": updated.model_dump(mode="json")})
+
+
+@onboarding_bp.route("/complete", methods=["POST"])
+@handle_api_errors
+def complete_onboarding():
+    store = get_onboarding_state_store()
+    requirements = compute_onboarding_requirements()
+    try:
+        updated = store.complete(requirements)
+    except OnboardingIncompleteError as exc:
+        return json_error(
+            "onboarding requirements not met",
+            status=409,
+            code="onboarding_incomplete",
+            extra={"missing": exc.missing},
+        )
+    return json_success({"state": updated.model_dump(mode="json")})
+
+
+@onboarding_bp.route("/dismiss", methods=["POST"])
+@handle_api_errors
+def dismiss_onboarding():
+    store = get_onboarding_state_store()
+    updated = store.dismiss()
+    return json_success({"state": updated.model_dump(mode="json")})
+
+
+@onboarding_bp.route("/reopen", methods=["POST"])
+@handle_api_errors
+def reopen_onboarding():
+    store = get_onboarding_state_store()
+    updated = store.reopen()
+    return json_success({"state": updated.model_dump(mode="json")})

--- a/backend/app/api/user_profile.py
+++ b/backend/app/api/user_profile.py
@@ -128,11 +128,12 @@ def upload_avatar():
     avatar_dir = store.avatar_dir
     filename = f"avatar-{uuid.uuid4().hex}{ext}"
     target_path = avatar_dir / filename
-    fd = os.open(str(target_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        os.write(fd, data)
-    finally:
-        os.close(fd)
+
+    def _opener(path: str, flags: int) -> int:
+        return os.open(path, flags, 0o600)
+
+    with open(target_path, "wb", opener=_opener) as handle:
+        handle.write(data)
 
     old_ref = profile.avatar_ref
     updated = store.set_avatar_ref(filename)
@@ -173,13 +174,17 @@ def delete_avatar():
             status=409,
             code="profile_required",
         )
-    if profile.avatar_ref:
-        avatar_path = store.avatar_dir / profile.avatar_ref
+    # Erst die Referenz im Store löschen, dann die Datei: schlägt der
+    # Store-Write fehl, bleibt keine baumelnde Referenz auf eine bereits
+    # gelöschte Datei zurück (Gemini-Finding PR #684).
+    old_ref = profile.avatar_ref
+    updated = store.clear_avatar_ref()
+    if old_ref:
+        avatar_path = store.avatar_dir / old_ref
         if avatar_path.exists():
             try:
                 avatar_path.unlink()
             except OSError as exc:
                 logger.warning("Konnte Avatar %s nicht löschen: %s", avatar_path, exc)
-    updated = store.clear_avatar_ref()
     profile_data = updated.model_dump(mode="json") if updated else None
     return json_success({"profile": profile_data})

--- a/backend/app/api/user_profile.py
+++ b/backend/app/api/user_profile.py
@@ -1,0 +1,185 @@
+"""User-Profile Blueprint (Onboarding Slice 2, Single-Workspace-Scope).
+
+Endpunkte (hinter Standard-Blueprint-Guard, identisch zur restlichen
+``/api/*``-Konvention):
+
+  - GET    /api/profile          — aktuelles Profil (oder ``null``)
+  - PUT    /api/profile          — partielles Update / Erstanlage
+  - POST   /api/profile/avatar   — Avatar-Upload (multipart, Feld "file")
+  - GET    /api/profile/avatar   — Avatar-Datei ausliefern
+  - DELETE /api/profile/avatar   — Avatar entfernen
+
+Der Avatar-Upload verlässt sich NIE nur auf den Content-Type-Header:
+zusätzlich zur Allowlist in ``ALLOWED_AVATAR_MIME_TYPES`` werden die
+Magic-Bytes der Datei geprüft — SVG und andere Formate werden damit
+strukturell abgelehnt (Script-Injection-Schutz, siehe Contract-Docstring).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+from flask import Blueprint, request, send_from_directory
+from pydantic import ValidationError
+
+from ..contracts.user_profile_contract import (
+    ALLOWED_AVATAR_MIME_TYPES,
+    MAX_AVATAR_BYTES,
+    UserProfileUpdateRequest,
+)
+from ..services.user_profile_store import get_user_profile_store
+from ..utils.api_responses import handle_api_errors, json_error, json_success
+from ..utils.logger import get_logger
+
+user_profile_bp = Blueprint("user_profile", __name__)
+logger = get_logger("agora.api.user_profile")
+
+# Magic-Bytes je erlaubtem Format. RIFF/WEBP hat einen 4-Byte-Präfix, eine
+# 4-Byte-Chunk-Size und dann die "WEBP"-Signatur (Bytes 8-11).
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_JPEG_MAGIC = b"\xff\xd8\xff"
+_RIFF_MAGIC = b"RIFF"
+_WEBP_MAGIC = b"WEBP"
+
+_EXT_TO_MIME: dict[str, str] = {
+    ext: mime for mime, ext in ALLOWED_AVATAR_MIME_TYPES.items()
+}
+
+
+def _looks_like(content_type: str, data: bytes) -> bool:
+    """Prüft die Magic-Bytes einer Datei gegen den angegebenen Content-Type."""
+    if content_type == "image/png":
+        return data.startswith(_PNG_MAGIC)
+    if content_type == "image/jpeg":
+        return data.startswith(_JPEG_MAGIC)
+    if content_type == "image/webp":
+        return (
+            len(data) >= 12
+            and data.startswith(_RIFF_MAGIC)
+            and data[8:12] == _WEBP_MAGIC
+        )
+    return False
+
+
+@user_profile_bp.route("", methods=["GET"])
+@user_profile_bp.route("/", methods=["GET"])
+@handle_api_errors
+def get_profile():
+    store = get_user_profile_store()
+    profile = store.load()
+    return json_success({"profile": profile.model_dump(mode="json") if profile else None})
+
+
+@user_profile_bp.route("", methods=["PUT"])
+@user_profile_bp.route("/", methods=["PUT"])
+@handle_api_errors
+def update_profile():
+    payload = request.get_json(silent=True) or {}
+    try:
+        body = UserProfileUpdateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return json_error(
+            "Invalid request body",
+            status=400,
+            code="invalid_request",
+            extra={"errors": exc.errors(include_url=False)},
+        )
+    store = get_user_profile_store()
+    try:
+        updated = store.update(body)
+    except ValueError:
+        return json_error(
+            "display_name required to create profile",
+            status=400,
+            code="display_name_required",
+        )
+    return json_success({"profile": updated.model_dump(mode="json")})
+
+
+@user_profile_bp.route("/avatar", methods=["POST"])
+@handle_api_errors
+def upload_avatar():
+    file_storage = request.files.get("file")
+    if file_storage is None:
+        return json_error("no file uploaded", status=400, code="missing_file")
+
+    store = get_user_profile_store()
+    profile = store.load()
+    if profile is None:
+        return json_error(
+            "profile must exist before an avatar can be uploaded",
+            status=409,
+            code="profile_required",
+        )
+
+    data = file_storage.read()
+    if len(data) > MAX_AVATAR_BYTES:
+        return json_error("avatar exceeds size limit", status=413, code="avatar_too_large")
+
+    content_type = (file_storage.mimetype or "").lower()
+    ext = ALLOWED_AVATAR_MIME_TYPES.get(content_type)
+    if ext is None or not _looks_like(content_type, data):
+        return json_error(
+            "unsupported avatar file type",
+            status=415,
+            code="unsupported_media_type",
+        )
+
+    avatar_dir = store.avatar_dir
+    filename = f"avatar-{uuid.uuid4().hex}{ext}"
+    target_path = avatar_dir / filename
+    fd = os.open(str(target_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+    old_ref = profile.avatar_ref
+    updated = store.set_avatar_ref(filename)
+
+    if old_ref and old_ref != filename:
+        old_path = avatar_dir / old_ref
+        if old_path.exists():
+            try:
+                old_path.unlink()
+            except OSError as exc:
+                logger.warning("Konnte alten Avatar %s nicht löschen: %s", old_path, exc)
+
+    return json_success({"profile": updated.model_dump(mode="json")}, status=201)
+
+
+@user_profile_bp.route("/avatar", methods=["GET"])
+@handle_api_errors
+def get_avatar():
+    store = get_user_profile_store()
+    profile = store.load()
+    if profile is None or not profile.avatar_ref:
+        return json_error("no avatar set", status=404, code="avatar_not_found")
+    avatar_path = store.avatar_dir / profile.avatar_ref
+    if not avatar_path.exists():
+        return json_error("avatar file missing", status=404, code="avatar_not_found")
+    mimetype = _EXT_TO_MIME.get(avatar_path.suffix, "application/octet-stream")
+    return send_from_directory(store.avatar_dir, profile.avatar_ref, mimetype=mimetype)
+
+
+@user_profile_bp.route("/avatar", methods=["DELETE"])
+@handle_api_errors
+def delete_avatar():
+    store = get_user_profile_store()
+    profile = store.load()
+    if profile is None:
+        return json_error(
+            "profile does not exist",
+            status=409,
+            code="profile_required",
+        )
+    if profile.avatar_ref:
+        avatar_path = store.avatar_dir / profile.avatar_ref
+        if avatar_path.exists():
+            try:
+                avatar_path.unlink()
+            except OSError as exc:
+                logger.warning("Konnte Avatar %s nicht löschen: %s", avatar_path, exc)
+    updated = store.clear_avatar_ref()
+    profile_data = updated.model_dump(mode="json") if updated else None
+    return json_success({"profile": profile_data})

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -95,6 +95,21 @@ from .ai_provider_contract import (
     ModelSource,
     ProviderConnection,
 )
+from .user_profile_contract import (
+    ALLOWED_AVATAR_MIME_TYPES,
+    MAX_AVATAR_BYTES,
+    ONBOARDING_STEP_ORDER,
+    REQUIRED_ONBOARDING_STEPS,
+    OnboardingRequirements,
+    OnboardingState,
+    OnboardingStatus,
+    OnboardingStatusResponse,
+    OnboardingStepId,
+    OnboardingStepUpdateRequest,
+    OperatingMode,
+    UserProfile,
+    UserProfileUpdateRequest,
+)
 from .report_v3 import (
     Claim,
     ChangeRecommendation,
@@ -184,6 +199,20 @@ __all__ = [
     "ModelCapabilities",
     "ModelSource",
     "ProviderConnection",
+    # UserProfile + Onboarding (Slice 2)
+    "ALLOWED_AVATAR_MIME_TYPES",
+    "MAX_AVATAR_BYTES",
+    "ONBOARDING_STEP_ORDER",
+    "REQUIRED_ONBOARDING_STEPS",
+    "OnboardingRequirements",
+    "OnboardingState",
+    "OnboardingStatus",
+    "OnboardingStatusResponse",
+    "OnboardingStepId",
+    "OnboardingStepUpdateRequest",
+    "OperatingMode",
+    "UserProfile",
+    "UserProfileUpdateRequest",
     # ReportV3 — 11 Pflichtabschnitt-DTOs
     "Claim",
     "ChangeRecommendation",

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -52,6 +52,13 @@ from app.contracts.llm_request import (
     NormalizedLlmError,
 )
 from app.contracts.ai_provider_contract import AiModel, AiRoute, ProviderConnection
+from app.contracts.user_profile_contract import (
+    OnboardingState,
+    OnboardingStatusResponse,
+    OnboardingStepUpdateRequest,
+    UserProfile,
+    UserProfileUpdateRequest,
+)
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -91,6 +98,11 @@ CONTRACTS: dict[str, type] = {
     "ai-provider-connection.schema.json": ProviderConnection,
     "ai-model.schema.json": AiModel,
     "ai-route.schema.json": AiRoute,
+    "user-profile.schema.json": UserProfile,
+    "user-profile-update-request.schema.json": UserProfileUpdateRequest,
+    "onboarding-state.schema.json": OnboardingState,
+    "onboarding-step-update-request.schema.json": OnboardingStepUpdateRequest,
+    "onboarding-status-response.schema.json": OnboardingStatusResponse,
 }
 
 

--- a/backend/app/contracts/user_profile_contract.py
+++ b/backend/app/contracts/user_profile_contract.py
@@ -1,0 +1,218 @@
+"""Canonical user profile and onboarding state contracts (Onboarding Slice 2).
+
+ADR-0008: Agora ist ein Single-User-System. ``UserProfile`` beschreibt die
+lokale Person und ihre Einstellungen — es ist ausdruecklich KEIN KI-Preset
+(``LlmProfile``). Beide leben in getrennten Schluesselraeumen und werden
+nicht vermischt.
+
+``OnboardingState`` ist der backendseitig persistierte, resumierbare Zustand
+des Erst-Onboardings. Jeder Schritt wird nach Abschluss gespeichert; Abbruch
+(``dismissed``) ist erlaubt und sperrt niemanden aus — Bestandsinstallationen
+koennen den Wizard jederzeit wegklicken und spaeter ueber die Einstellungen
+erneut oeffnen.
+
+Fachliche Completion (Profil gueltig + mindestens ein Chat-Modell + gueltige
+Embedding-Konfiguration, ADR-0008) wird serverseitig im Service geprueft;
+der Contract sichert nur die strukturelle Schritt-Konsistenz.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+_STRICT = ConfigDict(extra="forbid")
+
+ProfileLanguage = Literal["de", "en"]
+ProfileTheme = Literal["system", "light", "dark"]
+PrivacyMode = Literal["standard", "strict"]
+OperatingMode = Literal["local", "hybrid", "server"]
+OnboardingStatus = Literal["not_started", "in_progress", "dismissed", "completed"]
+OnboardingStepId = Literal[
+    "welcome",
+    "profile",
+    "providers",
+    "chat_model",
+    "embeddings",
+    "privacy",
+    "summary",
+]
+
+# Kanonische Schritt-Reihenfolge des Wizards. Slice 2 liefert das Grundgeruest;
+# die Schritte providers/chat_model/embeddings werden in Slice 3/4 funktional
+# und zeigen bis dahin den realen Systemzustand (keine Attrappen).
+ONBOARDING_STEP_ORDER: tuple[OnboardingStepId, ...] = (
+    "welcome",
+    "profile",
+    "providers",
+    "chat_model",
+    "embeddings",
+    "privacy",
+    "summary",
+)
+
+# Schritte, ohne die ein Onboarding nicht als "completed" gelten darf.
+REQUIRED_ONBOARDING_STEPS: frozenset[OnboardingStepId] = frozenset(
+    {"profile", "chat_model", "embeddings"}
+)
+
+# Avatar-Upload-Grenzen (SVG ist bewusst NICHT erlaubt — Script-Injection).
+ALLOWED_AVATAR_MIME_TYPES: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+MAX_AVATAR_BYTES: int = 2 * 1024 * 1024
+
+# Referenz auf eine serverseitig generierte Avatar-Datei. Das strikte Pattern
+# schliesst Path-Traversal und Fremdnamen bereits im Vertrag aus.
+_AVATAR_REF_PATTERN = r"^avatar-[0-9a-f]{32}\.(png|jpg|webp)$"
+AvatarRef = Annotated[str, Field(pattern=_AVATAR_REF_PATTERN)]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _validate_timezone(value: str) -> str:
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(f"unknown IANA timezone: {value!r}") from exc
+    return value
+
+
+IanaTimezone = Annotated[str, AfterValidator(_validate_timezone)]
+
+
+class UserProfile(BaseModel):
+    """Lokales Single-User-Profil (kein KI-Preset, keine Secrets)."""
+
+    model_config = _STRICT
+
+    avatar_ref: AvatarRef | None = None
+    display_name: str = Field(min_length=1, max_length=80)
+    username: str | None = Field(
+        default=None, pattern=r"^[a-z0-9][a-z0-9._-]{1,31}$"
+    )
+    role: str | None = Field(default=None, max_length=120)
+    organisation: str | None = Field(default=None, max_length=120)
+    language: ProfileLanguage = "de"
+    timezone: IanaTimezone = "Europe/Berlin"
+    report_language: ProfileLanguage = "de"
+    theme: ProfileTheme = "system"
+    privacy_mode: PrivacyMode = "standard"
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+    @field_validator("display_name")
+    @classmethod
+    def _strip_display_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("display_name must not be blank")
+        return stripped
+
+
+class UserProfileUpdateRequest(BaseModel):
+    """Partielles Update; ``avatar_ref`` ist bewusst ausgeschlossen und wird
+    ausschliesslich ueber die Avatar-Endpunkte veraendert."""
+
+    model_config = _STRICT
+
+    display_name: str | None = Field(default=None, min_length=1, max_length=80)
+    username: str | None = Field(
+        default=None, pattern=r"^[a-z0-9][a-z0-9._-]{1,31}$"
+    )
+    role: str | None = Field(default=None, max_length=120)
+    organisation: str | None = Field(default=None, max_length=120)
+    language: ProfileLanguage | None = None
+    timezone: IanaTimezone | None = None
+    report_language: ProfileLanguage | None = None
+    theme: ProfileTheme | None = None
+    privacy_mode: PrivacyMode | None = None
+
+    @field_validator("display_name")
+    @classmethod
+    def _strip_display_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("display_name must not be blank")
+        return stripped
+
+
+class OnboardingState(BaseModel):
+    """Resumierbarer Wizard-Zustand; wird nach jedem Schritt persistiert."""
+
+    model_config = _STRICT
+
+    status: OnboardingStatus = "not_started"
+    operating_mode: OperatingMode | None = None
+    current_step: OnboardingStepId = "welcome"
+    completed_steps: list[OnboardingStepId] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+    @field_validator("completed_steps")
+    @classmethod
+    def _no_duplicate_steps(
+        cls, value: list[OnboardingStepId]
+    ) -> list[OnboardingStepId]:
+        if len(value) != len(set(value)):
+            raise ValueError("completed_steps must not contain duplicates")
+        return value
+
+    @model_validator(mode="after")
+    def _completed_requires_required_steps(self) -> "OnboardingState":
+        if self.status == "completed":
+            missing = REQUIRED_ONBOARDING_STEPS - set(self.completed_steps)
+            if missing:
+                raise ValueError(
+                    "completed onboarding requires steps: "
+                    + ", ".join(sorted(missing))
+                )
+        return self
+
+
+class OnboardingStepUpdateRequest(BaseModel):
+    """Meldet einen abgeschlossenen Schritt; der Service berechnet den
+    naechsten offenen Schritt deterministisch aus ``ONBOARDING_STEP_ORDER``."""
+
+    model_config = _STRICT
+
+    step: OnboardingStepId
+    operating_mode: OperatingMode | None = None
+
+
+class OnboardingRequirements(BaseModel):
+    """Serverseitig berechnete Completion-Voraussetzungen (ADR-0008)."""
+
+    model_config = _STRICT
+
+    profile_valid: bool
+    # "configured", nicht "available": ein Live-Erreichbarkeitscheck kommt
+    # erst mit der Provider-Discovery in Slice 3.
+    chat_model_configured: bool
+    embedding_configured: bool
+
+
+class OnboardingStatusResponse(BaseModel):
+    """Antwort von ``GET /api/onboarding``."""
+
+    model_config = _STRICT
+
+    state: OnboardingState
+    requirements: OnboardingRequirements
+    onboarding_required: bool

--- a/backend/app/services/onboarding_state_store.py
+++ b/backend/app/services/onboarding_state_store.py
@@ -130,15 +130,14 @@ class OnboardingStateStore:
             payload.model_dump(mode="json"), indent=2, sort_keys=True
         ).encode("utf-8")
         tmp_path = self._path.with_suffix(".tmp")
-        fd = os.open(
-            str(tmp_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
-        )
-        try:
-            os.write(fd, serialized)
-        finally:
-            os.close(fd)
+
+        def _opener(path: str, flags: int) -> int:
+            return os.open(path, flags, 0o600)
+
+        with open(tmp_path, "wb", opener=_opener) as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(tmp_path, self._path)
         try:
             os.chmod(self._path, 0o600)
@@ -229,9 +228,12 @@ def compute_onboarding_requirements() -> OnboardingRequirements:
     """
     settings = get_settings()
     profile_valid = get_user_profile_store().load() is not None
-    chat_model_configured = bool(settings.llm_model_name.strip())
+    chat_model_configured = bool(
+        settings.llm_model_name and settings.llm_model_name.strip()
+    )
     embedding_configured = (
-        bool(settings.embedding_model.strip()) and settings.vector_dim > 0
+        bool(settings.embedding_model and settings.embedding_model.strip())
+        and (settings.vector_dim or 0) > 0
     )
     return OnboardingRequirements(
         profile_valid=profile_valid,

--- a/backend/app/services/onboarding_state_store.py
+++ b/backend/app/services/onboarding_state_store.py
@@ -1,0 +1,259 @@
+"""Persistenter JSON-Store für den resumierbaren Onboarding-Zustand (Slice 2).
+
+Storage-Pfad: ``backend/data/onboarding_state.json`` (überschreibbar via
+``AGORA_DATA_DIR``-Env). Locking-Muster identisch zu
+:mod:`app.services.user_profile_store` / :mod:`app.services.workspace_routing_store`.
+
+Fachliche Completion-Voraussetzungen (ADR-0008: gültiges Profil + konfiguriertes
+Chat-Modell + gültige Embedding-Konfiguration) werden hier serverseitig
+geprüft — der Contract in ``app.contracts.user_profile_contract`` sichert nur
+die strukturelle Schritt-Konsistenz (z. B. keine Duplikate, "completed"
+erfordert die Pflicht-Schritte).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Iterator, Optional
+
+from ..contracts.user_profile_contract import (
+    ONBOARDING_STEP_ORDER,
+    REQUIRED_ONBOARDING_STEPS,
+    OnboardingRequirements,
+    OnboardingState,
+    OnboardingStepId,
+    OnboardingStepUpdateRequest,
+)
+from ..settings import get_settings
+from ..utils.logger import get_logger
+from .user_profile_store import get_user_profile_store
+
+logger = get_logger("agora.services.onboarding_state_store")
+
+_DATA_DIR_ENV = "AGORA_DATA_DIR"
+_STORE_FILENAME = "onboarding_state.json"
+
+
+class OnboardingIncompleteError(Exception):
+    """Wird geworfen, wenn ``complete()`` ohne erfüllte Voraussetzungen aufgerufen wird."""
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = missing
+        super().__init__(
+            "onboarding cannot be completed, missing: " + ", ".join(missing)
+        )
+
+
+def _resolve_data_dir() -> Path:
+    raw = os.environ.get(_DATA_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path(__file__).resolve().parents[2] / "data"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _first_open_step(completed_steps: list[OnboardingStepId]) -> OnboardingStepId:
+    completed = set(completed_steps)
+    for step in ONBOARDING_STEP_ORDER:
+        if step not in completed:
+            return step
+    return "summary"
+
+
+class OnboardingStateStore:
+    """File-backed JSON-Store für den Onboarding-Wizard-Zustand."""
+
+    def __init__(self, *, data_dir: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._data_dir = data_dir or _resolve_data_dir()
+        self._path = self._data_dir / _STORE_FILENAME
+        self._lock_path = self._path.with_suffix(".lock")
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[IO[str]]:
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        with open(self._lock_path, "w", encoding="utf-8") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            try:
+                yield lock_fh
+            finally:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+    def load(self) -> OnboardingState:
+        with self._lock:
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> OnboardingState:
+        if not self._path.exists():
+            return OnboardingState()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            logger.warning(
+                "Onboarding-State-Store konnte nicht gelesen werden (%s): %s — "
+                "verwende Default-Zustand",
+                self._path,
+                exc,
+            )
+            return OnboardingState()
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Onboarding-State-Store ist korrupt (%s): %s — "
+                "verwende Default-Zustand. Bitte Datei manuell prüfen.",
+                self._path,
+                exc,
+            )
+            return OnboardingState()
+        try:
+            return OnboardingState.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 — defensiv, geloggt, kein Crash beim Boot
+            logger.warning(
+                "Onboarding-State-Store enthält ungültige Daten (%s): %s — "
+                "verwende Default-Zustand",
+                self._path,
+                exc,
+            )
+            return OnboardingState()
+
+    def _save_unlocked(self, state: OnboardingState) -> OnboardingState:
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        payload = state.model_copy(update={"updated_at": _now()})
+        serialized = json.dumps(
+            payload.model_dump(mode="json"), indent=2, sort_keys=True
+        ).encode("utf-8")
+        tmp_path = self._path.with_suffix(".tmp")
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            os.write(fd, serialized)
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, self._path)
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError as exc:
+            logger.warning(
+                "Konnte Rechte auf %s nicht auf 0600 setzen: %s",
+                self._path,
+                exc,
+            )
+        return payload
+
+    def save(self, state: OnboardingState) -> OnboardingState:
+        with self._lock, self._file_lock():
+            return self._save_unlocked(state)
+
+    def complete_step(self, request: OnboardingStepUpdateRequest) -> OnboardingState:
+        """Markiert einen Schritt als abgeschlossen (idempotent) und rückt den
+        Wizard auf den nächsten offenen Schritt vor."""
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            completed = list(current.completed_steps)
+            if request.step not in completed:
+                completed.append(request.step)
+            updates: dict[str, object] = {"completed_steps": completed}
+            if request.operating_mode is not None:
+                updates["operating_mode"] = request.operating_mode
+            if current.status != "completed":
+                updates["status"] = "in_progress"
+            updates["current_step"] = _first_open_step(completed)
+            updated = current.model_copy(update=updates)
+            return self._save_unlocked(updated)
+
+    def dismiss(self) -> OnboardingState:
+        """Setzt den Status auf 'dismissed' — no-op, falls bereits 'completed'."""
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            if current.status == "completed":
+                return current
+            updated = current.model_copy(update={"status": "dismissed"})
+            return self._save_unlocked(updated)
+
+    def reopen(self) -> OnboardingState:
+        """Setzt den Wizard zurück auf 'in_progress' und behält completed_steps
+        bei (Resume ab dem ersten offenen Schritt)."""
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            updated = current.model_copy(
+                update={
+                    "status": "in_progress",
+                    "current_step": _first_open_step(list(current.completed_steps)),
+                }
+            )
+            return self._save_unlocked(updated)
+
+    def complete(self, requirements: OnboardingRequirements) -> OnboardingState:
+        """Schliesst das Onboarding ab — wirft ``OnboardingIncompleteError``,
+        falls Voraussetzungen (ADR-0008) oder Pflicht-Schritte fehlen."""
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            missing: list[str] = []
+            if not requirements.profile_valid:
+                missing.append("profile_valid")
+            if not requirements.chat_model_configured:
+                missing.append("chat_model_configured")
+            if not requirements.embedding_configured:
+                missing.append("embedding_configured")
+            missing_steps = REQUIRED_ONBOARDING_STEPS - set(current.completed_steps)
+            missing.extend(sorted(missing_steps))
+            if missing:
+                raise OnboardingIncompleteError(missing)
+            updated = current.model_copy(update={"status": "completed"})
+            return self._save_unlocked(updated)
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            if self._path.exists():
+                self._path.unlink()
+            if self._lock_path.exists():
+                self._lock_path.unlink()
+
+
+def compute_onboarding_requirements() -> OnboardingRequirements:
+    """Berechnet die fachlichen Completion-Voraussetzungen (ADR-0008).
+
+    ``chat_model_configured`` prüft bewusst nur die Konfiguration, keine
+    Live-Erreichbarkeit — der Erreichbarkeitscheck kommt mit der
+    Provider-Discovery in Slice 3.
+    """
+    settings = get_settings()
+    profile_valid = get_user_profile_store().load() is not None
+    chat_model_configured = bool(settings.llm_model_name.strip())
+    embedding_configured = (
+        bool(settings.embedding_model.strip()) and settings.vector_dim > 0
+    )
+    return OnboardingRequirements(
+        profile_valid=profile_valid,
+        chat_model_configured=chat_model_configured,
+        embedding_configured=embedding_configured,
+    )
+
+
+_store_singleton: Optional[OnboardingStateStore] = None
+_singleton_lock = threading.Lock()
+
+
+def get_onboarding_state_store() -> OnboardingStateStore:
+    global _store_singleton
+    if _store_singleton is None:
+        with _singleton_lock:
+            if _store_singleton is None:
+                _store_singleton = OnboardingStateStore()
+    return _store_singleton
+
+
+def reset_onboarding_state_store_for_tests() -> None:
+    global _store_singleton
+    with _singleton_lock:
+        _store_singleton = None

--- a/backend/app/services/user_profile_store.py
+++ b/backend/app/services/user_profile_store.py
@@ -1,0 +1,208 @@
+"""Persistenter JSON-Store für das lokale Single-User-Profil (Onboarding Slice 2).
+
+Storage-Pfad: ``backend/data/user_profile.json`` (überschreibbar via
+``AGORA_DATA_DIR``-Env), Avatare unter ``<data_dir>/avatars/``. Locking auf
+zwei Ebenen — analog zu :mod:`app.services.workspace_routing_store`:
+
+- ``threading.Lock`` schützt innerhalb eines Python-Prozesses.
+- ``fcntl.flock`` auf einer ``.lock``-Sidecar-Datei schützt prozessübergreifend
+  (mehrere Gunicorn-Worker). Read-modify-write-Operationen (``update``,
+  ``set_avatar_ref``, ``clear_avatar_ref``) halten den File-Lock über den
+  gesamten Roundtrip — sonst gehen parallele Updates verloren (Lost Update).
+
+Atomic write über tmp-File + ``os.replace``; geschriebene Dateien bekommen
+``0600`` (Profil enthält keine Secrets, aber Konsistenz mit den übrigen
+Daten-Stores bleibt gewahrt).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Iterator, Optional
+
+from ..contracts.user_profile_contract import UserProfile, UserProfileUpdateRequest
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.services.user_profile_store")
+
+_DATA_DIR_ENV = "AGORA_DATA_DIR"
+_STORE_FILENAME = "user_profile.json"
+_AVATAR_DIRNAME = "avatars"
+
+
+def _resolve_data_dir() -> Path:
+    raw = os.environ.get(_DATA_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path(__file__).resolve().parents[2] / "data"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class UserProfileStore:
+    """File-backed JSON-Store für das lokale Benutzerprofil.
+
+    Schreib-Operationen sind sowohl innerhalb eines Prozesses
+    (``threading.Lock``) als auch zwischen Prozessen (``fcntl.flock`` auf
+    ``self._path.with_suffix(".lock")``) atomar.
+    """
+
+    def __init__(self, *, data_dir: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._data_dir = data_dir or _resolve_data_dir()
+        self._path = self._data_dir / _STORE_FILENAME
+        self._lock_path = self._path.with_suffix(".lock")
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[IO[str]]:
+        """Hält einen exklusiven ``fcntl.flock`` für die Lebensdauer des Blocks."""
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        with open(self._lock_path, "w", encoding="utf-8") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            try:
+                yield lock_fh
+            finally:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+    @property
+    def avatar_dir(self) -> Path:
+        directory = self._data_dir / _AVATAR_DIRNAME
+        os.makedirs(directory, exist_ok=True)
+        return directory
+
+    def load(self) -> Optional[UserProfile]:
+        with self._lock:
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> Optional[UserProfile]:
+        if not self._path.exists():
+            return None
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            logger.warning(
+                "User-Profile-Store konnte nicht gelesen werden (%s): %s — "
+                "behandle als 'kein Profil vorhanden'",
+                self._path,
+                exc,
+            )
+            return None
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "User-Profile-Store ist korrupt (%s): %s — "
+                "behandle als 'kein Profil vorhanden'. Bitte Datei manuell prüfen.",
+                self._path,
+                exc,
+            )
+            return None
+        try:
+            return UserProfile.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 — defensiv, geloggt, kein Crash beim Boot
+            logger.warning(
+                "User-Profile-Store enthält ungültige Daten (%s): %s — "
+                "behandle als 'kein Profil vorhanden'",
+                self._path,
+                exc,
+            )
+            return None
+
+    def _save_unlocked(self, profile: UserProfile) -> UserProfile:
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        payload = profile.model_copy(update={"updated_at": _now()})
+        serialized = json.dumps(
+            payload.model_dump(mode="json"), indent=2, sort_keys=True
+        ).encode("utf-8")
+        tmp_path = self._path.with_suffix(".tmp")
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            os.write(fd, serialized)
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, self._path)
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError as exc:
+            logger.warning(
+                "Konnte Rechte auf %s nicht auf 0600 setzen: %s",
+                self._path,
+                exc,
+            )
+        return payload
+
+    def save(self, profile: UserProfile) -> UserProfile:
+        with self._lock, self._file_lock():
+            return self._save_unlocked(profile)
+
+    def update(self, request: UserProfileUpdateRequest) -> UserProfile:
+        """Merged nur gesetzte Felder in ein bestehendes Profil.
+
+        Existiert noch kein Profil, wird eines neu angelegt — dafür ist
+        ``display_name`` im Request Pflicht.
+        """
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            updates = request.model_dump(exclude_unset=True)
+            if current is None:
+                display_name = updates.get("display_name")
+                if not display_name:
+                    raise ValueError("display_name required to create profile")
+                new_profile = UserProfile(**updates)
+                return self._save_unlocked(new_profile)
+            updated = current.model_copy(update=updates)
+            return self._save_unlocked(updated)
+
+    def set_avatar_ref(self, ref: str) -> UserProfile:
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            if current is None:
+                raise ValueError("no profile exists to attach an avatar to")
+            merged = {**current.model_dump(mode="json"), "avatar_ref": ref}
+            # model_validate statt model_copy: erzwingt die Contract-Pattern-
+            # Validierung von ``avatar_ref`` (Path-Traversal/Fremdnamen-Schutz).
+            updated = UserProfile.model_validate(merged)
+            return self._save_unlocked(updated)
+
+    def clear_avatar_ref(self) -> Optional[UserProfile]:
+        with self._lock, self._file_lock():
+            current = self._load_unlocked()
+            if current is None:
+                return None
+            updated = current.model_copy(update={"avatar_ref": None})
+            return self._save_unlocked(updated)
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            if self._path.exists():
+                self._path.unlink()
+            if self._lock_path.exists():
+                self._lock_path.unlink()
+
+
+_store_singleton: Optional[UserProfileStore] = None
+_singleton_lock = threading.Lock()
+
+
+def get_user_profile_store() -> UserProfileStore:
+    global _store_singleton
+    if _store_singleton is None:
+        with _singleton_lock:
+            if _store_singleton is None:
+                _store_singleton = UserProfileStore()
+    return _store_singleton
+
+
+def reset_user_profile_store_for_tests() -> None:
+    global _store_singleton
+    with _singleton_lock:
+        _store_singleton = None

--- a/backend/app/services/user_profile_store.py
+++ b/backend/app/services/user_profile_store.py
@@ -120,15 +120,14 @@ class UserProfileStore:
             payload.model_dump(mode="json"), indent=2, sort_keys=True
         ).encode("utf-8")
         tmp_path = self._path.with_suffix(".tmp")
-        fd = os.open(
-            str(tmp_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
-        )
-        try:
-            os.write(fd, serialized)
-        finally:
-            os.close(fd)
+
+        def _opener(path: str, flags: int) -> int:
+            return os.open(path, flags, 0o600)
+
+        with open(tmp_path, "wb", opener=_opener) as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(tmp_path, self._path)
         try:
             os.chmod(self._path, 0o600)

--- a/backend/tests/api/test_onboarding_api.py
+++ b/backend/tests/api/test_onboarding_api.py
@@ -1,0 +1,149 @@
+"""API-Tests für /api/onboarding (Onboarding Slice 2).
+
+Blueprint-/Client-Konventionen gespiegelt von
+``tests/api/test_api_keys_api.py``. ``get_settings`` wird gezielt gepatcht,
+um die Requirements (chat_model_configured/embedding_configured) hermetisch
+und unabhängig von ADR-0003-Pflichtfeldern (SECRET_KEY etc.) zu steuern.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+from app.api import onboarding_bp
+from app.contracts.user_profile_contract import (
+    ONBOARDING_STEP_ORDER,
+    UserProfileUpdateRequest,
+)
+from app.services.onboarding_state_store import reset_onboarding_state_store_for_tests
+from app.services.user_profile_store import (
+    get_user_profile_store,
+    reset_user_profile_store_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    reset_user_profile_store_for_tests()
+    reset_onboarding_state_store_for_tests()
+    yield
+    reset_user_profile_store_for_tests()
+    reset_onboarding_state_store_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _configured_settings(monkeypatch):
+    """Chat-Modell + Embeddings gelten standardmäßig als konfiguriert.
+
+    Tests, die die Requirements gezielt scheitern lassen wollen, patchen
+    das Fixture-Ergebnis erneut.
+    """
+    monkeypatch.setattr(
+        "app.services.onboarding_state_store.get_settings",
+        lambda: SimpleNamespace(
+            llm_model_name="test-chat-model",
+            embedding_model="test-embed-model",
+            vector_dim=768,
+        ),
+    )
+
+
+@pytest.fixture
+def app() -> Flask:
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(onboarding_bp, url_prefix="/api/onboarding")
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+def _create_profile() -> None:
+    get_user_profile_store().update(
+        UserProfileUpdateRequest(display_name="Alex Schneider")
+    )
+
+
+class TestGetOnboarding:
+    def test_not_started_by_default(self, client) -> None:
+        resp = client.get("/api/onboarding")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        data = body["data"]
+        assert data["state"]["status"] == "not_started"
+        assert data["requirements"]["chat_model_configured"] is True
+        assert data["requirements"]["embedding_configured"] is True
+        assert data["requirements"]["profile_valid"] is False
+        assert data["onboarding_required"] is True
+
+    def test_onboarding_required_true_while_in_progress(self, client) -> None:
+        client.put("/api/onboarding/step", json={"step": "welcome"})
+        resp = client.get("/api/onboarding")
+        data = resp.get_json()["data"]
+        assert data["state"]["status"] == "in_progress"
+        assert data["onboarding_required"] is True
+
+
+class TestPutStep:
+    def test_completing_step_advances_current_step(self, client) -> None:
+        resp = client.put("/api/onboarding/step", json={"step": "welcome"})
+        assert resp.status_code == 200
+        state = resp.get_json()["data"]["state"]
+        assert "welcome" in state["completed_steps"]
+        assert state["current_step"] == ONBOARDING_STEP_ORDER[1]
+
+    def test_repeating_step_is_idempotent(self, client) -> None:
+        client.put("/api/onboarding/step", json={"step": "welcome"})
+        resp = client.put("/api/onboarding/step", json={"step": "welcome"})
+        assert resp.status_code == 200
+        state = resp.get_json()["data"]["state"]
+        assert state["completed_steps"].count("welcome") == 1
+
+
+class TestCompleteOnboarding:
+    def test_incomplete_returns_409_with_missing_list(self, client) -> None:
+        resp = client.post("/api/onboarding/complete")
+        assert resp.status_code == 409
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["code"] == "onboarding_incomplete"
+        assert "profile_valid" in body["missing"]
+
+    def test_happy_path_returns_200_completed(self, client) -> None:
+        _create_profile()
+        for step in ("profile", "chat_model", "embeddings"):
+            client.put("/api/onboarding/step", json={"step": step})
+
+        resp = client.post("/api/onboarding/complete")
+        assert resp.status_code == 200
+        state = resp.get_json()["data"]["state"]
+        assert state["status"] == "completed"
+
+
+class TestDismissOnboarding:
+    def test_dismiss_sets_status_and_clears_onboarding_required(self, client) -> None:
+        resp = client.post("/api/onboarding/dismiss")
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["state"]["status"] == "dismissed"
+
+        follow_up = client.get("/api/onboarding")
+        assert follow_up.get_json()["data"]["onboarding_required"] is False
+
+
+class TestReopenOnboarding:
+    def test_reopen_resumes_with_completed_steps_intact(self, client) -> None:
+        client.put("/api/onboarding/step", json={"step": "welcome"})
+        client.post("/api/onboarding/dismiss")
+
+        resp = client.post("/api/onboarding/reopen")
+        assert resp.status_code == 200
+        state = resp.get_json()["data"]["state"]
+        assert state["status"] == "in_progress"
+        assert "welcome" in state["completed_steps"]

--- a/backend/tests/api/test_user_profile_api.py
+++ b/backend/tests/api/test_user_profile_api.py
@@ -1,0 +1,201 @@
+"""API-Tests für /api/profile (Onboarding Slice 2).
+
+Blueprint-/Client-Konventionen exakt gespiegelt von
+``tests/api/test_api_keys_api.py``: eigenständige Flask-App pro Testdatei,
+Blueprint direkt registriert, kein Auth-Header (Slice 2 hat noch keine
+API-Key-Pflicht für diese Endpunkte).
+"""
+from __future__ import annotations
+
+import io
+import re
+
+import pytest
+from flask import Flask
+
+from app.api import user_profile_bp
+from app.contracts.user_profile_contract import MAX_AVATAR_BYTES
+from app.services.user_profile_store import reset_user_profile_store_for_tests
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_MINIMAL_PNG = _PNG_MAGIC + b"\x00" * 32
+_SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+_AVATAR_REF_RE = re.compile(r"^avatar-[0-9a-f]{32}\.png$")
+
+
+@pytest.fixture(autouse=True)
+def _reset_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    reset_user_profile_store_for_tests()
+    yield
+    reset_user_profile_store_for_tests()
+
+
+@pytest.fixture
+def app() -> Flask:
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(user_profile_bp, url_prefix="/api/profile")
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+def _create_profile(client, display_name: str = "Alex Schneider") -> dict:
+    resp = client.put("/api/profile", json={"display_name": display_name})
+    assert resp.status_code == 200
+    return resp.get_json()["data"]["profile"]
+
+
+class TestGetProfile:
+    def test_returns_null_profile_when_none_exists(self, client) -> None:
+        resp = client.get("/api/profile")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["data"]["profile"] is None
+
+    def test_returns_profile_after_creation(self, client) -> None:
+        _create_profile(client)
+        resp = client.get("/api/profile")
+        assert resp.status_code == 200
+        profile = resp.get_json()["data"]["profile"]
+        assert profile["display_name"] == "Alex Schneider"
+
+
+class TestPutProfile:
+    def test_invalid_schema_returns_400(self, client) -> None:
+        resp = client.put("/api/profile", json={"theme": "not-a-real-theme"})
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["code"] == "invalid_request"
+
+    def test_extra_field_returns_400_invalid_request(self, client) -> None:
+        resp = client.put(
+            "/api/profile", json={"display_name": "Alex", "avatar_ref": "x"}
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "invalid_request"
+
+    def test_create_without_display_name_returns_display_name_required(
+        self, client
+    ) -> None:
+        resp = client.put("/api/profile", json={"role": "Redakteurin"})
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["code"] == "display_name_required"
+
+    def test_happy_path_creates_profile(self, client) -> None:
+        resp = client.put(
+            "/api/profile", json={"display_name": "Alex Schneider", "role": "Lead"}
+        )
+        assert resp.status_code == 200
+        profile = resp.get_json()["data"]["profile"]
+        assert profile["display_name"] == "Alex Schneider"
+        assert profile["role"] == "Lead"
+
+    def test_merge_update_preserves_untouched_fields(self, client) -> None:
+        _create_profile(client)
+        resp = client.put("/api/profile", json={"role": "Redakteurin"})
+        assert resp.status_code == 200
+        profile = resp.get_json()["data"]["profile"]
+        assert profile["display_name"] == "Alex Schneider"
+        assert profile["role"] == "Redakteurin"
+
+
+class TestPostAvatar:
+    def test_missing_file_returns_400(self, client) -> None:
+        resp = client.post(
+            "/api/profile/avatar", data={}, content_type="multipart/form-data"
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "missing_file"
+
+    def test_without_profile_returns_409_profile_required(self, client) -> None:
+        resp = client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(_MINIMAL_PNG), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 409
+        assert resp.get_json()["code"] == "profile_required"
+
+    def test_oversized_file_returns_413(self, client) -> None:
+        _create_profile(client)
+        oversized = _PNG_MAGIC + b"\x00" * (MAX_AVATAR_BYTES + 1)
+        resp = client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(oversized), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 413
+        assert resp.get_json()["code"] == "avatar_too_large"
+
+    def test_svg_with_faked_png_content_type_is_rejected(self, client) -> None:
+        _create_profile(client)
+        resp = client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(_SVG_BYTES), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 415
+        assert resp.get_json()["code"] == "unsupported_media_type"
+
+    def test_valid_png_upload_returns_201_with_avatar_ref(self, client) -> None:
+        _create_profile(client)
+        resp = client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(_MINIMAL_PNG), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        profile = resp.get_json()["data"]["profile"]
+        assert _AVATAR_REF_RE.match(profile["avatar_ref"])
+
+
+class TestGetAvatar:
+    def test_returns_404_without_avatar(self, client) -> None:
+        _create_profile(client)
+        resp = client.get("/api/profile/avatar")
+        assert resp.status_code == 404
+        assert resp.get_json()["code"] == "avatar_not_found"
+
+    def test_returns_image_after_upload(self, client) -> None:
+        _create_profile(client)
+        client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(_MINIMAL_PNG), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        resp = client.get("/api/profile/avatar")
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"].startswith("image/")
+        assert resp.data.startswith(_PNG_MAGIC)
+
+
+class TestDeleteAvatar:
+    def test_without_profile_returns_409(self, client) -> None:
+        resp = client.delete("/api/profile/avatar")
+        assert resp.status_code == 409
+        assert resp.get_json()["success"] is False
+
+    def test_removes_avatar_reference(self, client) -> None:
+        _create_profile(client)
+        client.post(
+            "/api/profile/avatar",
+            data={"file": (io.BytesIO(_MINIMAL_PNG), "avatar.png", "image/png")},
+            content_type="multipart/form-data",
+        )
+        resp = client.delete("/api/profile/avatar")
+        assert resp.status_code == 200
+        profile = resp.get_json()["data"]["profile"]
+        assert profile["avatar_ref"] is None
+
+        # Datei tatsächlich entfernt: erneuter GET liefert wieder 404.
+        follow_up = client.get("/api/profile/avatar")
+        assert follow_up.status_code == 404

--- a/backend/tests/contracts/test_user_profile_contract.py
+++ b/backend/tests/contracts/test_user_profile_contract.py
@@ -1,0 +1,201 @@
+"""Contract-Tests für UserProfile + Onboarding-Vertrag (Onboarding Slice 2).
+
+Testet ausschließlich den Vertrag (Pydantic v2-Validierung), keine
+Implementierung. Siehe ``app.contracts.user_profile_contract``.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.user_profile_contract import (
+    ONBOARDING_STEP_ORDER,
+    REQUIRED_ONBOARDING_STEPS,
+    OnboardingState,
+    UserProfile,
+    UserProfileUpdateRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# UserProfile
+# ---------------------------------------------------------------------------
+
+
+class TestUserProfileDefaults:
+    def test_defaults(self) -> None:
+        profile = UserProfile(display_name="Alex")
+        assert profile.language == "de"
+        assert profile.theme == "system"
+        assert profile.privacy_mode == "standard"
+        assert profile.timezone == "Europe/Berlin"
+        assert profile.report_language == "de"
+        assert profile.avatar_ref is None
+        assert profile.username is None
+
+    def test_display_name_empty_string_raises(self) -> None:
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            UserProfile(display_name="")
+
+    def test_display_name_whitespace_only_raises(self) -> None:
+        with pytest.raises(ValidationError, match="blank"):
+            UserProfile(display_name="   ")
+
+    def test_display_name_is_stripped(self) -> None:
+        profile = UserProfile(display_name="  Alex Schneider  ")
+        assert profile.display_name == "Alex Schneider"
+
+
+class TestUserProfileTimezone:
+    def test_invalid_timezone_raises(self) -> None:
+        with pytest.raises(ValidationError, match="timezone"):
+            UserProfile(display_name="Alex", timezone="Mars/Olympus")
+
+    def test_valid_exotic_timezone_ok(self) -> None:
+        profile = UserProfile(display_name="Alex", timezone="America/New_York")
+        assert profile.timezone == "America/New_York"
+
+
+class TestUserProfileUsername:
+    def test_uppercase_username_raises(self) -> None:
+        with pytest.raises(ValidationError, match="pattern"):
+            UserProfile(display_name="Alex", username="ALEX")
+
+    def test_single_char_username_raises(self) -> None:
+        with pytest.raises(ValidationError, match="pattern"):
+            UserProfile(display_name="Alex", username="a")
+
+    def test_valid_username_ok(self) -> None:
+        profile = UserProfile(display_name="Alex", username="alex.schneider")
+        assert profile.username == "alex.schneider"
+
+
+class TestUserProfileAvatarRef:
+    def test_path_traversal_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="pattern"):
+            UserProfile(display_name="Alex", avatar_ref="../../etc/passwd")
+
+    def test_non_hex_ref_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="pattern"):
+            UserProfile(display_name="Alex", avatar_ref="avatar-XYZ.png")
+
+    def test_svg_extension_rejected(self) -> None:
+        hex32 = "a" * 32
+        with pytest.raises(ValidationError, match="pattern"):
+            UserProfile(display_name="Alex", avatar_ref=f"avatar-{hex32}.svg")
+
+    def test_valid_png_ref_ok(self) -> None:
+        hex32 = "0123456789abcdef0123456789abcdef"[:32]
+        profile = UserProfile(display_name="Alex", avatar_ref=f"avatar-{hex32}.png")
+        assert profile.avatar_ref == f"avatar-{hex32}.png"
+
+
+class TestUserProfileStrict:
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            UserProfile(display_name="Alex", is_admin=True)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# UserProfileUpdateRequest
+# ---------------------------------------------------------------------------
+
+
+class TestUserProfileUpdateRequest:
+    def test_empty_object_is_valid(self) -> None:
+        request = UserProfileUpdateRequest()
+        assert request.model_dump(exclude_unset=True) == {}
+
+    def test_avatar_ref_field_is_rejected(self) -> None:
+        hex32 = "a" * 32
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            UserProfileUpdateRequest(avatar_ref=f"avatar-{hex32}.png")  # type: ignore[call-arg]
+
+    def test_display_name_blank_raises(self) -> None:
+        with pytest.raises(ValidationError, match="blank"):
+            UserProfileUpdateRequest(display_name="   ")
+
+
+# ---------------------------------------------------------------------------
+# OnboardingState
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingStateDefaults:
+    def test_defaults(self) -> None:
+        state = OnboardingState()
+        assert state.status == "not_started"
+        assert state.current_step == "welcome"
+        assert state.completed_steps == []
+        assert state.operating_mode is None
+
+
+class TestOnboardingStateCompletedSteps:
+    def test_duplicate_completed_steps_raise(self) -> None:
+        with pytest.raises(ValidationError, match="duplicates"):
+            OnboardingState(completed_steps=["welcome", "welcome"])
+
+    def test_unknown_step_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OnboardingState(completed_steps=["not-a-real-step"])  # type: ignore[list-item]
+
+    def test_unknown_current_step_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OnboardingState(current_step="not-a-real-step")  # type: ignore[arg-type]
+
+
+class TestOnboardingStateCompletion:
+    def test_completed_without_required_steps_raises(self) -> None:
+        with pytest.raises(ValidationError, match="completed onboarding requires steps"):
+            OnboardingState(status="completed", completed_steps=["welcome"])
+
+    def test_completed_with_required_steps_ok(self) -> None:
+        state = OnboardingState(
+            status="completed",
+            completed_steps=["profile", "chat_model", "embeddings"],
+        )
+        assert state.status == "completed"
+
+    def test_completed_with_all_steps_ok(self) -> None:
+        state = OnboardingState(
+            status="completed",
+            completed_steps=list(ONBOARDING_STEP_ORDER),
+        )
+        assert state.status == "completed"
+
+
+class TestOnboardingStateStrict:
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            OnboardingState(nonsense_field=True)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# ONBOARDING_STEP_ORDER / REQUIRED_ONBOARDING_STEPS
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingStepOrder:
+    def test_contains_all_seven_steps(self) -> None:
+        assert len(ONBOARDING_STEP_ORDER) == 7
+        assert set(ONBOARDING_STEP_ORDER) == {
+            "welcome",
+            "profile",
+            "providers",
+            "chat_model",
+            "embeddings",
+            "privacy",
+            "summary",
+        }
+
+    def test_starts_with_welcome(self) -> None:
+        assert ONBOARDING_STEP_ORDER[0] == "welcome"
+
+    def test_ends_with_summary(self) -> None:
+        assert ONBOARDING_STEP_ORDER[-1] == "summary"
+
+    def test_no_duplicates_in_order(self) -> None:
+        assert len(ONBOARDING_STEP_ORDER) == len(set(ONBOARDING_STEP_ORDER))
+
+    def test_required_steps_are_subset_of_order(self) -> None:
+        assert REQUIRED_ONBOARDING_STEPS.issubset(set(ONBOARDING_STEP_ORDER))

--- a/backend/tests/services/test_onboarding_state_store.py
+++ b/backend/tests/services/test_onboarding_state_store.py
@@ -1,0 +1,276 @@
+"""Service-Tests für OnboardingStateStore + compute_onboarding_requirements
+(Onboarding Slice 2).
+
+Instanzen werden direkt mit ``data_dir=tmp_path`` konstruiert. Für
+``compute_onboarding_requirements`` (die intern den ``UserProfileStore``-
+Singleton und ``get_settings`` verwendet) wird gezielt gepatcht statt echte
+Settings zu konstruieren (vermeidet Kopplung an ADR-0003-Pflichtfelder wie
+SECRET_KEY).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.contracts.user_profile_contract import (
+    ONBOARDING_STEP_ORDER,
+    OnboardingRequirements,
+    OnboardingStepUpdateRequest,
+    UserProfileUpdateRequest,
+)
+from app.services.onboarding_state_store import (
+    OnboardingIncompleteError,
+    OnboardingStateStore,
+    compute_onboarding_requirements,
+    get_onboarding_state_store,
+    reset_onboarding_state_store_for_tests,
+)
+from app.services.user_profile_store import (
+    get_user_profile_store,
+    reset_user_profile_store_for_tests,
+)
+
+
+@pytest.fixture
+def store(tmp_path) -> OnboardingStateStore:
+    return OnboardingStateStore(data_dir=tmp_path)
+
+
+class TestLoadDefault:
+    def test_load_returns_not_started_default(self, store: OnboardingStateStore) -> None:
+        state = store.load()
+        assert state.status == "not_started"
+        assert state.current_step == "welcome"
+        assert state.completed_steps == []
+
+
+class TestCompleteStepProgression:
+    def test_first_step_advances_status_and_current_step(
+        self, store: OnboardingStateStore
+    ) -> None:
+        state = store.complete_step(OnboardingStepUpdateRequest(step="welcome"))
+        assert state.status == "in_progress"
+        assert "welcome" in state.completed_steps
+        assert state.current_step == ONBOARDING_STEP_ORDER[1]
+
+    def test_full_progression_reaches_summary(self, store: OnboardingStateStore) -> None:
+        state = None
+        for step in ONBOARDING_STEP_ORDER:
+            state = store.complete_step(OnboardingStepUpdateRequest(step=step))
+        assert state is not None
+        assert set(state.completed_steps) == set(ONBOARDING_STEP_ORDER)
+        # Nach Abschluss aller Schritte bleibt current_step deterministisch
+        # bei "summary" (letzter Fallback in _first_open_step).
+        assert state.current_step == "summary"
+
+    def test_idempotent_repeat_does_not_duplicate(
+        self, store: OnboardingStateStore
+    ) -> None:
+        store.complete_step(OnboardingStepUpdateRequest(step="welcome"))
+        state = store.complete_step(OnboardingStepUpdateRequest(step="welcome"))
+        assert state.completed_steps.count("welcome") == 1
+
+
+class TestOperatingMode:
+    def test_operating_mode_is_persisted(self, store: OnboardingStateStore) -> None:
+        state = store.complete_step(
+            OnboardingStepUpdateRequest(step="welcome", operating_mode="local")
+        )
+        assert state.operating_mode == "local"
+
+    def test_operating_mode_survives_later_steps_without_it(
+        self, store: OnboardingStateStore
+    ) -> None:
+        store.complete_step(
+            OnboardingStepUpdateRequest(step="welcome", operating_mode="hybrid")
+        )
+        state = store.complete_step(OnboardingStepUpdateRequest(step="profile"))
+        assert state.operating_mode == "hybrid"
+
+
+class TestResume:
+    def test_second_instance_sees_state_from_first(self, tmp_path) -> None:
+        first = OnboardingStateStore(data_dir=tmp_path)
+        first.complete_step(OnboardingStepUpdateRequest(step="welcome"))
+        first.complete_step(OnboardingStepUpdateRequest(step="profile"))
+
+        second = OnboardingStateStore(data_dir=tmp_path)
+        state = second.load()
+        assert set(state.completed_steps) == {"welcome", "profile"}
+        assert state.current_step == "providers"
+
+
+class TestDismissReopen:
+    def test_dismiss_from_not_started(self, store: OnboardingStateStore) -> None:
+        state = store.dismiss()
+        assert state.status == "dismissed"
+
+    def test_dismiss_is_noop_when_already_completed(
+        self, store: OnboardingStateStore
+    ) -> None:
+        for step in ONBOARDING_STEP_ORDER:
+            store.complete_step(OnboardingStepUpdateRequest(step=step))
+        store.complete(
+            OnboardingRequirements(
+                profile_valid=True,
+                chat_model_configured=True,
+                embedding_configured=True,
+            )
+        )
+        state = store.dismiss()
+        assert state.status == "completed"
+
+    def test_reopen_restores_in_progress_and_keeps_completed_steps(
+        self, store: OnboardingStateStore
+    ) -> None:
+        store.complete_step(OnboardingStepUpdateRequest(step="welcome"))
+        store.dismiss()
+        state = store.reopen()
+        assert state.status == "in_progress"
+        assert "welcome" in state.completed_steps
+        assert state.current_step == "profile"
+
+
+class TestComplete:
+    def test_missing_requirement_raises_with_missing_list(
+        self, store: OnboardingStateStore
+    ) -> None:
+        for step in ("profile", "chat_model", "embeddings"):
+            store.complete_step(OnboardingStepUpdateRequest(step=step))
+        with pytest.raises(OnboardingIncompleteError) as excinfo:
+            store.complete(
+                OnboardingRequirements(
+                    profile_valid=False,
+                    chat_model_configured=True,
+                    embedding_configured=True,
+                )
+            )
+        assert "profile_valid" in excinfo.value.missing
+
+    def test_missing_required_step_raises_with_missing_list(
+        self, store: OnboardingStateStore
+    ) -> None:
+        # Kein Schritt abgeschlossen — profile/chat_model/embeddings fehlen.
+        with pytest.raises(OnboardingIncompleteError) as excinfo:
+            store.complete(
+                OnboardingRequirements(
+                    profile_valid=True,
+                    chat_model_configured=True,
+                    embedding_configured=True,
+                )
+            )
+        assert "profile" in excinfo.value.missing
+        assert "chat_model" in excinfo.value.missing
+        assert "embeddings" in excinfo.value.missing
+
+    def test_happy_path_sets_completed(self, store: OnboardingStateStore) -> None:
+        for step in ("profile", "chat_model", "embeddings"):
+            store.complete_step(OnboardingStepUpdateRequest(step=step))
+        state = store.complete(
+            OnboardingRequirements(
+                profile_valid=True,
+                chat_model_configured=True,
+                embedding_configured=True,
+            )
+        )
+        assert state.status == "completed"
+
+
+class TestSingleton:
+    def test_get_and_reset_singleton(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+        reset_onboarding_state_store_for_tests()
+        first = get_onboarding_state_store()
+        second = get_onboarding_state_store()
+        assert first is second
+        reset_onboarding_state_store_for_tests()
+        third = get_onboarding_state_store()
+        assert third is not first
+
+
+class TestComputeOnboardingRequirementsProfile:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+        reset_user_profile_store_for_tests()
+        yield
+        reset_user_profile_store_for_tests()
+
+    def test_profile_valid_is_false_without_profile(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="test-chat-model",
+                embedding_model="test-embed-model",
+                vector_dim=768,
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.profile_valid is False
+
+    def test_profile_valid_is_true_after_profile_created(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="test-chat-model",
+                embedding_model="test-embed-model",
+                vector_dim=768,
+            ),
+        )
+        get_user_profile_store().update(
+            UserProfileUpdateRequest(display_name="Alex Schneider")
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.profile_valid is True
+
+
+class TestComputeOnboardingRequirementsSettings:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+        reset_user_profile_store_for_tests()
+        yield
+        reset_user_profile_store_for_tests()
+
+    def test_chat_model_and_embedding_flip_with_blank_settings(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="", embedding_model="", vector_dim=0
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.chat_model_configured is False
+        assert requirements.embedding_configured is False
+
+    def test_chat_model_and_embedding_true_with_valid_settings(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="qwen2.5:32b",
+                embedding_model="nomic-embed-text",
+                vector_dim=768,
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.chat_model_configured is True
+        assert requirements.embedding_configured is True
+
+    def test_embedding_configured_false_when_vector_dim_zero(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="qwen2.5:32b",
+                embedding_model="nomic-embed-text",
+                vector_dim=0,
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.embedding_configured is False

--- a/backend/tests/services/test_user_profile_store.py
+++ b/backend/tests/services/test_user_profile_store.py
@@ -1,0 +1,124 @@
+"""Service-Tests für UserProfileStore (Onboarding Slice 2).
+
+Instanzen werden direkt mit ``data_dir=tmp_path`` konstruiert — kein
+Singleton-Zugriff nötig. Prüft Persistenz, Merge-Semantik, Dateirechte.
+"""
+from __future__ import annotations
+
+import json
+import stat
+
+import pytest
+
+from app.contracts.user_profile_contract import UserProfileUpdateRequest
+from app.services.user_profile_store import UserProfileStore
+
+
+@pytest.fixture
+def store(tmp_path) -> UserProfileStore:
+    return UserProfileStore(data_dir=tmp_path)
+
+
+class TestLoadWithoutProfile:
+    def test_load_returns_none_without_file(self, store: UserProfileStore) -> None:
+        assert store.load() is None
+
+    def test_load_returns_none_for_corrupt_file(self, tmp_path, store: UserProfileStore) -> None:
+        (tmp_path / "user_profile.json").write_text("{not valid json", encoding="utf-8")
+        assert store.load() is None
+
+    def test_load_returns_none_for_structurally_invalid_json(
+        self, tmp_path, store: UserProfileStore
+    ) -> None:
+        # Valides JSON, aber verletzt den Contract (display_name fehlt).
+        (tmp_path / "user_profile.json").write_text(
+            json.dumps({"language": "de"}), encoding="utf-8"
+        )
+        assert store.load() is None
+
+
+class TestSaveLoadRoundtrip:
+    def test_roundtrip(self, store: UserProfileStore) -> None:
+        created = store.update(UserProfileUpdateRequest(display_name="Alex Schneider"))
+        loaded = store.load()
+        assert loaded is not None
+        assert loaded.display_name == "Alex Schneider"
+        assert loaded.avatar_ref == created.avatar_ref
+
+
+class TestUpdate:
+    def test_update_creates_profile_with_display_name(
+        self, store: UserProfileStore
+    ) -> None:
+        profile = store.update(UserProfileUpdateRequest(display_name="Neu"))
+        assert profile.display_name == "Neu"
+
+    def test_update_without_display_name_and_no_existing_profile_raises(
+        self, store: UserProfileStore
+    ) -> None:
+        with pytest.raises(ValueError):
+            store.update(UserProfileUpdateRequest(role="Redakteurin"))
+
+    def test_update_merges_only_set_fields(self, store: UserProfileStore) -> None:
+        store.update(UserProfileUpdateRequest(display_name="Alex", role="Redakteur"))
+        updated = store.update(UserProfileUpdateRequest(role="Lead"))
+        assert updated.display_name == "Alex"
+        assert updated.role == "Lead"
+
+    def test_updated_at_increases_monotonically(self, store: UserProfileStore) -> None:
+        first = store.update(UserProfileUpdateRequest(display_name="Alex"))
+        second = store.update(UserProfileUpdateRequest(role="Lead"))
+        assert second.updated_at >= first.updated_at
+
+
+class TestFilePermissions:
+    def test_file_is_0600_after_save(self, tmp_path, store: UserProfileStore) -> None:
+        store.update(UserProfileUpdateRequest(display_name="Alex"))
+        path = tmp_path / "user_profile.json"
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestAvatarRef:
+    _HEX32 = "0123456789abcdef0123456789abcdef"[:32]
+
+    def test_set_avatar_ref_without_profile_raises(self, store: UserProfileStore) -> None:
+        with pytest.raises(ValueError):
+            store.set_avatar_ref(f"avatar-{self._HEX32}.png")
+
+    def test_set_avatar_ref_with_profile(self, store: UserProfileStore) -> None:
+        store.update(UserProfileUpdateRequest(display_name="Alex"))
+        updated = store.set_avatar_ref(f"avatar-{self._HEX32}.png")
+        assert updated.avatar_ref == f"avatar-{self._HEX32}.png"
+
+    def test_clear_avatar_ref_without_profile_returns_none(
+        self, store: UserProfileStore
+    ) -> None:
+        assert store.clear_avatar_ref() is None
+
+    def test_clear_avatar_ref_removes_reference(self, store: UserProfileStore) -> None:
+        store.update(UserProfileUpdateRequest(display_name="Alex"))
+        store.set_avatar_ref(f"avatar-{self._HEX32}.png")
+        cleared = store.clear_avatar_ref()
+        assert cleared is not None
+        assert cleared.avatar_ref is None
+
+
+class TestAvatarDir:
+    def test_avatar_dir_is_created_under_data_dir(
+        self, tmp_path, store: UserProfileStore
+    ) -> None:
+        directory = store.avatar_dir
+        assert directory.exists()
+        assert directory.parent == tmp_path
+
+
+class TestPersistenceAcrossInstances:
+    def test_second_instance_reads_state_written_by_first(self, tmp_path) -> None:
+        first = UserProfileStore(data_dir=tmp_path)
+        first.update(UserProfileUpdateRequest(display_name="Alex Schneider"))
+
+        second = UserProfileStore(data_dir=tmp_path)
+        loaded = second.load()
+        assert loaded is not None
+        assert loaded.display_name == "Alex Schneider"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 2938 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 145 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 3026 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 150 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3026 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 150 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 151 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -1,157 +1,153 @@
-# Handover — Onboarding/Provider-Unification Slice 1
+# Handover — Onboarding/Provider-Unification Slice 2
 
 ## Stand
 
 - Datum: 2026-07-11
-- Worktree: `/private/tmp/agora-onboarding-provider-contracts`
-- Branch: `codex/onboarding-provider-contracts`
-- Arbeitsstand: unabhängig verifiziert, committet und als PR eröffnet
-  (Root, 2026-07-11)
-- Slice 1 ist implementiert und unabhängig verifiziert. Der finale
-  unabhängige Re-Review des `base_url`-Fixes ist abgeschlossen:
-  **MERGE-READY** mit drei non-blocking Follow-ups (F1–F3, siehe
-  Arbeitsprotokoll).
-- Provider-Detection-SSoT
-  `backend/app/llm/providers/registry.py::detect_provider` blieb unverändert.
+- Worktree: `/private/tmp/agora-onboarding-slice-2`
+- Branch: `feat/onboarding-user-profile` (Basis: `main` @ `df6a2b3`, Slice 1
+  gemergt via PR #683)
+- Slice: 2 — Benutzerprofil und resumierbares Onboarding-Grundgerüst
+- Arbeitsstand: implementiert, alle Gates grün, Commit/PR in Arbeit
+- context-mode: funktionsfähig (Batch-Analysen in dieser Session)
+- code-review-graph: CLI 2.3.6 via `uvx`; Haupt-Repo-Graph am 2026-07-11 auf
+  `main`-Stand `df6a2b3` neu gebaut. `detect-changes` lief im Worktree gegen
+  eine frisch migrierte (leere) DB und ist daher NICHT belastbar (Risk 0.00
+  bei 22 Dateien). Belastbarer Nachweis ist die volle grüne Testsuite;
+  Graph-Refresh nach Merge auf `main` bleibt Follow-up.
 
-## Implementierter Vertrag
+## Implementiert
 
-- `ProviderConnection`, `AiModel` und `AiRoute` sind kanonische
-  Pydantic-v2-Verträge mit `extra="forbid"` sowie generierten JSON-Schemas und
-  strikten Zod-Spiegeln.
-- Secrets bleiben außerhalb der kanonischen Verträge; ausschließlich
-  `secret_ref` wird geführt.
-- Modellfähigkeiten sind Tri-State (`supported|unsupported|unknown`).
-  `unknown` gilt niemals als unterstützt.
-- `provider_options` ist eine geschlossene fachliche Allowlist. Aktuell sind
-  ausschließlich die tatsächlich verwendeten Routing-Optionen `base_url`,
-  `num_ctx` und die interne Legacy-Roundtrip-Struktur erlaubt. Credential-Keys
-  werden dadurch sowohl top-level als auch verschachtelt strukturell blockiert.
-- Gemeinsame Fixtures prüfen Pydantic, generiertes JSON-Schema und Zod auf
-  gültige und ungültige Grenzfälle.
+- **Layer 0**: `backend/app/contracts/user_profile_contract.py` —
+  `UserProfile`, `UserProfileUpdateRequest`, `OnboardingState`
+  (Status `not_started|in_progress|dismissed|completed`),
+  `OnboardingStepUpdateRequest`, `OnboardingRequirements`,
+  `OnboardingStatusResponse`; Konstanten `ONBOARDING_STEP_ORDER`,
+  `REQUIRED_ONBOARDING_STEPS`, `ALLOWED_AVATAR_MIME_TYPES`,
+  `MAX_AVATAR_BYTES`. Avatar-Referenzen per Pattern gegen Path-Traversal;
+  IANA-Zeitzonen-Validierung; `extra="forbid"`. 5 neue JSON-Schemas +
+  strikter Zod-Spiegel `frontend/src/contracts/userProfileContract.ts`.
+- **Persistenz**: `user_profile_store.py` und `onboarding_state_store.py`
+  (Muster `workspace_routing_store`: AGORA_DATA_DIR, flock, atomarer Write,
+  0600, defensives Lesen; Singletons mit Test-Reset). Benutzerprofil und
+  KI-Presets bleiben getrennte Schlüsselräume (ADR-0008, Migrationsplan).
+- **API**: `user_profile_bp` (`GET/PUT /api/profile`,
+  `POST/GET/DELETE /api/profile/avatar`) und `onboarding_bp`
+  (`GET /api/onboarding`, `PUT /step`, `POST /complete|dismiss|reopen`)
+  hinter dem Standard-Blueprint-Guard. Avatar-Upload prüft MIME-Allowlist
+  UND Magic-Bytes (PNG/JPEG/WebP; SVG strukturell abgelehnt), 2-MB-Limit,
+  serverseitig generierte Dateinamen. 409 `onboarding_incomplete` trägt
+  `missing` top-level im Envelope (per API-Test fixiert).
+- **Completion-Semantik (ADR-0008)**: serverseitig `profile_valid` +
+  `chat_model_configured` + `embedding_configured`; bewusst
+  Konfigurations- statt Erreichbarkeitscheck — Live-Discovery kommt in
+  Slice 3. `dismissed` sperrt niemanden aus (Bestandsinstallationen können
+  den Wizard wegklicken und über Settings wieder öffnen).
+- **Frontend**: Pinia-Store `userProfile` (ensureLoaded mit In-Flight-Dedupe,
+  Fail-open bei API-Fehlern), Router-Guard `onboardingGuard`
+  (Redirect nur bei `onboarding_required`; jeder Fehlerpfad lässt durch),
+  Wizard `/onboarding` (Betriebsmodus, Profilformular, ehrliche
+  Status-Schritte mit Settings-Verweis, Zusammenfassung, Später-einrichten),
+  `/settings/profile` mit gemeinsamem `ProfileForm`, Avatar als
+  authentifizierter Blob-Fetch + Object-URL (funktioniert im
+  AGORA_AUTH_TOKEN-Modus ohne Ticket-Nacharbeit), Sidebar „Users & Teams"
+  → „Profil", `/settings/users-teams` → Redirect. i18n-Namespaces
+  `onboarding`/`profileSettings` in de.json und en.json (Key-Parität geprüft).
 
-## Security-Remediations und Legacy-Adapter
+## Frisch verifiziert (2026-07-11, unabhängig vom Root)
 
-- Ein Legacy-`api_key` ohne aufgelöste Referenz erzeugt nicht mehr
-  `auth_mode="none"`, sondern explizit `auth_mode="api_key"`, Status
-  `degraded` und eine secret-freie Fehlstatusmeldung.
-- Der Rückadapter zu `ProviderDescriptor` verlangt das Fallback-Modell-Sidecar
-  zwingend; stiller Verlust durch ein implizites leeres Array ist unmöglich.
-- `StageLLMRoute`-Roundtrips erhalten einen kollidierenden reservierten Key mit
-  Wert `None` sowie `reasoning_effort=None` verlustfrei.
-- Kanonische `base_url` ist eine öffentliche HTTP(S)-Basis-URL: Scheme
-  `http`/`https` und Host sind Pflicht; Port und Pfad sind erlaubt. Userinfo,
-  Query und Fragment sind vollständig verboten.
-- Der `ProviderDescriptor`-Legacy-Adapter entfernt Userinfo, Query und Fragment
-  aus einer unsicheren Legacy-URL, übernimmt keinen privaten Anteil und
-  markiert die Verbindung mit einer secret-freien Reconfigure-Meldung als
-  `degraded`.
-- Der `StageLLMRoute`-Adapter lehnt eine unsichere `base_url` explizit ab.
+- Contracts importierbar; Schema-Dump idempotent (5 neue Schemas)
+- Backend-Contract-Suite: 284 bestanden
+- Voller Backend-Lauf: 3012 bestanden, 9 übersprungen, 7 deselektiert,
+  Exit 0 (Baseline Slice 1: 2920/9/7 → +92)
+- Ruff: grün; mypy: 211 Dateien, 0 Fehler
+- Frontend: 152 Testdateien / 1202 Tests grün (Baseline: 146/1150);
+  `bun run check` (Lint + Tests + Build) Exit 0; vue-tsc 0 Fehler
+- Vitest-Teardown-Blocker aus Phase 0 ist durch PR #678 behoben
+  (vor Slice-Beginn unabhängig mit Exit 0 verifiziert)
+- Gate 7/8 (verify-after-subagent): einziger `EXPORT_SCHEMA_VERSION`-Treffer
+  ist ein Bestands-Docstring identisch auf `main`; `report_agent.py` ist
+  inzwischen ein Paket — Muster nicht mehr vorhanden
 
-## Frisch verifiziert nach dem letzten `base_url`-Fix
+## Entscheidungen
 
-Vom Implementer:
+- `chat_model_available` → `chat_model_configured` umbenannt: ohne
+  Live-Discovery wäre „available" gelogen.
+- Onboarding-Schritte providers/chat_model/embeddings sind in Slice 2
+  ehrliche Status-Schritte (realer requirements-Zustand + Settings-Link),
+  keine Attrappen; geführte Einrichtung folgt in Slice 3/4.
+- Avatar-Anzeige über authentifizierten Blob-Fetch statt signierter
+  Tickets — kein neues `?token=`, keine Backend-Ticket-Nacharbeit nötig.
+- Kein Contract-Feld `avatar_ref` im Update-Request: Avatar wird
+  ausschließlich über die Avatar-Endpunkte verändert.
 
-- Backend-Zieltest: 39 bestanden
-- Frontend-Zieltest: 17 bestanden
-- Backend-Contract-Suite: 250 bestanden
-- mypy: 206 Dateien, 0 Fehler
-- Ruff: grün
-- Schema-Dump: idempotent
-- Frontend standalone: 146/146 Testdateien, 1150/1150 Tests
-- Frontend Lint, Typecheck und Build standalone: grün
-- Pytest-Inventar: 2934 total, 2927 selektiert, 7 deselektiert
+## Noch offen
 
-Vom Root unabhängig erneut bestätigt:
+- Codegraph-Delta gegen den Haupt-Repo-Graph nach Merge (s. o.).
+- Statusschritte verlinken einheitlich auf `SettingsLlmProviders`;
+  Differenzierung chat_model/embeddings sobald Slice 3/4 eigene Routen bringt.
+- Kein dedizierter Spec für `SettingsProfileView.vue` (Verhalten über
+  ProfileForm- und Store-Specs abgedeckt).
+- Playwright-E2E für Onboarding-Resume (Testplan) folgt, sobald die
+  E2E-Suite die neuen Routen aufnimmt (kein E2E-Bestand für Settings-Views).
 
-- Imports
-- Schema-Idempotenz
-- Backend-Zieltest: 39 bestanden
-- Backend-Contract-Suite: 250 bestanden
-- Ruff
-- mypy: 206 Dateien, 0 Fehler
+## Geänderte Verträge und Migrationen
 
-Vom Root am 2026-07-11 zusätzlich unabhängig bestätigt:
-
-- vollständiger Backend-Testlauf: 2920 bestanden, 9 übersprungen,
-  7 deselektiert, Exit 0
-- Frontend-Zieltest (17), Frontend Full (146 Testdateien / 1150 Tests),
-  Lint, Typecheck und Build — alle grün
-- Security-Probes: Credential-Keys in `provider_options` blockiert,
-  Userinfo-`base_url` abgelehnt, keine Secret-Muster im Diff
-
-## Bekannte Baselines und offene Punkte
-
-- Der letzte vollständige Backend-Lauf vor dem `base_url`-Fix hatte
-  2900 bestandene, 9 übersprungene und 7 deselektierte Tests; der
-  unabhängige Lauf nach dem Fix 2920/9/7 (Exit 0).
-- `npm run check` hatte vor dem `base_url`-Fix fachlich bestandene
-  Coverage-Tests, endete aber wegen eines vorbestehenden Vitest-
-  `EnvironmentTeardownError` aus `CompareView.spec.ts` mit Exit 1. Standalone
-  Full Tests, Lint, Typecheck und Build sind grün. Den Teardown nicht in diesem
-  Slice beheben.
-- Der vorherige Reviewer fand den `base_url`-Secret-Pfad. Der Fix ist
-  implementiert; der finale unabhängige Re-Review (2026-07-11) ergab
-  **MERGE-READY** mit drei non-blocking Follow-ups F1–F3 (Port-Parity-Drift
-  Zod/Pydantic, nicht-totaler Legacy-Adapter, Backslash-Host-Differential) —
-  Details im Arbeitsprotokoll.
-- Codegraph vor dem `base_url`-Fix, letzter Full-Stand: 945 Dateien,
-  8965 Knoten, 75474 Kanten und 624 Flows. Der damalige Impact war hoch:
-  138 zusätzliche Dateien, 1 Schema-Dump-Flow und 0 Testlücken. Der Refresh
-  nach dem `base_url`-Fix war in der Abschluss-Session nicht ausführbar
-  (CRG nicht verbunden) und bleibt Follow-up.
-- In einer früheren Prozessdiagnose wurde ein Credential eines fremden
-  Prozesses in einer Tool-Ausgabe sichtbar. Vorsorgliche Rotation ist separat
-  erforderlich; der Wert darf nicht erneut ausgegeben, dokumentiert oder
-  anderweitig reproduziert werden.
+- Nur additive Verträge; keine bestehenden Verträge geändert.
+- Neue Stores legen ihre Dateien lazy an; keine Migration bestehender Daten.
+- Rollback: Blueprints deregistrieren + neue Module entfernen; die
+  JSON-Dateien unter `AGORA_DATA_DIR` sind unabhängig und können bleiben.
 
 ## Nächste exakt ausführbare Schritte
 
-1. `git diff` und `git status` prüfen; Security-Probes für Credential-Keys und
-   öffentliche `base_url` unabhängig wiederholen.
-2. Vollständigen Backend-Testlauf ausführen und exakte Passed/Skipped/
-   Deselected-Zahlen festhalten.
-3. Frontend-Zieltest, Full Tests, Lint, Typecheck und Build unabhängig
-   wiederholen. Den bekannten Composite-Check-Teardown separat dokumentieren,
-   nicht in diesem Slice reparieren.
-4. Codegraph full oder inkrementell aktualisieren und Delta, Impact, Flow sowie
-   Testlücken prüfen.
-5. Reviewer-Re-Review des `base_url`-Fixes durchführen.
-6. Doku-Zahlen gegen die frischen unabhängigen Läufe prüfen und gegebenenfalls
-   korrigieren.
-7. Nur die konkreten Slice-Dateien stagen, atomaren Commit erstellen, Branch
-   pushen und PR eröffnen. Nicht direkt auf `main` mergen.
+1. PR-Review (inkl. Gemini-Findings) sichten; erst danach mergen.
+2. Nach Merge: `uvx code-review-graph build` auf `main` + Delta prüfen.
+3. Slice 3 (Provider-Verbindungen und Discovery) gemäß
+   `04-implementation-plan.md` beginnen; dabei die Onboarding-Schritte
+   providers/chat_model an die echte Discovery anbinden.
 
 ## Relevante Dateien
 
-- `backend/app/contracts/ai_provider_contract.py`
-- `backend/app/contracts/__init__.py`
-- `backend/app/contracts/dump_schemas.py`
-- `backend/tests/contracts/test_ai_provider_contract.py`
-- `frontend/src/contracts/aiProviderContract.ts`
-- `frontend/src/contracts/__tests__/aiProviderContract.spec.ts`
-- `schemas/ai-provider-connection.schema.json`
-- `schemas/ai-model.schema.json`
-- `schemas/ai-route.schema.json`
-- `schemas/fixtures/ai-provider-contract-fixtures.json`
-- `CHANGELOG.md`
-- `PLAN.md`
-- `docs/STATUS.md`
-- `docs/2026-07-10-onboarding-provider-unification-slice-1-arbeitsprotokoll.md`
+- `backend/app/contracts/user_profile_contract.py`
+- `backend/app/services/user_profile_store.py`
+- `backend/app/services/onboarding_state_store.py`
+- `backend/app/api/user_profile.py`, `backend/app/api/onboarding.py`
+- `backend/tests/contracts/test_user_profile_contract.py`
+- `backend/tests/services/test_user_profile_store.py`,
+  `backend/tests/services/test_onboarding_state_store.py`
+- `backend/tests/api/test_user_profile_api.py`,
+  `backend/tests/api/test_onboarding_api.py`
+- `frontend/src/contracts/userProfileContract.ts`
+- `frontend/src/api/profile.ts`, `frontend/src/store/userProfile.ts`
+- `frontend/src/router/onboardingGuard.ts`
+- `frontend/src/views/onboarding/OnboardingView.vue`
+- `frontend/src/views/Settings/SettingsProfileView.vue`
+- `frontend/src/components/v4/forms/ProfileForm.vue`
+- `schemas/user-profile*.json`, `schemas/onboarding-*.json`
+
+## Befehle zur Verifikation
+
+```bash
+cd backend && uv run pytest tests/contracts/ -q
+cd backend && uv run pytest tests/services/test_user_profile_store.py \
+  tests/services/test_onboarding_state_store.py \
+  tests/api/test_user_profile_api.py tests/api/test_onboarding_api.py -q
+cd backend && uv run python -m app.contracts.dump_schemas --check
+cd backend && uv run ruff check . && uv run mypy app
+cd frontend && bun run check
+```
 
 ## Doc-Impact
 
-- `README.md`: geprüft, nicht betroffen — noch kein neues Anwender- oder
-  UI-Verhalten.
-- `AGENTS.md`: geprüft, nicht betroffen — Contract-, Schema-, TDD- und
-  Security-Regeln decken den Slice bereits ab.
-- `CLAUDE.md`: geprüft, nicht betroffen — Detection-SSoT und Schema-Befehle
-  bleiben unverändert.
-- `PLAN.md`: aktualisiert — Slice implementiert, Root-Re-Review offen.
-- `docs/STATUS.md`: aktualisiert — aktuelles Pytest-Inventar und Frontend-
-  Testdateien.
-- `CHANGELOG.md`: aktualisiert — kanonische Verträge, öffentliche `base_url`
-  und Legacy-Sanitizing unter `[Unreleased]`.
-- Epic-`HANDOVER.md`: aktualisiert — dieser operative Übergabestand.
-- `docs/tooling/agent-tools.md`: geprüft, nicht betroffen — keine Tool-Version,
-  Installation oder Konfiguration geändert.
+- `README.md`: geprüft, nicht betroffen — Setup/Betrieb unverändert; das
+  Onboarding erklärt sich in der UI selbst (Anwenderdoku folgt mit dem
+  Epic-Abschluss, wenn der Wizard vollständig ist).
+- `AGENTS.md`: geprüft, nicht betroffen — Contract-/TDD-/Security-Regeln
+  decken den Slice ab; keine neuen Befehle oder Tools.
+- `CLAUDE.md`: geprüft, nicht betroffen.
+- `PLAN.md`: aktualisiert — Slice-Status, Baseline-Absatz, Fußzeile.
+- `docs/STATUS.md`: aktualisiert — via `scripts/sync-status.sh` regeneriert.
+- `CHANGELOG.md`: aktualisiert — Added-Block profile/onboarding unter
+  `[Unreleased]`.
+- Epic-`HANDOVER.md`: aktualisiert — dieses Dokument.
+- `docs/tooling/agent-tools.md`: geprüft, nicht betroffen — keine
+  Tool-Version oder -Konfiguration geändert.

--- a/frontend/src/api/__tests__/profile.spec.ts
+++ b/frontend/src/api/__tests__/profile.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * profile — API-Client-Smokes (Onboarding Slice 2, Nachbesserung).
+ *
+ * Tests:
+ *  1. completeOnboarding() spiegelt bei 409 "onboarding_incomplete" die
+ *     TOP-LEVEL `missing`-Liste aus dem rohen Envelope nach `details.missing`.
+ *  2. completeOnboarding() lässt andere Fehler unverändert durch.
+ *  3. fetchAvatarBlob() gibt den Blob bei Erfolg zurück und ruft den
+ *     authentifizierten service-Client mit responseType "blob" auf.
+ *  4. fetchAvatarBlob() gibt bei jedem Fehler null zurück (Initialen-Fallback).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '../envelope'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('../index', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { completeOnboarding, fetchAvatarBlob } from '../profile'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('completeOnboarding — 409 onboarding_incomplete Wire-Format', () => {
+  it('Test 1: spiegelt top-level `missing` aus dem rohen Envelope nach details.missing', async () => {
+    const rawEnvelope = {
+      success: false,
+      error: 'onboarding incomplete',
+      code: 'onboarding_incomplete',
+      missing: ['profile_valid', 'chat_model_configured'],
+    }
+    mockPost.mockRejectedValue(
+      new ApiError({
+        code: 'onboarding_incomplete',
+        status: 409,
+        message: 'onboarding incomplete',
+        originalResponse: rawEnvelope,
+      }),
+    )
+
+    await expect(completeOnboarding()).rejects.toMatchObject({
+      code: 'onboarding_incomplete',
+      details: { missing: ['profile_valid', 'chat_model_configured'] },
+    })
+  })
+
+  it('Test 2: lässt Fehler ohne top-level `missing` unverändert durch', async () => {
+    const err = new ApiError({ code: 'unknown_error', status: 500, message: 'boom' })
+    mockPost.mockRejectedValue(err)
+
+    await expect(completeOnboarding()).rejects.toBe(err)
+  })
+
+  it('Test 2b: lässt Nicht-onboarding_incomplete-Fehler mit `missing` unangetastet', async () => {
+    const err = new ApiError({
+      code: 'display_name_required',
+      status: 400,
+      message: 'display_name required',
+      originalResponse: { success: false, code: 'display_name_required', missing: ['x'] },
+    })
+    mockPost.mockRejectedValue(err)
+
+    await expect(completeOnboarding()).rejects.toBe(err)
+  })
+})
+
+describe('fetchAvatarBlob', () => {
+  it('Test 3: gibt den Blob bei Erfolg zurück (authentifizierter service-Client, responseType blob)', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' })
+    mockGet.mockResolvedValue(blob)
+
+    await expect(fetchAvatarBlob()).resolves.toBe(blob)
+    expect(mockGet).toHaveBeenCalledWith('/api/profile/avatar', { responseType: 'blob' })
+  })
+
+  it('Test 4: gibt bei jedem Fehler null zurück (Initialen-Fallback statt Crash)', async () => {
+    mockGet.mockRejectedValue(new ApiError({ code: 'avatar_not_found', status: 404, message: 'no avatar' }))
+
+    await expect(fetchAvatarBlob()).resolves.toBeNull()
+  })
+})

--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -1,0 +1,144 @@
+/**
+ * User-Profile & Onboarding — API-Client (Onboarding Slice 2).
+ *
+ * Envelope-Handling wie in api/llmProfiles.ts: `unwrapAndParse` liest
+ * `response.data` (den Envelope-Body) aus und validiert strict per Zod.
+ * Die `{"profile": ...}`/`{"state": ...}`-Hüllen sind keine eigenen
+ * Pydantic-Modelle im Backend — die lokalen Wrapper-Schemas hier bilden
+ * nur die tatsächliche Endpunkt-Antwortform ab, nicht den Contract selbst.
+ */
+import { z } from 'zod'
+import service from './index'
+import { ApiError, isApiError } from './envelope'
+import { unwrapAndParse } from './parse'
+import {
+  OnboardingStateSchema,
+  OnboardingStatusResponseSchema,
+  OnboardingStepUpdateRequestSchema,
+  UserProfileSchema,
+  UserProfileUpdateRequestSchema,
+  type OnboardingState,
+  type OnboardingStatusResponse,
+  type OnboardingStepId,
+  type OperatingMode,
+  type UserProfile,
+  type UserProfileUpdateRequest,
+} from '../contracts/userProfileContract'
+
+const ProfileNullableResponseSchema = z.object({ profile: UserProfileSchema.nullable() }).strict()
+const ProfileResponseSchema = z.object({ profile: UserProfileSchema }).strict()
+const OnboardingStateResponseSchema = z.object({ state: OnboardingStateSchema }).strict()
+
+export async function getProfile(): Promise<UserProfile | null> {
+  const res = await service.get('/api/profile')
+  return unwrapAndParse(res, ProfileNullableResponseSchema).profile
+}
+
+export async function updateProfile(req: UserProfileUpdateRequest): Promise<UserProfile> {
+  const body = UserProfileUpdateRequestSchema.parse(req)
+  const res = await service.put('/api/profile', body)
+  return unwrapAndParse(res, ProfileResponseSchema).profile
+}
+
+export async function uploadAvatar(file: File): Promise<UserProfile> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await service.post('/api/profile/avatar', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return unwrapAndParse(res, ProfileResponseSchema).profile
+}
+
+export async function deleteAvatar(): Promise<UserProfile | null> {
+  const res = await service.delete('/api/profile/avatar')
+  return unwrapAndParse(res, ProfileNullableResponseSchema).profile
+}
+
+/**
+ * Lädt die Avatar-Datei als Blob über den authentifizierten `service`-Client
+ * (Auth-Header via Interceptor, s. api/index.ts). Das ist der primäre
+ * Anzeigepfad: Aufrufer erzeugen daraus per `URL.createObjectURL` eine
+ * Object-URL fürs `<img>`-Tag. Jeder Fehler (kein Avatar gesetzt, 401, …)
+ * liefert `null` — Aufrufer fallen dann auf den Initialen-Fallback zurück.
+ */
+export async function fetchAvatarBlob(): Promise<Blob | null> {
+  try {
+    const res = await service.get('/api/profile/avatar', { responseType: 'blob' })
+    return res instanceof Blob ? res : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Baut die Avatar-Bild-URL als Pfad-Referenz (Cache-Buster über
+ * `avatar_ref`). Interner Hilfs-Helper — NICHT mehr der primäre Anzeigepfad
+ * (siehe `fetchAvatarBlob`), da ein direktes `<img src>` im
+ * token-geschützten Modus (`AGORA_AUTH_TOKEN` gesetzt) keinen Auth-Header
+ * mitschicken kann und mit 401 fehlschlägt.
+ */
+export function avatarUrl(avatarRef: string | null | undefined): string | null {
+  if (!avatarRef) return null
+  const base = import.meta.env.VITE_API_BASE_URL || ''
+  return `${base}/api/profile/avatar?v=${encodeURIComponent(avatarRef)}`
+}
+
+export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
+  const res = await service.get('/api/onboarding')
+  return unwrapAndParse(res, OnboardingStatusResponseSchema)
+}
+
+export async function completeOnboardingStep(
+  step: OnboardingStepId,
+  operatingMode?: OperatingMode | null,
+): Promise<OnboardingState> {
+  const body = OnboardingStepUpdateRequestSchema.parse({
+    step,
+    operating_mode: operatingMode ?? null,
+  })
+  const res = await service.put('/api/onboarding/step', body)
+  return unwrapAndParse(res, OnboardingStateResponseSchema).state
+}
+
+/**
+ * Wire-Format-Anpassung: `POST /api/onboarding/complete` liefert bei 409
+ * `{"success": false, "code": "onboarding_incomplete", "missing": [...]}` —
+ * `missing` liegt TOP-LEVEL im Envelope, es gibt kein `details`-Feld. Der
+ * globale Interceptor (api/index.ts) kennt nur `details`/`error`/`code`, das
+ * `missing`-Array würde sonst verworfen. Diese lokale Normalisierung liest
+ * `missing` aus dem rohen Envelope (`ApiError.originalResponse`) und spiegelt
+ * es nach `details.missing`, damit Aufrufer einheitlich `err.details?.missing`
+ * lesen können, ohne den globalen Wrapper anzufassen.
+ */
+function _normalizeOnboardingIncompleteError(err: unknown): unknown {
+  if (!isApiError(err) || err.code !== 'onboarding_incomplete') return err
+  const raw = err.originalResponse as { missing?: unknown } | null | undefined
+  const missing = Array.isArray(raw?.missing) ? raw.missing.map(String) : undefined
+  if (!missing) return err
+  return new ApiError({
+    code: err.code,
+    status: err.status,
+    message: err.message,
+    details: { ...err.details, missing },
+    originalResponse: err.originalResponse,
+  })
+}
+
+export async function completeOnboarding(): Promise<OnboardingState> {
+  try {
+    const res = await service.post('/api/onboarding/complete')
+    return unwrapAndParse(res, OnboardingStateResponseSchema).state
+  } catch (err) {
+    throw _normalizeOnboardingIncompleteError(err)
+  }
+}
+
+export async function dismissOnboarding(): Promise<OnboardingState> {
+  const res = await service.post('/api/onboarding/dismiss')
+  return unwrapAndParse(res, OnboardingStateResponseSchema).state
+}
+
+export async function reopenOnboarding(): Promise<OnboardingState> {
+  const res = await service.post('/api/onboarding/reopen')
+  return unwrapAndParse(res, OnboardingStateResponseSchema).state
+}

--- a/frontend/src/components/v4/forms/ProfileForm.vue
+++ b/frontend/src/components/v4/forms/ProfileForm.vue
@@ -1,0 +1,348 @@
+<script setup lang="ts">
+/**
+ * ProfileForm — wiederverwendbares Profil-Formular (Onboarding Slice 2).
+ *
+ * Reines Props/Emits-Component ohne eigenes Fetching — sowohl
+ * `OnboardingView` (Schritt "profile") als auch `SettingsProfileView`
+ * binden es ein und übernehmen Store-Zugriff + Persistenz selbst.
+ */
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Field from './Field.vue'
+import Input from './Input.vue'
+import Select from './Select.vue'
+import Button from './Button.vue'
+import {
+  ALLOWED_AVATAR_MIME_TYPES,
+  MAX_AVATAR_BYTES,
+  TIMEZONE_SUGGESTIONS,
+} from './profileFormConstants'
+import type { UserProfile, UserProfileUpdateRequest } from '@/contracts/userProfileContract'
+
+const { t } = useI18n()
+
+const props = withDefaults(
+  defineProps<{
+    profile: UserProfile | null
+    avatarUrl?: string | null
+    saving?: boolean
+  }>(),
+  {
+    avatarUrl: null,
+    saving: false,
+  },
+)
+
+const emit = defineEmits<{
+  save: [payload: UserProfileUpdateRequest]
+  'upload-avatar': [file: File]
+  'delete-avatar': []
+}>()
+
+// ---------------------------------------------------------------------------
+// Form-State (lokal, aus `profile`-Prop synchronisiert)
+// ---------------------------------------------------------------------------
+const displayName = ref('')
+const username = ref('')
+const role = ref('')
+const organisation = ref('')
+const language = ref('de')
+const timezone = ref('Europe/Berlin')
+const reportLanguage = ref('de')
+const theme = ref('system')
+const privacyMode = ref('standard')
+
+function syncFromProfile(profile: UserProfile | null): void {
+  displayName.value = profile?.display_name ?? ''
+  username.value = profile?.username ?? ''
+  role.value = profile?.role ?? ''
+  organisation.value = profile?.organisation ?? ''
+  language.value = profile?.language ?? 'de'
+  timezone.value = profile?.timezone ?? 'Europe/Berlin'
+  reportLanguage.value = profile?.report_language ?? 'de'
+  theme.value = profile?.theme ?? 'system'
+  privacyMode.value = profile?.privacy_mode ?? 'standard'
+}
+watch(() => props.profile, syncFromProfile, { immediate: true })
+
+// ---------------------------------------------------------------------------
+// Optionen für Select-Felder
+// ---------------------------------------------------------------------------
+const languageOptions = computed(() => [
+  { value: 'de', label: t('profileSettings.form.language.de') },
+  { value: 'en', label: t('profileSettings.form.language.en') },
+])
+const themeOptions = computed(() => [
+  { value: 'system', label: t('profileSettings.form.theme.system') },
+  { value: 'light', label: t('profileSettings.form.theme.light') },
+  { value: 'dark', label: t('profileSettings.form.theme.dark') },
+])
+const privacyModeOptions = computed(() => [
+  { value: 'standard', label: t('profileSettings.form.privacyMode.standard') },
+  { value: 'strict', label: t('profileSettings.form.privacyMode.strict') },
+])
+
+// ---------------------------------------------------------------------------
+// Validierung + Submit
+// ---------------------------------------------------------------------------
+const displayNameTouched = ref(false)
+const displayNameInvalid = computed(() => displayName.value.trim().length === 0)
+const canSave = computed(() => !displayNameInvalid.value && !props.saving)
+
+function handleSubmit(): void {
+  displayNameTouched.value = true
+  if (!canSave.value) return
+  const payload: UserProfileUpdateRequest = {
+    display_name: displayName.value.trim(),
+    username: username.value.trim() || null,
+    role: role.value.trim() || null,
+    organisation: organisation.value.trim() || null,
+    language: language.value as UserProfileUpdateRequest['language'],
+    timezone: timezone.value.trim() || null,
+    report_language: reportLanguage.value as UserProfileUpdateRequest['report_language'],
+    theme: theme.value as UserProfileUpdateRequest['theme'],
+    privacy_mode: privacyMode.value as UserProfileUpdateRequest['privacy_mode'],
+  }
+  emit('save', payload)
+}
+
+// ---------------------------------------------------------------------------
+// Avatar — Client-Vorprüfung (Größe + Typ) vor Emit
+// ---------------------------------------------------------------------------
+const avatarError = ref<string | null>(null)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+
+function triggerFileInput(): void {
+  fileInputRef.value?.click()
+}
+
+function onAvatarFileChange(event: Event): void {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0] ?? null
+  // Reset, damit dieselbe Datei erneut ausgewählt werden kann.
+  input.value = ''
+  if (!file) return
+
+  avatarError.value = null
+  if (!ALLOWED_AVATAR_MIME_TYPES.has(file.type)) {
+    avatarError.value = t('profileSettings.form.avatarUnsupportedType')
+    return
+  }
+  if (file.size > MAX_AVATAR_BYTES) {
+    avatarError.value = t('profileSettings.form.avatarTooLarge')
+    return
+  }
+  emit('upload-avatar', file)
+}
+
+function handleDeleteAvatar(): void {
+  emit('delete-avatar')
+}
+
+// ---------------------------------------------------------------------------
+// Initialen-Fallback
+// ---------------------------------------------------------------------------
+const initials = computed(() => {
+  const name = displayName.value.trim()
+  if (!name) return '?'
+  const parts = name.split(/\s+/).filter(Boolean)
+  const first = parts[0]?.charAt(0) ?? ''
+  const last = parts.length > 1 ? parts[parts.length - 1].charAt(0) : ''
+  return (first + last).toUpperCase()
+})
+
+defineExpose({ canSave, handleSubmit })
+</script>
+
+<template>
+  <div class="profile-form">
+    <div class="profile-form__avatar-row">
+      <div class="profile-form__avatar">
+        <img
+          v-if="avatarUrl"
+          :src="avatarUrl"
+          :alt="displayName"
+          class="profile-form__avatar-img"
+        />
+        <span v-else class="profile-form__avatar-initials" aria-hidden="true">{{ initials }}</span>
+      </div>
+      <div class="profile-form__avatar-actions">
+        <Button
+          variant="secondary"
+          size="sm"
+          type="button"
+          :disabled="saving"
+          @click="triggerFileInput"
+        >
+          {{ t('profileSettings.form.avatarUploadBtn') }}
+        </Button>
+        <Button
+          v-if="avatarUrl"
+          variant="ghost"
+          size="sm"
+          type="button"
+          :disabled="saving"
+          @click="handleDeleteAvatar"
+        >
+          {{ t('profileSettings.form.avatarDeleteBtn') }}
+        </Button>
+        <input
+          ref="fileInputRef"
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          class="profile-form__avatar-input"
+          data-testid="avatar-file-input"
+          @change="onAvatarFileChange"
+        />
+      </div>
+    </div>
+    <p v-if="avatarError" class="profile-form__error" role="alert">{{ avatarError }}</p>
+
+    <div class="profile-form__fields">
+      <Field :label="t('profileSettings.form.displayNameLabel')">
+        <Input
+          v-model="displayName"
+          :disabled="saving"
+          data-testid="profile-form-display-name"
+          @blur="displayNameTouched = true"
+        />
+        <span v-if="displayNameTouched && displayNameInvalid" class="profile-form__error">
+          {{ t('profileSettings.form.displayNameRequired') }}
+        </span>
+      </Field>
+
+      <Field :label="t('profileSettings.form.usernameLabel')">
+        <Input v-model="username" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.roleLabel')">
+        <Input v-model="role" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.organisationLabel')">
+        <Input v-model="organisation" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.languageLabel')">
+        <Select v-model="language" :options="languageOptions" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.timezoneLabel')">
+        <input
+          v-model="timezone"
+          list="profile-form-timezones"
+          class="v4-input v4-state-interactive"
+          :disabled="saving"
+        />
+        <datalist id="profile-form-timezones">
+          <option v-for="tz in TIMEZONE_SUGGESTIONS" :key="tz" :value="tz" />
+        </datalist>
+      </Field>
+
+      <Field :label="t('profileSettings.form.reportLanguageLabel')">
+        <Select v-model="reportLanguage" :options="languageOptions" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.themeLabel')">
+        <Select v-model="theme" :options="themeOptions" :disabled="saving" />
+      </Field>
+
+      <Field :label="t('profileSettings.form.privacyModeLabel')">
+        <Select v-model="privacyMode" :options="privacyModeOptions" :disabled="saving" />
+      </Field>
+    </div>
+
+    <div class="profile-form__footer">
+      <Button
+        variant="primary"
+        type="button"
+        :disabled="!canSave"
+        :loading="saving"
+        @click="handleSubmit"
+      >
+        {{ t('profileSettings.saveBtn') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.profile-form__avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.profile-form__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-inset, #f2f2f7);
+  border: 1px solid var(--hairline);
+  flex-shrink: 0;
+}
+
+.profile-form__avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-form__avatar-initials {
+  font-family: var(--font-sans);
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.profile-form__avatar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-form__avatar-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.profile-form__fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .profile-form__fields {
+    grid-template-columns: 1fr;
+  }
+}
+
+.profile-form__error {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  color: var(--status-red, #c0392b);
+}
+
+.profile-form__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/frontend/src/components/v4/forms/__tests__/ProfileForm.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/ProfileForm.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * ProfileForm — Vitest-Smokes (Onboarding Slice 2).
+ *
+ * Tests:
+ *  1. Mountet ohne Crash, Felder aus `profile`-Prop vorbefüllt.
+ *  2. i18n-Keys lösen auf (kein "profileSettings.*"-Rohdot im DOM).
+ *  3. Pflichtfeld display_name: leer → Fehlermeldung + save-Button disabled.
+ *  4. save() emittiert korrektes Payload bei validem Formular.
+ *  5. Avatar-Größenvorprüfung: zu große Datei → Fehlermeldung, kein Emit.
+ *  6. Avatar-Typvorprüfung: falscher MIME-Type → Fehlermeldung, kein Emit.
+ *  7. Gültige Avatar-Datei → emittiert 'upload-avatar'.
+ *  8. delete-avatar-Button emittiert 'delete-avatar'.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import ProfileForm from '../ProfileForm.vue'
+import de from '@/i18n/locales/de.json'
+import en from '@/i18n/locales/en.json'
+import type { UserProfile } from '@/contracts/userProfileContract'
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'de', fallbackLocale: 'en', messages: { de, en } })
+}
+
+function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    avatar_ref: null,
+    display_name: 'Alex Schneider',
+    username: 'alex',
+    role: 'Maintainer',
+    organisation: 'Agora',
+    language: 'de',
+    timezone: 'Europe/Berlin',
+    report_language: 'de',
+    theme: 'system',
+    privacy_mode: 'standard',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+interface MountFormProps {
+  profile?: UserProfile | null
+  avatarUrl?: string | null
+  saving?: boolean
+}
+
+function mountForm(props: MountFormProps = {}) {
+  return mount(ProfileForm, {
+    props: { profile: makeProfile(), avatarUrl: null, saving: false, ...props },
+    global: { plugins: [makeI18n()] },
+  })
+}
+
+describe('ProfileForm', () => {
+  it('Test 1: mountet ohne Crash, Felder aus profile-Prop vorbefüllt', () => {
+    const w = mountForm()
+    expect(w.exists()).toBe(true)
+    const displayNameInput = w.get('[data-testid="profile-form-display-name"]').element as HTMLInputElement
+    expect(displayNameInput.value).toBe('Alex Schneider')
+  })
+
+  it('Test 2: i18n-Keys lösen auf (kein Rohdot im DOM)', () => {
+    const w = mountForm()
+    expect(w.text()).not.toMatch(/profileSettings\./)
+  })
+
+  it('Test 3: leerer display_name → Fehlermeldung + Save-Button disabled', async () => {
+    const w = mountForm({ profile: makeProfile({ display_name: '' }) })
+    // Save-Button ist der letzte Button im Formular; über disabled-Attribut prüfen.
+    const primaryBtn = w.findAll('button').at(-1)
+    expect(primaryBtn?.attributes('disabled')).toBeDefined()
+
+    await w.get('[data-testid="profile-form-display-name"]').trigger('blur')
+    expect(w.text()).toContain(de.profileSettings.form.displayNameRequired)
+  })
+
+  it('Test 4: save() emittiert korrektes Payload bei validem Formular', async () => {
+    const w = mountForm()
+    const primaryBtn = w.findAll('button').at(-1)
+    await primaryBtn?.trigger('click')
+
+    const saveEvents = w.emitted('save')
+    expect(saveEvents).toBeTruthy()
+    expect(saveEvents?.[0]?.[0]).toMatchObject({
+      display_name: 'Alex Schneider',
+      username: 'alex',
+      role: 'Maintainer',
+      organisation: 'Agora',
+      language: 'de',
+      timezone: 'Europe/Berlin',
+      report_language: 'de',
+      theme: 'system',
+      privacy_mode: 'standard',
+    })
+  })
+
+  it('Test 5: Avatar-Größenvorprüfung — zu große Datei löst Fehler aus, kein Emit', async () => {
+    const w = mountForm()
+    const big = new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'big.png', { type: 'image/png' })
+    const input = w.get('[data-testid="avatar-file-input"]')
+    Object.defineProperty(input.element, 'files', { value: [big], configurable: true })
+    await input.trigger('change')
+
+    expect(w.text()).toContain(de.profileSettings.form.avatarTooLarge)
+    expect(w.emitted('upload-avatar')).toBeFalsy()
+  })
+
+  it('Test 6: Avatar-Typvorprüfung — falscher MIME-Type löst Fehler aus, kein Emit', async () => {
+    const w = mountForm()
+    const svg = new File(['<svg/>'], 'evil.svg', { type: 'image/svg+xml' })
+    const input = w.get('[data-testid="avatar-file-input"]')
+    Object.defineProperty(input.element, 'files', { value: [svg], configurable: true })
+    await input.trigger('change')
+
+    expect(w.text()).toContain(de.profileSettings.form.avatarUnsupportedType)
+    expect(w.emitted('upload-avatar')).toBeFalsy()
+  })
+
+  it('Test 7: gültige Avatar-Datei emittiert upload-avatar', async () => {
+    const w = mountForm()
+    const png = new File([new Uint8Array(1024)], 'ok.png', { type: 'image/png' })
+    const input = w.get('[data-testid="avatar-file-input"]')
+    Object.defineProperty(input.element, 'files', { value: [png], configurable: true })
+    await input.trigger('change')
+
+    const events = w.emitted('upload-avatar')
+    expect(events).toBeTruthy()
+    expect(events?.[0]?.[0]).toBe(png)
+  })
+
+  it('Test 8: delete-avatar-Button emittiert delete-avatar', async () => {
+    const w = mountForm({ avatarUrl: 'http://localhost/api/profile/avatar?v=x' })
+    const deleteBtn = w.findAll('button').find((b) =>
+      b.text() === de.profileSettings.form.avatarDeleteBtn,
+    )
+    expect(deleteBtn).toBeTruthy()
+    await deleteBtn?.trigger('click')
+    expect(w.emitted('delete-avatar')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/v4/forms/profileFormConstants.ts
+++ b/frontend/src/components/v4/forms/profileFormConstants.ts
@@ -1,0 +1,33 @@
+/**
+ * Client-seitige Vorprüf-Konstanten für den Avatar-Upload.
+ *
+ * Muss in Grenzwerten mit backend/app/contracts/user_profile_contract.py
+ * (`ALLOWED_AVATAR_MIME_TYPES`, `MAX_AVATAR_BYTES`) übereinstimmen — die
+ * serverseitige Prüfung (inkl. Magic-Bytes) bleibt die eigentliche
+ * Autorität, das hier ist nur eine schnelle Client-Vorprüfung.
+ */
+export const ALLOWED_AVATAR_MIME_TYPES: ReadonlySet<string> = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+])
+
+export const MAX_AVATAR_BYTES = 2 * 1024 * 1024
+
+/** Gängige IANA-Zeitzonen als Datalist-Vorschläge (Freitextfeld bleibt möglich). */
+export const TIMEZONE_SUGGESTIONS: readonly string[] = [
+  'Europe/Berlin',
+  'Europe/Vienna',
+  'Europe/Zurich',
+  'Europe/London',
+  'Europe/Paris',
+  'Europe/Madrid',
+  'America/New_York',
+  'America/Los_Angeles',
+  'America/Chicago',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Asia/Dubai',
+  'Australia/Sydney',
+  'UTC',
+]

--- a/frontend/src/components/v4/shell/Sidebar.vue
+++ b/frontend/src/components/v4/shell/Sidebar.vue
@@ -102,7 +102,7 @@ const settingsRouteNames = [
   'Settings',
   'SettingsGeneral',
   'SettingsIntegrations',
-  'SettingsUsersTeams',
+  'SettingsProfile',
   'SettingsApiKeys',
   'SettingsAuditLogs',
   'SettingsLlmRouting',
@@ -121,7 +121,7 @@ const navWorkspace = [
 const navSettings: NavSettingsItem[] = [
   { id: 'general',       label: t('sidebar.settings.general'),       to: { name: 'SettingsGeneral' } },
   { id: 'integrations',  label: t('sidebar.settings.integrations'),  to: { name: 'SettingsIntegrations' } },
-  { id: 'users-teams',   label: t('sidebar.settings.usersTeams'),    to: { name: 'SettingsUsersTeams' } },
+  { id: 'profile',       label: t('sidebar.settings.profile'),       to: { name: 'SettingsProfile' } },
   { id: 'api-keys',      label: t('sidebar.settings.apiKeys'),       to: { name: 'SettingsApiKeys' } },
   { id: 'audit',         label: t('sidebar.settings.auditLogs'),     to: { name: 'SettingsAuditLogs' } },
   { id: 'llm-providers', label: t('sidebar.settings.llmProviders'),  to: { name: 'SettingsLlmProviders' } },

--- a/frontend/src/components/v4/shell/__tests__/testRouter.ts
+++ b/frontend/src/components/v4/shell/__tests__/testRouter.ts
@@ -17,11 +17,13 @@ const BASE_ROUTES: RouteRecordRaw[] = [
   { path: '/settings',               name: 'Settings',            redirect: '/settings/general' },
   { path: '/settings/general',       name: 'SettingsGeneral',     component: stub },
   { path: '/settings/integrations',  name: 'SettingsIntegrations',component: stub },
-  { path: '/settings/users-teams',   name: 'SettingsUsersTeams',  component: stub },
+  { path: '/settings/users-teams',   name: 'SettingsUsersTeams',  redirect: '/settings/profile' },
+  { path: '/settings/profile',       name: 'SettingsProfile',     component: stub },
   { path: '/settings/api-keys',      name: 'SettingsApiKeys',     component: stub },
   { path: '/settings/audit-logs',    name: 'SettingsAuditLogs',   component: stub },
   { path: '/settings/llm-providers', name: 'SettingsLlmProviders',component: stub },
   { path: '/settings/llm-routing',   name: 'SettingsLlmRouting',  component: stub },
+  { path: '/onboarding',             name: 'Onboarding',          component: stub },
 ]
 
 /**

--- a/frontend/src/contracts/__tests__/userProfileContract.spec.ts
+++ b/frontend/src/contracts/__tests__/userProfileContract.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import userProfileJsonSchema from '../../../../schemas/user-profile.schema.json'
+import userProfileUpdateJsonSchema from '../../../../schemas/user-profile-update-request.schema.json'
+import onboardingStateJsonSchema from '../../../../schemas/onboarding-state.schema.json'
+import onboardingStatusResponseJsonSchema from '../../../../schemas/onboarding-status-response.schema.json'
+import onboardingStepUpdateJsonSchema from '../../../../schemas/onboarding-step-update-request.schema.json'
+
+import {
+  ONBOARDING_STEP_ORDER,
+  OnboardingRequirementsSchema,
+  OnboardingStateSchema,
+  OnboardingStatusResponseSchema,
+  OnboardingStepUpdateRequestSchema,
+  UserProfileSchema,
+  UserProfileUpdateRequestSchema,
+} from '../userProfileContract'
+
+describe('canonical user-profile / onboarding contracts', () => {
+  it('keeps Zod top-level fields aligned with generated Pydantic schemas', () => {
+    expect(Object.keys(UserProfileSchema.shape).sort()).toEqual(
+      Object.keys(userProfileJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(UserProfileUpdateRequestSchema.shape).sort()).toEqual(
+      Object.keys(userProfileUpdateJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(OnboardingStateSchema.shape).sort()).toEqual(
+      Object.keys(onboardingStateJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(OnboardingStatusResponseSchema.shape).sort()).toEqual(
+      Object.keys(onboardingStatusResponseJsonSchema.properties).sort(),
+    )
+    expect(Object.keys(OnboardingStepUpdateRequestSchema.shape).sort()).toEqual(
+      Object.keys(onboardingStepUpdateJsonSchema.properties).sort(),
+    )
+  })
+
+  it('mirrors the canonical ONBOARDING_STEP_ORDER from the backend enum', () => {
+    expect(ONBOARDING_STEP_ORDER).toEqual(
+      onboardingStateJsonSchema.properties.current_step.enum,
+    )
+  })
+
+  it('accepts a canonical, fully populated UserProfile', () => {
+    const result = UserProfileSchema.safeParse({
+      avatar_ref: 'avatar-0123456789abcdef0123456789abcdef.png',
+      display_name: 'Alex Schneider',
+      username: 'alex-s',
+      role: 'Maintainer',
+      organisation: 'Agora',
+      language: 'de',
+      timezone: 'Europe/Berlin',
+      report_language: 'de',
+      theme: 'system',
+      privacy_mode: 'standard',
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a minimal UserProfile (only display_name + timestamps) via defaults', () => {
+    const result = UserProfileSchema.safeParse({
+      display_name: 'Minimal',
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.avatar_ref).toBeNull()
+      expect(result.data.language).toBe('de')
+      expect(result.data.timezone).toBe('Europe/Berlin')
+    }
+  })
+
+  it.each(['', '   ', '\n\t'])('rejects a blank display_name: %j', (blank) => {
+    const result = UserProfileSchema.safeParse({
+      display_name: blank,
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it.each([
+    '../../etc/passwd',
+    'avatar-../../etc/passwd.png',
+    'avatar-abc.png', // zu kurz, kein 32-stelliger Hex-Block
+    'avatar-0123456789abcdef0123456789abcdef.svg', // svg ist nie erlaubt
+    '/etc/avatar-0123456789abcdef0123456789abcdef.png',
+  ])('rejects a path-traversal / non-conforming avatar_ref: %s', (avatarRef) => {
+    const result = UserProfileSchema.safeParse({
+      avatar_ref: avatarRef,
+      display_name: 'Alex',
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an unknown current_step literal', () => {
+    const result = OnboardingStateSchema.safeParse({
+      status: 'in_progress',
+      current_step: 'not-a-real-step',
+      completed_steps: [],
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an unknown step in completed_steps', () => {
+    const result = OnboardingStateSchema.safeParse({
+      completed_steps: ['welcome', 'not-a-real-step'],
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra/unknown keys on UserProfile (strict)', () => {
+    const result = UserProfileSchema.safeParse({
+      display_name: 'Alex',
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+      unexpected_field: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra/unknown keys on UserProfileUpdateRequest (strict)', () => {
+    expect(UserProfileUpdateRequestSchema.safeParse({ avatar_ref: 'x' }).success).toBe(false)
+  })
+
+  it('rejects extra/unknown keys on OnboardingState (strict)', () => {
+    const result = OnboardingStateSchema.safeParse({
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+      unexpected_field: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a canonical OnboardingStatusResponse', () => {
+    const result = OnboardingStatusResponseSchema.safeParse({
+      state: {
+        status: 'in_progress',
+        operating_mode: 'local',
+        current_step: 'profile',
+        completed_steps: ['welcome'],
+        created_at: '2026-07-11T00:00:00Z',
+        updated_at: '2026-07-11T00:00:00Z',
+      },
+      requirements: {
+        profile_valid: false,
+        chat_model_configured: false,
+        embedding_configured: false,
+      },
+      onboarding_required: true,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects OnboardingRequirements with missing required fields', () => {
+    expect(OnboardingRequirementsSchema.safeParse({ profile_valid: true }).success).toBe(false)
+  })
+
+  it('accepts a canonical OnboardingStepUpdateRequest with and without operating_mode', () => {
+    expect(OnboardingStepUpdateRequestSchema.safeParse({ step: 'welcome' }).success).toBe(true)
+    expect(
+      OnboardingStepUpdateRequestSchema.safeParse({ step: 'welcome', operating_mode: 'local' })
+        .success,
+    ).toBe(true)
+    expect(
+      OnboardingStepUpdateRequestSchema.safeParse({ step: 'not-a-real-step' }).success,
+    ).toBe(false)
+  })
+})

--- a/frontend/src/contracts/userProfileContract.ts
+++ b/frontend/src/contracts/userProfileContract.ts
@@ -1,0 +1,150 @@
+/**
+ * Canonical Zod mirror of backend/app/contracts/user_profile_contract.py.
+ *
+ * ADR-0008: Agora ist ein Single-User-System. `UserProfile` beschreibt die
+ * lokale Person und ihre Einstellungen — kein KI-Preset (siehe
+ * `llmProfileContract.ts`). `OnboardingState` ist der backendseitig
+ * persistierte, resumierbare Zustand des Erst-Onboardings.
+ *
+ * Der `completed`-Status erfordert serverseitig bestimmte `completed_steps`
+ * (siehe `REQUIRED_ONBOARDING_STEPS` im Backend-Contract) — diese
+ * Cross-Field-Regel wird hier bewusst NICHT nachgebaut, der Zod-Spiegel
+ * validiert nur die strukturelle Form.
+ */
+import { z } from 'zod'
+
+// === Literale (müssen exakt den Pydantic-Literalen entsprechen) ===
+export const ProfileLanguageSchema = z.enum(['de', 'en'])
+export type ProfileLanguage = z.infer<typeof ProfileLanguageSchema>
+
+export const ProfileThemeSchema = z.enum(['system', 'light', 'dark'])
+export type ProfileTheme = z.infer<typeof ProfileThemeSchema>
+
+export const PrivacyModeSchema = z.enum(['standard', 'strict'])
+export type PrivacyMode = z.infer<typeof PrivacyModeSchema>
+
+export const OperatingModeSchema = z.enum(['local', 'hybrid', 'server'])
+export type OperatingMode = z.infer<typeof OperatingModeSchema>
+
+export const OnboardingStatusSchema = z.enum([
+  'not_started',
+  'in_progress',
+  'dismissed',
+  'completed',
+])
+export type OnboardingStatus = z.infer<typeof OnboardingStatusSchema>
+
+export const OnboardingStepIdSchema = z.enum([
+  'welcome',
+  'profile',
+  'providers',
+  'chat_model',
+  'embeddings',
+  'privacy',
+  'summary',
+])
+export type OnboardingStepId = z.infer<typeof OnboardingStepIdSchema>
+
+/** Kanonische Schritt-Reihenfolge des Wizards — 1:1 zu ONBOARDING_STEP_ORDER im Backend. */
+export const ONBOARDING_STEP_ORDER: readonly OnboardingStepId[] = [
+  'welcome',
+  'profile',
+  'providers',
+  'chat_model',
+  'embeddings',
+  'privacy',
+  'summary',
+] as const
+
+// === Avatar-Referenz (Path-Traversal- und Fremdnamen-sicher per Pattern) ===
+const _AVATAR_REF_PATTERN = /^avatar-[0-9a-f]{32}\.(png|jpg|webp)$/
+export const AvatarRefSchema = z.string().regex(_AVATAR_REF_PATTERN)
+
+const _USERNAME_PATTERN = /^[a-z0-9][a-z0-9._-]{1,31}$/
+export const UsernameSchema = z.string().regex(_USERNAME_PATTERN)
+
+/** display_name: min/max wie im Backend + Blank-Check (Backend strippt + verwirft Leerstrings). */
+const _DisplayNameSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .refine((value) => value.trim().length > 0, {
+    message: 'display_name must not be blank',
+  })
+
+// === UserProfile ===
+export const UserProfileSchema = z
+  .object({
+    avatar_ref: AvatarRefSchema.nullable().default(null),
+    display_name: _DisplayNameSchema,
+    username: UsernameSchema.nullable().default(null),
+    role: z.string().max(120).nullable().default(null),
+    organisation: z.string().max(120).nullable().default(null),
+    language: ProfileLanguageSchema.default('de'),
+    timezone: z.string().default('Europe/Berlin'),
+    report_language: ProfileLanguageSchema.default('de'),
+    theme: ProfileThemeSchema.default('system'),
+    privacy_mode: PrivacyModeSchema.default('standard'),
+    created_at: z.string(), // ISO-String (datetime serialisiert als str)
+    updated_at: z.string(),
+  })
+  .strict()
+export type UserProfile = z.infer<typeof UserProfileSchema>
+
+// === UserProfileUpdateRequest (avatar_ref bewusst ausgeschlossen) ===
+export const UserProfileUpdateRequestSchema = z
+  .object({
+    display_name: _DisplayNameSchema.nullable().default(null),
+    username: UsernameSchema.nullable().default(null),
+    role: z.string().max(120).nullable().default(null),
+    organisation: z.string().max(120).nullable().default(null),
+    language: ProfileLanguageSchema.nullable().default(null),
+    timezone: z.string().nullable().default(null),
+    report_language: ProfileLanguageSchema.nullable().default(null),
+    theme: ProfileThemeSchema.nullable().default(null),
+    privacy_mode: PrivacyModeSchema.nullable().default(null),
+  })
+  .strict()
+export type UserProfileUpdateRequest = z.infer<typeof UserProfileUpdateRequestSchema>
+
+// === OnboardingState ===
+export const OnboardingStateSchema = z
+  .object({
+    status: OnboardingStatusSchema.default('not_started'),
+    operating_mode: OperatingModeSchema.nullable().default(null),
+    current_step: OnboardingStepIdSchema.default('welcome'),
+    completed_steps: z.array(OnboardingStepIdSchema).default([]),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strict()
+export type OnboardingState = z.infer<typeof OnboardingStateSchema>
+
+// === OnboardingStepUpdateRequest ===
+export const OnboardingStepUpdateRequestSchema = z
+  .object({
+    step: OnboardingStepIdSchema,
+    operating_mode: OperatingModeSchema.nullable().default(null),
+  })
+  .strict()
+export type OnboardingStepUpdateRequest = z.infer<typeof OnboardingStepUpdateRequestSchema>
+
+// === OnboardingRequirements ===
+export const OnboardingRequirementsSchema = z
+  .object({
+    profile_valid: z.boolean(),
+    chat_model_configured: z.boolean(),
+    embedding_configured: z.boolean(),
+  })
+  .strict()
+export type OnboardingRequirements = z.infer<typeof OnboardingRequirementsSchema>
+
+// === OnboardingStatusResponse (GET /api/onboarding) ===
+export const OnboardingStatusResponseSchema = z
+  .object({
+    state: OnboardingStateSchema,
+    requirements: OnboardingRequirementsSchema,
+    onboarding_required: z.boolean(),
+  })
+  .strict()
+export type OnboardingStatusResponse = z.infer<typeof OnboardingStatusResponseSchema>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -22,7 +22,9 @@
     "SettingsIntegrations": "Integrationen",
     "SettingsApiKeys": "API-Schlüssel",
     "SettingsUsersTeams": "Nutzer & Teams",
-    "SettingsAuditLogs": "Audit-Logs"
+    "SettingsAuditLogs": "Audit-Logs",
+    "SettingsProfile": "Profil",
+    "Onboarding": "Einrichtung"
   },
   "common": {
     "start": "Starten",
@@ -733,7 +735,8 @@
       "apiKeys": "API-Schlüssel",
       "llmProviders": "LLM-Anbieter",
       "llmRouting": "LLM-Routing",
-      "auditLogs": "Audit-Logs"
+      "auditLogs": "Audit-Logs",
+      "profile": "Profil"
     },
     "footer": {
       "collapse": "Einklappen"
@@ -1294,5 +1297,137 @@
     "loading": "Profile laden…",
     "error": "Profile konnten nicht geladen werden.",
     "defaultSuffix": "default"
+  },
+  "onboarding": {
+    "wizard": {
+      "title": "Einrichtung",
+      "stepIndicator": "Schritt {current} von {total}",
+      "laterBtn": "Später einrichten",
+      "backBtn": "Zurück",
+      "nextBtn": "Weiter",
+      "finishBtn": "Einrichtung abschließen",
+      "dismissConfirm": "Einrichtung später fortsetzen? Du kannst sie jederzeit über Einstellungen → Profil erneut öffnen.",
+      "stepStatus": {
+        "done": "Abgeschlossen",
+        "current": "Aktuell",
+        "open": "Offen"
+      }
+    },
+    "steps": {
+      "welcome": "Start",
+      "profile": "Profil",
+      "providers": "Provider",
+      "chat_model": "Chat-Modell",
+      "embeddings": "Embeddings",
+      "privacy": "Datenschutz",
+      "summary": "Zusammenfassung"
+    },
+    "welcome": {
+      "title": "Willkommen bei Agora",
+      "description": "Agora ist ein lokal-first Multi-Agent-Simulator. Die Einrichtung dauert wenige Minuten und lässt sich jederzeit unterbrechen.",
+      "operatingModeLabel": "Betriebsmodus",
+      "operatingMode": {
+        "local": {
+          "label": "Lokal",
+          "description": "Alle Modelle laufen auf dieser Maschine (z. B. Ollama). Keine Daten verlassen das Gerät."
+        },
+        "hybrid": {
+          "label": "Hybrid",
+          "description": "Lokale Modelle kombiniert mit optionalen Cloud-Providern für einzelne Schritte."
+        },
+        "server": {
+          "label": "Server",
+          "description": "Agora läuft auf einem zentralen Server, Provider sind dort konfiguriert."
+        }
+      }
+    },
+    "profile": {
+      "title": "Profil",
+      "description": "Diese Angaben personalisieren Agora und erscheinen in Berichten."
+    },
+    "providers": {
+      "title": "Provider",
+      "description": "Übersicht der konfigurierten LLM-Provider.",
+      "configured": "Konfiguriert",
+      "notConfigured": "Nicht konfiguriert",
+      "futureNotice": "Die geführte Einrichtung folgt in einem späteren Update. Provider lassen sich bereits jetzt in den Einstellungen verwalten.",
+      "settingsLink": "Zu den Provider-Einstellungen"
+    },
+    "chatModel": {
+      "title": "Chat-Modell",
+      "description": "Status des konfigurierten Chat-Modells.",
+      "futureNotice": "Die geführte Einrichtung folgt in einem späteren Update.",
+      "settingsLink": "Zu den Provider-Einstellungen"
+    },
+    "embeddings": {
+      "title": "Embeddings",
+      "description": "Status der konfigurierten Embedding-Anbindung.",
+      "futureNotice": "Die geführte Einrichtung folgt in einem späteren Update.",
+      "settingsLink": "Zu den Provider-Einstellungen"
+    },
+    "privacy": {
+      "title": "Datenschutz",
+      "text": "Agora ist lokal-first: Dokumente, Wissensgraphen und Simulationsergebnisse bleiben standardmäßig auf diesem Gerät. Cloud-Provider werden nur verwendet, wenn du sie explizit einrichtest.",
+      "confirmBtn": "Verstanden"
+    },
+    "summary": {
+      "title": "Zusammenfassung",
+      "profileHeading": "Profil",
+      "modeHeading": "Betriebsmodus",
+      "requirementsHeading": "Voraussetzungen",
+      "incompleteNotice": "Einrichtung ist noch nicht vollständig. Fehlend:",
+      "readyNotice": "Alle Voraussetzungen sind erfüllt."
+    },
+    "requirements": {
+      "profileValid": "Profil",
+      "chatModelConfigured": "Chat-Modell",
+      "embeddingConfigured": "Embeddings"
+    },
+    "errors": {
+      "loadFailed": "Onboarding-Status konnte nicht geladen werden.",
+      "saveFailed": "Schritt konnte nicht gespeichert werden.",
+      "incomplete": "Einrichtung kann noch nicht abgeschlossen werden."
+    }
+  },
+  "profileSettings": {
+    "title": "Profil",
+    "subtitle": "Persönliche Angaben und lokale Einstellungen.",
+    "reopenOnboardingBtn": "Onboarding erneut öffnen",
+    "saveBtn": "Speichern",
+    "saveSuccess": "Profil gespeichert.",
+    "saveError": "Profil konnte nicht gespeichert werden.",
+    "loadError": "Profil konnte nicht geladen werden.",
+    "form": {
+      "avatarLabel": "Avatar",
+      "avatarUploadBtn": "Bild hochladen",
+      "avatarDeleteBtn": "Entfernen",
+      "avatarTooLarge": "Datei ist größer als 2 MB.",
+      "avatarUnsupportedType": "Nur PNG, JPEG oder WebP erlaubt.",
+      "avatarUploadError": "Avatar-Upload fehlgeschlagen.",
+      "avatarDeleteError": "Avatar konnte nicht gelöscht werden.",
+      "displayNameLabel": "Anzeigename",
+      "displayNameRequired": "Anzeigename ist erforderlich.",
+      "usernameLabel": "Benutzername",
+      "roleLabel": "Rolle",
+      "organisationLabel": "Organisation",
+      "languageLabel": "Sprache",
+      "timezoneLabel": "Zeitzone",
+      "reportLanguageLabel": "Berichtssprache",
+      "themeLabel": "Theme",
+      "privacyModeLabel": "Datenschutzmodus",
+      "theme": {
+        "system": "System",
+        "light": "Hell",
+        "dark": "Dunkel"
+      },
+      "privacyMode": {
+        "standard": "Standard",
+        "strict": "Streng"
+      },
+      "language": {
+        "de": "Deutsch",
+        "en": "Englisch"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -22,7 +22,9 @@
     "SettingsIntegrations": "Integrations",
     "SettingsApiKeys": "API Keys",
     "SettingsUsersTeams": "Users & Teams",
-    "SettingsAuditLogs": "Audit Logs"
+    "SettingsAuditLogs": "Audit Logs",
+    "SettingsProfile": "Profile",
+    "Onboarding": "Setup"
   },
   "common": {
     "start": "Start",
@@ -733,7 +735,8 @@
       "apiKeys": "API Keys",
       "llmProviders": "LLM Providers",
       "llmRouting": "LLM Routing",
-      "auditLogs": "Audit Logs"
+      "auditLogs": "Audit Logs",
+      "profile": "Profile"
     },
     "footer": {
       "collapse": "Collapse"
@@ -1294,5 +1297,137 @@
     "loading": "Loading profiles…",
     "error": "Failed to load profiles.",
     "defaultSuffix": "default"
+  },
+  "onboarding": {
+    "wizard": {
+      "title": "Setup",
+      "stepIndicator": "Step {current} of {total}",
+      "laterBtn": "Set up later",
+      "backBtn": "Back",
+      "nextBtn": "Next",
+      "finishBtn": "Finish setup",
+      "dismissConfirm": "Continue setup later? You can reopen it anytime via Settings → Profile.",
+      "stepStatus": {
+        "done": "Done",
+        "current": "Current",
+        "open": "Open"
+      }
+    },
+    "steps": {
+      "welcome": "Start",
+      "profile": "Profile",
+      "providers": "Providers",
+      "chat_model": "Chat model",
+      "embeddings": "Embeddings",
+      "privacy": "Privacy",
+      "summary": "Summary"
+    },
+    "welcome": {
+      "title": "Welcome to Agora",
+      "description": "Agora is a local-first multi-agent simulator. Setup takes a few minutes and can be paused anytime.",
+      "operatingModeLabel": "Operating mode",
+      "operatingMode": {
+        "local": {
+          "label": "Local",
+          "description": "All models run on this machine (e.g. Ollama). No data leaves the device."
+        },
+        "hybrid": {
+          "label": "Hybrid",
+          "description": "Local models combined with optional cloud providers for individual steps."
+        },
+        "server": {
+          "label": "Server",
+          "description": "Agora runs on a central server, providers are configured there."
+        }
+      }
+    },
+    "profile": {
+      "title": "Profile",
+      "description": "These details personalise Agora and appear in reports."
+    },
+    "providers": {
+      "title": "Providers",
+      "description": "Overview of configured LLM providers.",
+      "configured": "Configured",
+      "notConfigured": "Not configured",
+      "futureNotice": "Guided setup follows in a later update. Providers can already be managed in Settings.",
+      "settingsLink": "Go to provider settings"
+    },
+    "chatModel": {
+      "title": "Chat model",
+      "description": "Status of the configured chat model.",
+      "futureNotice": "Guided setup follows in a later update.",
+      "settingsLink": "Go to provider settings"
+    },
+    "embeddings": {
+      "title": "Embeddings",
+      "description": "Status of the configured embedding connection.",
+      "futureNotice": "Guided setup follows in a later update.",
+      "settingsLink": "Go to provider settings"
+    },
+    "privacy": {
+      "title": "Privacy",
+      "text": "Agora is local-first: documents, knowledge graphs and simulation results stay on this device by default. Cloud providers are only used if you explicitly configure them.",
+      "confirmBtn": "Understood"
+    },
+    "summary": {
+      "title": "Summary",
+      "profileHeading": "Profile",
+      "modeHeading": "Operating mode",
+      "requirementsHeading": "Requirements",
+      "incompleteNotice": "Setup is not complete yet. Missing:",
+      "readyNotice": "All requirements are met."
+    },
+    "requirements": {
+      "profileValid": "Profile",
+      "chatModelConfigured": "Chat model",
+      "embeddingConfigured": "Embeddings"
+    },
+    "errors": {
+      "loadFailed": "Could not load onboarding status.",
+      "saveFailed": "Could not save step.",
+      "incomplete": "Setup cannot be completed yet."
+    }
+  },
+  "profileSettings": {
+    "title": "Profile",
+    "subtitle": "Personal details and local settings.",
+    "reopenOnboardingBtn": "Reopen onboarding",
+    "saveBtn": "Save",
+    "saveSuccess": "Profile saved.",
+    "saveError": "Could not save profile.",
+    "loadError": "Could not load profile.",
+    "form": {
+      "avatarLabel": "Avatar",
+      "avatarUploadBtn": "Upload image",
+      "avatarDeleteBtn": "Remove",
+      "avatarTooLarge": "File is larger than 2 MB.",
+      "avatarUnsupportedType": "Only PNG, JPEG or WebP are allowed.",
+      "avatarUploadError": "Avatar upload failed.",
+      "avatarDeleteError": "Could not delete avatar.",
+      "displayNameLabel": "Display name",
+      "displayNameRequired": "Display name is required.",
+      "usernameLabel": "Username",
+      "roleLabel": "Role",
+      "organisationLabel": "Organisation",
+      "languageLabel": "Language",
+      "timezoneLabel": "Timezone",
+      "reportLanguageLabel": "Report language",
+      "themeLabel": "Theme",
+      "privacyModeLabel": "Privacy mode",
+      "theme": {
+        "system": "System",
+        "light": "Light",
+        "dark": "Dark"
+      },
+      "privacyMode": {
+        "standard": "Standard",
+        "strict": "Strict"
+      },
+      "language": {
+        "de": "German",
+        "en": "English"
+      }
+    }
   }
 }

--- a/frontend/src/router/__tests__/onboardingGuard.spec.ts
+++ b/frontend/src/router/__tests__/onboardingGuard.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * onboardingGuard — Vitest-Smokes (Onboarding Slice 2).
+ *
+ * Tests:
+ *  1. Redirect zu Onboarding wenn store.onboardingRequired === true.
+ *  2. Durchlass wenn onboardingRequired === false (z.B. completed/dismissed).
+ *  3. Durchlass wenn Ziel selbst 'Onboarding' ist (kein Redirect-Loop).
+ *  4. Durchlass wenn Ziel 'NotFound' ist.
+ *  5. Durchlass bei API-Fehler (ensureLoaded() wirft) — kein Lockout.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { RouteLocationNormalized } from 'vue-router'
+
+vi.mock('../../api/profile', () => ({
+  getProfile: vi.fn(),
+  updateProfile: vi.fn(),
+  uploadAvatar: vi.fn(),
+  deleteAvatar: vi.fn(),
+  getOnboardingStatus: vi.fn(),
+  completeOnboardingStep: vi.fn(),
+  completeOnboarding: vi.fn(),
+  dismissOnboarding: vi.fn(),
+  reopenOnboarding: vi.fn(),
+}))
+
+import { getOnboardingStatus, getProfile } from '../../api/profile'
+import { onboardingGuard } from '../onboardingGuard'
+import type { OnboardingStatusResponse, UserProfile } from '../../contracts/userProfileContract'
+
+type MockFn = ReturnType<typeof vi.fn>
+const _getProfile = getProfile as unknown as MockFn
+const _getOnboardingStatus = getOnboardingStatus as unknown as MockFn
+
+function makeProfile(): UserProfile {
+  return {
+    avatar_ref: null,
+    display_name: 'Alex Schneider',
+    username: null,
+    role: null,
+    organisation: null,
+    language: 'de',
+    timezone: 'Europe/Berlin',
+    report_language: 'de',
+    theme: 'system',
+    privacy_mode: 'standard',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+  }
+}
+
+function makeOnboardingStatus(onboardingRequired: boolean): OnboardingStatusResponse {
+  return {
+    state: {
+      status: onboardingRequired ? 'in_progress' : 'completed',
+      operating_mode: 'local',
+      current_step: 'welcome',
+      completed_steps: [],
+      created_at: '2026-07-11T00:00:00Z',
+      updated_at: '2026-07-11T00:00:00Z',
+    },
+    requirements: {
+      profile_valid: !onboardingRequired,
+      chat_model_configured: !onboardingRequired,
+      embedding_configured: !onboardingRequired,
+    },
+    onboarding_required: onboardingRequired,
+  }
+}
+
+function route(name: string): RouteLocationNormalized {
+  return { name } as unknown as RouteLocationNormalized
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('onboardingGuard', () => {
+  it('Test 1: redirectet zu Onboarding wenn onboardingRequired === true', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus(true))
+
+    const result = await onboardingGuard(route('Dashboard'))
+    expect(result).toEqual({ name: 'Onboarding' })
+  })
+
+  it('Test 2: lässt Navigation durch wenn onboardingRequired === false', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus(false))
+
+    const result = await onboardingGuard(route('Dashboard'))
+    expect(result).toBe(true)
+  })
+
+  it('Test 3: kein Redirect-Loop wenn Ziel bereits Onboarding ist', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus(true))
+
+    const result = await onboardingGuard(route('Onboarding'))
+    expect(result).toBe(true)
+    // ensureLoaded() darf für die exempte Route gar nicht erst aufgerufen werden.
+    expect(_getProfile).not.toHaveBeenCalled()
+  })
+
+  it('Test 4: lässt NotFound immer durch', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus(true))
+
+    const result = await onboardingGuard(route('NotFound'))
+    expect(result).toBe(true)
+  })
+
+  it('Test 5: lässt Navigation durch bei API-Fehler (kein Lockout)', async () => {
+    _getProfile.mockRejectedValue(new Error('Netzwerkfehler'))
+    _getOnboardingStatus.mockRejectedValue(new Error('Netzwerkfehler'))
+
+    const result = await onboardingGuard(route('Dashboard'))
+    expect(result).toBe(true)
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
 import { getAgoraToken } from '../api/index'
+import { onboardingGuard } from './onboardingGuard'
 
 const routes: RouteRecordRaw[] = [
   // Root → Dashboard (v4-AppShell ist Default-Einstieg)
@@ -41,6 +42,13 @@ const routes: RouteRecordRaw[] = [
     props: true,
   },
 
+  // Onboarding — resumierbarer Erst-Einrichtungs-Wizard (Onboarding Slice 2)
+  {
+    path: '/onboarding',
+    name: 'Onboarding',
+    component: () => import('../views/onboarding/OnboardingView.vue'),
+  },
+
   // Settings — klassische View bleibt aktiv; /settings redirect auf /settings/general
   {
     path: '/settings',
@@ -58,9 +66,16 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/Settings/SettingsIntegrationsView.vue'),
   },
   {
+    path: '/settings/profile',
+    name: 'SettingsProfile',
+    component: () => import('../views/Settings/SettingsProfileView.vue'),
+  },
+  // Sidebar-IA-Fix (Onboarding-Epic): "Users & Teams" wurde durch das
+  // Profil-Setting ersetzt — bestehende Deep-Links leiten weiter um.
+  {
     path: '/settings/users-teams',
     name: 'SettingsUsersTeams',
-    component: () => import('../views/Settings/SettingsUsersTeamsView.vue'),
+    redirect: { name: 'SettingsProfile' },
   },
   {
     path: '/settings/api-keys',
@@ -202,5 +217,8 @@ router.beforeEach((to) => {
   if (getAgoraToken()) return true
   return { name: 'Dashboard', query: { authRequired: '1', next: to.fullPath } }
 })
+
+// Onboarding-Redirect — läuft NACH dem Auth-Guard (Onboarding Slice 2).
+router.beforeEach(onboardingGuard)
 
 export default router

--- a/frontend/src/router/onboardingGuard.ts
+++ b/frontend/src/router/onboardingGuard.ts
@@ -1,0 +1,36 @@
+/**
+ * onboardingGuard — Redirect-Guard fürs resumierbare Onboarding
+ * (Onboarding Slice 2).
+ *
+ * Läuft NACH dem bestehenden Auth-Guard in router/index.ts. Leitet auf
+ * `/onboarding` um, wenn `store.onboardingRequired` true ist und das Ziel
+ * weder die Onboarding-Route noch NotFound ist. `ensureLoaded()` lädt
+ * Profil + Onboarding-Status genau einmal; JEDER Fehlerpfad lässt die
+ * Navigation durch — ein Backend-Ausfall darf die App niemals sperren.
+ */
+import type { RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
+import { useUserProfileStore } from '../store/userProfile'
+
+const EXEMPT_ROUTE_NAMES = new Set(['Onboarding', 'NotFound'])
+
+export async function onboardingGuard(
+  to: RouteLocationNormalized,
+): Promise<boolean | RouteLocationRaw> {
+  if (to.name != null && EXEMPT_ROUTE_NAMES.has(String(to.name))) {
+    return true
+  }
+
+  let store: ReturnType<typeof useUserProfileStore>
+  try {
+    store = useUserProfileStore()
+    await store.ensureLoaded()
+  } catch {
+    // Kein aktives Pinia, Netzwerkfehler o.ä. — Navigation nie blockieren.
+    return true
+  }
+
+  if (store.onboardingRequired) {
+    return { name: 'Onboarding' }
+  }
+  return true
+}

--- a/frontend/src/store/__tests__/userProfile.spec.ts
+++ b/frontend/src/store/__tests__/userProfile.spec.ts
@@ -1,0 +1,296 @@
+/**
+ * userProfile-Store — Vitest-Smokes (Onboarding Slice 2).
+ *
+ * Tests:
+ *  1. ensureLoaded() lädt Profil + Onboarding genau einmal (In-Flight-Dedupe).
+ *  2. ensureLoaded() ist idempotent nach erfolgreichem Laden (kein zweiter Call).
+ *  3. Fehlerpfad: kein Lockout — loaded=true, onboardingRequired=false.
+ *  4. refresh() erzwingt einen neuen Load.
+ *  5. updateProfile()/uploadAvatar()/deleteAvatar() aktualisieren `profile`.
+ *  6. completeStep()/complete()/dismiss()/reopen() aktualisieren `onboarding.state`.
+ *  8. Avatar-Blob-Preview: lädt nach Profil-Load + nach Upload neu und
+ *     revoked die alte Object-URL, bevor die neue erzeugt wird.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('../../api/profile', () => ({
+  getProfile: vi.fn(),
+  updateProfile: vi.fn(),
+  uploadAvatar: vi.fn(),
+  deleteAvatar: vi.fn(),
+  fetchAvatarBlob: vi.fn(),
+  getOnboardingStatus: vi.fn(),
+  completeOnboardingStep: vi.fn(),
+  completeOnboarding: vi.fn(),
+  dismissOnboarding: vi.fn(),
+  reopenOnboarding: vi.fn(),
+}))
+
+import {
+  completeOnboarding,
+  completeOnboardingStep,
+  deleteAvatar,
+  dismissOnboarding,
+  fetchAvatarBlob,
+  getOnboardingStatus,
+  getProfile,
+  reopenOnboarding,
+  updateProfile,
+  uploadAvatar,
+} from '../../api/profile'
+import { useUserProfileStore } from '../userProfile'
+import type {
+  OnboardingState,
+  OnboardingStatusResponse,
+  UserProfile,
+  UserProfileUpdateRequest,
+} from '../../contracts/userProfileContract'
+
+type MockFn = ReturnType<typeof vi.fn>
+const _getProfile = getProfile as unknown as MockFn
+const _updateProfile = updateProfile as unknown as MockFn
+const _uploadAvatar = uploadAvatar as unknown as MockFn
+const _deleteAvatar = deleteAvatar as unknown as MockFn
+const _fetchAvatarBlob = fetchAvatarBlob as unknown as MockFn
+const _getOnboardingStatus = getOnboardingStatus as unknown as MockFn
+const _completeOnboardingStep = completeOnboardingStep as unknown as MockFn
+const _completeOnboarding = completeOnboarding as unknown as MockFn
+const _dismissOnboarding = dismissOnboarding as unknown as MockFn
+const _reopenOnboarding = reopenOnboarding as unknown as MockFn
+
+function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    avatar_ref: null,
+    display_name: 'Alex Schneider',
+    username: null,
+    role: null,
+    organisation: null,
+    language: 'de',
+    timezone: 'Europe/Berlin',
+    report_language: 'de',
+    theme: 'system',
+    privacy_mode: 'standard',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeOnboardingState(overrides: Partial<OnboardingState> = {}): OnboardingState {
+  return {
+    status: 'in_progress',
+    operating_mode: null,
+    current_step: 'welcome',
+    completed_steps: [],
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeUpdateRequest(overrides: Partial<UserProfileUpdateRequest> = {}): UserProfileUpdateRequest {
+  return {
+    display_name: 'Neuer Name',
+    username: null,
+    role: null,
+    organisation: null,
+    language: null,
+    timezone: null,
+    report_language: null,
+    theme: null,
+    privacy_mode: null,
+    ...overrides,
+  }
+}
+
+function makeOnboardingStatus(
+  overrides: Partial<OnboardingStatusResponse> = {},
+): OnboardingStatusResponse {
+  return {
+    state: makeOnboardingState(),
+    requirements: {
+      profile_valid: false,
+      chat_model_configured: false,
+      embedding_configured: false,
+    },
+    onboarding_required: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('useUserProfileStore', () => {
+  it('Test 1: ensureLoaded() lädt Profil + Onboarding genau einmal (In-Flight-Dedupe)', async () => {
+    const profile = makeProfile()
+    const status = makeOnboardingStatus()
+    _getProfile.mockResolvedValue(profile)
+    _getOnboardingStatus.mockResolvedValue(status)
+
+    const store = useUserProfileStore()
+    // Zwei parallele Aufrufe dürfen nur EINEN API-Roundtrip auslösen.
+    await Promise.all([store.ensureLoaded(), store.ensureLoaded()])
+
+    expect(_getProfile).toHaveBeenCalledTimes(1)
+    expect(_getOnboardingStatus).toHaveBeenCalledTimes(1)
+    expect(store.profile).toEqual(profile)
+    expect(store.onboarding.state).toEqual(status.state)
+    expect(store.onboarding.requirements).toEqual(status.requirements)
+    expect(store.onboardingRequired).toBe(true)
+    expect(store.loaded).toBe(true)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('Test 2: ensureLoaded() ist nach erfolgreichem Laden idempotent', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+
+    const store = useUserProfileStore()
+    await store.ensureLoaded()
+    await store.ensureLoaded()
+
+    expect(_getProfile).toHaveBeenCalledTimes(1)
+    expect(_getOnboardingStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('Test 3: Fehlerpfad sperrt die App nicht (loaded=true, onboardingRequired=false)', async () => {
+    _getProfile.mockRejectedValue(new Error('Backend offline'))
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+
+    const store = useUserProfileStore()
+    await store.ensureLoaded()
+
+    expect(store.loaded).toBe(true)
+    expect(store.loading).toBe(false)
+    expect(store.onboardingRequired).toBe(false)
+    expect(store.error).toBe('Backend offline')
+  })
+
+  it('Test 4: refresh() erzwingt einen neuen Load-Zyklus', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+
+    const store = useUserProfileStore()
+    await store.ensureLoaded()
+    await store.refresh()
+
+    expect(_getProfile).toHaveBeenCalledTimes(2)
+    expect(_getOnboardingStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('Test 5: updateProfile()/uploadAvatar()/deleteAvatar() aktualisieren `profile`', async () => {
+    const store = useUserProfileStore()
+
+    const updated = makeProfile({ display_name: 'Neuer Name' })
+    _updateProfile.mockResolvedValue(updated)
+    await store.updateProfile(makeUpdateRequest())
+    expect(store.profile).toEqual(updated)
+
+    const withAvatar = makeProfile({
+      display_name: 'Neuer Name',
+      avatar_ref: 'avatar-0123456789abcdef0123456789abcdef.png',
+    })
+    _uploadAvatar.mockResolvedValue(withAvatar)
+    await store.uploadAvatar(new File(['x'], 'a.png', { type: 'image/png' }))
+    expect(store.profile?.avatar_ref).toBe('avatar-0123456789abcdef0123456789abcdef.png')
+
+    const withoutAvatar = makeProfile({ display_name: 'Neuer Name', avatar_ref: null })
+    _deleteAvatar.mockResolvedValue(withoutAvatar)
+    await store.deleteAvatar()
+    expect(store.profile?.avatar_ref).toBeNull()
+  })
+
+  it('Test 6: completeStep()/complete()/dismiss()/reopen() aktualisieren `onboarding.state`', async () => {
+    const store = useUserProfileStore()
+    store.onboarding.onboardingRequired = true
+
+    const afterWelcome = makeOnboardingState({ current_step: 'profile', completed_steps: ['welcome'] })
+    _completeOnboardingStep.mockResolvedValue(afterWelcome)
+    await store.completeStep('welcome', 'local')
+    expect(store.onboarding.state).toEqual(afterWelcome)
+
+    const completed = makeOnboardingState({ status: 'completed', current_step: 'summary' })
+    _completeOnboarding.mockResolvedValue(completed)
+    await store.complete()
+    expect(store.onboarding.state).toEqual(completed)
+    expect(store.onboardingRequired).toBe(false)
+
+    const dismissed = makeOnboardingState({ status: 'dismissed' })
+    _dismissOnboarding.mockResolvedValue(dismissed)
+    await store.dismiss()
+    expect(store.onboarding.state).toEqual(dismissed)
+    expect(store.onboardingRequired).toBe(false)
+
+    const reopened = makeOnboardingState({ status: 'in_progress' })
+    _reopenOnboarding.mockResolvedValue(reopened)
+    await store.reopen()
+    expect(store.onboarding.state).toEqual(reopened)
+    expect(store.onboardingRequired).toBe(true)
+  })
+
+  it('Test 7: Fehlgeschlagene Mutation wirft und setzt `error`', async () => {
+    const store = useUserProfileStore()
+    _updateProfile.mockRejectedValue(new Error('Validierungsfehler'))
+
+    await expect(
+      store.updateProfile(makeUpdateRequest({ display_name: '' })),
+    ).rejects.toThrow('Validierungsfehler')
+    expect(store.error).toBe('Validierungsfehler')
+  })
+
+  it('Test 8: Avatar-Blob-Preview lädt nach Profil-Load und nach Upload neu, revoked alte Object-URL', async () => {
+    let objectUrlCounter = 0
+    const createObjectUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(() => `blob:mock-${++objectUrlCounter}`)
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    const avatarBlobA = new Blob(['a'], { type: 'image/png' })
+    const avatarBlobB = new Blob(['b'], { type: 'image/png' })
+
+    const profileWithAvatar = makeProfile({
+      avatar_ref: 'avatar-0123456789abcdef0123456789abcdef.png',
+    })
+    _getProfile.mockResolvedValue(profileWithAvatar)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+    _fetchAvatarBlob.mockResolvedValueOnce(avatarBlobA)
+
+    const store = useUserProfileStore()
+    await store.ensureLoaded()
+
+    // Nach Profil-Load: Blob wurde geladen, Object-URL gesetzt.
+    expect(_fetchAvatarBlob).toHaveBeenCalledTimes(1)
+    expect(store.avatarObjectUrl).toBe('blob:mock-1')
+    expect(revokeObjectUrlSpy).not.toHaveBeenCalled()
+
+    // Upload: neue avatar_ref → Blob wird neu geladen, alte Object-URL revoked.
+    const profileWithNewAvatar = makeProfile({
+      avatar_ref: 'avatar-fedcba9876543210fedcba9876543210.webp',
+    })
+    _uploadAvatar.mockResolvedValue(profileWithNewAvatar)
+    _fetchAvatarBlob.mockResolvedValueOnce(avatarBlobB)
+
+    await store.uploadAvatar(new File(['b'], 'b.webp', { type: 'image/webp' }))
+
+    expect(_fetchAvatarBlob).toHaveBeenCalledTimes(2)
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:mock-1')
+    expect(store.avatarObjectUrl).toBe('blob:mock-2')
+
+    // Delete: avatar_ref wird null → Preview wird revoked und geleert.
+    _deleteAvatar.mockResolvedValue(makeProfile({ avatar_ref: null }))
+    await store.deleteAvatar()
+
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:mock-2')
+    expect(store.avatarObjectUrl).toBeNull()
+    // Kein Avatar mehr gesetzt → kein dritter fetchAvatarBlob-Call nötig.
+    expect(_fetchAvatarBlob).toHaveBeenCalledTimes(2)
+
+    createObjectUrlSpy.mockRestore()
+    revokeObjectUrlSpy.mockRestore()
+  })
+})

--- a/frontend/src/store/userProfile.ts
+++ b/frontend/src/store/userProfile.ts
@@ -1,0 +1,233 @@
+/**
+ * userProfile — Pinia-Store für Benutzerprofil + resumierbares Onboarding
+ * (Onboarding Slice 2).
+ *
+ * `ensureLoaded()` lädt Onboarding-Status + Profil genau einmal (In-Flight-
+ * Dedupe über `loadPromise`). Ein API-Ausfall darf die App NIE sperren:
+ * Fehlerpfad setzt `loaded = true` und `onboarding.onboardingRequired =
+ * false`, damit der Router-Guard durchlässt statt zu blockieren.
+ */
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  completeOnboarding as apiCompleteOnboarding,
+  completeOnboardingStep,
+  deleteAvatar as apiDeleteAvatar,
+  dismissOnboarding as apiDismissOnboarding,
+  fetchAvatarBlob,
+  getOnboardingStatus,
+  getProfile,
+  reopenOnboarding as apiReopenOnboarding,
+  updateProfile as apiUpdateProfile,
+  uploadAvatar as apiUploadAvatar,
+} from '../api/profile'
+import type {
+  OnboardingRequirements,
+  OnboardingState,
+  OnboardingStepId,
+  OperatingMode,
+  UserProfile,
+  UserProfileUpdateRequest,
+} from '../contracts/userProfileContract'
+
+interface OnboardingSlice {
+  state: OnboardingState | null
+  requirements: OnboardingRequirements | null
+  onboardingRequired: boolean
+}
+
+function _errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback
+}
+
+export const useUserProfileStore = defineStore('userProfile', () => {
+  const profile = ref<UserProfile | null>(null)
+  const onboarding = ref<OnboardingSlice>({
+    state: null,
+    requirements: null,
+    onboardingRequired: false,
+  })
+  const loaded = ref(false)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  /** Object-URL des per Blob geladenen Avatars — primärer Anzeigepfad (s. api/profile.ts::fetchAvatarBlob). */
+  const avatarObjectUrl = ref<string | null>(null)
+
+  /** Bequemer Top-Level-Zugriff, u.a. für den Router-Guard. */
+  const onboardingRequired = computed(() => onboarding.value.onboardingRequired)
+
+  let loadPromise: Promise<void> | null = null
+
+  /** Revoked die aktuelle Object-URL (falls vorhanden) — immer vor Ersatz/Wegfall aufrufen. */
+  function _releaseAvatarObjectUrl(): void {
+    if (avatarObjectUrl.value) {
+      URL.revokeObjectURL(avatarObjectUrl.value)
+      avatarObjectUrl.value = null
+    }
+  }
+
+  /**
+   * Lädt den Avatar als Blob neu und ersetzt die Object-URL; ohne avatar_ref
+   * bleibt sie leer. Schlägt der Blob-Load fehl, bleibt die App beim
+   * Initialen-Fallback — ein Avatar-Ladefehler darf nie den Profil-/
+   * Onboarding-Load selbst zum Scheitern bringen.
+   */
+  async function _refreshAvatarPreview(): Promise<void> {
+    _releaseAvatarObjectUrl()
+    if (!profile.value?.avatar_ref) return
+    try {
+      const blob = await fetchAvatarBlob()
+      if (blob) {
+        avatarObjectUrl.value = URL.createObjectURL(blob)
+      }
+    } catch {
+      // Initialen-Fallback bleibt — kein sichtbarer Fehler nötig.
+    }
+  }
+
+  async function _load(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const [profileResult, onboardingResult] = await Promise.all([
+        getProfile(),
+        getOnboardingStatus(),
+      ])
+      profile.value = profileResult
+      onboarding.value = {
+        state: onboardingResult.state,
+        requirements: onboardingResult.requirements,
+        onboardingRequired: onboardingResult.onboarding_required,
+      }
+      await _refreshAvatarPreview()
+    } catch (err) {
+      // Fail-open: niemals die App sperren, nur sichtbaren Fehler setzen.
+      error.value = _errorMessage(err, 'Profil/Onboarding konnten nicht geladen werden.')
+      onboarding.value = { ...onboarding.value, onboardingRequired: false }
+    } finally {
+      loading.value = false
+      loaded.value = true
+    }
+  }
+
+  /** Lädt Profil + Onboarding-Status genau einmal; wiederholte Aufrufe sind No-Ops. */
+  function ensureLoaded(): Promise<void> {
+    if (loaded.value) return Promise.resolve()
+    if (!loadPromise) {
+      loadPromise = _load().finally(() => {
+        loadPromise = null
+      })
+    }
+    return loadPromise
+  }
+
+  /** Erzwingt einen frischen Reload (z.B. nach externem State-Change). */
+  async function refresh(): Promise<void> {
+    loaded.value = false
+    await ensureLoaded()
+  }
+
+  async function updateProfile(req: UserProfileUpdateRequest): Promise<void> {
+    error.value = null
+    try {
+      profile.value = await apiUpdateProfile(req)
+    } catch (err) {
+      error.value = _errorMessage(err, 'Profil konnte nicht gespeichert werden.')
+      throw err
+    }
+  }
+
+  async function uploadAvatar(file: File): Promise<void> {
+    error.value = null
+    try {
+      profile.value = await apiUploadAvatar(file)
+      await _refreshAvatarPreview()
+    } catch (err) {
+      error.value = _errorMessage(err, 'Avatar-Upload fehlgeschlagen.')
+      throw err
+    }
+  }
+
+  async function deleteAvatar(): Promise<void> {
+    error.value = null
+    try {
+      profile.value = await apiDeleteAvatar()
+      await _refreshAvatarPreview()
+    } catch (err) {
+      error.value = _errorMessage(err, 'Avatar konnte nicht gelöscht werden.')
+      throw err
+    }
+  }
+
+  async function completeStep(
+    step: OnboardingStepId,
+    operatingMode?: OperatingMode | null,
+  ): Promise<void> {
+    error.value = null
+    try {
+      const nextState = await completeOnboardingStep(step, operatingMode)
+      onboarding.value = { ...onboarding.value, state: nextState }
+    } catch (err) {
+      error.value = _errorMessage(err, 'Schritt konnte nicht gespeichert werden.')
+      throw err
+    }
+  }
+
+  async function complete(): Promise<void> {
+    error.value = null
+    try {
+      const nextState = await apiCompleteOnboarding()
+      onboarding.value = { ...onboarding.value, state: nextState, onboardingRequired: false }
+    } catch (err) {
+      error.value = _errorMessage(err, 'Einrichtung konnte nicht abgeschlossen werden.')
+      throw err
+    }
+  }
+
+  async function dismiss(): Promise<void> {
+    error.value = null
+    try {
+      const nextState = await apiDismissOnboarding()
+      onboarding.value = { ...onboarding.value, state: nextState, onboardingRequired: false }
+    } catch (err) {
+      error.value = _errorMessage(err, 'Onboarding konnte nicht übersprungen werden.')
+      throw err
+    }
+  }
+
+  async function reopen(): Promise<void> {
+    error.value = null
+    try {
+      const nextState = await apiReopenOnboarding()
+      onboarding.value = { ...onboarding.value, state: nextState, onboardingRequired: true }
+    } catch (err) {
+      error.value = _errorMessage(err, 'Onboarding konnte nicht erneut geöffnet werden.')
+      throw err
+    }
+  }
+
+  /** Explizites Aufräumen der aktuellen Avatar-Object-URL (z.B. bei App-Teardown). */
+  function disposeAvatarPreview(): void {
+    _releaseAvatarObjectUrl()
+  }
+
+  return {
+    profile,
+    onboarding,
+    onboardingRequired,
+    avatarObjectUrl,
+    loaded,
+    loading,
+    error,
+    ensureLoaded,
+    refresh,
+    updateProfile,
+    uploadAvatar,
+    deleteAvatar,
+    completeStep,
+    complete,
+    dismiss,
+    reopen,
+    disposeAvatarPreview,
+  }
+})

--- a/frontend/src/views/Settings/SettingsProfileView.vue
+++ b/frontend/src/views/Settings/SettingsProfileView.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+/**
+ * SettingsProfileView — Profil-Einstellungen (Onboarding Slice 2).
+ *
+ * Bettet `ProfileForm` ein, persistiert über `useUserProfileStore` und
+ * bietet einen Wiedereinstieg in den Onboarding-Wizard ("Onboarding erneut
+ * öffnen"). Ersetzt den "Users & Teams"-Sidebar-Eintrag (IA-Fix).
+ */
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import AppShell from '@/components/v4/shell/AppShell.vue'
+import PageHeader from '@/components/v4/shell/PageHeader.vue'
+import Card from '@/components/v4/forms/Card.vue'
+import Button from '@/components/v4/forms/Button.vue'
+import ProfileForm from '@/components/v4/forms/ProfileForm.vue'
+import { useUserProfileStore } from '@/store/userProfile'
+import type { UserProfileUpdateRequest } from '@/contracts/userProfileContract'
+
+const { t } = useI18n()
+const router = useRouter()
+const store = useUserProfileStore()
+
+const saving = ref(false)
+const saveError = ref<string | null>(null)
+const saveSuccess = ref(false)
+
+const breadcrumbs = computed(() => [
+  { label: t('nav.SettingsGeneral'), to: { name: 'SettingsGeneral' } },
+  { label: t('profileSettings.title') },
+])
+
+// Primärer Anzeigepfad: Blob-basierte Object-URL aus dem Store (funktioniert
+// auch im token-geschützten Modus, da der Fetch über den authentifizierten
+// service-Client läuft). Fällt bei Fehlern auf den Initialen-Fallback in
+// ProfileForm zurück.
+const avatarImageUrl = computed(() => store.avatarObjectUrl)
+
+async function handleSave(payload: UserProfileUpdateRequest): Promise<void> {
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+  try {
+    await store.updateProfile(payload)
+    saveSuccess.value = true
+  } catch {
+    saveError.value = store.error ?? t('profileSettings.saveError')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleUploadAvatar(file: File): Promise<void> {
+  saveError.value = null
+  try {
+    await store.uploadAvatar(file)
+  } catch {
+    saveError.value = store.error ?? t('profileSettings.form.avatarUploadError')
+  }
+}
+
+async function handleDeleteAvatar(): Promise<void> {
+  saveError.value = null
+  try {
+    await store.deleteAvatar()
+  } catch {
+    saveError.value = store.error ?? t('profileSettings.form.avatarDeleteError')
+  }
+}
+
+async function handleReopenOnboarding(): Promise<void> {
+  try {
+    await store.reopen()
+  } finally {
+    void router.push({ name: 'Onboarding' })
+  }
+}
+
+onMounted(() => {
+  void store.ensureLoaded()
+})
+</script>
+
+<template>
+  <AppShell :breadcrumbs="breadcrumbs">
+    <PageHeader :title="t('profileSettings.title')" :subtitle="t('profileSettings.subtitle')">
+      <template #right>
+        <Button variant="secondary" size="sm" type="button" @click="handleReopenOnboarding">
+          {{ t('profileSettings.reopenOnboardingBtn') }}
+        </Button>
+      </template>
+    </PageHeader>
+
+    <Card>
+      <p
+        v-if="saveError"
+        class="settings-profile__banner settings-profile__banner--error"
+        role="alert"
+      >
+        {{ saveError }}
+      </p>
+      <p v-if="saveSuccess" class="settings-profile__banner settings-profile__banner--success">
+        {{ t('profileSettings.saveSuccess') }}
+      </p>
+
+      <ProfileForm
+        :profile="store.profile"
+        :avatar-url="avatarImageUrl"
+        :saving="saving"
+        @save="handleSave"
+        @upload-avatar="handleUploadAvatar"
+        @delete-avatar="handleDeleteAvatar"
+      />
+    </Card>
+  </AppShell>
+</template>
+
+<style scoped>
+.settings-profile__banner {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: var(--r-4, 8px);
+  margin-bottom: 16px;
+}
+
+.settings-profile__banner--error {
+  color: var(--status-red, #c0392b);
+  border: 1px solid var(--status-red, #c0392b);
+}
+
+.settings-profile__banner--success {
+  color: var(--status-green, #2e7d32);
+  border: 1px solid var(--status-green, #2e7d32);
+}
+</style>

--- a/frontend/src/views/onboarding/OnboardingView.vue
+++ b/frontend/src/views/onboarding/OnboardingView.vue
@@ -1,0 +1,621 @@
+<script setup lang="ts">
+/**
+ * OnboardingView — resumierbarer Erst-Einrichtungs-Wizard (Onboarding Slice 2).
+ *
+ * `providers`/`chat_model`/`embeddings` sind bewusst ehrliche Statusschritte:
+ * sie zeigen den realen `requirements`-Status und verlinken auf die
+ * bestehenden Settings-Routen. Die geführte Einrichtung folgt in einem
+ * späteren Update — hier gibt es keine Attrappen.
+ */
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import AppShell from '@/components/v4/shell/AppShell.vue'
+import PageHeader from '@/components/v4/shell/PageHeader.vue'
+import Card from '@/components/v4/forms/Card.vue'
+import Button from '@/components/v4/forms/Button.vue'
+import ProfileForm from '@/components/v4/forms/ProfileForm.vue'
+import { isApiError } from '@/api/envelope'
+import { useUserProfileStore } from '@/store/userProfile'
+import { ONBOARDING_STEP_ORDER } from '@/contracts/userProfileContract'
+import type {
+  OnboardingStepId,
+  OperatingMode,
+  UserProfileUpdateRequest,
+} from '@/contracts/userProfileContract'
+
+const { t } = useI18n()
+const router = useRouter()
+const store = useUserProfileStore()
+
+const OPERATING_MODES: readonly OperatingMode[] = ['local', 'hybrid', 'server']
+
+interface StatusStepConfig {
+  step: OnboardingStepId
+  titleKey: string
+  descriptionKey: string
+  futureNoticeKey: string
+  settingsLinkKey: string
+  settingsRouteName: string
+  configured: () => boolean
+}
+
+const viewStep = ref<OnboardingStepId>('welcome')
+const selectedOperatingMode = ref<OperatingMode | null>(null)
+const busy = ref(false)
+const profileSaving = ref(false)
+const stepError = ref<string | null>(null)
+const completeMissing = ref<string[]>([])
+
+const stepIndex = computed(() => ONBOARDING_STEP_ORDER.indexOf(viewStep.value))
+const completedSteps = computed(() => store.onboarding.state?.completed_steps ?? [])
+// Primärer Anzeigepfad: Blob-basierte Object-URL aus dem Store (siehe
+// store/userProfile.ts::_refreshAvatarPreview) — funktioniert auch im
+// token-geschützten Modus.
+const avatarImageUrl = computed(() => store.avatarObjectUrl)
+
+const statusSteps = computed<StatusStepConfig[]>(() => [
+  {
+    step: 'providers',
+    titleKey: 'onboarding.providers.title',
+    descriptionKey: 'onboarding.providers.description',
+    futureNoticeKey: 'onboarding.providers.futureNotice',
+    settingsLinkKey: 'onboarding.providers.settingsLink',
+    settingsRouteName: 'SettingsLlmProviders',
+    configured: () => store.onboarding.requirements?.chat_model_configured ?? false,
+  },
+  {
+    step: 'chat_model',
+    titleKey: 'onboarding.chatModel.title',
+    descriptionKey: 'onboarding.chatModel.description',
+    futureNoticeKey: 'onboarding.chatModel.futureNotice',
+    settingsLinkKey: 'onboarding.chatModel.settingsLink',
+    settingsRouteName: 'SettingsLlmProviders',
+    configured: () => store.onboarding.requirements?.chat_model_configured ?? false,
+  },
+  {
+    step: 'embeddings',
+    titleKey: 'onboarding.embeddings.title',
+    descriptionKey: 'onboarding.embeddings.description',
+    futureNoticeKey: 'onboarding.embeddings.futureNotice',
+    settingsLinkKey: 'onboarding.embeddings.settingsLink',
+    settingsRouteName: 'SettingsLlmProviders',
+    configured: () => store.onboarding.requirements?.embedding_configured ?? false,
+  },
+])
+
+const activeStatusStep = computed(
+  () => statusSteps.value.find((entry) => entry.step === viewStep.value) ?? null,
+)
+
+// Backend-Codes für `OnboardingRequirements`-Felder → i18n-Label, damit die
+// 409-`missing`-Liste ("profile_valid", "chat_model_configured", …) lesbar
+// statt als Rohcode dargestellt wird.
+const MISSING_CODE_LABEL_KEYS: Record<string, string> = {
+  profile_valid: 'onboarding.requirements.profileValid',
+  chat_model_configured: 'onboarding.requirements.chatModelConfigured',
+  embedding_configured: 'onboarding.requirements.embeddingConfigured',
+}
+
+function labelForMissingCode(code: string): string {
+  const key = MISSING_CODE_LABEL_KEYS[code]
+  return key ? t(key) : code
+}
+
+const requirementsMissing = computed<string[]>(() => {
+  const req = store.onboarding.requirements
+  if (!req) return []
+  const missing: string[] = []
+  if (!req.profile_valid) missing.push(t('onboarding.requirements.profileValid'))
+  if (!req.chat_model_configured) missing.push(t('onboarding.requirements.chatModelConfigured'))
+  if (!req.embedding_configured) missing.push(t('onboarding.requirements.embeddingConfigured'))
+  return missing
+})
+
+function stepStatus(step: OnboardingStepId): 'done' | 'current' | 'open' {
+  if (completedSteps.value.includes(step)) return 'done'
+  if (step === viewStep.value) return 'current'
+  return 'open'
+}
+
+function goBack(): void {
+  if (stepIndex.value <= 0) return
+  stepError.value = null
+  viewStep.value = ONBOARDING_STEP_ORDER[stepIndex.value - 1]
+}
+
+function advanceAfterCompletion(): void {
+  const next = store.onboarding.state?.current_step
+  const fallbackIndex = Math.min(stepIndex.value + 1, ONBOARDING_STEP_ORDER.length - 1)
+  viewStep.value = next ?? ONBOARDING_STEP_ORDER[fallbackIndex]
+}
+
+async function confirmWelcome(): Promise<void> {
+  if (!selectedOperatingMode.value) return
+  busy.value = true
+  stepError.value = null
+  try {
+    await store.completeStep('welcome', selectedOperatingMode.value)
+    advanceAfterCompletion()
+  } catch {
+    stepError.value = store.error ?? t('onboarding.errors.saveFailed')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function handleProfileSave(payload: UserProfileUpdateRequest): Promise<void> {
+  profileSaving.value = true
+  stepError.value = null
+  try {
+    await store.updateProfile(payload)
+    await store.completeStep('profile')
+    advanceAfterCompletion()
+  } catch {
+    stepError.value = store.error ?? t('onboarding.errors.saveFailed')
+  } finally {
+    profileSaving.value = false
+  }
+}
+
+async function handleUploadAvatar(file: File): Promise<void> {
+  stepError.value = null
+  try {
+    await store.uploadAvatar(file)
+  } catch {
+    stepError.value = store.error ?? t('profileSettings.form.avatarUploadError')
+  }
+}
+
+async function handleDeleteAvatar(): Promise<void> {
+  stepError.value = null
+  try {
+    await store.deleteAvatar()
+  } catch {
+    stepError.value = store.error ?? t('profileSettings.form.avatarDeleteError')
+  }
+}
+
+async function confirmCurrentStatusStep(): Promise<void> {
+  const step = viewStep.value
+  busy.value = true
+  stepError.value = null
+  try {
+    await store.completeStep(step)
+    advanceAfterCompletion()
+  } catch {
+    stepError.value = store.error ?? t('onboarding.errors.saveFailed')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function handleComplete(): Promise<void> {
+  busy.value = true
+  stepError.value = null
+  completeMissing.value = []
+  try {
+    await store.complete()
+    void router.push({ name: 'Dashboard' })
+  } catch (err) {
+    if (isApiError(err) && err.code === 'onboarding_incomplete') {
+      const rawMissing = err.details?.['missing']
+      completeMissing.value = Array.isArray(rawMissing)
+        ? rawMissing.map((code) => labelForMissingCode(String(code)))
+        : requirementsMissing.value
+      stepError.value = t('onboarding.errors.incomplete')
+    } else {
+      stepError.value = store.error ?? t('onboarding.errors.saveFailed')
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+async function handleDismiss(): Promise<void> {
+  busy.value = true
+  stepError.value = null
+  try {
+    await store.dismiss()
+    void router.push({ name: 'Dashboard' })
+  } catch {
+    stepError.value = store.error ?? t('onboarding.errors.saveFailed')
+  } finally {
+    busy.value = false
+  }
+}
+
+onMounted(async () => {
+  await store.ensureLoaded()
+  viewStep.value = store.onboarding.state?.current_step ?? 'welcome'
+  selectedOperatingMode.value = store.onboarding.state?.operating_mode ?? null
+})
+</script>
+
+<template>
+  <AppShell :breadcrumbs="[{ label: t('onboarding.wizard.title') }]">
+    <PageHeader :title="t('onboarding.wizard.title')" />
+
+    <ol class="onboarding-steps" aria-label="onboarding-steps">
+      <li
+        v-for="step in ONBOARDING_STEP_ORDER"
+        :key="step"
+        class="onboarding-steps__item"
+        :class="`onboarding-steps__item--${stepStatus(step)}`"
+      >
+        <span class="onboarding-steps__dot" aria-hidden="true" />
+        <span class="onboarding-steps__label">{{ t(`onboarding.steps.${step}`) }}</span>
+        <span class="onboarding-steps__status">
+          {{ t(`onboarding.wizard.stepStatus.${stepStatus(step)}`) }}
+        </span>
+      </li>
+    </ol>
+
+    <Card>
+      <p v-if="stepError" class="onboarding-error" role="alert">{{ stepError }}</p>
+
+      <!-- welcome -->
+      <div v-if="viewStep === 'welcome'" class="onboarding-step">
+        <h2 class="onboarding-step__title">{{ t('onboarding.welcome.title') }}</h2>
+        <p class="onboarding-step__description">{{ t('onboarding.welcome.description') }}</p>
+
+        <p class="onboarding-step__field-label">{{ t('onboarding.welcome.operatingModeLabel') }}</p>
+        <div class="onboarding-mode-grid">
+          <button
+            v-for="mode in OPERATING_MODES"
+            :key="mode"
+            type="button"
+            class="onboarding-mode-card v4-state-interactive"
+            :class="{ 'onboarding-mode-card--active': selectedOperatingMode === mode }"
+            @click="selectedOperatingMode = mode"
+          >
+            <span class="onboarding-mode-card__label">
+              {{ t(`onboarding.welcome.operatingMode.${mode}.label`) }}
+            </span>
+            <span class="onboarding-mode-card__description">
+              {{ t(`onboarding.welcome.operatingMode.${mode}.description`) }}
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <!-- profile -->
+      <div v-else-if="viewStep === 'profile'" class="onboarding-step">
+        <h2 class="onboarding-step__title">{{ t('onboarding.profile.title') }}</h2>
+        <p class="onboarding-step__description">{{ t('onboarding.profile.description') }}</p>
+        <ProfileForm
+          :profile="store.profile"
+          :avatar-url="avatarImageUrl"
+          :saving="profileSaving"
+          @save="handleProfileSave"
+          @upload-avatar="handleUploadAvatar"
+          @delete-avatar="handleDeleteAvatar"
+        />
+      </div>
+
+      <!-- providers / chat_model / embeddings — ehrliche Statusschritte -->
+      <div v-else-if="activeStatusStep" class="onboarding-step">
+        <h2 class="onboarding-step__title">{{ t(activeStatusStep.titleKey) }}</h2>
+        <p class="onboarding-step__description">{{ t(activeStatusStep.descriptionKey) }}</p>
+        <p
+          class="onboarding-status"
+          :class="activeStatusStep.configured() ? 'onboarding-status--ok' : 'onboarding-status--pending'"
+        >
+          {{
+            activeStatusStep.configured()
+              ? t('onboarding.providers.configured')
+              : t('onboarding.providers.notConfigured')
+          }}
+        </p>
+        <p class="onboarding-step__notice">{{ t(activeStatusStep.futureNoticeKey) }}</p>
+        <RouterLink :to="{ name: activeStatusStep.settingsRouteName }" class="onboarding-step__link">
+          {{ t(activeStatusStep.settingsLinkKey) }}
+        </RouterLink>
+      </div>
+
+      <!-- privacy -->
+      <div v-else-if="viewStep === 'privacy'" class="onboarding-step">
+        <h2 class="onboarding-step__title">{{ t('onboarding.privacy.title') }}</h2>
+        <p class="onboarding-step__description">{{ t('onboarding.privacy.text') }}</p>
+      </div>
+
+      <!-- summary -->
+      <div v-else-if="viewStep === 'summary'" class="onboarding-step">
+        <h2 class="onboarding-step__title">{{ t('onboarding.summary.title') }}</h2>
+
+        <div class="onboarding-summary-block">
+          <h3>{{ t('onboarding.summary.profileHeading') }}</h3>
+          <p>{{ store.profile?.display_name ?? '—' }}</p>
+        </div>
+
+        <div class="onboarding-summary-block">
+          <h3>{{ t('onboarding.summary.modeHeading') }}</h3>
+          <p>
+            {{
+              selectedOperatingMode
+                ? t(`onboarding.welcome.operatingMode.${selectedOperatingMode}.label`)
+                : '—'
+            }}
+          </p>
+        </div>
+
+        <div class="onboarding-summary-block">
+          <h3>{{ t('onboarding.summary.requirementsHeading') }}</h3>
+          <ul class="onboarding-requirements-list">
+            <li>
+              {{ t('onboarding.requirements.profileValid') }}:
+              {{ store.onboarding.requirements?.profile_valid ? '✓' : '—' }}
+            </li>
+            <li>
+              {{ t('onboarding.requirements.chatModelConfigured') }}:
+              {{ store.onboarding.requirements?.chat_model_configured ? '✓' : '—' }}
+            </li>
+            <li>
+              {{ t('onboarding.requirements.embeddingConfigured') }}:
+              {{ store.onboarding.requirements?.embedding_configured ? '✓' : '—' }}
+            </li>
+          </ul>
+        </div>
+
+        <p v-if="completeMissing.length" class="onboarding-error" role="alert">
+          {{ t('onboarding.summary.incompleteNotice') }} {{ completeMissing.join(', ') }}
+        </p>
+      </div>
+
+      <div class="onboarding-footer">
+        <Button variant="ghost" type="button" :disabled="busy" @click="handleDismiss">
+          {{ t('onboarding.wizard.laterBtn') }}
+        </Button>
+
+        <div class="onboarding-footer__nav">
+          <Button
+            v-if="stepIndex > 0"
+            variant="secondary"
+            type="button"
+            :disabled="busy"
+            @click="goBack"
+          >
+            {{ t('onboarding.wizard.backBtn') }}
+          </Button>
+
+          <Button
+            v-if="viewStep === 'welcome'"
+            variant="primary"
+            type="button"
+            :disabled="busy || !selectedOperatingMode"
+            :loading="busy"
+            @click="confirmWelcome"
+          >
+            {{ t('onboarding.wizard.nextBtn') }}
+          </Button>
+
+          <Button
+            v-else-if="activeStatusStep"
+            variant="primary"
+            type="button"
+            :disabled="busy"
+            :loading="busy"
+            @click="confirmCurrentStatusStep"
+          >
+            {{ t('onboarding.wizard.nextBtn') }}
+          </Button>
+
+          <Button
+            v-else-if="viewStep === 'privacy'"
+            variant="primary"
+            type="button"
+            :disabled="busy"
+            :loading="busy"
+            @click="confirmCurrentStatusStep"
+          >
+            {{ t('onboarding.privacy.confirmBtn') }}
+          </Button>
+
+          <Button
+            v-else-if="viewStep === 'summary'"
+            variant="primary"
+            type="button"
+            :disabled="busy"
+            :loading="busy"
+            @click="handleComplete"
+          >
+            {{ t('onboarding.wizard.finishBtn') }}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  </AppShell>
+</template>
+
+<style scoped>
+.onboarding-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+}
+
+.onboarding-steps__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--r-pill, 999px);
+  border: 1px solid var(--hairline);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.onboarding-steps__item--current {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.onboarding-steps__item--done {
+  color: var(--status-green, #2e7d32);
+}
+
+.onboarding-steps__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.onboarding-steps__status {
+  color: var(--text-tertiary);
+}
+
+.onboarding-step__title {
+  margin: 0 0 6px;
+  font-family: var(--font-sans);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.onboarding-step__description {
+  margin: 0 0 16px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.onboarding-step__field-label {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+}
+
+.onboarding-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .onboarding-mode-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.onboarding-mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 12px 14px;
+  border-radius: var(--r-4, 8px);
+  --v4-state-rest-bg: var(--surface-elevated, #fff);
+  --v4-state-hover-bg: var(--surface-elevated, #fff);
+}
+
+.onboarding-mode-card--active {
+  border-color: var(--accent);
+  background: var(--accent-subtle, #f0f5ff);
+}
+
+.onboarding-mode-card__label {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.onboarding-mode-card__description {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+
+.onboarding-status {
+  display: inline-flex;
+  width: fit-content;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: var(--r-pill, 999px);
+  margin: 0 0 10px;
+}
+
+.onboarding-status--ok {
+  background: var(--status-green-bg);
+  color: var(--status-green);
+}
+
+.onboarding-status--pending {
+  background: var(--status-orange-bg);
+  color: var(--status-orange);
+}
+
+.onboarding-step__notice {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+}
+
+.onboarding-step__link {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--accent);
+}
+
+.onboarding-summary-block {
+  margin-bottom: 14px;
+}
+
+.onboarding-summary-block h3 {
+  margin: 0 0 4px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.onboarding-summary-block p {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.onboarding-requirements-list {
+  margin: 0;
+  padding-left: 18px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.onboarding-error {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--status-red, #c0392b);
+  padding: 8px 12px;
+  border: 1px solid var(--status-red, #c0392b);
+  border-radius: var(--r-4, 8px);
+  margin: 0 0 14px;
+}
+
+.onboarding-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--separator, var(--hairline));
+}
+
+.onboarding-footer__nav {
+  display: flex;
+  gap: 10px;
+}
+</style>

--- a/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
+++ b/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
@@ -1,0 +1,247 @@
+/**
+ * OnboardingView — Vitest-Smokes (Onboarding Slice 2).
+ *
+ * Tests:
+ *  1. Mountet ohne Crash.
+ *  2. Resume: startet bei `state.current_step` statt immer bei 'welcome'.
+ *  3. i18n-Keys lösen auf (kein "onboarding.*"-Rohdot im DOM).
+ *  4. welcome-Schritt: Betriebsmodus wählen + Weiter → completeOnboardingStep('welcome', mode).
+ *  5. "Später einrichten" ruft dismissOnboarding() und navigiert zum Dashboard.
+ *  6. summary-Schritt: 409 "onboarding_incomplete" (top-level `missing` im
+ *     Envelope, normalisiert nach `details.missing` in api/profile.ts) zeigt
+ *     die tatsächlichen missing-Punkte an — nicht den Client-Fallback.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
+import { ApiError } from '@/api/envelope'
+import de from '@/i18n/locales/de.json'
+import en from '@/i18n/locales/en.json'
+import type { OnboardingState, OnboardingStatusResponse, UserProfile } from '@/contracts/userProfileContract'
+
+vi.mock('@/api/profile', () => ({
+  getProfile: vi.fn(),
+  updateProfile: vi.fn(),
+  uploadAvatar: vi.fn(),
+  deleteAvatar: vi.fn(),
+  fetchAvatarBlob: vi.fn().mockResolvedValue(null),
+  getOnboardingStatus: vi.fn(),
+  completeOnboardingStep: vi.fn(),
+  completeOnboarding: vi.fn(),
+  dismissOnboarding: vi.fn(),
+  reopenOnboarding: vi.fn(),
+  avatarUrl: vi.fn(() => null),
+}))
+
+vi.mock('@/components/v4/shell/AppShell.vue', () => ({
+  default: {
+    name: 'AppShell',
+    props: ['breadcrumbs'],
+    template: '<div class="app-shell-stub"><slot /></div>',
+  },
+}))
+vi.mock('@/components/v4/shell/PageHeader.vue', () => ({
+  default: {
+    name: 'PageHeader',
+    props: ['title', 'subtitle'],
+    template: '<div class="page-header-stub"><h1>{{ title }}</h1></div>',
+  },
+}))
+
+import {
+  completeOnboarding,
+  completeOnboardingStep,
+  dismissOnboarding,
+  getOnboardingStatus,
+  getProfile,
+} from '@/api/profile'
+import OnboardingView from '../OnboardingView.vue'
+
+type MockFn = ReturnType<typeof vi.fn>
+const _getProfile = getProfile as unknown as MockFn
+const _getOnboardingStatus = getOnboardingStatus as unknown as MockFn
+const _completeOnboardingStep = completeOnboardingStep as unknown as MockFn
+const _completeOnboarding = completeOnboarding as unknown as MockFn
+const _dismissOnboarding = dismissOnboarding as unknown as MockFn
+
+function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    avatar_ref: null,
+    display_name: 'Alex Schneider',
+    username: null,
+    role: null,
+    organisation: null,
+    language: 'de',
+    timezone: 'Europe/Berlin',
+    report_language: 'de',
+    theme: 'system',
+    privacy_mode: 'standard',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeOnboardingState(overrides: Partial<OnboardingState> = {}): OnboardingState {
+  return {
+    status: 'in_progress',
+    operating_mode: null,
+    current_step: 'welcome',
+    completed_steps: [],
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeOnboardingStatus(
+  overrides: Partial<OnboardingStatusResponse> = {},
+): OnboardingStatusResponse {
+  return {
+    state: makeOnboardingState(),
+    requirements: {
+      profile_valid: false,
+      chat_model_configured: false,
+      embedding_configured: false,
+    },
+    onboarding_required: true,
+    ...overrides,
+  }
+}
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'de', fallbackLocale: 'en', messages: { de, en } })
+}
+
+async function mountView() {
+  const router = makeTestRouter()
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  await router.push('/onboarding')
+  await router.isReady()
+  const wrapper = mount(OnboardingView, {
+    global: { plugins: [router, pinia, makeI18n()] },
+  })
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('OnboardingView', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('Test 1: mountet ohne Crash', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+
+    const { wrapper } = await mountView()
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('Test 2: Resume — startet bei state.current_step statt immer bei welcome', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'privacy',
+          completed_steps: ['welcome', 'profile', 'providers', 'chat_model', 'embeddings'],
+          operating_mode: 'local',
+        }),
+      }),
+    )
+
+    const { wrapper } = await mountView()
+    expect(wrapper.text()).toContain(de.onboarding.privacy.title)
+    expect(wrapper.text()).not.toContain(de.onboarding.welcome.title)
+  })
+
+  it('Test 3: i18n-Keys lösen auf (kein Rohdot im DOM)', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+
+    const { wrapper } = await mountView()
+    expect(wrapper.text()).not.toMatch(/onboarding\.[a-zA-Z]/)
+  })
+
+  it('Test 4: welcome-Schritt — Modus wählen + Weiter ruft completeOnboardingStep', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+    _completeOnboardingStep.mockResolvedValue(
+      makeOnboardingState({ current_step: 'profile', completed_steps: ['welcome'], operating_mode: 'hybrid' }),
+    )
+
+    const { wrapper } = await mountView()
+    const modeButtons = wrapper.findAll('.onboarding-mode-card')
+    expect(modeButtons.length).toBe(3)
+    await modeButtons[1].trigger('click') // hybrid
+
+    const nextBtn = wrapper.findAll('button').find((b) => b.text() === de.onboarding.wizard.nextBtn)
+    expect(nextBtn).toBeTruthy()
+    await nextBtn?.trigger('click')
+    await flushPromises()
+
+    expect(_completeOnboardingStep).toHaveBeenCalledWith('welcome', 'hybrid')
+    expect(wrapper.text()).toContain(de.onboarding.profile.title)
+  })
+
+  it('Test 5: "Später einrichten" ruft dismissOnboarding und navigiert zum Dashboard', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(makeOnboardingStatus())
+    _dismissOnboarding.mockResolvedValue(makeOnboardingState({ status: 'dismissed' }))
+
+    const { wrapper, router } = await mountView()
+    const laterBtn = wrapper.findAll('button').find((b) => b.text() === de.onboarding.wizard.laterBtn)
+    expect(laterBtn).toBeTruthy()
+    await laterBtn?.trigger('click')
+    await flushPromises()
+
+    expect(_dismissOnboarding).toHaveBeenCalledTimes(1)
+    expect(router.currentRoute.value.name).toBe('Dashboard')
+  })
+
+  it('Test 6: summary — 409 onboarding_incomplete zeigt server-seitige missing-Liste, nicht den Client-Fallback', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    // Requirements sind clientseitig ALLE erfüllt — der Client-Fallback wäre
+    // also leer. Trotzdem meldet das Backend "chat_model_configured" fehlend
+    // (Race/Server-Wahrheit gewinnt) — die UI muss GENAU diese Liste zeigen.
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'summary',
+          completed_steps: ['welcome', 'profile', 'providers', 'chat_model', 'embeddings', 'privacy'],
+          operating_mode: 'local',
+        }),
+        requirements: {
+          profile_valid: true,
+          chat_model_configured: true,
+          embedding_configured: true,
+        },
+      }),
+    )
+    // Simuliert das bereits normalisierte api/profile.ts-Ergebnis: die
+    // TOP-LEVEL `missing`-Liste aus dem 409-Envelope landet in details.missing
+    // (siehe api/__tests__/profile.spec.ts für die Wire-Format-Normalisierung selbst).
+    _completeOnboarding.mockRejectedValue(
+      new ApiError({
+        code: 'onboarding_incomplete',
+        status: 409,
+        message: 'onboarding incomplete',
+        details: { missing: ['chat_model_configured'] },
+      }),
+    )
+
+    const { wrapper, router } = await mountView()
+    const finishBtn = wrapper.findAll('button').find((b) => b.text() === de.onboarding.wizard.finishBtn)
+    expect(finishBtn).toBeTruthy()
+    await finishBtn?.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(de.onboarding.requirements.chatModelConfigured)
+    expect(wrapper.text()).toContain(de.onboarding.summary.incompleteNotice)
+    // Button bleibt aktiv (kein disabled-Attribut nach Fehler).
+    expect(finishBtn?.attributes('disabled')).toBeUndefined()
+    // Keine Navigation weg von /onboarding.
+    expect(router.currentRoute.value.name).toBe('Onboarding')
+  })
+})

--- a/schemas/onboarding-state.schema.json
+++ b/schemas/onboarding-state.schema.json
@@ -1,0 +1,78 @@
+{
+  "$id": "https://alexle135.de/schemas/onboarding-state.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Resumierbarer Wizard-Zustand; wird nach jedem Schritt persistiert.",
+  "properties": {
+    "completed_steps": {
+      "items": {
+        "enum": [
+          "welcome",
+          "profile",
+          "providers",
+          "chat_model",
+          "embeddings",
+          "privacy",
+          "summary"
+        ],
+        "type": "string"
+      },
+      "title": "Completed Steps",
+      "type": "array"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "current_step": {
+      "default": "welcome",
+      "enum": [
+        "welcome",
+        "profile",
+        "providers",
+        "chat_model",
+        "embeddings",
+        "privacy",
+        "summary"
+      ],
+      "title": "Current Step",
+      "type": "string"
+    },
+    "operating_mode": {
+      "anyOf": [
+        {
+          "enum": [
+            "local",
+            "hybrid",
+            "server"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Operating Mode"
+    },
+    "status": {
+      "default": "not_started",
+      "enum": [
+        "not_started",
+        "in_progress",
+        "dismissed",
+        "completed"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "updated_at": {
+      "format": "date-time",
+      "title": "Updated At",
+      "type": "string"
+    }
+  },
+  "title": "OnboardingState",
+  "type": "object"
+}

--- a/schemas/onboarding-status-response.schema.json
+++ b/schemas/onboarding-status-response.schema.json
@@ -1,0 +1,128 @@
+{
+  "$defs": {
+    "OnboardingRequirements": {
+      "additionalProperties": false,
+      "description": "Serverseitig berechnete Completion-Voraussetzungen (ADR-0008).",
+      "properties": {
+        "chat_model_configured": {
+          "title": "Chat Model Configured",
+          "type": "boolean"
+        },
+        "embedding_configured": {
+          "title": "Embedding Configured",
+          "type": "boolean"
+        },
+        "profile_valid": {
+          "title": "Profile Valid",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "profile_valid",
+        "chat_model_configured",
+        "embedding_configured"
+      ],
+      "title": "OnboardingRequirements",
+      "type": "object"
+    },
+    "OnboardingState": {
+      "additionalProperties": false,
+      "description": "Resumierbarer Wizard-Zustand; wird nach jedem Schritt persistiert.",
+      "properties": {
+        "completed_steps": {
+          "items": {
+            "enum": [
+              "welcome",
+              "profile",
+              "providers",
+              "chat_model",
+              "embeddings",
+              "privacy",
+              "summary"
+            ],
+            "type": "string"
+          },
+          "title": "Completed Steps",
+          "type": "array"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "current_step": {
+          "default": "welcome",
+          "enum": [
+            "welcome",
+            "profile",
+            "providers",
+            "chat_model",
+            "embeddings",
+            "privacy",
+            "summary"
+          ],
+          "title": "Current Step",
+          "type": "string"
+        },
+        "operating_mode": {
+          "anyOf": [
+            {
+              "enum": [
+                "local",
+                "hybrid",
+                "server"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Operating Mode"
+        },
+        "status": {
+          "default": "not_started",
+          "enum": [
+            "not_started",
+            "in_progress",
+            "dismissed",
+            "completed"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "title": "OnboardingState",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/onboarding-status-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Antwort von ``GET /api/onboarding``.",
+  "properties": {
+    "onboarding_required": {
+      "title": "Onboarding Required",
+      "type": "boolean"
+    },
+    "requirements": {
+      "$ref": "#/$defs/OnboardingRequirements"
+    },
+    "state": {
+      "$ref": "#/$defs/OnboardingState"
+    }
+  },
+  "required": [
+    "state",
+    "requirements",
+    "onboarding_required"
+  ],
+  "title": "OnboardingStatusResponse",
+  "type": "object"
+}

--- a/schemas/onboarding-step-update-request.schema.json
+++ b/schemas/onboarding-step-update-request.schema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://alexle135.de/schemas/onboarding-step-update-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Meldet einen abgeschlossenen Schritt; der Service berechnet den\nnaechsten offenen Schritt deterministisch aus ``ONBOARDING_STEP_ORDER``.",
+  "properties": {
+    "operating_mode": {
+      "anyOf": [
+        {
+          "enum": [
+            "local",
+            "hybrid",
+            "server"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Operating Mode"
+    },
+    "step": {
+      "enum": [
+        "welcome",
+        "profile",
+        "providers",
+        "chat_model",
+        "embeddings",
+        "privacy",
+        "summary"
+      ],
+      "title": "Step",
+      "type": "string"
+    }
+  },
+  "required": [
+    "step"
+  ],
+  "title": "OnboardingStepUpdateRequest",
+  "type": "object"
+}

--- a/schemas/user-profile-update-request.schema.json
+++ b/schemas/user-profile-update-request.schema.json
@@ -1,0 +1,140 @@
+{
+  "$id": "https://alexle135.de/schemas/user-profile-update-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Partielles Update; ``avatar_ref`` ist bewusst ausgeschlossen und wird\nausschliesslich ueber die Avatar-Endpunkte veraendert.",
+  "properties": {
+    "display_name": {
+      "anyOf": [
+        {
+          "maxLength": 80,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Display Name"
+    },
+    "language": {
+      "anyOf": [
+        {
+          "enum": [
+            "de",
+            "en"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Language"
+    },
+    "organisation": {
+      "anyOf": [
+        {
+          "maxLength": 120,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Organisation"
+    },
+    "privacy_mode": {
+      "anyOf": [
+        {
+          "enum": [
+            "standard",
+            "strict"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Privacy Mode"
+    },
+    "report_language": {
+      "anyOf": [
+        {
+          "enum": [
+            "de",
+            "en"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Report Language"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "maxLength": 120,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Role"
+    },
+    "theme": {
+      "anyOf": [
+        {
+          "enum": [
+            "system",
+            "light",
+            "dark"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Theme"
+    },
+    "timezone": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timezone"
+    },
+    "username": {
+      "anyOf": [
+        {
+          "pattern": "^[a-z0-9][a-z0-9._-]{1,31}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Username"
+    }
+  },
+  "title": "UserProfileUpdateRequest",
+  "type": "object"
+}

--- a/schemas/user-profile.schema.json
+++ b/schemas/user-profile.schema.json
@@ -1,0 +1,123 @@
+{
+  "$id": "https://alexle135.de/schemas/user-profile.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Lokales Single-User-Profil (kein KI-Preset, keine Secrets).",
+  "properties": {
+    "avatar_ref": {
+      "anyOf": [
+        {
+          "pattern": "^avatar-[0-9a-f]{32}\\.(png|jpg|webp)$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Avatar Ref"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "display_name": {
+      "maxLength": 80,
+      "minLength": 1,
+      "title": "Display Name",
+      "type": "string"
+    },
+    "language": {
+      "default": "de",
+      "enum": [
+        "de",
+        "en"
+      ],
+      "title": "Language",
+      "type": "string"
+    },
+    "organisation": {
+      "anyOf": [
+        {
+          "maxLength": 120,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Organisation"
+    },
+    "privacy_mode": {
+      "default": "standard",
+      "enum": [
+        "standard",
+        "strict"
+      ],
+      "title": "Privacy Mode",
+      "type": "string"
+    },
+    "report_language": {
+      "default": "de",
+      "enum": [
+        "de",
+        "en"
+      ],
+      "title": "Report Language",
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "maxLength": 120,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Role"
+    },
+    "theme": {
+      "default": "system",
+      "enum": [
+        "system",
+        "light",
+        "dark"
+      ],
+      "title": "Theme",
+      "type": "string"
+    },
+    "timezone": {
+      "default": "Europe/Berlin",
+      "title": "Timezone",
+      "type": "string"
+    },
+    "updated_at": {
+      "format": "date-time",
+      "title": "Updated At",
+      "type": "string"
+    },
+    "username": {
+      "anyOf": [
+        {
+          "pattern": "^[a-z0-9][a-z0-9._-]{1,31}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Username"
+    }
+  },
+  "required": [
+    "display_name"
+  ],
+  "title": "UserProfile",
+  "type": "object"
+}


### PR DESCRIPTION
## Epic

`onboarding-provider-unification` — Slice 2 gemäß [04-implementation-plan.md](docs/epics/onboarding-provider-unification/04-implementation-plan.md) und ADR-0008. Folgt auf Slice 1 (#683).

## Inhalt

**Layer 0 (Contracts):** `UserProfile` + `OnboardingState` als Pydantic-v2-SSoT (`extra="forbid"`), Avatar-Referenzen per Pattern gegen Path-Traversal gesichert, IANA-Zeitzonen-Validierung, 5 neue JSON-Schemas, strikter Zod-Spiegel. Benutzerprofil und KI-Presets (`LlmProfile`) bleiben getrennte Schlüsselräume.

**Backend:** Datei-basierte Single-User-Stores (`user_profile.json`, `onboarding_state.json` unter `AGORA_DATA_DIR`; flock, atomarer Write, 0600). Blueprints `/api/profile` (GET/PUT + Avatar POST/GET/DELETE) und `/api/onboarding` (GET, PUT /step, POST /complete|dismiss|reopen). Avatar-Upload validiert MIME-Allowlist **und** Magic-Bytes (PNG/JPEG/WebP — SVG strukturell abgelehnt), 2-MB-Limit, serverseitig generierte Dateinamen. Completion serverseitig: gültiges Profil + `chat_model_configured` + `embedding_configured` (bewusst Konfigurations- statt Erreichbarkeitscheck — Live-Discovery kommt in Slice 3).

**Frontend:** Wizard unter `/onboarding` (resumierbar ab `current_step`, Betriebsmodus-Wahl, Profilformular, ehrliche Status-Schritte mit Settings-Verweis statt Attrappen, „Später einrichten"). Router-Guard mit Fail-open-Semantik: API-Fehler oder `dismissed` sperren niemals aus — Bestandsinstallationen können den Wizard wegklicken und über Settings wieder öffnen. Neue Seite `/settings/profile` (gemeinsames `ProfileForm`), Avatar-Anzeige über authentifizierten Blob-Fetch (funktioniert im `AGORA_AUTH_TOKEN`-Modus, kein neues `?token=`). Sidebar-IA: „Users & Teams" → „Profil", `/settings/users-teams` redirectet.

## Verifikation (unabhängig vom Root wiederholt)

| Gate | Ergebnis |
|---|---|
| Schema-Dump | idempotent, 5 neue Schemas |
| Contract-Suite | 284 passed |
| Backend voll | 3012 passed, 9 skipped, 7 deselected (Baseline 2920/9/7) |
| ruff / mypy | grün / 211 Dateien, 0 Fehler |
| Frontend | 152 Testdateien / 1202 Tests grün (Baseline 146/1150) |
| `bun run check` | Exit 0 (Lint + Tests + Build) |

Der Phase-0-Vitest-Teardown-Blocker ist durch #678 behoben (vor Slice-Beginn mit Exit 0 verifiziert).

## Migration / Rollback

Nur additive Verträge, keine Migration bestehender Daten; Stores legen Dateien lazy an. Rollback = Blueprints deregistrieren + Module entfernen. Details im [HANDOVER.md](docs/epics/onboarding-provider-unification/HANDOVER.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)