### PR TITLE
feat(routing): add canonical AiRoute resolution

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -404,7 +404,7 @@ Source of Truth:
 | 4.2 | Embedding-Configuration-Service + API + Legacy-Adapter | ✅ gemergt (PR #688) |
 | 4.3.1 | Migrations-Service + Ollama-Download (Backend) | ✅ implementiert, PR offen |
 | 4.3.2 | Frontend-Store + View + Onboarding-Anbindung | offen |
-| 5 | Gemeinsamer Model-Picker und Routing | offen |
+| 5 | Gemeinsamer Model-Picker und Routing | 🟡 5.1–5.3 implementiert; 5.4–5.6 offen |
 | 6 | Persona-Count-End-to-End-Invariante | offen |
 | 7 | Golden-Gate-Designsystem und Informationsarchitektur | offen |
 | 8+ | Projekte, Datensätze, Vorlagen, Monitoring als einzelne MVPs | offen |

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -14,6 +14,11 @@ from ..services.runtime_run_config import RuntimeRunConfig
 from ..services.run_registry import RunRegistry
 from ..services.workspace_routing_store import get_workspace_routing_store
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
+from ..contracts.ai_provider_contract import (
+    AiRoute,
+    RouteSource,
+    ai_route_from_stage_route,
+)
 from ..contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
 from ..utils.api_responses import handle_api_errors, json_success, json_error
 from ..utils.artifact_locator import ArtifactLocator
@@ -31,6 +36,43 @@ ALL_STAGE_IDS: tuple[StageId, ...] = (
     "report_generation",
     "evaluation",
 )
+
+_PUBLIC_AI_PROVIDER_OPTION_KEYS = frozenset({"base_url", "num_ctx"})
+
+
+def _serialize_public_ai_route(
+    route: StageLLMRoute,
+    *,
+    source: RouteSource,
+) -> dict[str, object]:
+    """Serialize the canonical route without its private legacy round-trip marker."""
+    public_route = route.model_copy(
+        update={
+            "provider_options": {
+                key: value
+                for key, value in route.provider_options.items()
+                if key in _PUBLIC_AI_PROVIDER_OPTION_KEYS
+            }
+        }
+    )
+    payload = ai_route_from_stage_route(public_route).model_dump(mode="json")
+    payload["source"] = source
+    provider_options = payload.get("provider_options")
+    if isinstance(provider_options, dict):
+        provider_options.pop("__legacy_stage_route__", None)
+    return AiRoute.model_validate(payload).model_dump(mode="json")
+
+
+def _with_ai_route(
+    legacy_payload: dict[str, object],
+    route: StageLLMRoute,
+    *,
+    source: RouteSource,
+) -> dict[str, object]:
+    return {
+        **legacy_payload,
+        "ai_route": _serialize_public_ai_route(route, source=source),
+    }
 
 def _get_run_state(run_id: str):
     run = run_registry.get_run(run_id)
@@ -75,11 +117,17 @@ def get_run_llm_routing(run_id: str):
         if snap:
             snapshots[stage] = snap
 
-    return json_success({
-        "runtime_config": config.model_dump(mode="json"),
-        "snapshots": snapshots,
-        "invocation_events": _load_invocation_events(run_id),
-    })
+    return json_success(
+        _with_ai_route(
+            {
+                "runtime_config": config.model_dump(mode="json"),
+                "snapshots": snapshots,
+                "invocation_events": _load_invocation_events(run_id),
+            },
+            config.global_default,
+            source="legacy",
+        )
+    )
 
 @runs_bp.route("/<run_id>/llm-routing", methods=["PUT"])
 @handle_api_errors(logger=logger)
@@ -100,7 +148,13 @@ def update_run_llm_routing(run_id: str):
         new_config.routing_version = old_config.routing_version + 1
         config_service.save_config(new_config)
 
-        return json_success(new_config.model_dump(mode="json"))
+        return json_success(
+            _with_ai_route(
+                new_config.model_dump(mode="json"),
+                new_config.global_default,
+                source="run_override",
+            )
+        )
     except ValidationError as exc:
         return json_error(
             "Validation failed",
@@ -141,7 +195,13 @@ def patch_stage_llm_routing(run_id: str, stage_id: str):
         config.routing_version += 1
 
         config_service.save_config(config)
-        return json_success(config.model_dump(mode="json"))
+        return json_success(
+            _with_ai_route(
+                config.model_dump(mode="json"),
+                route_override,
+                source="stage_override",
+            )
+        )
     except ValidationError as exc:
         return json_error(
             "Validation failed",
@@ -161,7 +221,13 @@ def patch_stage_llm_routing(run_id: str, stage_id: str):
 def get_routing_defaults():
     """Return the workspace-wide routing defaults."""
     defaults = get_workspace_routing_store().load()
-    return json_success(defaults.model_dump(mode="json"))
+    return json_success(
+        _with_ai_route(
+            defaults.model_dump(mode="json"),
+            defaults.global_default,
+            source="workspace",
+        )
+    )
 
 
 @llm_bp.route("/routing/defaults", methods=["PUT"])
@@ -179,7 +245,13 @@ def replace_routing_defaults():
             extra={"details": exc.errors()},
         )
     stored = get_workspace_routing_store().save(model)
-    return json_success(stored.model_dump(mode="json"))
+    return json_success(
+        _with_ai_route(
+            stored.model_dump(mode="json"),
+            stored.global_default,
+            source="workspace",
+        )
+    )
 
 
 @llm_bp.route("/routing/defaults/stages/<stage_id>", methods=["PATCH"])
@@ -198,7 +270,14 @@ def patch_routing_default_stage(stage_id: str):
 
     if payload.get("clear") is True or payload == {}:
         defaults = store.set_stage_override(stage_id, None)
-        return json_success(defaults.model_dump(mode="json"))
+        active_route = defaults.stage_overrides.get(stage_id, defaults.global_default)
+        return json_success(
+            _with_ai_route(
+                defaults.model_dump(mode="json"),
+                active_route,
+                source="workspace",
+            )
+        )
 
     try:
         route = StageLLMRoute.model_validate(payload)
@@ -210,7 +289,13 @@ def patch_routing_default_stage(stage_id: str):
             extra={"details": exc.errors()},
         )
     defaults = store.set_stage_override(stage_id, route)
-    return json_success(defaults.model_dump(mode="json"))
+    return json_success(
+        _with_ai_route(
+            defaults.model_dump(mode="json"),
+            route,
+            source="workspace",
+        )
+    )
 
 
 @llm_bp.route("/routing/defaults/global", methods=["PUT"])
@@ -228,4 +313,10 @@ def replace_global_default():
             extra={"details": exc.errors()},
         )
     defaults = get_workspace_routing_store().set_global_default(route)
-    return json_success(defaults.model_dump(mode="json"))
+    return json_success(
+        _with_ai_route(
+            defaults.model_dump(mode="json"),
+            defaults.global_default,
+            source="workspace",
+        )
+    )

--- a/backend/app/api/llm_routing.py
+++ b/backend/app/api/llm_routing.py
@@ -270,7 +270,7 @@ def patch_routing_default_stage(stage_id: str):
 
     if payload.get("clear") is True or payload == {}:
         defaults = store.set_stage_override(stage_id, None)
