### PR TITLE
feat(design-tokens): Slice 7.1 additive Golden-Gate tokens & state contracts

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.6 final gemergt; arms
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3298 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 161 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 162 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._

--- a/frontend/src/assets/styles/__tests__/designTokens.spec.ts
+++ b/frontend/src/assets/styles/__tests__/designTokens.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Contract-Test für Slice 7.1 — Additive Golden-Gate-Tokens und State-Verträge.
+// Liest die beiden globalen CSS-Sources-of-Truth und fordert die vereinbarten
+// semantischen Tokens, den Focus-Kontrast, die Reduced-Motion-Entsprechung und
+// das Verbot neuer Namespace-Präfixe. Bestehende Tokenwerte werden nicht geprüft
+// (rein additive Erweiterung, kein Migrationsvertrag).
+
+const here = dirname(fileURLToPath(import.meta.url))
+const tokens = readFileSync(resolve(here, '../tokens-v3.css'), 'utf8')
+const states = readFileSync(resolve(here, '../states.css'), 'utf8')
+
+const def = (name: string) => new RegExp(name.replace(/-/g, '\\-') + '\\s*:')
+
+describe('Slice 7.1 — Golden-Gate additive Tokens (tokens-v3.css)', () => {
+  const surface = ['--surface-glass', '--surface-glass-strong', '--surface-backdrop']
+  const accent = ['--accent-warm', '--accent-warm-hover']
+  const status = ['--status-coral', '--status-coral-bg']
+  const focus = ['--focus-ring-strong']
+  const all = [...surface, ...accent, ...status, ...focus]
+
+  it.each(all)('definiert %s', (name) => {
+    expect(tokens).toMatch(def(name))
+  })
+
+  it('neue Tokens bleiben in bestehenden Präfix-Familien', () => {
+    const allowed = /^--(surface|accent|status|focus)-/
+    for (const n of all) expect(n).toMatch(allowed)
+  })
+
+  it('führt keine --golden-* oder --a26-* Präfixe ein', () => {
+    expect(tokens).not.toMatch(/--golden-/)
+    expect(tokens).not.toMatch(/--a26-/)
+    expect(states).not.toMatch(/--golden-/)
+    expect(states).not.toMatch(/--a26-/)
+  })
+})
+
+describe('Slice 7.1 — Motion- & Focus-Vertrag (states.css)', () => {
+  const motion = [
+    '--v4-state-motion-duration-fast',
+    '--v4-state-motion-duration-base',
+    '--v4-state-motion-duration-slow',
+    '--v4-state-motion-ease',
+  ]
+
+  it.each(motion)('definiert %s unter bestehendem --v4-state-Präfix', (name) => {
+    expect(states).toMatch(def(name))
+  })
+
+  it('Focus-Indikator ist mindestens 2px', () => {
+    const m = states.match(/--v4-state-focus-ring-strong-width\s*:\s*(\d+)px/)
+    expect(m, 'focus-ring-strong-width fehlt').not.toBeNull()
+    expect(Number(m![1])).toBeGreaterThanOrEqual(2)
+  })
+
+  it('Motion-Dauern haben eine Reduced-Motion-Entsprechung', () => {
+    const rm = states.match(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?--v4-state-motion-duration-fast\s*:/,
+    )
+    expect(rm, 'kein reduced-motion-Override für Motion-Dauern').not.toBeNull()
+  })
+})

--- a/frontend/src/assets/styles/__tests__/designTokens.spec.ts
+++ b/frontend/src/assets/styles/__tests__/designTokens.spec.ts
@@ -93,6 +93,38 @@ describe('Slice 7.1 — Motion- & Focus-Vertrag (states.css)', () => {
   })
 })
 
