### PR TITLE
fix(e2e): Gemini-Findings aus Slice 7.2 beheben

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -26,6 +26,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.49.0",
         "@types/d3": "^7.4.3",
@@ -34,7 +35,6 @@
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/coverage-v8": "^4.1.5",
         "@vue/test-utils": "^2.4.10",
-        "axe-core": "^4.12.1",
         "eslint": "^10.3.0",
         "eslint-plugin-vue": "^10.9.1",
         "globals": "^17.6.0",
@@ -61,6 +61,8 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/generator": ["@babel/generator@8.0.0-rc.5", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.5", "@babel/types": "^8.0.0-rc.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.49.0",
     "@types/d3": "^7.4.3",
@@ -49,7 +50,6 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.5",
     "@vue/test-utils": "^2.4.10",
-    "axe-core": "^4.12.1",
     "eslint": "^10.3.0",
     "eslint-plugin-vue": "^10.9.1",
     "globals": "^17.6.0",

--- a/frontend/tests/accessibility-helpers.spec.ts
+++ b/frontend/tests/accessibility-helpers.spec.ts
@@ -1,0 +1,143 @@
+import type { Page } from '@playwright/test';
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkFocusVisible,
+  diffFocusStyle,
+  parseMaxDuration,
+  type FocusStyleSnapshot,
+} from './e2e/helpers/accessibility';
+
+const DEFAULT_CONTROL_STYLE: FocusStyleSnapshot = {
+  outlineStyle: 'none',
+  outlineWidth: '0px',
+  outlineColor: 'rgb(0, 0, 0)',
+  outlineOffset: '0px',
+  boxShadow: 'none',
+  borderTopStyle: 'solid',
+  borderTopWidth: '1px',
+  borderTopColor: 'rgb(118, 118, 118)',
+  borderRightStyle: 'solid',
+  borderRightWidth: '1px',
+  borderRightColor: 'rgb(118, 118, 118)',
+  borderBottomStyle: 'solid',
+  borderBottomWidth: '1px',
+  borderBottomColor: 'rgb(118, 118, 118)',
+  borderLeftStyle: 'solid',
+  borderLeftWidth: '1px',
+  borderLeftColor: 'rgb(118, 118, 118)',
+};
+
+describe('diffFocusStyle', () => {
+  it('rejects an unchanged native control border as focus indicator', () => {
+    expect(diffFocusStyle(DEFAULT_CONTROL_STYLE, DEFAULT_CONTROL_STYLE)).toBe(false);
+  });
+
+  it('detects a visible outline or box shadow added on focus', () => {
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        outlineStyle: 'solid',
+        outlineWidth: '2px',
+      }),
+    ).toBe(true);
+
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        boxShadow: 'rgb(0, 95, 204) 0px 0px 0px 3px',
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a visible border color or width change', () => {
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        borderTopColor: 'rgb(0, 95, 204)',
+      }),
+    ).toBe(true);
+
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        borderTopWidth: '2px',
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores border changes while the focused border remains invisible', () => {
+    const invisibleBorder = {
+      ...DEFAULT_CONTROL_STYLE,
+      borderTopStyle: 'none',
+      borderRightStyle: 'none',
+      borderBottomStyle: 'none',
+      borderLeftStyle: 'none',
+    };
+
+    expect(
+      diffFocusStyle(invisibleBorder, {
+        ...invisibleBorder,
+        borderTopWidth: '2px',
+        borderTopColor: 'rgb(0, 95, 204)',
+      }),
+    ).toBe(false);
+  });
+
+  it('requires the changed border side itself to remain visible', () => {
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        borderTopStyle: 'none',
+        borderTopWidth: '2px',
+        borderTopColor: 'rgb(0, 95, 204)',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('checkFocusVisible', () => {
+  it('keeps the before snapshot bound to the focused element when focus mutates the DOM', async () => {
+    document.body.innerHTML = '<button>first</button><button>target</button>';
+    const [first, target] = Array.from(document.querySelectorAll('button'));
+    first.style.border = '1px solid rgb(118, 118, 118)';
+    target.style.border = '1px solid rgb(118, 118, 118)';
+    target.addEventListener('focus', () => {
+      target.style.outlineStyle = 'solid';
+      target.style.outlineWidth = '2px';
+      target.style.outlineColor = 'rgb(0, 95, 204)';
+      target.insertAdjacentHTML('beforebegin', '<button>inserted on focus</button>');
+    });
+
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      callback(0);
+      return 1;
+    };
+
+    const handles = [first, target].map((element) => ({
+      evaluate: async (fn: (node: Element, arg?: unknown) => unknown, arg?: unknown) =>
+        fn(element, arg),
+      dispose: async () => undefined,
+    }));
+    const page = {
+      evaluate: async (fn: (arg?: unknown) => unknown, arg?: unknown) => fn(arg),
+      keyboard: { press: async () => target.focus() },
+      locator: () => ({ elementHandles: async () => handles }),
+    } as unknown as Page;
+
+    await expect(checkFocusVisible(page)).resolves.toBeUndefined();
+  });
+});
+
+describe('parseMaxDuration', () => {
+  it('normalizes milliseconds and returns the longest list entry in seconds', () => {
+    expect(parseMaxDuration('0.05s, 250ms, 0.1s')).toBe(0.25);
+    expect(parseMaxDuration(' 100MS , .15s ')).toBe(0.15);
+  });
+
+  it('ignores invalid and negative duration tokens', () => {
+    expect(parseMaxDuration('invalid, 100msjunk, -2s')).toBe(0);
+    expect(parseMaxDuration('invalid, 75ms')).toBe(0.075);
+    expect(parseMaxDuration('')).toBe(0);
+  });
+});

--- a/frontend/tests/accessibility-helpers.spec.ts
+++ b/frontend/tests/accessibility-helpers.spec.ts
@@ -50,6 +50,38 @@ describe('diffFocusStyle', () => {
     ).toBe(true);
   });
 