-        active_route = defaults.stage_overrides.get(stage_id, defaults.global_default)
+        active_route = defaults.stage_overrides.get(stage_id) or defaults.global_default
         return json_success(
             _with_ai_route(
                 defaults.model_dump(mode="json"),

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -98,6 +98,7 @@ from .ai_provider_contract import (
     ProviderConnection,
     ProviderConnectionResponse,
     ProviderConnectionUpsertRequest,
+    RouteSource,
 )
 from .user_profile_contract import (
     ALLOWED_AVATAR_MIME_TYPES,
@@ -224,6 +225,7 @@ __all__ = [
     "ProviderConnection",
     "ProviderConnectionResponse",
     "ProviderConnectionUpsertRequest",
+    "RouteSource",
     # UserProfile + Onboarding (Slice 2)
     "ALLOWED_AVATAR_MIME_TYPES",
     "MAX_AVATAR_BYTES",

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -60,7 +60,17 @@ ProviderTransport = Literal["http", "local"]
 ProviderAuthMode = Literal["none", "api_key", "oauth", "session"]
 ProviderStatus = Literal["unknown", "connected", "degraded", "disconnected", "error"]
 ModelStatus = Literal["unknown", "available", "unavailable", "deprecated"]
-RouteSource = Literal["default", "profile", "stage_override", "runtime", "legacy"]
+RouteSource = Literal[
+    "default",
+    "profile",
+    "stage_override",
+    "run_override",
+    "project",
+    "workspace",
+    "provider_fallback",
+    "runtime",
+    "legacy",
+]
 
 
 def _validate_public_base_url(value: str) -> str:
@@ -141,7 +151,7 @@ class LegacyStageRouteOptions(TypedDict, closed=True):  # type: ignore[call-arg]
 class AiProviderOptions(TypedDict, total=False, closed=True):  # type: ignore[call-arg]  # mypy lacks PEP 728
     """Secret-free options currently consumed by Agora routing."""
 
-    base_url: PublicBaseUrl | None
+    base_url: PublicBaseUrl | LocalOllamaBaseUrl | None
     num_ctx: Annotated[int, Field(gt=0)]
     __legacy_stage_route__: LegacyStageRouteOptions
 
@@ -250,7 +260,29 @@ class AiModel(BaseModel):
 
 
 class AiRoute(BaseModel):
-    model_config = _STRICT
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"source": {"const": "provider_fallback"}},
+                        "required": ["source"],
+                    },
+                    "then": {
+                        "properties": {
+                            "fallback_reason": {
+                                "minLength": 1,
+                                "pattern": r"\S",
+                                "type": "string",
+                            }
+                        },
+                        "required": ["fallback_reason"],
+                    },
+                }
+            ]
+        },
+    )
 
     stage: StageId | None = None
     provider_connection_id: str | None = None
@@ -258,6 +290,16 @@ class AiRoute(BaseModel):
     source: RouteSource
     validated_capabilities: dict[str, CapabilityState] = Field(default_factory=dict)
     provider_options: AiProviderOptions = Field(default_factory=_empty_provider_options)
