### PR TITLE
feat(onboarding): Onboarding-Step 'embeddings' an echte Embedding-Konfiguration anbinden (Slice 4.3.3)

### DIFF
--- a/backend/app/contracts/user_profile_contract.py
+++ b/backend/app/contracts/user_profile_contract.py
@@ -206,6 +206,14 @@ class OnboardingRequirements(BaseModel):
     # erst mit der Provider-Discovery in Slice 3.
     chat_model_configured: bool
     embedding_configured: bool
+    # Quelle der aktiven Embedding-Konfiguration (Slice 4.2 + 4.3.3):
+    # - "store": kanonische Konfiguration im EmbeddingConfigurationStore
+    # - "legacy": aus Config.EMBEDDING_* abgeleitet (kein Probe, ungeprueft)
+    # - "none": keine Konfiguration vorhanden
+    # Das Frontend nutzt das, um Legacy-Migrations-Hinweise und
+    # Ollama-Download-Aktionen anzuzeigen, statt nur ein boolean zu
+    # rendern.
+    embedding_source: str = "none"
 
 
 class OnboardingStatusResponse(BaseModel):

--- a/backend/app/services/onboarding_state_store.py
+++ b/backend/app/services/onboarding_state_store.py
@@ -232,14 +232,49 @@ def compute_onboarding_requirements() -> OnboardingRequirements:
     chat_model_configured = bool(
         settings.llm_model_name and settings.llm_model_name.strip()
     )
-    embedding_configured = (
-        bool(settings.embedding_model and settings.embedding_model.strip())
-        and (settings.vector_dim or 0) > 0
-    )
+    # Slice 4.2/4.3.3: Embedding-Completion jetzt aus dem kanonischen
+    # EmbeddingConfigurationStore, nicht mehr aus Config.EMBEDDING_*.
+    # Legacy-Werte zaehlen weiterhin als "configured" (siehe
+    # EmbeddingConfigurationService.get_active_global_configuration),
+    # aber die Quelle wird separat exponiert, damit das Frontend einen
+    # Legacy-Migrations-Hinweis zeigen kann.
+    try:
+        from app.services.embedding_configuration_store import (
+            EmbeddingConfigurationStore,
+        )
+
+        embedding_store = EmbeddingConfigurationStore()
+        active_embedding = embedding_store.get_active_global_configuration()
+        if active_embedding is not None:
+            embedding_configured = True
+            embedding_source = "store"
+        else:
+            # Kein kanonischer Eintrag. Pruefe Legacy (Config.EMBEDDING_*).
+            legacy_configured = bool(
+                settings.embedding_model and settings.embedding_model.strip()
+            ) and (settings.vector_dim or 0) > 0
+            embedding_configured = legacy_configured
+            embedding_source = "legacy" if legacy_configured else "none"
+    except (ImportError, OSError, ValueError, TypeError) as exc:
+        # Wenn der Embedding-Store nicht initialisiert werden kann
+        # (z. B. AGORA_DATA_DIR fehlt, oder das JSON ist korrupt),
+        # fallen wir auf die Legacy-Pruefung zurueck. Hartaer Fail
+        # wuerde das Onboarding in Produktion brechen, falls der
+        # Data-Dir temporaer wegfaellt — gewollt defensiv.
+        logger.warning(
+            "EmbeddingConfigurationStore nicht verfuegbar, fallback auf Legacy: %s",
+            exc,
+        )
+        legacy_configured = bool(
+            settings.embedding_model and settings.embedding_model.strip()
+        ) and (settings.vector_dim or 0) > 0
+        embedding_configured = legacy_configured
+        embedding_source = "legacy" if legacy_configured else "none"
     return OnboardingRequirements(
         profile_valid=profile_valid,
         chat_model_configured=chat_model_configured,
         embedding_configured=embedding_configured,
+        embedding_source=embedding_source,
     )
 
 

--- a/backend/tests/services/test_onboarding_state_store.py
+++ b/backend/tests/services/test_onboarding_state_store.py
@@ -274,3 +274,81 @@ class TestComputeOnboardingRequirementsSettings:
         )
         requirements = compute_onboarding_requirements()
         assert requirements.embedding_configured is False
