### PR TITLE
fix(frontend): align Slice 5.6 test contracts

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.3 verifiziert, v1.0.0
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3297 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3298 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 161 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/components/v4/forms/__tests__/AiModelPicker.discovery.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/AiModelPicker.discovery.spec.ts
@@ -14,8 +14,8 @@ import AiModelPicker from '../AiModelPicker.vue'
 
 const discoveredModels = [
   { provider_connection_id: 'conn-local', provider_kind: 'ollama', display_name: 'Ollama lokal', model_id: 'qwen3', context_window: 32768, capabilities: ['chat', 'streaming'], status: 'available', local_or_cloud: 'local' },
-  { provider_connection_id: 'conn-offline', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'gpt-offline', context_window: null, capabilities: ['chat'], status: 'unavailable', local_or_cloud: 'cloud' },
-  { provider_connection_id: 'conn-embedding', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'embed-3', context_window: null, capabilities: ['embeddings'], unsupported_capabilities: ['chat'], status: 'available', local_or_cloud: 'cloud' },
+  { provider_connection_id: 'conn-offline', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'gpt-offline', capabilities: ['chat'], status: 'unavailable', local_or_cloud: 'cloud' },
+  { provider_connection_id: 'conn-embedding', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'embed-3', capabilities: ['embeddings'], unsupported_capabilities: ['chat'], status: 'available', local_or_cloud: 'cloud' },
 ]
 
 async function mountPicker(props: Record<string, unknown> = {}) {

--- a/frontend/src/components/v4/forms/__tests__/AiModelPicker.discovery.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/AiModelPicker.discovery.spec.ts
@@ -15,7 +15,7 @@ import AiModelPicker from '../AiModelPicker.vue'
 const discoveredModels = [
   { provider_connection_id: 'conn-local', provider_kind: 'ollama', display_name: 'Ollama lokal', model_id: 'qwen3', context_window: 32768, capabilities: ['chat', 'streaming'], status: 'available', local_or_cloud: 'local' },
   { provider_connection_id: 'conn-offline', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'gpt-offline', context_window: null, capabilities: ['chat'], status: 'unavailable', local_or_cloud: 'cloud' },
-  { provider_connection_id: 'conn-embedding', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'embed-3', context_window: null, capabilities: ['embeddings'], status: 'available', local_or_cloud: 'cloud' },
+  { provider_connection_id: 'conn-embedding', provider_kind: 'openai', display_name: 'Cloud AI', model_id: 'embed-3', context_window: null, capabilities: ['embeddings'], unsupported_capabilities: ['chat'], status: 'available', local_or_cloud: 'cloud' },
 ]
 
 async function mountPicker(props: Record<string, unknown> = {}) {

--- a/frontend/src/components/v4/forms/__tests__/AiModelPicker.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/AiModelPicker.spec.ts
@@ -90,6 +90,7 @@ const MOCK_OPTIONS: AiModelRefInput[] = [
     model_id: 'text-embed-test',
     context_window: 0,
     capabilities: ['embeddings'],
+    unsupported_capabilities: ['chat'],
     status: 'available',
     local_or_cloud: 'cloud',
   },

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -33,6 +33,7 @@ export const AiModelPickerTestId = {
 export type AiModelPickerTestId = (typeof AiModelPickerTestId)[keyof typeof AiModelPickerTestId]
 
 export const LlmRoutingTestId = {
+  runId: 'llm-routing-run-id',
   stageRow: 'llm-routing-stage-row',
   stageSave: 'stage-override-save',
 } as const

--- a/frontend/src/views/Settings/LlmRoutingView.vue
+++ b/frontend/src/views/Settings/LlmRoutingView.vue
@@ -7,6 +7,7 @@ import Field from '@/components/v4/forms/Field.vue'
 import Input from '@/components/v4/forms/Input.vue'
 import Select from '@/components/v4/forms/Select.vue'
 import RunLlmRoutingPanel from '@/components/LlmRouting/LlmRoutingView.vue'
+import { LlmRoutingTestId } from '@/contracts/testIds'
 import { listRuns } from '@/api/runs'
 import type { RunRecord } from '@/types/run'
 import type { RunDetail } from '@/contracts/runsContract'
@@ -97,7 +98,7 @@ onMounted(() => {
           <Input
             v-model="selectedRunId"
             mono
-            data-testid="llm-routing-run-id"
+            :data-testid="LlmRoutingTestId.runId"
             placeholder="run_..."
           />
         </Field>

--- a/frontend/src/views/__tests__/LlmRoutingView.spec.ts
+++ b/frontend/src/views/__tests__/LlmRoutingView.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
+import { LlmRoutingTestId } from '@/contracts/testIds'
 
 const mocks = vi.hoisted(() => ({
   listRuns: vi.fn(),
@@ -54,7 +55,6 @@ vi.mock('@/components/v4/forms/Input.vue', () => ({
     emits: ['update:modelValue'],
     template: `
       <input
-        data-testid="manual-run-id"
         :value="modelValue"
         @input="$emit('update:modelValue', $event.target.value)"
       />
@@ -169,7 +169,7 @@ describe('LlmRoutingView', () => {
   it('uebernimmt manuelle Run-ID-Eingaben fuer das Routing-Panel', async () => {
     const wrapper = await mountView()
 
-    await wrapper.find('[data-testid="manual-run-id"]').setValue('run_manual')
+    await wrapper.find(`[data-testid="${LlmRoutingTestId.runId}"]`).setValue('run_manual')
     await flushPromises()
 
     expect(wrapper.find('[data-testid="run-llm-routing-panel"]').text()).toBe('run_manual')

--- a/frontend/tests/e2e/ai-model-picker.spec.ts
+++ b/frontend/tests/e2e/ai-model-picker.spec.ts
@@ -52,7 +52,7 @@ test.describe('Slice 5.6 · AiModelPicker E2E', () => {
     await login(context)
     await page.goto('/settings/llm-routing', { waitUntil: 'domcontentloaded' })
     // Run-ID eintragen → RunLlmRoutingPanel mountet (v-if selectedRunIdTrimmed).
-    await page.getByTestId('llm-routing-run-id').fill(E2E_RUN_ID)
+    await page.getByTestId(LlmRoutingTestId.runId).fill(E2E_RUN_ID)
     // Warten bis der Stage-Picker fuer document_ingest gerendert ist.
     await expect(getStagePicker(page, STAGE)).toBeVisible()
   })


### PR DESCRIPTION
## Problem

PR #707 hat die Chat-Capability-Auswertung bewusst auf explizite unsupported_capabilities umgestellt. Drei Unit-Test-Fixtures modellierten Embedding-Modelle weiterhin ohne dieses Negativsignal; außerdem verwendete der LlmRoutingView-Test noch den alten manual-run-id-Selector.

## Fix

- Embedding-Fixtures markieren chat explizit als unsupported
- llm-routing-run-id wird Teil der LlmRoutingTestId-SSoT
- Settings-View, Unit-Test und Playwright-Spec verwenden dieselbe Test-ID

## Verifikation

- 19/19 gezielte Regressionstests grün
- bash scripts/pre-push-gate.sh frontend grün
- 162 Testdateien, 1366 Tests grün
- ESLint, vue-tsc und Production-Build grün

Fixes den roten Frontend PR smoke gate in #708. Kein Merge ohne Review.