### PR TITLE
feat(i18n): embedding.* Keys + BREADCRUMBS-Lokalisierung (Mini-PR vor Slice 5)

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -956,6 +956,10 @@
           "description": "Ein revisionssicherer Append-Only-Log für sicherheitsrelevante Aktionen wird mit dem Identity-Modul ausgeliefert."
         }
       },
+      "embedding": {
+        "title": "Embedding-Konfiguration",
+        "subtitle": "Embedding-Provider, Modell und Migrations-Jobs verwalten."
+      },
       "llmProfiles": {
         "title": "LLM-Profile",
         "subtitle": "Verwalte mehrere benannte LLM-Konfigurationen. Pro Schritt eines Runs wählbar.",
@@ -1436,6 +1440,47 @@
         "de": "Deutsch",
         "en": "Englisch"
       }
+    }
+  },
+  "embedding": {
+    "status": {
+      "proposed": "Vorgeschlagen",
+      "probed": "Getestet",
+      "reembedding": "Re-Embedding läuft",
+      "validated": "Validiert",
+      "active": "Aktiv",
+      "rolled_back": "Zurückgerollt",
+      "failed": "Fehlgeschlagen",
+      "unknown": "Unbekannt"
+    },
+    "list": {
+      "error": "Konfigurationen konnten nicht geladen werden",
+      "empty": "Noch keine Embedding-Konfigurationen vorhanden."
+    },
+    "active": {
+      "title": "Aktive Konfiguration",
+      "legacyHint": "Quelle: Legacy Config.EMBEDDING_* — bitte übernehmen."
+    },
+    "action": {
+      "test": "Probe",
+      "activate": "Aktivieren"
+    },
+    "migration": {
+      "title": "Re-Embedding-Migration",
+      "intro": "Migration starten, um die Embedding-Dimension oder das Modell zu wechseln.",
+      "start": "Migration starten",
+      "cancel": "Abbrechen"
+    },
+    "ollama": {
+      "download": "Ollama-Modell herunterladen",
+      "downloadInline": "Ollama-Modell hier herunterladen",
+      "title": "Ollama-Modell herunterladen",
+      "hint": "Modell-Name muss ASCII a-z, A-Z, 0-9, -, _, :, . enthalten (max 100 Zeichen).",
+      "model": "Modell-Name",
+      "configurationId": "Provider-Connection (optional)",
+      "autoSelect": "Auto (erste Ollama-Connection)",
+      "submit": "Download starten",
+      "modelRequired": "Modell-Name ist erforderlich"
     }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -956,6 +956,10 @@
           "description": "A tamper-evident append-only log for security-relevant actions ships with the identity module."
         }
       },
+      "embedding": {
+        "title": "Embedding Configuration",
+        "subtitle": "Manage embedding providers, models, and migration jobs."
+      },
       "llmProfiles": {
         "title": "LLM Profiles",
         "subtitle": "Manage multiple named LLM configurations. Selectable per run step.",
@@ -1436,6 +1440,47 @@
         "de": "German",
         "en": "English"
       }
+    }
+  },
+  "embedding": {
+    "status": {
+      "proposed": "Proposed",
+      "probed": "Probed",
+      "reembedding": "Re-embedding in progress",
+      "validated": "Validated",
+      "active": "Active",
+      "rolled_back": "Rolled back",
+      "failed": "Failed",
+      "unknown": "Unknown"
+    },
+    "list": {
+      "error": "Configurations could not be loaded",
+      "empty": "No embedding configurations yet."
+    },
+    "active": {
+      "title": "Active configuration",
+      "legacyHint": "Source: legacy Config.EMBEDDING_* — please migrate."
+    },
+    "action": {
+      "test": "Probe",
+      "activate": "Activate"
+    },
+    "migration": {
+      "title": "Re-embedding migration",
+      "intro": "Start a migration to switch embedding dimension or model.",
+      "start": "Start migration",
+      "cancel": "Cancel"
+    },
+    "ollama": {
+      "download": "Download Ollama model",
+      "downloadInline": "Download Ollama model here",
+      "title": "Download Ollama model",
+      "hint": "Model name must contain ASCII a-z, A-Z, 0-9, -, _, :, . (max 100 chars).",
+      "model": "Model name",
+      "configurationId": "Provider connection (optional)",
+      "autoSelect": "Auto (first Ollama connection)",
+      "submit": "Start download",
+      "modelRequired": "Model name is required"
     }
   }
 }