+
+
+class TestComputeOnboardingRequirementsEmbeddingSource:
+    """Slice 4.3.3: ``embedding_source`` macht die Herkunft der aktiven
+    Embedding-Konfiguration explizit sichtbar (``store`` / ``legacy`` /
+    ``none``), damit das Onboarding-Frontend gezielt einen Legacy-Hinweis
+    und Migrations-Aktionen anzeigen kann.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+        reset_user_profile_store_for_tests()
+        yield
+        reset_user_profile_store_for_tests()
+
+    def test_embedding_source_none_when_legacy_blank(self, monkeypatch) -> None:
+        """Kein kanonischer Eintrag, keine Legacy-Config -> ``none``."""
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="qwen2.5:32b",
+                embedding_model="",
+                vector_dim=0,
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.embedding_configured is False
+        assert requirements.embedding_source == "none"
+
+    def test_embedding_source_legacy_when_only_legacy_settings(self, monkeypatch) -> None:
+        """Nur Config.EMBEDDING_* gesetzt -> ``legacy`` (Operator-Hinweis)."""
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="qwen2.5:32b",
+                embedding_model="nomic-embed-text",
+                vector_dim=768,
+            ),
+        )
+        requirements = compute_onboarding_requirements()
+        assert requirements.embedding_configured is True
+        assert requirements.embedding_source == "legacy"
+
+    def test_embedding_source_store_when_canonical_active(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Kanonische Konfiguration im Store aktiv -> ``store`` (Source of Truth)."""
+        from app.services.embedding_configuration_store import (
+            EmbeddingConfigurationStore,
+        )
+
+        monkeypatch.setattr(
+            "app.services.onboarding_state_store.get_settings",
+            lambda: SimpleNamespace(
+                llm_model_name="qwen2.5:32b",
+                embedding_model="nomic-embed-text",  # Legacy zusaetzlich gesetzt
+                vector_dim=768,
+            ),
+        )
+        # Direkt am Store (kein Service-Overhead) eine globale, aktive
+        # Konfiguration anlegen — reicht fuer die Source-Erkennung, weil
+        # ``compute_onboarding_requirements`` selbst nur den Store liest.
+        embedding_store = EmbeddingConfigurationStore(data_dir=tmp_path)
+        embedding_store.upsert_configuration(
+            configuration_id="emb-test-canonical",
+            provider_connection_id="conn-test",
+            provider_kind="ollama",
+            model_id="nomic-embed-text",
+            dimensions=768,
+            scope="global",
+            project_id=None,
+            status="active",
+        )
+
+        requirements = compute_onboarding_requirements()
+        assert requirements.embedding_configured is True
+        assert requirements.embedding_source == "store"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3236 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3239 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 154 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/components/v4/shell/Sidebar.vue
+++ b/frontend/src/components/v4/shell/Sidebar.vue
@@ -107,6 +107,7 @@ const settingsRouteNames = [
   'SettingsAuditLogs',
   'SettingsLlmRouting',
   'SettingsLlmProviders',
+  'SettingsEmbedding',
 ]
 
 const navWorkspace = [
@@ -126,6 +127,7 @@ const navSettings: NavSettingsItem[] = [
   { id: 'audit',         label: t('sidebar.settings.auditLogs'),     to: { name: 'SettingsAuditLogs' } },
   { id: 'llm-providers', label: t('sidebar.settings.llmProviders'),  to: { name: 'SettingsLlmProviders' } },
   { id: 'llm-routing',   label: t('sidebar.settings.llmRouting'),    to: { name: 'SettingsLlmRouting' } },
+  { id: 'embedding',     label: t('sidebar.settings.embedding'),     to: { name: 'SettingsEmbedding' } },
 ]
 </script>
 

--- a/frontend/src/components/v4/shell/__tests__/testRouter.ts
+++ b/frontend/src/components/v4/shell/__tests__/testRouter.ts
@@ -23,6 +23,7 @@ const BASE_ROUTES: RouteRecordRaw[] = [
   { path: '/settings/audit-logs',    name: 'SettingsAuditLogs',   component: stub },
   { path: '/settings/llm-providers', name: 'SettingsLlmProviders',component: stub },
   { path: '/settings/llm-routing',   name: 'SettingsLlmRouting',  component: stub },
+  { path: '/settings/embedding',     name: 'SettingsEmbedding',   component: stub },
   { path: '/onboarding',             name: 'Onboarding',          component: stub },
 ]
 

--- a/frontend/src/contracts/__tests__/userProfileContract.spec.ts
+++ b/frontend/src/contracts/__tests__/userProfileContract.spec.ts
@@ -155,6 +155,7 @@ describe('canonical user-profile / onboarding contracts', () => {
         profile_valid: false,
         chat_model_configured: false,
         embedding_configured: false,
+        embedding_source: 'none',
       },
       onboarding_required: true,
     })
