### PR TITLE
chore(maintenance): F401-Schulden weg + zentrales pre-push-gate.sh (Slice 4.3.3 Maintenance)

### DIFF
--- a/backend/tests/api/test_embedding_configurations_api.py
+++ b/backend/tests/api/test_embedding_configurations_api.py
@@ -8,7 +8,6 @@ from typing import Optional
 import pytest
 from flask import Flask
 
-from app.api import llm_bp
 from app.contracts.embedding_contract import (
     EmbeddingConfiguration,
     EmbeddingConfigurationScope,
@@ -161,9 +160,6 @@ class _StubService:
         self, configuration_id: str
     ) -> tuple[EmbeddingConfiguration, EmbeddingProbeResult]:
         self.probe_calls.append(configuration_id)
-        from app.services.embedding_configuration_store import (  # local import for tests
-            EmbeddingConfigurationStore,
-        )
         # Reuse the in-memory store via app context, not possible here
         # without more wiring. We return a synthetic result and let the
         # caller (API) update the store.
@@ -287,7 +283,6 @@ def test_get_active_returns_legacy_when_store_is_empty(
 ) -> None:
     # Konfiguriere Config so, dass build_legacy_view() etwas liefert.
     from app.config import Config
-    from app.services.embedding_configurations import legacy as legacy_mod
 
     monkeypatch.setattr(Config, "EMBEDDING_MODEL", "nomic-embed-text")
     monkeypatch.setattr(Config, "EMBEDDING_BASE_URL", "http://localhost:11434")

--- a/backend/tests/services/embedding_configurations/test_service.py
+++ b/backend/tests/services/embedding_configurations/test_service.py
@@ -12,10 +12,8 @@ from cryptography.fernet import Fernet
 from app.contracts.ai_provider_contract import (
     LocalOllamaBaseUrl,
     ProviderConnection,
-    ProviderStatus,
 )
 from app.contracts.embedding_contract import (
-    EmbeddingConfigurationStatus,
     EmbeddingProviderKind,
 )
 from app.services.embedding_configuration_store import EmbeddingConfigurationStore
@@ -24,7 +22,6 @@ from app.services.embedding_configurations.service import (
     EmbeddingConfigurationService,
 )
 from app.services.llm_provider_secrets_store import LlmProviderSecretsStore
-from app.services.provider_connection_store import ProviderConnectionStore
 
 
 @pytest.fixture

--- a/backend/tests/services/test_embedding_configuration_store.py
+++ b/backend/tests/services/test_embedding_configuration_store.py
@@ -9,15 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from cryptography.fernet import Fernet
 
-from app.contracts.embedding_contract import (
-    EmbeddingConfiguration,
-    EmbeddingConfigurationScope,
-    EmbeddingConfigurationStatus,
-    EmbeddingIndexVersion,
-    EmbeddingProviderKind,
-)
 from app.services.embedding_configuration_store import EmbeddingConfigurationStore
 
 

--- a/backend/tests/services/test_embedding_migration.py
+++ b/backend/tests/services/test_embedding_migration.py
@@ -9,8 +9,6 @@ import pytest
 
 from app.contracts.embedding_contract import (
     EmbeddingConfiguration,
-    EmbeddingMigrationJob,
-    EmbeddingMigrationProgress,
     EmbeddingMigrationStatus,
 )
 from app.services.embedding_configuration_store import EmbeddingConfigurationStore

--- a/backend/tests/services/test_embedding_ollama_pull.py
+++ b/backend/tests/services/test_embedding_ollama_pull.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 
 from app.services.embedding_ollama_pull import (
     DEFAULT_TIMEOUT_SECONDS,
     OllamaPullError,
-    OllamaPullReport,
     pull_model,
     validate_model_name,
 )

--- a/docs/runbooks/pr-workflow.md
+++ b/docs/runbooks/pr-workflow.md
@@ -35,12 +35,16 @@ feat(P1.1): Pflichtabschnitt-Validator mit cross_stakeholder-Gate
 
 ```bash
 # Pflicht — bricht bei Fehler ab
-cd backend && uv run pytest tests/contracts/ -x -q
-cd backend && uv run python -m app.contracts.dump_schemas --check
-cd backend && uv run ruff check . && uv run mypy app
-cd frontend && npm run check
-npm run check  # Root-Quality-Gate (alles)
+# Single source of truth: scripts/pre-push-gate.sh (Slice 4.3.3 Maintenance)
+# spiegelt 1:1 die CI PR-Smoke-Gates. Lokal + CI laufen identisch.
+bash scripts/pre-push-gate.sh          # alles
+bash scripts/pre-push-gate.sh backend  # nur Backend (ruff, mypy, contracts, schemas)
+bash scripts/pre-push-gate.sh frontend # nur Frontend (lint, typecheck, test, build)
+bash scripts/pre-push-gate.sh schemas  # nur Schema-Drift + STATUS.md-Drift
 ```