+    resolved_at: datetime | None = None
+    fallback_reason: str | None = None
+
+    @model_validator(mode="after")
+    def validate_provider_fallback_reason(self) -> AiRoute:
+        if self.source == "provider_fallback" and not (
+            self.fallback_reason and self.fallback_reason.strip()
+        ):
+            raise ValueError("provider_fallback requires a non-blank fallback_reason")
+        return self
 
 
 def provider_connection_from_descriptor(

--- a/backend/app/services/ai_route_audit.py
+++ b/backend/app/services/ai_route_audit.py
@@ -1,0 +1,44 @@
+"""Secret-free, idempotent audit events for resolved AI routes."""
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from ..contracts.ai_provider_contract import AiRoute
+from ..contracts.llm_routing_contract import StageId
+from .runtime_run_config import RuntimeRunConfig, _publish_json_once_atomic
+
+
+class AiRouteAudit:
+    def __init__(self, run_id: str):
+        self.runtime = RuntimeRunConfig(run_id)
+
+    def record_routing_resolved(
+        self,
+        stage_id: StageId,
+        route: AiRoute,
+        *,
+        fallback_reason: str | None = None,
+        resolved_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        timestamp = resolved_at or route.resolved_at or datetime.now(timezone.utc)
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        event = {
+            "event": "routing_resolved",
+            "stage": stage_id,
+            "provider_connection_id": route.provider_connection_id,
+            "model_id": route.model_id,
+            "source": route.source,
+            "validated_capabilities": dict(route.validated_capabilities),
+            "resolved_at": timestamp.astimezone(timezone.utc).isoformat(),
+            "fallback_reason": (
+                fallback_reason
+                if fallback_reason is not None
+                else route.fallback_reason
+            ),
+        }
+        path = os.path.join(
+            self.runtime.stages_dir, f"{stage_id}_routing_resolved.json"
+        )
+        return _publish_json_once_atomic(path, event)

--- a/backend/app/services/ai_route_resolver.py
+++ b/backend/app/services/ai_route_resolver.py
@@ -1,0 +1,95 @@
+"""Pure, deterministic resolution of explicit AI route candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from datetime import datetime
+
+from app.contracts.ai_provider_contract import AiRoute, RouteSource
+
+
+class AiRouteResolutionError(Exception):
+    """Base class for typed route-resolution failures."""
+
+
+class NoAiRouteCandidateError(AiRouteResolutionError):
+    """Raised when no candidate exists at any supported resolution level."""
+
+    def __init__(self, required_capabilities: Collection[str]) -> None:
+        self.required_capabilities = tuple(sorted(set(required_capabilities)))
+        super().__init__("No AI route candidate is configured")
+
+
+class AiRouteCapabilityMismatchError(AiRouteResolutionError):
+    """Raised when the highest-priority candidate lacks required capabilities."""
+
+    def __init__(
+        self,
+        *,
+        source: RouteSource,
+        candidate: AiRoute,
+        missing_capabilities: Collection[str],
+    ) -> None:
+        self.source = source
+        self.candidate = candidate
+        self.missing_capabilities = tuple(sorted(set(missing_capabilities)))
+        joined = ", ".join(self.missing_capabilities)
+        super().__init__(f"AI route candidate from {source} lacks capabilities: {joined}")
+
+
+def resolve_ai_route(
+    *,
+    stage_override: AiRoute | None = None,
+    run_override: AiRoute | None = None,
+    project_route: AiRoute | None = None,
+    workspace_route: AiRoute | None = None,
+    provider_fallback: AiRoute | None = None,
+    required_capabilities: Collection[str] = (),
+    resolved_at: datetime,
+) -> AiRoute:
+    """Resolve explicit candidates in strict Stage > Run > Project > Workspace order."""
+
+    candidates: tuple[tuple[RouteSource, AiRoute | None], ...] = (
+        ("stage_override", stage_override),
+        ("run_override", run_override),
+        ("project", project_route),
+        ("workspace", workspace_route),
+        ("provider_fallback", provider_fallback),
+    )
+    selected = next(
+        ((source, candidate) for source, candidate in candidates if candidate is not None),
+        None,
+    )
+    if selected is None:
+        raise NoAiRouteCandidateError(required_capabilities)
+
+    source, candidate = selected
+    missing_capabilities = {
+        capability
+        for capability in required_capabilities
+        if candidate.validated_capabilities.get(capability) != "supported"
+    }
+    if missing_capabilities:
+        raise AiRouteCapabilityMismatchError(
+            source=source,
+            candidate=candidate,
+            missing_capabilities=missing_capabilities,
+        )
+
+    data = candidate.model_dump(mode="python")
+    data.update(
+        source=source,
+        resolved_at=resolved_at,
+        fallback_reason=(
+            candidate.fallback_reason if source == "provider_fallback" else None
+        ),
+    )
+    return AiRoute.model_validate(data)
+
+
+__all__ = [
+    "AiRouteCapabilityMismatchError",
+    "AiRouteResolutionError",
+    "NoAiRouteCandidateError",
+    "resolve_ai_route",
+]

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -16,6 +16,7 @@ from ..contracts import (
 )
 from ..llm.providers.registry import detect_provider
 from ..contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute, StageId
+from ..contracts.ai_provider_contract import AiRoute
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.logger import get_logger
 
@@ -30,6 +31,30 @@ _SECRET_KEYS = {
     "secret",
     "token",
 }
+
+
+def _publish_json_once_atomic(path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Atomically publish JSON without replacing an existing winner."""
+    target_dir = os.path.dirname(path)
+    os.makedirs(target_dir, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=target_dir
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_path, path)
+        except FileExistsError:
+            pass
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 def _sanitize_url(value: str) -> str:
@@ -127,21 +152,42 @@ class RuntimeRunConfig:
                 return json.load(f)
         return None
 
-    def save_stage_snapshot(self, stage_id: StageId, snapshot: Dict[str, Any]) -> None:
+    def save_stage_snapshot(self, stage_id: StageId, snapshot: Dict[str, Any]) -> Dict[str, Any]:
         """Persist stage-specific LLM route snapshot as a write-once lock."""
-        os.makedirs(self.stages_dir, exist_ok=True)
         path = os.path.join(self.stages_dir, f"{stage_id}_llm_route_snapshot.json")
         data = self._sanitize_deep(snapshot)
-        payload = json.dumps(data, indent=2)
+        return _publish_json_once_atomic(path, data)
 
+    def load_ai_route_snapshot(self, stage_id: StageId) -> Optional[AiRoute]:
+        """Read canonical snapshots and project legacy ResolvedRoute snapshots."""
+        canonical_path = os.path.join(
+            self.stages_dir, f"{stage_id}_ai_route_snapshot.json"
+        )
+        if os.path.exists(canonical_path):
+            with open(canonical_path, "r", encoding="utf-8") as handle:
+                return AiRoute.model_validate(json.load(handle))
+
+        snapshot = self.load_stage_snapshot(stage_id)
+        if snapshot is None:
+            return None
         try:
-            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            return
+            return AiRoute.model_validate(snapshot)
+        except ValueError:
+            return AiRoute(
+                stage=snapshot.get("stage", stage_id),
+                provider_connection_id=snapshot.get("provider_id"),
+                model_id=snapshot.get("model"),
+                source="legacy",
+            )
 
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(payload)
-            handle.write("\n")
+    def save_ai_route_snapshot(self, stage_id: StageId, route: AiRoute) -> AiRoute:
+        """Publish a canonical route and return the stored first-writer winner."""
+        path = os.path.join(self.stages_dir, f"{stage_id}_ai_route_snapshot.json")
+        winner = _publish_json_once_atomic(
+            path,
+            self._sanitize_deep(route.model_dump(mode="json", exclude_none=True)),
+        )
+        return AiRoute.model_validate(winner)
 
     def _sanitize_deep(self, data: Any, key: str | None = None) -> Any:
         """Recursively remove secret keys and persisted URL credentials."""

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -3,8 +3,10 @@ Stage Model Router.
 Resolve(run_id, stage_id, runtime_cfg) -> ResolvedRoute.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
+from pydantic import ValidationError
+from ..contracts.ai_provider_contract import AiRoute
 from ..contracts.llm_routing_contract import (
     RuntimeLlmRouting,
     ResolvedRoute,
@@ -12,6 +14,7 @@ from ..contracts.llm_routing_contract import (
 )
 from .runtime_run_config import RuntimeRunConfig, _detect_default_provider_id
 from .secret_resolver import SecretResolver
+from .ai_route_audit import AiRouteAudit
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.stage_model_router")
@@ -28,7 +31,12 @@ class StageModelRouter:
         # 1. Check for existing snapshot (locked-for-execution)
         snapshot = self.config_service.load_stage_snapshot(stage_id)
         if snapshot:
-            return ResolvedRoute.model_validate(snapshot)
+            return self._resolved_from_snapshot(stage_id, snapshot)
+        canonical_snapshot = self.config_service.load_ai_route_snapshot(stage_id)
+        if canonical_snapshot is not None:
+            return self._resolved_from_snapshot(
+                stage_id, canonical_snapshot.model_dump(mode="json")
+            )
 
         # 2. Resolve from runtime config
         cfg = runtime_cfg or self.config_service.load_config()
@@ -49,10 +57,51 @@ class StageModelRouter:
             reasoning_effort=route.reasoning_effort,
             routing_version=cfg.routing_version,
             provider_options=route.provider_options,
-            started_at=datetime.now().isoformat()
+            started_at=datetime.now(timezone.utc).isoformat()
         )
         return resolved
 
-    def lock_stage(self, stage_id: StageId, resolved_route: ResolvedRoute) -> None:
+    def lock_stage(self, stage_id: StageId, resolved_route: ResolvedRoute) -> ResolvedRoute:
         """Lock the route for a stage by persisting the snapshot."""
-        self.config_service.save_stage_snapshot(stage_id, resolved_route.model_dump(mode="json"))
+        winner = self.config_service.save_stage_snapshot(
+            stage_id, resolved_route.model_dump(mode="json")
+        )
+        stored = ResolvedRoute.model_validate(winner)
+        config = self.config_service.load_config()
+        source = "stage_override" if stage_id in config.stage_overrides else "legacy"
+        canonical = self.config_service.save_ai_route_snapshot(
+            stage_id,
+            AiRoute(
+                stage=stage_id,
+                provider_connection_id=stored.provider_id,
+                model_id=stored.model,
+                source=source,
+                resolved_at=stored.started_at,
+            ),
+        )
+        AiRouteAudit(self.run_id).record_routing_resolved(stage_id, canonical)
+        return self._resolved_from_snapshot(stage_id, winner)
+
+    def _resolved_from_snapshot(
+        self, stage_id: StageId, snapshot: dict[str, object]
+    ) -> ResolvedRoute:
+        try:
+            return ResolvedRoute.model_validate(snapshot)
+        except ValidationError:
+            route = AiRoute.model_validate(snapshot)
+            options = dict(route.provider_options)
+            legacy_options = options.pop("__legacy_stage_route__", None) or {}
+            base_url = options.get("base_url")
+            provider_id = route.provider_connection_id or _detect_default_provider_id(
+                base_url, route.model_id
+            )
+            return ResolvedRoute(
+                stage=route.stage or stage_id,
+                provider_id=provider_id,
+                model=route.model_id or "",
+                base_url_sanitized=SecretResolver().sanitize_url(base_url),
+                reasoning_effort=legacy_options.get("reasoning_effort") or "none",
+                routing_version=1,
+                provider_options=options,
+                started_at=getattr(route, "resolved_at", None),
+            )

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -103,5 +103,7 @@ class StageModelRouter:
                 reasoning_effort=legacy_options.get("reasoning_effort") or "none",
                 routing_version=1,
                 provider_options=options,
-                started_at=getattr(route, "resolved_at", None),
+                started_at=(
+                    route.resolved_at.isoformat() if route.resolved_at else None
+                ),
             )

--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -49,8 +49,16 @@ def test_get_run_llm_routing(client):
         mock_events.return_value = [{"stage": "report_generation", "success": True}]
         resp = client.get("/api/runs/proj_123/llm-routing")
         assert resp.status_code == 200
-        assert "runtime_config" in resp.json["data"]
-        assert resp.json["data"]["invocation_events"][0]["stage"] == "report_generation"
+        data = resp.json["data"]
+        assert data["ai_route"]["provider_connection_id"] == "o"
+        assert data["ai_route"]["model_id"] == "m"
+        assert data["ai_route"]["source"] == "legacy"
+        assert data["ai_route"]["provider_options"] == {}
+        assert {key: value for key, value in data.items() if key != "ai_route"} == {
+            "runtime_config": mock_load.return_value.model_dump(mode="json"),
+            "snapshots": {},
+            "invocation_events": [{"stage": "report_generation", "success": True}],
+        }
 
 def test_patch_stage_llm_routing_locked(client):
     with patch("app.services.runtime_run_config.RuntimeRunConfig.load_stage_snapshot") as mock_snap:
@@ -58,3 +66,121 @@ def test_patch_stage_llm_routing_locked(client):
         resp = client.patch("/api/runs/proj_123/llm-routing/stages/graph_build", json={})
         assert resp.status_code == 409
         assert resp.json["code"] == "stage_already_started"
+
+
+def test_public_ai_route_serializer_strips_internal_legacy_marker():
+    from app.api.llm_routing import _serialize_public_ai_route
+    from app.contracts.ai_provider_contract import AiRoute
+    from app.contracts.llm_routing_contract import StageLLMRoute
+
+    public = _serialize_public_ai_route(
+        StageLLMRoute(
+            provider_id="provider-1",
+            model="model-1",
+            temperature=0.2,
+            provider_options={
+                "base_url": "http://localhost:11434",
+                "num_ctx": 4096,
+                "api_key": "must-not-leak",
+                "timeout": 30,
+            },
+        ),
+        source="legacy",
+    )
+
+    assert public["provider_options"] == {
+        "base_url": "http://localhost:11434",
+        "num_ctx": 4096,
+    }
+    assert "__legacy_stage_route__" not in str(public)
+    assert AiRoute.model_validate(public).model_dump(mode="json") == public
+
+
+def test_replace_run_routing_is_additive(client):
+    from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+
+    old = RuntimeLlmRouting(global_default=StageLLMRoute(provider_id="old", model="old"))
+    payload = {
+        "global_default": {"provider_id": "new", "model": "model"},
+        "stage_overrides": {},
+        "routing_version": 1,
+    }
+    with patch("app.services.runtime_run_config.RuntimeRunConfig.load_config", return_value=old), patch(
+        "app.services.runtime_run_config.RuntimeRunConfig.save_config"
+    ):
+        resp = client.put("/api/runs/proj_123/llm-routing", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json["data"]
+    assert data["ai_route"]["provider_connection_id"] == "new"
+    assert data["ai_route"]["source"] == "run_override"
+    legacy = RuntimeLlmRouting.model_validate(payload).model_copy(update={"routing_version": 2})
+    assert {key: value for key, value in data.items() if key != "ai_route"} == legacy.model_dump(mode="json")
+
+
+def test_patch_run_stage_routing_is_additive(client):
+    from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+
+    config = RuntimeLlmRouting(global_default=StageLLMRoute(provider_id="base", model="base"))
+    with patch(
+        "app.services.runtime_run_config.RuntimeRunConfig.load_stage_snapshot", return_value=None
+    ), patch(
+        "app.services.runtime_run_config.RuntimeRunConfig.load_config", return_value=config
+    ), patch("app.services.runtime_run_config.RuntimeRunConfig.save_config"):
+        resp = client.patch(
+            "/api/runs/proj_123/llm-routing/stages/graph_build",
+            json={"provider_id": "stage-provider", "model": "stage-model"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json["data"]
+    assert data["ai_route"]["provider_connection_id"] == "stage-provider"
+    assert data["ai_route"]["model_id"] == "stage-model"
+    assert data["ai_route"]["source"] == "stage_override"
+    assert data["stage_overrides"]["graph_build"]["provider_id"] == "stage-provider"
+
+
+def test_get_workspace_defaults_is_additive(client):
+    from app.contracts.llm_routing_contract import StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+
+    defaults = WorkspaceLlmRoutingDefaults(
+        global_default=StageLLMRoute(provider_id="workspace-provider", model="workspace-model")
+    )
+    with patch("app.api.llm_routing.get_workspace_routing_store") as get_store:
+        get_store.return_value.load.return_value = defaults
+        resp = client.get("/api/llm/routing/defaults")
+
+    data = resp.json["data"]
+    assert data["ai_route"]["source"] == "workspace"
+    assert data["ai_route"]["provider_connection_id"] == "workspace-provider"
+    assert {key: value for key, value in data.items() if key != "ai_route"} == defaults.model_dump(mode="json")
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("put", "/api/llm/routing/defaults"),
+        ("patch", "/api/llm/routing/defaults/stages/graph_build"),
+    ],
+)
+def test_mutate_workspace_defaults_is_additive(client, method, path):
+    from app.contracts.llm_routing_contract import StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+
+    route = StageLLMRoute(provider_id="workspace-provider", model="workspace-model")
+    defaults = WorkspaceLlmRoutingDefaults(
+        global_default=route,
+        stage_overrides={"graph_build": route} if method == "patch" else {},
+    )
+    payload = defaults.model_dump(mode="json") if method == "put" else route.model_dump(mode="json")
+    with patch("app.api.llm_routing.get_workspace_routing_store") as get_store:
+        get_store.return_value.save.return_value = defaults
+        get_store.return_value.set_stage_override.return_value = defaults
+        resp = getattr(client, method)(path, json=payload)
+
+    assert resp.status_code == 200
+    data = resp.json["data"]
+    assert data["ai_route"]["source"] == "workspace"
+    assert data["ai_route"]["provider_connection_id"] == "workspace-provider"
+    assert {key: value for key, value in data.items() if key != "ai_route"} == defaults.model_dump(mode="json")

--- a/backend/tests/contracts/test_ai_provider_contract.py
+++ b/backend/tests/contracts/test_ai_provider_contract.py
@@ -192,6 +192,80 @@ def test_canonical_contracts_are_strict_and_secret_free() -> None:
             contract.model_validate({**instance.model_dump(), "unexpected": True})
 
 
+@pytest.mark.parametrize(
+    "source",
+    ["run_override", "project", "workspace", "provider_fallback"],
+)
+def test_ai_route_accepts_additive_resolution_sources(source: str) -> None:
+    data = {
+        "provider_connection_id": "provider-1",
+        "model_id": "model-1",
+        "source": source,
+    }
+    if source == "provider_fallback":
+        data["fallback_reason"] = "No configured route was available"
+
+    assert AiRoute.model_validate(data).source == source
+
+
+@pytest.mark.parametrize("fallback_reason", [None, "", "   "])
+def test_provider_fallback_requires_a_non_blank_reason(
+    fallback_reason: str | None,
+) -> None:
+    with pytest.raises(ValidationError, match="fallback_reason"):
+        AiRoute(
+            provider_connection_id="provider-fallback",
+            model_id="fallback-model",
+            source="provider_fallback",
+            fallback_reason=fallback_reason,
+        )
+
+
+def test_ai_route_records_resolution_metadata() -> None:
+    route = AiRoute(
+        provider_connection_id="provider-fallback",
+        model_id="fallback-model",
+        source="provider_fallback",
+        resolved_at=NOW,
+        fallback_reason="Workspace route is not configured",
+    )
+
+    assert route.resolved_at == NOW
+    assert route.fallback_reason == "Workspace route is not configured"
+
+
+def test_ai_route_json_schema_requires_provider_fallback_reason() -> None:
+    validator = Draft202012Validator(AiRoute.model_json_schema())
+
+    validator.validate(
+        {
+            "source": "provider_fallback",
+            "fallback_reason": "No configured route was available",
+        }
+    )
+    with pytest.raises(JsonSchemaValidationError):
+        validator.validate({"source": "provider_fallback"})
+    with pytest.raises(JsonSchemaValidationError):
+        validator.validate(
+            {"source": "provider_fallback", "fallback_reason": "   "}
+        )
+
+
+def test_legacy_stage_route_adapter_keeps_new_resolution_metadata_optional() -> None:
+    legacy = StageLLMRoute(
+        stage="report_generation",
+        provider_id="ollama-local",
+        model="qwen3:8b",
+    )
+
+    canonical = ai_route_from_stage_route(legacy)
+
+    assert canonical.source == "legacy"
+    assert canonical.resolved_at is None
+    assert canonical.fallback_reason is None
+    assert stage_route_from_ai_route(canonical) == legacy
+
+
 @pytest.mark.parametrize("contract_name", CONTRACT_CASES)
 def test_shared_fixtures_match_pydantic_and_generated_json_schema(
     contract_name: str,

--- a/backend/tests/services/test_ai_route_resolver.py
+++ b/backend/tests/services/test_ai_route_resolver.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiRoute
+from app.services.ai_route_resolver import (
+    AiRouteCapabilityMismatchError,
+    AiRouteResolutionError,
+    NoAiRouteCandidateError,
+    resolve_ai_route,
+)
+
+
+RESOLVED_AT = datetime(2026, 7, 13, 10, 30, tzinfo=timezone.utc)
+
+
+def _route(
+    name: str,
+    *,
+    capabilities: dict[str, str] | None = None,
+    fallback_reason: str | None = None,
+) -> AiRoute:
+    data = {
+        "provider_connection_id": f"provider-{name}",
+        "model_id": f"model-{name}",
+        "source": "default",
+        "validated_capabilities": capabilities or {"chat": "supported"},
+    }
+    if fallback_reason is not None:
+        data["fallback_reason"] = fallback_reason
+    return AiRoute.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    ("present", "expected_source"),
+    [
+        (
+            ("stage_override", "run_override", "project", "workspace", "provider_fallback"),
+            "stage_override",
+        ),
+        (("run_override", "project", "workspace", "provider_fallback"), "run_override"),
+        (("project", "workspace", "provider_fallback"), "project"),
+        (("workspace", "provider_fallback"), "workspace"),
+        (("provider_fallback",), "provider_fallback"),
+    ],
+)
+def test_resolver_uses_strict_candidate_precedence(
+    present: tuple[str, ...],
+    expected_source: str,
+) -> None:
+    candidates = {
+        name: _route(
+            name,
+            fallback_reason=(
+                "No configured route was available" if name == "provider_fallback" else None
+            ),
+        )
+        for name in present
+    }
+
+    resolved = resolve_ai_route(
+        stage_override=candidates.get("stage_override"),
+        run_override=candidates.get("run_override"),
+        project_route=candidates.get("project"),
+        workspace_route=candidates.get("workspace"),
+        provider_fallback=candidates.get("provider_fallback"),
+        required_capabilities={"chat"},
+        resolved_at=RESOLVED_AT,
+    )
+
+    assert resolved.source == expected_source
+    assert resolved.provider_connection_id == f"provider-{expected_source}"
+    assert resolved.model_id == f"model-{expected_source}"
+    assert resolved.resolved_at == RESOLVED_AT
+
+
+def test_resolver_is_deterministic_and_does_not_mutate_candidate() -> None:
+    candidate = _route("project")
+    arguments = {
+        "project_route": candidate,
+        "required_capabilities": {"chat"},
+        "resolved_at": RESOLVED_AT,
+    }
+
+    first = resolve_ai_route(**arguments)
+    second = resolve_ai_route(**arguments)
+
+    assert first == second
+    assert first is not candidate
+    assert candidate.source == "default"
+    assert candidate.resolved_at is None
+
+
+def test_resolver_raises_typed_error_when_no_candidate_exists() -> None:
+    with pytest.raises(NoAiRouteCandidateError) as raised:
+        resolve_ai_route(
+            required_capabilities={"chat"},
+            resolved_at=RESOLVED_AT,
+        )
+
+    assert isinstance(raised.value, AiRouteResolutionError)
+    assert raised.value.required_capabilities == ("chat",)
+
+
+def test_resolver_raises_typed_error_for_capability_mismatch() -> None:
+    candidate = _route(
+        "stage_override",
+        capabilities={
+            "chat": "supported",
+            "json_schema": "unsupported",
+            "tool_calling": "unknown",
+        },
+    )
+
+    with pytest.raises(AiRouteCapabilityMismatchError) as raised:
+        resolve_ai_route(
+            stage_override=candidate,
+            provider_fallback=_route(
+                "provider_fallback",
+                capabilities={
+                    "chat": "supported",
+                    "json_schema": "supported",
+                    "tool_calling": "supported",
+                },
+                fallback_reason="Stage override lacks required capabilities",
+            ),
+            required_capabilities={"chat", "json_schema", "tool_calling"},
+            resolved_at=RESOLVED_AT,
+        )
+
+    assert isinstance(raised.value, AiRouteResolutionError)
+    assert raised.value.source == "stage_override"
+    assert raised.value.missing_capabilities == ("json_schema", "tool_calling")
+    assert raised.value.candidate is candidate
+
+
+def test_resolver_treats_absent_capability_as_mismatch() -> None:
+    candidate = _route("workspace", capabilities={"chat": "supported"})
+
+    with pytest.raises(AiRouteCapabilityMismatchError) as raised:
+        resolve_ai_route(
+            workspace_route=candidate,
+            required_capabilities={"vision"},
+            resolved_at=RESOLVED_AT,
+        )
+
+    assert raised.value.missing_capabilities == ("vision",)

--- a/backend/tests/services/test_ai_route_snapshot_audit.py
+++ b/backend/tests/services/test_ai_route_snapshot_audit.py
@@ -1,6 +1,7 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -107,6 +108,7 @@ def test_canonical_snapshot_is_read_through_resolved_route_adapter(runtime):
             provider_connection_id="connection-1",
             model_id="gpt-4o",
             source="stage_override",
+            resolved_at=datetime(2026, 7, 13, 8, tzinfo=timezone.utc),
         ),
     )
 