@@ -163,6 +164,38 @@ describe('canonical user-profile / onboarding contracts', () => {
 
   it('rejects OnboardingRequirements with missing required fields', () => {
     expect(OnboardingRequirementsSchema.safeParse({ profile_valid: true }).success).toBe(false)
+  })
+
+  it.each(['store', 'legacy', 'none'] as const)(
+    'accepts OnboardingRequirements.embedding_source = %s',
+    (source) => {
+      const result = OnboardingRequirementsSchema.safeParse({
+        profile_valid: true,
+        chat_model_configured: true,
+        embedding_configured: true,
+        embedding_source: source,
+      })
+      expect(result.success).toBe(true)
+    },
+  )
+
+  it('rejects unknown embedding_source literal (Slice 4.3.3 enum closed)', () => {
+    const result = OnboardingRequirementsSchema.safeParse({
+      profile_valid: true,
+      chat_model_configured: true,
+      embedding_configured: true,
+      embedding_source: 'unknown-source',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects OnboardingRequirements with missing embedding_source', () => {
+    const result = OnboardingRequirementsSchema.safeParse({
+      profile_valid: true,
+      chat_model_configured: true,
+      embedding_configured: true,
+    })
+    expect(result.success).toBe(false)
   })
 
   it('accepts a canonical OnboardingStepUpdateRequest with and without operating_mode', () => {

--- a/frontend/src/contracts/userProfileContract.ts
+++ b/frontend/src/contracts/userProfileContract.ts
@@ -135,6 +135,11 @@ export const OnboardingRequirementsSchema = z
     profile_valid: z.boolean(),
     chat_model_configured: z.boolean(),
     embedding_configured: z.boolean(),
+    // Quelle der aktiven Embedding-Konfiguration (Slice 4.2 + 4.3.3):
+    // - "store": kanonische Konfiguration im EmbeddingConfigurationStore
+    // - "legacy": aus Config.EMBEDDING_* abgeleitet (kein Probe)
+    // - "none": keine Konfiguration vorhanden
+    embedding_source: z.enum(['store', 'legacy', 'none']),
   })
   .strict()
 export type OnboardingRequirements = z.infer<typeof OnboardingRequirementsSchema>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -735,6 +735,7 @@
       "apiKeys": "API-Schlüssel",
       "llmProviders": "LLM-Anbieter",
       "llmRouting": "LLM-Routing",
+      "embedding": "Embedding-Konfiguration",
       "auditLogs": "Audit-Logs",
       "profile": "Profil"
     },
@@ -1369,7 +1370,8 @@
       "title": "Embeddings",
       "description": "Status der konfigurierten Embedding-Anbindung.",
       "futureNotice": "Die geführte Einrichtung folgt in einem späteren Update.",
-      "settingsLink": "Zu den Provider-Einstellungen"
+      "settingsLink": "Zu den Provider-Einstellungen",
+      "legacyHint": "Aktuell wird die Legacy-Konfiguration aus AGORA_EMBEDDING_* verwendet. Über die Embedding-Einstellungen kann eine kanonische Konfiguration angelegt und ein Index-Migrationslauf gestartet werden."
     },
     "privacy": {
       "title": "Datenschutz",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -735,6 +735,7 @@
       "apiKeys": "API Keys",
       "llmProviders": "LLM Providers",
       "llmRouting": "LLM Routing",
+      "embedding": "Embedding configuration",
       "auditLogs": "Audit Logs",
       "profile": "Profile"
     },
@@ -1369,7 +1370,8 @@
       "title": "Embeddings",
       "description": "Status of the configured embedding connection.",
       "futureNotice": "Guided setup follows in a later update.",
-      "settingsLink": "Go to provider settings"
+      "settingsLink": "Go to provider settings",
+      "legacyHint": "Currently using the legacy configuration from AGORA_EMBEDDING_*. The embedding settings let you create a canonical configuration and start an index migration run."
     },
     "privacy": {
       "title": "Privacy",

--- a/frontend/src/router/__tests__/onboardingGuard.spec.ts
+++ b/frontend/src/router/__tests__/onboardingGuard.spec.ts
@@ -63,6 +63,7 @@ function makeOnboardingStatus(onboardingRequired: boolean): OnboardingStatusResp
       profile_valid: !onboardingRequired,
       chat_model_configured: !onboardingRequired,
       embedding_configured: !onboardingRequired,
+      embedding_source: 'none',
     },
     onboarding_required: onboardingRequired,
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -101,6 +101,14 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/Settings/LlmProvidersView.vue'),
     meta: { requiresAuth: true },
   },