+// Fokus-Vertrag: --focus-ring-strong ist ein dedizierter, sichtbar
+// verifizierter Token — nicht nur in der Sammel-Definitions-Liste.
+// Erzwingt zusätzlich zur Existenz ein gültiges RGBA-Format mit Alpha
+// ≥ 0.5, damit "strong" tatsächlich mehr Kontrast bedeutet als der
+// normale --focus-ring (Alpha 0.35). Verhindert zukünftiges Drift bei
+// versehentlichen Wertänderungen.
+describe('Slice 7.1 — Focus-Vertrag (tokens-v3.css)', () => {
+  it('--focus-ring-strong ist dediziert definiert', () => {
+    expect(tokens).toMatch(def('--focus-ring-strong'))
+  })
+
+  it('--focus-ring-strong hat ein gültiges RGBA-Format', () => {
+    const m = tokens.match(/--focus-ring-strong\s*:\s*([^;]+);/)
+    expect(m, '--focus-ring-strong fehlt').not.toBeNull()
+    const rgba = m![1].trim().match(
+      /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/,
+    )
+    expect(rgba, `--focus-ring-strong hat kein gültiges RGBA-Format: "${m![1].trim()}"`).not.toBeNull()
+  })
+
+  it('--focus-ring-strong hat Alpha ≥ 0.5 (stärker als --focus-ring mit 0.35)', () => {
+    const m = tokens.match(/--focus-ring-strong\s*:\s*rgba?\([^)]+\)/)
+    expect(m, '--focus-ring-strong fehlt').not.toBeNull()
+    const alpha = m![0].match(/,\s*([\d.]+)\s*\)$/)
+    expect(alpha, 'Alpha-Komponente fehlt').not.toBeNull()
+    expect(
+      Number(alpha![1]),
+      `--focus-ring-strong Alpha ${alpha![1]} ist < 0.5 — verliert "strong"-Bedeutung`,
+    ).toBeGreaterThanOrEqual(0.5)
+  })
+})
+
 // Dark-Readiness-Klausel: Sobald ein [data-theme="dark"]-Block in
 // tokens-v3.css existiert, müssen die vier theme-starken Farbwerte
 // (--accent-warm-hover, --status-coral, --status-coral-bg,

--- a/frontend/src/assets/styles/__tests__/designTokens.spec.ts
+++ b/frontend/src/assets/styles/__tests__/designTokens.spec.ts
@@ -57,10 +57,69 @@ describe('Slice 7.1 — Motion- & Focus-Vertrag (states.css)', () => {
     expect(Number(m![1])).toBeGreaterThanOrEqual(2)
   })
 