@@ -115,6 +117,7 @@ def test_canonical_snapshot_is_read_through_resolved_route_adapter(runtime):
     assert isinstance(resolved, ResolvedRoute)
     assert resolved.provider_id == "connection-1"
     assert resolved.model == "gpt-4o"
+    assert resolved.started_at == "2026-07-13T08:00:00+00:00"
 
 
 def test_routing_audit_is_idempotent_utc_and_secret_free(runtime):

--- a/backend/tests/services/test_ai_route_snapshot_audit.py
+++ b/backend/tests/services/test_ai_route_snapshot_audit.py
@@ -1,0 +1,147 @@
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiRoute
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.services.ai_route_audit import AiRouteAudit
+from app.services.runtime_run_config import RuntimeRunConfig
+from app.services.stage_model_router import StageModelRouter
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    run_dir = tmp_path / "runs" / "run-snapshot"
+    run_dir.mkdir(parents=True)
+    with patch(
+        "app.utils.artifact_locator.ArtifactLocator.run_dir",
+        return_value=str(run_dir),
+    ):
+        yield RuntimeRunConfig("run-snapshot"), run_dir
+
+
+def test_snapshot_first_writer_wins_and_loser_receives_winner(runtime):
+    service, _ = runtime
+    first = {"provider_id": "openai", "model": "gpt-4o"}
+    second = {"provider_id": "google", "model": "gemini"}
+
+    assert service.save_stage_snapshot("graph_build", first) == first
+    assert service.save_stage_snapshot("graph_build", second) == first
+    assert service.load_stage_snapshot("graph_build") == first
+
+
+def test_failed_publication_is_retryable_and_never_exposes_partial_json(runtime, monkeypatch):
+    service, run_dir = runtime
+    real_link = os.link
+    calls = 0
+
+    def fail_once(source, target):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert not os.path.exists(target)
+            raise OSError("publication failed")
+        return real_link(source, target)
+
+    monkeypatch.setattr(os, "link", fail_once)
+    with pytest.raises(OSError, match="publication failed"):
+        service.save_stage_snapshot("graph_build", {"provider_id": "openai"})
+
+    assert service.load_stage_snapshot("graph_build") is None
+    winner = service.save_stage_snapshot("graph_build", {"provider_id": "google"})
+    assert winner == {"provider_id": "google"}
+    assert not list((run_dir / "stages").glob("*.tmp"))
+
+
+def test_concurrent_snapshot_writers_observe_same_stored_winner(runtime):
+    service, _ = runtime
+    candidates = [{"provider_id": f"provider-{index}"} for index in range(8)]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(
+            pool.map(
+                lambda candidate: service.save_stage_snapshot("graph_build", candidate),
+                candidates,
+            )
+        )
+
+    stored = service.load_stage_snapshot("graph_build")
+    assert stored in candidates
+    assert results == [stored] * len(candidates)
+
+
+def test_ai_route_helpers_read_canonical_and_legacy_snapshots(runtime):
+    service, _ = runtime
+    canonical = AiRoute(
+        stage="graph_build",
+        provider_connection_id="connection-1",
+        model_id="gpt-4o",
+        source="stage_override",
+    )
+    assert service.save_ai_route_snapshot("graph_build", canonical) == canonical
+    assert service.load_ai_route_snapshot("graph_build") == canonical
+
+    legacy = {
+        "stage": "simulation_rounds",
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+        "routing_version": 3,
+    }
+    service.save_stage_snapshot("simulation_rounds", legacy)
+    converted = service.load_ai_route_snapshot("simulation_rounds")
+    assert converted is not None
+    assert converted.provider_connection_id == "openai"
+    assert converted.model_id == "gpt-4o-mini"
+    assert converted.source == "legacy"
+
+
+def test_canonical_snapshot_is_read_through_resolved_route_adapter(runtime):
+    service, _ = runtime
+    service.save_ai_route_snapshot(
+        "graph_build",
+        AiRoute(
+            stage="graph_build",
+            provider_connection_id="connection-1",
+            model_id="gpt-4o",
+            source="stage_override",
+        ),
+    )
+
+    resolved = StageModelRouter("run-snapshot").resolve("graph_build")
+
+    assert isinstance(resolved, ResolvedRoute)
+    assert resolved.provider_id == "connection-1"
+    assert resolved.model == "gpt-4o"
+
+
+def test_routing_audit_is_idempotent_utc_and_secret_free(runtime):
+    _, run_dir = runtime
+    audit = AiRouteAudit("run-snapshot")
+    route = AiRoute(
+        stage="graph_build",
+        provider_connection_id="connection-1",
+        model_id="gpt-4o",
+        source="default",
+        provider_options={"base_url": "https://example.test/v1"},
+    )
+
+    first = audit.record_routing_resolved(
+        "graph_build", route, fallback_reason="workspace route unavailable"
+    )
+    second = audit.record_routing_resolved(
+        "graph_build", route, fallback_reason="must not overwrite"
+    )
+
+    assert second == first
+    assert first["resolved_at"].endswith("+00:00")
+    assert first["source"] == "default"
+    assert first["fallback_reason"] == "workspace route unavailable"
+    serialized = json.dumps(first).lower()
+    assert "provider_options" not in serialized
+    assert "base_url" not in serialized
+    assert "example.test" not in serialized
+    audit_files = list((run_dir / "stages").glob("*_routing_resolved.json"))
+    assert len(audit_files) == 1

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -55,6 +55,12 @@ def test_stage_model_router_snapshot_isolation(temp_run_dir):
     # 1. Resolve and lock stage
     resolved = router.resolve("document_ingest")
     router.lock_stage("document_ingest", resolved)
