### PR TITLE
fix(embedding+api): Gemini-Findings (HIGH+MEDIUM) auf PR #686

### DIFF
--- a/backend/app/contracts/embedding_contract.py
+++ b/backend/app/contracts/embedding_contract.py
@@ -36,30 +36,13 @@ Wichtige Invarianten:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .provider_types import ProviderConnectionKind
 
 _STRICT = ConfigDict(extra="forbid")
-
-# ----------------------------------------------------------------------
-# Sub-Restriktion: Welche ProviderConnectionKind-Werte duerfen als
-# Embedding-Quelle dienen? Anthropic, OpenCode Go und CLI-Bridges sind
-# bewusst ausgeschlossen.
-# ----------------------------------------------------------------------
-
-_EMBEDDING_PROVIDER_KINDS: frozenset[str] = frozenset(
-    {
-        "ollama",
-        "openai",
-        "google",
-        "custom",
-        "ollama_cloud",
-        "openai_compatible",
-    }
-)
 
 EmbeddingProviderKind = Literal[
     "ollama",
@@ -69,6 +52,20 @@ EmbeddingProviderKind = Literal[
     "ollama_cloud",
     "openai_compatible",
 ]
+
+# ----------------------------------------------------------------------
+# Sub-Restriktion: Welche ProviderConnectionKind-Werte duerfen als
+# Embedding-Quelle dienen? Anthropic, OpenCode Go und CLI-Bridges sind
+# bewusst ausgeschlossen.
+# ----------------------------------------------------------------------
+
+# Das Set wird dynamisch aus dem Literal-Type abgeleitet, damit neue
+# Provider-Arten nur an einer einzigen Stelle (``EmbeddingProviderKind``)
+# hinzugefügt werden müssen und es nicht zu Drift zwischen Vertrag und
+# Laufzeit-Helper kommen kann.
+_EMBEDDING_PROVIDER_KINDS: frozenset[str] = frozenset(
+    get_args(EmbeddingProviderKind)
+)
 
 # Konfigurationsstatus. Proposed -> Probed -> (Reembedding | Active) -> ...
 # (siehe 03-target-architecture.md, "Embedding-Lifecycle").
@@ -219,9 +216,13 @@ class EmbeddingConfigurationResponse(BaseModel):
 class EmbeddingMigrationProgress(BaseModel):
     """Fortschritt einer Re-Embedding-Migration.
 
-    ``processed`` + ``failed`` <= ``total``. Die Konsistenz wird im Service
-    erzwungen, nicht im Vertrag, weil der Vertrag sonst Transienten
-    ausgesetzt waere (running -> Progress kann temporaer inkonsistent sein).
+    ``processed`` + ``failed`` <= ``total``. Die numerische Konsistenz
+    wird im Service erzwungen, nicht im Vertrag, weil der Vertrag sonst
+    Transienten ausgesetzt waere (running -> Progress kann temporaer
+    inkonsistent sein). Die zeitliche Konsistenz der Zeitstempel
+    wird hingegen strukturell geprueft, weil sie invariant ist: ein
+    ``finished_at`` ohne ``started_at`` oder ein ``finished_at`` vor
+    ``started_at`` waere ein klarer Vertragsbruch.
     """
 
     model_config = _STRICT
@@ -231,6 +232,18 @@ class EmbeddingMigrationProgress(BaseModel):
     failed: int = Field(ge=0)
     started_at: datetime | None = None
     finished_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def validate_timestamps(self) -> EmbeddingMigrationProgress:
+        if self.finished_at is not None and self.started_at is None:
+            raise ValueError("started_at must be set if finished_at is set")
+        if (
+            self.started_at is not None
+            and self.finished_at is not None
+            and self.finished_at < self.started_at
+        ):
+            raise ValueError("finished_at cannot be before started_at")
+        return self
 
 
 class EmbeddingMigrationJob(BaseModel):
@@ -297,6 +310,8 @@ class EmbeddingIndexVersion(BaseModel):
     def validate_status_with_retired(self) -> EmbeddingIndexVersion:
         if self.status == "retired" and self.retired_at is None:
             raise ValueError("retired_at is required when status='retired'")
+        if self.status != "retired" and self.retired_at is not None:
+            raise ValueError("retired_at must be None when status is not 'retired'")
         return self
 
 

--- a/backend/app/utils/api_responses.py
+++ b/backend/app/utils/api_responses.py
@@ -118,7 +118,12 @@ def _to_jsonable(value: Any) -> Any:
         return value
     if isinstance(value, BaseException):
         return str(value)
-    return to_jsonable_python(value)
+    # ``fallback=str`` ist die letzte Verteidigungslinie: wenn weder
+    # Pydantics eingebauter Coercer noch die obige Exception-Klausel
+    # greifen, wird der Wert in seinen String-Repr überführt, statt eine
+    # ``PydanticSerializationError``-Escalation in einen HTTP 500 zu
+    # verwandeln.
+    return to_jsonable_python(value, fallback=str)
 
 
 def json_success(data: Any = None, *, status: int = 200, **extra: Any):

--- a/backend/tests/contracts/test_embedding_contract.py
+++ b/backend/tests/contracts/test_embedding_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import get_args
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -391,6 +392,79 @@ def test_embedding_index_version_accepts_all_statuses(
         retired_at=retired_at,
     )
     assert version.status == status
+
+
+@pytest.mark.parametrize("status", ["active", "superseded", "rolled_back"])
+def test_embedding_index_version_rejects_retired_at_for_non_retired_status(
+    status: EmbeddingIndexStatus,
+) -> None:
+    """Gemini-Finding (MEDIUM): ``retired_at`` darf nur gesetzt sein,
+    wenn der Status tatsaechlich ``'retired'`` ist. Sonst entstehen
+    zustaende, in denen ein aktiver Index ein Retirement-Datum haette.
+    """
+    with pytest.raises(ValidationError, match="retired_at"):
+        EmbeddingIndexVersion(
+            version=1,
+            provider_connection_id="conn-1",
+            model_id="nomic-embed-text",
+            dimensions=768,
+            index_name="entity_embedding_v1",
+            property_key="embedding_v1",
+            status=status,
+            created_at=NOW,
+            retired_at=NOW,
+        )
+
+
+def test_embedding_migration_progress_rejects_finished_at_without_started_at() -> None:
+    """Gemini-Finding (MEDIUM): ``finished_at`` ohne ``started_at`` ist ein
+    klarer Vertragsbruch — ein Job kann nicht enden, ohne je begonnen
+    zu haben.
+    """
+    with pytest.raises(ValidationError, match="started_at"):
+        EmbeddingMigrationProgress(
+            total=10, processed=10, failed=0, started_at=None, finished_at=NOW
+        )
+
+
+def test_embedding_migration_progress_rejects_finished_at_before_started_at() -> None:
+    with pytest.raises(ValidationError, match="finished_at"):
+        EmbeddingMigrationProgress(
+            total=10,
+            processed=10,
+            failed=0,
+            started_at=NOW,
+            finished_at=NOW.replace(year=NOW.year - 1),
+        )
+
+
+def test_embedding_migration_progress_accepts_consistent_timestamps() -> None:
+    later = NOW.replace(year=NOW.year + 1)
+    progress = EmbeddingMigrationProgress(
+        total=10, processed=10, failed=0, started_at=NOW, finished_at=later
+    )
+    assert progress.started_at == NOW
+    assert progress.finished_at == later
+
+
+def test_embedding_migration_progress_accepts_running_state_with_no_finish() -> None:
+    """Waehrend ``running`` ist ``finished_at`` None — das ist erlaubt und
+    der haeufigste Fall. Der Test pinnt, dass der neue Validator den
+    Normalfall nicht verschlechtert.
+    """
+    progress = EmbeddingMigrationProgress(
+        total=100, processed=42, failed=0, started_at=NOW, finished_at=None
+    )
+    assert progress.finished_at is None
+
+
+def test_embedding_provider_kinds_helper_is_derived_from_literal() -> None:
+    """Gemini-Finding (MEDIUM): das ``_EMBEDDING_PROVIDER_KINDS``-Set muss
+    dynamisch aus dem ``EmbeddingProviderKind``-Literal abgeleitet sein,
+    damit es nicht zu Drift zwischen Vertrag und Laufzeit kommen kann.
+    """
+    kinds = embedding_provider_kinds()
+    assert kinds == frozenset(get_args(EmbeddingProviderKind))
 
 
 # ----------------------------------------------------------------------

--- a/backend/tests/test_api_responses.py
+++ b/backend/tests/test_api_responses.py
@@ -296,3 +296,27 @@ def test_json_error_sanitizes_pydantic_validation_error_payload():
             for v in ctx.values():
                 assert not isinstance(v, BaseException)
 
+
+def test_json_error_falls_back_to_string_for_unknown_objects():
+    """Gemini-Finding (HIGH): ``_to_jsonable`` muss auch fuer Objekte, die
+    weder Pydantic noch der Exception-Klausel bekannt sind, eine JSON-
+    kompatible Form liefern. Sonst kippt die Sanitizer-Sicherheit.
+    """
+
+    class _Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    app = _build_app()
+    with app.test_request_context():
+        response, status = json_error(
+            "boom",
+            status=400,
+            extra={"weird": _Weird(), "container": {"nested": _Weird()}},
+        )
+        payload = response.get_json()
+
+    assert status == 400
+    assert payload["weird"] == "<weird>"
+    assert payload["container"] == {"nested": "<weird>"}
+

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3144 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3153 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 153 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/schemas/embedding-migration-job-response.schema.json
+++ b/schemas/embedding-migration-job-response.schema.json
@@ -77,7 +77,7 @@
     },
     "EmbeddingMigrationProgress": {
       "additionalProperties": false,
-      "description": "Fortschritt einer Re-Embedding-Migration.\n\n``processed`` + ``failed`` <= ``total``. Die Konsistenz wird im Service\nerzwungen, nicht im Vertrag, weil der Vertrag sonst Transienten\nausgesetzt waere (running -> Progress kann temporaer inkonsistent sein).",
+      "description": "Fortschritt einer Re-Embedding-Migration.\n\n``processed`` + ``failed`` <= ``total``. Die numerische Konsistenz\nwird im Service erzwungen, nicht im Vertrag, weil der Vertrag sonst\nTransienten ausgesetzt waere (running -> Progress kann temporaer\ninkonsistent sein). Die zeitliche Konsistenz der Zeitstempel\nwird hingegen strukturell geprueft, weil sie invariant ist: ein\n``finished_at`` ohne ``started_at`` oder ein ``finished_at`` vor\n``started_at`` waere ein klarer Vertragsbruch.",
       "properties": {
         "failed": {
           "minimum": 0,

--- a/schemas/embedding-migration-job.schema.json
+++ b/schemas/embedding-migration-job.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "EmbeddingMigrationProgress": {
       "additionalProperties": false,
-      "description": "Fortschritt einer Re-Embedding-Migration.\n\n``processed`` + ``failed`` <= ``total``. Die Konsistenz wird im Service\nerzwungen, nicht im Vertrag, weil der Vertrag sonst Transienten\nausgesetzt waere (running -> Progress kann temporaer inkonsistent sein).",
+      "description": "Fortschritt einer Re-Embedding-Migration.\n\n``processed`` + ``failed`` <= ``total``. Die numerische Konsistenz\nwird im Service erzwungen, nicht im Vertrag, weil der Vertrag sonst\nTransienten ausgesetzt waere (running -> Progress kann temporaer\ninkonsistent sein). Die zeitliche Konsistenz der Zeitstempel\nwird hingegen strukturell geprueft, weil sie invariant ist: ein\n``finished_at`` ohne ``started_at`` oder ein ``finished_at`` vor\n``started_at`` waere ein klarer Vertragsbruch.",
       "properties": {
         "failed": {
           "minimum": 0,


### PR DESCRIPTION
Adressiert die 4 Review-Findings von gemini-code-assist auf PR #686 (Slice 4.1).

### HIGH
- `to_jsonable_python(value, fallback=str)` in
  `app/utils/api_responses.py`: letzte Verteidigungslinie fuer
  nicht-Pydantic-bekannte Objekte. Verhindert HTTP 500 durch
  `PydanticSerializationError` bei beliebigen Werten in `extra`.

### MEDIUM
- `_EMBEDDING_PROVIDER_KINDS` jetzt dynamisch aus
  `get_args(EmbeddingProviderKind)` abgeleitet. Eliminiert Drift
  zwischen Vertrag und Laufzeit-Helper.
- `EmbeddingMigrationProgress.validate_timestamps`:
  `finished_at` ohne `started_at` → reject;
  `finished_at < started_at` → reject.
- `EmbeddingIndexVersion`: `retired_at` muss `None` sein, wenn
  `status != 'retired'` (Symmetrie zur bestehenden
  `retired_at`-Pflicht bei `status='retired'`).

### Tests
- `test_json_error_falls_back_to_string_for_unknown_objects` (api-responses)
- 6 neue Embedding-Contract-Tests (retired_at-Validierung,
  Zeitstempel-Validator, Literal-Ableitung)

### Gates
- Backend 3139 passed / 9 skipped / 7 deselected (+9 Tests)
- ruff clean; mypy 0 Fehler; Schema-Dump 46/46 driftfrei
- Frontend unberuehrt (keine Aenderung)