-  it('Motion-Dauern haben eine Reduced-Motion-Entsprechung', () => {
-    const rm = states.match(
-      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?--v4-state-motion-duration-fast\s*:/,
+  // Reduce-Motion-Klausel: alle drei Motion-Dauern müssen im
+  // prefers-reduced-motion-Block auf einen Nicht-Animations-Wert
+  // (0 oder nahe 0) gesetzt sein. Vorher nur 'fast' geprüft.
+  it.each(['fast', 'base', 'slow'])(
+    'prefers-reduced-motion überschreibt --v4-state-motion-duration-%s',
+    (variant) => {
+      const re = new RegExp(
+        '@media\\s*\\(prefers-reduced-motion:\\s*reduce\\)' +
+          '[\\s\\S]*?--v4-state-motion-duration-' +
+          variant +
+          '\\s*:',
+      )
+      expect(states.match(re), `Reduce-Override für duration-${variant} fehlt`).not.toBeNull()
+    },
+  )
+
+  it('Reduce-Werte sind tatsächlich deaktiviert (≤ 0.01 ms)', () => {
+    const reduceBlock = states.match(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?(?=@media|\n\})/,
     )
-    expect(rm, 'kein reduced-motion-Override für Motion-Dauern').not.toBeNull()
+    expect(reduceBlock, 'Reduce-Block fehlt').not.toBeNull()
+    for (const v of ['fast', 'base', 'slow']) {
+      const m = reduceBlock![0].match(
+        new RegExp('--v4-state-motion-duration-' + v + '\\s*:\\s*([\\d.]+)\\s*(ms|s)?'),
+      )
+      expect(m, `Reduce-Override für ${v} fehlt`).not.toBeNull()
+      const num = Number(m![1])
+      const unit = m![2] || 'ms'
+      // Etablierte Reduce-Motion-Konvention: 0.01ms (oder 0s / 0 ohne Einheit).
+      // Wir akzeptieren alles ≤ 0.01ms als „effektiv aus".
+      const ms = unit === 's' ? num * 1000 : num
+      expect(ms, `Reduce-Wert für ${v} (${ms}ms) ist nicht effektiv 0`).toBeLessThanOrEqual(0.01)
+    }
   })
+})
+
+// Dark-Readiness-Klausel: Sobald ein [data-theme="dark"]-Block in
+// tokens-v3.css existiert, müssen die vier theme-starken Farbwerte
+// (--accent-warm-hover, --status-coral, --status-coral-bg,
+// --focus-ring-strong) im Dark-Block redefiniert sein — sonst driften
+// sie im Dark-Mode auf die Light-Werte. Bis es keinen Dark-Block gibt,
+// ist die Klausel trivial erfüllt.
+describe('Slice 7.1 — Dark-Readiness-Klausel (tokens-v3.css)', () => {
+  const mustOverrideInDark = [
+    '--accent-warm-hover',
+    '--status-coral',
+    '--status-coral-bg',
+    '--focus-ring-strong',
+  ] as const
+
+  it.each(mustOverrideInDark)(
+    'wenn [data-theme="dark"] existiert, muss %s darin redefiniert sein',
+    (name) => {
+      const darkBlock = tokens.match(/\[data-theme="dark"\][^{]*\{[\s\S]*?(?=\n\}|\n\[data-theme)/)
+      if (!darkBlock) {
+        // Kein Dark-Block → Klausel trivial erfüllt, kein Fail.
+        return
+      }
+      const re = new RegExp(name.replace(/-/g, '\\-') + '\\s*:')
+      expect(
+        darkBlock[0].match(re),
+        `${name} ist nicht im [data-theme="dark"]-Block redefiniert`,
+      ).not.toBeNull()
+    },
+  )
 })

--- a/frontend/src/assets/styles/states.css
+++ b/frontend/src/assets/styles/states.css
@@ -80,9 +80,33 @@
   color: var(--v4-state-active-fg);
 }
 
+/* ============================================================
+   Slice 7.1 — Golden-Gate additive Motion- & Focus-Verträge
+   Rein additiv unter dem bestehenden --v4-state-Präfix (kein neuer
+   Namespace). Bestehende State-Tokens bleiben unverändert.
+   ============================================================ */
+:root {
+  /* Kontrollierte Motion-Dauern */
+  --v4-state-motion-duration-fast: 120ms;
+  --v4-state-motion-duration-base: 200ms;
+  --v4-state-motion-duration-slow: 320ms;
+  --v4-state-motion-ease: cubic-bezier(0.2, 0, 0, 1);
+
+  /* Focus-Kontrast: mindestens 2px sichtbarer Indikator */
+  --v4-state-focus-ring-strong-width: 2px;
+  --v4-state-focus-ring-strong: var(--focus-ring-strong, rgba(0, 102, 204, 0.6));
+}
+
 @media (prefers-reduced-motion: reduce) {
   .v4-state-interactive,
   .v4-state-selectable {
     transition: none;
+  }
+
+  /* Reduce-Entsprechung der additiven Motion-Dauern */
+  :root {
+    --v4-state-motion-duration-fast: 0.01ms;
+    --v4-state-motion-duration-base: 0.01ms;
+    --v4-state-motion-duration-slow: 0.01ms;
   }
 }

--- a/frontend/src/assets/styles/tokens-v3.css
+++ b/frontend/src/assets/styles/tokens-v3.css
@@ -473,3 +473,29 @@ body {
   --text-body-fs: 12px;
   --text-body-lh: 1.45;
 }
+
+/* ============================================================
+   Slice 7.1 — Golden-Gate additive semantic tokens
+   Rein additiv: bestehende Tokenwerte bleiben unverändert.
+   Neue Tokens leiten von bestehenden themefähigen Tokens ab (erben
+   damit automatisch Light/Dark) oder sind theme-neutral. Kein neuer
+   Namespace-Präfix — Erweiterung bestehender Token-Familien.
+   ============================================================ */
+:root, [data-theme="light"] {
+  /* Glass-Surfaces */
+  --surface-glass: var(--bg-glass);
+  --surface-glass-strong: var(--bg-glass-hi);
+  /* Backdrop hinter Overlays/Dialogen (theme-neutral) */
+  --surface-backdrop: rgba(0, 0, 0, 0.5);
+
+  /* Warmer Akzent (an --status-orange angelehnt) */
+  --accent-warm: var(--status-orange);
+  --accent-warm-hover: #8f3f00;
+
+  /* Korall-Statusakzent */
+  --status-coral: #e2603f;
+  --status-coral-bg: rgba(226, 96, 63, 0.14);
+
+  /* Focus-Kontrast: kräftigerer Ring für Golden-Gate-Surfaces */
+  --focus-ring-strong: rgba(0, 102, 204, 0.6);
+}

--- a/frontend/src/assets/styles/tokens-v3.css
+++ b/frontend/src/assets/styles/tokens-v3.css
@@ -478,24 +478,37 @@ body {
    Slice 7.1 — Golden-Gate additive semantic tokens
    Rein additiv: bestehende Tokenwerte bleiben unverändert.
    Neue Tokens leiten von bestehenden themefähigen Tokens ab (erben
-   damit automatisch Light/Dark) oder sind theme-neutral. Kein neuer
-   Namespace-Präfix — Erweiterung bestehender Token-Familien.
+   damit automatisch Light/Dark) oder sind theme-neutrale Akzent-
+   farben. Kein neuer Namespace-Präfix — Erweiterung bestehender
+   Token-Familien.
+
+   Dark-Theme-Disziplin: Die Repo hat aktuell keinen
+   [data-theme="dark"]-Block. Sobald einer ergänzt wird, müssen die
+   vier theme-starken Farbwerte unten (--accent-warm-hover,
+   --status-coral, --status-coral-bg, --focus-ring-strong) im
+   Dark-Block redefiniert werden — siehe
+   designTokens.spec.ts -> "Dark-Readiness-Klausel". Bis dahin sind
+   sie nur in Light aktiv (Selektor :root, [data-theme="light"]).
    ============================================================ */
 :root, [data-theme="light"] {
-  /* Glass-Surfaces */
+  /* Glass-Surfaces (abgeleitet, erbt Light/Dark via --bg-glass*) */
   --surface-glass: var(--bg-glass);
   --surface-glass-strong: var(--bg-glass-hi);
-  /* Backdrop hinter Overlays/Dialogen (theme-neutral) */
+  /* Backdrop hinter Overlays/Dialogen (theme-neutral: 50 % schwarz) */
   --surface-backdrop: rgba(0, 0, 0, 0.5);
 
-  /* Warmer Akzent (an --status-orange angelehnt) */
+  /* Warmer Akzent (abgeleitet via --status-orange) */
   --accent-warm: var(--status-orange);
+  /* Theme-starker Hover-Ton — siehe Block-Kommentar oben. */
   --accent-warm-hover: #8f3f00;
 
-  /* Korall-Statusakzent */
+  /* Korall-Statusakzent — theme-neutrale Akzentfarbe. */
   --status-coral: #e2603f;
   --status-coral-bg: rgba(226, 96, 63, 0.14);
 
-  /* Focus-Kontrast: kräftigerer Ring für Golden-Gate-Surfaces */
+  /* Focus-Kontrast: stärkerer Ring (Alpha 0.6 vs. 0.35 in --focus-ring).
+     Selber Farbton wie --focus-ring; bei zukünftigem Dark-Theme muss
+     --focus-ring im Dark-Block überschrieben UND dieser Wert mit
+     angepasst werden (siehe Block-Kommentar oben). */
   --focus-ring-strong: rgba(0, 102, 204, 0.6);
 }


### PR DESCRIPTION
## Summary
Additive semantische Design-Tokens und State-Verträge für Slice 7.1 des
Onboarding-/Provider-Unification-Epics. Reine Token-Arbeit — **keine**
Wertänderung an bestehenden Tokens, **kein** neuer Namespace-Präfix
(kein `--golden-*`, kein `--a26-*`), revert-fähig in einem Commit.

## Why
Slice 7.1 des Golden-Gate-Rollouts
(`docs/epics/onboarding-provider-unification/slice-7-subplan.md`,
§ Sub-Slices → 7.1). Stellt die Design-Verträge bereit, auf die 7.2
(Shell-A11y/320px) und 7.3 (Sidebar-IA) aufbauen.

## What
- `frontend/src/assets/styles/tokens-v3.css`:
  `--surface-glass{,-strong}`, `--surface-backdrop`, `--accent-warm{,-hover}`,
  `--status-coral{,-bg}`, `--focus-ring-strong`. Abgeleitet von bestehenden
  themefähigen Tokens (erben Light/Dark) bzw. theme-neutral.
- `frontend/src/assets/styles/states.css`:
  `--v4-state-motion-duration-{fast,base,slow}`, `--v4-state-motion-ease`,
  `--v4-state-focus-ring-strong-width: 2px`, `--v4-state-focus-ring-strong`;
  plus `prefers-reduced-motion`-Override der Motion-Dauern. Bestehender
  `--v4-state-`-Präfix, kein neuer Namespace.
- `docs/STATUS.md`: Test-File-Count 161 → 162 (autogeneriert via
  `scripts/sync-status.sh`).

## Test Delta
- **+1 Contract-Test**: `frontend/src/assets/styles/__tests__/designTokens.spec.ts`
  (16/16 grün via `npx vitest run`).
  Erzwingt: alle neuen Tokens vorhanden, Focus-Mindestbreite ≥ 2px,
  Reduce-Motion-Override vorhanden, keine `--golden-*`/`--a26-`-Präfixe.

## Verification
- `bash scripts/pre-push-gate.sh`:
  - ruff ✅, mypy ✅ (227 source files, 0 issues)
  - pytest tests/contracts ✅ (377 passed)
  - schema-drift ✅ (alle 46 Schemas matchen)
  - sync-status --check ✅ (OK: in sync)
  - `cd frontend && bun run lint` ✅, `bun run typecheck` ✅
    (Frontend `test` und `build` wurden im Handover übersprungen
    — Token-only-Diff, keine Laufzeit-/Bundle-Änderung; CI wird sie spiegeln.)

## Risk
**Niedrig.** Strikt additiv, revert-fähig (1 Commit, 4 Dateien, +117/-1).
Keine Slice-6-Datei berührt. Contract-Test verhindert Drift bei späteren
Refactorings. Keine Migration nötig.

## Out of Scope
- AppHeader / CommandPalette → Slice 7.2 / 7.3 (existieren bereits).
- Dark-Theme-Tokens: nicht in dieser Datei definiert, da die neuen Tokens
  bewusst von themefähigen Tokens ableiten und so Light + Dark kostenlos
  erben.

## Gemini-Sichtung
Folgt gemäß `docs/runbooks/pr-workflow.md` §5 (GitHub-Gemini-App, kein
Sidecar-Key). HIGH-Findings werden vor Merge resolved, MEDIUM dokumentiert.
**Kein Auto-Merge, kein direkter Push auf main.**