### PR TITLE
test(e2e): AiModelPicker Playwright-E2E final (Slice 5.6)

### DIFF
--- a/deploy/compose/docker-compose.e2e.override.yml
+++ b/deploy/compose/docker-compose.e2e.override.yml
@@ -29,3 +29,22 @@ services:
       # und Job-Level-env ohne .env-Append den Container nicht erreicht.
       # e2e-up.sh appended den Wert zusätzlich in .env (doppelte Absicherung).
       - AGORA_E2E_LLM_MODE=${AGORA_E2E_LLM_MODE:-}
+
+  # Slice 5.6: Mock-Model-Server fuer die AiModelPicker-Discovery-Probe.
+  #
+  # Der agora-Container erreicht ihn im Compose-Default-Netzwerk (siehe
+  # docker-compose.yml `networks: default:`) unter dem DNS-Namen
+  # `mock-models`. Das ist absichtlich kein localhost/IP, weil
+  # `_validate_public_base_url` (ai_provider_contract) lokale Adressen
+  # ablehnt, DNS-Namen aber erlaubt. Der Mock liefert eine statische
+  # OpenAI-kompatible /models-Antwort (`data[].id`), siehe
+  # adapters._HttpModelsAdapter (protocol openai_compatible).
+  mock-models:
+    image: nginx:alpine
+    init: true
+    volumes:
+      # Pfade relativ zur Compose-Projekt-Wurzel (Repo-Root, dir der ersten
+      # `-f`-Datei) — nicht zum Override-File. Siehe docker-compose.yml
+      # `./backend/...`-Konvention.
+      - ./deploy/e2e/mock-models/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./deploy/e2e/mock-models/models.json:/usr/share/nginx/html/models.json:ro

--- a/deploy/e2e/mock-models/models.json
+++ b/deploy/e2e/mock-models/models.json
@@ -1,0 +1,1 @@
+{"data":[{"id":"qwen2.5:14b"},{"id":"gpt-oss-20b"}]}

--- a/deploy/e2e/mock-models/nginx.conf
+++ b/deploy/e2e/mock-models/nginx.conf
@@ -1,0 +1,22 @@
+# Mock-Model-Server fuer den AiModelPicker-E2E (Slice 5.6).
+#
+# Bedient eine statische OpenAI-kompatible /models-Antwort. Der
+# agora-Container erreicht diesen Service im Compose-Default-Netzwerk
+# unter dem DNS-Namen `mock-models`. Siehe
+# deploy/compose/docker-compose.e2e.override.yml.
+server {
+  listen 80 default_server;
+  server_name _;
+
+  # OpenAI-kompatibler Models-Endpunkt (protocol openai_compatible,
+  # adapters._HttpModelsAdapter). Statisches JSON mit zwei Modellen.
+  location = /models {
+    default_type application/json;
+    alias /usr/share/nginx/html/models.json;
+  }
+
+  # Alles andere → 404 (nur /models wird fuer die Discovery-Probe gebraucht).
+  location / {
+    return 404;
+  }
+}

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -26,6 +26,7 @@ import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue';
 import { useLlmProvidersStore } from '@/store/aiModels';
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter';
 import type { AiModelRef } from '@/contracts/aiModelRef';
