### PR TITLE
feat(ci): grep-check gegen v3-model-picker-stellen (5.5 grep-prep)

### DIFF
--- a/.github/scripts/check_legacy_model_picker.py
+++ b/.github/scripts/check_legacy_model_picker.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""check_legacy_model_picker.py — Grep-CI-Check für v3-Model-Picker.
+
+Sub-Slice 5.5 der Epic ``onboarding-provider-unification`` deprecated die
+alten v3-Model-Picker-Komponenten und -Stores. Damit sie nicht versehentlich
+wieder in den Code wandern, blockiert dieser Check PRs, die folgende
+Importe neu einführen:
+
+* ``frontend/src/components/ui/ModelPicker.vue``            (Legacy v3)
+* ``frontend/src/components/llm/LlmProfilePicker.vue``     (Legacy v3)
+* ``frontend/src/components/ActiveModelBadge.vue``         (Legacy v3)
+* ``@/store/llmProviders`` (genau diese Specifier, nicht ``…/llmProviders/…``)
+* ``@/store/llmProfiles``
+* ``@/store/llmRoutingDefaults``
+* ``@/composables/useRuntimeLlmOptions``
+
+Wird ein v3-Picker für den Migrations-Wrapper in 5.5 selbst gebraucht,
+kann die Datei über den Magic-Comment ``legacy-model-picker-allow: <reason>``
+(TS: ``// …``, Vue: ``<!-- … -->``) freigeschaltet werden. Begründung
+im Comment, damit das nächste Audit nachvollziehen kann, warum der
+v3-Pfad noch leben darf.
+
+Verwendung
+==========
+
+    python3 .github/scripts/check_legacy_model_picker.py [TARGET_DIR]
+
+Default ``TARGET_DIR``: ``frontend/src`` (relativ zum Repo-Root).
+
+GH-Actions-Ausgabe
+-------------------
+
+Treffer werden als ``::error file=…,line=…,col=…::MSG`` emittiert, damit
+GitHub sie als Inline-Annotation in der PR-Diff anzeigt. Mit ``--github``
+(oder automatisch, wenn ``GITHUB_ACTIONS=true``) wird der Modus
+explizit aktiviert; ``--no-github`` unterdrückt das Präfix für lokale
+Läufe.
+
+Exit-Codes
+----------
+
+* ``0`` — keine Treffer (alles sauber)
+* ``1`` — verbotene v3-Importe gefunden
+* ``2`` — Usage-Fehler (z. B. Zielpfad fehlt)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Regeln
+# ---------------------------------------------------------------------------
+
+# Jeder Eintrag: (substring, Migrations-Hinweis).
+# Ein Import-Specifier ist verboten, wenn er mit dem Substring endet.
+# Damit ist ``@/store/llmProviders`` (Treffer) verboten, aber ein
+# zukünftiges ``@/store/llmProviders/index`` (Subpfad) bleibt erlaubt —
+# ``endswith`` matcht den Subpfad nicht.
+FORBIDDEN_SUBSTRINGS: list[tuple[str, str]] = [
+    (
+        "/components/ui/ModelPicker.vue",
+        "v3 ModelPicker.vue → v4 AiModelPicker.vue (Slice 5.1)",
+    ),
+    (
+        "/components/llm/LlmProfilePicker.vue",
+        "v3 LlmProfilePicker.vue → v4 AiModelPicker.vue (Slice 5.1)",
+    ),
+    (
+        "/components/ActiveModelBadge.vue",
+        "v3 ActiveModelBadge.vue → v4 AiModelPicker.vue (Slice 5.1)",
+    ),
+    (
+        "/store/llmProviders",
+        "v3 store llmProviders → aiModels.ts / useActiveModelStore (Slice 5.5)",
+    ),
+    (
+        "/store/llmProfiles",
+        "v3 store llmProfiles → aiModels.ts / useActiveModelStore (Slice 5.5)",
+    ),
+    (
+        "/store/llmRoutingDefaults",
+        "v3 store llmRoutingDefaults → aiModels.ts / useActiveModelStore (Slice 5.5)",
+    ),
+    (
+        "/composables/useRuntimeLlmOptions",
+        "v3 composable useRuntimeLlmOptions → useActiveModelStore (Slice 5.5)",
+    ),
+]
+
+# Magic-Comment, mit dem eine einzelne Datei sich freischalten darf.
+# Form: ``legacy-model-picker-allow: <reason>`` — Reason ist Pflicht,
+# damit die Opt-in-Spur im Audit sichtbar bleibt.
+OPT_IN_MARKER = "legacy-model-picker-allow:"
+
+# Datei-Endungen, die der Scanner berücksichtigt.
+SCAN_EXTENSIONS = {".vue", ".ts"}
+
+# Verzeichnisse, die der Scanner überspringt (typische Build-Artefakte).
+SKIP_DIRS = {"__pycache__", "node_modules", ".nuxt", "dist", "coverage"}
+
+# ---------------------------------------------------------------------------
+# Regex
+# ---------------------------------------------------------------------------
+
+# Holt jeden Import-Specifier aus einer Zeile. Erkennt:
+#   import { x } from 'spec'
+#   import x from 'spec'
+#   import 'spec'                  (Side-Effect)
+#   import type { x } from 'spec'
+#   import('@/spec')               (Dynamic)
+#   require('@/spec')              (CommonJS — wider Erwarten in .ts möglich)
+# Specifiers können Anführungszeichen ' oder " haben.
+IMPORT_RE = re.compile(
+    r"""
+    (?: ^ | \b )
+    (?:
+        from \s+
+      | import \s+ (?: [^'"\n]+? \s+ from \s+ )?
+      | require \s* \( \s*
+      | import \s* \( \s*
+    )
+    ['"](?P<spec>[^'"\n]+?)['"]
+    """,
+    re.VERBOSE,
+)
+
+
+def _offset_to_linecol(text: str, offset: int) -> tuple[int, int]:
+    """Mappt einen Zeichen-Offset auf (1-basierte Zeile, 1-basierte Spalte)."""
+    prefix = text[:offset]
+    line = prefix.count("\n") + 1
+    last_nl = prefix.rfind("\n")
+    col = offset - last_nl if last_nl >= 0 else offset + 1
+    return line, col
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+
+def _is_forbidden(specifier: str) -> str | None:
+    """Gibt die Migrations-Begründung zurück, wenn der Specifier verboten ist."""
+    for substring, message in FORBIDDEN_SUBSTRINGS:
+        if specifier.endswith(substring):
+            return f"{message} (verboten: `{specifier}`)"
+    return None
+
+
+def _has_opt_in(text: str) -> bool:
+    """True, wenn die Datei den Magic-Comment mit Begründung trägt."""
+    if OPT_IN_MARKER not in text:
+        return False
+    # Mindestens ein nicht-leeres Zeichen nach dem Doppelpunkt verlangen,
+    # damit leere Marker (``legacy-model-picker-allow:``) nicht durchgehen.
+    for line in text.splitlines():
+        if OPT_IN_MARKER in line:
+            tail = line.split(OPT_IN_MARKER, 1)[1].strip()
+            # Kommentar-Close tolerieren (Vue/HTML: -->, TS/JS: \n)
+            tail = tail.rstrip("/>").rstrip("-").strip()
+            if tail:
+                return True
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[int, int, str]]:
+    """Liest ``path`` und gibt alle verbotenen Treffer als (line, col, msg)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        # Binärdateien oder Permissions-Probleme: ignorieren, sind keine
+        # Vue/TS-Quellen.
+        print(f"::warning file={path}::skip: {exc}", file=sys.stderr)
+        return []
+
+    if _has_opt_in(text):
+        return []
+
+    violations: list[tuple[int, int, str]] = []
+    for m in IMPORT_RE.finditer(text):
+        spec = m.group("spec")
+        msg = _is_forbidden(spec)
+        if msg is None:
+            continue
+        offset = m.start("spec")
+        line, col = _offset_to_linecol(text, offset)
+        violations.append((line, col, msg))
+    return violations
+
+
+def scan(root: Path) -> list[tuple[Path, int, int, str]]:
+    """Scannt ``root`` rekursiv und gibt alle Treffer zurück."""
+    if not root.exists():
+        raise FileNotFoundError(f"target directory does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"target is not a directory: {root}")
+
+    results: list[tuple[Path, int, int, str]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix not in SCAN_EXTENSIONS:
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        for line, col, msg in _scan_file(path):
+            results.append((path, line, col, msg))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_github(file: Path, line: int, col: int, message: str) -> str:
+    rel = file.resolve()
+    return f"::error file={rel},line={line},col={col}::{message}"
+
+
+def _format_plain(file: Path, line: int, col: int, message: str) -> str:
+    return f"{file}:{line}:{col}: error: {message}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Grep-CI-Check: keine v3-Model-Picker-Stellen erlauben.",
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default="frontend/src",
+        help="Zielverzeichnis (default: frontend/src).",
+    )
+    parser.add_argument(
+        "--github",
+        dest="github",
+        action="store_true",
+        default=None,
+        help="GH-Actions-Annotations erzwingen (sonst Auto via GITHUB_ACTIONS).",
+    )
+    parser.add_argument(
+        "--no-github",
+        dest="github",
+        action="store_false",
+        help="GH-Actions-Annotations unterdrücken (für lokale Läufe).",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    try:
+        results = scan(target)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        print(f"usage error: {exc}", file=sys.stderr)
+        return 2
+
+    github_mode = args.github
+    if github_mode is None:
+        github_mode = bool(__import__("os").environ.get("GITHUB_ACTIONS"))
+
+    if not results:
+        print(
+            f"check_legacy_model_picker: clean ({target}) — "
+            f"no v3 picker imports found.",
+            file=sys.stderr,
+        )
+        return 0
+
+    fmt = _format_github if github_mode else _format_plain
+    for file, line, col, msg in results:
+        print(fmt(file, line, col, msg))
+
+    print(
+        f"\ncheck_legacy_model_picker: {len(results)} violation(s) in {target}.",
+        file=sys.stderr,
+    )
+    print(
+        "  Hint: Use the magic comment `legacy-model-picker-allow: <reason>` "
+        "to opt in a file for 5.5 wrappers.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_legacy_model_picker.py
+++ b/.github/scripts/test_check_legacy_model_picker.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Tests für ``check_legacy_model_picker.py``.
+
+Stdlib-only (kein pytest nötig — ``python3 -m unittest`` reicht). Jeder
+Test baut ein eigenes Temp-Verzeichnis mit Fixture-Dateien auf, läuft
+den Scanner darüber und assertiert das Ergebnis.
+
+Aufruf
+======
+
+    python3 .github/scripts/test_check_legacy_model_picker.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Pfad zum geprüften Script (relativ zu diesem Test)
+SCRIPT = Path(__file__).resolve().parent / "check_legacy_model_picker.py"
+
+
+def _run(target: Path) -> subprocess.CompletedProcess[str]:
+    """Ruft das Script mit ``--no-github`` (lokale Plain-Output) auf."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--no-github", str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class CheckLegacyModelPickerTests(unittest.TestCase):
+    """Fixture-Tests für den v3-Picker-Grep-Check."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    # ------------------------------------------------------------------
+    # 1. Komplett sauberes Repo: kein verbotener Import
+    # ------------------------------------------------------------------
+    def test_clean_tree_returns_zero(self) -> None:
+        _write(
+            self.root / "components/v4/AiModelPicker.vue",
+            "<template><div /></template>\n",
+        )
+        _write(
+            self.root / "store/llmProviders/index.ts",
+            "export const x = 1\n",
+        )
+        _write(
+            self.root / "store/llmProfiles/sub.ts",
+            "export const y = 2\n",
+        )
+        _write(
+            self.root / "composables/useFoo.ts",
+            "import { useLlmProvidersStore } from '@/store/llmProviders/index'\n",
+        )
+
+        proc = _run(self.root)
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"erwartet exit 0, got {proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}",
+        )
+        self.assertIn("clean", proc.stderr.lower())
+
+    # ------------------------------------------------------------------
+    # 2. Verbotene Importe: exit 1, alle sieben Regeln abgedeckt
+    # ------------------------------------------------------------------
+    def test_dirty_tree_returns_one_with_all_seven_rules(self) -> None:
+        _write(
+            self.root / "A.vue",
+            "import ModelPicker from '@/components/ui/ModelPicker.vue'\n",
+        )
+        _write(
+            self.root / "B.vue",
+            "import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'\n",
+        )
+        _write(
+            self.root / "C.vue",
+            "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n",
+        )
+        _write(
+            self.root / "D.ts",
+            "import { useLlmProvidersStore } from '@/store/llmProviders'\n",
+        )
+        _write(
+            self.root / "E.ts",
+            "import { useLlmProfilesStore } from '@/store/llmProfiles'\n",
+        )
+        _write(
+            self.root / "F.ts",
+            "import { useLlmRoutingDefaultsStore } from '@/store/llmRoutingDefaults'\n",
+        )
+        _write(
+            self.root / "G.ts",
+            "import { useRuntime } from '@/composables/useRuntimeLlmOptions'\n",
+        )
+
+        proc = _run(self.root)
+        self.assertEqual(
+            proc.returncode,
+            1,
+            f"erwartet exit 1, got {proc.returncode}\nstderr={proc.stderr}",
+        )
+        # Alle 7 Regeln müssen im Output auftauchen.
+        self.assertIn("ModelPicker.vue", proc.stdout)
+        self.assertIn("LlmProfilePicker.vue", proc.stdout)
+        self.assertIn("ActiveModelBadge.vue", proc.stdout)
+        self.assertIn("store llmProviders", proc.stdout)
+        self.assertIn("store llmProfiles", proc.stdout)
+        self.assertIn("store llmRoutingDefaults", proc.stdout)
+        self.assertIn("useRuntimeLlmOptions", proc.stdout)
+
+    # ------------------------------------------------------------------
+    # 3. Opt-in-Marker: Datei mit Magic-Comment wird ignoriert
+    # ------------------------------------------------------------------
+    def test_opt_in_marker_skips_file(self) -> None:
+        _write(
+            self.root / "wrapper.ts",
+            (
+                "// legacy-model-picker-allow: 5.5 wrapper für v3-Backcompat\n"
+                "import { useLlmProvidersStore } from '@/store/llmProviders'\n"
+                "import { useRuntime } from '@/composables/useRuntimeLlmOptions'\n"
+            ),
+        )
+        _write(
+            self.root / "wrapper.vue",
+            (
+                "<!-- legacy-model-picker-allow: 5.5 wrapper für v3-Badge -->\n"
+                "<script setup lang=\"ts\">\n"
+                "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n"
+                "</script>\n"
+            ),
+        )
+
+        proc = _run(self.root)
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"Opt-in muss exit 0 ergeben\nstdout={proc.stdout}\nstderr={proc.stderr}",
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Leerer Opt-in-Marker (kein Reason) wird zurückgewiesen
+    # ------------------------------------------------------------------
+    def test_empty_opt_in_reason_still_flags(self) -> None:
+        _write(
+            self.root / "lazy.ts",
+            (
+                "// legacy-model-picker-allow:\n"
+                "import { useLlmProvidersStore } from '@/store/llmProviders'\n"
+            ),
+        )
+        proc = _run(self.root)
+        self.assertEqual(
+            proc.returncode,
+            1,
+            "leerer Opt-in-Reason darf nicht durchgehen",
+        )
+        self.assertIn("llmProviders", proc.stdout)
+
+    # ------------------------------------------------------------------
+    # 5. Subpfad-Importe sind erlaubt (Zukunftssicherheit)
+    # ------------------------------------------------------------------
+    def test_subpath_store_imports_are_allowed(self) -> None:
+        _write(
+            self.root / "future.ts",
+            (
+                "import { a } from '@/store/llmProviders/index'\n"
+                "import { b } from '@/store/llmProviders/sub/deep'\n"
+                "import { c } from '@/store/llmProfiles/v2'\n"
+                "import { d } from '@/store/llmRoutingDefaults/foo'\n"
+            ),
+        )
+        proc = _run(self.root)
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"Subpfade müssen erlaubt sein\nstdout={proc.stdout}",
+        )
+
+    # ------------------------------------------------------------------
+    # 6. Relative Imports werden genauso erkannt
+    # ------------------------------------------------------------------
+    def test_relative_imports_are_caught(self) -> None:
+        _write(
+            self.root / "x.ts",
+            "import { x } from '../store/llmProviders'\n",
+        )
+        _write(
+            self.root / "y.ts",
+            "import { y } from '../../components/ui/ModelPicker.vue'\n",
+        )
+        proc = _run(self.root)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("x.ts", proc.stdout)
+        self.assertIn("y.ts", proc.stdout)
+
+    # ------------------------------------------------------------------
+    # 7. Usage-Fehler: exit 2 bei unbekanntem Pfad
+    # ------------------------------------------------------------------
+    def test_unknown_target_returns_two(self) -> None:
+        proc = _run(self.root / "does-not-exist")
+        self.assertEqual(
+            proc.returncode,
+            2,
+            f"erwartet exit 2, got {proc.returncode}\nstderr={proc.stderr}",
+        )
+        self.assertIn("usage error", proc.stderr)
+
+    # ------------------------------------------------------------------
+    # 8. GH-Actions-Format: ::error file=…,line=…,col=…
+    # ------------------------------------------------------------------
+    def test_github_format_emits_annotation(self) -> None:
+        _write(
+            self.root / "x.ts",
+            "import { x } from '@/store/llmProviders'\n",
+        )
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--github", str(self.root)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "GITHUB_ACTIONS": ""},
+        )
+        self.assertEqual(proc.returncode, 1)
+        # Format: ::error file=…,line=N,col=N::MSG
+        self.assertIn("::error file=", proc.stdout)
+        self.assertIn(",line=", proc.stdout)
+        self.assertIn(",col=", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/check-legacy-model-picker.yml
+++ b/.github/workflows/check-legacy-model-picker.yml
@@ -1,0 +1,49 @@
+name: check-legacy-model-picker
+
+# Blockt PRs, die v3-Picker-Importe (ModelPicker.vue, LlmProfilePicker.vue,
+# ActiveModelBadge.vue, llmProviders/llmProfiles/llmRoutingDefaults-Stores
+# oder useRuntimeLlmOptions-Composable) zurück in den Code bringen — Sub-Slice
+# 5.5 der Epic ``onboarding-provider-unification`` deprecated diese Pfade.
+# Opt-in via Magic-Comment (siehe Script-Docstring).
+#
+# Bewusst nur pull_request: Push auf main ist hier okay, weil 5.5 selbst
+# (oder Reverts) durchlaufen müssen, ohne dass jeder Push den Check triggert.
+# ``paths`` beschränkt die Auslösung auf frontend/src-Änderungen.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "frontend/src/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  grep:
+    name: Keine v3-Picker-Importe
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: v3-Picker-Grep-Check
+        env:
+          GITHUB_ACTIONS: "true"
+        run: python3 -u .github/scripts/check_legacy_model_picker.py

--- a/docs/epics/onboarding-provider-unification/HANDOVER.md
+++ b/docs/epics/onboarding-provider-unification/HANDOVER.md
@@ -46,3 +46,32 @@
 - 5.5 deprecatet alte Picker/Stores vollständig.
 - 5.6 ergänzt Playwright-E2E einschließlich Run-Snapshot.
 - Danach folgen Slice 6 (Persona-Count) und Slice 7 (Golden-Gate-Designsystem).
+
+## Sub-Slice 5.5 — Grep-Prep
+
+- Datum: 2026-07-13
+- Worktree: `/private/tmp/agora-onboarding-slice-5-5-grep-prep`
+- Branch: `codex/onboarding-model-picker-slice-5-5-grep-prep`
+- Basis: `origin/main` @ `165d22f5` (PR #700, gemergt)
+- PR: [#702](https://github.com/arn0ld87/agora/pull/702)
+- Slice: 5.5 (Vorbereitung) — Grep-CI-Check gegen v3-Picker-Importe
+
+### Notiz an 5.5 (Deprecation)
+
+Check ist scharf, Opt-in-Marker existiert, Wrapper-Dateien können sich
+freischalten via `<!-- legacy-model-picker-allow: ... -->` bzw.
+`// legacy-model-picker-allow: ...`. Subpfade wie
+`@/store/llmProviders/index` sind auch ohne Marker erlaubt — der Check
+matcht nur den genauen Bare-Specifier.
+
+Aktuell tragen 18 v3-Importe einen Grandfather-Marker
+(`pre-5.5 v3 picker importer — see slice-5-subplan.md`); mit der
+Migration in 5.4/5.5 sind die Importe zu entfernen (damit fällt der
+Marker automatisch mit weg). Leere Opt-in-Reason-Strings werden
+zurückgewiesen — der Reason bleibt Pflicht für die Audit-Spur.
+
+CI-Workflow: `.github/workflows/check-legacy-model-picker.yml`
+(triggert auf `pull_request` mit `paths: frontend/src/**`).
+Lokaler Aufruf: `python3 .github/scripts/check_legacy_model_picker.py`
+(Spiegel siehe `docs/runbooks/pre-push-gate.md`, Abschnitt
+„Legacy-Picker-Check").

--- a/docs/runbooks/pre-push-gate.md
+++ b/docs/runbooks/pre-push-gate.md
@@ -68,3 +68,40 @@ Wenn die CI ein neues Gate bekommt (z. B. `bandit`, `pip-audit`),
 MUSS `scripts/pre-push-gate.sh` in derselben PR erweitert werden —
 sonst driftet die Pipeline. Reihenfolge: Gate zuerst in CI einführen
 (sofort wirksam), dann im selben Release-Cycle lokal spiegeln.
+
+## Legacy-Picker-Check (Sub-Slice 5.5 Grep-Prep)
+
+CI-Gate, das verhindert, dass v3-Picker-Stellen
+(`ModelPicker.vue`, `LlmProfilePicker.vue`, `ActiveModelBadge.vue`,
+`@/store/llmProviders|llmProfiles|llmRoutingDefaults`,
+`@/composables/useRuntimeLlmOptions`) nach 5.5 zurück in den Code
+kommen. Spiegel-Workflow: `.github/workflows/check-legacy-model-picker.yml`.
+
+Lokal ausführen:
+
+```bash
+python3 .github/scripts/check_legacy_model_picker.py
+# oder mit explizitem Ziel:
+python3 .github/scripts/check_legacy_model_picker.py frontend/src
+```
+
+Exit-Codes: `0` clean · `1` Treffer · `2` Usage-Fehler.
+
+**Opt-in für 5.5-Wrapper-Dateien:** Wenn eine Datei den v3-Pfad
+weiterhin braucht (z. B. ein Read-Adapter-Shim), trägt sie genau
+einen Magic-Comment in der **ersten Zeile**:
+
+- `.ts` / `.spec.ts`: `// legacy-model-picker-allow: <reason>`
+- `.vue`: `<!-- legacy-model-picker-allow: <reason -->`
+
+Reason ist Pflicht (Audit-Spur). Leere Marker werden zurückgewiesen.
+Subpfade wie `@/store/llmProviders/index` sind auch ohne Marker
+erlaubt — der Check matcht nur den **genauen** Bare-Specifier.
+
+Unit-Tests für den Check selbst:
+
+```bash
+python3 .github/scripts/test_check_legacy_model_picker.py
+```
+
+(8 Stdlib-`unittest`-Tests, kein `pip install nötig`.)

--- a/frontend/src/__tests__/main.spec.ts
+++ b/frontend/src/__tests__/main.spec.ts
@@ -1,3 +1,4 @@
+// legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes)
 /**
  * Bootstrap-Tests für main.ts.
  *

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup>
 import { ref, computed, onMounted, watch, watchEffect } from 'vue'
 import { usePersonaActions } from '../composables/usePersonaActions'

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { useEventStream } from '../composables/useEventStream'

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch, type ComponentPublicInstance } from 'vue'
 import { useIncrementalLogPolling } from '../composables/useIncrementalLogPolling'

--- a/frontend/src/components/__tests__/LlmProfilePicker.spec.ts
+++ b/frontend/src/components/__tests__/LlmProfilePicker.spec.ts
@@ -1,3 +1,4 @@
+// legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes)
 /**
  * LlmProfilePicker — Vitest-Spec (LPP-01).
  *

--- a/frontend/src/components/llm/LlmProfilePicker.vue
+++ b/frontend/src/components/llm/LlmProfilePicker.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { computed, onMounted, useId } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/frontend/src/components/step2/EnvSetupModelPanel.vue
+++ b/frontend/src/components/step2/EnvSetupModelPanel.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/frontend/src/components/step4/ReportBranchControls.vue
+++ b/frontend/src/components/step4/ReportBranchControls.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import Button from '@/components/v4/forms/Button.vue'

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/frontend/src/components/v4/forms/ModelPicker.vue
+++ b/frontend/src/components/v4/forms/ModelPicker.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 /**
  * ModelPicker — wählt eine LLM-Route (Provider + Modell) per Dropdown.

--- a/frontend/src/components/v4/forms/StepModelOverrideChip.vue
+++ b/frontend/src/components/v4/forms/StepModelOverrideChip.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 /**
  * StepModelOverrideChip — Per-Step-Modellauswahl-Chip.

--- a/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
@@ -1,3 +1,4 @@
+// legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes)
 import { describe, it, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'

--- a/frontend/src/composables/useAvailableModels.ts
+++ b/frontend/src/composables/useAvailableModels.ts
@@ -1,3 +1,4 @@
+// legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes)
 /**
  * useAvailableModels — Discovery aus dem kanonischen ProviderConnectionStore.
  *

--- a/frontend/src/layouts/WorkspaceHeader.vue
+++ b/frontend/src/layouts/WorkspaceHeader.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 import ActiveModelBadge from '../components/ActiveModelBadge.vue'
 </script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+// legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes)
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/frontend/src/views/Settings/LlmProvidersView.vue
+++ b/frontend/src/views/Settings/LlmProvidersView.vue
@@ -1,3 +1,4 @@
+<!-- legacy-model-picker-allow: pre-5.5 v3 picker importer — see docs/epics/onboarding-provider-unification/slice-5-subplan.md (5.4 migrates, 5.5 removes) -->
 <script setup lang="ts">
 /**
  * LlmProvidersView — Workspace-weite LLM-Provider-Konfiguration.


### PR DESCRIPTION
## Sub-Slice 5.5 — Grep-Prep

Vorbereitung für die Deprecation der v3-Model-Picker in Sub-Slice 5.5 der
Epic `onboarding-provider-unification`. CI-Gate, das verbietet, dass die
v3-Pfade (`ModelPicker.vue`, `LlmProfilePicker.vue`, `ActiveModelBadge.vue`,
`@/store/llmProviders|llmProfiles|llmRoutingDefaults`,
`@/composables/useRuntimeLlmOptions`) nach 5.5 in neuen Commits wieder
auftauchen.

## Was ändert sich

- `.github/scripts/check_legacy_model_picker.py` (neu) — stdlib-only,
  GH-Actions-Annotationen (`::error file=…,line=…,col=…::MSG`), Exit 0/1/2.
- `.github/scripts/test_check_legacy_model_picker.py` (neu) — 8 unittest-Fixes
  mit `tempfile.TemporaryDirectory`, decken saubere Bäume, alle 7 verbotenen
  Imports, Opt-in-Marker mit/ohne Reason, Subpfad-Erlaubnis, relative
  Imports, Usage-Fehler und GH-Format ab.
- `.github/workflows/check-legacy-model-picker.yml` (neu) — `pull_request` auf
  `main`, `paths: frontend/src/**`, Python 3.11, gehärteter Runner.
- `docs/runbooks/pre-push-gate.md` — neuer Abschnitt „Legacy-Picker-Check"
  mit lokalem Aufruf und Opt-in-Syntax.
- 18 v3-Picker-Importe (Commit 2) bekommen den Magic-Comment
  `legacy-model-picker-allow: <reason>` in der ersten Zeile, damit der
  Check auf main grün ist. Diese Marker werden in 5.4/5.5 zusammen mit
  dem jeweiligen v3-Import entfernt.

## Opt-in für 5.5-Wrapper-Dateien

```ts
// legacy-model-picker-allow: 5.5 wrapper für v3-Backcompat
import { useLlmProvidersStore } from '@/store/llmProviders'
```

```vue
<!-- legacy-model-picker-allow: 5.5 wrapper für v3-Badge -->
<script setup lang="ts">…</script>
```

Subpfade wie `@/store/llmProviders/index` sind auch ohne Marker erlaubt —
der Check matcht nur den genauen Bare-Specifier.

## Out of Scope

- Deprecation der v3-Picker / Stores selbst (5.5)
- Migration v3 → v4 (5.4)
- Playwright-E2E (5.6)
- ADR-0002 Evidence-Gating-Hard-Anker (intakt, nicht angefasst)

## Verifikation

```bash
python3 .github/scripts/test_check_legacy_model_picker.py   # 8/8 ok
python3 .github/scripts/check_legacy_model_picker.py        # 0 violations
bash scripts/pre-push-gate.sh                                # ALL GREEN
```

## Handover an 5.5

Check ist scharf, Opt-in-Marker existiert, Wrapper-Dateien können sich
freischalten via `<!-- legacy-model-picker-allow: ... -->`.
