### PR TITLE
test(routing): regression tests for PR #700 review findings

### DIFF
--- a/backend/tests/api/test_llm_routing_api.py
+++ b/backend/tests/api/test_llm_routing_api.py
@@ -157,6 +157,35 @@ def test_get_workspace_defaults_is_additive(client):
     assert {key: value for key, value in data.items() if key != "ai_route"} == defaults.model_dump(mode="json")
 
 
+def test_patch_routing_default_stage_clear_falls_back_to_global(client):
+    """Regression für PR-#700-Review-Finding #1: Ein Workspace-Stage-Override
+    muss sich per ``{"clear": true}`` löschen lassen und danach auf den globalen
+    Workspace-Default zurückfallen — HTTP 200, ``ai_route`` entspricht
+    ``global_default``. ``set_stage_override(stage_id, None)`` poppt den Key;
+    ``active_route = defaults.stage_overrides.get(stage_id) or defaults.global_default``
+    muss den Default liefern und darf nicht None werden."""
+    from app.contracts.llm_routing_contract import StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+
+    global_route = StageLLMRoute(provider_id="workspace-provider", model="workspace-model")
+    cleared = WorkspaceLlmRoutingDefaults(global_default=global_route, stage_overrides={})
+    with patch("app.api.llm_routing.get_workspace_routing_store") as get_store:
+        get_store.return_value.set_stage_override.return_value = cleared
+        resp = client.patch(
+            "/api/llm/routing/defaults/stages/graph_build",
+            json={"clear": True},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json["data"]
+    assert data["ai_route"]["source"] == "workspace"
+    assert data["ai_route"]["provider_connection_id"] == "workspace-provider"
+    assert data["ai_route"]["model_id"] == "workspace-model"
+    assert "graph_build" not in data["stage_overrides"]
+    # Store wurde zum Löschen mit None aufgerufen.
+    get_store.return_value.set_stage_override.assert_called_once_with("graph_build", None)
+
+
 @pytest.mark.parametrize(
     ("method", "path"),
     [

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -78,6 +78,39 @@ def test_stage_model_router_snapshot_isolation(temp_run_dir):
     assert resolved_other.routing_version == 2
 
 
+def test_resolve_from_canonical_snapshot_yields_iso8601_started_at(temp_run_dir):
+    """Regression für PR-#700-Review-Finding #2: Wird nur ein kanonischer
+    ``AiRoute``-Snapshot gespeichert (kein Legacy-Stage-Snapshot), muss
+    ``StageModelRouter.resolve()`` über den Canonical-Adapter laufen und ein
+    ``started_at`` als ISO-8601-String liefern — nicht als ``datetime``.
+    ``ResolvedRoute.started_at`` ist ``str | None``; der Adapter muss
+    ``resolved_at.isoformat()`` aufrufen."""
+    from datetime import datetime, timezone
+    from app.contracts.ai_provider_contract import AiRoute
+
+    service = RuntimeRunConfig(temp_run_dir)
+    resolved_at = datetime(2026, 7, 13, 11, 12, 41, tzinfo=timezone.utc)
+    service.save_ai_route_snapshot(
+        "graph_build",
+        AiRoute(
+            stage="graph_build",
+            provider_connection_id="openai",
+            model_id="gpt-4o",
+            source="stage_override",
+            resolved_at=resolved_at,
+        ),
+    )
+
+    resolved = StageModelRouter(temp_run_dir).resolve("graph_build")
+
+    assert resolved.provider_id == "openai"
+    assert resolved.model == "gpt-4o"
+    assert isinstance(resolved.started_at, str)
+    assert resolved.started_at == resolved_at.isoformat()
+    # ISO-8601 rundum-parsbar zum selben Instant.
+    assert datetime.fromisoformat(resolved.started_at) == resolved_at
+
+
 def test_detect_default_provider_id_matches_mainstream_hosts():
     """Mainstream hosts still resolve to the expected provider IDs now that
     detection is delegated to the SSoT (``app.llm.providers.registry.detect_provider``,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.3 verifiziert, v1.0.0
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3283 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3285 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 160 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Kontext

PR #700 (`feat(routing): add canonical AiRoute resolution`) ist gemergt. Der Review vom 13.07. benannte zwei Blocker — beide Code-Fixes waren jedoch bereits im gemergten PR #700 (Commit `165d22f5`) enthalten:

- `stage_overrides.get(stage_id) or defaults.global_default` → `backend/app/api/llm_routing.py:273`, `backend/app/services/stage_model_router.py:43`
- `started_at = route.resolved_at.isoformat() if route.resolved_at else None` → `backend/app/services/stage_model_router.py:106-108`

Die im Review geforderten **Regressionstests** fehlten jedoch. Dieser PR reicht sie nach.

## Änderungen

1. `test_patch_routing_default_stage_clear_falls_back_to_global` — Workspace-Stage-Override per `{"clear": true}` löschen → HTTP 200, `ai_route` entspricht globalem Workspace-Default, Stage-Key aus `stage_overrides` entfernt, `set_stage_override(stage_id, None)` wird gerufen.
2. `test_resolve_from_canonical_snapshot_yields_iso8601_started_at` — Nur kanonischen `AiRoute`-Snapshot speichern, `StageModelRouter.resolve()` ausführen → `started_at` ist ISO-8601-`str` (nicht `datetime`), rundum-parsbar zum selben Instant.
3. `docs/STATUS.md` sync (3283 → 3285 collected).

## Verifikation

- `uv run pytest tests/api/test_llm_routing_api.py tests/services/test_llm_routing_logic.py -q` → 20 passed
- `bash scripts/pre-push-gate.sh backend` → ALL GREEN (Schemas, Contracts, ruff, mypy, sync-status)

Kein Prod-Code berührt — nur Tests + STATUS-Sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)