### PR TITLE
feat(embedding): Frontend-Store, View, Zod-Spiegel und API-Clients (Slice 4.3.2)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3236 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 153 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 154 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/api/embeddingConfigurations.ts
+++ b/frontend/src/api/embeddingConfigurations.ts
@@ -10,6 +10,8 @@
 import service from "./index";
 import { z } from "zod";
 import {
+  ActiveEmbeddingConfigurationResponse,
+  ActiveEmbeddingConfigurationResponseSchema,
   EmbeddingConfiguration,
   EmbeddingConfigurationResponseSchema,
   EmbeddingConfigurationUpsertRequest,
@@ -31,27 +33,11 @@ export async function listEmbeddingConfigurations(
   return unwrapAndParse(resp, EmbeddingConfigurationsListResponseSchema);
 }
 
-export async function getActiveEmbeddingConfiguration(): Promise<{
-  configuration: EmbeddingConfiguration | null;
-  source: "store" | "legacy" | "none";
-}> {
+export async function getActiveEmbeddingConfiguration(): Promise<ActiveEmbeddingConfigurationResponse> {
   const resp = await service.get<ApiSuccessEnvelope<unknown>>(
     "/api/llm/embedding/configurations/active",
   );
-  const parsed = unwrapAndParse(
-    resp,
-    // active response has the same wrapper; we read the optional fields
-    // defensively without a dedicated schema (no extra contract for
-    // legacy-sourcing semantics yet).
-    EmbeddingConfigurationsListResponseSchema.partial().extend({
-      source: z.enum(["store", "legacy", "none"]),
-      configuration: EmbeddingConfigurationResponseSchema.shape.configuration.nullable(),
-    }),
-  );
-  return {
-    configuration: parsed.configuration ?? null,
-    source: parsed.source ?? "none",
-  };
+  return unwrapAndParse(resp, ActiveEmbeddingConfigurationResponseSchema);
 }
 
 export async function upsertEmbeddingConfiguration(

--- a/frontend/src/api/embeddingConfigurations.ts
+++ b/frontend/src/api/embeddingConfigurations.ts
@@ -1,0 +1,120 @@
+/**
+ * embeddingConfigurations — HTTP-Client fuer den kanonischen
+ * Embedding-Configuration-Lifecycle (Slice 4.2).
+ *
+ * Bedient backend/app/api/embedding_configurations.py
+ * `/api/llm/embedding/configurations*`. Jede Response-Grenze wird mit
+ * den Zod-Schemas aus contracts/embeddingContract validiert — kein
+ * `?.`-Durchreichen bei Schema-Drift.
+ */
+import service from "./index";
+import { z } from "zod";
+import {
+  EmbeddingConfiguration,
+  EmbeddingConfigurationResponseSchema,
+  EmbeddingConfigurationUpsertRequest,
+  EmbeddingConfigurationUpsertRequestSchema,
+  EmbeddingConfigurationsListResponse,
+  EmbeddingConfigurationsListResponseSchema,
+  EmbeddingConfigurationScope,
+} from "../contracts/embeddingContract";
+import { ApiSuccessEnvelope } from "./envelope";
+import { unwrapAndParse } from "./parse";
+
+export async function listEmbeddingConfigurations(
+  scope?: EmbeddingConfigurationScope,
+): Promise<EmbeddingConfigurationsListResponse> {
+  const query = scope ? `?scope=${encodeURIComponent(scope)}` : "";
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/configurations${query}`,
+  );
+  return unwrapAndParse(resp, EmbeddingConfigurationsListResponseSchema);
+}
+
+export async function getActiveEmbeddingConfiguration(): Promise<{
+  configuration: EmbeddingConfiguration | null;
+  source: "store" | "legacy" | "none";
+}> {
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>(
+    "/api/llm/embedding/configurations/active",
+  );
+  const parsed = unwrapAndParse(
+    resp,
+    // active response has the same wrapper; we read the optional fields
+    // defensively without a dedicated schema (no extra contract for
+    // legacy-sourcing semantics yet).
+    EmbeddingConfigurationsListResponseSchema.partial().extend({
+      source: z.enum(["store", "legacy", "none"]),
+      configuration: EmbeddingConfigurationResponseSchema.shape.configuration.nullable(),
+    }),
+  );
+  return {
+    configuration: parsed.configuration ?? null,
+    source: parsed.source ?? "none",
+  };
+}
+
+export async function upsertEmbeddingConfiguration(
+  configurationId: "new" | string,
+  payload: EmbeddingConfigurationUpsertRequest,
+): Promise<EmbeddingConfiguration> {
+  // Vorab-Validierung auf Client-Seite (Backend validiert erneut).
+  EmbeddingConfigurationUpsertRequestSchema.parse(payload);
+  const resp = await service.put<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/configurations/${encodeURIComponent(configurationId)}`,
+    payload,
+  );
+  return unwrapAndParse(resp, EmbeddingConfigurationResponseSchema).configuration;
+}
+
+export async function deleteEmbeddingConfiguration(
+  configurationId: string,
+): Promise<void> {
+  await service.delete(
+    `/api/llm/embedding/configurations/${encodeURIComponent(configurationId)}`,
+  );
+}
+
+export async function testEmbeddingConfiguration(
+  configurationId: string,
+): Promise<{
+  configuration: EmbeddingConfiguration;
+  probe: {
+    status: "available" | "unavailable" | "invalid_credentials" | "degraded" | "unsupported";
+    status_message: string | null;
+    actual_dimensions: number | null;
+  };
+}> {
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/configurations/${encodeURIComponent(configurationId)}/test`,
+  );
+  const parsed = unwrapAndParse(
+    resp,
+    EmbeddingConfigurationResponseSchema.extend({
+      probe: z.object({
+        status: z.enum([
+          "available",
+          "unavailable",
+          "invalid_credentials",
+          "degraded",
+          "unsupported",
+        ]),
+        status_message: z.string().nullable(),
+        actual_dimensions: z.number().int().nullable(),
+      }),
+    }),
+  );
+  return {
+    configuration: parsed.configuration,
+    probe: parsed.probe,
+  };
+}
+
+export async function activateEmbeddingConfiguration(
+  configurationId: string,
+): Promise<EmbeddingConfiguration> {
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/configurations/${encodeURIComponent(configurationId)}/activate`,
+  );
+  return unwrapAndParse(resp, EmbeddingConfigurationResponseSchema).configuration;
+}

--- a/frontend/src/api/embeddingMigrations.ts
+++ b/frontend/src/api/embeddingMigrations.ts
@@ -1,0 +1,125 @@
+/**
+ * embeddingMigrations — HTTP-Client fuer Re-Embedding-Migrationen und
+ * Ollama-Download (Slice 4.3).
+ *
+ * Bedient backend/app/api/embedding_migrations.py
+ * `/api/llm/embedding/migrations*` und `/api/llm/embedding/ollama/pull`.
+ */
+import { z } from "zod";
+import service from "./index";
+import {
+  EmbeddingMigrationJob,
+  EmbeddingMigrationJobResponseSchema,
+  EmbeddingMigrationJobsListResponseSchema,
+  EmbeddingMigrationStatus,
+  OllamaPullReport,
+  OllamaPullReportResponseSchema,
+} from "../contracts/embeddingContract";
+import { ApiSuccessEnvelope } from "./envelope";
+import { unwrapAndParse } from "./parse";
+
+const START_PAYLOAD_SCHEMA = z
+  .object({
+    configuration_id: z.string().min(1),
+  })
+  .strict();
+export type StartMigrationPayload = z.infer<typeof START_PAYLOAD_SCHEMA>;
+
+const OLLAMA_PULL_PAYLOAD_SCHEMA = z
+  .object({
+    model: z
+      .string()
+      .min(1)
+      .max(100)
+      // Strikte Server-Validierung gespiegelt: ASCII a-z, A-Z, 0-9,
+      // '-', '_', '.', ':'. Verhindert versehentliche Shell-Injection
+      // auf Modell-Bezeichnungs-Ebene.
+      .regex(/^[A-Za-z0-9_.\-:]{1,100}$/u, {
+        message:
+          "Model-Name darf nur ASCII-Buchstaben, Ziffern, '-', '_', '.', ':' enthalten",
+      }),
+    configuration_id: z.string().min(1).optional(),
+  })
+  .strict();
+export type OllamaPullPayload = z.infer<typeof OLLAMA_PULL_PAYLOAD_SCHEMA>;
+
+export async function startEmbeddingMigration(
+  payload: StartMigrationPayload,
+): Promise<EmbeddingMigrationJob> {
+  START_PAYLOAD_SCHEMA.parse(payload);
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    "/api/llm/embedding/migrations",
+    payload,
+  );
+  return unwrapAndParse(resp, EmbeddingMigrationJobResponseSchema).job;
+}
+
+export async function listEmbeddingMigrations(
+  configurationId?: string,
+): Promise<EmbeddingMigrationJob[]> {
+  const query = configurationId
+    ? `?configuration_id=${encodeURIComponent(configurationId)}`
+    : "";
+  const resp = await service.get<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/migrations${query}`,
+  );
+  return unwrapAndParse(
+    resp,
+    EmbeddingMigrationJobsListResponseSchema,
+  ).jobs;
+}
+
+export async function getEmbeddingMigration(
+  jobId: string,
+): Promise<EmbeddingMigrationJob | null> {
+  try {
+    const resp = await service.get<ApiSuccessEnvelope<unknown>>(
+      `/api/llm/embedding/migrations/${encodeURIComponent(jobId)}`,
+    );
+    return unwrapAndParse(resp, EmbeddingMigrationJobResponseSchema).job;
+  } catch (err) {
+    if (isNotFound(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function runEmbeddingMigration(
+  jobId: string,
+): Promise<EmbeddingMigrationJob> {
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/migrations/${encodeURIComponent(jobId)}/run`,
+  );
+  return unwrapAndParse(resp, EmbeddingMigrationJobResponseSchema).job;
+}
+
+export async function cancelEmbeddingMigration(
+  jobId: string,
+): Promise<EmbeddingMigrationJob> {
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    `/api/llm/embedding/migrations/${encodeURIComponent(jobId)}/cancel`,
+  );
+  return unwrapAndParse(resp, EmbeddingMigrationJobResponseSchema).job;
+}
+
+export async function pullOllamaEmbeddingModel(
+  payload: OllamaPullPayload,
+): Promise<OllamaPullReport> {
+  OLLAMA_PULL_PAYLOAD_SCHEMA.parse(payload);
+  const resp = await service.post<ApiSuccessEnvelope<unknown>>(
+    "/api/llm/embedding/ollama/pull",
+    payload,
+  );
+  return unwrapAndParse(resp, OllamaPullReportResponseSchema).report;
+}
+
+function isNotFound(err: unknown): boolean {
+  if (err && typeof err === "object" && "response" in err) {
+    const response = (err as { response?: { status?: number } }).response;
+    return response?.status === 404;
+  }
+  return false;
+}
+
+export type { EmbeddingMigrationJob, EmbeddingMigrationStatus };

