### PR TITLE
feat(ai-model-picker): isolierte AiModelPicker.vue mit reka-ui (Sub-Slice 5.1)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3252 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 154 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 155 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/docs/decisions/0009-unified-model-picker.md
+++ b/docs/decisions/0009-unified-model-picker.md
@@ -1,8 +1,8 @@
 # ADR-0009: Einheitlicher Model-Picker und Routing-Hierarchie
 
-- Status: Proposed
-- Datum: 2026-07-13
-- Vorgeschlagener Branch: `codex/onboarding-model-picker`
+- Status: **Accepted**
+- Datum: 2026-07-13 (Proposed + Accepted via User-Sign-off)
+- Branch: `codex/onboarding-model-picker`
 - Bezug: Master-Prompt §5.3, §5.4, §6.1-6.3
 - Sub-Plan: `docs/epics/onboarding-provider-unification/slice-5-subplan.md`
 
@@ -46,7 +46,7 @@ tatsächlich genutzten Auswahl, kein einheitlicher Audit-Trail.
 Siehe `docs/epics/onboarding-provider-unification/slice-5-subplan.md` für
 verbindliche Sub-Slice-Reihenfolge und Akzeptanzkriterien.
 
-- **5.0 Discovery + Spec-Doc** (dieser PR): Sub-Plan + ADR Proposed.
+- **5.0 Discovery + Spec-Doc**: Sub-Plan + ADR Accepted (PR #696).
 - **5.1 `AiModelPicker.vue` isoliert:** Mock-Daten, Combobox-Pattern,
   ARIA, Tastatur, keine Live-API.
 - **5.2 Discovery-getriebene Daten:** Anbindung an `ProviderConnectionStore`

--- a/frontend/src/components/v4/forms/AiModelPicker.vue
+++ b/frontend/src/components/v4/forms/AiModelPicker.vue
@@ -158,8 +158,14 @@ const REQUIRED_CAPABILITY: Record<AiModelPickerMode, AiCapability> = {
 /**
  * Gefilterte + sortierte Optionen:
  * - Capability-Filter (mode + optional capabilityFilter-Prop)
- * - Workspace-Default zuerst (gruppiert)
- * - Provider alphabetisch, innerhalb Gruppe nach model_id
+ * - Provider-Gruppen alphabetisch nach display_name
+ * - innerhalb einer Gruppe: is_workspace_default zuerst, dann nach model_id
+ *
+ * Gemini-Review (PR #697, MEDIUM): "Provider-Gruppen alphabetisch
+ * sicherstellen, nicht global nach is_workspace_default sortieren" — der
+ * Default-Pin gilt jetzt **innerhalb** seiner Provider-Gruppe, nicht
+ * quer durch alle Optionen. So bleibt die Provider-Reihenfolge
+ * vorhersagbar und der Default ist trotzdem sichtbar vorne.
  */
 const filteredOptions = computed<readonly AiModelRefInput[]>(() => {
   const base = props.options ?? MOCK_OPTIONS
@@ -174,11 +180,14 @@ const filteredOptions = computed<readonly AiModelRefInput[]>(() => {
     })
     .slice()
     .sort((a, b) => {
-      if (a.is_workspace_default && !b.is_workspace_default) return -1
-      if (!a.is_workspace_default && b.is_workspace_default) return 1
-      const providerCmp = a.display_name.localeCompare(b.display_name)
-      if (providerCmp !== 0) return providerCmp
-      return a.model_id.localeCompare(b.model_id)
+      // Innerhalb derselben Provider-Gruppe: Default zuerst, dann model_id.
+      if (a.display_name === b.display_name) {
+        if (a.is_workspace_default && !b.is_workspace_default) return -1
+        if (!a.is_workspace_default && b.is_workspace_default) return 1
+        return a.model_id.localeCompare(b.model_id)
+      }
+      // Provider-uebergreifend: strikt alphabetisch.
+      return a.display_name.localeCompare(b.display_name)
     })
 })
 
@@ -216,6 +225,16 @@ const fallbackReason = (input: AiModelRefInput): string | undefined => {
 
 function onUpdate(value: string | null | undefined): void {
   if (!value) {
+    emit('update:modelValue', null)
+    return
+  }
+  // Gemini-Review (PR #697, MEDIUM): defensive Validierung der Item-ID.
+  // ComboboxItem kann bei externer Mutation eine ID ohne Separator liefern;
+  // ein Wurf waere hier ein Runtime-Crash im Live-Run. Stattdessen: null
+  // emittieren und mit console.warn auf das Problem hinweisen.
+  const sep = value.indexOf('\u0000')
+  if (sep < 0) {
+    console.warn('[AiModelPicker] invalid item id, no separator:', value)
     emit('update:modelValue', null)
     return
   }
@@ -283,6 +302,11 @@ function statusTone(input: AiModelRefInput): 'green' | 'orange' | 'red' | 'gray'
     case 'unavailable':
     case 'unsupported':
       return 'red'
+    // Gemini-Review (PR #697, MEDIUM): expliziter Default-Branch, damit
+    // ein neuer AiModelStatus-Wert (z. B. "unknown") nicht undefined
+    // liefert und das CSS-Tone-Attribut leer bleibt.
+    default:
+      return 'gray'
   }
 }
 

--- a/frontend/src/components/v4/forms/AiModelPicker.vue
+++ b/frontend/src/components/v4/forms/AiModelPicker.vue
@@ -1,0 +1,540 @@
+<script setup lang="ts">
+/**
+ * AiModelPicker — einheitliche Modellauswahl (Slice 5.1).
+ *
+ * - Headless Combobox aus `reka-ui` (ComboboxRoot + ComboboxInput +
+ *   ComboboxItem + ComboboxGroup + ComboboxEmpty + ComboboxViewport).
+ * - Provider-Gruppierung via ComboboxGroup, alphabetisch sortiert.
+ * - Capability-Badges, Status-Indicator (verfuegbar/degraded/unavailable),
+ *   Workspace-Default-Stern.
+ * - Suche ueber reka-ui ComboboxInput (eingebautes TextValue-Matching).
+ * - Tastatur (Pfeile, Enter, Esc, Tab) und ARIA out-of-the-box von reka-ui.
+ * - Mock-Daten ueber Prop `options` ueberschreibbar (fuer Tests).
+ *
+ * Slice 5.0+5.1: noch keine Store-Anbindung. In 5.2 wird die
+ * `useAvailableModels()`-Datenquelle angebunden und die Mock-Liste
+ * durch ProviderConnection-Discovery ersetzt.
+ *
+ * Master-Prompt §6.1-6.3, ADR-0009, docs/epics/onboarding-provider-unification/slice-5-subplan.md
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxLabel,
+  ComboboxPortal,
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxViewport,
+} from 'reka-ui'
+import {
+  aiModelItemId,
+  parseAiModelItemId,
+  type AiCapability,
+  type AiModelPickerMode,
+  type AiModelRef,
+  type AiModelRefInput,
+  type AiModelSource,
+} from '@/contracts/aiModelRef'
+
+const { t } = useI18n()
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: AiModelRef | null
+    mode?: AiModelPickerMode
+    placeholder?: string
+    disabled?: boolean
+    allowWorkspaceDefault?: boolean
+    capabilityFilter?: AiCapability
+    options?: readonly AiModelRefInput[]
+  }>(),
+  {
+    modelValue: null,
+    mode: 'chat',
+    placeholder: '',
+    disabled: false,
+    allowWorkspaceDefault: true,
+    capabilityFilter: undefined,
+    options: undefined,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: AiModelRef | null]
+}>()
+
+/**
+ * Mock-Daten fuer Slice 5.1. Wird in 5.2 durch `useAvailableModels()`
+ * ersetzt. Tests koennen `options`-Prop setzen, um eigene Listen
+ * einzuspeisen.
+ */
+const MOCK_OPTIONS: readonly AiModelRefInput[] = [
+  {
+    provider_connection_id: 'conn-ollama-local',
+    provider_kind: 'ollama',
+    display_name: 'Ollama (lokal)',
+    model_id: 'qwen2.5:14b',
+    context_window: 32768,
+    capabilities: ['chat', 'streaming', 'tool_calling'],
+    status: 'available',
+    is_workspace_default: true,
+    local_or_cloud: 'local',
+  },
+  {
+    provider_connection_id: 'conn-ollama-local',
+    provider_kind: 'ollama',
+    display_name: 'Ollama (lokal)',
+    model_id: 'llama3.1:8b',
+    context_window: 131072,
+    capabilities: ['chat', 'streaming', 'tool_calling'],
+    status: 'available',
+    local_or_cloud: 'local',
+  },
+  {
+    provider_connection_id: 'conn-ollama-cloud',
+    provider_kind: 'ollama_cloud',
+    display_name: 'Ollama Cloud',
+    model_id: 'gpt-oss:20b-cloud',
+    context_window: 65536,
+    capabilities: ['chat', 'streaming', 'tool_calling'],
+    status: 'available',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-openai',
+    provider_kind: 'openai',
+    display_name: 'OpenAI',
+    model_id: 'gpt-4o',
+    context_window: 128000,
+    capabilities: ['chat', 'streaming', 'tool_calling', 'vision', 'json_schema'],
+    status: 'available',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-openai',
+    provider_kind: 'openai',
+    display_name: 'OpenAI',
+    model_id: 'gpt-4o-mini',
+    context_window: 128000,
+    capabilities: ['chat', 'streaming', 'tool_calling', 'vision', 'json_schema'],
+    status: 'available',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-gemini',
+    provider_kind: 'gemini',
+    display_name: 'Google Gemini',
+    model_id: 'gemini-2.5-pro',
+    context_window: 1048576,
+    capabilities: ['chat', 'streaming', 'vision', 'json_schema', 'reasoning'],
+    status: 'unavailable',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-anthropic',
+    provider_kind: 'anthropic',
+    display_name: 'Anthropic',
+    model_id: 'claude-sonnet-4-5',
+    context_window: 200000,
+    capabilities: ['chat', 'streaming', 'tool_calling', 'vision', 'reasoning'],
+    status: 'degraded',
+    local_or_cloud: 'cloud',
+  },
+]
+
+/** Required-Capability je mode (Master-Prompt §5.4). */
+const REQUIRED_CAPABILITY: Record<AiModelPickerMode, AiCapability> = {
+  chat: 'chat',
+  embedding: 'embeddings',
+}
+
+/**
+ * Gefilterte + sortierte Optionen:
+ * - Capability-Filter (mode + optional capabilityFilter-Prop)
+ * - Workspace-Default zuerst (gruppiert)
+ * - Provider alphabetisch, innerhalb Gruppe nach model_id
+ */
+const filteredOptions = computed<readonly AiModelRefInput[]>(() => {
+  const base = props.options ?? MOCK_OPTIONS
+  const required = REQUIRED_CAPABILITY[props.mode]
+  return base
+    .filter((o) => {
+      if (!o.capabilities.includes(required)) return false
+      if (props.capabilityFilter && !o.capabilities.includes(props.capabilityFilter)) {
+        return false
+      }
+      return true
+    })
+    .slice()
+    .sort((a, b) => {
+      if (a.is_workspace_default && !b.is_workspace_default) return -1
+      if (!a.is_workspace_default && b.is_workspace_default) return 1
+      const providerCmp = a.display_name.localeCompare(b.display_name)
+      if (providerCmp !== 0) return providerCmp
+      return a.model_id.localeCompare(b.model_id)
+    })
+})
+
+/** Provider-Gruppen (fuer ComboboxGroup). */
+const providerGroups = computed(() => {
+  const groups = new Map<string, AiModelRefInput[]>()
+  for (const o of filteredOptions.value) {
+    const key = o.display_name
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(o)
+  }
+  return Array.from(groups.entries()).map(([name, items]) => ({ name, items }))
+})
+
+/** Current selection als stable ID. */
+const selectedId = computed(() => {
+  if (!props.modelValue) return null
+  return `${props.modelValue.provider_connection_id}\u0000${props.modelValue.model_id}`
+})
+
+/** Source-derivation: workspace-default | explicit | fallback. */
+const deriveSource = (input: AiModelRefInput): AiModelSource => {
+  if (input.is_workspace_default) return 'workspace-default'
+  if (input.status === 'unavailable' || input.status === 'degraded') {
+    return 'fallback'
+  }
+  return 'explicit'
+}
+
+const fallbackReason = (input: AiModelRefInput): string | undefined => {
+  if (input.status === 'unavailable') return 'provider_offline'
+  if (input.status === 'degraded') return 'provider_degraded'
+  return undefined
+}
+
+function onUpdate(value: string | null | undefined): void {
+  if (!value) {
+    emit('update:modelValue', null)
+    return
+  }
+  const input = filteredOptions.value.find((o) => aiModelItemId(o) === value)
+  if (!input) {
+    // Unbekannte ID (z.B. Provider offline) — Auswahl beibehalten als fallback
+    const parsed = parseAiModelItemId(value)
+    emit('update:modelValue', {
+      provider_connection_id: parsed.provider_connection_id,
+      model_id: parsed.model_id,
+      source: 'fallback',
+      fallback_reason: 'unknown_provider',
+    })
+    return
+  }
+  const ref: AiModelRef = {
+    provider_connection_id: input.provider_connection_id,
+    model_id: input.model_id,
+    source: deriveSource(input),
+    ...(input.is_workspace_default ? {} : { capability_filter: REQUIRED_CAPABILITY[props.mode] }),
+    ...(fallbackReason(input) ? { fallback_reason: fallbackReason(input) } : {}),
+  }
+  emit('update:modelValue', ref)
+}
+
+/** Anzeige-Label des aktuell ausgewaehlten Modells (fuer Trigger). */
+const selectedLabel = computed(() => {
+  if (!props.modelValue) return ''
+  const found = filteredOptions.value.find(
+    (o) => aiModelItemId(o) === selectedId.value,
+  )
+  if (found) return `${found.display_name} — ${found.model_id}`
+  // Fallback: model_id reicht, wenn Provider offline
+  return props.modelValue.model_id
+})
+
+const placeholderText = computed(
+  () => props.placeholder || t('aiModelPicker.placeholder', 'Modell wählen …'),
+)
+
+const searchPlaceholder = computed(() =>
+  t('aiModelPicker.searchPlaceholder', 'Modell suchen …'),
+)
+
+const emptyText = computed(() => t('aiModelPicker.empty', 'Keine Modelle verfügbar.'))
+
+const workspaceDefaultLabel = computed(() =>
+  t('aiModelPicker.workspaceDefault', 'Workspace-Standard'),
+)
+
+const localBadge = computed(() => t('aiModelPicker.badge.local', 'lokal'))
+const cloudBadge = computed(() => t('aiModelPicker.badge.cloud', 'Cloud'))
+const degradedBadge = computed(() => t('aiModelPicker.badge.degraded', 'eingeschränkt'))
+const unavailableBadge = computed(() =>
+  t('aiModelPicker.badge.unavailable', 'nicht verfügbar'),
+)
+
+function statusTone(input: AiModelRefInput): 'green' | 'orange' | 'red' | 'gray' {
+  switch (input.status) {
+    case 'available':
+      return 'green'
+    case 'degraded':
+    case 'invalid_credentials':
+      return 'orange'
+    case 'unavailable':
+    case 'unsupported':
+      return 'red'
+  }
+}
+
+function isDisabled(input: AiModelRefInput): boolean {
+  return input.status === 'unavailable' || input.status === 'unsupported'
+}
+
+defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel })
+</script>
+
+<template>
+  <div class="ai-model-picker" :data-mode="mode" :data-disabled="disabled || undefined">
+    <ComboboxRoot
+      :model-value="selectedId ?? ''"
+      :disabled="disabled"
+      :open-on-focus="true"
+      @update:model-value="onUpdate"
+    >
+      <ComboboxAnchor class="ai-model-picker__anchor">
+        <ComboboxInput
+          class="ai-model-picker__input"
+          :placeholder="placeholderText"
+          :disabled="disabled"
+          :display-value="() => selectedLabel"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <ComboboxTrigger class="ai-model-picker__trigger" :aria-label="placeholderText" tabindex="-1">
+          <span aria-hidden="true">▾</span>
+        </ComboboxTrigger>
+      </ComboboxAnchor>
+
+      <ComboboxPortal>
+        <ComboboxContent class="ai-model-picker__content">
+          <ComboboxViewport class="ai-model-picker__viewport">
+            <ComboboxInput
+              class="ai-model-picker__search"
+              :placeholder="searchPlaceholder"
+              autocomplete="off"
+              spellcheck="false"
+            />
+
+            <ComboboxEmpty class="ai-model-picker__empty">
+              {{ emptyText }}
+            </ComboboxEmpty>
+
+            <ComboboxGroup
+              v-for="group in providerGroups"
+              :key="group.name"
+              class="ai-model-picker__group"
+            >
+              <ComboboxLabel class="ai-model-picker__group-label">
+                {{ group.name }}
+              </ComboboxLabel>
+
+              <ComboboxItem
+                v-for="item in group.items"
+                :key="aiModelItemId(item)"
+                :value="aiModelItemId(item)"
+                :disabled="isDisabled(item)"
+                :text-value="`${item.display_name} ${item.model_id}`"
+                class="ai-model-picker__item"
+                :data-status="item.status"
+              >
+                <span class="ai-model-picker__item-row">
+                  <span
+                    class="ai-model-picker__status-dot"
+                    :data-tone="statusTone(item)"
+                    aria-hidden="true"
+                  />
+                  <span class="ai-model-picker__item-label">
+                    <span class="ai-model-picker__model-name">{{ item.model_id }}</span>
+                    <span v-if="item.is_workspace_default" class="ai-model-picker__badge ai-model-picker__badge--default">
+                      {{ workspaceDefaultLabel }}
+                    </span>
+                    <span class="ai-model-picker__badge">
+                      {{ item.local_or_cloud === 'local' ? localBadge : cloudBadge }}
+                    </span>
+                    <span
+                      v-if="item.status === 'degraded'"
+                      class="ai-model-picker__badge ai-model-picker__badge--warn"
+                    >
+                      {{ degradedBadge }}
+                    </span>
+                    <span
+                      v-if="item.status === 'unavailable'"
+                      class="ai-model-picker__badge ai-model-picker__badge--err"
+                    >
+                      {{ unavailableBadge }}
+                    </span>
+                  </span>
+                </span>
+                <ComboboxItemIndicator class="ai-model-picker__indicator">
+                  <span aria-hidden="true">✓</span>
+                </ComboboxItemIndicator>
+              </ComboboxItem>
+            </ComboboxGroup>
+          </ComboboxViewport>
+        </ComboboxContent>
+      </ComboboxPortal>
+    </ComboboxRoot>
+  </div>
+</template>
+
+<style scoped>
+.ai-model-picker {
+  display: block;
+  width: 100%;
+  position: relative;
+}
+.ai-model-picker__anchor {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--hairline, #d1d5db);
+  border-radius: var(--r-4, 8px);
+  background: var(--surface-elevated, #fff);
+  min-height: var(--ctl-h-md, 36px);
+  padding: 0 8px;
+}
+.ai-model-picker__anchor:focus-within {
+  border-color: var(--accent, #2563eb);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, #2563eb) 20%, transparent);
+}
+.ai-model-picker__input {
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--fs-callout, 14px);
+  color: var(--text-primary);
+  padding: 6px 4px;
+  outline: none;
+}
+.ai-model-picker__trigger {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 4px 6px;
+  color: var(--text-muted, #6b7280);
+}
+.ai-model-picker__content {
+  background: var(--surface-elevated, #fff);
+  border: 1px solid var(--hairline, #d1d5db);
+  border-radius: var(--r-4, 8px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  z-index: 50;
+}
+.ai-model-picker__viewport {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px;
+}
+.ai-model-picker__search {
+  width: calc(100% - 8px);
+  margin: 4px;
+  padding: 6px 8px;
+  border: 1px solid var(--hairline, #d1d5db);
+  border-radius: var(--r-4, 6px);
+  font-size: var(--fs-callout, 14px);
+  outline: none;
+}
+.ai-model-picker__search:focus {
+  border-color: var(--accent, #2563eb);
+}
+.ai-model-picker__empty {
+  padding: 12px;
+  text-align: center;
+  color: var(--text-muted, #6b7280);
+  font-size: var(--fs-footnote, 13px);
+}
+.ai-model-picker__group {
+  margin-top: 4px;
+}
+.ai-model-picker__group-label {
+  padding: 4px 8px;
+  font-size: var(--fs-footnote, 12px);
+  font-weight: 600;
+  color: var(--text-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ai-model-picker__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: var(--r-4, 6px);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+.ai-model-picker__item[data-highlighted] {
+  background: color-mix(in srgb, var(--accent, #2563eb) 12%, transparent);
+}
+.ai-model-picker__item[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ai-model-picker__item-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ai-model-picker__status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.ai-model-picker__status-dot[data-tone='green'] { background: #16a34a; }
+.ai-model-picker__status-dot[data-tone='orange'] { background: #d97706; }
+.ai-model-picker__status-dot[data-tone='red'] { background: #dc2626; }
+.ai-model-picker__status-dot[data-tone='gray'] { background: #9ca3af; }
+.ai-model-picker__item-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.ai-model-picker__model-name {
+  font-size: var(--fs-callout, 14px);
+  color: var(--text-primary);
+}
+.ai-model-picker__badge {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 11px;
+  background: var(--surface-subtle, #f3f4f6);
+  color: var(--text-muted, #6b7280);
+  border-radius: 999px;
+  font-weight: 500;
+}
+.ai-model-picker__badge--default {
+  background: color-mix(in srgb, var(--accent, #2563eb) 15%, transparent);
+  color: var(--accent, #2563eb);
+}
+.ai-model-picker__badge--warn {
+  background: #fef3c7;
+  color: #b45309;
+}
+.ai-model-picker__badge--err {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+.ai-model-picker__indicator {
+  flex: 0 0 auto;
+  color: var(--accent, #2563eb);
+  margin-left: 8px;
+}
+</style>

--- a/frontend/src/components/v4/forms/__tests__/AiModelPicker.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/AiModelPicker.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * AiModelPicker — Spec-Tests (Slice 5.1).
+ *
+ * Reka-ui Combobox rendert Items nur im offenen Dropdown. Wir testen
+ * Logik ueber die `defineExpose`-API (filteredOptions, providerGroups)
+ * und Emits ueber die echte ComboboxRoot-Komponente.
+ *
+ * 1. mountet ohne Crash
+ * 2. gefilterte Optionen im Default-Mock-Set (mode=chat)
+ * 3. filtert mode=embedding (Capability-Filter)
+ * 4. Workspace-Default steht in der sortierten Liste vorne
+ * 5. emittiert update:modelValue mit korrekter AiModelRef-Struktur
+ * 6. emittiert 'null' bei clear
+ * 7. akzeptiert options-Prop (kein Default-Mock-Lookup)
+ * 8. markiert unavailable Modelle als ComboboxItem disabled
+ * 9. sortiert Provider-Gruppen alphabetisch
+ * 10. respektiert disabled-Prop (Input disabled)
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import AiModelPicker from '../AiModelPicker.vue'
+import type { AiModelRefInput } from '@/contracts/aiModelRef'
+
+const MOCK_OPTIONS: AiModelRefInput[] = [
+  {
+    provider_connection_id: 'conn-test-1',
+    provider_kind: 'ollama',
+    display_name: 'Test Ollama',
+    model_id: 'qwen-test',
+    context_window: 32768,
+    capabilities: ['chat', 'streaming'],
+    status: 'available',
+    is_workspace_default: true,
+    local_or_cloud: 'local',
+  },
+  {
+    provider_connection_id: 'conn-test-1',
+    provider_kind: 'ollama',
+    display_name: 'Test Ollama',
+    model_id: 'llama-test',
+    context_window: 8192,
+    capabilities: ['chat'],
+    status: 'available',
+    local_or_cloud: 'local',
+  },
+  {
+    provider_connection_id: 'conn-test-2',
+    provider_kind: 'openai',
+    display_name: 'Test OpenAI',
+    model_id: 'gpt-test',
+    context_window: 128000,
+    capabilities: ['chat', 'streaming', 'vision'],
+    status: 'available',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-test-3',
+    provider_kind: 'openai',
+    display_name: 'Test OpenAI Degraded',
+    model_id: 'gpt-degraded',
+    context_window: 128000,
+    capabilities: ['chat', 'streaming'],
+    status: 'degraded',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-test-4',
+    provider_kind: 'openai',
+    display_name: 'Test OpenAI Offline',
+    model_id: 'gpt-offline',
+    context_window: 128000,
+    capabilities: ['chat'],
+    status: 'unavailable',
+    local_or_cloud: 'cloud',
+  },
+  {
+    provider_connection_id: 'conn-test-emb',
+    provider_kind: 'openai',
+    display_name: 'Test Embeddings',
+    model_id: 'text-embed-test',
+    context_window: 0,
+    capabilities: ['embeddings'],
+    status: 'available',
+    local_or_cloud: 'cloud',
+  },
+]
+
+function makeI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: {
+      en: {
+        aiModelPicker: {
+          placeholder: 'Select model …',
+          searchPlaceholder: 'Search model …',
+          empty: 'No models available.',
+          workspaceDefault: 'Workspace default',
+          inheritWorkspaceDefault: 'Use workspace default',
+          loading: 'Loading models …',
+          badge: {
+            local: 'local',
+            cloud: 'Cloud',
+            degraded: 'degraded',
+            unavailable: 'unavailable',
+          },
+        },
+      },
+    },
+  })
+}
+
+async function mountPicker(overrides: Record<string, unknown> = {}) {
+  const i18n = makeI18n()
+  const wrapper = mount(AiModelPicker, {
+    props: { options: MOCK_OPTIONS, ...overrides },
+    global: { plugins: [i18n] },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('AiModelPicker (Slice 5.1, isolated)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mountet ohne Crash', async () => {
+    const w = await mountPicker()
+    expect(w.exists()).toBe(true)
+    expect(w.find('.ai-model-picker').exists()).toBe(true)
+  })
+
+  it('rendert im Default-Mock-Set genau 5 chat-faehige Modelle (1 Embedding ausgefiltert)', async () => {
+    const w = await mountPicker()
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+    }
+    expect(exposed.filteredOptions).toBeDefined()
+    expect(exposed.filteredOptions.length).toBe(5)
+    expect(exposed.filteredOptions.every((o) => o.capabilities.includes('chat'))).toBe(true)
+  })
+
+  it('filtert mode=embedding so dass nur Embedding-Modelle bleiben', async () => {
+    const w = await mountPicker({ mode: 'embedding' })
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+    }
+    expect(exposed.filteredOptions.length).toBe(1)
+    expect(exposed.filteredOptions[0].model_id).toBe('text-embed-test')
+  })
+
+  it('stellt Workspace-Default in der sortierten Liste nach vorne', async () => {
+    const w = await mountPicker()
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+    }
+    expect(exposed.filteredOptions[0].model_id).toBe('qwen-test')
+    expect(exposed.filteredOptions[0].is_workspace_default).toBe(true)
+  })
+
+  it('emittiert update:modelValue mit korrekter AiModelRef-Struktur', async () => {
+    const w = await mountPicker()
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+      selectedId: string | null
+    }
+    // Simuliert: User waehlt qwen-test (Workspace-Default)
+    const target = exposed.filteredOptions[0]
+    expect(target.model_id).toBe('qwen-test')
+    // update ueber ComboboxRoot emulieren
+    const itemId = `${target.provider_connection_id}\u0000${target.model_id}`
+    const root = w.findComponent({ name: 'ComboboxRoot' })
+    expect(root.exists()).toBe(true)
+    await root.vm.$emit('update:modelValue', itemId)
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted!.length).toBe(1)
+    const payload = emitted![0][0] as {
+      provider_connection_id: string
+      model_id: string
+      source: string
+    }
+    expect(payload.provider_connection_id).toBe('conn-test-1')
+    expect(payload.model_id).toBe('qwen-test')
+    expect(payload.source).toBe('workspace-default')
+  })
+
+  it('emittiert null, wenn das Dropdown ohne Auswahl geschlossen wird (clear)', async () => {
+    const w = await mountPicker({
+      modelValue: {
+        provider_connection_id: 'conn-test-1',
+        model_id: 'qwen-test',
+        source: 'workspace-default',
+      },
+    })
+    const root = w.findComponent({ name: 'ComboboxRoot' })
+    await root.vm.$emit('update:modelValue', '')
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted![emitted!.length - 1][0]).toBeNull()
+  })
+
+  it('akzeptiert options-Prop (kein Default-Mock-Lookup)', async () => {
+    const custom: AiModelRefInput[] = [
+      {
+        provider_connection_id: 'only-one',
+        provider_kind: 'mock',
+        display_name: 'Spezial',
+        model_id: 'special-model',
+        context_window: 4096,
+        capabilities: ['chat'],
+        status: 'available',
+        local_or_cloud: 'local',
+      },
+    ]
+    const w = await mountPicker({ options: custom })
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+    }
+    expect(exposed.filteredOptions.length).toBe(1)
+    expect(exposed.filteredOptions[0].model_id).toBe('special-model')
+  })
+
+  it('markiert unavailable Modelle als ComboboxItem disabled (Logik via isDisabled-Pattern)', async () => {
+    // Die Component entscheidet ueber isDisabled(input) im Template. Hier
+    // verifizieren wir die Datengrundlage: alle 5 chat-Modelle sind
+    // in den filteredOptions enthalten, und die unavailable-Status-Markierung
+    // bleibt sichtbar (wird vom Template als data-disabled gerendert).
+    const w = await mountPicker()
+    const exposed = w.vm as unknown as {
+      filteredOptions: readonly AiModelRefInput[]
+    }
+    const offline = exposed.filteredOptions.find((o) => o.model_id === 'gpt-offline')
+    expect(offline).toBeDefined()
+    expect(offline!.status).toBe('unavailable')
+  })
+
+  it('sortiert Provider-Gruppen alphabetisch nach display_name', async () => {
+    const w = await mountPicker()
+    const exposed = w.vm as unknown as {
+      providerGroups: ReadonlyArray<{ name: string; items: AiModelRefInput[] }>
+    }
+    const groupNames = exposed.providerGroups.map((g) => g.name)
+    // Test Ollama < Test OpenAI < Test OpenAI Degraded < Test OpenAI Offline
+    const sorted = [...groupNames].sort()
+    expect(groupNames).toEqual(sorted)
+  })
+
+  it('respektiert disabled-Prop am Input-Element', async () => {
+    const w = await mountPicker({ disabled: true })
+    const root = w.find('.ai-model-picker')
+    expect(root.attributes('data-disabled')).toBeDefined()
+    const input = w.find('.ai-model-picker__input')
+    expect(input.attributes('disabled')).toBeDefined()
+  })
+})

--- a/frontend/src/contracts/aiModelRef.ts
+++ b/frontend/src/contracts/aiModelRef.ts
@@ -1,0 +1,114 @@
+/**
+ * AiModelRef — kanonische Modell-Referenz fuer AiModelPicker und Run-Snapshots.
+ *
+ * Slice 5.0+5.1: TS-SSoT, noch keine Backend-Anbindung.
+ * Backend-Spiegel kommt in Slice 5.3 als `AiRoute` in
+ * `backend/app/contracts/ai_route_contract.py`.
+ *
+ * Eine AiModelRef identifiziert ein (Provider-Connection, Modell)-Paar
+ * plus die Quelle der Auswahl. Sie ist bewusst klein gehalten — groessere
+ * Metadaten (Capabilities, Status) bleiben in der ProviderConnection bzw.
+ * im Model-Katalog und werden bei Bedarf nachgeschlagen.
+ *
+ * Master-Prompt §6.3: jede effektive Auswahl muss im Run-Snapshot und
+ * Audit-Trail mit Provider, Modell, Quelle der Auswahl und Faehigkeiten
+ * gespeichert werden. Diese Struktur deckt das ab.
+ */
+export interface AiModelRef {
+  /** Provider-Connection-ID (Slice 3). */
+  readonly provider_connection_id: string
+  /** Modell-Name innerhalb der Connection. */
+  readonly model_id: string
+  /** Quelle der Auswahl (Master-Prompt §6.3 Hierarchie). */
+  readonly source: AiModelSource
+  /** Optional: Capability-Filter, der bei der Auswahl aktiv war. */
+  readonly capability_filter?: string
+  /** Optional: Begruendung fuer Fallback (z.B. "Provider offline"). */
+  readonly fallback_reason?: string
+}
+
+/** Quelle der Auswahl — gespiegelt mit Slice 5.3 Routing-Hierarchie. */
+export type AiModelSource =
+  | 'stage-override'
+  | 'run-override'
+  | 'project-default'
+  | 'workspace-default'
+  | 'explicit'
+  | 'fallback'
+
+/**
+ * AiModelRefInput — was die Picker-Komponente als Input akzeptiert
+ * (Mock-Daten-Format fuer Slice 5.1).
+ *
+ * Slice 5.2 ersetzt das durch `useAvailableModels()` mit Capability-
+ * Filter, Live-Status, Provider-Group-Logik. Diese Struktur bleibt
+ * aber der Daten-Vertrag fuer die Komponente.
+ */
+export interface AiModelRefInput {
+  readonly provider_connection_id: string
+  readonly provider_kind: AiProviderKind
+  readonly display_name: string
+  readonly model_id: string
+  readonly context_window?: number
+  readonly capabilities: readonly AiCapability[]
+  readonly status: AiModelStatus
+  readonly is_workspace_default?: boolean
+  readonly local_or_cloud: 'local' | 'cloud'
+}
+
+export type AiProviderKind =
+  | 'ollama'
+  | 'ollama_cloud'
+  | 'openai'
+  | 'anthropic'
+  | 'gemini'
+  | 'openai_compatible'
+  | 'mock'
+
+export type AiCapability =
+  | 'chat'
+  | 'embeddings'
+  | 'streaming'
+  | 'tool_calling'
+  | 'json_object'
+  | 'json_schema'
+  | 'vision'
+  | 'reasoning'
+
+export type AiModelStatus =
+  | 'available'
+  | 'unavailable'
+  | 'degraded'
+  | 'unsupported'
+  | 'invalid_credentials'
+
+/**
+ * Mode der Picker-Komponente.
+ * - `chat`: waehlt aus chat-faehigen Modellen.
+ * - `embedding`: waehlt aus embedding-faehigen Modellen.
+ * Slice 5.1 unterstuetzt beide; Capabilities werden je nach mode gefiltert.
+ */
+export type AiModelPickerMode = 'chat' | 'embedding'
+
+/**
+ * Stable String-ID fuer Combobox-Items. Komposition aus
+ * `provider_connection_id` und `model_id`, getrennt durch `\u0000`,
+ * damit sie nicht mit normalen User-Strings kollidieren kann.
+ */
+export function aiModelItemId(input: AiModelRefInput): string {
+  return `${input.provider_connection_id}\u0000${input.model_id}`
+}
+
+export function parseAiModelItemId(id: string): {
+  provider_connection_id: string
+  model_id: string
+} {
+  const sep = id.indexOf('\u0000')
+  if (sep < 0) {
+    throw new Error(`Ungueltige AiModel-Item-ID: ${JSON.stringify(id)}`)
+  }
+  return {
+    provider_connection_id: id.slice(0, sep),
+    model_id: id.slice(sep + 1),
+  }
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1043,6 +1043,20 @@
       }
     }
   },
+  "aiModelPicker": {
+    "placeholder": "Modell wählen …",
+    "searchPlaceholder": "Modell suchen …",
+    "empty": "Keine Modelle verfügbar.",
+    "workspaceDefault": "Workspace-Standard",
+    "inheritWorkspaceDefault": "Workspace-Standard verwenden",
+    "loading": "Modelle werden geladen …",
+    "badge": {
+      "local": "lokal",
+      "cloud": "Cloud",
+      "degraded": "eingeschränkt",
+      "unavailable": "nicht verfügbar"
+    }
+  },
   "activeModel": {
     "label": "Aktives Modell",
     "idle": "Bereit",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1043,6 +1043,20 @@
       }
     }
   },
+  "aiModelPicker": {
+    "placeholder": "Select model …",
+    "searchPlaceholder": "Search model …",
+    "empty": "No models available.",
+    "workspaceDefault": "Workspace default",
+    "inheritWorkspaceDefault": "Use workspace default",
+    "loading": "Loading models …",
+    "badge": {
+      "local": "local",
+      "cloud": "Cloud",
+      "degraded": "degraded",
+      "unavailable": "unavailable"
+    }
+  },
   "activeModel": {
     "label": "Active model",
     "idle": "Idle",


### PR DESCRIPTION
## Hintergrund

Sub-Slice 5.1 — erste konkrete Code-Komponente fuer den gemeinsamen Model-Picker. Bewusst **ohne** Store-/API-Anbindung: Mock-Daten inline, 10 Spec-Tests, ADR-0009-Accepted. Wird in 5.2 (Discovery-getriebene Daten) und 5.4 (Migration der Auswahlstellen) produktiv genutzt.

## Was ist drin

- **`frontend/src/contracts/aiModelRef.ts` (neu, 3.5 KB):**
  `AiModelRef` als TS-SSoT (provider_connection_id, model_id, source, capability_filter, fallback_reason). `AiModelSource` spiegelt die Routing-Hierarchie aus Master-Prompt §6.3 (stage-override > run-override > project-default > workspace-default > explicit > fallback). Plus `AiModelRefInput` (Mock-Format), `AiProviderKind`, `AiCapability`, `AiModelStatus`, `AiModelPickerMode` und `aiModelItemId`/`parseAiModelItemId`-Helper fuer stable Combobox-Item-IDs (separiert mit \\u0000).
- **`frontend/src/components/v4/forms/AiModelPicker.vue` (neu, 16.5 KB):**
  reka-ui **Combobox** (ComboboxRoot + ComboboxInput + ComboboxGroup + ComboboxItem + ComboboxEmpty + ComboboxViewport + ComboboxPortal). Capability-Filter ueber mode-Prop (`chat`|`embedding`). Provider-Gruppierung alphabetisch. Status-Indicator mit 4 Tones (green/orange/red/gray). Workspace-Default-Stern + lokale/Cloud-Badges. ComboboxItem disabled bei `unavailable`/`unsupported`. Vollstaendiges Styling via CSS-Custom-Properties (konsistent mit v4 ModelPicker). `defineExpose(`filteredOptions`, `providerGroups`, `selectedId`, `selectedLabel`)` fuer testfreundliche Logik-Verifikation (reka-ui Combobox rendert Items nur bei offenem Dropdown, daher Logik-Tests ueber exposed API).
- **`frontend/src/components/v4/forms/__tests__/AiModelPicker.spec.ts` (neu, 8.9 KB):** 10 Spec-Tests:
  1. mountet ohne Crash
  2. 5 chat-Modelle aus MOCK_OPTIONS (1 Embedding ausgefiltert)
  3. mode=embedding filtert auf 1 Embedding-Modell
  4. Workspace-Default steht in sortierter Liste vorne
  5. emittiert `update:modelValue` mit korrekter `AiModelRef` (Source=workspace-default)
  6. emittiert `null` bei clear
  7. akzeptiert `options`-Prop (kein Default-Mock-Lookup)
  8. unavailable-Modelle in `filteredOptions` markiert (Template rendert data-disabled)
  9. Provider-Gruppen alphabetisch sortiert
  10. `disabled`-Prop deaktiviert Input
- **`frontend/src/i18n/locales/{de,en}.json`:** neuer Top-Level `aiModelPicker`-Block (placeholder, searchPlaceholder, empty, workspaceDefault, inheritWorkspaceDefault, loading, badge.{local,cloud,degraded,unavailable}).
- **`docs/decisions/0009-unified-model-picker.md`:** Status `Proposed` → `Accepted` (User-Sign-off), Datum aktualisiert, Sub-Slice-5.0-Eintrag nachgezogen.

## Bewusst NICHT in diesem Sub-Slice

- **Keine Store-/API-Anbindung** (Master-Prompt §5.3 bleibt durch Mock-Daten semi-erfuellt). 5.2 ersetzt Mock durch `useAvailableModels()`.
- **Kein Live-Provider-Discovery**: MOCK_OPTIONS sind 7 statische Eintraege. 5.2 laedt dynamisch.
- **Kein Run-Snapshot/Audit-Trail**: kommt in 5.3 mit `AiRoute`-Resolver.
- **Keine Migration bestehender Picker**: 5.4 (`HeroNewRun`, `LlmProvidersView`, `LlmRoutingView`, `StepModelOverrideChip`, `SettingsGeneral`).
- **Capability-Badges noch nicht UI-rendered** (chat/streaming/vision etc. sind in den Mock-Daten, werden aber noch nicht als Badges angezeigt — kommt in 5.2).
- **Combobox-Suche** nutzt reka-ui `textValue`-Matching (Provider-Name + Modell-ID). Kein Fuzzy-Match, kein Highlighting der Treffer (Master-Prompt §6.2 — reicht fuer 5.1, Polish in 5.2/5.4).

## Verifikation

`bash scripts/pre-push-gate.sh frontend` → **ALL GREEN** (eslint, vue-tsc, vitest, vite build, Zod-Spiegel). 10 neue Spec-Tests passed.

## Bezug

- ADR-0009 (Accepted) — eine Komponente, eine kanonische Datenquelle
- `slice-5-subplan.md` Sub-Slice 5.1
- Master-Prompt §6.1-6.3 (Picker-Spec, Routing-Hierarchie, Audit)
- Master-Prompt §5.3 (kanonische Provider-Registry) — 5.2 setzt das um

## Folge

Nach Merge: Sub-Slice **5.2** (Discovery-getriebene Daten — `useAvailableModels()` anbinden, Pilot-Einsatz in `SettingsGeneralView.vue`).