### PR TITLE
feat(embedding): echte Neo4j-Re-Embedding-Engine mit Resume (Slice 4.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Added (embedding-reembedder — 2026-07-13)
+
+- **Echte Neo4j-Re-Embedding-Engine (Onboarding Slice 4.3.4)**:
+  ``backend/app/services/embedding_reembedder.py`` ersetzt den
+  ``_NoopReEmbedder``-Stub. ``Neo4jReEmbedder`` liest alle
+  ``(n:Entity)``-Knoten batchweise per ``uuid``-Cursor, erzeugt
+  Embeddings über den konfigurierten Provider, prüft jede
+  Vektor-Dimension gegen die verifizierte Konfiguration und schreibt
+  in die versionierte Property (``db.create.setNodeVectorProperty``,
+  Index via ``CREATE VECTOR INDEX ... IF NOT EXISTS`` — niemals DROP,
+  ADR-0007). Nach jedem Batch wird ein Checkpoint persistiert;
+  ``EmbeddingMigrationProgress.last_processed_id`` (neues
+  Vertragsfeld inkl. Zod-Spiegel) macht den Lauf nach einem Crash
+  über ``POST /migrations/<id>/run`` wiederaufnehmbar (Job-Status
+  ``running`` gilt als Resume). Dimension-Mismatch führt zu
+  ``failed`` ohne Index-Switch. Gemini-Re-Embedding wird explizit
+  als „noch nicht unterstützt" abgelehnt statt vorgetäuscht.
+  Bewusst offen: ``RELATION.fact_embedding``-Re-Embed und
+  ``scope="project"``-Filter.
+
 ### Added (embedding-migration — 2026-07-12)
 
 - **Embedding-Migrations-Service (Onboarding Slice 4.3)**:

--- a/PLAN.md
+++ b/PLAN.md
@@ -375,8 +375,13 @@ eigene PRs, TDD, Verhaltens-Regression vermeiden (bestehende Tests bleiben grün
 
 **Status:** Phase 0, Slice 1, Slice 2 und Slice 3 gemergt (PR #682, #683,
 #684, #685). Slice 4 (Embedding-Setup und sichere Re-Embedding-Migration)
-ist in Bearbeitung; Sub-Slice 4.1 (kanonische Embedding-Provider- und
-Konfigurationsverträge) ist implementiert und verifiziert. Bestehende
+ist in Bearbeitung; Sub-Slices 4.1–4.3.3 plus Maintenance sind gemergt
+(PR #686–#691, #693). Sub-Slice 4.3.4 ersetzt den `_NoopReEmbedder` durch
+die echte Neo4j-Re-Embedding-Engine (`Neo4jReEmbedder`: Read-Loop über
+`(n:Entity)` per `uuid`-Cursor, Checkpoint nach jedem Batch, Resume über
+`EmbeddingMigrationProgress.last_processed_id` nach Crash). Offen im
+Slice-4-Umfeld: Fact-Embedding-Re-Embed (`RELATION.fact_embedding`),
+Gemini-Batch-Embedding, `scope="project"`-Filter. Bestehende
 Profile bleiben unverändert lesbar; Benutzerprofil und KI-Presets sind
 getrennte Schlüsselräume (ADR-0008). Embedding-Provider und Chat-Provider
 teilen nur die `provider_connection_id` als Referenz; die strukturelle

--- a/backend/app/api/embedding_migrations.py
+++ b/backend/app/api/embedding_migrations.py
@@ -27,9 +27,12 @@ from flask import request
 from pydantic import BaseModel, ConfigDict, Field
 
 from . import llm_bp
+from ..config import Config
+from ..contracts.embedding_contract import EmbeddingConfiguration
 from ..services.embedding_configuration_store import EmbeddingConfigurationStore
 from ..services.embedding_migration import EmbeddingMigrationService
 from ..services.embedding_ollama_pull import OllamaPullError, pull_model_via_configuration
+from ..services.embedding_reembedder import EmbedTexts, Neo4jReEmbedder
 from ..services.llm_provider_secrets_store import get_llm_provider_secrets_store
 from ..services.provider_connection_store import ProviderConnectionStore
 from ..utils.api_responses import handle_api_errors, json_error, json_success
@@ -53,9 +56,69 @@ class _OllamaPullRequest(BaseModel):
     configuration_id: str | None = None
 
 
+def _neo4j_driver():
+    """Eigener, lazy erzeugter Driver — die Engine schliesst ihn nach dem Lauf.
+
+    Bewusst kein Zugriff auf den ``Neo4jStorage``-Pool: der Migrationslauf
+    ist ein langlaufender Operator-Vorgang und soll den App-Pool nicht
+    blockieren.
+    """
+    from neo4j import GraphDatabase
+
+    return GraphDatabase.driver(
+        Config.NEO4J_URI, auth=(Config.NEO4J_USER, Config.NEO4J_PASSWORD)
+    )
+
+
+def _embedder_for_configuration(config: EmbeddingConfiguration) -> EmbedTexts:
+    """Baut die Batch-Embedding-Funktion fuer die Ziel-Konfiguration.
+
+    Aufloesung analog zum Probe-Pfad (``EmbeddingConfigurationService``):
+    ProviderConnection liefert die ``base_url``, der Secret-Store den
+    API-Key. Gemini nutzt ein anderes URL-Schema als der bestehende
+    ``EmbeddingService`` und wird ehrlich abgelehnt statt vorgetaeuscht.
+    """
+    if config.provider_kind == "google":
+        raise RuntimeError(
+            "Re-Embedding ueber Gemini wird noch nicht unterstuetzt — "
+            "bitte einen Ollama- oder OpenAI-kompatiblen Embedding-"
+            "Provider verwenden."
+        )
+    connection = next(
+        (
+            c
+            for c in ProviderConnectionStore().list_connections()
+            if c.id == config.provider_connection_id
+        ),
+        None,
+    )
+    if connection is None:
+        raise KeyError(
+            f"ProviderConnection fehlt: {config.provider_connection_id}"
+        )
+    api_key = (
+        get_llm_provider_secrets_store().get_plaintext(connection.secret_ref)
+        if connection.secret_ref
+        else None
+    )
+    from ..storage.embedding_service import EmbeddingService
+
+    service = EmbeddingService(
+        model=config.model_id,
+        base_url=connection.base_url,
+        api_key=api_key,
+        timeout=60,
+    )
+    return service.embed_batch
+
+
 def _service() -> EmbeddingMigrationService:
     return EmbeddingMigrationService(
         store=EmbeddingConfigurationStore(),
+        re_embedder=Neo4jReEmbedder(
+            driver_factory=_neo4j_driver,
+            embedder_factory=_embedder_for_configuration,
+        ),
     )
 
 

--- a/backend/app/contracts/embedding_contract.py
+++ b/backend/app/contracts/embedding_contract.py
@@ -230,6 +230,10 @@ class EmbeddingMigrationProgress(BaseModel):
     total: int = Field(ge=0)
     processed: int = Field(ge=0)
     failed: int = Field(ge=0)
+    # Resume-Cursor der Re-Embedding-Engine (Slice 4.3.4): die zuletzt
+    # vollstaendig verarbeitete Entity-UUID. Nach einem Crash setzt ein
+    # erneuter ``run()`` beim ersten Knoten mit ``uuid > cursor`` fort.
+    last_processed_id: str | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
 

--- a/backend/app/services/embedding_migration.py
+++ b/backend/app/services/embedding_migration.py
@@ -5,11 +5,12 @@ Orchestriert den Re-Embedding-Lifecycle gemaess
 ``docs/epics/onboarding-provider-unification/06-migration-plan.md``.
 
 Der eigentliche Re-Embedding-Loop (Neo4j-Query, Embedding-Service-Aufruf,
-Schreiben der neuen Property) ist bewusst NICHT hier implementiert. Statt
-dessen erwartet der Service einen injizierten ``ReEmbedder``-Callable,
-damit Tests ohne Neo4j und ohne echte Embedding-Backends laufen koennen.
-Die echte Re-Embedding-Engine wird in einem Folge-Slice ergaenzt, sobald
-Neo4j-Read-Loop + Embedding-Service-Cache aufeinander abgestimmt sind.
+Schreiben der neuen Property) lebt in
+``app.services.embedding_reembedder.Neo4jReEmbedder`` (Slice 4.3.4) und
+wird als ``ReEmbedder`` injiziert, damit Tests ohne Neo4j und ohne echte
+Embedding-Backends laufen koennen. Der Default bleibt der No-Op-Stub —
+die API-Schicht (``app.api.embedding_migrations``) verdrahtet die echte
+Engine.
 
 Was der Service garantiert (Slice 4.3):
 
@@ -57,12 +58,15 @@ from app.services.embedding_configuration_store import EmbeddingConfigurationSto
 class ReEmbedder(Protocol):
     """Schnittstelle fuer den eigentlichen Re-Embedding-Loop.
 
-    Eine konkrete Implementierung liest die betroffenen Neo4j-Knoten,
-    erzeugt neue Embeddings mit dem konfigurierten Provider und
-    schreibt sie in die neue Property. Der Service ruft
-    ``run(target_index_name)`` auf; die Implementierung aktualisiert
-    den uebergebenen ``EmbeddingMigrationProgress`` nach jedem Batch
-    und gibt den Endstatus zurueck (``completed`` / ``failed``).
+    Eine konkrete Implementierung (``Neo4jReEmbedder``) liest die
+    betroffenen Neo4j-Knoten, erzeugt neue Embeddings mit dem in
+    ``configuration`` beschriebenen Provider und schreibt sie in die
+    neue Property. Nach jedem Batch ruft sie ``checkpoint(progress)``
+    mit einem aktualisierten ``EmbeddingMigrationProgress`` auf (inkl.
+    ``last_processed_id`` als Resume-Cursor); der Service persistiert
+    den Job-Zustand. Der uebergebene ``progress`` ist der Startzustand
+    — bei Resume traegt er den letzten Checkpoint. Rueckgabe ist der
+    Endstatus (``completed`` / ``failed``).
     """
 
     def run(
@@ -71,6 +75,9 @@ class ReEmbedder(Protocol):
         target_property_key: str,
         expected_dimensions: int,
         progress: EmbeddingMigrationProgress,
+        *,
+        configuration: EmbeddingConfiguration,
+        checkpoint: Callable[[EmbeddingMigrationProgress], None],
     ) -> EmbeddingMigrationStatus: ...
 
 
@@ -78,9 +85,9 @@ class _NoopReEmbedder:
     """Default-Re-Embedder, der den Lifecycle treibt ohne Daten zu mutieren.
 
     Praktisch fuer Tests und fuer Erst-Migrationen ohne vorhandene
-    Embeddings. Eine echte Re-Embedding-Engine wird in einem Folge-Slice
-    ergaenzt, der eine Neo4j-Read-Loop + Embedding-Service-Cache
-    orchestriert.
+    Embeddings. Die echte Engine ist ``Neo4jReEmbedder``
+    (``app.services.embedding_reembedder``); die API-Schicht injiziert
+    sie explizit.
     """
 
     def run(
@@ -89,6 +96,9 @@ class _NoopReEmbedder:
         target_property_key: str,
         expected_dimensions: int,
         progress: EmbeddingMigrationProgress,
+        *,
+        configuration: EmbeddingConfiguration,
+        checkpoint: Callable[[EmbeddingMigrationProgress], None],
     ) -> EmbeddingMigrationStatus:
         return "completed"
 
@@ -189,12 +199,17 @@ class EmbeddingMigrationService:
         Der eigentliche Re-Embedding-Loop wird durch den injizierten
         ``re_embedder`` ausgefuehrt. Bei ``failed`` bleibt der alte
         Index aktiv und der neue wird auf ``rolled_back`` gesetzt.
+
+        Ein Job im Status ``running`` darf erneut ausgefuehrt werden
+        (Crash-Recovery): der Re-Embedder erhaelt den zuletzt
+        persistierten Progress inklusive ``last_processed_id`` und
+        setzt dort fort. ``started_at`` bleibt dabei erhalten.
         """
         job = self._load_job(job_id)
-        if job.status != "pending":
+        if job.status not in ("pending", "running"):
             raise ValueError(
-                f"Job {job_id} ist nicht im 'pending'-Status, "
-                f"sondern '{job.status}'."
+                f"Job {job_id} ist weder 'pending' noch 'running' "
+                f"(Resume), sondern '{job.status}'."
             )
         config = self._store.get_configuration(job.configuration_id)
         if config is None:
@@ -208,14 +223,23 @@ class EmbeddingMigrationService:
                 f"Ziel-Index-Version {job.target_index_version} fehlt im Store"
             )
 
-        # pending -> running
+        # pending -> running; bei Resume bleibt started_at erhalten.
+        started_at = job.progress.started_at or self._now()
         job = self._update_job_status(
             job,
             status="running",
             progress=job.progress.model_copy(
-                update={"started_at": self._now()}
+                update={"started_at": started_at}
             ),
         )
+
+        def _persist_checkpoint(progress: EmbeddingMigrationProgress) -> None:
+            latest = self._load_job(job_id)
+            self._save_job(
+                latest.model_copy(
+                    update={"progress": progress, "updated_at": self._now()}
+                )
+            )
 
         try:
             final_status = self._re_embedder.run(
@@ -223,8 +247,11 @@ class EmbeddingMigrationService:
                 target_index.property_key,
                 config.dimensions,
                 job.progress,
+                configuration=config,
+                checkpoint=_persist_checkpoint,
             )
         except Exception as exc:  # noqa: BLE001 — wir wollen alle Re-Embedder-Fehler fangen
+            job = self._load_job(job_id)
             return self._update_job_status(
                 job,
                 status="failed",
@@ -232,6 +259,7 @@ class EmbeddingMigrationService:
             )
 
         if final_status == "failed":
+            job = self._load_job(job_id)
             return self._update_job_status(
                 job, status="failed", error_message="Re-Embedder meldete failed"
             )

--- a/backend/app/services/embedding_reembedder.py
+++ b/backend/app/services/embedding_reembedder.py
@@ -1,0 +1,231 @@
+"""Echte Neo4j-Re-Embedding-Engine (Onboarding Slice 4.3.4).
+
+Ersetzt den ``_NoopReEmbedder``-Stub aus Slice 4.3.1 durch einen echten
+Read-Loop ueber alle ``(n:Entity)``-Knoten:
+
+1. Versionierten Ziel-Vector-Index anlegen (``CREATE ... IF NOT EXISTS``,
+   niemals DROP — ADR-0007).
+2. Gesamtzahl der Knoten zaehlen (``progress.total``).
+3. Batchweise lesen, sortiert nach ``n.uuid`` mit Cursor
+   ``uuid > last_processed_id`` — dadurch ist der Loop nach einem Crash
+   ueber ``EmbeddingMigrationProgress.last_processed_id`` wiederaufnehmbar.
+4. Pro Batch Embeddings ueber den konfigurierten Provider erzeugen,
+   Dimension gegen die verifizierte Konfiguration pruefen und nur
+   passende Vektoren in die neue Property schreiben
+   (``db.create.setNodeVectorProperty``).
+5. Nach jedem Batch ``checkpoint(progress)`` aufrufen — der
+   ``EmbeddingMigrationService`` persistiert den Job-Zustand.
+
+Endstatus: ``failed`` sobald mindestens ein Knoten keine gueltige
+Dimension bekam (kein Switch auf einen unvollstaendigen Index),
+``completed`` sonst. Ein leerer Graph ist eine gueltige Erst-Migration.
+
+Bewusste Nicht-Ziele dieses Slices (dokumentiert im Epic-Handover):
+
+* ``RELATION.fact_embedding`` wird nicht re-embedded — der versionierte
+  Index-Vertrag (``EmbeddingIndexVersion``) verwaltet bisher nur
+  ``entity_embedding_vN``.
+* Kein ``scope="project"``-Filter — die Zuordnung Projekt -> Graph ist
+  nicht Teil des Embedding-Vertrags; die Engine laeuft global.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+from app.contracts.embedding_contract import (
+    EmbeddingConfiguration,
+    EmbeddingMigrationProgress,
+    EmbeddingMigrationStatus,
+)
+from app.utils.logger import get_logger
+
+logger = get_logger("agora.embedding_reembedder")
+
+# Index- und Property-Namen kommen aus dem eigenen Store
+# (``entity_embedding_vN``), nie aus User-Input. Der Guard verhindert
+# trotzdem strukturell jede Cypher-Injection ueber die DDL-F-Strings.
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+_COUNT_QUERY = """
+MATCH (n:Entity)
+WHERE n.uuid IS NOT NULL
+RETURN count(n) AS total
+"""
+
+# ``summary`` ist der Text, der beim Ingest embedded wurde
+# (``ingestion_pipeline.embed_entities_and_relations``); der coalesce-
+# Fallback rekonstruiert ihn fuer Bestandsknoten ohne summary-Property.
+_BATCH_QUERY = """
+MATCH (n:Entity)
+WHERE n.uuid IS NOT NULL
+  AND ($cursor IS NULL OR n.uuid > $cursor)
+RETURN
+    n.uuid AS uuid,
+    coalesce(n.summary, n.name + ' (' + coalesce(n.entity_type, '') + ')') AS text
+ORDER BY n.uuid
+LIMIT $limit
+"""
+
+_WRITE_QUERY = """
+UNWIND $rows AS row
+MATCH (n:Entity {uuid: row.uuid})
+CALL db.create.setNodeVectorProperty(n, $property_key, row.vector)
+RETURN count(n) AS written
+"""
+
+EmbedTexts = Callable[[list[str]], list[list[float]]]
+
+
+class Neo4jReEmbedder:
+    """Re-Embedding-Loop ueber Neo4j-Entities, batchweise mit Checkpoints.
+
+    ``driver_factory`` liefert einen Neo4j-Driver (lazy — die Engine
+    verbindet erst beim ``run()``); ``embedder_factory`` baut aus der
+    ``EmbeddingConfiguration`` eine Batch-Embedding-Funktion. Beide sind
+    injizierbar, damit Tests ohne Neo4j und ohne Embedding-Backend laufen.
+    """
+
+    def __init__(
+        self,
+        *,
+        driver_factory: Callable[[], Any],
+        embedder_factory: Callable[[EmbeddingConfiguration], EmbedTexts],
+        batch_size: int = 50,
+    ) -> None:
+        if batch_size < 1:
+            raise ValueError("batch_size muss >= 1 sein")
+        self._driver_factory = driver_factory
+        self._embedder_factory = embedder_factory
+        self._batch_size = batch_size
+
+    def run(
+        self,
+        target_index_name: str,
+        target_property_key: str,
+        expected_dimensions: int,
+        progress: EmbeddingMigrationProgress,
+        *,
+        configuration: EmbeddingConfiguration,
+        checkpoint: Callable[[EmbeddingMigrationProgress], None],
+    ) -> EmbeddingMigrationStatus:
+        if not _IDENTIFIER.match(target_index_name):
+            raise ValueError(
+                f"Ungueltiger Index-Name: {target_index_name!r}"
+            )
+        if not _IDENTIFIER.match(target_property_key):
+            raise ValueError(
+                f"Ungueltiger Property-Key: {target_property_key!r}"
+            )
+
+        embed_texts = self._embedder_factory(configuration)
+        driver = self._driver_factory()
+        try:
+            with driver.session() as session:
+                ddl = _index_ddl(
+                    target_index_name, target_property_key, expected_dimensions
+                )
+                session.execute_write(lambda tx: tx.run(ddl).consume())
+
+                total = session.execute_read(
+                    lambda tx: int(tx.run(_COUNT_QUERY).single()["total"])
+                )
+                progress = progress.model_copy(update={"total": total})
+                checkpoint(progress)
+
+                cursor = progress.last_processed_id
+                while True:
+                    rows = session.execute_read(
+                        lambda tx, cursor_=cursor: [
+                            dict(record)
+                            for record in tx.run(
+                                _BATCH_QUERY,
+                                cursor=cursor_,
+                                limit=self._batch_size,
+                            )
+                        ]
+                    )
+                    if not rows:
+                        break
+
+                    texts = [str(row.get("text") or "") for row in rows]
+                    vectors = embed_texts(texts)
+
+                    writable: list[dict[str, Any]] = []
+                    failed = 0
+                    for row, vector in zip(rows, vectors):
+                        if len(vector) == expected_dimensions:
+                            writable.append(
+                                {
+                                    "uuid": row["uuid"],
+                                    "vector": [float(x) for x in vector],
+                                }
+                            )
+                        else:
+                            failed += 1
+                            logger.warning(
+                                "Re-Embedding: Entity %s lieferte Dimension "
+                                "%d statt %d — Knoten uebersprungen",
+                                row["uuid"],
+                                len(vector),
+                                expected_dimensions,
+                            )
+                    # Defensiv: liefert der Embedder weniger Vektoren als
+                    # Texte, zaehlen die fehlenden Knoten als failed.
+                    if len(vectors) < len(rows):
+                        failed += len(rows) - len(vectors)
+
+                    if writable:
+                        session.execute_write(
+                            lambda tx, rows_=writable: tx.run(
+                                _WRITE_QUERY,
+                                rows=rows_,
+                                property_key=target_property_key,
+                            ).consume()
+                        )
+
+                    cursor = rows[-1]["uuid"]
+                    progress = progress.model_copy(
+                        update={
+                            "processed": progress.processed + len(writable),
+                            "failed": progress.failed + failed,
+                            "last_processed_id": cursor,
+                        }
+                    )
+                    checkpoint(progress)
+        finally:
+            driver.close()
+
+        if progress.failed > 0:
+            logger.warning(
+                "Re-Embedding beendet mit %d fehlgeschlagenen Knoten "
+                "(processed=%d, total=%d) — kein Index-Switch",
+                progress.failed,
+                progress.processed,
+                progress.total,
+            )
+            return "failed"
+        logger.info(
+            "Re-Embedding abgeschlossen: %d/%d Knoten in Property %s",
+            progress.processed,
+            progress.total,
+            target_property_key,
+        )
+        return "completed"
+
+
+def _index_ddl(index_name: str, property_key: str, dimensions: int) -> str:
+    """Versionierten Vector-Index anlegen — additiv, niemals DROP."""
+    return f"""
+CREATE VECTOR INDEX {index_name} IF NOT EXISTS
+FOR (n:Entity) ON (n.{property_key})
+OPTIONS {{indexConfig: {{
+    `vector.dimensions`: {int(dimensions)},
+    `vector.similarity_function`: 'cosine'
+}}}}
+"""
+
+
+__all__ = ["Neo4jReEmbedder", "EmbedTexts"]

--- a/backend/app/services/embedding_reembedder.py
+++ b/backend/app/services/embedding_reembedder.py
@@ -64,7 +64,7 @@ WHERE n.uuid IS NOT NULL
   AND ($cursor IS NULL OR n.uuid > $cursor)
 RETURN
     n.uuid AS uuid,
-    coalesce(n.summary, n.name + ' (' + coalesce(n.entity_type, '') + ')') AS text
+    coalesce(n.summary, coalesce(n.name, '') + ' (' + coalesce(n.entity_type, '') + ')') AS text
 ORDER BY n.uuid
 LIMIT $limit
 """
@@ -152,11 +152,21 @@ class Neo4jReEmbedder:
 
                     texts = [str(row.get("text") or "") for row in rows]
                     vectors = embed_texts(texts)
+                    # Laengen-Mismatch heisst: die Positionszuordnung
+                    # Text -> Vektor ist nicht mehr verlaesslich. Weiter-
+                    # machen wuerde falsche Vektoren an falsche Knoten
+                    # schreiben (Alignment-Drift) — harter Abbruch.
+                    if len(vectors) != len(rows):
+                        raise RuntimeError(
+                            f"Embedder lieferte {len(vectors)} Vektoren fuer "
+                            f"{len(rows)} Texte — Abbruch, um Alignment-"
+                            "Drift zu verhindern."
+                        )
 
                     writable: list[dict[str, Any]] = []
                     failed = 0
                     for row, vector in zip(rows, vectors):
-                        if len(vector) == expected_dimensions:
+                        if vector is not None and len(vector) == expected_dimensions:
                             writable.append(
                                 {
                                     "uuid": row["uuid"],
@@ -169,13 +179,9 @@ class Neo4jReEmbedder:
                                 "Re-Embedding: Entity %s lieferte Dimension "
                                 "%d statt %d — Knoten uebersprungen",
                                 row["uuid"],
-                                len(vector),
+                                len(vector) if vector is not None else 0,
                                 expected_dimensions,
                             )
-                    # Defensiv: liefert der Embedder weniger Vektoren als
-                    # Texte, zaehlen die fehlenden Knoten als failed.
-                    if len(vectors) < len(rows):
-                        failed += len(rows) - len(vectors)
 
                     if writable:
                         session.execute_write(

--- a/backend/tests/contracts/test_embedding_contract.py
+++ b/backend/tests/contracts/test_embedding_contract.py
@@ -458,6 +458,29 @@ def test_embedding_migration_progress_accepts_running_state_with_no_finish() -> 
     assert progress.finished_at is None
 
 
+def test_embedding_migration_progress_last_processed_id_defaults_to_none() -> None:
+    """Slice 4.3.4: ``last_processed_id`` ist der Resume-Cursor der
+    Re-Embedding-Engine. Default None (frischer Job); persistierte
+    Alt-Jobs ohne das Feld bleiben ladbar.
+    """
+    progress = EmbeddingMigrationProgress(total=0, processed=0, failed=0)
+    assert progress.last_processed_id is None
+
+    legacy_payload = '{"total": 5, "processed": 5, "failed": 0, "started_at": null, "finished_at": null}'
+    parsed = EmbeddingMigrationProgress.model_validate_json(legacy_payload)
+    assert parsed.last_processed_id is None
+
+
+def test_embedding_migration_progress_last_processed_id_roundtrip() -> None:
+    progress = EmbeddingMigrationProgress(
+        total=10, processed=4, failed=1, last_processed_id="uuid-003"
+    )
+    restored = EmbeddingMigrationProgress.model_validate_json(
+        progress.model_dump_json()
+    )
+    assert restored.last_processed_id == "uuid-003"
+
+
 def test_embedding_provider_kinds_helper_is_derived_from_literal() -> None:
     """Gemini-Finding (MEDIUM): das ``_EMBEDDING_PROVIDER_KINDS``-Set muss
     dynamisch aus dem ``EmbeddingProviderKind``-Literal abgeleitet sein,

--- a/backend/tests/services/test_embedding_migration.py
+++ b/backend/tests/services/test_embedding_migration.py
@@ -177,6 +177,88 @@ def test_run_with_failed_re_embedder_result_keeps_old_index_active(
     assert config.status == "probed", "alter Index bleibt aktiv"
 
 
+def test_run_passes_configuration_and_persists_checkpoints(
+    store: EmbeddingConfigurationStore, fixed_now: datetime
+) -> None:
+    _seed_probed_configuration(store)
+    seen: dict[str, object] = {}
+
+    class _Checkpointing:
+        def run(self, *args, **kwargs) -> EmbeddingMigrationStatus:
+            progress = args[3]
+            seen["configuration_id"] = kwargs["configuration"].id
+            kwargs["checkpoint"](
+                progress.model_copy(
+                    update={
+                        "total": 4,
+                        "processed": 2,
+                        "last_processed_id": "uuid-001",
+                    }
+                )
+            )
+            return "completed"
+
+    service = EmbeddingMigrationService(
+        store=store, re_embedder=_Checkpointing(), now=lambda: fixed_now
+    )
+    job = service.start("emb-1")
+    final = service.run(job.id)
+
+    assert seen["configuration_id"] == "emb-1"
+    assert final.status == "completed"
+    # Der Checkpoint wurde persistiert und ueberlebt bis in den Endzustand.
+    assert final.progress.total == 4
+    assert final.progress.processed == 2
+    assert final.progress.last_processed_id == "uuid-001"
+
+
+def test_run_resumes_job_stuck_in_running(
+    store: EmbeddingConfigurationStore, fixed_now: datetime
+) -> None:
+    """Crash-Recovery: ein Job in 'running' darf erneut ausgefuehrt werden.
+
+    Der Re-Embedder bekommt dabei den zuletzt persistierten Progress
+    inklusive ``last_processed_id`` und setzt dort fort.
+    """
+    _seed_probed_configuration(store)
+    received: dict[str, object] = {}
+
+    class _Recorder:
+        def run(self, *args, **kwargs) -> EmbeddingMigrationStatus:
+            received["last_processed_id"] = args[3].last_processed_id
+            return "completed"
+
+    service = EmbeddingMigrationService(
+        store=store, re_embedder=_Recorder(), now=lambda: fixed_now
+    )
+    job = service.start("emb-1")
+
+    # Simulierter Crash: Job haengt in 'running' mit Checkpoint-Progress.
+    running = service.get_job(job.id)
+    assert running is not None
+    stuck = running.model_copy(
+        update={
+            "status": "running",
+            "progress": running.progress.model_copy(
+                update={
+                    "total": 10,
+                    "processed": 6,
+                    "last_processed_id": "uuid-005",
+                    "started_at": fixed_now,
+                }
+            ),
+        }
+    )
+    service._save_job(stuck)  # noqa: SLF001 — Testaufbau fuer Crash-Zustand
+
+    final = service.run(job.id)
+
+    assert final.status == "completed"
+    assert received["last_processed_id"] == "uuid-005"
+    # started_at bleibt der urspruengliche Wert, kein Neustart der Uhr.
+    assert final.progress.started_at == fixed_now
+
+
 # ----------------------------------------------------------------------
 # cancel
 # ----------------------------------------------------------------------

--- a/backend/tests/services/test_embedding_reembedder.py
+++ b/backend/tests/services/test_embedding_reembedder.py
@@ -285,6 +285,34 @@ def test_run_rejects_invalid_index_or_property_identifier() -> None:
         )
 
 
+def test_run_aborts_on_vector_count_mismatch() -> None:
+    """Gemini-Finding (HIGH): liefert der Embedder weniger Vektoren als
+    Texte, ist die Positionszuordnung nicht mehr verlaesslich — weiter-
+    machen wuerde falsche Vektoren an falsche Knoten schreiben.
+    """
+    graph = _FakeGraph(_entities(3))
+
+    def _short(texts: list[str]) -> list[list[float]]:
+        return [[1.0] * _DIMS for _ in texts[:-1]]  # ein Vektor fehlt
+
+    with pytest.raises(RuntimeError, match="Alignment"):
+        _run(_engine(graph, embedder=_short, batch_size=3))
+    assert graph.written == [], "kein Batch darf teilgeschrieben werden"
+
+
+def test_run_counts_none_vector_as_failed() -> None:
+    graph = _FakeGraph(_entities(2))
+
+    def _with_none(texts: list[str]) -> list[Any]:
+        return [None, [1.0] * _DIMS]
+
+    status, checkpoints = _run(_engine(graph, embedder=_with_none, batch_size=2))
+
+    assert status == "failed"
+    assert checkpoints[-1].failed == 1
+    assert checkpoints[-1].processed == 1
+
+
 def test_run_propagates_embedder_errors() -> None:
     graph = _FakeGraph(_entities(2))
 

--- a/backend/tests/services/test_embedding_reembedder.py
+++ b/backend/tests/services/test_embedding_reembedder.py
@@ -1,0 +1,296 @@
+"""Tests fuer ``Neo4jReEmbedder`` (Onboarding Slice 4.3.4).
+
+Die Engine wird gegen einen Fake-Neo4j-Driver getestet: der Fake haelt
+eine sortierte Entity-Liste im Speicher, beantwortet Count-, Batch- und
+Write-Queries und protokolliert alle Schreibzugriffe. So laufen die
+Tests ohne Neo4j und ohne echtes Embedding-Backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.contracts.embedding_contract import (
+    EmbeddingConfiguration,
+    EmbeddingMigrationProgress,
+)
+from app.services.embedding_reembedder import Neo4jReEmbedder
+
+# ----------------------------------------------------------------------
+# Fakes
+# ----------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self._records = records
+
+    def single(self) -> dict[str, Any]:
+        return self._records[0]
+
+    def consume(self) -> None:
+        return None
+
+    def __iter__(self):
+        return iter(self._records)
+
+
+class _FakeTx:
+    """Beantwortet die drei Query-Formen der Engine."""
+
+    def __init__(self, graph: "_FakeGraph") -> None:
+        self._graph = graph
+
+    def run(self, query: str, **params: Any) -> _FakeResult:
+        self._graph.queries.append((query, params))
+        if "CREATE VECTOR INDEX" in query:
+            self._graph.created_indexes.append(query)
+            return _FakeResult([])
+        if "count(n) AS total" in query:
+            return _FakeResult([{"total": len(self._graph.entities)}])
+        if "UNWIND $rows" in query:
+            self._graph.written.append(
+                {"property_key": params["property_key"], "rows": params["rows"]}
+            )
+            return _FakeResult([{"written": len(params["rows"])}])
+        if "ORDER BY n.uuid" in query:
+            cursor = params.get("cursor")
+            limit = params["limit"]
+            remaining = [
+                e for e in self._graph.entities if cursor is None or e["uuid"] > cursor
+            ]
+            return _FakeResult(remaining[:limit])
+        raise AssertionError(f"Unerwartete Query: {query}")
+
+
+class _FakeSession:
+    def __init__(self, graph: "_FakeGraph") -> None:
+        self._graph = graph
+
+    def __enter__(self) -> "_FakeSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute_read(self, fn: Any) -> Any:
+        return fn(_FakeTx(self._graph))
+
+    def execute_write(self, fn: Any) -> Any:
+        return fn(_FakeTx(self._graph))
+
+
+class _FakeGraph:
+    """Gemeinsamer Zustand von Driver, Session und Tx."""
+
+    def __init__(self, entities: list[dict[str, Any]]) -> None:
+        self.entities = sorted(entities, key=lambda e: e["uuid"])
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+        self.written: list[dict[str, Any]] = []
+        self.created_indexes: list[str] = []
+        self.closed = False
+
+
+class _FakeDriver:
+    def __init__(self, graph: _FakeGraph) -> None:
+        self._graph = graph
+
+    def session(self) -> _FakeSession:
+        return _FakeSession(self._graph)
+
+    def close(self) -> None:
+        self._graph.closed = True
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+_DIMS = 4
+
+
+def _configuration() -> EmbeddingConfiguration:
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 7, 13, 8, 0, tzinfo=timezone.utc)
+    return EmbeddingConfiguration(
+        id="emb-1",
+        provider_connection_id="conn-1",
+        provider_kind="ollama",
+        model_id="nomic-embed-text",
+        dimensions=_DIMS,
+        scope="global",
+        project_id=None,
+        index_version=1,
+        status="reembedding",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _entities(count: int) -> list[dict[str, Any]]:
+    return [
+        {"uuid": f"uuid-{i:03d}", "text": f"Entity {i} (ORG)"} for i in range(count)
+    ]
+
+
+def _good_embedder(texts: list[str]) -> list[list[float]]:
+    return [[float(len(t))] * _DIMS for t in texts]
+
+
+def _engine(
+    graph: _FakeGraph,
+    embedder: Any = _good_embedder,
+    batch_size: int = 2,
+) -> Neo4jReEmbedder:
+    return Neo4jReEmbedder(
+        driver_factory=lambda: _FakeDriver(graph),
+        embedder_factory=lambda configuration: embedder,
+        batch_size=batch_size,
+    )
+
+
+def _run(
+    engine: Neo4jReEmbedder,
+    progress: EmbeddingMigrationProgress | None = None,
+) -> tuple[str, list[EmbeddingMigrationProgress]]:
+    checkpoints: list[EmbeddingMigrationProgress] = []
+    status = engine.run(
+        "entity_embedding_v1",
+        "embedding_v1",
+        _DIMS,
+        progress or EmbeddingMigrationProgress(total=0, processed=0, failed=0),
+        configuration=_configuration(),
+        checkpoint=checkpoints.append,
+    )
+    return status, checkpoints
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+
+def test_run_reembeds_all_entities_in_batches() -> None:
+    graph = _FakeGraph(_entities(5))
+    status, checkpoints = _run(_engine(graph, batch_size=2))
+
+    assert status == "completed"
+    written_uuids = [
+        row["uuid"] for batch in graph.written for row in batch["rows"]
+    ]
+    assert written_uuids == [f"uuid-{i:03d}" for i in range(5)]
+    assert all(batch["property_key"] == "embedding_v1" for batch in graph.written)
+    assert all(
+        len(row["vector"]) == _DIMS
+        for batch in graph.written
+        for row in batch["rows"]
+    )
+    # Erster Checkpoint traegt den Total-Count, danach einer pro Batch.
+    assert checkpoints[0].total == 5
+    assert len(checkpoints) == 1 + 3  # ceil(5/2) Batches
+    final = checkpoints[-1]
+    assert final.processed == 5
+    assert final.failed == 0
+    assert final.last_processed_id == "uuid-004"
+    assert graph.closed is True
+
+
+def test_run_creates_versioned_vector_index() -> None:
+    graph = _FakeGraph(_entities(1))
+    status, _ = _run(_engine(graph))
+
+    assert status == "completed"
+    assert len(graph.created_indexes) == 1
+    ddl = graph.created_indexes[0]
+    assert "entity_embedding_v1" in ddl
+    assert "IF NOT EXISTS" in ddl
+    assert "n.embedding_v1" in ddl
+    assert f"`vector.dimensions`: {_DIMS}" in ddl
+
+
+def test_run_resumes_from_last_processed_id() -> None:
+    graph = _FakeGraph(_entities(5))
+    progress = EmbeddingMigrationProgress(
+        total=5, processed=3, failed=0, last_processed_id="uuid-002"
+    )
+    status, checkpoints = _run(_engine(graph, batch_size=2), progress=progress)
+
+    assert status == "completed"
+    written_uuids = [
+        row["uuid"] for batch in graph.written for row in batch["rows"]
+    ]
+    assert written_uuids == ["uuid-003", "uuid-004"], "nur Rest nach Cursor"
+    final = checkpoints[-1]
+    assert final.processed == 5
+    assert final.last_processed_id == "uuid-004"
+
+
+def test_run_counts_dimension_mismatch_as_failed() -> None:
+    graph = _FakeGraph(_entities(3))
+
+    def _mixed(texts: list[str]) -> list[list[float]]:
+        # Erster Text pro Batch bekommt eine falsche Dimension.
+        return [
+            ([0.0] * (_DIMS - 1) if i == 0 else [1.0] * _DIMS)
+            for i, _ in enumerate(texts)
+        ]
+
+    status, checkpoints = _run(_engine(graph, embedder=_mixed, batch_size=3))
+
+    assert status == "failed", "Dimension-Mismatch darf keinen Switch ausloesen"
+    final = checkpoints[-1]
+    assert final.failed == 1
+    assert final.processed == 2
+    written_uuids = [
+        row["uuid"] for batch in graph.written for row in batch["rows"]
+    ]
+    assert "uuid-000" not in written_uuids
+
+
+def test_run_with_empty_graph_completes_without_writes() -> None:
+    graph = _FakeGraph([])
+    status, checkpoints = _run(_engine(graph))
+
+    assert status == "completed"
+    assert graph.written == []
+    assert checkpoints[-1].total == 0
+    assert checkpoints[-1].processed == 0
+
+
+def test_run_rejects_invalid_index_or_property_identifier() -> None:
+    graph = _FakeGraph(_entities(1))
+    engine = _engine(graph)
+    progress = EmbeddingMigrationProgress(total=0, processed=0, failed=0)
+
+    with pytest.raises(ValueError):
+        engine.run(
+            "evil name; DROP INDEX x",
+            "embedding_v1",
+            _DIMS,
+            progress,
+            configuration=_configuration(),
+            checkpoint=lambda p: None,
+        )
+    with pytest.raises(ValueError):
+        engine.run(
+            "entity_embedding_v1",
+            "embedding_v1`); MATCH (n) DETACH DELETE n; //",
+            _DIMS,
+            progress,
+            configuration=_configuration(),
+            checkpoint=lambda p: None,
+        )
+
+
+def test_run_propagates_embedder_errors() -> None:
+    graph = _FakeGraph(_entities(2))
+
+    def _exploding(texts: list[str]) -> list[list[float]]:
+        raise RuntimeError("embedding backend down")
+
+    with pytest.raises(RuntimeError, match="embedding backend down"):
+        _run(_engine(graph, embedder=_exploding))
+    assert graph.closed is True, "Driver wird auch im Fehlerfall geschlossen"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3239 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3250 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 154 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3250 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3252 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 154 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -1,214 +1,155 @@
-# Handover — Onboarding/Provider-Unification Slice 4.3.1
+# Handover — Onboarding/Provider-Unification Slice 4.3.4
 
 ## Stand
 
-- Datum: 2026-07-12
-- Worktree: `/private/tmp/agora-onboarding-slice-4-3`
-- Branch: `codex/onboarding-embedding-migration` (Basis: `main` @
-  `bcc50ba`, PR #688 mit Slice 4.2 in main gemergt)
-- Slice: 4.3.1 — Migrations-Service + Ollama-Download (Backend)
-  (Frontend-Store + View + Onboarding-Anbindung kommt als
-  Sub-Slice 4.3.2 in einer Folge-Session)
-- Arbeitsstand: implementiert, alle Gates grün, Commit/PR in Arbeit
-- Teststatus: Backend **3222 passed / 9 skipped / 7 deselected** (Exit 0);
-  Contracts 363 passed (unverändert); Frontend 154 Testdateien / 1228
-  Tests grün; ruff grün; mypy 0 Fehler; Schema-Dump `--check` grün für
-  46 Schemas (kein struktureller Vertrags-Drift; nur ein neuer
-  Sentinel-Wert in `EmbeddingMigrationJob`).
-- context-mode: nicht in dieser Session aktiv.
-- code-review-graph: CLI 2.3.6 via `uvx`; Worktree-Graph frisch
-  gebaut.
+- Datum: 2026-07-13
+- Worktree: `/private/tmp/agora-onboarding-slice-4-3-4`
+- Branch: `codex/embedding-neo4j-reembedder` (Basis: `main` @ `dcfba4a`,
+  PR #693 gemergt)
+- Slice: 4.3.4 — Echte Neo4j-Re-Embedding-Engine (`Neo4jReEmbedder`
+  ersetzt `_NoopReEmbedder`; Read-Loop + Checkpoint + Resume)
+- Arbeitsstand: implementiert, `bash scripts/pre-push-gate.sh` komplett
+  grün (Backend + Frontend + Schemas + STATUS-Sync)
+- Teststatus: Slice-Tests 90 passed (7 neue Engine-Tests, 2 neue
+  Service-Tests, 2 neue Contract-Tests, 2 neue Frontend-Spec-Tests);
+  Zahlen-SSoT in `docs/STATUS.md` (via `scripts/sync-status.sh`
+  regeneriert, 3250 collected)
+- context-mode: aktiv in dieser Session (ctx_batch_execute für Reads)
+- code-review-graph: CLI in dieser Session nicht installiert;
+  Discovery lief über context-mode-Batches
 
 ## Dokumentations-Sync
 
-- README.md: **geprüft, nicht betroffen** — Backend-only.
-- AGENTS.md: **geprüft, nicht betroffen** — keine neuen allgemeinen
-  Regeln.
-- CLAUDE.md: **geprüft, nicht betroffen**.
-- PLAN.md: **aktualisiert** — Slice 4.1/4.2 als gemergt markiert,
-  Slice 4.3 in 4.3.1 (Backend, implementiert) + 4.3.2 (Frontend,
-  offen) aufgeteilt.
-- docs/STATUS.md: **aktualisiert via `scripts/sync-status.sh`**
-  (Backend-Test-Count 3187 → 3222, +35).
-- CHANGELOG.md: **aktualisiert** — neuer Abschnitt
-  `### Added (embedding-migration — 2026-07-12)`.
-- docs/decisions/0007: **keine Aenderung** — ADR-Status bleibt
-  Accepted (Slice 4.3 setzt die in der ADR geforderten Garantien
-  strukturell um; der Re-Embedding-Loop selbst kommt mit Neo4j-
-  Anbindung in einem Folge-Slice).
-- Epic-HANDOVER.md: **aktualisiert** — dieser Stand.
-- docs/tooling/agent-tools.md: **geprüft, nicht betroffen**.
+- README.md: geprüft, nicht betroffen (Operator-Doku der Migration
+  bleibt gültig; Engine ist Implementierungsdetail hinter derselben API)
+- AGENTS.md: geprüft, nicht betroffen
+- CLAUDE.md: geprüft, nicht betroffen
+- PLAN.md: aktualisiert (Abschnitt 12, Slice-4-Status)
+- docs/STATUS.md: aktualisiert (sync-status.sh)
+- CHANGELOG.md: aktualisiert (Added embedding-reembedder 2026-07-13)
+- docs/tooling/agent-tools.md: geprüft, nicht betroffen
 
-## Fertig (Sub-Slice 4.3.1, Backend)
+## Fertig (Sub-Slice 4.3.4)
 
-- **`EmbeddingMigrationService`**
-  (`backend/app/services/embedding_migration.py`):
-  vollstaendiger Lifecycle mit Statusuebergaengen
-  `pending → running → validating → completed | rolled_back | failed`,
-  atomarer Switch nach erfolgreicher Validierung, idempotenter
-  `start()` (doppelter Job fuer dieselbe Konfiguration wirft
-  `ValueError`), explizites `cancel()` setzt auf `rolled_back` statt
-  `failed` (Operator-Entscheidung), `ReEmbedder`-Protocol fuer
-  injizierbaren Re-Embedding-Loop (Tests ohne Neo4j), No-Op-Default-
-  Re-Embedder, Job-Persistenz als flache JSON-Dateien unter
-  `AGORA_DATA_DIR/embedding_migration_<job_id>.json`.
-- **`OllamaPullService`**
-  (`backend/app/services/embedding_ollama_pull.py`): laedt ein
-  Embedding-Modell von `POST {base_url}/api/pull` (NDJSON-Stream)
-  und liefert einen strukturierten `OllamaPullReport`. Sicherheit:
-  strikte Model-Name-Validierung (ASCII a-z, A-Z, 0-9, '-', '_',
-  '.', ':', 1-100 Zeichen — schliesst Shell-Injection aus), keine
-  Shell-Aufrufe (immer strukturierte JSON-Requests via
-  `requests.post`), Loopback/Ollama-Cloud-Einschraenkung, 10-Minuten-
-  Default-Timeout, 60-Sekunden-Stream-Read-Timeout,
-  `resolve_ollama_base_url()`-Helper mit Loopback/Ollama-Cloud-
-  Filterung.
-- **Migrations-API** unter `/api/llm/embedding/migrations`:
-  - `POST /` startet eine neue Migration
-  - `GET /` listet alle Jobs (optional `?configuration_id=...`)
-  - `GET /<job_id>` liefert einen einzelnen Job
-  - `POST /<job_id>/run` zieht den Lifecycle durch
-  - `POST /<job_id>/cancel` bricht ab
-- **Ollama-Download-API** unter `/api/llm/embedding/ollama/pull`:
-  synchroner Endpoint mit strukturiertem JSON-Report, kein
-  Server-Sent-Event-Stream (UI-Setup-Wizard braucht das Ergebnis
-  atomar). 502 `upstream_error` bei Ollama-Fehlern, 404 bei
-  unbekannter Connection, 400 bei ungueltigem Model.
-- **`EmbeddingMigrationJob`-Vertrag erweitert**:
-  `source_index_version=0` ist jetzt der Cold-Start-Sentinel fuer
-  Migrationen ohne Quell-Index. Vertrag stellt sicher, dass
-  `source=0` nur mit `target=1` kombiniert wird und `source < target`
-  immer gilt (sonst `ValueError`).
-- **35 neue Tests**:
-  - 12 × Migrations-Service (Start, Run, Cancel, Validation,
-    Lifecycle, Idempotenz)
-  - 23 × Ollama-Download (Model-Name-Validierung 6+10 parametrisiert,
-    Base-URL-Validierung, Stream-Parsing, Auth-Fehler, Bearer-Header,
-    Empty-Stream-Handling, Default-Timeout-Konfiguration)
+- `backend/app/services/embedding_reembedder.py` (neu):
+  `Neo4jReEmbedder` mit
+  - `CREATE VECTOR INDEX <entity_embedding_vN> IF NOT EXISTS` auf der
+    versionierten Property (niemals DROP — ADR-0007), Identifier-Guard
+    gegen Cypher-Injection in der DDL,
+  - Count + batchweisem Read-Loop über `(n:Entity)` sortiert nach
+    `uuid` mit Cursor `uuid > $cursor`,
+  - Embedding-Text = `coalesce(n.summary, name + ' (' + entity_type + ')')`
+    (identisch zum Ingest-Pfad `ingestion_pipeline`),
+  - Dimensionsprüfung pro Vektor; Mismatch → Knoten wird nicht
+    geschrieben, zählt als `failed`, Endstatus `failed` (kein Switch),
+  - Schreiben via `db.create.setNodeVectorProperty` (UNWIND-Batch),
+  - Checkpoint-Aufruf nach jedem Batch.
+- `backend/app/contracts/embedding_contract.py`:
+  `EmbeddingMigrationProgress.last_processed_id: str | None = None`
+  (Resume-Cursor; Alt-Payloads ohne Feld bleiben ladbar).
+- `backend/app/services/embedding_migration.py`:
+  - `ReEmbedder`-Protocol erweitert um `configuration` +
+    `checkpoint`-Callback; der Service persistiert jeden Checkpoint
+    (`_persist_checkpoint` → `_save_job`),
+  - `run()` akzeptiert jetzt auch Status `running` = Crash-Resume
+    (`started_at` bleibt erhalten),
+  - `failed`-Pfade laden den Job vor dem Endzustand neu, damit
+    Checkpoint-Progress nicht verloren geht.
+- `backend/app/api/embedding_migrations.py`: `_service()` verdrahtet
+  die echte Engine — Driver lazy via `GraphDatabase.driver(Config.NEO4J_*)`
+  (eigener Driver, nicht der App-Pool), Embedder aus Konfiguration +
+  `ProviderConnectionStore` + Secret-Store (analog Probe-Pfad).
+  Gemini (`provider_kind="google"`) wird mit klarer Fehlermeldung
+  abgelehnt (anderes URL-Schema als `EmbeddingService`).
+- Frontend: `EmbeddingMigrationProgressSchema` um
+  `last_processed_id: z.string().nullable().default(null)` ergänzt
+  + 2 Spec-Tests.
+- Schemas: `embedding-migration-job(.response)` regeneriert.
+- Tests: `backend/tests/services/test_embedding_reembedder.py` (neu, 7),
+  `test_embedding_migration.py` (+2: Checkpoint-Persistenz, Resume),
+  `test_embedding_contract.py` (+2: Default/Roundtrip).
 
-## Noch offen (Sub-Slice 4.3.2, Frontend)
+## Noch offen (bewusst, mit Begründung)
 
-- **Frontend-Store** fuer Embedding-Konfigurationen (Pinia, analog
-  zu `LlmProvidersView` / `providerConnections.ts`)
-- **Frontend-View** mit Status-Badges, Probe-Button, Activate-Button,
-  Migrations-Progress-Anzeige, Ollama-Download-Wizard
-- **Zod-Spiegel** der Embedding-Verträge (analog zu
-  `aiProviderContract.ts`)
-- **Onboarding-Schritt `embeddings` an die echte Konfiguration
-  anbinden** (analog zur Slice-3-Anbindung der Provider-Connections
-  im `LlmProvidersView`)
-- **Echte Neo4j-Re-Embedding-Engine**: konkrete `ReEmbedder`-
-  Implementierung, die betroffene Knoten liest, neue Embeddings mit
-  dem konfigurierten Provider erzeugt und in die neue Property
-  schreibt. Aktuell ist die Re-Embedding-Schleife ein No-Op-Stub;
-  der Slice-4.3-Service garantiert das Lifecycle, der Slice-4.3.2
-  Service liefert die echte Daten-Mutation.
+- **`RELATION.fact_embedding`-Re-Embed**: Der versionierte
+  Index-Vertrag (`EmbeddingIndexVersion`) verwaltet nur
+  `entity_embedding_vN`. Facts brauchen eine eigene Index-Versionierung
+  → eigener Slice.
+- **Search-Pfad nutzt weiter den unversionierten `entity_embedding`-Index**
+  (`search_service.py` hardcodet `entity_embedding`/`fact_embedding`).
+  Der Umschwenk der Query-Seite auf `entity_embedding_vN` ist der
+  logische Folge-Sub-Slice nach dem ersten echten Re-Embed.
+- **Gemini-Batch-Embedding**: `EmbeddingService` spricht nur
+  Ollama-/OpenAI-kompatible Endpunkte. Gemini-Embed-Batch wäre ein
+  eigener Adapter — bis dahin ehrliche Ablehnung.
+- **`scope="project"`-Filter**: Zuordnung Projekt → Graph ist nicht
+  Teil des Embedding-Vertrags; Engine läuft global.
+- **Migration läuft synchron im Request** (`POST /migrations/<id>/run`):
+  bei großen Graphen lange Requests. Resume macht das erträglich;
+  Job-Queue/SSE-Streaming bleibt der bekannte offene Punkt aus 4.3.1.
+- **i18n-Keys** für die Embedding-View (`embedding.title` etc.) —
+  Mini-Folge-Aufgabe, nicht Teil dieses Slices.
 
 ## Entscheidungen
 
-- **Re-Embedder als Protocol injizierbar**: Tests laufen ohne Neo4j
-  und ohne echte Embedding-Backends. Die echte Implementierung
-  kommt mit Neo4j-Anbindung in einer Folge-Session; der Service
-  bleibt davon unberuehrt.
-- **`source_index_version=0` als Cold-Start-Sentinel**: die
-  ursprueglich strengere Validierung (``source != target``) wurde
-  gelockert, weil eine Erst-Migration logischerweise keinen
-  Quell-Index hat. Sentinel 0 ist sprechend und kann ohne
-  zusaetzliche Flags genutzt werden.
-- **Kein SSE fuer den Ollama-Download**: der UI-Setup-Wizard braucht
-  das Ergebnis atomar, nicht als Stream. Wenn eine Frontend-Streaming-
-  UX noetig wird, kommt sie in Sub-Slice 4.3.2 mit Server-Sent-
-  Events ueber einen separaten Endpoint.
-- **Strikte Model-Name-Validierung**: ASCII-Zeichen + Bindestrich +
-  Unterstrich + Doppelpunkt + Punkt, 1-100 Zeichen. Schliesst
-  Shell-Injection auf der Modell-Bezeichnungs-Ebene aus, ohne
-  die gaengigen Ollama-Naming-Conventions
-  (``name:tag``, ``name.variant``) zu beschraenken.
-- **Job-Persistenz als flache JSON-Dateien**: ein Job pro Datei
-  unter `AGORA_DATA_DIR/embedding_migration_<id>.json`. Einfacher
-  als eine zweite Collection im Embedding-Configuration-Store;
-  unkompliziert fuer Folge-Slices, die z. B. nach ``completed``
-  aufraeumen koennen.
-- **Migrations-Service fuehrt KEIN `DROP INDEX` aus**: ADR-0007
-  verbietet das bis zur expliziten Operator-Bestaetigung. Der
-  `completed`-Pfad macht nur den Konfigurations-Switch und setzt
-  den alten Index auf `superseded` (lesbar, nicht aktiv).
-  Neo4j-Index-Switch (``CALL db.index.setProperty`` o. ae.)
-  ist ein eigener Schritt, der in einem Folge-Slice nach
-  Live-Tests abgesichert wird.
+- Resume über `uuid`-Cursor (`last_processed_id`) statt Offset:
+  stabil gegen parallel wachsende Graphen, kein Skip/Doppel-Embed.
+- Job-Status `running` gilt bei `run()` als Resume (Crash-Recovery);
+  ein Operator-Abbruch bleibt `rolled_back` und ist nicht resumebar.
+- `failed > 0` ⇒ Endstatus `failed`, kein Index-Switch: ein
+  unvollständig befüllter Index darf nie aktiv werden (ADR-0007
+  Dimensionssicherheit).
+- Eigener lazy Neo4j-Driver pro Migrationslauf statt App-Pool:
+  langlaufender Operator-Vorgang soll den Flask-Pool nicht blockieren.
+- Checkpoint-Persistenz macht der Service (nicht die Engine), damit
+  die Engine ohne Kenntnis des Job-Speicherformats testbar bleibt.
 
 ## Bekannte Risiken
 
-- **Re-Embedder ist ein No-Op-Stub**: Migrationen laufen
-  "durch" (Lifecycle completed), aber es werden null Knoten
-  re-embedded. Solange die echte Neo4j-Implementierung fehlt,
-  ist der Migrations-Service ehrlich gesagt ein
-  "Switch-Operator": er macht nur den Konfigurations-Switch
-  und Index-Status-Wechsel, nicht den eigentlichen Re-Embed.
-  Bis der echte Loop steht, ist ein Operator-Aufruf von
-  `POST /migrations/<id>/run` ein No-Op-Switch. Mitigation:
-  Handover dokumentiert das prominent; Frontend sollte im
-  Migrations-Wizard eine sichtbare Warnung zeigen, bis der
-  echte Loop steht.
-- **Ollama-Download-Endpoint ist synchron**: bei grossen
-  Modellen kann der HTTP-Request 10 Minuten dauern und blockiert
-  einen Worker. Mitigation: in Produktion hinter einem
-  Job-Queue-Endpoint (geplant fuer 4.3.2), oder mit
-  Async-Worker-Pattern.
-- **`request.get_json(silent=True)`**: schluckt JSON-Parse-Fehler
-  still; das ist Absicht (der Body-Validator fängt das mit
-  `ValueError` ab und liefert 400). Aber Endpunkt-Aufrufer mit
-  kaputten JSON-Body bekommen 400, nicht 415 — falls das
-  jemals relevant wird, muss der Endpunkt auf
-  `silent=False` umgestellt und `BadRequest` gefangen werden.
+- Der neue versionierte Index wird von der Suche noch nicht abgefragt
+  (siehe „Noch offen"). Nach einem Modellwechsel mit anderer Dimension
+  liefert die Suche weiterhin Ergebnisse aus dem alten Index — der
+  Operator sieht den Fortschritt nur im Migrations-Job.
+- `EmbeddingService.embed_batch` cached in-memory pro Instanz
+  (`_cache_max_size` 2000) — bei sehr großen Graphen unkritisch,
+  aber erwähnt.
+- Entities ohne `uuid`-Property (sehr alte Bestandsgraphen) werden
+  bewusst übersprungen (`WHERE n.uuid IS NOT NULL`) und tauchen nicht
+  in `total` auf.
 
 ## Geänderte Verträge und Migrationen
 
-- **`EmbeddingMigrationJob.source_index_version`** darf jetzt
-  `0` sein (Sentinel fuer Cold-Start). Vertrag: `Field(ge=0)`
-  statt `Field(ge=1)`. Service: `start()` setzt
-  `source_index_version=0` wenn `next_version == 1`.
-- **Keine JSON-Schema-Drift**: das OpenAPI-Schema aendert sich
-  nur in der Minimum-Constraint, was die generierten Schemas
-  nicht beruehrt (Schema-Drift-Check ist 46/46 gruen).
-- **Keine Datenmigration** noetig — die Job-Dateien werden
-  lazy angelegt, wenn der erste Job gestartet wird.
+- `EmbeddingMigrationProgress` + `last_processed_id` (additiv,
+  Default `None`; Schema-Dump + Zod-Spiegel synchron; Alt-Job-Dateien
+  bleiben ladbar).
+- Keine Datenbank-Migration; die Engine legt nur additiv
+  `entity_embedding_vN`-Indizes und `embedding_vN`-Properties an.
 
 ## Nächste exakt ausführbare Schritte
 
-1. Atomarer Commit auf `codex/onboarding-embedding-migration`,
-   Branch pushen, PR gegen `main` eroeffnen; Gemini-Findings
-   sichten, erst danach mergen.
-2. Nach Merge: `uvx --from 'code-review-graph==2.3.6'
-   code-review-graph build` auf `main` + Delta pruefen.
-3. Sub-Slice 4.3.2: Frontend-Store, View, Zod-Spiegel,
-   Onboarding-Anbindung in einer Folge-Session.
-4. Folge-Slice: echte Neo4j-Re-Embedding-Engine
-   (`ReEmbedder`-Implementierung mit Neo4j-Read-Loop + Embedding-
-   Service-Cache).
+1. PR gegen `main` eröffnen, 90 s warten, Gemini-Findings sichten,
+   erst dann mergen.
+2. Nach Merge: Codegraph auf `main` neu bauen (`uvx --from
+   'code-review-graph==2.3.6' code-review-graph build`).
+3. Slice 5 (gemeinsamer Model-Picker, Discovery-getrieben) beginnen;
+   Search-Pfad-Umschwenk auf versionierte Indizes bleibt als
+   dokumentierter Folge-Sub-Slice.
 
 ## Relevante Dateien
 
+- `backend/app/services/embedding_reembedder.py`
 - `backend/app/services/embedding_migration.py`
-- `backend/app/services/embedding_ollama_pull.py`
+- `backend/app/contracts/embedding_contract.py`
 - `backend/app/api/embedding_migrations.py`
-- `backend/app/api/__init__.py` (Import-Update)
-- `backend/app/contracts/embedding_contract.py` (Sentinel-Erweiterung)
-- `backend/tests/services/test_embedding_migration.py`
-- `backend/tests/services/test_embedding_ollama_pull.py`
-- `docs/epics/onboarding-provider-unification/04-implementation-plan.md`
-- `docs/decisions/0007-embedding-configuration-and-index-migration.md`
+- `frontend/src/contracts/embeddingContract.ts`
+- `backend/tests/services/test_embedding_reembedder.py`
 
 ## Befehle zur Verifikation
 
 ```bash
-cd backend && uv run pytest tests/services/test_embedding_migration.py \
-  tests/services/test_embedding_ollama_pull.py -q
-cd backend && uv run python -m app.contracts.dump_schemas --check
-cd backend && uv run ruff check app/ tests/
-cd backend && uv run mypy app
-cd backend && uv run pytest -q
-cd frontend && bun run test
-bash scripts/sync-status.sh --check
-uvx --from 'code-review-graph==2.3.6' code-review-graph status --repo .
+cd /private/tmp/agora-onboarding-slice-4-3-4
+bash scripts/pre-push-gate.sh
+cd backend && uv run pytest tests/services/test_embedding_reembedder.py \
+  tests/services/test_embedding_migration.py \
+  tests/contracts/test_embedding_contract.py -q
 ```

--- a/frontend/src/contracts/__tests__/embeddingContract.spec.ts
+++ b/frontend/src/contracts/__tests__/embeddingContract.spec.ts
@@ -175,6 +175,29 @@ describe('embeddingContract — Zod-Spiegel der Backend-Contracts', () => {
     ).toThrow(/finished_at/)
   })
 
+  it('EmbeddingMigrationProgress: last_processed_id defaultet auf null (Legacy-Payloads)', () => {
+    const parsed = EmbeddingMigrationProgressSchema.parse({
+      total: 5,
+      processed: 5,
+      failed: 0,
+      started_at: null,
+      finished_at: null,
+    })
+    expect(parsed.last_processed_id).toBeNull()
+  })
+
+  it('EmbeddingMigrationProgress: last_processed_id wird als Resume-Cursor durchgereicht', () => {
+    const parsed = EmbeddingMigrationProgressSchema.parse({
+      total: 10,
+      processed: 4,
+      failed: 1,
+      last_processed_id: 'uuid-003',
+      started_at: '2026-07-13T08:00:00+00:00',
+      finished_at: null,
+    })
+    expect(parsed.last_processed_id).toBe('uuid-003')
+  })
+
   it('EmbeddingConfigurationScope akzeptiert nur global oder project', () => {
     expect(() => EmbeddingConfigurationScopeSchema.parse('team')).toThrow()
   })

--- a/frontend/src/contracts/embeddingContract.ts
+++ b/frontend/src/contracts/embeddingContract.ts
@@ -197,6 +197,8 @@ export const EmbeddingMigrationProgressSchema = z
     total: z.number().int().min(0),
     processed: z.number().int().min(0),
     failed: z.number().int().min(0),
+    // Resume-Cursor der Re-Embedding-Engine (Slice 4.3.4)
+    last_processed_id: z.string().nullable().default(null),
     started_at: NullableDateTimeSchema,
     finished_at: NullableDateTimeSchema,
   })

--- a/schemas/embedding-migration-job-response.schema.json
+++ b/schemas/embedding-migration-job-response.schema.json
@@ -97,6 +97,18 @@
           "default": null,
           "title": "Finished At"
         },
+        "last_processed_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Processed Id"
+        },
         "processed": {
           "minimum": 0,
           "title": "Processed",

--- a/schemas/embedding-migration-job.schema.json
+++ b/schemas/embedding-migration-job.schema.json
@@ -22,6 +22,18 @@
           "default": null,
           "title": "Finished At"
         },
+        "last_processed_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Processed Id"
+        },
         "processed": {
           "minimum": 0,
           "title": "Processed",


### PR DESCRIPTION
## Was

Sub-Slice 4.3.4 des Epics `onboarding-provider-unification`: der `_NoopReEmbedder`-Stub aus Slice 4.3.1 wird durch die echte Neo4j-Re-Embedding-Engine ersetzt.

## Wie

- **`backend/app/services/embedding_reembedder.py` (neu)**: `Neo4jReEmbedder` — batchweiser Read-Loop über `(n:Entity)` sortiert nach `uuid` mit Cursor (`uuid > $cursor`), Embedding-Text identisch zum Ingest-Pfad (`coalesce(n.summary, name + ' (' + entity_type + ')')`), Dimensionsprüfung pro Vektor gegen die verifizierte Konfiguration, Schreiben via `db.create.setNodeVectorProperty` (UNWIND-Batch). Ziel-Index additiv per `CREATE VECTOR INDEX … IF NOT EXISTS` — niemals DROP (ADR-0007). Identifier-Guard gegen Cypher-Injection in der DDL.
- **Contract (Layer 0, additiv)**: `EmbeddingMigrationProgress.last_processed_id: str | null` als Resume-Cursor. Schema-Dump regeneriert, Zod-Spiegel synchron (`.nullable().default(null)` — Alt-Payloads bleiben ladbar).
- **Service**: `ReEmbedder`-Protocol erweitert um `configuration` + `checkpoint`; der Service persistiert jeden Batch-Checkpoint. `run()` akzeptiert jetzt auch Jobs in `running` = Crash-Resume (`started_at` bleibt erhalten). `failed`-Pfade behalten den letzten Checkpoint.
- **API-Wiring**: `_service()` baut die echte Engine — lazy dedizierter Neo4j-Driver (nicht der App-Pool), Embedder-Auflösung analog zum Probe-Pfad (ProviderConnection → base_url, Secret-Store → API-Key). Gemini wird ehrlich mit klarer Fehlermeldung abgelehnt (anderes URL-Schema), statt einen No-Op vorzutäuschen.

## Invarianten

- `failed > 0` ⇒ Endstatus `failed`, **kein** Index-Switch — ein unvollständiger Index darf nie aktiv werden.
- Leerer Graph ⇒ gültige Erst-Migration (`completed`, 0 Writes).
- Kein DROP INDEX, keine destruktive Mutation bestehender Properties.

## Bewusst offen (im Epic-HANDOVER dokumentiert)

- `RELATION.fact_embedding`-Re-Embed (Index-Vertrag kennt nur `entity_embedding_vN`)
- Search-Pfad fragt weiterhin den unversionierten `entity_embedding`-Index ab (Folge-Sub-Slice)
- Gemini-Batch-Embedding-Adapter, `scope="project"`-Filter, Job-Queue/SSE für lange Läufe

## Tests

- `tests/services/test_embedding_reembedder.py` (neu, 7 Tests, Fake-Driver ohne Neo4j): Batching, Index-DDL, Resume ab Cursor, Dimension-Mismatch ⇒ failed, leerer Graph, Injection-Guard, Fehler-Propagation
- `tests/services/test_embedding_migration.py` (+2): Checkpoint-Persistenz, Resume aus `running`
- `tests/contracts/test_embedding_contract.py` (+2): Default/Roundtrip von `last_processed_id`
- Frontend-Spec (+2): Zod-Default und Cursor-Durchreichung

`bash scripts/pre-push-gate.sh` — ALL GREEN (ruff, mypy, contracts, dump_schemas --check, sync-status --check, eslint, vue-tsc, vitest, vite build, Schema-Spiegel-Smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)