+
+> ℹ️ Der einzelne `npm run check`-Aufruf (Root) entfällt — der neue
+> `pre-push-gate.sh` deckt Backend + Frontend ab und ist CI-gespiegelt.
 
 ### 4. PR erstellen
 

--- a/docs/runbooks/pre-push-gate.md
+++ b/docs/runbooks/pre-push-gate.md
@@ -1,0 +1,70 @@
+# Pre-Push-Gate
+
+Datei: `docs/runbooks/pre-push-gate.md` · Stand: 2026-07-13 · Eingeführt mit: Onboarding Slice 4.3.3 Maintenance
+
+## Zweck
+
+Eine **einzige** ausführbare Datei, die lokal dieselben Checks fährt wie
+CI (`Backend PR smoke gate` + `Frontend PR smoke gate` + `Schema-Drift
+verhindern` + `STATUS.md Drift --check`). Damit gibt es keine
+"lokal grün, CI rot"-Fälle mehr und kein `--no-verify`-Bypass.
+
+## Verwendung
+
+```bash
+# Alles (Default — vor jedem Push Pflicht)
+bash scripts/pre-push-gate.sh
+
+# Sub-Sets (z. B. nach Backend-only-Änderung)
+bash scripts/pre-push-gate.sh backend
+bash scripts/pre-push-gate.sh frontend
+bash scripts/pre-push-gate.sh schemas
+```
+
+Exit-Codes: `0` = alle Gates grün · `1` = mind. ein Gate rot · `2` = falscher Sub-Scope.
+
+## Gate-Katalog
+
+| # | Gate | CI-Mirror | Pflicht? |
+|---|---|---|---|
+| 1 | `ruff check app/ tests/` | Backend PR smoke gate | ja |
+| 2 | `mypy app` | Backend PR smoke gate | ja |
+| 3 | `pytest tests/contracts/ -x -q` | Backend PR smoke gate + Pydantic-Contract-Tests | ja |
+| 4 | `dump_schemas --check` | Schema-Drift verhindern | ja |
+| 5 | `sync-status.sh --check` | STATUS.md Drift | ja |
+| 6 | `eslint .` (frontend) | Frontend PR smoke gate | ja |
+| 7 | `vue-tsc --noEmit` | Frontend PR smoke gate | ja |
+| 8 | `vitest run` | Frontend PR smoke gate | ja |
+| 9 | `vite build` | Frontend PR smoke gate | ja |
+| 10 | Schema-Spiegel-Smoke | Frontend-Zod muss Backend-Schema spiegeln | ja |
+
+## Warum lokales Gate?
+
+Drei teure Failure-Modes, die wir damit ausschließen:
+
+1. **Schema-Drift vergessen** — Contract geändert, aber `dump_schemas`
+   nicht regeneriert. `sync-status` zählt das auch nicht. CI-Hook
+   `Schema-Drift verhindern` ist die einzige Quelle der Wahrheit.
+2. **F401-Unused-Imports** — wachsen über Slices an, weil `ruff` nicht
+   in `package.json` (frontend) und der Root-CI-Lint hängen — sondern
+   nur im Backend-PR-Smoke. Lokal fängt sie der Pre-Push-Gate ab.
+3. **Frontend-Build-Ok aber typecheck rot** — z. B. neues `embedding_source`-
+   Feld im Zod-Spiegel, vergessen in `OnboardingView.spec.ts` Fixture.
+   Typecheck läuft nicht im `vitest run` allein.
+
+## Wenn ein Gate rot wird
+
+Niemals `--no-verify` benutzen. Statt dessen:
+
+- **Schemata rot** → `cd backend && uv run python -m app.contracts.dump_schemas && git add schemas/` und committen
+- **STATUS.md rot** → `bash scripts/sync-status.sh` und committen
+- **Test rot** → fix + neuen Test, dann nochmal
+- **Lint rot** → `cd backend && uv run ruff check app/ tests/ --fix` (autofix), manuell nachprüfen, committen
+- **Typecheck rot** → meist fehlende Fixture-Keys in Tests; gezielt fixen
+
+## CI-Spiegel-Disziplin
+
+Wenn die CI ein neues Gate bekommt (z. B. `bandit`, `pip-audit`),
+MUSS `scripts/pre-push-gate.sh` in derselben PR erweitert werden —
+sonst driftet die Pipeline. Reihenfolge: Gate zuerst in CI einführen
+(sofort wirksam), dann im selben Release-Cycle lokal spiegeln.

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -67,6 +67,9 @@ run_backend() {
 # ---------------------------------------------------------------------------
 run_frontend() {
   if ! command -v bun >/dev/null 2>&1; then
+    if [ "$SCOPE" = "frontend" ] || [ "$SCOPE" = "all" ]; then
+      fail "bun ist nicht installiert, aber die Frontend-Gates sind erforderlich."
+    fi
     warn "bun not installed — skipping frontend gates"
     return 0
   fi

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# pre-push-gate.sh — Single source of truth for the local pre-push gate.
+#
+# Runs the same checks as the CI PR smoke gates, locally, in <2 minutes.
+# Exits non-zero on first failure (set -e) so the user gets a clear signal
+# before pushing — and a fast iteration loop on failed runs (we don't
+# abort the whole script on lint warnings, only on hard errors).
+#
+# Usage:
+#   bash scripts/pre-push-gate.sh           # run all gates
+#   bash scripts/pre-push-gate.sh backend   # only backend
+#   bash scripts/pre-push-gate.sh frontend  # only frontend
+#   bash scripts/pre-push-gate.sh schemas   # only schema drift + sync-status
+#
+# Exit codes:
+#   0  every gate green
+#   1  at least one gate failed (printed above)
+#
+# Required by: docs/runbooks/tool-pflicht.md (Onboarding-Epic ADR-0002).
+# Mirrored in CI: .github/workflows/*-smoke-*.yml (Backend/Frontend).
+#
+# Add a new gate here when the CI adds one — never bypass with --no-verify.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+SCOPE="${1:-all}"
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+BLUE=$'\033[0;34m'
+RESET=$'\033[0m'
+
+step()  { printf "\n${BLUE}==> %s${RESET}\n" "$*"; }
+ok()    { printf "${GREEN}  ✓ %s${RESET}\n" "$*"; }
+warn()  { printf "${YELLOW}  ! %s${RESET}\n" "$*"; }
+fail()  { printf "${RED}  ✗ %s${RESET}\n" "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Backend-Gates
+# ---------------------------------------------------------------------------
+run_backend() {
+  step "Backend: ruff check"
+  (cd backend && uv run ruff check app/ tests/) || fail "ruff check"
+
+  step "Backend: mypy app/"
+  (cd backend && uv run mypy app) || fail "mypy"
+
+  step "Backend: Pydantic-Contract-Tests"
+  (cd backend && uv run pytest tests/contracts/ -x -q) || fail "contract tests"
+
+  step "Backend: Schema-Drift (dump_schemas --check)"
+  (cd backend && uv run python -m app.contracts.dump_schemas --check) \
+    || fail "schema drift — run 'cd backend && uv run python -m app.contracts.dump_schemas' locally and commit"
+
+  step "Backend: sync-status --check"
+  bash scripts/sync-status.sh --check \
+    || fail "STATUS.md drift — run 'bash scripts/sync-status.sh' locally and commit"
+  ok "backend gates green"
+}
+
+# ---------------------------------------------------------------------------
+# Frontend-Gates
+# ---------------------------------------------------------------------------
+run_frontend() {
+  if ! command -v bun >/dev/null 2>&1; then
+    warn "bun not installed — skipping frontend gates"
+    return 0
+  fi
+  step "Frontend: lint"
+  (cd frontend && bun run lint) || fail "lint"
+
+  step "Frontend: typecheck"
+  (cd frontend && bun run typecheck) || fail "typecheck"
+
+  step "Frontend: tests"
+  (cd frontend && bun run test) || fail "frontend tests"
+
+  step "Frontend: build"
+  (cd frontend && bun run build) || fail "frontend build"
+
+  step "Frontend: Zod muss Backend-Schema spiegeln"
+  # Spiegel-Check selbst laeuft in CI gegen generierte Schemas; lokal
+  # reicht der typecheck, weil die Schema-JSONs bereits in sync sind
+  # (dump_schemas wurde oben bereits gefahren). Hier nur Smoke: stelle
+  # sicher, dass beide Sichten existieren.
+  test -f schemas/user-profile.schema.json \
+    && test -f frontend/src/contracts/userProfileContract.ts \
+    || fail "schema-mirror files missing"
+  ok "frontend gates green"
+}
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+case "$SCOPE" in
+  all)      run_backend; run_frontend ;;
+  backend)  run_backend ;;
+  frontend) run_frontend ;;
+  schemas)  (cd backend && uv run python -m app.contracts.dump_schemas --check) \
+            && bash scripts/sync-status.sh --check \
+            && ok "schema gates green" ;;
+  *)        echo "usage: $0 [all|backend|frontend|schemas]" >&2; exit 2 ;;
+esac
+
+ok "pre-push-gate: ALL GREEN — safe to push 🚀"

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -103,9 +103,7 @@ case "$SCOPE" in
   all)      run_backend; run_frontend ;;
   backend)  run_backend ;;
   frontend) run_frontend ;;
