### PR TITLE
test(e2e): AiModelPicker E2E skeleton with skip annotations (Slice 5.6-Prep)

### DIFF
--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -75,3 +75,146 @@ CI-Workflow: `.github/workflows/check-legacy-model-picker.yml`
 Lokaler Aufruf: `python3 .github/scripts/check_legacy_model_picker.py`
 (Spiegel siehe `docs/runbooks/pre-push-gate.md`, Abschnitt
 „Legacy-Picker-Check").
+---
+
+# Handover — Onboarding/Provider-Unification Slice 5.6-Prep
+
+## Stand
+
+- Datum: 2026-07-13
+- Worktree: `/private/tmp/agora-onboarding-slice-5-6-prep`
+- Branch: `codex/onboarding-model-picker-slice-5-6-prep`
+- Basis: `origin/main` @ `165d22f5` (PR #700 gemergt, AiRoute +
+  AiModelPicker Discovery in `main`)
+- Slice: **5.6-Prep** — Playwright-E2E-Skeleton fuer AiModelPicker.
+  Diese Vorbereitung laeuft PARALLEL zu Sub-Slice 5.4
+  (`codex/onboarding-model-picker-slice-5-4`, derzeit offen) in einem
+  separaten Branch. Der Prep-Branch haengt **nicht** von 5.4 ab und
+  darf gemergt werden, sobald die Spec lauffaehig (mit `test.describe.skip()`)
+  ist. 5.6 final muss dann nur die `.skip`-Annotation entfernen und
+  ggf. Selektor-Pfade an die in 5.4 konkret migrierten Routen anpassen.
+
+## Daten-testid-SSoT
+
+`frontend/src/contracts/testIds.ts` (neu) — wird sowohl von der
+Komponente (`AiModelPicker.vue` importiert `@/contracts/testIds`) als
+auch von den E2E-Helpern (`frontend/tests/e2e/helpers/testIds.ts`
+re-exportiert ueber relativen Pfad, weil
+`tsconfig.playwright.json` keinen `@/`-Alias hat) verwendet.
+
+Vergabe-Schema (collision-safe ueber Namespace-Prefix `ai-model-picker-*`):
+
+| Konstante                  | data-testid-Wert           | Wer rendert                                                       |
+| -------------------------- | -------------------------- | ----------------------------------------------------------------- |
+| `AiModelPickerTestId.root`   | `ai-model-picker`            | Root-Container `<div class="ai-model-picker">`                      |
+| `AiModelPickerTestId.input`  | `ai-model-picker-input`      | Trigger-Input (ComboboxInput)                                       |
+| `AiModelPickerTestId.search` | `ai-model-picker-search`     | Such-Input im geoeffneten Content                                   |
+| `AiModelPickerTestId.group`  | `ai-model-picker-group`      | ComboboxGroup, zusaetzlich `data-provider-connection-id`            |
+| `AiModelPickerTestId.option` | `ai-model-picker-option`     | ComboboxItem, zusaetzlich `data-provider-connection-id` + `data-model-id` |
+| `AiModelPickerTestId.status` | `ai-model-picker-status`     | Group-Status-Badge (Reserviert; aktuell nicht im Template, fuer 5.4) |
+| `AiModelPickerTestId.empty`  | `ai-model-picker-empty`      | ComboboxEmpty (Empty-State)                                          |
+
+5.4 muss in den migrierten Views (HeroNewRun, SettingsGeneralView,
+LlmRoutingView, StepModelOverrideChip) **dieselben IDs** vergeben.
+Sollte 5.4 weitere Selektoren brauchen, bitte hier ergaenzen — kein
+String-Drift zwischen Komponente und Spec.
+
+## data-testid-Anpassungen an `AiModelPicker.vue`
+
+Klein, sauber, additiv. Keine Logik-Aenderung, keine CSS-Anpassung.
+Component-Unit-Tests (AiModelPicker.spec.ts + AiModelPicker.discovery.spec.ts)
+bleiben gruen (14/14). `vue-tsc` und `eslint` ohne Befund.
+
+- `providerGroups`-Computed: Typ um `provider_connection_id: string`
+  erweitert (wird als `data-provider-connection-id` auf der Group
+  gerendert). Filter- und Sort-Logik unveraendert.
+- `data-testid` an: root `<div>`, Trigger-`<ComboboxInput>`, Such-
+  `<ComboboxInput>`, `<ComboboxEmpty>`, `<ComboboxGroup>`, `<ComboboxItem>`.
+- Group erhaelt zusaetzlich `:data-provider-connection-id="group.provider_connection_id"`.
+- Item erhaelt zusaetzlich `:data-provider-connection-id` und
+  `:data-model-id`.
+
+Damit kann eine E2E-Spec gezielt auf eine Provider-Gruppe oder ein
+Modell zugreifen, ohne sich auf den (i18n-lokalisierbaren) Display-
+Namen verlassen zu muessen.
+
+## Spec-Struktur (Skeletons)
+
+`frontend/tests/e2e/ai-model-picker.spec.ts` (neu) — `test.describe.skip()`,
+damit CI gruen bleibt bis 5.4 die Komponente in den Ziel-Views mountet.
+
+Drei Test-Gruppen (jeweils mit `// 5.4: aktiveren sobald ...` Kommentar):
+
+1. **Tastatur-Navigation** (2 Tests)
+   - `↓↓↑Enter` oeffnet Combobox, wandert Auswahl, committed.
+   - Suche filtert Optionen, Pfeile wandern ueber Treffer.
+
+2. **Provider offline** (2 Tests)
+   - Modell mit `status=unavailable` hat `data-disabled` /
+     `aria-disabled` UND sichtbares Error-Badge
+     (`.ai-model-picker__badge--err`).
+   - Provider-Group rendert Status-Label im Group-Header.
+
+3. **Run-Snapshot** (1 Test)
+   - GET `/api/runs/<run_id>/llm-routing` liefert
+     `ai_route.provider_connection_id` und `ai_route.model_id` passend
+     zur Picker-Auswahl; `ai_route.source === 'stage-override'`.
+   - Setzt voraus, dass 5.3 (PR #700, gemergt in main) das `ai_route`-
+     Feld liefert und 5.4 die Stage-Override-UI auf AiModelPicker
+     umgestellt hat.
+
+`frontend/tests/e2e/helpers/aiModelPicker.ts` (neu) — Locator- und
+Action-Funktionen ausschliesslich auf `data-testid`-Basis:
+
+- `login(page|context, token?)` — Wrapper fuer `injectAuthToken`
+  (Single-User-Token-Mode).
+- `getPicker`, `getPickerInput`, `getPickerSearch`,
+  `getGroupByConnectionId`, `getOption` — Locator-Builder.
+- `openPicker`, `selectOptionByClick`, `drillKeyboard`,
+  `readSelectedLabel` — Action-Helfer.
+
+Kein Klassen- oder ARIA-Selector — die Helper sind immun gegen
+CSS-Refactors und i18n-Aenderungen.
+
+## Verifikation (lokal)
+
+- `bash scripts/pre-push-gate.sh` — grun (Backend + Frontend + Schemas).
+  Spec-File alleine bricht das Gate nicht.
+- `vitest run src/components/v4/forms/__tests__/AiModelPicker` —
+  14/14 Tests pass (Component-Aenderungen sind additiv).
+- `vue-tsc --noEmit` — sauber.
+- `tsc --noEmit -p tsconfig.playwright.json` — nur der pre-existing
+  Fehler in `tests/e2e/minimal-report.spec.ts:69` (`import.meta` mit
+  `module: CommonJS`), nicht von diesen Aenderungen verursacht.
+- `playwright test --list tests/e2e/ai-model-picker.spec.ts` —
+  5 Tests gelistet, alle als skip markiert.
+
+## Out of Scope (bewusst)
+
+- Echte Migrations-Schritte → Sub-Slice 5.4.
+- Store-Konsolidierung → Sub-Slice 5.5.
+- 5.6 final: `test.describe.skip()` entfernen, Seed-Daten aus
+  5.4 ableiten (konkrete `provider_connection_id` + `model_id`),
+  ggf. Save-Button-`data-testid` in der Stage-Override-View ergaenzen,
+  grun laufen lassen.
+
+## Naechste Schritte (5.6 final)
+
+1. PR mergen (Prep-Skeleton ist grun, 5.4 unabhaengig).
+2. Sobald 5.4 den Picker in einer View gemountet hat: `beforeEach`-
+   `goto` in `ai-model-picker.spec.ts` an die echte Route anpassen.
+3. Skip-Annotation entfernen, Seed-Daten fest verdrahten
+   (Empfehlung: dedizierter Test-Provider mit `status=unavailable` im
+   global-setup oder im ProviderConnectionStore-Seed).
+4. `bash scripts/pre-push-gate.sh` final grun halten.
+
+## Relevante Dateien (Diff zu `origin/main`)
+
+- `frontend/src/components/v4/forms/AiModelPicker.vue` (data-testid +
+  provider_connection_id in providerGroups-Type)
+- `frontend/src/contracts/testIds.ts` (neu)
+- `frontend/tests/e2e/helpers/testIds.ts` (neu, Re-Export)
+- `frontend/tests/e2e/helpers/aiModelPicker.ts` (neu)
+- `frontend/tests/e2e/ai-model-picker.spec.ts` (neu)
+- `docs/epics/onboarding-provider-unification/HANDOVER.md` (dieser Abschnitt)
+

--- a/frontend/src/components/v4/forms/AiModelPicker.vue
+++ b/frontend/src/components/v4/forms/AiModelPicker.vue
@@ -19,6 +19,7 @@
  */
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { AiModelPickerTestId as testIds } from '@/contracts/testIds'
 import {
   ComboboxAnchor,
   ComboboxContent,
@@ -117,12 +118,28 @@ const filteredOptions = computed<readonly AiModelRefInput[]>(() => {
     })
 })
 
-/** Provider-Gruppen (fuer ComboboxGroup). */
+/**
+ * Provider-Gruppen (fuer ComboboxGroup).
+ *
+ * Slice 5.6-Prep: `provider_connection_id` ist neu in der Group-Struktur
+ * und wird als data-Provider-connection-id auf dem Group-Root
+ * gerendert. E2E-Selektoren koennen damit gezielt auf eine
+ * Provider-Gruppe zugreifen, ohne sich auf den (i18n-lokalisierbaren)
+ * `name` verlassen zu muessen. Aenderungsgruende in 5.6: stable
+ * Selektoren fuer Specs, unabhängig von Display-Namen.
+ */
 const providerGroups = computed(() => {
-  const groups = new Map<string, { name: string; status: AiModelStatus; items: AiModelRefInput[] }>()
+  const groups = new Map<string, { name: string; provider_connection_id: string; status: AiModelStatus; items: AiModelRefInput[] }>()
   for (const o of filteredOptions.value) {
     const key = o.provider_connection_id
-    if (!groups.has(key)) groups.set(key, { name: o.display_name, status: o.status, items: [] })
+    if (!groups.has(key)) {
+      groups.set(key, {
+        name: o.display_name,
+        provider_connection_id: o.provider_connection_id,
+        status: o.status,
+        items: [],
+      })
+    }
     groups.get(key)!.items.push(o)
   }
   return Array.from(groups.values()).sort((left, right) => left.name.localeCompare(right.name))
@@ -247,7 +264,12 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
 </script>
 
 <template>
-  <div class="ai-model-picker" :data-mode="mode" :data-disabled="disabled || undefined">
+  <div
+    class="ai-model-picker"
+    :data-mode="mode"
+    :data-disabled="disabled || undefined"
+    :data-testid="testIds.root"
+  >
     <ComboboxRoot
       :model-value="selectedId ?? ''"
       :disabled="disabled"
@@ -262,6 +284,7 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
           :display-value="() => selectedLabel"
           autocomplete="off"
           spellcheck="false"
+          :data-testid="testIds.input"
         />
         <ComboboxTrigger class="ai-model-picker__trigger" :aria-label="placeholderText" tabindex="-1">
           <span aria-hidden="true">▾</span>
@@ -276,9 +299,10 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
               :placeholder="searchPlaceholder"
               autocomplete="off"
               spellcheck="false"
+              :data-testid="testIds.search"
             />
 
-            <ComboboxEmpty class="ai-model-picker__empty">
+            <ComboboxEmpty class="ai-model-picker__empty" :data-testid="testIds.empty">
               {{ emptyText }}
             </ComboboxEmpty>
 
@@ -286,6 +310,8 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
               v-for="group in providerGroups"
               :key="group.name"
               class="ai-model-picker__group"
+              :data-testid="testIds.group"
+              :data-provider-connection-id="group.provider_connection_id"
             >
               <ComboboxLabel class="ai-model-picker__group-label">
                 {{ group.name }} · {{ providerStatusLabel(group.status) }}
@@ -299,6 +325,9 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
                 :text-value="`${item.display_name} ${item.model_id}`"
                 class="ai-model-picker__item"
                 :data-status="item.status"
+                :data-testid="testIds.option"
+                :data-provider-connection-id="item.provider_connection_id"
+                :data-model-id="item.model_id"
               >
                 <span class="ai-model-picker__item-row">
                   <span

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -1,0 +1,33 @@
+/**
+ * Zentrales data-testid-Register fuer E2E + Komponenten-Tests.
+ *
+ * Single source of truth fuer stabile Test-Selektoren. Sowohl die
+ * Vue-Komponenten (data-testid-Attribute) als auch die Playwright-
+ * Specs (Locator-Building) greifen auf DIESE Konstanten zu — kein
+ * String-Drift zwischen Komponente und Spec.
+ *
+ * Namensschema: `<namespace>-<element>[-<modifier>]`
+ *
+ * Slice 5.6-Prep: angelegt fuer AiModelPicker. 5.4 (Migration der
+ * Auswahlstellen) und 5.5 (Deprecation) muessen dieselben IDs in
+ * den migrierten Views (HeroNewRun, SettingsGeneralView,
+ * StepModelOverrideChip) wiederverwenden, damit die Specs ohne
+ * Selector-Aenderungen weiterlaufen. Bei neuen Pickern bitte
+ * eigenen Namespace waehlen (z. B. `embedding-picker-*`).
+ *
+ * Kollisionen werden bei Lint-Zeit sichtbar, weil jeder Namespace
+ * als eigenes Objekt unter `AiModelPickerTestId` etc. deklariert
+ * ist.
+ */
+
+export const AiModelPickerTestId = {
+  root: 'ai-model-picker',
+  input: 'ai-model-picker-input',
+  search: 'ai-model-picker-search',
+  group: 'ai-model-picker-group',
+  option: 'ai-model-picker-option',
+  status: 'ai-model-picker-status',
+  empty: 'ai-model-picker-empty',
+} as const
+
+export type AiModelPickerTestId = (typeof AiModelPickerTestId)[keyof typeof AiModelPickerTestId]

--- a/frontend/tests/e2e/ai-model-picker.spec.ts
+++ b/frontend/tests/e2e/ai-model-picker.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * AiModelPicker — Playwright-E2E (Sub-Slice 5.6-Prep).
+ *
+ * Stand: 2026-07-13 — SKELETON. Der gesamte describe-Block ist mit
+ * `test.describe.skip()` markiert, weil die Komponente noch in KEINER
+ * produktiven View gemountet ist. Sub-Slice 5.4 (Migration der
+ * Auswahlstellen) liefert die Views; 5.6 final muss dann nur die
+ * `.skip`-Annotation entfernen und ggf. Selektor-Pfade an die
+ * konkret migrierten Routen anpassen.
+ *
+ * Aktivierung pro Test:
+ *
+ *   1) Tastatur-Navigation ↓↓↑Enter
+ *      Voraussetzung: 5.4 hat AiModelPicker in mindestens einer
+ *      Settings/Dashboard-View gemountet (Empfehlung slice-5:
+ *      SettingsGeneralView). 5.6 final: `await page.goto('/settings/general')`
+ *      o. ae. statt des hier dokumentierten `goto`/Stub.
+ *
+ *   2) Provider offline
+ *      Voraussetzung: Backend liefert im Test-Fixture mindestens
+ *      einen Provider mit status='unavailable' (siehe useAvailableModels
+ *      Composable + ProviderConnectionStore). 5.6 final: Seed im
+ *      global-setup oder ein dedizierter Test-Helper-Endpoint.
+ *
+ *   3) Run-Snapshot
+ *      Voraussetzung: 5.4 hat die Stage-Override-UI auf AiModelPicker
+ *      umgestellt (z. B. in LlmRoutingView.vue) UND 5.3 (PR #700) ist
+ *      gemergt — AiRoute ist im Endpoint
+ *      GET /api/runs/<run_id>/llm-routing verfuegbar.
+ *
+ * Helper: siehe frontend/tests/e2e/helpers/aiModelPicker.ts.
+ * testId-SSoT: frontend/src/contracts/testIds.ts.
+ *
+ * Out of Scope hier: 5.4 (Migration), 5.5 (Deprecation). Die Spec
+ * ist absichtlich eng am 5.6-Sub-Plan-Scope gehalten, damit sie
+ * nicht versehentlich Migrations-Logik mitverifiziert.
+ */
+import { test, expect, request, type APIRequestContext } from '@playwright/test'
+import {
+  login,
+  getPicker,
+  getPickerInput,
+  getPickerSearch,
+  getOption,
+  getGroupByConnectionId,
+  openPicker,
+  selectOptionByClick,
+  drillKeyboard,
+  readSelectedLabel,
+} from './helpers/aiModelPicker'
+import { authHeader } from './helpers/auth'
+
+// 5.4: aktivieren sobald die Komponente in mindestens einer View gemountet ist.
+test.describe.skip('Slice 5.6 · AiModelPicker E2E', () => {
+  test.beforeEach(async ({ page, context }) => {
+    // Single-User-Token-Mode (siehe health.spec.ts Test 4): kein
+    // klassisches Login, sondern Token-Inject in localStorage.
+    await login(context)
+    // 5.4 muss diese Route in App.vue (oder dem Hash-Router) registrieren.
+    // Solange 5.4 offen ist, fuehrt goto() in einen 404 — daher der skip.
+    await page.goto('/settings/general', { waitUntil: 'domcontentloaded' })
+  })
+
+  // -------------------------------------------------------------------------
+  // 1) Tastatur-Navigation ↓↓↑Enter
+  // -------------------------------------------------------------------------
+  test.describe('Tastatur-Navigation', () => {
+    test('↓↓↑Enter oeffnet Combobox, wandert Auswahl und committed', async ({ page }) => {
+      const picker = getPicker(page)
+      await expect(picker).toBeVisible()
+
+      // 1. Trigger-Input ist fokussierbar.
+      const input = getPickerInput(page, picker)
+      await expect(input).toBeVisible()
+      await expect(input).toBeEnabled()
+
+      // 2. ↓↓↑Enter: reka-ui Combobox-Logik navigiert ueber die
+      //    sichtbaren Items. Nach ↓↓↑ ist das 2. Item aktiv
+      //    (initial ↓ markiert 1., ↓ markiert 2., ↑ geht zurueck auf 1.).
+      //    Enter committed den Eintrag.
+      await drillKeyboard(page, picker)
+
+      // 3. Nach Enter: Trigger-Input zeigt das gewaehlte Modell.
+      //    (Konkrete Erwartung wird in 5.6 final gesetzt, sobald die
+      //    Seed-Daten aus useAvailableModels feststehen.)
+      const label = await readSelectedLabel(page, picker)
+      expect(label.length).toBeGreaterThan(0)
+      // 5.4: aktiveren, sobald SettingsGeneralView den Picker nutzt.
+    })
+
+    test('Suche filtert Optionen, Pfeile wandern ueber Treffer', async ({ page }) => {
+      const picker = getPicker(page)
+      await openPicker(page, picker)
+      // reka-ui ComboboxInput im Content ist die Such-Leiste.
+      const search = getPickerSearch(page, picker)
+      await expect(search).toBeVisible()
+      await search.fill('qwen')
+
+      // Treffer-Liste: die als `qwen` matchenden Optionen.
+      // 5.6 final: konkrete provider_connection_id aus Seed ableiten.
+      const firstMatch = picker.locator('[data-testid^="ai-model-picker-option"]').first()
+      await expect(firstMatch).toBeVisible()
+
+      // 5.4: aktiveren, sobald Seed verfuegbar ist.
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 2) Provider offline: Status-Badge + disabled Modell
+  // -------------------------------------------------------------------------
+  test.describe('Provider offline', () => {
+    test('Modell mit status=unavailable hat disabled-Attribut und Status-Badge', async ({ page }) => {
+      const picker = getPicker(page)
+      await openPicker(page, picker)
+
+      // 5.6 final: provider_connection_id + model_id aus dem
+      // Test-Seed ableiten (Empfehlung: dedizierter
+      // 'unavailable'-Provider im Test-Fixture).
+      const offlineOption = getOption(
+        page,
+        { providerConnectionId: 'conn-offline', modelId: 'gpt-offline' },
+        picker,
+      )
+
+      // a) data-status reflektiert 'unavailable' (Quelle: AiModelPicker.vue,
+      //    :data-status="item.status" — schon vor diesem PR gesetzt).
+      await expect(offlineOption).toHaveAttribute('data-status', 'unavailable')
+
+      // b) ComboboxItem rendert das disabled-Attribut. reka-ui setzt
+      //    zusaetzlich aria-disabled; beide sind akzeptabel.
+      const ariaDisabled = await offlineOption.getAttribute('aria-disabled')
+      const nativeDisabled = await offlineOption.getAttribute('data-disabled')
+      expect(ariaDisabled === 'true' || nativeDisabled !== null).toBe(true)
+
+      // c) Status-Badge ist sichtbar (reka-ui ComboboxItem ist der
+      //    Traeger; Badge liegt innerhalb des Items). Text ist i18n,
+      //    daher Pruefung auf Klasse ai-model-picker__badge--err.
+      await expect(
+        offlineOption.locator('.ai-model-picker__badge--err'),
+      ).toBeVisible()
+
+      // 5.4: aktiveren, sobald Seed einen 'unavailable'-Provider enthaelt.
+    })
+
+    test('Provider-Group rendert Status-Label im Group-Header', async ({ page }) => {
+      const picker = getPicker(page)
+      await openPicker(page, picker)
+
+      const offlineGroup = getGroupByConnectionId(page, 'conn-offline', picker)
+      // Group-Header enthaelt den lokalisierten Status.
+      // Textuelle Assertion ist i18n-fest, daher Pruefung auf die
+      // Group-Label-Klasse.
+      await expect(offlineGroup.locator('.ai-model-picker__group-label')).toBeVisible()
+      // 5.4: aktiveren, sobald Seed verfuegbar ist.
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 3) Run-Snapshot: Auswahl landet im canonical ai_route
+  // -------------------------------------------------------------------------
+  test.describe('Run-Snapshot', () => {
+    // 5.3 (PR #700) liefert das `ai_route`-Feld im Endpoint
+    // GET /api/runs/<run_id>/llm-routing. 5.4 muss die Stage-Override-UI
+    // auf AiModelPicker umgestellt haben.
+    test('gewaehltes Modell landet im Run-Snapshot (ai_route)', async ({ page, baseURL }) => {
+      // Bestehender Run mit laufender Stage-Override-Konfiguration.
+      // 5.6 final: run_id aus einem frischen Test-Run ableiten
+      // (z. B. ueber helpers/upload.ts + minimal-report.spec.ts-Pattern).
+      const runId = 'run_e2e_placeholder'
+
+      const picker = getPicker(page)
+      // 5.4: Annahme — die Stage-Override-View (z. B. LlmRoutingView)
+      // enthaelt den Picker pro Stage. Der Pfad muss in 5.6 final an
+      // die echte Route angepasst werden.
+      await page.goto(`/runs/${runId}/routing`, { waitUntil: 'domcontentloaded' })
+
+      // 1) Auswahl via Picker treffen.
+      const target = {
+        providerConnectionId: 'conn-ollama-local',
+        modelId: 'qwen2.5:14b',
+      }
+      await selectOptionByClick(page, target, picker)
+
+      // 2) Speichern (Button-Text ist i18n; 5.6 final nutzt ein
+      //    dediziertes data-testid am Save-Button, sobald 5.4 ihn
+      //    umgestellt hat).
+      // await page.getByTestId('stage-override-save').click()
+
+      // 3) Run-Snapshot-Endpoint pruefen.
+      //    GET /api/runs/<run_id>/llm-routing liefert seit PR #700
+      //    das canonical `ai_route`-Feld (AiRoute-Schema, siehe
+      //    backend/app/contracts/ai_provider_contract.py).
+      const ctx: APIRequestContext = await request.newContext({
+        extraHTTPHeaders: authHeader(),
+      })
+      const res = await ctx.get(`${baseURL}/api/runs/${runId}/llm-routing`)
+      expect(res.ok()).toBe(true)
+
+      const body = (await res.json()) as { data?: { ai_route?: { provider_connection_id?: string; model_id?: string; source?: string } } }
+      const route = body.data?.ai_route
+      expect(route).toBeDefined()
+      expect(route?.provider_connection_id).toBe(target.providerConnectionId)
+      expect(route?.model_id).toBe(target.modelId)
+      // Source ist seit 5.3 'stage-override' (siehe slice-5-subplan §5.3).
+      expect(route?.source).toBe('stage-override')
+
+      await ctx.dispose()
+      // 5.4: aktiveren, sobald Stage-Override-View den Picker nutzt
+      //       UND 5.3 in main gemergt ist (PR #700).
+    })
+  })
+})

--- a/frontend/tests/e2e/helpers/aiModelPicker.ts
+++ b/frontend/tests/e2e/helpers/aiModelPicker.ts
@@ -1,0 +1,187 @@
+import type { BrowserContext, Locator, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { AiModelPickerTestId } from './testIds'
+import { injectAuthToken } from './auth'
+
+/**
+ * AiModelPicker — Playwright-Helper fuer E2E.
+ *
+ * Stellt Locator- und Action-Funktionen bereit, die ausschliesslich
+ * auf den data-testid-Attributen aus `./testIds.ts` aufsetzen. Klass-
+ * oder ARIA-Selektoren werden bewusst NICHT verwendet, damit
+ * CSS-Refactors oder i18n-Aenderungen die Specs nicht brechen.
+ *
+ * Slice 5.6-Prep: Skeleton. Die hier exponierten Funktionen werden
+ * in 5.6 final von der Spec aktiv genutzt (Skip-Annotationen raus,
+ * sobald 5.4 die Komponente in den Ziel-Views mountet).
+ *
+ * Voraussetzungen (von 5.4 zu erfuellen, dokumentiert in slice-5-subplan.md):
+ *   - AiModelPicker in mindestens einer v4-View gemountet
+ *     (Empfehlung slice-5: SettingsGeneralView, HeroNewRun,
+ *     StepModelOverrideChip).
+ *   - ProviderConnection-Backend liefert mind. eine 'available'-Connection
+ *     und eine 'unavailable'-Connection (siehe Test 2).
+ *   - Run-Snapshot-Endpoint /api/runs/<run_id>/llm-routing liefert das
+ *     canonical `ai_route`-Feld (siehe PR #700, ai_provider_contract.AiRoute).
+ */
+
+/**
+ * Login-Shim.
+ *
+ * Agora laeuft im Single-User-Token-Mode (siehe health.spec.ts Test 4).
+ * Es gibt kein klassisches Login-Formular — der Token wird per
+ * `injectAuthToken()` aus `helpers/auth.ts` in localStorage injiziert
+ * und vom Frontend als Bearer-Token mitgesendet.
+ *
+ * Akzeptiert wahlweise Page (zieht context raus) oder direkt den
+ * BrowserContext, damit Specs bequem `await login(page)` schreiben
+ * koennen.
+ */
+export async function login(
+  target: Page | BrowserContext,
+  token?: string,
+): Promise<void> {
+  const context: BrowserContext = 'context' in target ? target.context() : target
+  await injectAuthToken(context, token)
+}
+
+/**
+ * Locator fuer den AiModelPicker-Root-Container.
+ * Mehrere Picker pro Seite sind erlaubt; ueber `index` oder
+ * `.filter()` kann ein bestimmter Picker gewaehlt werden.
+ */
+export function getPicker(page: Page): Locator {
+  return page.getByTestId(AiModelPickerTestId.root)
+}
+
+/**
+ * Locator fuer den Trigger-Input (zeigt aktuell gewaehltes Modell
+ * oder Platzhalter). Fokus auf dieses Element oeffnet den Combobox.
+ */
+export function getPickerInput(page: Page, picker?: Locator): Locator {
+  const scope = picker ?? getPicker(page)
+  return scope.getByTestId(AiModelPickerTestId.input)
+}
+
+/**
+ * Locator fuer das Suchfeld (sichtbar, sobald der Picker geoeffnet ist).
+ */
+export function getPickerSearch(page: Page, picker?: Locator): Locator {
+  const scope = picker ?? getPicker(page)
+  return scope.getByTestId(AiModelPickerTestId.search)
+}
+
+/**
+ * Locator fuer eine bestimmte Provider-Group (z. B. fuer
+ * Sichtbarkeits-Assertion "Ollama-Gruppe vorhanden").
+ */
+export function getGroupByConnectionId(
+  page: Page,
+  providerConnectionId: string,
+  picker?: Locator,
+): Locator {
+  const scope = picker ?? getPicker(page)
+  return scope.locator(
+    `[data-testid="${AiModelPickerTestId.group}"][data-provider-connection-id="${cssEscape(providerConnectionId)}"]`,
+  )
+}
+
+/**
+ * Locator fuer eine bestimmte Modell-Option.
+ *
+ * Selektiert (provider_connection_id, model_id) — beide Attribute
+ * sind Pflicht, damit die Assertion nicht versehentlich auf das
+ * falsche Modell in einer anderen Provider-Gruppe passt.
+ */
+export function getOption(
+  page: Page,
+  args: { providerConnectionId: string; modelId: string },
+  picker?: Locator,
+): Locator {
+  const scope = picker ?? getPicker(page)
+  return scope.locator(
+    `[data-testid="${AiModelPickerTestId.option}"][data-provider-connection-id="${cssEscape(args.providerConnectionId)}"][data-model-id="${cssEscape(args.modelId)}"]`,
+  )
+}
+
+/**
+ * Action: Picker oeffnen (Fokus auf Trigger-Input).
+ *
+ * Wartet NICHT explizit auf das Oeffnen des Combobox-Contents, weil
+ * reka-ui das Content-Portal in einer separaten Subtree rendert.
+ * Specs sollten direkt mit `expect(...).toBeVisible()` auf der
+ * gewuenschten Option arbeiten — Playwright wartet dann implizit.
+ */
+export async function openPicker(page: Page, picker?: Locator): Promise<void> {
+  await getPickerInput(page, picker).click()
+}
+
+/**
+ * Action: Modell per Klick auswaehlen.
+ *
+ * Voraussetzung: Picker ist bereits geoeffnet (openPicker()).
+ * Erwartet: die Option ist sichtbar UND nicht disabled.
+ */
+export async function selectOptionByClick(
+  page: Page,
+  args: { providerConnectionId: string; modelId: string },
+  picker?: Locator,
+): Promise<void> {
+  const option = getOption(page, args, picker)
+  await expect(option).toBeVisible()
+  await expect(option).toBeEnabled()
+  await option.click()
+}
+
+/**
+ * Action: Tastatur-Drill ↓↓↑Enter.
+ *
+ * Erwartet: Picker ist geoeffnet, der erste navigierbare Eintrag
+ * wird mit ArrowDown markiert. Specs muessen pruefen, dass das
+ * markierte Item bei jedem Schritt wechselt.
+ */
+export async function drillKeyboard(
+  page: Page,
+  picker?: Locator,
+): Promise<void> {
+  const input = getPickerInput(page, picker)
+  // Erstes ArrowDown oeffnet ggf. das Drop-Down falls der Picker
+  // nicht durch Klick geoeffnet wurde; danach folgen zwei ↓, ein
+  // ↑ und Enter. reka-ui Combobox-Logik ueber List-Navigation.
+  await input.press('ArrowDown')
+  await input.press('ArrowDown')
+  await input.press('ArrowUp')
+  await input.press('Enter')
+}
+
+/**
+ * Action: aktuelle Selektion aus dem Trigger-Input lesen.
+ *
+ * Liefert den sichtbaren Text (Display-Value) des Trigger-Inputs.
+ * Specs koennen darauf asserten, dass die Auswahl angezeigt wird.
+ */
+export async function readSelectedLabel(
+  page: Page,
+  picker?: Locator,
+): Promise<string> {
+  return (await getPickerInput(page, picker).inputValue()).trim()
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * CSS.escape-Polyfill, weil nicht alle Playwright-Versionen einen
+ * eingebauten Escape fuer Attribut-Selektoren liefern. Strings mit
+ * Sonderzeichen (z. B. Doppelpunkt in "qwen2.5:14b") wuerden
+ * sonst den Selektor zerlegen.
+ */
+function cssEscape(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value)
+  }
+  // Minimaler Fallback: nur Zeichen escapen, die in
+  // CSS-Attribut-Selektoren problematisch sind.
+  return value.replace(/(["\\\]\[])/g, '\\$1')
+}

--- a/frontend/tests/e2e/helpers/testIds.ts
+++ b/frontend/tests/e2e/helpers/testIds.ts
@@ -1,0 +1,19 @@
+/**
+ * Re-Export der zentralen testIds aus `src/contracts/testIds.ts`.
+ *
+ * E2E-Specs und Helper importieren von `./testIds`, damit die
+ * Importpfade in tests/e2e/ kompakt bleiben. Die Quelle der Wahrheit
+ * ist und bleibt `src/contracts/testIds.ts` — wenn dieser Re-Export
+ * divergiert, faengt das TypeScript-Compiler-Error.
+ *
+ * Hinweis: `tsconfig.playwright.json` definiert KEINEN `@/`-Pfad-Alias
+ * (paths: {} ueberschreibt das Parent-tsconfig), darum hier ein
+ * relativer Import. Wer den `@/`-Alias auch fuer Playwright haben
+ * moechte, kann tsconfig.playwright.json erweitern — siehe
+ * PR-Diskussion zu #701.
+ *
+ * `export { AiModelPickerTestId } from '...'` re-exportiert sowohl den
+ * Const-Wert als auch den同名 type — daher KEIN zusaetzliches
+ * `export type { ... }` (wuerde TS2300 Duplicate identifier werfen).
+ */
+export { AiModelPickerTestId } from '../../../src/contracts/testIds'

--- a/frontend/tsconfig.playwright.json
+++ b/frontend/tsconfig.playwright.json
@@ -13,5 +13,5 @@
     "tests/e2e/**/*.ts",
     "playwright.config.ts"
   ],
-  "exclude": ["node_modules", "dist", "src"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Slice 5.6-Prep — Playwright-E2E-Skeleton fuer AiModelPicker

Lauffaehiges Skeleton + data-testid-SSoT, damit 5.6 final nur die
test.describe.skip()-Annotation entfernen muss, sobald 5.4 den
AiModelPicker in den Ziel-Views gemountet hat.

### Was diese PR liefert

- **Spec-Skeleton** (frontend/tests/e2e/ai-model-picker.spec.ts) mit
  3 Test-Gruppen, alle mit `test.describe.skip()` + Begruendung:
  1. Tastatur-Navigation ↓↓↑Enter + Suche
  2. Provider offline: data-status=unavailable, aria-disabled, Error-Badge
  3. Run-Snapshot: GET /api/runs/<run_id>/llm-routing → ai_route

- **Helper** (frontend/tests/e2e/helpers/aiModelPicker.ts) — Locator-
  und Action-Funktionen ausschliesslich auf data-testid-Basis, immun
  gegen CSS-Refactors und i18n-Aenderungen. login() reused den
  bestehenden Single-User-Token-Mode aus helpers/auth.ts.

- **data-testid-SSoT** (frontend/src/contracts/testIds.ts) — Namespace
  `ai-model-picker-*` (root, input, search, group, option, status,
  empty). Wird von der Komponente UND den E2E-Helpern geteilt.

- **data-testid-Patches** an AiModelPicker.vue (additiv, keine
  Logik-Aenderung, keine CSS-Aenderung). providerGroups-Typ um
  `provider_connection_id` erweitert, damit E2E-Specs gezielt auf
  eine Provider-Gruppe zugreifen koennen (ohne i18n-Display-Name).

- **Handover-Update** (docs/epics/onboarding-provider-unification/HANDOVER.md)
  mit 5.6-Prep-Abschnitt inkl. data-testid-Vergabe-Schema und
  Verifikations-Status.

### Was diese PR NICHT tut (Out of Scope)

- Echte Migrations-Schritte → Sub-Slice 5.4
  (`codex/onboarding-model-picker-slice-5-4`, derzeit offen,
  **anderer Branch**).
- Store-Konsolidierung → Sub-Slice 5.5.
- 5.6 final: `.skip` entfernen, Seed-Daten fest verdrahten.

### Voraussetzungen fuer 5.6 final

- 5.4 muss AiModelPicker in mindestens einer v4-View mounten
  (Empfehlung slice-5: SettingsGeneralView fuer Tastatur-Test,
  LlmRoutingView fuer Run-Snapshot-Test).
- 5.4 muss das beforeEach-`page.goto` in der Spec auf die echte
  Route anpassen.
- 5.4 (oder 5.6) muss einen dedizierten Test-Provider mit
  `status=unavailable` im global-setup oder im
  ProviderConnectionStore-Seed liefern, damit der Offline-Test
  deterministische IDs hat.

### Verifikation (lokal)

- `bash scripts/pre-push-gate.sh` — ALL GREEN (Backend + Frontend + Schemas)
- `vue-tsc --noEmit` — sauber
- `tsc --noEmit -p tsconfig.playwright.json` — nur pre-existing Fehler
  in tests/e2e/minimal-report.spec.ts:69 (nicht von dieser PR)
- `vitest run src/components/v4/forms/__tests__/AiModelPicker` — 14/14
- `playwright test --list tests/e2e/ai-model-picker.spec.ts` — 5 Tests,
  alle als skip markiert

### Kein Konflikt mit 5.4

- Branch basiert auf `origin/main` @ `165d22f5` (PR #700), nicht
  auf `codex/onboarding-model-picker-slice-5-4`.
- Vorbereitung ist unabhaengig und darf gemergt werden, sobald die
  Spec lauffaehig (mit skip) ist.
- 5.4 kann dieselben data-testid-IDs aus `src/contracts/testIds.ts`
  uebernehmen, ohne Doubletten oder Kollisionen.

### Refs

- Sub-Plan: docs/epics/onboarding-provider-unification/slice-5-subplan.md
  Abschnitt 5.6
- Discovery: PR #699 (useAvailableModels + Provider-Connection-Status)
- Backend: PR #700 (AiRoute-Hierarchie + Run-Snapshot)
- Komponente: PR #697 (isolierte AiModelPicker.vue mit reka-ui)
- Handover: docs/epics/onboarding-provider-unification/HANDOVER.md
  Abschnitt 5.6-Prep