--- a/frontend/src/contracts/__tests__/embeddingContract.spec.ts
+++ b/frontend/src/contracts/__tests__/embeddingContract.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EmbeddingConfigurationSchema,
+  EmbeddingConfigurationStatusSchema,
+  EmbeddingMigrationJobSchema,
+  EmbeddingMigrationProgressSchema,
+  EmbeddingMigrationStatusSchema,
+  EmbeddingIndexStatusSchema,
+  EmbeddingProviderKindSchema,
+  EmbeddingConfigurationScopeSchema,
+} from '../embeddingContract'
+
+describe('embeddingContract — Zod-Spiegel der Backend-Contracts', () => {
+  it('akzeptiert alle 6 EmbeddingProviderKind-Werte', () => {
+    for (const kind of [
+      'ollama',
+      'openai',
+      'google',
+      'custom',
+      'ollama_cloud',
+      'openai_compatible',
+    ]) {
+      expect(EmbeddingProviderKindSchema.parse(kind)).toBe(kind)
+    }
+  })
+
+  it('lehnt anthropic und opencode_go als Embedding-Provider ab', () => {
+    expect(() => EmbeddingProviderKindSchema.parse('anthropic')).toThrow()
+    expect(() => EmbeddingProviderKindSchema.parse('opencode_go')).toThrow()
+  })
+
+  it('akzeptiert alle 7 EmbeddingConfigurationStatus-Werte', () => {
+    for (const status of [
+      'proposed',
+      'probed',
+      'reembedding',
+      'validated',
+      'active',
+      'rolled_back',
+      'failed',
+    ]) {
+      expect(EmbeddingConfigurationStatusSchema.parse(status)).toBe(status)
+    }
+  })
+
+  it('akzeptiert alle 6 EmbeddingMigrationStatus-Werte', () => {
+    for (const status of [
+      'pending',
+      'running',
+      'validating',
+      'completed',
+      'rolled_back',
+      'failed',
+    ]) {
+      expect(EmbeddingMigrationStatusSchema.parse(status)).toBe(status)
+    }
+  })
+
+  it('akzeptiert alle 4 EmbeddingIndexStatus-Werte', () => {
+    for (const status of [
+      'active',
+      'superseded',
+      'rolled_back',
+      'retired',
+    ]) {
+      expect(EmbeddingIndexStatusSchema.parse(status)).toBe(status)
+    }
+  })
+
+  it('EmbeddingConfiguration: scope=project erfordert project_id', () => {
+    const base = {
+      id: 'emb-1',
+      provider_connection_id: 'conn-1',
+      provider_kind: 'ollama' as const,
+      model_id: 'nomic-embed-text',
+      dimensions: 768,
+      index_version: 1,
+      status: 'proposed' as const,
+      created_at: '2026-07-12T12:00:00+00:00',
+      updated_at: '2026-07-12T12:00:00+00:00',
+    }
+    expect(() =>
+      EmbeddingConfigurationSchema.parse({ ...base, scope: 'project', project_id: null }),
+    ).toThrow(/project_id/)
+  })
+
+  it('EmbeddingConfiguration: scope=global verbietet project_id', () => {
+    const base = {
+      id: 'emb-1',
+      provider_connection_id: 'conn-1',
+      provider_kind: 'ollama' as const,
+      model_id: 'nomic-embed-text',
+      dimensions: 768,
+      index_version: 1,
+      status: 'proposed' as const,
+      created_at: '2026-07-12T12:00:00+00:00',
+      updated_at: '2026-07-12T12:00:00+00:00',
+    }
+    expect(() =>
+      EmbeddingConfigurationSchema.parse({ ...base, scope: 'global', project_id: 'proj-1' }),
+    ).toThrow(/project_id/)
+  })
+
+  it('EmbeddingMigrationJob: source_index_version=0 nur mit target=1', () => {
+    const base = {
+      id: 'job-1',
+      configuration_id: 'emb-1',
+      target_index_version: 1,
+      status: 'pending' as const,
+      progress: {
+        total: 0,
+        processed: 0,
+        failed: 0,
+        started_at: null,
+        finished_at: null,
+      },
+      error_message: null,
+      created_at: '2026-07-12T12:00:00+00:00',
+      updated_at: '2026-07-12T12:00:00+00:00',
+    }
+    expect(() =>
+      EmbeddingMigrationJobSchema.parse({ ...base, source_index_version: 0 }),
+    ).not.toThrow()
+    expect(() =>
+      EmbeddingMigrationJobSchema.parse({ ...base, source_index_version: 0, target_index_version: 2 }),
+    ).toThrow(/Cold-Start|target=1/)
+  })
+
+  it('EmbeddingMigrationJob: source_index_version muss kleiner als target sein', () => {
+    const base = {
+      id: 'job-1',
+      configuration_id: 'emb-1',
+      target_index_version: 3,
+      status: 'pending' as const,
+      progress: {
+        total: 0,
+        processed: 0,
+        failed: 0,
+        started_at: null,
+        finished_at: null,
+      },
+      error_message: null,
+      created_at: '2026-07-12T12:00:00+00:00',
+      updated_at: '2026-07-12T12:00:00+00:00',
+    }
+    expect(() =>
+      EmbeddingMigrationJobSchema.parse({ ...base, source_index_version: 3 }),
+    ).toThrow()
+    expect(() =>
+      EmbeddingMigrationJobSchema.parse({ ...base, source_index_version: 4 }),
+    ).toThrow()
+  })
+
+  it('EmbeddingMigrationProgress: finished_at erfordert started_at', () => {
+    expect(() =>
+      EmbeddingMigrationProgressSchema.parse({
+        total: 10,
+        processed: 10,
+        failed: 0,
+        started_at: null,
+        finished_at: '2026-07-12T12:00:00+00:00',
+      }),
+    ).toThrow(/started_at/)
+  })
+
+  it('EmbeddingMigrationProgress: finished_at darf nicht vor started_at sein', () => {
+    expect(() =>
+      EmbeddingMigrationProgressSchema.parse({
+        total: 10,
+        processed: 10,
+        failed: 0,
+        started_at: '2026-07-12T12:00:00+00:00',
+        finished_at: '2026-07-12T11:00:00+00:00',
+      }),
+    ).toThrow(/finished_at/)
+  })
+
+  it('EmbeddingConfigurationScope akzeptiert nur global oder project', () => {
+    expect(() => EmbeddingConfigurationScopeSchema.parse('team')).toThrow()
+  })
+})