+import { LlmRoutingTestId } from '@/contracts/testIds';
 
 const props = defineProps<{
   runId: string;
@@ -175,7 +176,7 @@ defineExpose({
         </div>
 
         <h3>{{ t('llm.routing.stage_overrides') }}</h3>
-        <div v-for="stage in STAGES" :key="stage" class="stage-row card" :class="{ locked: isStageLocked(stage) }">
+        <div v-for="stage in STAGES" :key="stage" class="stage-row card" :class="{ locked: isStageLocked(stage) }" :data-testid="LlmRoutingTestId.stageRow" :data-stage="stage">
           <h4>{{ t(`llm.stages.${stage}`) }}</h4>
           <div v-if="isStageLocked(stage)" class="locked-badge">
              <span class="icon">🔒</span> {{ t('llm.routing.locked') }}
@@ -194,6 +195,8 @@ defineExpose({
               v-if="routing.stage_overrides[stage]"
               @click="saveStage(stage, routing.stage_overrides[stage])"
               :disabled="loading || isStageLocked(stage)"
+              :data-testid="LlmRoutingTestId.stageSave"
+              :data-stage="stage"
             >
               {{ t('common.apply') }}
             </button>

--- a/frontend/src/components/v4/forms/AiModelPicker.vue
+++ b/frontend/src/components/v4/forms/AiModelPicker.vue
@@ -99,7 +99,13 @@ const filteredOptions = computed<readonly AiModelRefInput[]>(() => {
   const required = REQUIRED_CAPABILITY[props.mode]
   return base
     .filter((o) => {
-      if (!o.capabilities.includes(required)) return false
+      if (props.mode === 'chat') {
+        // chat: 'unknown' gilt als geeignet — nur explizit 'unsupported' ausfiltern.
+        if (o.unsupported_capabilities?.includes(required)) return false
+      } else {
+        // embedding: positive Capability verlangt (Backend setzt 'supported').
+        if (!o.capabilities.includes(required)) return false
+      }
       if (props.capabilityFilter && !o.capabilities.includes(props.capabilityFilter)) {
         return false
       }

--- a/frontend/src/composables/useAvailableModels.ts
+++ b/frontend/src/composables/useAvailableModels.ts
@@ -75,6 +75,7 @@ function toPickerModel(
     model_id: model.model_id,
     context_window: model.context_window ?? undefined,
     capabilities: pickerCapabilities(model),
+    unsupported_capabilities: PICKER_CAPABILITIES.filter((capability) => model.capabilities[capability] === 'unsupported'),
     status: pickerStatus(connection, model, unsupported),
     local_or_cloud: model.local_or_cloud === 'local' || connection.transport === 'local' ? 'local' : 'cloud',
     provider_id: connection.id,

--- a/frontend/src/contracts/aiModelRef.ts
+++ b/frontend/src/contracts/aiModelRef.ts
@@ -81,6 +81,7 @@ export const AiModelRefInputSchema = z.object({
   status: AiModelStatusSchema,
   is_workspace_default: z.boolean().optional(),
   local_or_cloud: z.enum(['local', 'cloud']),
+  unsupported_capabilities: z.array(AiCapabilitySchema).optional(),
 }).strict()
 export type AiModelRefInputValidated = z.infer<typeof AiModelRefInputSchema>
 
@@ -124,6 +125,7 @@ export interface AiModelRefInput {
   readonly status: AiModelStatus
   readonly is_workspace_default?: boolean
   readonly local_or_cloud: 'local' | 'cloud'
+  readonly unsupported_capabilities?: readonly AiCapability[]
 }
 
 export type AiProviderKind =

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -31,3 +31,10 @@ export const AiModelPickerTestId = {
 } as const
 
 export type AiModelPickerTestId = (typeof AiModelPickerTestId)[keyof typeof AiModelPickerTestId]
+
+export const LlmRoutingTestId = {
+  stageRow: 'llm-routing-stage-row',
+  stageSave: 'stage-override-save',
+} as const
+
+export type LlmRoutingTestId = (typeof LlmRoutingTestId)[keyof typeof LlmRoutingTestId]

--- a/frontend/src/views/Settings/LlmRoutingView.vue
+++ b/frontend/src/views/Settings/LlmRoutingView.vue
@@ -97,6 +97,7 @@ onMounted(() => {
           <Input
             v-model="selectedRunId"
             mono
+            data-testid="llm-routing-run-id"
             placeholder="run_..."
           />
         </Field>

--- a/frontend/tests/e2e/ai-model-picker.spec.ts
+++ b/frontend/tests/e2e/ai-model-picker.spec.ts
@@ -1,44 +1,33 @@
 /**
- * AiModelPicker — Playwright-E2E (Sub-Slice 5.6-Prep).
+ * AiModelPicker — Playwright-E2E (Sub-Slice 5.6 final).
  *
- * Stand: 2026-07-13 — SKELETON. Der gesamte describe-Block ist mit
- * `test.describe.skip()` markiert, weil die Komponente noch in KEINER
- * produktiven View gemountet ist. Sub-Slice 5.4 (Migration der
- * Auswahlstellen) liefert die Views; 5.6 final muss dann nur die
- * `.skip`-Annotation entfernen und ggf. Selektor-Pfade an die
- * konkret migrierten Routen anpassen.
+ * Stand: 2026-07-13 — echte Browser-Runs (Skip-Annotationen entfernt).
  *
- * Aktivierung pro Test:
+ * Stack (siehe global-setup.ts + scripts/e2e-up.sh):
+ *   - Compose-Override haengt einen `mock-models` nginx-Service ein, der
+ *     `GET /models` mit `{"data":[{"id":"qwen2.5:14b"},{"id":"gpt-oss-20b"}]}`
+ *     bedient (OpenAI-kompatibel).
+ *   - global-setup seeded zwei Provider-Connections:
+ *       openai_compatible (online)  → http://mock-models         (2 Modelle)
+ *       openai            (offline) → nicht aufloesbarer DNS-Name (0 Modelle)
+ *   - Backend-Capability-Inference existiert nicht (adapters._ai_model
+ *     setzt keine Capabilities → alle 'unknown'). Der chat-mode behandelt
+ *     'unknown' als geeignet und filtert nur explizit 'unsupported' aus
+ *     (siehe AiModelPicker.vue filteredOptions, Slice 5.6).
  *
- *   1) Tastatur-Navigation ↓↓↑Enter
- *      Voraussetzung: 5.4 hat AiModelPicker in mindestens einer
- *      Settings/Dashboard-View gemountet (Empfehlung slice-5:
- *      SettingsGeneralView). 5.6 final: `await page.goto('/settings/general')`
- *      o. ae. statt des hier dokumentierten `goto`/Stub.
+ * Ziel-View: /settings/llm-routing (RunLlmRoutingPanel mountet pro Stage
+ * einen AiModelPicker). Run-ID wird ins Run-ID-Feld eingetragen; das
+ * Backend synthetisiert fuer unbekannte run_ids einen Default-Config
+ * (RuntimeRunConfig.load_config braucht keinen RunRegistry-Eintrag),
+ * sodass PATCH mit einer festen Test-run_id funktioniert.
  *
- *   2) Provider offline
- *      Voraussetzung: Backend liefert im Test-Fixture mindestens
- *      einen Provider mit status='unavailable' (siehe useAvailableModels
- *      Composable + ProviderConnectionStore). 5.6 final: Seed im
- *      global-setup oder ein dedizierter Test-Helper-Endpoint.
- *
- *   3) Run-Snapshot
- *      Voraussetzung: 5.4 hat die Stage-Override-UI auf AiModelPicker
- *      umgestellt (z. B. in LlmRoutingView.vue) UND 5.3 (PR #700) ist
- *      gemergt — AiRoute ist im Endpoint
- *      GET /api/runs/<run_id>/llm-routing verfuegbar.
- *
- * Helper: siehe frontend/tests/e2e/helpers/aiModelPicker.ts.
- * testId-SSoT: frontend/src/contracts/testIds.ts.
- *
- * Out of Scope hier: 5.4 (Migration), 5.5 (Deprecation). Die Spec
- * ist absichtlich eng am 5.6-Sub-Plan-Scope gehalten, damit sie
- * nicht versehentlich Migrations-Logik mitverifiziert.
+ * Selektor-Pfad: ausschliesslich data-testid (keine Klassen-/ARIA-/
+ * i18n-Selektoren). Siehe helpers/aiModelPicker.ts + contracts/testIds.ts.
  */
-import { test, expect, request, type APIRequestContext } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import {
   login,
-  getPicker,
+  getStagePicker,
   getPickerInput,
   getPickerSearch,
   getOption,
@@ -48,165 +37,150 @@ import {
   drillKeyboard,
   readSelectedLabel,
 } from './helpers/aiModelPicker'
-import { authHeader } from './helpers/auth'
+import { LlmRoutingTestId } from './helpers/testIds'
 
-// 5.4: aktivieren sobald die Komponente in mindestens einer View gemountet ist.
-test.describe.skip('Slice 5.6 · AiModelPicker E2E', () => {
+const E2E_RUN_ID = 'run_e2e_model_picker'
+const STAGE = 'document_ingest'
+const ONLINE_CONN = 'openai_compatible'
+const OFFLINE_CONN = 'openai'
+const ONLINE_MODEL = 'qwen2.5:14b'
+const OTHER_MODEL = 'gpt-oss-20b'
+
+test.describe('Slice 5.6 · AiModelPicker E2E', () => {
   test.beforeEach(async ({ page, context }) => {
-    // Single-User-Token-Mode (siehe health.spec.ts Test 4): kein
-    // klassisches Login, sondern Token-Inject in localStorage.
+    // Single-User-Token-Mode: Token-Inject in localStorage.
     await login(context)
-    // 5.4 muss diese Route in App.vue (oder dem Hash-Router) registrieren.
-    // Solange 5.4 offen ist, fuehrt goto() in einen 404 — daher der skip.
-    await page.goto('/settings/general', { waitUntil: 'domcontentloaded' })
+    await page.goto('/settings/llm-routing', { waitUntil: 'domcontentloaded' })
+    // Run-ID eintragen → RunLlmRoutingPanel mountet (v-if selectedRunIdTrimmed).
+    await page.getByTestId('llm-routing-run-id').fill(E2E_RUN_ID)
+    // Warten bis der Stage-Picker fuer document_ingest gerendert ist.
+    await expect(getStagePicker(page, STAGE)).toBeVisible()
   })
 
   // -------------------------------------------------------------------------
   // 1) Tastatur-Navigation ↓↓↑Enter
   // -------------------------------------------------------------------------
-  test.describe('Tastatur-Navigation', () => {
-    test('↓↓↑Enter oeffnet Combobox, wandert Auswahl und committed', async ({ page }) => {
-      const picker = getPicker(page)
-      await expect(picker).toBeVisible()
+  test('↓↓↑Enter navigiert die Combobox und committet die Auswahl', async ({ page }) => {
+    const picker = getStagePicker(page, STAGE)
+    await openPicker(page, picker)
 
-      // 1. Trigger-Input ist fokussierbar.
-      const input = getPickerInput(page, picker)
-      await expect(input).toBeVisible()
-      await expect(input).toBeEnabled()
+    // Warten bis die Discovery-Modelle geladen sind (Option sichtbar),
+    // sonst hat ↓↓↑Enter keine Liste zum Navigieren.
+    await expect(
+      getOption(page, { providerConnectionId: ONLINE_CONN, modelId: OTHER_MODEL }),
+    ).toBeVisible()
 
-      // 2. ↓↓↑Enter: reka-ui Combobox-Logik navigiert ueber die
-      //    sichtbaren Items. Nach ↓↓↑ ist das 2. Item aktiv
-      //    (initial ↓ markiert 1., ↓ markiert 2., ↑ geht zurueck auf 1.).
-      //    Enter committed den Eintrag.
-      await drillKeyboard(page, picker)
+    const input = getPickerInput(page, picker)
+    await expect(input).toBeEnabled()
 
-      // 3. Nach Enter: Trigger-Input zeigt das gewaehlte Modell.
-      //    (Konkrete Erwartung wird in 5.6 final gesetzt, sobald die
-      //    Seed-Daten aus useAvailableModels feststehen.)
-      const label = await readSelectedLabel(page, picker)
-      expect(label.length).toBeGreaterThan(0)
-      // 5.4: aktiveren, sobald SettingsGeneralView den Picker nutzt.
-    })
+    // ↓↓↑Enter: ↓ markiert 1. (gpt-oss-20b, alphabetisch zuerst), ↓ 2.
+    // (qwen2.5:14b), ↑ zurueck auf 1., Enter committed.
+    await drillKeyboard(page, picker)
 
-    test('Suche filtert Optionen, Pfeile wandern ueber Treffer', async ({ page }) => {
-      const picker = getPicker(page)
-      await openPicker(page, picker)
-      // reka-ui ComboboxInput im Content ist die Such-Leiste.
-      const search = getPickerSearch(page, picker)
-      await expect(search).toBeVisible()
-      await search.fill('qwen')
-
-      // Treffer-Liste: die als `qwen` matchenden Optionen.
-      // 5.6 final: konkrete provider_connection_id aus Seed ableiten.
-      const firstMatch = picker.locator('[data-testid^="ai-model-picker-option"]').first()
-      await expect(firstMatch).toBeVisible()
-
-      // 5.4: aktiveren, sobald Seed verfuegbar ist.
-    })
+    const label = await readSelectedLabel(page, picker)
+    expect(label.length).toBeGreaterThan(0)
   })
 
   // -------------------------------------------------------------------------
-  // 2) Provider offline: Status-Badge + disabled Modell
+  // 2) Suche filtert Optionen
   // -------------------------------------------------------------------------
-  test.describe('Provider offline', () => {
-    test('Modell mit status=unavailable hat disabled-Attribut und Status-Badge', async ({ page }) => {
-      const picker = getPicker(page)
-      await openPicker(page, picker)
+  test('Suche filtert die Optionen auf Treffer', async ({ page }) => {
+    const picker = getStagePicker(page, STAGE)
+    await openPicker(page, picker)
 
-      // 5.6 final: provider_connection_id + model_id aus dem
-      // Test-Seed ableiten (Empfehlung: dedizierter
-      // 'unavailable'-Provider im Test-Fixture).
-      const offlineOption = getOption(
-        page,
-        { providerConnectionId: 'conn-offline', modelId: 'gpt-offline' },
-        picker,
-      )
+    const search = getPickerSearch(page)
+    await expect(search).toBeVisible()
+    await search.fill('qwen')
 
-      // a) data-status reflektiert 'unavailable' (Quelle: AiModelPicker.vue,
-      //    :data-status="item.status" — schon vor diesem PR gesetzt).
-      await expect(offlineOption).toHaveAttribute('data-status', 'unavailable')
-
-      // b) ComboboxItem rendert das disabled-Attribut. reka-ui setzt
-      //    zusaetzlich aria-disabled; beide sind akzeptabel.
-      const ariaDisabled = await offlineOption.getAttribute('aria-disabled')
-      const nativeDisabled = await offlineOption.getAttribute('data-disabled')
-      expect(ariaDisabled === 'true' || nativeDisabled !== null).toBe(true)
-
-      // c) Status-Badge ist sichtbar (reka-ui ComboboxItem ist der
-      //    Traeger; Badge liegt innerhalb des Items). Text ist i18n,
-      //    daher Pruefung auf Klasse ai-model-picker__badge--err.
-      await expect(
-        offlineOption.locator('.ai-model-picker__badge--err'),
-      ).toBeVisible()
-
-      // 5.4: aktiveren, sobald Seed einen 'unavailable'-Provider enthaelt.
-    })
-
-    test('Provider-Group rendert Status-Label im Group-Header', async ({ page }) => {
-      const picker = getPicker(page)
-      await openPicker(page, picker)
-
-      const offlineGroup = getGroupByConnectionId(page, 'conn-offline', picker)
-      // Group-Header enthaelt den lokalisierten Status.
-      // Textuelle Assertion ist i18n-fest, daher Pruefung auf die
-      // Group-Label-Klasse.
-      await expect(offlineGroup.locator('.ai-model-picker__group-label')).toBeVisible()
-      // 5.4: aktiveren, sobald Seed verfuegbar ist.
-    })
+    // 'qwen' matcht model_id 'qwen2.5:14b', nicht 'gpt-oss-20b'.
+    await expect(
+      getOption(page, { providerConnectionId: ONLINE_CONN, modelId: ONLINE_MODEL }),
+    ).toBeVisible()
+    await expect(
+      getOption(page, { providerConnectionId: ONLINE_CONN, modelId: OTHER_MODEL }),
+    ).toHaveCount(0)
   })
 
   // -------------------------------------------------------------------------
-  // 3) Run-Snapshot: Auswahl landet im canonical ai_route
+  // 3) Online-Modell ist verfuegbar (data-status=available, nicht disabled)
   // -------------------------------------------------------------------------
-  test.describe('Run-Snapshot', () => {
-    // 5.3 (PR #700) liefert das `ai_route`-Feld im Endpoint
-    // GET /api/runs/<run_id>/llm-routing. 5.4 muss die Stage-Override-UI
-    // auf AiModelPicker umgestellt haben.
-    test('gewaehltes Modell landet im Run-Snapshot (ai_route)', async ({ page, baseURL }) => {
-      // Bestehender Run mit laufender Stage-Override-Konfiguration.
-      // 5.6 final: run_id aus einem frischen Test-Run ableiten
-      // (z. B. ueber helpers/upload.ts + minimal-report.spec.ts-Pattern).
-      const runId = 'run_e2e_placeholder'
+  test('Online-Modell ist verfuegbar und auswaehlbar', async ({ page }) => {
+    const picker = getStagePicker(page, STAGE)
+    await openPicker(page, picker)
 
-      const picker = getPicker(page)
-      // 5.4: Annahme — die Stage-Override-View (z. B. LlmRoutingView)
-      // enthaelt den Picker pro Stage. Der Pfad muss in 5.6 final an
-      // die echte Route angepasst werden.
-      await page.goto(`/runs/${runId}/routing`, { waitUntil: 'domcontentloaded' })
+    const onlineOption = getOption(page, { providerConnectionId: ONLINE_CONN, modelId: ONLINE_MODEL })
+    await expect(onlineOption).toBeVisible()
+    // data-status="available" (Quelle: AiModelPicker.vue :data-status="item.status").
+    await expect(onlineOption).toHaveAttribute('data-status', 'available')
+    // Nicht disabled → auswaehlbar (isDisabled filtert unavailable/unsupported).
+    await expect(onlineOption).toBeEnabled()
+  })
 
-      // 1) Auswahl via Picker treffen.
-      const target = {
-        providerConnectionId: 'conn-ollama-local',
-        modelId: 'qwen2.5:14b',
-      }
-      await selectOptionByClick(page, target, picker)
+  // -------------------------------------------------------------------------
+  // 4) Provider offline: keine Gruppe / keine Option (Discovery schlägt fehl)
+  // -------------------------------------------------------------------------
+  test('Offline-Connection liefert keine Modelle (keine Gruppe, keine Option)', async ({ page }) => {
+    const picker = getStagePicker(page, STAGE)
+    await openPicker(page, picker)
 
-      // 2) Speichern (Button-Text ist i18n; 5.6 final nutzt ein
-      //    dediziertes data-testid am Save-Button, sobald 5.4 ihn
-      //    umgestellt hat).
-      // await page.getByTestId('stage-override-save').click()
+    // Warten bis die Online-Gruppe da ist (stellt sicher, dass die
+    // Discovery ueberhaupt zurueckgekehrt ist), bevor auf Abwesenheit
+    // der Offline-Gruppe assertiert wird.
+    await expect(
+      getGroupByConnectionId(page, ONLINE_CONN),
+    ).toBeVisible()
 
-      // 3) Run-Snapshot-Endpoint pruefen.
-      //    GET /api/runs/<run_id>/llm-routing liefert seit PR #700
-      //    das canonical `ai_route`-Feld (AiRoute-Schema, siehe
-      //    backend/app/contracts/ai_provider_contract.py).
-      const ctx: APIRequestContext = await request.newContext({
-        extraHTTPHeaders: authHeader(),
-      })
-      const res = await ctx.get(`${baseURL}/api/runs/${runId}/llm-routing`)
-      expect(res.ok()).toBe(true)
+    // Offline-Connection: Probe schlägt fehl → 0 Modelle → keine Gruppe.
+    await expect(
+      getGroupByConnectionId(page, OFFLINE_CONN),
+    ).toHaveCount(0)
+    // Keine Option aus der Offline-Connection.
+    await expect(
+      getOption(page, { providerConnectionId: OFFLINE_CONN, modelId: 'any' }),
+    ).toHaveCount(0)
+  })
 
-      const body = (await res.json()) as { data?: { ai_route?: { provider_connection_id?: string; model_id?: string; source?: string } } }
-      const route = body.data?.ai_route
-      expect(route).toBeDefined()
-      expect(route?.provider_connection_id).toBe(target.providerConnectionId)
-      expect(route?.model_id).toBe(target.modelId)
-      // Source ist seit 5.3 'stage-override' (siehe slice-5-subplan §5.3).
-      expect(route?.source).toBe('stage-override')
+  // -------------------------------------------------------------------------
+  // 5) Run-Snapshot: Auswahl landet im canonical ai_route (PATCH-Response)
+  // -------------------------------------------------------------------------
+  test('Stage-Override landet im ai_route (source=stage_override)', async ({ page }) => {
+    const picker = getStagePicker(page, STAGE)
+    await openPicker(page, picker)
 
-      await ctx.dispose()
-      // 5.4: aktiveren, sobald Stage-Override-View den Picker nutzt
-      //       UND 5.3 in main gemergt ist (PR #700).
-    })
+    // Warten bis die Option verfuegbar ist, dann per Klick auswaehlen.
+    await selectOptionByClick(
+      page,
+      { providerConnectionId: ONLINE_CONN, modelId: ONLINE_MODEL },
+      picker,
+    )
+
+    // Auswahl setzt routing.stage_overrides[document_ingest] → der
+    // Apply-Button (v-if) rendert. PATCH
+    // /api/runs/<run_id>/llm-routing/stages/<stage_id> liefert im
+    // Response-Body das canonical ai_route-Feld (PR #700, source=stage_override).
+    const applyButton = page.locator(
+      `[data-testid="${LlmRoutingTestId.stageSave}"][data-stage="${STAGE}"]`,
+    )
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().includes(`/llm-routing/stages/${STAGE}`) &&
+          resp.request().method() === 'PATCH',
+      ),
+      applyButton.click(),
+    ])
+
+    expect(response.ok()).toBe(true)
+    const body = (await response.json()) as {
+      data?: { ai_route?: { provider_connection_id?: string; model_id?: string; source?: string } }
+      ai_route?: { provider_connection_id?: string; model_id?: string; source?: string }
+    }
+    // Tolerante Huelle (json_success schachtelt unter 'data').
+    const aiRoute = body.data?.ai_route ?? body.ai_route
+    expect(aiRoute).toBeDefined()
+    expect(aiRoute?.provider_connection_id).toBe(ONLINE_CONN)
+    expect(aiRoute?.model_id).toBe(ONLINE_MODEL)
+    expect(aiRoute?.source).toBe('stage_override')
   })
 })

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -11,13 +11,94 @@ function repoRootPath(): string {
   return resolve(process.cwd(), '..');
 }
 
+// Slice 5.6: Seeded zwei Provider-Connections, gegen die der AiModelPicker
+// im E2E-Stack live discovered:
+//   - openai_compatible (online)  → http://mock-models      (liefert 2 Modelle)
+//   - openai            (offline) → nicht auflösbarer DNS-Name (Probe schlägt fehl)
+//
+// connection_id MUSS == provider_kind sein (upsert_provider_connection
+// validiert das). Zwei distinct kinds → zwei distinct Connections. Der
+// Backend-Validator `_validate_public_base_url` lehnt localhost ab,
+// erlaubt aber DNS-Namen — deshalb der Service-Name statt 127.0.0.1.
+//
+// api_key ist ein offensichtlicher Platzhalter (kein Secret-Wert); der
+// openai_compatible-Adapter braucht einen non-empty Bearer-Header.
+const ONLINE_CONN = {
+  connectionId: 'openai_compatible',
+  displayName: 'E2E Mock (online)',
+  providerKind: 'openai_compatible',
+  baseUrl: 'http://mock-models',
+} as const
+const OFFLINE_CONN = {
+  connectionId: 'openai',
+  displayName: 'E2E Mock (offline)',
+  providerKind: 'openai',
+  baseUrl: 'http://mock-models-unreachable:8080',
+} as const
+
+const E2E_MOCK_API_KEY = 'e2e-mock-placeholder'
+const E2E_TOKEN = process.env.AGORA_AUTH_TOKEN ?? 'e2e-test-token-fixed-for-ci'
+const E2E_PROXY_BASE = `http://127.0.0.1:${process.env.AGORA_PROXY_PORT ?? '80'}`
+
+interface SeedConnection {
+  connectionId: string
+  displayName: string
+  providerKind: string
+  baseUrl: string
+}
+
+async function putConnection(conn: SeedConnection): Promise<void> {
+  const url = `${E2E_PROXY_BASE}/api/llm/provider-connections/${conn.connectionId}`
+  const body = {
+    display_name: conn.displayName,
+    provider_kind: conn.providerKind,
+    base_url: conn.baseUrl,
+    enabled: true,
+    api_key: E2E_MOCK_API_KEY,
+  }
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Agora-Token': E2E_TOKEN,
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`[e2e-globalSetup] seed ${conn.connectionId} failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+// Backend ist nach /healthz ready, aber der erste Seed kann selten einen
+// Race mit dem Flask-Worker-Startup verlieren. 3 Versuche mit kleinem Backoff.
+async function seedConnections(): Promise<void> {
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await putConnection(ONLINE_CONN)
+      await putConnection(OFFLINE_CONN)
+      console.log('[e2e-globalSetup] seeded provider-connections (openai_compatible online, openai offline)')
+      return
+    } catch (err) {
+      lastErr = err
+      console.warn(`[e2e-globalSetup] seed attempt ${attempt} failed:`, err instanceof Error ? err.message : err)
+      await new Promise((r) => setTimeout(r, 500))
+    }
+  }
+  throw new Error(`[e2e-globalSetup] seeding provider-connections failed after 3 attempts: ${lastErr}`)
+}
+
 export default async function globalSetup() {
   if (process.env.AGORA_E2E_SKIP_STACK === 'true') {
     console.log('[e2e-globalSetup] AGORA_E2E_SKIP_STACK=true — assuming stack is already up');
-    return;
+  } else {
+    const repoRoot = repoRootPath();
+    const script = resolve(repoRoot, 'scripts', 'e2e-up.sh');
+    console.log(`[e2e-globalSetup] running ${script}`);
+    execSync(`bash "${script}"`, { stdio: 'inherit', cwd: repoRoot });
   }
-  const repoRoot = repoRootPath();
-  const script = resolve(repoRoot, 'scripts', 'e2e-up.sh');
-  console.log(`[e2e-globalSetup] running ${script}`);
-  execSync(`bash "${script}"`, { stdio: 'inherit', cwd: repoRoot });
+  // Seeding muss in beiden Pfaden laufen — auch wenn der Stack von außen
+  // hochgefahren wurde (AGORA_E2E_SKIP_STACK=true), brauchen die Specs
+  // die beiden Provider-Connections.
+  await seedConnections();
 }

--- a/frontend/tests/e2e/helpers/aiModelPicker.ts
+++ b/frontend/tests/e2e/helpers/aiModelPicker.ts
@@ -1,41 +1,29 @@
 import type { BrowserContext, Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
-import { AiModelPickerTestId } from './testIds'
+import { AiModelPickerTestId, LlmRoutingTestId } from './testIds'
 import { injectAuthToken } from './auth'
 
 /**
- * AiModelPicker — Playwright-Helper fuer E2E.
+ * AiModelPicker — Playwright-Helper fuer E2E (Slice 5.6 final).
  *
  * Stellt Locator- und Action-Funktionen bereit, die ausschliesslich
  * auf den data-testid-Attributen aus `./testIds.ts` aufsetzen. Klass-
  * oder ARIA-Selektoren werden bewusst NICHT verwendet, damit
  * CSS-Refactors oder i18n-Aenderungen die Specs nicht brechen.
  *
- * Slice 5.6-Prep: Skeleton. Die hier exponierten Funktionen werden
- * in 5.6 final von der Spec aktiv genutzt (Skip-Annotationen raus,
- * sobald 5.4 die Komponente in den Ziel-Views mountet).
- *
- * Voraussetzungen (von 5.4 zu erfuellen, dokumentiert in slice-5-subplan.md):
- *   - AiModelPicker in mindestens einer v4-View gemountet
- *     (Empfehlung slice-5: SettingsGeneralView, HeroNewRun,
- *     StepModelOverrideChip).
- *   - ProviderConnection-Backend liefert mind. eine 'available'-Connection
- *     und eine 'unavailable'-Connection (siehe Test 2).
- *   - Run-Snapshot-Endpoint /api/runs/<run_id>/llm-routing liefert das
- *     canonical `ai_route`-Feld (siehe PR #700, ai_provider_contract.AiRoute).
+ * WICHTIG — ComboboxPortal-Topologie:
+ *   reka-ui `ComboboxPortal` teleportiert den Combobox-Content
+ *   (Search, Empty, Groups, Options) in einen Portal am <body>. Diese
+ *   Elemente liegen NICHT mehr innerhalb des Picker-Root-Scope. Daher
+ *   sind getPickerSearch / getPickerEmpty / getGroupByConnectionId /
+ *   getOption PAGE-LEVEL (kein Picker-Scope) implementiert.
+ *   Nur der Trigger-Anchor (ComboboxInput + Trigger) bleibt im
+ *   Picker-Root → getPickerInput ist weiterhin SCOPED auf den Picker.
  */
 
 /**
- * Login-Shim.
- *
- * Agora laeuft im Single-User-Token-Mode (siehe health.spec.ts Test 4).
- * Es gibt kein klassisches Login-Formular — der Token wird per
- * `injectAuthToken()` aus `helpers/auth.ts` in localStorage injiziert
- * und vom Frontend als Bearer-Token mitgesendet.
- *
- * Akzeptiert wahlweise Page (zieht context raus) oder direkt den
- * BrowserContext, damit Specs bequem `await login(page)` schreiben
- * koennen.
+ * Login-Shim. Agora laeuft im Single-User-Token-Mode — der Token wird
+ * per `injectAuthToken()` in localStorage injiziert.
  */
 export async function login(
   target: Page | BrowserContext,
@@ -45,18 +33,14 @@ export async function login(
   await injectAuthToken(context, token)
 }
 
-/**
- * Locator fuer den AiModelPicker-Root-Container.
- * Mehrere Picker pro Seite sind erlaubt; ueber `index` oder
- * `.filter()` kann ein bestimmter Picker gewaehlt werden.
- */
+/** Locator fuer den AiModelPicker-Root-Container. */
 export function getPicker(page: Page): Locator {
   return page.getByTestId(AiModelPickerTestId.root)
 }
 
 /**
- * Locator fuer den Trigger-Input (zeigt aktuell gewaehltes Modell
- * oder Platzhalter). Fokus auf dieses Element oeffnet den Combobox.
+ * Locator fuer den Trigger-Input (Anchor) — bleibt im Picker-Root,
+ * NICHT portaled. Darum SCOPED auf den Picker.
  */
 export function getPickerInput(page: Page, picker?: Locator): Locator {
   const scope = picker ?? getPicker(page)
@@ -64,102 +48,85 @@ export function getPickerInput(page: Page, picker?: Locator): Locator {
 }
 
 /**
- * Locator fuer das Suchfeld (sichtbar, sobald der Picker geoeffnet ist).
+ * PAGE-LEVEL — ComboboxPortal teleportiert die Suche nach <body>.
+ * `picker` wird bewusst ignoriert (Signatur bleibt aus Kompatibilitaet).
  */
-export function getPickerSearch(page: Page, picker?: Locator): Locator {
-  const scope = picker ?? getPicker(page)
-  return scope.getByTestId(AiModelPickerTestId.search)
+export function getPickerSearch(page: Page, _picker?: Locator): Locator {
+  return page.getByTestId(AiModelPickerTestId.search)
 }
 
-/**
- * Locator fuer eine bestimmte Provider-Group (z. B. fuer
- * Sichtbarkeits-Assertion "Ollama-Gruppe vorhanden").
- */
+/** PAGE-LEVEL — Empty-Hinweis lebt im portaled Content. */
+export function getPickerEmpty(page: Page, _picker?: Locator): Locator {
+  return page.getByTestId(AiModelPickerTestId.empty)
+}
+
+/** PAGE-LEVEL — Provider-Group lebt im portaled Content. */
 export function getGroupByConnectionId(
   page: Page,
   providerConnectionId: string,
-  picker?: Locator,
+  _picker?: Locator,
 ): Locator {
-  const scope = picker ?? getPicker(page)
-  return scope.locator(
+  return page.locator(
     `[data-testid="${AiModelPickerTestId.group}"][data-provider-connection-id="${cssEscape(providerConnectionId)}"]`,
   )
 }
 
-/**
- * Locator fuer eine bestimmte Modell-Option.
- *
- * Selektiert (provider_connection_id, model_id) — beide Attribute
- * sind Pflicht, damit die Assertion nicht versehentlich auf das
- * falsche Modell in einer anderen Provider-Gruppe passt.
- */
+/** PAGE-LEVEL — Modell-Option lebt im portaled Content. */
 export function getOption(
   page: Page,
   args: { providerConnectionId: string; modelId: string },
-  picker?: Locator,
+  _picker?: Locator,
 ): Locator {
-  const scope = picker ?? getPicker(page)
-  return scope.locator(
+  return page.locator(
     `[data-testid="${AiModelPickerTestId.option}"][data-provider-connection-id="${cssEscape(args.providerConnectionId)}"][data-model-id="${cssEscape(args.modelId)}"]`,
   )
 }
 
 /**
- * Action: Picker oeffnen (Fokus auf Trigger-Input).
- *
- * Wartet NICHT explizit auf das Oeffnen des Combobox-Contents, weil
- * reka-ui das Content-Portal in einer separaten Subtree rendert.
- * Specs sollten direkt mit `expect(...).toBeVisible()` auf der
- * gewuenschten Option arbeiten — Playwright wartet dann implizit.
+ * Stage-Row im LlmRouting-Panel (Slice 5.6 final).
+ * Selektion via data-testid + data-stage (stabil, kein i18n-Label).
  */
+export function getStageRow(page: Page, stage: string): Locator {
+  return page.locator(
+    `[data-testid="${LlmRoutingTestId.stageRow}"][data-stage="${cssEscape(stage)}"]`,
+  )
+}
+
+/** AiModelPicker innerhalb einer bestimmten Stage-Row. */
+export function getStagePicker(page: Page, stage: string): Locator {
+  return getStageRow(page, stage).getByTestId(AiModelPickerTestId.root)
+}
+
+/** Action: Picker oeffnen (Fokus/Klick auf Trigger-Input). */
 export async function openPicker(page: Page, picker?: Locator): Promise<void> {
   await getPickerInput(page, picker).click()
 }
 
-/**
- * Action: Modell per Klick auswaehlen.
- *
- * Voraussetzung: Picker ist bereits geoeffnet (openPicker()).
- * Erwartet: die Option ist sichtbar UND nicht disabled.
- */
+/** Action: Modell per Klick auswaehlen (Picker muss geoeffnet sein). */
 export async function selectOptionByClick(
   page: Page,
   args: { providerConnectionId: string; modelId: string },
-  picker?: Locator,
+  _picker?: Locator,
 ): Promise<void> {
-  const option = getOption(page, args, picker)
+  const option = getOption(page, args)
   await expect(option).toBeVisible()
   await expect(option).toBeEnabled()
   await option.click()
 }
 
-/**
- * Action: Tastatur-Drill ↓↓↑Enter.
- *
- * Erwartet: Picker ist geoeffnet, der erste navigierbare Eintrag
- * wird mit ArrowDown markiert. Specs muessen pruefen, dass das
- * markierte Item bei jedem Schritt wechselt.
- */
+/** Action: Tastatur-Drill ↓↓↑Enter. */
 export async function drillKeyboard(
   page: Page,
   picker?: Locator,
 ): Promise<void> {
   const input = getPickerInput(page, picker)
-  // Erstes ArrowDown oeffnet ggf. das Drop-Down falls der Picker
-  // nicht durch Klick geoeffnet wurde; danach folgen zwei ↓, ein
-  // ↑ und Enter. reka-ui Combobox-Logik ueber List-Navigation.
   await input.press('ArrowDown')
   await input.press('ArrowDown')
   await input.press('ArrowUp')
   await input.press('Enter')
 }
 
-/**
- * Action: aktuelle Selektion aus dem Trigger-Input lesen.
- *
- * Liefert den sichtbaren Text (Display-Value) des Trigger-Inputs.
- * Specs koennen darauf asserten, dass die Auswahl angezeigt wird.
- */
+/** Action: aktuelle Selektion aus dem Trigger-Input lesen. */
 export async function readSelectedLabel(
   page: Page,
   picker?: Locator,
@@ -171,17 +138,10 @@ export async function readSelectedLabel(
 // Internals
 // ---------------------------------------------------------------------------
 
-/**
- * CSS.escape-Polyfill, weil nicht alle Playwright-Versionen einen
- * eingebauten Escape fuer Attribut-Selektoren liefern. Strings mit
- * Sonderzeichen (z. B. Doppelpunkt in "qwen2.5:14b") wuerden
- * sonst den Selektor zerlegen.
- */
+/** CSS.escape-Polyfill fuer Attribut-Selektoren (Doppelpunkt in model_id). */
 function cssEscape(value: string): string {
   if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
     return CSS.escape(value)
   }
-  // Minimaler Fallback: nur Zeichen escapen, die in
-  // CSS-Attribut-Selektoren problematisch sind.
   return value.replace(/(["\\\]\[])/g, '\\$1')
 }

--- a/frontend/tests/e2e/helpers/testIds.ts
+++ b/frontend/tests/e2e/helpers/testIds.ts
@@ -16,4 +16,4 @@
  * Const-Wert als auch den同名 type — daher KEIN zusaetzliches
  * `export type { ... }` (wuerde TS2300 Duplicate identifier werfen).
  */
-export { AiModelPickerTestId } from '../../../src/contracts/testIds'
+export { AiModelPickerTestId, LlmRoutingTestId } from '../../../src/contracts/testIds'

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -36,6 +36,14 @@ fi
 {
   [[ -n "${AGORA_AUTH_TOKEN:-}" ]] && echo "AGORA_AUTH_TOKEN=${AGORA_AUTH_TOKEN}"
   [[ -n "${SECRET_KEY:-}" ]] && echo "SECRET_KEY=${SECRET_KEY}"
+  # Slice 5.6: Fernet-Master-Key für den LLM-Provider-Secrets-Store
+  # (llm_provider_secrets_store.py, env AGORA_SECRET_KEY). Wird beim Seeden
+  # von Provider-Connections MIT api_key benötigt (frontend/tests/e2e/
+  # global-setup.ts seed). Ohne diesen Key schlägt _secrets_store.upsert mit
+  # RuntimeError fehl → API 503 store_unavailable. Wert muss ein gültiger
+  # Fernet-Key sein (urlsafe base64, 32 Bytes); im Runner generieren via
+  #   python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+  [[ -n "${AGORA_SECRET_KEY:-}" ]] && echo "AGORA_SECRET_KEY=${AGORA_SECRET_KEY}"
   [[ -n "${NEO4J_PASSWORD:-}" ]] && echo "NEO4J_PASSWORD=${NEO4J_PASSWORD}"
   [[ -n "${AGORA_PROXY_PORT:-}" ]] && echo "AGORA_PROXY_PORT=${AGORA_PROXY_PORT}"
   # Ollama gibt es im CI-Stack nicht — Backend-Boot würde sonst an der


### PR DESCRIPTION
## Sub-Slice 5.6 final — AiModelPicker Playwright-E2E

Hebt die Skip-Annotationen aus 5.6-Prep (#701) auf und ersetzt das Skeleton
durch 5 echte Browser-Tests gegen einen gemockten Model-Discovery-Stack.

### Scope
- **5 E2E-Tests** (`frontend/tests/e2e/ai-model-picker.spec.ts`):
  1. `↓↓↑Enter`-Tastatur-Navigation + Commit
  2. Suchfilter auf Treffer
  3. Online-Modell `data-status=available` + enabled
  4. Offline-Connection → keine Gruppe/Option (Discovery-Probe schlägt fehl)
  5. Run-Snapshot: Stage-Override landet im canonical `ai_route` (`source=stage_override`, via PATCH-Response)
- **Mock-Model-Server** (`deploy/e2e/mock-models/`): nginx:alpine bedient statisch
  `GET /models` (OpenAI-kompatibel, 2 Modelle). Im Compose-Override
  (`docker-compose.e2e.override.yml`) als Service `mock-models` angebunden.
- **Provider-Connection-Seed** (`global-setup.ts`): zwei Connections (online
  `openai_compatible` → `http://mock-models`, offline `openai` → nicht
  auflösbarer DNS-Name), `AGORA_SECRET_KEY`-Append in `e2e-up.sh` für den
  Fernet-Secrets-Store beim Seeden mit `api_key`.
- **LlmRoutingTestId-SSoT** (`contracts/testIds.ts`): `stageRow`,
  `stageSave` + `data-stage` auf Stage-Row/Apply-Button; `llm-routing-run-id`
  auf dem Run-ID-Input. Einziger Selektor-Pfad: data-testid.
- **chat-mode Capability-Filter-Relaxation** (`AiModelPicker.vue`,
  `aiModelRef.ts`, `useAvailableModels.ts`): im chat-mode gilt `unknown` als
  geeignet, nur explizit `unsupported` wird ausgefiltert (`unsupported_capabilities`).
  Begründung: Backend-Capability-Inference existiert nicht → Live-Modelle
  kommen ohne `chat`-Capability und würden sonst alle herausgefiltert.

### ⚠️ Verifikationsstand
**Rekonstruktion aus Sitzungs-Gedächtnis** — der ursprüngliche 5.6-Worktree
ging uncommittet verloren, dieser Commit baut die Edits neu auf. Die
Playwright-E2E wurde **noch nicht grün bestätigt**; lokal ist Docker defekt,
die Verifikation läuft auf `armserver` nach. Review mit diesem Vorbehalt.

### Out of Scope
- 5.5 Deprecation, Backend-Behaviour
- Persona-Count (Slice 6)
- ADR-0002 Evidence-Gating-Hartanker

🤖 Generated with [Claude Code](https://claude.com/claude-code)