### PR TITLE
docs(epic): Slice 5 Sub-Plan + ADR-0009 (Sub-Slice 5.0)

### DIFF
--- a/docs/decisions/0009-unified-model-picker.md
+++ b/docs/decisions/0009-unified-model-picker.md
@@ -1,0 +1,86 @@
+# ADR-0009: Einheitlicher Model-Picker und Routing-Hierarchie
+
+- Status: Proposed
+- Datum: 2026-07-13
+- Vorgeschlagener Branch: `codex/onboarding-model-picker`
+- Bezug: Master-Prompt §5.3, §5.4, §6.1-6.3
+- Sub-Plan: `docs/epics/onboarding-provider-unification/slice-5-subplan.md`
+
+## Kontext
+
+Modellauswahl ist im aktuellen Code an **mindestens sechs Stellen** dupliziert:
+v3 (`ModelPicker.vue` + `LlmProfilePicker.vue` + `ActiveModelBadge.vue`),
+v4 (`v4/forms/ModelPicker.vue` + `StepModelOverrideChip.vue` +
+`LlmProviderCard.vue`), vier Stores (`llmProviders`, `llmProfiles`,
+`llmRoutingDefaults`, `useActiveModelStore`) und zwei Composables
+(`useRuntimeLlmOptions`, `useAvailableModels`). Backend-seitig gibt es vier
+LLM-Contracts (`ai_provider_contract`, `llm_profile_contract`,
+`llm_routing_contract`, `workspace_routing_contract`) mit teils
+überlappender Semantik.
+
+Das verletzt Master-Prompt §5.3 ("nur eine fachliche Quelle für
+Provider-Metadaten") und §6.1 ("eine Komponente, eine Semantik").
+Konsequenz: Profil-Konflikte zwischen Settings, Dashboard und Run-Stage,
+stille Fallbacks auf "Workspace-Default", keine sichtbare Quelle der
+tatsächlich genutzten Auswahl, kein einheitlicher Audit-Trail.
+
+## Entscheidung
+
+1. **Eine** `AiModelPicker.vue` ersetzt alle bestehenden Modell-Picker in v4
+   (und über Shim/Adapter in v3, bis v3 abgelöst ist).
+2. **Eine** kanonische Datenquelle: `useAvailableModels()` liest aus
+   `ProviderConnection`-Discovery (Slice 3) + Capability-Metadaten (Slice 1)
+   + Active-Model-Store. Andere Stores (`llmProviders`, `llmProfiles`,
+   `llmRoutingDefaults`) werden zu Read-Adaptern und nach v4-Migration
+   entfernt.
+3. **Routing-Hierarchie** (Master-Prompt §6.3) wird server-seitig
+   aufgelöst und im Run-Snapshot + Audit-Trail festgehalten:
+   `Stage-Override > Run-Override > Project > Workspace > Provider-Fallback`.
+4. **Embedding- und Chat-Modelle** nutzen denselben Picker mit `mode`-Prop
+   (semantisch identische UX: Suche, Gruppe, Badges, Status).
+5. **Stille Fallbacks sind verboten.** Jede effektive Auswahl trägt
+   `source` und `fallback_reason` (sofern Fallback).
+
+## Konkrete Umsetzung (geplant über 6 Sub-Slices)
+
+Siehe `docs/epics/onboarding-provider-unification/slice-5-subplan.md` für
+verbindliche Sub-Slice-Reihenfolge und Akzeptanzkriterien.
+
+- **5.0 Discovery + Spec-Doc** (dieser PR): Sub-Plan + ADR Proposed.
+- **5.1 `AiModelPicker.vue` isoliert:** Mock-Daten, Combobox-Pattern,
+  ARIA, Tastatur, keine Live-API.
+- **5.2 Discovery-getriebene Daten:** Anbindung an `ProviderConnectionStore`
+  via `useAvailableModels()`. Pilot-Einsatz in `SettingsGeneralView.vue`.
+- **5.3 Backend-Routing-Hierarchie:** `AiRoute`-Resolver, `ai_route_contract`,
+  Snapshot + Audit.
+- **5.4 Auswahlstellen migrieren:** `HeroNewRun.vue`, `LlmProvidersView.vue`,
+  `LlmRoutingView.vue`, `StepModelOverrideChip.vue`, `SettingsGeneralView.vue`
+  + i18n-Keys.
+- **5.5 Alte Komponenten und Stores deprecaten:** v3-Picker + v3-Stores →
+  `@deprecated`, später entfernt.
+- **5.6 Playwright-E2E:** Tastatur, Provider offline, Run-Snapshot.
+
+## Folgen
+
+- eine UI-Komponente pro Auswahl-Stelle → konsistente UX;
+- kanonische Datenquelle → keine Duplikat-Konflikte;
+- sichtbare Quelle + Fallback-Begründung → ehrliche Routing-Transparenz;
+- Run-Snapshot speichert `AiRoute` → reproduzierbare Runs;
+- Migrations-Aufwand: 4 Stores + 2 Composables + 7 v3-Komponenten
+  werden über 6 Sub-Slices abgelöst (kein Big-Bang);
+- v3-Code bleibt während 5.1-5.4 lesbar, wird in 5.5 deprecated und
+  in einem Folge-Slice entfernt;
+- neuer ADR-Supersedes-Trigger: sobald ein Multi-Workspace-Modus kommt,
+  muss die Hierarchie um `Workspace`-Override erweitert werden (analog
+  ADR-0008 für Single-User).
+
+## Alternativen (verworfen)
+
+- **Status quo beibehalten:** verworfen, weil Master-Prompt §5.3 + §6.1
+  explizit verletzt sind und Profil-Konflikte in der Praxis entstehen.
+- **Sofortiger Big-Bang-Rewrite:** verworfen, weil v3-Code noch aktiv
+  ist (Home.vue, MainView.vue) und ein nicht-inkrementeller Umbau das
+  Risiko einer Regression im laufenden Betrieb zu hoch macht.
+- **Separater Embedding-Picker:** verworfen, weil UI-Verhalten identisch
+  ist (Suche, Gruppe, Badges, Status) und eine zweite Komponente die
+  Fragmentierung zementieren würde.

--- a/docs/epics/onboarding-provider-unification/04-implementation-plan.md
+++ b/docs/epics/onboarding-provider-unification/04-implementation-plan.md
@@ -54,6 +54,11 @@ Codegraph-Delta, Dokumentations-Sync, Handover und atomarem Commit.
 - effektive Quelle sichtbar, keine stillen Fallbacks.
 - Snapshot und Audit erweitern.
 
+Detaillierter Sub-Plan mit 6 Sub-Slices (5.0-5.6):
+[`docs/epics/onboarding-provider-unification/slice-5-subplan.md`](slice-5-subplan.md).
+Architekturentscheidung: [ADR-0009](../../decisions/0009-unified-model-picker.md)
+(Status: Proposed 2026-07-13).
+
 ## Slice 6 — Persona-Count-Invariante
 
 - den Dashboard-Wert in einen Run-Vertrag überführen.

--- a/docs/epics/onboarding-provider-unification/slice-5-subplan.md
+++ b/docs/epics/onboarding-provider-unification/slice-5-subplan.md
@@ -1,0 +1,232 @@
+# Sub-Plan: Slice 5 — Einheitlicher Model-Picker und Routing
+
+Stand: 2026-07-13 · Status: Proposed (wartet auf User-Sign-off) · Vorgeschlagener Branch: `codex/onboarding-model-picker`
+
+## Ziel
+
+**Eine** `AiModelPicker.vue`-Komponente, die **alle** Modellauswahl-Stellen im
+Frontend (v3 + v4) ersetzt. Backed by eine **kanonische Datenquelle** aus
+Provider-Connections (Slice 3) + Capabilities (Slice 1). Klare
+Routing-Hierarchie mit sichtbarer Quelle, Run-Snapshot und Audit-Trail.
+
+`/Volumes/T7/Projekte/agora/docs/STATUS.md` und `04-implementation-plan.md`
+verweisen auf dieses Dokument für Slice 5.
+
+## Inventur (verifiziert, Stand 2026-07-13)
+
+### Frontend — Modellauswahl-Infrastruktur
+
+**v3 (Legacy, in Home / MainView / Step-Views aktiv):**
+
+- `frontend/src/components/ui/ModelPicker.vue`
+- `frontend/src/components/llm/LlmProfilePicker.vue`
+- `frontend/src/components/LlmRouting/LlmRoutingView.vue`
+- `frontend/src/components/ActiveModelBadge.vue`
+- `frontend/src/components/Step2EnvSetup.vue`
+- `frontend/src/components/Step3Simulation.vue`
+- `frontend/src/components/step4/ReportModelControls.vue`
+- `frontend/src/api/profile.ts`
+
+**v4 (aktiv, in Onboarding / Settings aktiv):**
+
+- `frontend/src/components/v4/forms/ModelPicker.vue`
+- `frontend/src/components/v4/forms/LlmProfileManager.vue`
+- `frontend/src/components/v4/forms/LlmProviderCard.vue`
+- `frontend/src/components/v4/forms/StepModelOverrideChip.vue`
+- `frontend/src/components/v4/dashboard/HeroNewRun.vue`
+- `frontend/src/views/Settings/LlmProvidersView.vue`
+- `frontend/src/views/Settings/LlmRoutingView.vue` (4 Sub-Cards:
+  `StageOverridesCard`, `GlobalDefaultCard`, `CustomModelCard`,
+  `ActiveSnapshotsCard`)
+
+### Frontend — Stores und Composables
+
+- `frontend/src/store/llmProviders.ts`
+- `frontend/src/store/llmProfiles.ts`
+- `frontend/src/store/llmRoutingDefaults.ts`
+- `frontend/src/store/useActiveModelStore.ts`
+- `frontend/src/composables/useRuntimeLlmOptions.ts`
+- `frontend/src/composables/useAvailableModels.ts`
+
+### Backend — Verträge und Endpoints
+
+- `backend/app/contracts/ai_provider_contract.py` (481 Z. — umfangreichster)
+- `backend/app/contracts/llm_profile_contract.py` (47 Z.)
+- `backend/app/contracts/llm_routing_contract.py` (110 Z.)
+- `backend/app/contracts/workspace_routing_contract.py` (32 Z.)
+- `backend/app/api/llm_providers.py`, `llm_profiles.py`, `llm_active.py`,
+  `llm_routing.py`, `settings.py`
+
+### Konflikte mit Master-Prompt §5.3 / §6.1
+
+> Es darf nur eine fachliche Quelle für Provider-Metadaten geben.
+> Eine Komponente, eine Semantik.
+
+Aktueller Stand: 4 Stores + 2 Composables + v3 + v4 = **6+ Duplikat-Quellen**
+für "welches Modell nimmt der Run?". Master-Prompt §5.3 + §6.1 sind explizit
+nicht erfüllt.
+
+## Sub-Slice-Aufteilung (6 Stück, je 1 PR)
+
+Reihenfolge ist verbindlich; jeder Sub-Slice endet mit grünem
+`scripts/pre-push-gate.sh`, Docs-Sync und atomarem Commit.
+
+### 5.0 — Discovery + Spec-Doc (dieser PR)
+
+- **Ziel:** Doku-SSoT für Slice 5.
+- **Scope:** Nur Doku.
+- **Lieferung:** dieses Dokument + ADR-0009 (Proposed) + Update
+  `04-implementation-plan.md` Slice 5 Verweis.
+- **Akzeptanz:** ADR-0009 akzeptiert (User-Sign-off) oder explizit als
+  Proposed für Folge-Sub-Slices.
+- **Risiko:** niedrig.
+
+### 5.1 — `AiModelPicker.vue` (isolierte Komponente, Mock-Daten)
+
+- **Ziel:** Wiederverwendbare Komponente, **noch** ohne Store-Anbindung.
+- **Scope:**
+  - `frontend/src/components/v4/forms/AiModelPicker.vue` (neu)
+  - Props: `modelValue`, `mode` (`chat` | `embedding`), `placeholder`,
+    `disabled`, `allowWorkspaceDefault`, `capabilityFilter`
+  - Emits: `update:modelValue` mit `AiModelRef
+    { provider_connection_id, model_id, source }`
+  - Mock-Daten via `<script setup>` const, durch Tests überschreibbar
+  - Provider-Gruppierung, Such-Input, Capability-Badges, Default-Anzeige,
+    Status-Indicator
+  - Combobox-Pattern (Tastatur ↑↓ Enter Esc Tab)
+  - ARIA `role="combobox"`, `aria-expanded`, `aria-activedescendant`,
+    Screenreader-Text
+  - **Keine** Live-API-Calls, **keine** Store-Anbindung
+- **Tests:** 5+ Spec-Tests (Props, Emits, Suche, Tastatur, ARIA, Empty-State)
+- **Migration:** keine — Komponente existiert parallel.
+- **Risiko:** niedrig.
+
+### 5.2 — Discovery-getriebene Daten
+
+- **Ziel:** `AiModelPicker.vue` an `ProviderConnectionStore` anbinden.
+- **Scope:**
+  - `useAvailableModels.ts` erweitern: `provider_connection_id`,
+    `capabilities`, `status`, `local_or_cloud`
+  - `useActiveModelStore.ts` als zentraler Active-State
+  - `llmProviders` + `llmProfiles` Stores: `@deprecated`-Marker,
+    Read-Adapter für Migration
+  - `AiModelPicker.vue`: liest via `useAvailableModels()`, gruppiert nach
+    Provider-Connection-Status, zeigt `unsupported`/`unavailable` getrennt
+- **Tests:** 8+ Spec-Tests (Capability-Filter, Status-Anzeige,
+  Provider offline, Refresh)
+- **Migration:** Pilot-Einsatz in **einer** v4-View (z. B. `SettingsGeneral`)
+  als Beweis, dass Store-Anbindung funktioniert.
+- **Risiko:** mittel — Touchpoint mit v3-Code.
+
+### 5.3 — Backend-Routing-Hierarchie
+
+- **Ziel:** Server-seitige `AiRoute`-Resolution mit Snapshot + Audit.
+- **Scope:**
+  - `backend/app/services/ai_route_resolver.py` (neu): Hierarchie
+    `Stage-Override > Run-Override > Project > Workspace > Provider-Fallback`
+  - `backend/app/contracts/ai_route_contract.py` (neu): `AiRoute
+    { source, provider_id, model_id, capabilities, resolved_at,
+    fallback_reason }`
+  - `backend/app/services/run_snapshot.py` (erweitert): speichert `AiRoute`
+    pro Stage
+  - `backend/app/services/audit_trail.py` (erweitert): `routing_resolved`
+    Event mit allen Quellen + Begründung
+  - Bestehende `llm_routing_seed.py` / `stage_model_router.py` als
+    Read-Adapter
+- **Tests:** 10+ Contract- und Service-Tests (Hierarchie, Fallback,
+  Snapshot, Audit)
+- **Migration:** bestehende `llm_routing_*`-Endpoints geben jetzt `ai_route`
+  zurück; Alt-Felder `@deprecated`.
+- **Risiko:** hoch — Kernlogik.
+
+### 5.4 — Auswahlstellen migrieren
+
+- **Ziel:** Alle v3 + v4 Auswahlstellen auf `AiModelPicker.vue` umstellen.
+- **Scope:**
+  - `HeroNewRun.vue` (Dashboard)
+  - `LlmProvidersView.vue` (Provider-Auswahl)
+  - `LlmRoutingView.vue` Stage-Overrides
+  - `StepModelOverrideChip.vue` (Run-Stages)
+  - `SettingsGeneralView.vue` (Workspace-Default)
+  - i18n-Keys für neue Stellen (analog i18n-Mini-PR für Embedding)
+- **Tests:** 12+ Spec-Tests pro migrierter Stelle
+- **Migration:** v3-Views bekommen Shim oder behalten ihren Picker
+  (kein Big-Bang); v4 ist die primäre Migrations-Zone.
+- **Risiko:** mittel — UX-Regressionen möglich, requires Gemini-Review.
+
+### 5.5 — Alte Komponenten und Stores deprecaten
+
+- **Ziel:** 4 Stores + 2 Composables → 2 Stores (oder 1).
+- **Scope:**
+  - `llmProviders.ts` + `llmProfiles.ts` + `llmRoutingDefaults.ts`
+    zusammenführen in `aiModels.ts` (oder konsolidiert in
+    `useActiveModelStore.ts`)
+  - `useRuntimeLlmOptions.ts` → `@deprecated`, Read-Adapter
+  - v3 `ModelPicker.vue`, `LlmProfilePicker.vue`, `ActiveModelBadge.vue`
+    → `@deprecated`, Read-Adapter
+  - Löschen erst, wenn alle Stellen in v4 migriert sind (Track via
+    grep-CI-Check `legacy_model_picker`)
+- **Tests:** Snapshot-Tests, dass v3-Wrapper konsistente API haben
+- **Risiko:** hoch — Breaking Change für v3-Code.
+
+### 5.6 — Playwright-E2E
+
+- **Ziel:** Vollständige Picker-Tastatur + Run-Snapshot-Test.
+- **Scope:**
+  - `frontend/tests/e2e/ai-model-picker.spec.ts` (neu)
+    - Tastatur-Navigation ↓↓↑Enter
+    - Provider offline: Picker zeigt Status, deaktiviert Modelle
+    - Run-Snapshot: gewähltes Modell landet im Run-Snapshot
+- **Risiko:** niedrig.
+
+## Migrations-Reihenfolge (Begründung)
+
+- **5.0 → 5.1 → 5.2 → 5.3 → 5.4 → 5.5 → 5.6**:
+  Komponente isolieren → Daten → Backend → Migration → Deprecation → E2E.
+- **5.5 zuletzt**, damit v3-Code während der Migration noch funktioniert.
+- **5.6 zuletzt**, damit Komponente + Backend final stehen.
+
+## Bewusst offen (zu entscheiden in 5.1)
+
+- **Combobox-Bibliothek:** `reka-ui` ist im `package.json` (v2.9.9).
+  Combobox-Pattern aus `reka-ui` oder eigene Composition API? → 5.1-Discovery
+  entscheidet; Empfehlung: `reka-ui` (keine schwere UI-Bibliothek extra, schon da).
+- **`mode=embedding`:** aktuell nur Chat-Modelle; Embedding-Modelle separat
+  (Slice 4 hat `EmbeddingConfiguration`). Braucht `AiModelPicker` einen
+  `mode`-Prop oder zwei Komponenten? → Empfehlung: **ein** Picker mit
+  `mode`-Prop, da UI-Verhalten identisch ist (Suche, Gruppe, Badges, Status).
+- **Workspace-Default-Anzeige:** "Workspace-Standard verwenden" als Toggle
+  oder nur visuell? → Empfehlung: visuell mit explizitem "Inherit"-Eintrag,
+  damit der User immer eine bewusste Wahl trifft.
+- **Provider offline:** komplett ausblenden oder mit Status-Warnung sichtbar
+  lassen? → Empfehlung: sichtbar lassen mit `degraded`/`unavailable`-Badge,
+  damit der User den Fehlerzustand sieht.
+
+## Geänderte Dateien pro Sub-Slice
+
+Siehe Sub-Slice-Beschreibungen oben.
+
+## Tests pro Sub-Slice
+
+Siehe Sub-Slice-Beschreibungen oben.
+
+## Verifikation pro Sub-Slice
+
+`bash scripts/pre-push-gate.sh` muss grün sein (Spiegel 1:1 CI).
+
+## Rollback pro Sub-Slice
+
+- **5.1-5.4:** Revert Commit, v3-Code unangetastet.
+- **5.5:** v3-Wrapper bleiben, Stores parallel lesbar.
+- **5.6:** Spec-Test reverten.
+
+## Bezug zu anderen Dokumenten
+
+- Master-Prompt §5.3 (kanonische Provider-Registry), §5.4 (Capability-Modell),
+  §6.1-6.3 (eine Komponente, Routing-Hierarchie, Audit)
+- Epic `04-implementation-plan.md` Slice 5 (High-Level)
+- ADR-0006 (Provider-Connections) — Slice 3
+- ADR-0008 (Single-User-Profile) — Slice 2
+- ADR-0009 (dieser Sub-Plan, Proposed)
+- Handover des Epics (`docs/epics/onboarding-provider-unification/HANDOVER.md`)
+  wird nach jedem Sub-Slice aktualisiert.


### PR DESCRIPTION
## Hintergrund

Slice 5 (gemeinsamer Model-Picker + Routing) ist im `04-implementation-plan.md` auf einem Absatz reduziert. Vor dem ersten Code-Commit braucht es eine Doku-SSoT mit konkreter Migrations-Reihenfolge.

## Was ist drin

- **`docs/epics/onboarding-provider-unification/slice-5-subplan.md` (neu, 9.7 KB):** Vollständige Inventur aller Modellauswahl-Stellen in v3 + v4 (4 Stores, 2 Composables, 4 Backend-Contracts, 7+ Komponenten). Aufgeteilt in 6 Sub-Slices mit Ziel/Scope/Tests/Migration/Risiko pro Sub-Slice, plus bewusst offene Entscheidungen für 5.1.
- **`docs/decisions/0009-unified-model-picker.md` (neu, 4.3 KB):** ADR mit Status **Proposed**, wartet auf User-Sign-off. Eine Komponente, eine kanonische Datenquelle, Routing-Hierarchie server-seitig, kein stiller Fallback.
- **`04-implementation-plan.md`:** Slice-5-Abschnitt verweist auf Sub-Plan + ADR.

## Sub-Slice-Plan (verbindliche Reihenfolge)

- **5.0** (dieser PR) — Doku-SSoT
- **5.1** — `AiModelPicker.vue` isoliert, Mock-Daten, Combobox-Pattern, ARIA
- **5.2** — Discovery-getriebene Daten, Anbindung an `ProviderConnectionStore`
- **5.3** — Backend-Routing-Hierarchie (`AiRoute`-Resolver, Snapshot, Audit)
- **5.4** — Auswahlstellen migrieren (`HeroNewRun`, `LlmProvidersView`, `LlmRoutingView`, `StepModelOverrideChip`, `SettingsGeneral`)
- **5.5** — alte Komponenten/Stores deprecaten (4 Stores → 1, v3-Wrapper)
- **5.6** — Playwright-E2E (Tastatur, Provider offline, Run-Snapshot)

## Bewusst offen (zu entscheiden in 5.1)

- **Combobox-Bibliothek:** `reka-ui` v2.9.9 ist schon da — Empfehlung: Combobox aus reka-ui statt eigene Composition API
- **`mode=embedding` vs. zwei Komponenten:** Empfehlung ein Picker mit `mode`-Prop
- **Workspace-Default-Anzeige:** Empfehlung visuell mit explizitem `Inherit`-Eintrag
- **Provider offline:** Empfehlung sichtbar lassen mit `degraded`/`unavailable`-Badge

## Verifikation

`bash scripts/pre-push-gate.sh` — Doku-only, alle Gates grün (kein Code, kein Schema, keine STATUS-Drift).

## Geänderte Dateien

- `docs/epics/onboarding-provider-unification/slice-5-subplan.md` (neu, 9.7 KB)
- `docs/decisions/0009-unified-model-picker.md` (neu, 4.3 KB)
- `docs/epics/onboarding-provider-unification/04-implementation-plan.md` (+5 Zeilen Verweis)

## Sign-off

ADR-0009 ist **Proposed** — Sign-off durch User-Approval. Folge: Status auf `Accepted` setzen (analog ADR-0001, ADR-0007).