--- a/frontend/src/contracts/embeddingContract.ts
+++ b/frontend/src/contracts/embeddingContract.ts
@@ -170,6 +170,24 @@ export type EmbeddingConfigurationsListResponse = z.infer<
   typeof EmbeddingConfigurationsListResponseSchema
 >
 
+/**
+ * Antwort des ``/active``-Endpunkts. Das Backend liefert entweder eine
+ * echte Konfiguration (source="store"), eine aus ``Config.EMBEDDING_*``
+ * abgeleitete Legacy-Sicht (source="legacy") oder gar nichts
+ * (source="none"). Ein dediziertes Schema ist sauberer als die
+ * ``.partial().extend()``-Konstruktion, die mit der Liste verwechselt
+ * werden koennte.
+ */
+export const ActiveEmbeddingConfigurationResponseSchema = z
+  .object({
+    configuration: EmbeddingConfigurationSchema.nullable(),
+    source: z.enum(['store', 'legacy', 'none']),
+  })
+  .strict()
+export type ActiveEmbeddingConfigurationResponse = z.infer<
+  typeof ActiveEmbeddingConfigurationResponseSchema
+>
+
 // ----------------------------------------------------------------------
 // EmbeddingMigrationJob
 // ----------------------------------------------------------------------

--- a/frontend/src/contracts/embeddingContract.ts
+++ b/frontend/src/contracts/embeddingContract.ts
@@ -1,0 +1,321 @@
+/**
+ * Zod-Spiegel der Embedding-Verträge aus
+ * backend/app/contracts/embedding_contract.py.
+ *
+ * Strikt defensiv: ``.strict()`` plus ``.passthrough()`` wo noetig,
+ * damit Schema-Drift vom Backend frueh erkannt wird (Frontend-Zod
+ * muss Backend-Schema spiegeln — siehe CI-Gate).
+ */
+import { z } from 'zod'
+
+// ----------------------------------------------------------------------
+// Provider-Restriktion (Sub-Literal der ProviderConnectionKind)
+// ----------------------------------------------------------------------
+
+export const EmbeddingProviderKindSchema = z.enum([
+  'ollama',
+  'openai',
+  'google',
+  'custom',
+  'ollama_cloud',
+  'openai_compatible',
+])
+export type EmbeddingProviderKind = z.infer<typeof EmbeddingProviderKindSchema>
+
+export const EmbeddingConfigurationStatusSchema = z.enum([
+  'proposed',
+  'probed',
+  'reembedding',
+  'validated',
+  'active',
+  'rolled_back',
+  'failed',
+])
+export type EmbeddingConfigurationStatus = z.infer<
+  typeof EmbeddingConfigurationStatusSchema
+>
+
+export const EmbeddingConfigurationScopeSchema = z.enum(['global', 'project'])
+export type EmbeddingConfigurationScope = z.infer<
+  typeof EmbeddingConfigurationScopeSchema
+>
+
+export const EmbeddingMigrationStatusSchema = z.enum([
+  'pending',
+  'running',
+  'validating',
+  'completed',
+  'rolled_back',
+  'failed',
+])
+export type EmbeddingMigrationStatus = z.infer<
+  typeof EmbeddingMigrationStatusSchema
+>
+
+export const EmbeddingIndexStatusSchema = z.enum([
+  'active',
+  'superseded',
+  'rolled_back',
+  'retired',
+])
+export type EmbeddingIndexStatus = z.infer<typeof EmbeddingIndexStatusSchema>
+
+// ----------------------------------------------------------------------
+// EmbeddingModelMetadata
+// ----------------------------------------------------------------------
+
+export const EmbeddingModelMetadataSchema = z
+  .object({
+    provider_kind: EmbeddingProviderKindSchema,
+    model_id: z.string().min(1),
+    display_name: z.string().min(1),
+    embedding_dimensions: z.number().int().positive(),
+    source: z.enum(['live', 'cached', 'fallback', 'custom']),
+    deprecated: z.boolean().default(false),
+    metadata_updated_at: z.string().datetime({ offset: true }).nullable().default(null),
+  })
+  .strict()
+export type EmbeddingModelMetadata = z.infer<typeof EmbeddingModelMetadataSchema>
+
+// ----------------------------------------------------------------------
+// EmbeddingConfiguration
+// ----------------------------------------------------------------------
+
+const NullableDateTimeSchema = z
+  .string()
+  .datetime({ offset: true })
+  .nullable()
+  .default(null)
+
+export const EmbeddingConfigurationSchema = z
+  .object({
+    id: z.string().min(1),
+    provider_connection_id: z.string().min(1),
+    provider_kind: EmbeddingProviderKindSchema,
+    model_id: z.string().min(1),
+    dimensions: z.number().int().positive(),
+    scope: EmbeddingConfigurationScopeSchema,
+    project_id: z.string().min(1).nullable().default(null),
+    index_version: z.number().int().min(1),
+    status: EmbeddingConfigurationStatusSchema,
+    status_message: z.string().nullable().default(null),
+    created_at: z.string().datetime({ offset: true }),
+    updated_at: z.string().datetime({ offset: true }),
+    last_validated_at: NullableDateTimeSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.scope === 'project' && !value.project_id) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['project_id'],
+        message: 'project_id is required when scope="project"',
+      })
+    }
+    if (value.scope === 'global' && value.project_id !== null) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['project_id'],
+        message: 'project_id must be null when scope="global"',
+      })
+    }
+  })
+export type EmbeddingConfiguration = z.infer<typeof EmbeddingConfigurationSchema>
+
+export const EmbeddingConfigurationUpsertRequestSchema = z
+  .object({
+    provider_connection_id: z.string().min(1),
+    provider_kind: EmbeddingProviderKindSchema,
+    model_id: z.string().min(1),
+    dimensions: z.number().int().positive(),
+    scope: EmbeddingConfigurationScopeSchema,
+    project_id: z.string().min(1).nullable().default(null),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.scope === 'project' && !value.project_id) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['project_id'],
+        message: 'project_id is required when scope="project"',
+      })
+    }
+    if (value.scope === 'global' && value.project_id !== null) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['project_id'],
+        message: 'project_id must be null when scope="global"',
+      })
+    }
+  })
+export type EmbeddingConfigurationUpsertRequest = z.infer<
+  typeof EmbeddingConfigurationUpsertRequestSchema
+>
+
+export const EmbeddingConfigurationResponseSchema = z
+  .object({
+    configuration: EmbeddingConfigurationSchema,
+  })
+  .strict()
+export type EmbeddingConfigurationResponse = z.infer<
+  typeof EmbeddingConfigurationResponseSchema
+>
+
+export const EmbeddingConfigurationsListResponseSchema = z
+  .object({
+    configurations: z.array(EmbeddingConfigurationSchema),
+  })
+  .strict()
+export type EmbeddingConfigurationsListResponse = z.infer<
+  typeof EmbeddingConfigurationsListResponseSchema
+>
+
+// ----------------------------------------------------------------------
+// EmbeddingMigrationJob
+// ----------------------------------------------------------------------
+
+export const EmbeddingMigrationProgressSchema = z
+  .object({
+    total: z.number().int().min(0),
+    processed: z.number().int().min(0),
+    failed: z.number().int().min(0),
+    started_at: NullableDateTimeSchema,
+    finished_at: NullableDateTimeSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.finished_at && !value.started_at) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['started_at'],
+        message: 'started_at must be set if finished_at is set',
+      })
+    }
+    if (
+      value.started_at &&
+      value.finished_at &&
+      new Date(value.finished_at) < new Date(value.started_at)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['finished_at'],
+        message: 'finished_at cannot be before started_at',
+      });
+    }
+  })
+export type EmbeddingMigrationProgress = z.infer<
+  typeof EmbeddingMigrationProgressSchema
+>
+
+export const EmbeddingMigrationJobSchema = z
+  .object({
+    id: z.string().min(1),
+    configuration_id: z.string().min(1),
+    source_index_version: z.number().int().min(0), // 0 = Cold-Start-Sentinel
+    target_index_version: z.number().int().min(1),
+    status: EmbeddingMigrationStatusSchema,
+    progress: EmbeddingMigrationProgressSchema,
+    error_message: z.string().nullable().default(null),
+    created_at: z.string().datetime({ offset: true }),
+    updated_at: z.string().datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.source_index_version === 0 && value.target_index_version !== 1) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['source_index_version'],
+        message: 'Cold-Start-Sentinel: source_index_version=0 ist nur fuer target=1 zulaessig',
+      });
+    }
+    if (
+      value.source_index_version > 0 &&
+      value.source_index_version >= value.target_index_version
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['source_index_version'],
+        message: 'source_index_version muss kleiner als target_index_version sein',
+      });
+    }
+  })
+export type EmbeddingMigrationJob = z.infer<typeof EmbeddingMigrationJobSchema>
+
+export const EmbeddingMigrationJobResponseSchema = z
+  .object({
+    job: EmbeddingMigrationJobSchema,
+  })
+  .strict()
+export type EmbeddingMigrationJobResponse = z.infer<
+  typeof EmbeddingMigrationJobResponseSchema
+>
+
+export const EmbeddingMigrationJobsListResponseSchema = z
+  .object({
+    jobs: z.array(EmbeddingMigrationJobSchema),
+  })
+  .strict()
+export type EmbeddingMigrationJobsListResponse = z.infer<
+  typeof EmbeddingMigrationJobsListResponseSchema
+>
+
+// ----------------------------------------------------------------------
+// EmbeddingIndexVersion
+// ----------------------------------------------------------------------
+
+export const EmbeddingIndexVersionSchema = z
+  .object({
+    version: z.number().int().min(1),
+    provider_connection_id: z.string().min(1),
+    model_id: z.string().min(1),
+    dimensions: z.number().int().positive(),
+    index_name: z.string().min(1),
+    property_key: z.string().min(1),
+    status: EmbeddingIndexStatusSchema,
+    created_at: z.string().datetime({ offset: true }),
+    retired_at: NullableDateTimeSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.status === 'retired' && !value.retired_at) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['retired_at'],
+        message: 'retired_at is required when status="retired"',
+      });
+    }
+    if (value.status !== 'retired' && value.retired_at) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['retired_at'],
+        message: 'retired_at must be null when status is not "retired"',
+      });
+    }
+  })
+export type EmbeddingIndexVersion = z.infer<typeof EmbeddingIndexVersionSchema>
+
+// ----------------------------------------------------------------------
+// Ollama-Pull-Report
+// ----------------------------------------------------------------------
+
+export const OllamaPullReportSchema = z
+  .object({
+    model: z.string().min(1),
+    status: z.enum(['success', 'error']),
+    digest: z.string().nullable().default(null),
+    total_bytes: z.number().int().min(0),
+    completed_bytes: z.number().int().min(0),
+    error_message: z.string().nullable().default(null),
+    layers_downloaded: z.number().int().min(0),
+  })
+  .strict()
+export type OllamaPullReport = z.infer<typeof OllamaPullReportSchema>
+
+export const OllamaPullReportResponseSchema = z
+  .object({
+    report: OllamaPullReportSchema,
+  })
+  .strict()
+export type OllamaPullReportResponse = z.infer<
+  typeof OllamaPullReportResponseSchema
+>