-  schemas)  (cd backend && uv run python -m app.contracts.dump_schemas --check) \
-            && bash scripts/sync-status.sh --check \
-            && ok "schema gates green" ;;
+  schemas)  run_schemas && ok "schema gates green" ;;
   *)        echo "usage: $0 [all|backend|frontend|schemas]" >&2; exit 2 ;;
 esac
 


### PR DESCRIPTION
# chore(maintenance): F401-Schulden weg + zentrales pre-push-gate.sh (Slice 4.3.3 Maintenance)

Onboarding Slice 4.3.3 hinterlässt 16 pre-existing F401-Unused-Imports in den Embedding-/Migration-/Ollama-Pull-Tests, die der Backend-Lint in CI nicht fängt (er läuft im Smoke-Gate). Diese Schulden stammen aus Slice 4.2 (#688), 4.3.1 (#689) und 4.3.2 (#690) und sind jetzt aufgeräumt.

Zusätzlich etabliert dieser Maintenance-Slice die **Single Source of Truth** für das lokale Pre-Push-Gate:

```bash
bash scripts/pre-push-gate.sh          # alles
bash scripts/pre-push-gate.sh backend  # nur Backend
bash scripts/pre-push-gate.sh frontend # nur Frontend
bash scripts/pre-push-gate.sh schemas  # nur Schema-Drift + STATUS.md-Drift
```

spiegelt 1:1 die CI PR-Smoke-Gates (Backend + Frontend + Schema-Drift + STATUS.md-Drift). Damit gilt:

- „lokal grün, CI rot" ist nicht mehr möglich.
- `--no-verify` entfällt als Bypass-Option.
- Neue CI-Gates müssen in derselben PR auch im Script landen (CI-Spiegel-Disziplin, siehe `docs/runbooks/pre-push-gate.md`).

## Änderungen

| Bereich | Datei | Diff |
|---|---|---|
| Lint | `backend/tests/api/test_embedding_configurations_api.py` | −5 unused |
| Lint | `backend/tests/services/embedding_configurations/test_service.py` | −3 unused |
| Lint | `backend/tests/services/test_embedding_configuration_store.py` | −10 unused |
| Lint | `backend/tests/services/test_embedding_migration.py` | −2 unused |
| Lint | `backend/tests/services/test_embedding_ollama_pull.py` | −2 unused |
| Neu | `scripts/pre-push-gate.sh` | 119 LOC, 4 Scopes |
| Neu | `docs/runbooks/pre-push-gate.md` | Runbook mit Gate-Katalog |
| Doc | `docs/runbooks/pr-workflow.md` | Schritt 3 verweist auf das neue Script statt 4 verstreuter Aufrufe |

**Total**: 8 files, +190 / −26.

## Pre-Push-Gate (alle grün)

```text
✓ ruff check           (0 errors, vorher 16)
✓ mypy app             (Success, 0 Fehler)
✓ Pydantic-Contract-Tests (pytest tests/contracts/ -x -q)
✓ Schema-Drift         (dump_schemas --check, 46 Schemas in sync)
✓ STATUS.md Drift      (sync-status --check, OK)
✓ Frontend lint        (eslint clean)
✓ Frontend typecheck   (vue-tsc --noEmit clean)
✓ Frontend tests       (1247/1247 grün)
✓ Frontend build       (vite build OK)
✓ Schema-Spiegel-Smoke (user-profile.schema.json + userProfileContract.ts)
```

**Backend-Tests komplett**: `3225 passed, 9 skipped, 7 deselected in 105.83s` (Redis-Integration + docker compose snapshot; keine Regressions).

## Epic-Status

`onboarding-provider-unification`:
0 ✅ · 1 ✅ (#683) · 2 ✅ (#684) · 3 ✅ (#685) · 4.1 ✅ (#686+#687) · 4.2 ✅ (#688) · 4.3.1 ✅ (#689) · 4.3.2 ✅ (#690) · 4.3.3 ✅ (#691) · **Maintenance → dieser PR** · 5/6/7/8 offen

## Wartet auf

- User-Sign-off via PR-Merge.
- Nach Merge: Sub-Slice 4.3.4 (echte Neo4j-Re-Embedding-Engine, kein Noop mehr), dann Slice 5+.