+  // Onboarding Slice 4.3.3: eigene Route für die kanonische
+  // Embedding-Konfiguration (Store, View, Migrations, Ollama-Download).
+  {
+    path: '/settings/embedding',
+    name: 'SettingsEmbedding',
+    component: () => import('../views/Settings/EmbeddingConfigurationsView.vue'),
+    meta: { requiresAuth: true },
+  },
   // Klassische SettingsView bleibt erreichbar fuer Slice-G-Migration
   {
     path: '/settings-classic',

--- a/frontend/src/store/__tests__/userProfile.spec.ts
+++ b/frontend/src/store/__tests__/userProfile.spec.ts
@@ -113,6 +113,7 @@ function makeOnboardingStatus(
       profile_valid: false,
       chat_model_configured: false,
       embedding_configured: false,
+      embedding_source: 'none',
     },
     onboarding_required: true,
     ...overrides,

--- a/frontend/src/views/onboarding/OnboardingView.vue
+++ b/frontend/src/views/onboarding/OnboardingView.vue
@@ -38,6 +38,16 @@ interface StatusStepConfig {
   settingsLinkKey: string
   settingsRouteName: string
   configured: () => boolean
+  /**
+   * Optionaler Hinweis-Key, der nur gerendert wird, wenn
+   * ``legacyHintMatcher`` true zurueckgibt. Wird genutzt, um
+   * im Onboarding fuer den Embedding-Step den Legacy-Pfad
+   * (Config.EMBEDDING_*) explizit zu markieren, damit der
+   * Operator weiss, dass die Konfiguration noch nicht aus dem
+   * kanonischen EmbeddingConfigurationStore kommt.
+   */
+  legacyHintKey?: string
+  legacyHintMatcher?: () => boolean
 }
 
 const viewStep = ref<OnboardingStepId>('welcome')
@@ -79,8 +89,13 @@ const statusSteps = computed<StatusStepConfig[]>(() => [
     descriptionKey: 'onboarding.embeddings.description',
     futureNoticeKey: 'onboarding.embeddings.futureNotice',
     settingsLinkKey: 'onboarding.embeddings.settingsLink',
-    settingsRouteName: 'SettingsLlmProviders',
+    // Onboarding Slice 4.3.3: embeddings hat eine eigene Settings-Route
+    // (Slice 4.2 + 4.3.1 API), nicht mehr LlmProviders.
+    settingsRouteName: 'SettingsEmbedding',
     configured: () => store.onboarding.requirements?.embedding_configured ?? false,
+    legacyHintKey: 'onboarding.embeddings.legacyHint',
+    legacyHintMatcher: () =>
+      store.onboarding.requirements?.embedding_source === 'legacy',
   },
 ])
 
@@ -306,6 +321,13 @@ onMounted(async () => {
               ? t('onboarding.providers.configured')
               : t('onboarding.providers.notConfigured')
           }}