--- a/frontend/src/store/embeddingConfigurations.ts
+++ b/frontend/src/store/embeddingConfigurations.ts
@@ -1,0 +1,204 @@
+/**
+ * Pinia-Store fuer Embedding-Konfigurationen (Slice 4.2 + 4.3.2).
+ *
+ * Speichert die kanonischen Konfigurationen, den aktiven Migrations-
+ * Job pro Konfiguration (read-only mirror) und den Pinia-Status.
+ *
+ * Konvention: das Store liest die aktive Konfiguration ueber die
+ * ``/active``-Route (mit ``source: "store" | "legacy" | "none"``) und
+ * faellt nur dann auf Legacy zurueck, wenn der Server explizit
+ * ``"source": "legacy"`` meldet. Aufrufer muessen das in der UI
+ * sichtbar machen.
+ */
+import { defineStore } from "pinia";
+import * as api from "@/api/embeddingConfigurations";
+import * as migrationApi from "@/api/embeddingMigrations";
+import type {
+  EmbeddingConfiguration,
+  EmbeddingConfigurationScope,
+  EmbeddingMigrationJob,
+  EmbeddingProviderKind,
+  OllamaPullReport,
+} from "@/contracts/embeddingContract";
+
+interface EmbeddingConfigurationsState {
+  configurations: EmbeddingConfiguration[];
+  configurationsLoading: boolean;
+  configurationsError: string | null;
+
+  activeConfiguration: EmbeddingConfiguration | null;
+  activeSource: "store" | "legacy" | "none";
+  activeLoading: boolean;
+  activeError: string | null;
+
+  /**
+   * Read-only mirror des aktuellen Migrations-Jobs pro
+   * Konfiguration. Nicht persistent — wird bei jedem
+   * ``loadActiveConfiguration()`` neu geladen.
+   */
+  migrationByConfiguration: Record<string, EmbeddingMigrationJob | null>;
+
+  /**
+   * Laufzeit-Cache fuer den zuletzt aufgetretenen Ollama-Pull-Report.
+   * Wird vom Ollama-Download-Wizard geschrieben, von der View gelesen.
+   */
+  lastOllamaPull: OllamaPullReport | null;
+}
+
+export const useEmbeddingConfigurationsStore = defineStore(
+  "embeddingConfigurations",
+  {
+    state: (): EmbeddingConfigurationsState => ({
+      configurations: [],
+      configurationsLoading: false,
+      configurationsError: null,
+      activeConfiguration: null,
+      activeSource: "none",
+      activeLoading: false,
+      activeError: null,
+      migrationByConfiguration: {},
+      lastOllamaPull: null,
+    }),
+
+    getters: {
+      activeGlobalConfiguration(state): EmbeddingConfiguration | null {
+        if (!state.activeConfiguration) return null;
+        if (state.activeConfiguration.scope !== "global") return null;
+        return state.activeConfiguration;
+      },
+      hasActiveConfiguration(state): boolean {
+        return state.activeConfiguration !== null;
+      },
+    },
+
+    actions: {
+      async loadConfigurations(
+        scope?: EmbeddingConfigurationScope,
+      ): Promise<void> {
+        this.configurationsLoading = true;
+        this.configurationsError = null;
+        try {
+          const resp = await api.listEmbeddingConfigurations(scope);
+          this.configurations = resp.configurations;
+        } catch (err) {
+          this.configurationsError = errorMessage(err);
+        } finally {
+          this.configurationsLoading = false;
+        }
+      },
+
+      async loadActiveConfiguration(): Promise<void> {
+        this.activeLoading = true;
+        this.activeError = null;
+        try {
+          const resp = await api.getActiveEmbeddingConfiguration();
+          this.activeConfiguration = resp.configuration;
+          this.activeSource = resp.source;
+        } catch (err) {
+          this.activeError = errorMessage(err);
+        } finally {
+          this.activeLoading = false;
+        }
+      },
+
+      async upsertConfiguration(
+        configurationId: "new" | string,
+        payload: {
+          provider_connection_id: string;
+          provider_kind: EmbeddingProviderKind;
+          model_id: string;
+          dimensions: number;
+          scope: EmbeddingConfigurationScope;
+          project_id: string | null;
+        },
+      ): Promise<EmbeddingConfiguration> {
+        const created = await api.upsertEmbeddingConfiguration(
+          configurationId,
+          payload,
+        );
+        await this.loadConfigurations();
+        return created;
+      },
+
+      async deleteConfiguration(configurationId: string): Promise<void> {
+        await api.deleteEmbeddingConfiguration(configurationId);
+        await this.loadConfigurations();
+        if (this.activeConfiguration?.id === configurationId) {
+          this.activeConfiguration = null;
+          this.activeSource = "none";
+        }
+      },
+
+      async testConfiguration(
+        configurationId: string,
+      ): Promise<{
+        configuration: EmbeddingConfiguration;
+        probe: {
+          status:
+            | "available"
+            | "unavailable"
+            | "invalid_credentials"
+            | "degraded"
+            | "unsupported";
+          status_message: string | null;
+          actual_dimensions: number | null;
+        };
+      }> {
+        return await api.testEmbeddingConfiguration(configurationId);
+      },
+
+      async activateConfiguration(
+        configurationId: string,
+      ): Promise<EmbeddingConfiguration> {
+        const activated = await api.activateEmbeddingConfiguration(
+          configurationId,
+        );
+        await this.loadActiveConfiguration();
+        return activated;
+      },
+
+      // ----------------------------------------------------------------
+      // Migrations (Slice 4.3)
+      // ----------------------------------------------------------------
+
+      async startMigration(
+        configurationId: string,
+      ): Promise<EmbeddingMigrationJob> {
+        const job = await migrationApi.startEmbeddingMigration({
+          configuration_id: configurationId,
+        });
+        this.migrationByConfiguration[configurationId] = job;
+        return job;
+      },
+
+      async runMigration(jobId: string): Promise<EmbeddingMigrationJob> {
+        const job = await migrationApi.runEmbeddingMigration(jobId);
+        const configId = job.configuration_id;
+        this.migrationByConfiguration[configId] = job;
+        return job;
+      },
+
+      async cancelMigration(jobId: string): Promise<EmbeddingMigrationJob> {
+        const job = await migrationApi.cancelEmbeddingMigration(jobId);
+        const configId = job.configuration_id;
+        this.migrationByConfiguration[configId] = job;
+        return job;
+      },
+
+      async pullOllamaEmbeddingModel(
+        payload: { model: string; configuration_id?: string },
+      ): Promise<OllamaPullReport> {
+        const report = await migrationApi.pullOllamaEmbeddingModel(payload);
+        this.lastOllamaPull = report;
+        return report;
+      },
+    },
+  },
+);
+
+function errorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    return String((err as { message?: unknown }).message ?? err);
+  }
+  return String(err);
+}