+  it('ignores a computed box shadow whose pixel lengths are all zero', () => {
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        boxShadow: 'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      }),
+    ).toBe(false);
+  });
+
+  it('requires opacity and non-zero geometry in the same shadow layer', () => {
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        boxShadow: 'rgba(0, 0, 0, 0) 0px 0px 0px 3px',
+      }),
+    ).toBe(false);
+
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        boxShadow: 'rgba(0, 0, 0, 0) 0px 0px 0px 3px, rgb(0, 0, 0) 0px 0px 0px 0px',
+      }),
+    ).toBe(false);
+
+    expect(
+      diffFocusStyle(DEFAULT_CONTROL_STYLE, {
+        ...DEFAULT_CONTROL_STYLE,
+        boxShadow: 'rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgb(0, 0, 0) 0px 0px 0px 3px',
+      }),
+    ).toBe(true);
+  });
+
   it('detects a visible border color or width change', () => {
     expect(
       diffFocusStyle(DEFAULT_CONTROL_STYLE, {

--- a/frontend/tests/e2e/helpers/accessibility.ts
+++ b/frontend/tests/e2e/helpers/accessibility.ts
@@ -1,10 +1,6 @@
-import type { Page } from '@playwright/test';
+import type { ElementHandle, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
-import type { AxeResults, Result } from 'axe-core';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import AxeBuilder from '@axe-core/playwright';
 
 /**
  * Slice 7.2 — Accessibility-Gate Helper.
@@ -17,41 +13,126 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * - Reduced Motion (prefers-reduced-motion: reduce)
  */
 
-export interface AxeCheckOptions {
-  rules?: Record<string, { enabled: boolean }>;
+export type AxeCheckOptions = Parameters<AxeBuilder['options']>[0];
+export type AxeResults = Awaited<ReturnType<AxeBuilder['analyze']>>;
+export type Result = AxeResults['violations'][number];
+
+export interface FocusStyleSnapshot {
+  outlineStyle: string;
+  outlineWidth: string;
+  outlineColor: string;
+  outlineOffset: string;
+  boxShadow: string;
+  borderTopStyle: string;
+  borderTopWidth: string;
+  borderTopColor: string;
+  borderRightStyle: string;
+  borderRightWidth: string;
+  borderRightColor: string;
+  borderBottomStyle: string;
+  borderBottomWidth: string;
+  borderBottomColor: string;
+  borderLeftStyle: string;
+  borderLeftWidth: string;
+  borderLeftColor: string;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+const FOCUS_STYLE_PROPERTIES: Record<keyof FocusStyleSnapshot, string> = {
+  outlineStyle: 'outline-style',
+  outlineWidth: 'outline-width',
+  outlineColor: 'outline-color',
+  outlineOffset: 'outline-offset',
+  boxShadow: 'box-shadow',
+  borderTopStyle: 'border-top-style',
+  borderTopWidth: 'border-top-width',
+  borderTopColor: 'border-top-color',
+  borderRightStyle: 'border-right-style',
+  borderRightWidth: 'border-right-width',
+  borderRightColor: 'border-right-color',
+  borderBottomStyle: 'border-bottom-style',
+  borderBottomWidth: 'border-bottom-width',
+  borderBottomColor: 'border-bottom-color',
+  borderLeftStyle: 'border-left-style',
+  borderLeftWidth: 'border-left-width',
+  borderLeftColor: 'border-left-color',
+};
+
+const BORDER_SIDES = ['Top', 'Right', 'Bottom', 'Left'] as const;
+
+export function diffFocusStyle(before: FocusStyleSnapshot, after: FocusStyleSnapshot): boolean {
+  const outlineChanged = (['outlineStyle', 'outlineWidth', 'outlineColor', 'outlineOffset'] as const).some(
+    (property) => before[property] !== after[property],
+  );
+  const hasVisibleOutline = after.outlineStyle !== 'none' && Number.parseFloat(after.outlineWidth) > 0;
+
+  const boxShadowChanged = before.boxShadow !== after.boxShadow;
+  const hasVisibleBoxShadow = after.boxShadow !== 'none';
+
+  const hasVisibleBorderChange = BORDER_SIDES.some((side) => {
+    const sideChanged = ([`border${side}Style`, `border${side}Width`, `border${side}Color`] as const).some(
+      (property) => before[property] !== after[property],
+    );
+    return (
+      sideChanged &&
+      after[`border${side}Style`] !== 'none' &&
+      Number.parseFloat(after[`border${side}Width`]) > 0
+    );
+  });
+
+  return (
+    (outlineChanged && hasVisibleOutline) ||
+    (boxShadowChanged && hasVisibleBoxShadow) ||
+    hasVisibleBorderChange
+  );
+}
+
+export function parseMaxDuration(value: string): number {
+  const durations = value.split(',').map((entry) => {
+    const match = /^(-?(?:\d+(?:\.\d*)?|\.\d+))(ms|s)?$/i.exec(entry.trim());
+    if (!match) return 0;
+
+    const duration = Number.parseFloat(match[1]);
+    if (!Number.isFinite(duration) || duration < 0) return 0;
+    return match[2]?.toLowerCase() === 'ms' ? duration / 1000 : duration;
+  });
+
+  return Math.max(0, ...durations);
+}
+
+async function captureFocusStyle(element: ElementHandle<HTMLElement>): Promise<FocusStyleSnapshot> {
+  return element.evaluate((node, properties) => {
+    const style = window.getComputedStyle(node);
+    return Object.fromEntries(
+      Object.entries(properties).map(([key, property]) => [key, style.getPropertyValue(property)]),
+    ) as unknown as FocusStyleSnapshot;
+  }, FOCUS_STYLE_PROPERTIES);
 }
 
 /**
  * Führt axe-core im Browser-Kontext aus und gibt die Results zurück.
  */
-export async function runAxe(
-  page: Page,
-  options: AxeCheckOptions = {},
-): Promise<AxeResults> {
-  // Inject axe-core script in browser context
-  const axePath = resolve(__dirname, '../../../node_modules/axe-core/axe.min.js');
-  await page.addScriptTag({ path: axePath });
-
-  return page.evaluate(async (opts) => {
-    // @ts-expect-error — axe is injected via addScriptTag
-    return window.axe.run(document, opts);
-  }, options);
+export async function runAxe(page: Page, options: AxeCheckOptions = {}): Promise<AxeResults> {
+  return new AxeBuilder({ page }).options(options).analyze();
 }
 
 /**
  * Prüft, dass keine serious oder critical violations vorliegen.
  */
 export function assertNoCriticalViolations(results: AxeResults): void {
-  const violations = results.violations.filter(
-    (v: Result) => v.impact === 'serious' || v.impact === 'critical',
-  );
+  const violations = results.violations.filter((v: Result) => v.impact === 'serious' || v.impact === 'critical');
 
   if (violations.length > 0) {
     const summary = violations
-      .map(
-        (v: Result) =>
-          `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`,
-      )
+      .map((v: Result) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
       .join('\n');
     throw new Error(`Accessibility violations found:\n${summary}`);
   }
@@ -73,10 +154,7 @@ export async function check320pxNoHorizontalScroll(page: Page): Promise<void> {
 /**
  * Prüft Tastatur-Navigation durch alle fokussierbaren Elemente.
  */
-export async function checkKeyboardNavigation(
-  page: Page,
-  tabCount: number = 10,
-): Promise<void> {
+export async function checkKeyboardNavigation(page: Page, tabCount: number = 10): Promise<void> {
   const focusableSelectors = [
     'a[href]',
     'button:not([disabled])',
@@ -106,64 +184,66 @@ export async function checkKeyboardNavigation(
  * Prüft, dass :focus-visible Styles vorhanden sind.
  */
 export async function checkFocusVisible(page: Page): Promise<void> {
-  // Fokussiere das erste fokussierbare Element
-  await page.keyboard.press('Tab');
-
-  const hasFocusVisible = await page.evaluate(() => {
-    const el = document.activeElement;
-    if (!el || el === document.body) return false;
-
-    // Prüfe computed style für outline oder box-shadow
-    const style = window.getComputedStyle(el);
-    const hasOutline = style.outlineStyle !== 'none' && parseFloat(style.outlineWidth) > 0;
-    const hasBoxShadow = style.boxShadow !== 'none';
-    const hasBorder = style.borderStyle !== 'none' && parseFloat(style.borderWidth) > 0;
-
-    return hasOutline || hasBoxShadow || hasBorder;
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
   });
 
-  expect(hasFocusVisible).toBe(true);
+  const focusableElements = (await page.locator(FOCUSABLE_SELECTOR).elementHandles()) as ElementHandle<HTMLElement>[];
+  try {
+    expect(focusableElements.length).toBeGreaterThan(0);
+    const beforeStyles = await Promise.all(focusableElements.map(captureFocusStyle));
+
+    await page.keyboard.press('Tab');
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+
+    let focusedIndex = -1;
+    for (let index = 0; index < focusableElements.length; index += 1) {
+      if (await focusableElements[index].evaluate((element) => element === document.activeElement)) {
+        focusedIndex = index;
+        break;
+      }
+    }
+
+    const afterStyle = focusedIndex >= 0 ? await captureFocusStyle(focusableElements[focusedIndex]) : undefined;
+    expect(afterStyle ? diffFocusStyle(beforeStyles[focusedIndex], afterStyle) : false).toBe(true);
+  } finally {
+    await Promise.all(focusableElements.map((element) => element.dispose()));
+  }
 }
 
 /**
  * Prüft, dass prefers-reduced-motion: reduce nicht-essentielle Animationen unterdrückt.
  */
 export async function checkReducedMotion(page: Page): Promise<void> {
-  // Emuliere prefers-reduced-motion: reduce
   await page.emulateMedia({ reducedMotion: 'reduce' });
+  try {
+    const reducedMotion = await page.evaluate(() => {
+      const animatedElements = document.querySelectorAll(
+        '[class*="animate"], [class*="transition"], [style*="transition"]',
+      );
 
-  // Prüfe, dass transition-duration für animierte Elemente 0 oder sehr kurz ist
-  const hasReducedMotion = await page.evaluate(() => {
-    const animatedElements = document.querySelectorAll(
-      '[class*="animate"], [class*="transition"], [style*="transition"]',
-    );
+      return {
+        isReduced: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+        durations: Array.from(animatedElements, (element) => {
+          const style = window.getComputedStyle(element);
+          return [style.transitionDuration, style.animationDuration];
+        }).flat(),
+      };
+    });
 
-    const isReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    for (const el of animatedElements) {
-      const style = window.getComputedStyle(el);
-      const transitionDuration = parseFloat(style.transitionDuration || '0');
-      const animationDuration = parseFloat(style.animationDuration || '0');
-      if (isReduced && (transitionDuration > 0.1 || animationDuration > 0.1)) {
-        return false;
-      }
-    }
-    return true;
-  });
-
-  expect(hasReducedMotion).toBe(true);
-
-  // Reset
-  await page.emulateMedia({ reducedMotion: 'no-preference' });
+    expect(reducedMotion.isReduced).toBe(true);
+    expect(reducedMotion.durations.every((value) => parseMaxDuration(value) <= 0.1)).toBe(true);
+  } finally {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+  }
 }
 
 /**
  * Kombinierte Accessibility-Prüfung für eine Route.
  */
-export async function checkAccessibilityGate(
-  page: Page,
-  route: string,
-  options: AxeCheckOptions = {},
-): Promise<void> {
+export async function checkAccessibilityGate(page: Page, route: string, options: AxeCheckOptions = {}): Promise<void> {
   await page.goto(route, { waitUntil: 'domcontentloaded' });
 
   // axe-core

--- a/frontend/tests/e2e/helpers/accessibility.ts
+++ b/frontend/tests/e2e/helpers/accessibility.ts
@@ -68,6 +68,45 @@ const FOCUS_STYLE_PROPERTIES: Record<keyof FocusStyleSnapshot, string> = {
 
 const BORDER_SIDES = ['Top', 'Right', 'Bottom', 'Left'] as const;
 
+function splitBoxShadowLayers(value: string): string[] {
+  const layers: string[] = [];
+  let depth = 0;
+  let layerStart = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] === '(') depth += 1;
+    if (value[index] === ')') depth = Math.max(0, depth - 1);
+    if (value[index] === ',' && depth === 0) {
+      layers.push(value.slice(layerStart, index).trim());
+      layerStart = index + 1;
+    }
+  }
+
+  layers.push(value.slice(layerStart).trim());
+  return layers;
+}
+
+function isVisibleBoxShadow(value: string): boolean {
+  const zeroAlpha = String.raw`(?:0(?:\.0+)?|\.0+)%?`;
+  const legacyTransparent = new RegExp(
+    String.raw`rgba\(\s*(?:[^,]+,\s*){3}${zeroAlpha}\s*\)`,
+    'i',
+  );
+  const modernTransparent = new RegExp(
+    String.raw`(?:rgba?|hsla?|color)\([^)]*\/\s*${zeroAlpha}\s*\)`,
+    'i',
+  );
+
+  return splitBoxShadowLayers(value).some((layer) => {
+    const isTransparent =
+      /\btransparent\b/i.test(layer) ||
+      legacyTransparent.test(layer) ||
+      modernTransparent.test(layer);
+    const lengths = layer.match(/-?(?:\d+(?:\.\d*)?|\.\d+)px/g) ?? [];
+    return !isTransparent && lengths.some((length) => Number.parseFloat(length) !== 0);
+  });
+}
+
 export function diffFocusStyle(before: FocusStyleSnapshot, after: FocusStyleSnapshot): boolean {
   const outlineChanged = (['outlineStyle', 'outlineWidth', 'outlineColor', 'outlineOffset'] as const).some(
     (property) => before[property] !== after[property],
@@ -75,7 +114,7 @@ export function diffFocusStyle(before: FocusStyleSnapshot, after: FocusStyleSnap
   const hasVisibleOutline = after.outlineStyle !== 'none' && Number.parseFloat(after.outlineWidth) > 0;
 
   const boxShadowChanged = before.boxShadow !== after.boxShadow;
-  const hasVisibleBoxShadow = after.boxShadow !== 'none';
+  const hasVisibleBoxShadow = isVisibleBoxShadow(after.boxShadow);
 
   const hasVisibleBorderChange = BORDER_SIDES.some((side) => {
     const sideChanged = ([`border${side}Style`, `border${side}Width`, `border${side}Color`] as const).some(


### PR DESCRIPTION
## Zusammenfassung

- ersetzt die fragile `axe-core`-Pfadinjektion durch `@axe-core/playwright` und behält `runAxe(page, options)` bei
- vergleicht Fokus-Styles am selben DOM-Element vor/nach `Tab`, einschließlich sichtbarer Outline-, Shadow- und Border-Diffs
- parst komma-separierte Transition-/Animation-Dauern robust in `s` und `ms`
- ergänzt fokussierte Regressionstests für die Gemini-Findings und zwei Review-Randfälle

## Kontext

Post-Merge-Follow-up zu #714. Die dortige letzte Fix-Commit war Ausgangspunkt der drei späteren Gemini-Findings.

## Validierung

- [x] `bun run test tests/accessibility-helpers.spec.ts` — 10/10 bestanden
- [x] `bun run typecheck`
- [x] Gemini-Follow-up — Zero-Pixel-, transparente und mehrlagige `box-shadow`-Werte abgedeckt
- [x] unabhängiger Subagent-Review — beide P2-Randfälle behoben
- [ ] `bash scripts/pre-push-gate.sh frontend` — Full-Vitest-Phase beendete sich im Tool-Zeitfenster nicht; kein Build-Nachweis. Draft-PR auf ausdrücklichen User-Wunsch trotzdem erstellt.

## Hinweise

`AxeResults` und `Result` werden aus den öffentlichen `AxeBuilder`-Signaturen abgeleitet, weil `@axe-core/playwright` diese Typen nicht direkt exportiert.