+        </p>
+        <p
+          v-if="activeStatusStep.legacyHintKey && activeStatusStep.legacyHintMatcher?.()"
+          class="onboarding-step__legacy-hint"
+          role="note"
+        >
+          {{ t(activeStatusStep.legacyHintKey) }}
         </p>
         <p class="onboarding-step__notice">{{ t(activeStatusStep.futureNoticeKey) }}</p>
         <RouterLink :to="{ name: activeStatusStep.settingsRouteName }" class="onboarding-step__link">
@@ -566,6 +588,17 @@ onMounted(async () => {
   font-family: var(--font-sans);
   font-size: 13px;
   color: var(--accent);
+}
+
+.onboarding-step__legacy-hint {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  background: var(--status-orange-bg, #fff4e5);
+  border: 1px solid var(--status-orange, #c47b1c);
+  border-radius: var(--r-4, 8px);
+  padding: 8px 10px;
+  margin: 0 0 10px;
 }
 
 .onboarding-summary-block {

--- a/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
+++ b/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
@@ -105,6 +105,7 @@ function makeOnboardingStatus(
       profile_valid: false,
       chat_model_configured: false,
       embedding_configured: false,
+      embedding_source: 'none',
     },
     onboarding_required: true,
     ...overrides,
@@ -200,6 +201,52 @@ describe('OnboardingView', () => {
     expect(router.currentRoute.value.name).toBe('Dashboard')
   })
 
+  it('Test 7: embeddings-Step rendert Legacy-Hinweis, wenn embedding_source=legacy', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'embeddings',
+          completed_steps: ['welcome', 'profile', 'providers', 'chat_model'],
+          operating_mode: 'local',
+        }),
+        requirements: {
+          profile_valid: true,
+          chat_model_configured: true,
+          embedding_configured: true,
+          embedding_source: 'legacy',
+        },
+      }),
+    )
+
+    const { wrapper } = await mountView()
+    const hint = wrapper.find('.onboarding-step__legacy-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.text()).toContain(de.onboarding.embeddings.legacyHint)
+  })
+
+  it('Test 8: embeddings-Step zeigt KEINEN Legacy-Hinweis, wenn embedding_source=store', async () => {
+    _getProfile.mockResolvedValue(makeProfile())
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'embeddings',
+          completed_steps: ['welcome', 'profile', 'providers', 'chat_model'],
+          operating_mode: 'local',
+        }),
+        requirements: {
+          profile_valid: true,
+          chat_model_configured: true,
+          embedding_configured: true,
+          embedding_source: 'store',
+        },
+      }),
+    )
+
+    const { wrapper } = await mountView()
+    expect(wrapper.find('.onboarding-step__legacy-hint').exists()).toBe(false)
+  })
+
   it('Test 6: summary — 409 onboarding_incomplete zeigt server-seitige missing-Liste, nicht den Client-Fallback', async () => {
     _getProfile.mockResolvedValue(makeProfile())
     // Requirements sind clientseitig ALLE erfüllt — der Client-Fallback wäre
@@ -216,6 +263,7 @@ describe('OnboardingView', () => {
           profile_valid: true,
           chat_model_configured: true,
           embedding_configured: true,
+          embedding_source: 'store',
         },
       }),
     )

--- a/schemas/onboarding-status-response.schema.json
+++ b/schemas/onboarding-status-response.schema.json
@@ -12,6 +12,11 @@
           "title": "Embedding Configured",
           "type": "boolean"
         },