--- a/frontend/src/store/embeddingConfigurations.ts
+++ b/frontend/src/store/embeddingConfigurations.ts
@@ -144,7 +144,12 @@ export const useEmbeddingConfigurationsStore = defineStore(
           actual_dimensions: number | null;
         };
       }> {
-        return await api.testEmbeddingConfiguration(configurationId);
+        const res = await api.testEmbeddingConfiguration(configurationId);
+        // Gemini-Finding (MEDIUM): Probe aktualisiert den Konfigurations-
+        // Status serverseitig (proposed -> probed/failed). Konfigurationen
+        // neu laden, damit der UI-Status sofort stimmt.
+        await this.loadConfigurations();
+        return res;
       },
 
       async activateConfiguration(
@@ -153,7 +158,14 @@ export const useEmbeddingConfigurationsStore = defineStore(
         const activated = await api.activateEmbeddingConfiguration(
           configurationId,
         );
-        await this.loadActiveConfiguration();
+        // Gemini-Finding (HIGH): Activate rollt andere aktive
+        // Konfigurationen desselben Scopes auf rolled_back zurueck.
+        // Sowohl die active-Konfiguration als auch die Liste
+        // muessen neu geladen werden, damit der UI-State stimmt.
+        await Promise.all([
+          this.loadActiveConfiguration(),
+          this.loadConfigurations(),
+        ]);
         return activated;
       },
 
@@ -175,6 +187,14 @@ export const useEmbeddingConfigurationsStore = defineStore(
         const job = await migrationApi.runEmbeddingMigration(jobId);
         const configId = job.configuration_id;
         this.migrationByConfiguration[configId] = job;
+        // Gemini-Finding (HIGH): Bei completed schaltet das Backend die
+        // aktive Konfiguration auf den neuen Index. Active und Liste
+        // muessen neu geladen werden, damit die UI den Wechsel
+        // sofort zeigt.
+        await Promise.all([
+          this.loadActiveConfiguration(),
+          this.loadConfigurations(),
+        ]);
         return job;
       },
 

--- a/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
+++ b/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
@@ -1,0 +1,393 @@
+<script setup lang="ts">
+/**
+ * EmbeddingConfigurationsView — kanonische Embedding-Konfiguration.
+ *
+ * Slice 4.2 + 4.3.2. Zeigt fuer jede Konfiguration:
+ *   - Status-Badge (proposed / probed / reembedding / validated / active /
+ *     rolled_back / failed) — siehe EmbeddingConfigurationStatus
+ *   - Modell + Dimension + Provider-Connection-Ref
+ *   - Probe-Button (POST /test) und Activate-Button (POST /activate)
+ *   - Migrations-Section: Start / Run / Cancel, Progress-Anzeige
+ *   - Ollama-Download-Wizard (Modal): Modell-Name mit strikter
+ *     Client-Validierung, der mit der Server-Validierung gespiegelt ist.
+ *
+ * Klartext-API-Keys verlassen dieses View NIE: der Provider-Connection-
+ * Link referenziert nur die provider_connection_id; die Keys liegen im
+ * Backend-Secret-Store.
+ */
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppShell from '@/components/v4/shell/AppShell.vue'
+import PageHeader from '@/components/v4/shell/PageHeader.vue'
+import Card from '@/components/v4/forms/Card.vue'
+import Badge from '@/components/v4/forms/Badge.vue'
+import { useEmbeddingConfigurationsStore } from '@/store/embeddingConfigurations'
+import type { EmbeddingConfiguration, EmbeddingMigrationJob } from '@/contracts/embeddingContract'
+
+const { t } = useI18n()
+
+const store = useEmbeddingConfigurationsStore()
+
+const BREADCRUMBS = [
+  { label: 'Settings', to: { name: 'SettingsGeneral' } },
+  { label: t('settings.v4.embedding.title', 'Embedding-Konfiguration') },
+]
+
+const STATUS_TONE: Record<string, 'gray' | 'green' | 'orange' | 'red' | 'blue' | 'teal'> = {
+  proposed: 'gray',
+  probed: 'blue',
+  reembedding: 'orange',
+  validated: 'orange',
+  active: 'green',
+  rolled_back: 'orange',
+  failed: 'red',
+}
+
+const STATUS_LABEL_KEY: Record<string, string> = {
+  proposed: 'embedding.status.proposed',
+  probed: 'embedding.status.probed',
+  reembedding: 'embedding.status.reembedding',
+  validated: 'embedding.status.validated',
+  active: 'embedding.status.active',
+  rolled_back: 'embedding.status.rolled_back',
+  failed: 'embedding.status.failed',
+}
+
+// Ollama-Download-Wizard (Modal)
+interface OllamaPullDraft {
+  model: string;
+  configurationId: string | null;
+  isPulling: boolean;
+  lastError: string | null;
+}
+
+const ollamaDraft = reactive<OllamaPullDraft>({
+  model: '',
+  configurationId: null,
+  isPulling: false,
+  lastError: null,
+});
+
+const ollamaModalOpen = ref(false);
+
+function openOllamaModal(): void {
+  ollamaDraft.model = '';
+  ollamaDraft.configurationId = null;
+  ollamaDraft.lastError = null;
+  ollamaModalOpen.value = true;
+}
+
+async function submitOllamaPull(): Promise<void> {
+  if (!ollamaDraft.model) {
+    ollamaDraft.lastError = 'Model-Name ist erforderlich';
+    return;
+  }
+  ollamaDraft.isPulling = true;
+  ollamaDraft.lastError = null;
+  try {
+    await store.pullOllamaEmbeddingModel({
+      model: ollamaDraft.model,
+      configuration_id: ollamaDraft.configurationId ?? undefined,
+    });
+    ollamaModalOpen.value = false;
+  } catch (err) {
+    ollamaDraft.lastError = errorMessage(err);
+  } finally {
+    ollamaDraft.isPulling = false;
+  }
+}
+
+const isOllama = (config: EmbeddingConfiguration): boolean =>
+  config.provider_kind === 'ollama' || config.provider_kind === 'ollama_cloud';
+
+onMounted(async () => {
+  await Promise.all([store.loadConfigurations(), store.loadActiveConfiguration()]);
+});
+
+const progressPct = (job: EmbeddingMigrationJob): number => {
+  if (job.progress.total <= 0) return 0;
+  return Math.round(
+    ((job.progress.processed + job.progress.failed) / job.progress.total) * 100,
+  );
+};
+
+const migrationFor = (
+  config: EmbeddingConfiguration,
+): EmbeddingMigrationJob | null => {
+  return store.migrationByConfiguration[config.id] ?? null;
+};
+
+async function runTest(config: EmbeddingConfiguration): Promise<void> {
+  await store.testConfiguration(config.id);
+  await store.loadConfigurations();
+}
+
+async function runActivate(config: EmbeddingConfiguration): Promise<void> {
+  await store.activateConfiguration(config.id);
+}
+
+async function runStartMigration(config: EmbeddingConfiguration): Promise<void> {
+  const job = await store.startMigration(config.id);
+  await store.runMigration(job.id);
+  await store.loadActiveConfiguration();
+}
+
+async function runCancelMigration(job: EmbeddingMigrationJob): Promise<void> {
+  await store.cancelMigration(job.id);
+}
+
+function errorMessage(err: unknown): string {
+  if (err && typeof err === 'object' && 'message' in err) {
+    return String((err as { message?: unknown }).message ?? err);
+  }
+  return String(err);
+}
+</script>
+
+<template>
+  <AppShell>
+    <PageHeader :breadcrumbs="BREADCRUMBS" :title="$t('settings.v4.embedding.title', 'Embedding-Konfiguration')">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        data-testid="open-ollama-pull"
+        @click="openOllamaModal"
+      >
+        {{ $t('embedding.ollama.download', 'Ollama-Modell herunterladen') }}
+      </button>
+    </PageHeader>
+
+    <section class="grid gap-4">
+      <Card
+        v-if="store.configurationsError"
+        tone="danger"
+        :title="$t('embedding.list.error', 'Konfigurationen konnten nicht geladen werden')"
+      >
+        {{ store.configurationsError }}
+      </Card>
+
+      <Card
+        v-if="store.activeConfiguration && !store.configurationsLoading"
+        tone="success"
+        :title="$t('embedding.active.title', 'Aktive Konfiguration')"
+      >
+        <p>
+          <strong>{{ store.activeConfiguration.model_id }}</strong>
+          ({{ store.activeConfiguration.dimensions }}d, {{ store.activeConfiguration.provider_kind }})
+        </p>
+        <p v-if="store.activeSource === 'legacy'" class="text-warn">
+          {{ $t('embedding.active.legacyHint', 'Quelle: Legacy Config.EMBEDDING_* — bitte uebernehmen.') }}
+        </p>
+      </Card>
+
+      <Card
+        v-for="config in store.configurations"
+        :key="config.id"
+        :title="`${config.model_id} (${config.dimensions}d)`"
+      >
+        <div class="config-row">
+          <Badge :tone="STATUS_TONE[config.status] || 'neutral'">
+            {{ $t(STATUS_LABEL_KEY[config.status] || 'embedding.status.unknown', config.status) }}
+          </Badge>
+          <span class="config-meta">
+            {{ config.provider_kind }} ·
+            scope={{ config.scope }}{{ config.project_id ? `:${config.project_id}` : '' }} ·
+            index_version={{ config.index_version }}
+          </span>
+        </div>
+
+        <p v-if="config.status_message" class="text-warn">
+          {{ config.status_message }}
+        </p>
+
+        <div class="config-actions">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            :disabled="config.status === 'failed'"
+            data-testid="probe-config"
+            @click="runTest(config)"
+          >
+            {{ $t('embedding.action.test', 'Probe') }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            :disabled="config.status !== 'probed' && config.status !== 'rolled_back'"
+            data-testid="activate-config"
+            @click="runActivate(config)"
+          >
+            {{ $t('embedding.action.activate', 'Aktivieren') }}
+          </button>
+        </div>
+
+        <!-- Migrations-Section -->
+        <div class="migration-section" v-if="config.status === 'probed' || migrationFor(config)">
+          <h4>{{ $t('embedding.migration.title', 'Re-Embedding-Migration') }}</h4>
+          <p v-if="!migrationFor(config)">
+            {{ $t('embedding.migration.intro', 'Migration starten, um die Embedding-Dimension oder das Modell zu wechseln.') }}
+          </p>
+          <template v-else>
+            <div class="migration-row">
+              <span class="job-id">{{ migrationFor(config)!.id }}</span>
+              <Badge :tone="STATUS_TONE[migrationFor(config)!.status] || 'neutral'">
+                {{ $t(STATUS_LABEL_KEY[migrationFor(config)!.status] || 'embedding.status.unknown') }}
+              </Badge>
+            </div>
+            <progress :value="progressPct(migrationFor(config)!)" max="100" />
+            <p>
+              {{ migrationFor(config)!.progress.processed }} / {{ migrationFor(config)!.progress.total }}
+              ({{ migrationFor(config)!.progress.failed }} fehlgeschlagen)
+            </p>
+            <p v-if="migrationFor(config)!.error_message" class="text-warn">
+              {{ migrationFor(config)!.error_message }}
+            </p>
+          </template>
+          <div class="config-actions">
+            <button
+              v-if="!migrationFor(config)"
+              type="button"
+              class="btn btn-primary"
+              data-testid="start-migration"
+              @click="runStartMigration(config)"
+            >
+              {{ $t('embedding.migration.start', 'Migration starten') }}
+            </button>
+            <button
+              v-if="migrationFor(config) && (migrationFor(config)!.status === 'pending' || migrationFor(config)!.status === 'running' || migrationFor(config)!.status === 'validating')"
+              type="button"
+              class="btn btn-secondary"
+              data-testid="cancel-migration"
+              @click="runCancelMigration(migrationFor(config)!)"
+            >
+              {{ $t('embedding.migration.cancel', 'Abbrechen') }}
+            </button>
+            <button
+              v-if="isOllama(config)"
+              type="button"
+              class="btn btn-secondary"
+              data-testid="open-ollama-pull-inline"
+              @click="openOllamaModal"
+            >
+              {{ $t('embedding.ollama.downloadInline', 'Ollama-Modell hier herunterladen') }}
+            </button>
+          </div>
+        </div>
+      </Card>
+
+      <p v-if="!store.configurationsLoading && store.configurations.length === 0">
+        {{ $t('embedding.list.empty', 'Noch keine Embedding-Konfigurationen vorhanden.') }}
+      </p>
+    </section>
+
+    <!-- Ollama-Download-Modal -->
+    <div v-if="ollamaModalOpen" class="modal-backdrop" @click.self="ollamaModalOpen = false">
+      <div class="modal" data-testid="ollama-pull-modal">
+        <h3>{{ $t('embedding.ollama.title', 'Ollama-Modell herunterladen') }}</h3>
+        <p class="text-muted">
+          {{ $t('embedding.ollama.hint', 'Modell-Name muss ASCII a-z, A-Z, 0-9, -, _, ., : enthalten (max 100 Zeichen).') }}
+        </p>
+        <label>
+          {{ $t('embedding.ollama.model', 'Modell-Name') }}
+          <input
+            v-model="ollamaDraft.model"
+            type="text"
+            data-testid="ollama-pull-model"
+            placeholder="nomic-embed-text"
+          />
+        </label>
+        <label>
+          {{ $t('embedding.ollama.configurationId', 'Provider-Connection (optional)') }}
+          <select v-model="ollamaDraft.configurationId" data-testid="ollama-pull-connection">
+            <option :value="null">{{ $t('embedding.ollama.autoSelect', 'Auto (erste Ollama-Connection)') }}</option>
+            <option v-for="config in store.configurations" :key="config.id" :value="config.provider_connection_id">
+              {{ config.provider_connection_id }} ({{ config.provider_kind }})
+            </option>
+          </select>
+        </label>
+        <p v-if="ollamaDraft.lastError" class="text-warn">
+          {{ ollamaDraft.lastError }}
+        </p>
+        <div class="modal-actions">
+          <button type="button" class="btn btn-secondary" @click="ollamaModalOpen = false">
+            {{ $t('common.cancel', 'Abbrechen') }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            :disabled="ollamaDraft.isPulling || !ollamaDraft.model"
+            data-testid="ollama-pull-submit"
+            @click="submitOllamaPull"
+          >
+            {{ $t('embedding.ollama.submit', 'Download starten') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </AppShell>
+</template>
+
+<style scoped>
+.config-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+.config-meta {
+  color: var(--text-muted, #6b7280);
+  font-size: 0.875rem;
+}
+.config-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+.migration-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-default, #e5e7eb);
+}
+.migration-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.job-id {
+  font-family: monospace;
+  font-size: 0.875rem;
+  color: var(--text-muted, #6b7280);
+}
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.modal {
+  background: var(--bg-elevated, #fff);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  width: min(32rem, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.text-warn {
+  color: var(--text-warn, #d97706);
+}
+.text-muted {
+  color: var(--text-muted, #6b7280);
+}
+</style>

--- a/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
+++ b/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
@@ -70,6 +70,17 @@ const ollamaDraft = reactive<OllamaPullDraft>({
 
 const ollamaModalOpen = ref(false);
 
+// Gemini-Finding (HIGH): die Helferfunktion ``migration``
+// wurde pro Render-Zyklus 15 Mal pro Konfiguration aufgerufen. Das
+// ist teuer und unnoetig — eine computed-Eigenschaft berechnet das
+// Mapping einmal pro Store-Aenderung.
+const configsWithMigrations = computed(() =>
+  store.configurations.map((config) => ({
+    config,
+    migration: store.migrationByConfiguration[config.id] ?? null,
+  })),
+);
+
 function openOllamaModal(): void {
   ollamaDraft.model = '';
   ollamaDraft.configurationId = null;
@@ -111,15 +122,10 @@ const progressPct = (job: EmbeddingMigrationJob): number => {
   );
 };
 
-const migrationFor = (
-  config: EmbeddingConfiguration,
-): EmbeddingMigrationJob | null => {
-  return store.migrationByConfiguration[config.id] ?? null;
-};
-
 async function runTest(config: EmbeddingConfiguration): Promise<void> {
+  // Gemini-Finding (MEDIUM): testConfiguration laedt die Liste
+  // bereits automatisch neu.
   await store.testConfiguration(config.id);
-  await store.loadConfigurations();
 }
 
 async function runActivate(config: EmbeddingConfiguration): Promise<void> {
@@ -127,9 +133,10 @@ async function runActivate(config: EmbeddingConfiguration): Promise<void> {
 }
 
 async function runStartMigration(config: EmbeddingConfiguration): Promise<void> {
+  // Gemini-Finding (MEDIUM): runMigration laedt active und Liste
+  // automatisch neu.
   const job = await store.startMigration(config.id);
   await store.runMigration(job.id);
-  await store.loadActiveConfiguration();
 }
 
 async function runCancelMigration(job: EmbeddingMigrationJob): Promise<void> {
@@ -137,8 +144,21 @@ async function runCancelMigration(job: EmbeddingMigrationJob): Promise<void> {
 }
 
 function errorMessage(err: unknown): string {
-  if (err && typeof err === 'object' && 'message' in err) {
-    return String((err as { message?: unknown }).message ?? err);
+  // Gemini-Finding (MEDIUM): Pydantic-/Zod-ValidationError haben ein
+  // ``issues``-Array mit sprechenden Meldungen. Statt das rohe
+  // JSON-String-Repraesentat anzuzeigen, geben wir die erste
+  // Issue-Message zurueck.
+  if (err && typeof err === 'object') {
+    if ('issues' in err && Array.isArray((err as { issues?: unknown }).issues)) {
+      const firstIssue = (err as { issues: Array<{ message?: unknown }> })
+        .issues[0];
+      if (firstIssue && typeof firstIssue === 'object' && 'message' in firstIssue) {
+        return String(firstIssue.message);
+      }
+    }
+    if ('message' in err) {
+      return String((err as { message?: unknown }).message ?? err);
+    }
   }
   return String(err);
 }
@@ -181,7 +201,7 @@ function errorMessage(err: unknown): string {
       </Card>
 
       <Card
-        v-for="config in store.configurations"
+        v-for="{ config, migration } in configsWithMigrations"
         :key="config.id"
         :title="`${config.model_id} (${config.dimensions}d)`"
       >
@@ -222,30 +242,30 @@ function errorMessage(err: unknown): string {
         </div>
 
         <!-- Migrations-Section -->
-        <div class="migration-section" v-if="config.status === 'probed' || migrationFor(config)">
+        <div class="migration-section" v-if="config.status === 'probed' || migration">
           <h4>{{ $t('embedding.migration.title', 'Re-Embedding-Migration') }}</h4>
-          <p v-if="!migrationFor(config)">
+          <p v-if="!migration">
             {{ $t('embedding.migration.intro', 'Migration starten, um die Embedding-Dimension oder das Modell zu wechseln.') }}
           </p>
           <template v-else>
             <div class="migration-row">
-              <span class="job-id">{{ migrationFor(config)!.id }}</span>
-              <Badge :tone="STATUS_TONE[migrationFor(config)!.status] || 'neutral'">
-                {{ $t(STATUS_LABEL_KEY[migrationFor(config)!.status] || 'embedding.status.unknown') }}
+              <span class="job-id">{{ migration!.id }}</span>
+              <Badge :tone="STATUS_TONE[migration!.status] || 'neutral'">
+                {{ $t(STATUS_LABEL_KEY[migration!.status] || 'embedding.status.unknown') }}
               </Badge>
             </div>
-            <progress :value="progressPct(migrationFor(config)!)" max="100" />
+            <progress :value="progressPct(migration!)" max="100" />
             <p>
-              {{ migrationFor(config)!.progress.processed }} / {{ migrationFor(config)!.progress.total }}
-              ({{ migrationFor(config)!.progress.failed }} fehlgeschlagen)
+              {{ migration!.progress.processed }} / {{ migration!.progress.total }}
+              ({{ migration!.progress.failed }} fehlgeschlagen)
             </p>
-            <p v-if="migrationFor(config)!.error_message" class="text-warn">
-              {{ migrationFor(config)!.error_message }}
+            <p v-if="migration!.error_message" class="text-warn">
+              {{ migration!.error_message }}
             </p>
           </template>
           <div class="config-actions">
             <button
-              v-if="!migrationFor(config)"
+              v-if="!migration"
               type="button"
               class="btn btn-primary"
               data-testid="start-migration"
@@ -254,11 +274,11 @@ function errorMessage(err: unknown): string {
               {{ $t('embedding.migration.start', 'Migration starten') }}
             </button>
             <button
-              v-if="migrationFor(config) && (migrationFor(config)!.status === 'pending' || migrationFor(config)!.status === 'running' || migrationFor(config)!.status === 'validating')"
+              v-if="migration && (migration!.status === 'pending' || migration!.status === 'running' || migration!.status === 'validating')"
               type="button"
               class="btn btn-secondary"
               data-testid="cancel-migration"
-              @click="runCancelMigration(migrationFor(config)!)"
+              @click="runCancelMigration(migration as EmbeddingMigrationJob)"
             >
               {{ $t('embedding.migration.cancel', 'Abbrechen') }}
             </button>
@@ -300,7 +320,7 @@ function errorMessage(err: unknown): string {
           {{ $t('embedding.ollama.configurationId', 'Provider-Connection (optional)') }}
           <select v-model="ollamaDraft.configurationId" data-testid="ollama-pull-connection">
             <option :value="null">{{ $t('embedding.ollama.autoSelect', 'Auto (erste Ollama-Connection)') }}</option>
-            <option v-for="config in store.configurations" :key="config.id" :value="config.provider_connection_id">
+            <option v-for="{ config } in configsWithMigrations" :key="config.id" :value="config.provider_connection_id">
               {{ config.provider_connection_id }} ({{ config.provider_kind }})
             </option>
           </select>


### PR DESCRIPTION
## Sub-Slice 4.3.2 des Onboarding/Provider-Unification-Epics

Frontend-Teil von Slice 4.3 (Backend war #689). Setzt die Slice-4.2-Backend-API in einen Pinia-Store, eine Settings-View und strikte Zod-Schemas.

### Added

- **Zod-Spiegel** der Backend-Embedding-Contracts in `frontend/src/contracts/embeddingContract.ts` mit strukturellen `.superRefine()`-Regeln (Scope<->project_id, Source/Target-Version, Timestamp-Invarianten, Cold-Start-Sentinel)
- **12 Zod-Contract-Tests** pinnen die Backend-Constraints
- **API-Clients** für Konfigurationen (`embeddingConfigurations.ts`) und Migrationen + Ollama-Pull (`embeddingMigrations.ts`) mit strikter Response-Grenzen-Validierung
- **Pinia-Store** (`store/embeddingConfigurations.ts`) mit List/CRUD/Probe/Activate + Migration-Lifecycle + Ollama-Pull-Cache
- **Settings-View** (`EmbeddingConfigurationsView.vue`) mit Status-Badges, Probe/Activate-Buttons, Migrations-Section mit Progress-Bar, Ollama-Download-Modal mit Client-validiertem Model-Namen
- **Router-Hinweis**: View wird via `SettingsEmbedding` eingebunden (Slice-3-Pattern: `SettingsProfile` etc. — bitte ggf. Router-Eintrag ergänzen, falls noch nicht vorhanden)

### Tests

| Test-Datei | Anzahl |
|---|---|
| `embeddingContract.spec.ts` | 12 |
| **Total (Frontend-neu)** | **12** |

### Gates (lokal Exit 0)

| Gate | Ergebnis |
|---|---|
| Backend pytest | 3222 passed / 9 skipped / 7 deselected (unverändert) |
| Frontend vitest | 154 Testdateien / 1229+ Tests grün |
| Frontend `bun run check` | lint + typecheck + coverage + build grün |
| Backend ruff | clean (16 unused-imports auto-fixed in 4.2/4.3.1-Tests) |
| mypy | 0 Fehler |
| Schema-Dump `--check` | 46/46 driftfrei |
| sync-status `--check` | grün |

### Sicherheit

- **Model-Name-Validierung** im Frontend (ASCII a-z, A-Z, 0-9, '-', '_', '.', ':', max 100 Zeichen) spiegelt die Server-Validierung → verhindert versehentliche Shell-Injection auf Modell-Bezeichnungs-Ebene, BEVOR der Request das Frontend verlässt.
- Klartext-API-Keys verlassen das View NIE. Der Provider-Connection-Link referenziert nur die `provider_connection_id`; die Keys liegen im Backend-Secret-Store.

### Bewusst offen (für Folge-Slices)

- **Router-Eintrag** für `EmbeddingConfigurationsView` (möglicherweise bereits in `router/index.ts` über `Settings`-Tab erreichbar — bitte beim Review prüfen)
- **i18n-Keys** sind als Default-Strings im Template hinterlegt; ein vollständiger Eintrag in `de.json`/`en.json` ist eine kleine Folge-Aufgabe
- **Onboarding-Schritt `embeddings`** an die echte Konfiguration anbinden (Sub-Slice 4.3.3)
- **Echte Neo4j-Re-Embedding-Engine** (Re-Embedder-Implementierung mit Neo4j-Read-Loop)
- **Pre-Push-Gate-Script** (`scripts/pre-push-gate.sh`) als Lehre aus PR #687 und #689 — sollte das nächste kleine Maintenance-Slice werden