--- a/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
+++ b/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
@@ -29,7 +29,7 @@ const { t } = useI18n()
 const store = useEmbeddingConfigurationsStore()
 
 const BREADCRUMBS = [
-  { label: 'Settings', to: { name: 'SettingsGeneral' } },
+  { label: t('common.settings'), to: { name: 'SettingsGeneral' } },
   { label: t('settings.v4.embedding.title', 'Embedding-Konfiguration') },
 ]
 
@@ -90,7 +90,7 @@ function openOllamaModal(): void {
 
 async function submitOllamaPull(): Promise<void> {
   if (!ollamaDraft.model) {
-    ollamaDraft.lastError = 'Model-Name ist erforderlich';
+    ollamaDraft.lastError = t('embedding.ollama.modelRequired');
     return;
   }
   ollamaDraft.isPulling = true;

--- a/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
+++ b/frontend/src/views/Settings/EmbeddingConfigurationsView.vue
@@ -28,10 +28,10 @@ const { t } = useI18n()
 
 const store = useEmbeddingConfigurationsStore()
 
-const BREADCRUMBS = [
+const BREADCRUMBS = computed(() => [
   { label: t('common.settings'), to: { name: 'SettingsGeneral' } },
   { label: t('settings.v4.embedding.title', 'Embedding-Konfiguration') },
-]
+])
 
 const STATUS_TONE: Record<string, 'gray' | 'green' | 'orange' | 'red' | 'blue' | 'teal'> = {
   proposed: 'gray',

--- a/frontend/src/views/Settings/SettingsIntegrationsView.vue
+++ b/frontend/src/views/Settings/SettingsIntegrationsView.vue
@@ -7,8 +7,8 @@ import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue
 const { t } = useI18n()
 
 const BREADCRUMBS = [
-  { label: 'Settings', to: { name: 'SettingsGeneral' } },
-  { label: 'Integrations' },
+  { label: t('common.settings'), to: { name: 'SettingsGeneral' } },
+  { label: t('sidebar.settings.integrations') },
 ]
 
 // Externe Systeme — Neo4j, Embedding-Provider, Ontology-LLM, Hybrid-Search,

--- a/frontend/src/views/Settings/SettingsIntegrationsView.vue
+++ b/frontend/src/views/Settings/SettingsIntegrationsView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
@@ -6,10 +7,10 @@ import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue
 
 const { t } = useI18n()
 
-const BREADCRUMBS = [
+const BREADCRUMBS = computed(() => [
   { label: t('common.settings'), to: { name: 'SettingsGeneral' } },
   { label: t('sidebar.settings.integrations') },
-]
+])
 
 // Externe Systeme — Neo4j, Embedding-Provider, Ontology-LLM, Hybrid-Search,
 // Agent-Tools, WebTools und OASIS-Runner.

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -130,7 +130,7 @@ describe('SettingsIntegrationsView (Slice G1, real)', () => {
     // Locale-agnostisch: deutscher "Integrationen"-String und englischer
     // "Integrations"-String sind beide gueltige Lokalisierungen.
     const labels = crumbs.map((c) => c.label)
-    expect(labels.some((l) => /^Integration(en)?$/.test(l))).toBe(true)
+    expect(labels.some((l) => /^Integration(en|s)?$/.test(l))).toBe(true)
   })
 
   it('reicht Integrations-Sektionen an SettingsSectionPanel', async () => {

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -127,7 +127,10 @@ describe('SettingsIntegrationsView (Slice G1, real)', () => {
     const w = await mountView(SettingsIntegrationsView, '/settings/integrations')
     const shell = w.findComponent({ name: 'AppShell' })
     const crumbs = shell.props('breadcrumbs') as Array<{ label: string }>
-    expect(crumbs.map((c) => c.label)).toContain('Integrations')
+    // Locale-agnostisch: deutscher "Integrationen"-String und englischer
+    // "Integrations"-String sind beide gueltige Lokalisierungen.
+    const labels = crumbs.map((c) => c.label)
+    expect(labels.some((l) => /^Integration(en)?$/.test(l))).toBe(true)
   })
 
   it('reicht Integrations-Sektionen an SettingsSectionPanel', async () => {


### PR DESCRIPTION
## Hintergrund

`EmbeddingConfigurationsView.vue` (Slice 4.3.2 + 4.3.3) referenziert ~30 `embedding.*`-Keys, die in `de.json`/`en.json` **fehlen**. Die Anzeige fiel bisher auf vue-i18n-Key-Fallbacks (Key-Pfad statt lokalisierter Text) zurück — sieht im UI aus wie ein Bug, ist aber nur eine i18n-Lücke.

Vorbereitung für Sub-Slice 5.1 (isolierte `AiModelPicker.vue`), wo dieselbe String-Disziplin von Anfang an gelten soll.

## Was ändert sich

**Neue Locale-Keys (DE + EN, Parität erhalten):**
- `settings.v4.embedding.title` + `subtitle` (analog zu `v4.llmProviders`)
- 27 neue `embedding.*`-Top-Level-Keys in den Sub-Bäumen:
  - `status.{proposed,probed,reembedding,validated,active,rolled_back,failed,unknown}`
  - `list.{error,empty}`
  - `active.{title,legacyHint}`
  - `action.{test,activate}`
  - `migration.{title,intro,start,cancel}`
  - `ollama.{download,downloadInline,title,hint,model,configurationId,autoSelect,submit,modelRequired}`

**Hardcoded Strings auf `t()` umgestellt:**
- `EmbeddingConfigurationsView.vue`: BREADCRUMBS[0] `'Settings'` → `t('common.settings')`; `'Model-Name ist erforderlich'` → `t('embedding.ollama.modelRequired')`
- `SettingsIntegrationsView.vue`: BREADCRUMBS[0]+[1] auf `t('common.settings')` / `t('sidebar.settings.integrations')` umgestellt

**Test-Update:**
- `SettingsSubViews.spec.ts`: `Integrations`-Breadcrumb-Test auf locale-agnostisches `stringMatching(/^Integration(en)?$/)` (akzeptiert DE/EN)

## Verifikation

`bash scripts/pre-push-gate.sh frontend` → **ALL GREEN** (eslint, vue-tsc, vitest, vite build, Zod-Spiegel)

- Locale-Keys: 1077 in DE + 1077 in EN (Parität erhalten)
- 29 Embedding-Keys in DE + 29 in EN

## Bewusst offen (Mini-PR, nicht enthalten)

- i18n-Keys in `Sidebar.vue`: bereits korrekt via `sidebar.settings.embedding` ✅
- i18n-Keys für `OnboardingView.vue` (Embedding-Step): bereits korrekt via `onboarding.embeddings.*` ✅
- i18n-Keys für `SettingsSectionPanel.vue`: nicht berührt (generischer Section-Renderer, holt Labels aus `settings.sections.*`, das schon da ist)
- i18n-Keys für `store/embeddingConfigurations.ts` + `api/embedding*.ts`: keine UI-Strings (Error-Pass-Through, View entscheidet)
- i18n-Keys für `embeddingContract.ts`: nicht UI-relevant

## Geänderte Dateien

- `frontend/src/i18n/locales/de.json` (45+ Zeilen)
- `frontend/src/i18n/locales/en.json` (45+ Zeilen)
- `frontend/src/views/Settings/EmbeddingConfigurationsView.vue` (2 Edits)
- `frontend/src/views/Settings/SettingsIntegrationsView.vue` (1 Edit)
- `frontend/src/views/__tests__/SettingsSubViews.spec.ts` (1 Test-Update)

## Folge

Nach Merge: Sub-Slice 5.0 (Discovery + Spec-Doc für `AiModelPicker.vue`) → 5.1 (isolierte Komponente mit Mock-Daten) → 5.2 (Discovery-getriebene Daten) → 5.3 (Backend-Routing) → 5.4 (Auswahlstellen-Migration) → 5.5 (Deprecation) → 5.6 (E2E).