+    canonical = service.load_ai_route_snapshot("document_ingest")
+    assert canonical is not None
+    assert canonical.provider_connection_id == "openai"
+    assert canonical.model_id == "gpt-4o"
+    assert canonical.source == "legacy"
+    assert canonical.resolved_at is not None
 
     # 2. Update runtime config
     new_global_default = StageLLMRoute(provider_id="ollama", model="qwen")

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 offen, v1.0.0)
+Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.3 verifiziert, v1.0.0)
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 
@@ -19,7 +19,7 @@ Stand: 2026-07-11 (Onboarding/Provider-Unification Slice 1 verifiziert, PR #683 
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3252 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3283 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 156 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -1,55 +1,48 @@
-# Handover — Onboarding/Provider-Unification Slice 5.2
+# Handover — Onboarding/Provider-Unification Slice 5.3
 
 ## Stand
 
 - Datum: 2026-07-13
-- Worktree: `/private/tmp/agora-onboarding-slice-5-2`
-- Branch: `codex/onboarding-model-picker-slice-5-2` (Basis: `origin/main` @
-  `2ce211a2`, PR #697 gemergt)
-- Slice: 5.2 — Discovery-getriebene Daten für den einheitlichen Model-Picker
-- Arbeitsstand: implementiert; Frontend-Check und zielgerichtete Picker-/
-  Discovery-Specs grün. Pre-Push-Gate sowie PR/CI/Merge stehen noch aus.
+- Worktree: `/private/tmp/agora-onboarding-slice-5-3`
+- Branch: `codex/onboarding-model-picker-slice-5-3`
+- Basis: `origin/main` @ `331193d7` (Slice 5.2, PR #699, gemergt)
+- Slice: 5.3 — Backend-Routing-Hierarchie (`AiRoute`)
 
-## Fertig (Sub-Slice 5.2)
+## Fertig (Sub-Slice 5.3)
 
-- `useAvailableModels()` bezieht Modelle ausschließlich über den kanonischen
-  `llmProviders`-Connection-State (`loadConnections()` +
-  `fetchConnectionModels()`). Der bisherige v3-kompatible `PickerModel`-Shape
-  bleibt als Read-Adapter erhalten.
-- Die Discovery normalisiert `provider_connection_id`, bestätigte
-  Capabilities, Connection-/Model-Status und `local_or_cloud`. Nicht
-  erreichbare Provider bleiben sichtbar und sind `unavailable`; explizit
-  nicht unterstützte Connections bleiben getrennt `unsupported`.
-- `AiModelPicker.vue` hat keine produktiven Mock-Daten mehr. `options` ist
-  ausschließlich ein expliziter Test-Override; `mode` und
-  `capabilityFilter` arbeiten auf demselben Discovery-Datenpfad.
-- Der Picker zeigt Provider-Status je Gruppe und unterscheidet die Labels für
-  `unavailable` und `unsupported`. Deutsche und englische i18n-Keys liegen
-  unter `aiModelPicker.status` und `aiModelPicker.badge`.
-- `SettingsGeneralView.vue` verwendet den Picker als v4-Pilot.
-- Neue Specs decken Discovery-Normalisierung, Capability-Filter, Offline- und
-  Unsupported-Zustand sowie erzwungenen Refresh ab.
-
-## Dokumentations-Sync
-
-- `docs/STATUS.md`: mit `bash scripts/sync-status.sh` aktualisiert.
-- `docs/epics/onboarding-provider-unification/slice-5-subplan.md`: Scope
-  bleibt Referenz; Status erst nach PR-Merge auf abgeschlossen setzen.
-- `PLAN.md`, `README.md`, `CHANGELOG.md`, `AGENTS.md`, `CLAUDE.md`: geprüft,
-  für diesen isolierten Frontend-Datenpfad nicht betroffen.
+- Die bestehende Contract-SSoT `AiRoute` in
+  `backend/app/contracts/ai_provider_contract.py` wurde additiv um die
+  Quellen `run_override`, `project`, `workspace`, `provider_fallback` sowie
+  `resolved_at` und `fallback_reason` erweitert. Es gibt bewusst keinen
+  zweiten `ai_route_contract.py`.
+- `ai_route_resolver.py` löst deterministisch
+  `Stage-Override > Run-Override > Project > Workspace > Provider-Fallback`
+  auf und lehnt fehlende bzw. capability-inkompatible Kandidaten typisiert ab.
+- Stage-Snapshots werden crash- und race-sicher per atomarem First-writer-wins
+  publiziert. Der bestehende `ResolvedRoute`-Snapshot bleibt als v3-Read-
+  Adapter erhalten; zusätzlich wird pro Stage ein kanonischer, secret-freier
+  `AiRoute`-Snapshot geschrieben.
+- `ai_route_audit.py` persistiert pro Stage genau ein secret-freies
+  `routing_resolved`-Event mit UTC-Zeit, Quelle und Fallback-Begründung.
+- Die bestehenden `llm-routing`-Endpunkte liefern `ai_route` additiv. Alte
+  Felder und Request-Shapes bleiben unverändert; die Frontend-Response-Typen
+  markieren sie mit `@deprecated`. Der öffentliche Serializer entfernt den
+  internen Legacy-Marker sowie nicht kanonische bzw. geheime Optionen.
+- Backend-, Zod- und JSON-Schema-Spiegel sind synchron; lokale Ollama-
+  Loopback-URLs bleiben im kanonischen Route-Vertrag zulässig.
 
 ## Verifikation
 
-- `cd frontend && bun run check` — grün.
-- Picker-/Discovery-Specs: 20 passed.
-- `graphify update .` — Graph aktualisiert; anschließende Query enthielt
-  `AiModelPicker.vue`, `useAvailableModels.ts`, `llmProviders.ts` und
-  `SettingsGeneralView.vue` im selben Kontext.
-- Vor Push zwingend: `bash scripts/pre-push-gate.sh`.
+- Fokussierter Backend-Lauf: 96 passed.
+- `ruff` und fokussiertes `mypy`: grün.
+- Contract-/Frontend-Gates und voller Pre-Push-Gate: siehe PR-Checks.
+- `graphify update .`: Graph auf 19.488 Nodes / 31.044 Edges aktualisiert.
 
 ## Bewusst offen
 
-- 5.3 — Backend-Routing-Hierarchie (`AiRoute`).
-- 5.4 — übrige Auswahlstellen migrieren.
-- 5.5 — alte Picker und Stores deprecaten.
-- 5.6 — Playwright-E2E.
+- 5.4 migriert die produktiven Auswahlstellen auf den neuen Resolver. Die
+  bestehende, bereits verflachte `RuntimeLlmRouting` bleibt bis dahin ein
+  Legacy-Read-Adapter und erfindet keine Project-/Workspace-Provenienz.
+- 5.5 deprecatet alte Picker/Stores vollständig.
+- 5.6 ergänzt Playwright-E2E einschließlich Run-Snapshot.
+- Danach folgen Slice 6 (Persona-Count) und Slice 7 (Golden-Gate-Designsystem).

--- a/docs/epics/onboarding-provider-unification/slice-5-subplan.md
+++ b/docs/epics/onboarding-provider-unification/slice-5-subplan.md
@@ -1,6 +1,6 @@
 # Sub-Plan: Slice 5 — Einheitlicher Model-Picker und Routing
 
-Stand: 2026-07-13 · Status: In Umsetzung (5.0/5.1 gemergt, 5.2 PR ausstehend) · Vorgeschlagener Branch: `codex/onboarding-model-picker`
+Stand: 2026-07-13 · Status: In Umsetzung (5.0–5.3 implementiert; 5.4–5.6 offen) · Vorgeschlagener Branch: `codex/onboarding-model-picker`
 
 ## Ziel
 
@@ -121,23 +121,25 @@ Reihenfolge ist verbindlich; jeder Sub-Slice endet mit grünem
 
 ### 5.3 — Backend-Routing-Hierarchie
 
+- **Status:** implementiert (dedizierter Slice-5.3-Branch).
 - **Ziel:** Server-seitige `AiRoute`-Resolution mit Snapshot + Audit.
 - **Scope:**
   - `backend/app/services/ai_route_resolver.py` (neu): Hierarchie
     `Stage-Override > Run-Override > Project > Workspace > Provider-Fallback`
-  - `backend/app/contracts/ai_route_contract.py` (neu): `AiRoute
-    { source, provider_id, model_id, capabilities, resolved_at,
-    fallback_reason }`
-  - `backend/app/services/run_snapshot.py` (erweitert): speichert `AiRoute`
-    pro Stage
-  - `backend/app/services/audit_trail.py` (erweitert): `routing_resolved`
-    Event mit allen Quellen + Begründung
+  - bestehende Contract-SSoT
+    `backend/app/contracts/ai_provider_contract.py`: `AiRoute
+    { source, provider_connection_id, model_id, validated_capabilities,
+    resolved_at, fallback_reason }`
+  - `backend/app/services/runtime_run_config.py` (erweitert): atomarer
+    Legacy-Snapshot plus kanonischer `AiRoute`-Snapshot pro Stage
+  - `backend/app/services/ai_route_audit.py` (neu): idempotentes,
+    secret-freies `routing_resolved`-Event mit Quelle + Begründung
   - Bestehende `llm_routing_seed.py` / `stage_model_router.py` als
     Read-Adapter
 - **Tests:** 10+ Contract- und Service-Tests (Hierarchie, Fallback,
   Snapshot, Audit)
-- **Migration:** bestehende `llm_routing_*`-Endpoints geben jetzt `ai_route`
-  zurück; Alt-Felder `@deprecated`.
+- **Migration:** bestehende `llm_routing_*`-Endpoints geben `ai_route`
+  additiv zurück; Alt-Felder sind in den Frontend-Response-Typen `@deprecated`.
 - **Risiko:** hoch — Kernlogik.
 
 ### 5.4 — Auswahlstellen migrieren

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -6,39 +6,75 @@ import {
   StageLLMRoute,
   LlmInvocationEvent,
 } from "../contracts/llmRoutingContract";
+import type { AiRoute } from "../contracts/aiProviderContract";
 import { ApiSuccessEnvelope } from "./envelope";
 
+export interface RunLlmRoutingResponse {
+  /** @deprecated Use `ai_route`; retained for v3 consumers. */
+  runtime_config: RuntimeLlmRouting;
+  /** @deprecated Use the canonical route snapshot; retained for v3 consumers. */
+  snapshots: Record<string, ResolvedRoute>;
+  invocation_events: LlmInvocationEvent[];
+  ai_route: AiRoute;
+}
+
+export interface RuntimeLlmRoutingResponse {
+  /** @deprecated Use `ai_route`; retained for v3 consumers. */
+  global_default: RuntimeLlmRouting["global_default"];
+  /** @deprecated Use `ai_route`; retained for v3 consumers. */
+  stage_overrides: RuntimeLlmRouting["stage_overrides"];
+  /** @deprecated Retained for v3 consumers. */
+  routing_version: RuntimeLlmRouting["routing_version"];
+  ai_route: AiRoute;
+}
+
 export async function listLlmProviders(): Promise<ProviderDescriptor[]> {
-  const resp = await service.get<ApiSuccessEnvelope<ProviderDescriptor[]>>("/api/llm/providers");
+  const resp =
+    await service.get<ApiSuccessEnvelope<ProviderDescriptor[]>>(
+      "/api/llm/providers",
+    );
   return (resp as any).data;
 }
 
-export async function listProviderModels(providerId: string, baseUrl?: string): Promise<any[]> {
+export async function listProviderModels(
+  providerId: string,
+  baseUrl?: string,
+): Promise<any[]> {
   const query = baseUrl ? `?base_url=${encodeURIComponent(baseUrl)}` : "";
-  const resp = await service.get<ApiSuccessEnvelope<any[]>>(`/api/llm/providers/${providerId}/models${query}`);
+  const resp = await service.get<ApiSuccessEnvelope<any[]>>(
+    `/api/llm/providers/${providerId}/models${query}`,
+  );
   return (resp as any).data;
 }
 
-export async function getRunLlmRouting(runId: string): Promise<{
-  runtime_config: RuntimeLlmRouting,
-  snapshots: Record<string, ResolvedRoute>,
-  invocation_events: LlmInvocationEvent[],
-}> {
-  const resp = await service.get<ApiSuccessEnvelope<{
-    runtime_config: RuntimeLlmRouting,
-    snapshots: Record<string, ResolvedRoute>,
-    invocation_events: LlmInvocationEvent[],
-  }>>(`/api/runs/${runId}/llm-routing`);
+export async function getRunLlmRouting(
+  runId: string,
+): Promise<RunLlmRoutingResponse> {
+  const resp = await service.get<ApiSuccessEnvelope<RunLlmRoutingResponse>>(
+    `/api/runs/${runId}/llm-routing`,
+  );
   return (resp as any).data;
 }
 
-export async function updateRunLlmRouting(runId: string, config: RuntimeLlmRouting): Promise<RuntimeLlmRouting> {
-  const resp = await service.put<ApiSuccessEnvelope<RuntimeLlmRouting>>(`/api/runs/${runId}/llm-routing`, config);
+export async function updateRunLlmRouting(
+  runId: string,
+  config: RuntimeLlmRouting,
+): Promise<RuntimeLlmRoutingResponse> {
+  const resp = await service.put<ApiSuccessEnvelope<RuntimeLlmRoutingResponse>>(
+    `/api/runs/${runId}/llm-routing`,
+    config,
+  );
   return (resp as any).data;
 }
 
-export async function patchStageLlmRouting(runId: string, stageId: string, route: StageLLMRoute): Promise<RuntimeLlmRouting> {
-  const resp = await service.patch<ApiSuccessEnvelope<RuntimeLlmRouting>>(`/api/runs/${runId}/llm-routing/stages/${stageId}`, route);
+export async function patchStageLlmRouting(
+  runId: string,
+  stageId: string,
+  route: StageLLMRoute,
+): Promise<RuntimeLlmRoutingResponse> {
+  const resp = await service.patch<
+    ApiSuccessEnvelope<RuntimeLlmRoutingResponse>
+  >(`/api/runs/${runId}/llm-routing/stages/${stageId}`, route);
   return (resp as any).data;
 }
 
@@ -55,15 +91,22 @@ export interface ActiveLlmConfigUpdate {
 }
 
 export async function getActiveLlmConfig(): Promise<ActiveLlmConfig> {
-  const resp = await service.get<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config");
+  const resp = await service.get<ApiSuccessEnvelope<ActiveLlmConfig>>(
+    "/api/llm/active-config",
+  );
   return (resp as any).data || {};
 }
 
-export async function setActiveLlmConfig(cfg: ActiveLlmConfigUpdate): Promise<ActiveLlmConfig> {
+export async function setActiveLlmConfig(
+  cfg: ActiveLlmConfigUpdate,
+): Promise<ActiveLlmConfig> {
   const payload: ActiveLlmConfigUpdate = {
     provider_id: cfg.provider_id,
     model: cfg.model,
   };
-  const resp = await service.put<ApiSuccessEnvelope<ActiveLlmConfig>>("/api/llm/active-config", payload);
+  const resp = await service.put<ApiSuccessEnvelope<ActiveLlmConfig>>(
+    "/api/llm/active-config",
+    payload,
+  );
   return (resp as any).data;
 }

--- a/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
+++ b/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
@@ -102,6 +102,29 @@ describe('canonical AI provider contracts', () => {
     expect(AiRouteSchema.safeParse({ unexpected: true }).success).toBe(false)
   })
 
+  it.each(['run_override', 'project', 'workspace'])(
+    'accepts the additive route source %s',
+    (source) => {
+      expect(AiRouteSchema.safeParse({
+        source,
+        resolved_at: '2026-07-13T10:30:00Z',
+      }).success).toBe(true)
+    },
+  )
+
+  it('requires a non-blank reason for provider fallback routes', () => {
+    expect(AiRouteSchema.safeParse({
+      source: 'provider_fallback',
+      fallback_reason: 'No configured route was available',
+      resolved_at: '2026-07-13T10:30:00Z',
+    }).success).toBe(true)
+    expect(AiRouteSchema.safeParse({ source: 'provider_fallback' }).success).toBe(false)
+    expect(AiRouteSchema.safeParse({
+      source: 'provider_fallback',
+      fallback_reason: '   ',
+    }).success).toBe(false)
+  })
+
   it('accepts the canonical Pydantic-shaped payload without secret values', () => {
     const result = ProviderConnectionSchema.safeParse({
       id: 'ollama-local',

--- a/frontend/src/contracts/aiProviderContract.ts
+++ b/frontend/src/contracts/aiProviderContract.ts
@@ -213,12 +213,35 @@ export const AiProviderOptionsSchema = z.object({
 }).strict()
 export type AiProviderOptions = z.infer<typeof AiProviderOptionsSchema>
 
+export const RouteSourceSchema = z.enum([
+  'default',
+  'profile',
+  'stage_override',
+  'run_override',
+  'project',
+  'workspace',
+  'provider_fallback',
+  'runtime',
+  'legacy',
+])
+export type RouteSource = z.infer<typeof RouteSourceSchema>
+
 export const AiRouteSchema = z.object({
   stage: StageIdSchema.nullable().default(null),
   provider_connection_id: z.string().nullable().default(null),
   model_id: z.string().nullable().default(null),
-  source: z.enum(['default', 'profile', 'stage_override', 'runtime', 'legacy']),
+  source: RouteSourceSchema,
   validated_capabilities: z.record(z.string(), CapabilityStateSchema).default({}),
   provider_options: AiProviderOptionsSchema.default({}),
-}).strict()
+  resolved_at: NullableDateTimeSchema,
+  fallback_reason: z.string().nullable().default(null),
+}).strict().superRefine((route, context) => {
+  if (route.source === 'provider_fallback' && !route.fallback_reason?.trim()) {
+    context.addIssue({
+      code: 'custom',
+      message: 'provider_fallback requires a non-blank fallback_reason',
+      path: ['fallback_reason'],
+    })
+  }
+})
 export type AiRoute = z.infer<typeof AiRouteSchema>

--- a/schemas/ai-route.schema.json
+++ b/schemas/ai-route.schema.json
@@ -94,7 +94,45 @@
   "$id": "https://alexle135.de/schemas/ai-route.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "const": "provider_fallback"
+          }
+        },
+        "required": [
+          "source"
+        ]
+      },
+      "then": {
+        "properties": {
+          "fallback_reason": {
+            "minLength": 1,
+            "pattern": "\\S",
+            "type": "string"
+          }
+        },
+        "required": [
+          "fallback_reason"
+        ]
+      }
+    }
+  ],
   "properties": {
+    "fallback_reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Fallback Reason"
+    },
     "model_id": {
       "anyOf": [
         {
@@ -122,11 +160,28 @@
     "provider_options": {
       "$ref": "#/$defs/AiProviderOptions"
     },
+    "resolved_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Resolved At"
+    },
     "source": {
       "enum": [
         "default",
         "profile",
         "stage_override",
+        "run_override",
+        "project",
+        "workspace",
+        "provider_fallback",
         "runtime",
         "legacy"
       ],


### PR DESCRIPTION
## Summary

- resolves AiRoute candidates in strict stage, run, project, workspace, provider-fallback order
- adds atomic canonical stage snapshots and secret-free idempotent routing audit events
- returns ai_route additively from existing routing endpoints while preserving deprecated legacy fields
- synchronizes Pydantic, Zod, JSON Schema, status, plan, and handover documentation

## Verification

- bash scripts/pre-push-gate.sh
- 3283 backend tests collected
- 374 contract tests passed
- 157 frontend test files / 1264 tests passed
- 46 generated schemas matched
- graphify update completed