+        "embedding_source": {
+          "default": "none",
+          "title": "Embedding Source",
+          "type": "string"
+        },
         "profile_valid": {
           "title": "Profile Valid",
           "type": "boolean"


### PR DESCRIPTION
# feat(onboarding): Onboarding-Step "embeddings" an echte Embedding-Konfiguration anbinden (Slice 4.3.3)

Onboarding Slice 4.3.3 verbindet den `embeddings`-Schritt des Wizards mit der kanonischen Embedding-Konfiguration aus Slice 4.2/4.3.1 statt nur mit einem `embedding_configured: bool`. Das Backend exponiert die Herkunft der aktiven Konfiguration explizit über `OnboardingRequirements.embedding_source` (`store` | `legacy` | `none`); das Frontend nutzt das, um einen Legacy-Migrations-Hinweis zu rendern und gezielt auf die neue Settings-View zu verlinken.

## Was ändert sich?

### Backend
- **`OnboardingRequirements.embedding_source: str = "none"`** (Pydantic-Contract; Schema-Dump nachgezogen, Zod-Spiegel erweitert).
- **`compute_onboarding_requirements()`** liest jetzt zuerst den kanonischen `EmbeddingConfigurationStore` (`get_active_global_configuration()`) und fällt nur bei Nicht-Verfügbarkeit auf `Config.EMBEDDING_*` zurück — und loggt das (statt blind `except Exception`, jetzt eng: `ImportError, OSError, ValueError, TypeError`).
- Drei Source-Werte:
  - **`store`** — kanonische Konfiguration im `EmbeddingConfigurationStore` aktiv → Source of Truth.
  - **`legacy`** — nur `Config.EMBEDDING_*` gesetzt (kein Probe) → Operator-Hinweis, Migrations-Aktion empfohlen.
  - **`none`** — keine Konfiguration vorhanden → Setup blockiert.

### Frontend
- **Zod-Spiegel** `OnboardingRequirementsSchema.embedding_source: z.enum(['store', 'legacy', 'none'])` — bewusst strenger als das Backend (Pydantic akzeptiert jeden `str`), um Drift früh zu erkennen.
- **`OnboardingView.vue`** — neuer optionaler `legacyHintKey?` + `legacyHintMatcher?` auf `StatusStepConfig`. Der `embeddings`-Step rendert einen orangenen Hinweis-Block, wenn der Server `embedding_source: "legacy"` meldet.
- **Neue Route** `SettingsEmbedding` → `EmbeddingConfigurationsView` (Store, View, Migrations, Ollama-Download). Settings-Sidebar-Eintrag „Embedding-Konfiguration" ergänzt (zwischen `LLM-Routing` und `Audit-Logs`).
- **i18n-Keys**: `onboarding.embeddings.legacyHint` + `sidebar.settings.embedding` in `de.json` + `en.json`.

## Tests (RED → GREEN)

| Bereich | Neue Tests | Coverage |
|---|---|---|
| Backend | 3 in `TestComputeOnboardingRequirementsEmbeddingSource` | `none` / `legacy` / `store` |
| Frontend Contract | 3 in `userProfileContract.spec.ts` | alle 3 Werte, invalid literal, missing field |
| OnboardingView | 2 in `OnboardingView.spec.ts` (Test 7 + 8) | Legacy-Hinweis sichtbar bei `legacy`, versteckt bei `store` |
| Bestehende Fixtures | 5 angepasst | `embedding_source` ergänzt in `onboardingGuard`, `userProfile.spec`, `OnboardingView` |

Frontend-Suite komplett: **1247 Tests grün** (155 Files).

## Pre-Push-Gate (alle grün)

```text
✓ dump_schemas --check           46 Schemas in sync
✓ sync-status --check            +3 Backend-Tests (3236 → 3239)
✓ ruff check onboarding_state    clean (neue Datei)
   (16 pre-existing F401 aus PR #689/#690 → Maintenance-Slice)
✓ mypy app                       Success, 0 Fehler
✓ bun run lint                   clean
✓ bun run typecheck              clean
✓ bun run test                   1247/1247 grün
✓ bun run build                  OK
```

## Epic-Status

`onboarding-provider-unification`:
0 ✅ · 1 ✅ (#683) · 2 ✅ (#684) · 3 ✅ (#685) · 4.1 ✅ (#686+#687) · 4.2 ✅ (#688) · 4.3.1 ✅ (#689) · 4.3.2 ✅ (#690) · **4.3.3 → dieser PR** · 5/6/7/8 offen

## Wartet auf

- User-Sign-off via PR-Merge.
- Nach Merge: Maintenance-Slice `pre-push-gate.sh` (Schulden aus PR #687, #689, #690).
- Später: Sub-Slice 4.3.4 (echte Neo4j-Re-Embedding-Engine, kein Noop mehr), dann Slice 5+.
