### PR TITLE
fix(security): enforce workspace path boundaries at the storage layer

### DIFF
--- a/backend/app/services/artifact_store.py
+++ b/backend/app/services/artifact_store.py
@@ -143,12 +143,6 @@ class LocalFilesystemArtifactStore:
         rel = _resolve_relative_path(artifact)
         return safe_join_within_root(self._root, simulation_id, rel)
 
-    def _ensure_simulation_dir(self, simulation_id: str) -> str:
-        validate_path_id(simulation_id, field_name="simulation_id")
-        sim_dir = safe_join_within_root(self._root, simulation_id)
-        os.makedirs(sim_dir, exist_ok=True)
-        return sim_dir
-
     def read_json(
         self, simulation_id: str, artifact: str, default: Any = None
     ) -> Any:
@@ -158,7 +152,6 @@ class LocalFilesystemArtifactStore:
         )
 
     def write_json(self, simulation_id: str, artifact: str, payload: Any) -> None:
-        self._ensure_simulation_dir(simulation_id)
         path = self._abs_path(simulation_id, artifact)
         # ``write_json_atomic`` already creates parent dirs (e.g. ipc_commands/).
         write_json_atomic(path, payload)

--- a/backend/app/services/artifact_store.py
+++ b/backend/app/services/artifact_store.py
@@ -22,6 +22,7 @@ from typing import Any, Iterable, Optional, Protocol, runtime_checkable
 from ..utils.artifact_locator import ArtifactLocator
 from ..utils.json_io import read_json_file, write_json_atomic
 from ..utils.logger import get_logger
+from ..utils.path_safety import safe_join_within_root, validate_path_id
 
 logger = get_logger("agora.artifact_store")
 
@@ -133,11 +134,18 @@ class LocalFilesystemArtifactStore:
         self._root = simulations_root or ArtifactLocator.simulations_dir()
 
     def _abs_path(self, simulation_id: str, artifact: str) -> str:
+        # SEC-1: validate user-controlled simulation_id before path construction.
+        # Pydantic contracts only enforce min_length=1; CodeQL (py/path-injection
+        # alerts #9, #349–#353) flags the unvalidated os.path.join sink. The
+        # central boundary check also rejects ``..``/absolute/symlink escapes
+        # via canonical realpath containment (see app.utils.path_safety).
+        validate_path_id(simulation_id, field_name="simulation_id")
         rel = _resolve_relative_path(artifact)
-        return os.path.join(self._root, simulation_id, rel)
+        return safe_join_within_root(self._root, simulation_id, rel)
 
     def _ensure_simulation_dir(self, simulation_id: str) -> str:
-        sim_dir = os.path.join(self._root, simulation_id)
+        validate_path_id(simulation_id, field_name="simulation_id")
+        sim_dir = safe_join_within_root(self._root, simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         return sim_dir
 
@@ -168,7 +176,8 @@ class LocalFilesystemArtifactStore:
     def list_artifacts(
         self, simulation_id: str, prefix: str = ""
     ) -> list[str]:
-        sim_dir = os.path.join(self._root, simulation_id)
+        validate_path_id(simulation_id, field_name="simulation_id")
+        sim_dir = safe_join_within_root(self._root, simulation_id)
         if not os.path.isdir(sim_dir):
             return []
         results: list[str] = []

--- a/backend/app/utils/path_safety.py
+++ b/backend/app/utils/path_safety.py
@@ -1,0 +1,102 @@
+"""Central workspace path-boundary checks (SEC-1).
+
+Verhindert Path-Traversal über user-kontrollierte IDs (``simulation_id``,
+``run_id``, ``report_id``), die an Speicher-Adapter weitergereicht werden.
+
+Kontext: Die Pydantic-Verträge validieren diese IDs bisher nur mit
+``Field(min_length=1)`` — ohne Pattern. CodeQL (``py/path-injection``) modelliert
+die Schema-Validierung nicht und flaggt jeden Flow von Request-Input in
+``os.path.join``/Dateioperationen. Dieser Helper ist die kanonische,
+plattform-sichere Boundary-Prüfung, die an den Speicher-Call-Sites als einziger
+Pfad-Resolver verwendet wird.
+
+Design-Entscheidungen (SEC-1-Anforderungen):
+
+- IDs werden *vor* der Pfad-Konstruktion streng validiert (keine Separatoren,
+  kein ``..``, kein absoluter Pfad, kein führender Punkt, kein Backslash,
+  kein Null-Byte). Reale Agora-IDs sind ``sim_<hex>`` / UUID-Derivate und
+  matchen ``[A-Za-z0-9_-]+``.
+- Der kanonische Ziel-Pfad wird via ``os.path.realpath`` aufgelöst (resolviert
+  Symlinks und ``..``) und muss innerhalb des kanonischen Roots bleiben
+  (``os.path.commonpath``-Containment, kein String-Prefix-Vergleich).
+- Positive wie negative Cases sind testbar; normale IDs bleiben funktionsfähig.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class PathTraversalError(ValueError):
+    """Kanonischer Pfad verlässt das erlaubte Root oder enthält illegale Bestandteile."""
+
+
+# Erlaubte Zeichen für Workspace-IDs: alphanumerisch plus ``_`` und ``-``.
+# Deckt reale Agora-IDs (``sim_<hex>``, ``run_<id>``, ``rep_<id>``). ``.``, ``/``,
+# ``\`` und Null-Bytes sind verboten — damit sind ``..``, absolute Pfade und
+# Separatoren-Injektion strukturell ausgeschlossen.
+_ID_ALLOWED = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+)
+
+
+def validate_path_id(value: str, *, field_name: str = "id") -> str:
+    """Validiere eine user-kontrollierte Workspace-ID streng.
+
+    Lässt ``[A-Za-z0-9_-]+`` zu; verwirft leere Werte, absolute Pfade,
+    Separatoren (``/``, ``\\``), ``..``, führende ``.`` und Null-Bytes.
+    Gibt den Wert unverändert zurück, sodass die Funktion als Inline-Guard
+    am Call-Site dienen kann.
+    """
+    if value is None:
+        raise PathTraversalError(f"{field_name} must not be None")
+    if not isinstance(value, str):
+        raise PathTraversalError(f"{field_name} must be a string, got {type(value)!r}")
+    if value == "":
+        raise PathTraversalError(f"{field_name} must not be empty")
+    if "\x00" in value:
+        raise PathTraversalError(f"{field_name} contains null byte")
+    if os.path.isabs(value):
+        raise PathTraversalError(f"{field_name} must not be absolute: {value!r}")
+    if value.startswith("."):
+        raise PathTraversalError(f"{field_name} must not start with '.': {value!r}")
+    if "/" in value or "\\" in value:
+        raise PathTraversalError(f"{field_name} must not contain path separators: {value!r}")
+    if not set(value) <= _ID_ALLOWED:
+        raise PathTraversalError(
+            f"{field_name} contains illegal characters (allowed: [A-Za-z0-9_-]): {value!r}"
+        )
+    return value
+
+
+def safe_join_within_root(root: str, *parts: str) -> str:
+    """Füge ``parts`` unter ``root`` zusammen und stelle sicher, dass der
+    kanonische Ziel-Pfad innerhalb von ``root`` bleibt.
+
+    ``parts`` dürfen relative Sub-Pfade (z. B. ``ipc_commands/cmd1.json``)
+    enthalten — die kanonische Containment-Prüfung fängt jeden Escape ab.
+    Absolute ``parts`` und Null-Bytes werden vorab verworfen.
+
+    Rückgabe: absoluter kanonischer Pfad innerhalb von ``root``.
+    Raise: ``PathTraversalError`` bei Escape-Versuch oder illegalem Part.
+    """
+    if not parts:
+        raise PathTraversalError("safe_join_within_root requires at least one part")
+    root_real = os.path.realpath(root)
+    norm_parts: list[str] = []
+    for p in parts:
+        if p is None or p == "":
+            raise PathTraversalError("empty path part rejected")
+        if "\x00" in p:
+            raise PathTraversalError(f"path part contains null byte: {p!r}")
+        if os.path.isabs(p):
+            raise PathTraversalError(f"absolute path part rejected: {p!r}")
+        norm_parts.append(p)
+    target_real = os.path.realpath(os.path.join(root_real, *norm_parts))
+    # ``commonpath`` ist die plattform-sichere Containment-Prüfung (kein
+    # String-Prefix-Vergleich). Gleiche Pfade → commonpath == root_real.
+    if os.path.commonpath([root_real, target_real]) != root_real:
+        raise PathTraversalError(
+            f"path escapes root: {target_real!r} not within {root_real!r}"
+        )
+    return target_real

--- a/backend/tests/test_path_safety.py
+++ b/backend/tests/test_path_safety.py
@@ -1,0 +1,146 @@
+"""SEC-1: Workspace path-boundary validation.
+
+RED-Tests für Path-Traversal über user-kontrollierte ``simulation_id``.
+Repräsentative Alerts: CodeQL ``py/path-injection`` #9, #349–#353 in
+``backend/app/services/artifact_store.py``. Die Pydantic-Verträge validieren
+``simulation_id`` nur mit ``min_length=1``; ``os.path.join(root, simulation_id,
+rel)`` lässt ``..``/absolute Pfade durch — der Sink ist über die API erreichbar.
+
+Diese Suite fixiert das Verhalten: traversal-IDs müssen ``PathTraversalError``
+werfen, normale IDs bleiben funktionsfähig.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services.artifact_store import LocalFilesystemArtifactStore
+from app.utils.path_safety import (
+    PathTraversalError,
+    safe_join_within_root,
+    validate_path_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# path_safety unit
+# ---------------------------------------------------------------------------
+
+VALID_IDS = ["sim_test_001", "sim_abcdef012345", "run_42", "rep_x-y_z"]
+
+
+@pytest.mark.parametrize("value", VALID_IDS)
+def test_validate_path_id_accepts_real_ids(value):
+    assert validate_path_id(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        ".",
+        "..",
+        "../etc",
+        "..%2f",
+        "/etc/passwd",
+        "sim/../../etc",
+        "sim\\..\\etc",
+        "\x00sim",
+        "sim.txt",
+        "sim.id",
+        " leading",
+        "sim evil",
+    ],
+)
+def test_validate_path_id_rejects_traversal(value):
+    with pytest.raises(PathTraversalError):
+        validate_path_id(value)
+
+
+def test_validate_path_id_rejects_none_and_non_str():
+    with pytest.raises(PathTraversalError):
+        validate_path_id(None)  # type: ignore[arg-type]
+    with pytest.raises(PathTraversalError):
+        validate_path_id(123)  # type: ignore[arg-type]
+
+
+def test_safe_join_within_root_accepts_subdir(tmp_path):
+    root = str(tmp_path)
+    p = safe_join_within_root(root, "sim_abc", "ipc_commands/cmd1.json")
+    assert os.path.commonpath([os.path.realpath(root), p]) == os.path.realpath(root)
+
+
+def test_safe_join_within_root_rejects_traversal(tmp_path):
+    root = str(tmp_path)
+    # realpath resolves ``..`` → target escapes root.
+    with pytest.raises(PathTraversalError):
+        safe_join_within_root(root, "..", "..", "etc", "passwd")
+
+
+def test_safe_join_within_root_rejects_absolute_part(tmp_path):
+    with pytest.raises(PathTraversalError):
+        safe_join_within_root(str(tmp_path), "sim", "/etc/passwd")
+
+
+def test_safe_join_within_root_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "sim_link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(PathTraversalError):
+        safe_join_within_root(str(root), "sim_link", "state.json")
+
+
+# ---------------------------------------------------------------------------
+# ArtifactStore integration (production adapter)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fs_store(tmp_path) -> LocalFilesystemArtifactStore:
+    return LocalFilesystemArtifactStore(simulations_root=str(tmp_path))
+
+
+def test_artifact_store_rejects_traversal_sim_id(fs_store):
+    # RED: currently no error — ``..`` escapes root.
+    with pytest.raises(PathTraversalError):
+        fs_store.read_json("../../../../etc", "state")
+
+
+def test_artifact_store_rejects_absolute_sim_id(fs_store):
+    with pytest.raises(PathTraversalError):
+        fs_store.read_json("/etc/passwd", "state")
+
+
+def test_artifact_store_rejects_dotdot_sim_id_write(fs_store):
+    with pytest.raises(PathTraversalError):
+        fs_store.write_json("..", "state", {"x": 1})
+
+
+def test_artifact_store_rejects_traversal_delete(fs_store):
+    with pytest.raises(PathTraversalError):
+        fs_store.delete("../..", "state")
+
+
+def test_artifact_store_rejects_traversal_list(fs_store):
+    with pytest.raises(PathTraversalError):
+        fs_store.list_artifacts("../..")
+
+
+def test_artifact_store_normal_id_roundtrip(fs_store):
+    # Positive case: real IDs stay fully functional (regression guard).
+    fs_store.write_json("sim_test_001", "state", {"x": 1})
+    assert fs_store.exists("sim_test_001", "state") is True
+    assert fs_store.read_json("sim_test_001", "state") == {"x": 1}
+    fs_store.delete("sim_test_001", "state")
+    assert fs_store.exists("sim_test_001", "state") is False
+
+
+def test_artifact_store_normal_id_ipc_subdir(fs_store):
+    # IPC sub-directory path must still work (contains a ``/`` in the rel part).
+    fs_store.write_json("sim_test_001", "ipc_command/cmd1", {"ping": 1})
+    assert fs_store.read_json("sim_test_001", "ipc_command/cmd1") == {"ping": 1}
+    assert "ipc_command/cmd1" in fs_store.list_artifacts("sim_test_001")

--- a/backend/tests/test_path_safety.py
+++ b/backend/tests/test_path_safety.py
@@ -90,7 +90,10 @@ def test_safe_join_within_root_rejects_symlink_escape(tmp_path):
     outside = tmp_path / "outside"
     outside.mkdir()
     link = root / "sim_link"
-    link.symlink_to(outside, target_is_directory=True)
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform (requires admin on Windows)")
     with pytest.raises(PathTraversalError):
         safe_join_within_root(str(root), "sim_link", "state.json")
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.6 final gemergt; arms
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3298 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3327 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 162 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## SEC-1: Path-Boundary-Validierung (Storage Layer)

**Betroffene Alerts:** CodeQL `py/path-injection` #9, #349–#353 (6 von 77)

### Root Cause

`simulation_id`/`run_id`/`report_id` werden in den Pydantic-Verträgen nur mit `Field(min_length=1)` validiert — ohne Pattern. CodeQL (77 `py/path-injection`-Alerts) flaggt jeden Flow von Request-Input in `os.path.join`/Dateioperationen, weil es die Schema-Validierung nicht modelliert. Die Storage-Schicht hatte keinen kanonischen Boundary-Check — eine `simulation_id` wie `../../etc` würde das Workspace-Root verlassen.

### Fix

- **`app/utils/path_safety.py`** (neu): `validate_path_id` (strenge ID-Validierung: `[A-Za-z0-9_-]+`, verwirft Separatoren, `..`, absolute Pfade, führenden Punkt, Null-Bytes) und `safe_join_within_root` (kanonische `realpath`-Containment-Prüfung, kein String-Prefix-Vergleich).
- Angewendet in `LocalFilesystemArtifactStore._abs_path`, `_ensure_simulation_dir`, `list_artifacts`.

### Threat Model

Lokal-first Single-User-Deployment. Ein Angreifer mit API-Zugriff könnte via unvalidierte `simulation_id` das Workspace-Root traversieren. Der Fix blockiert Traversal an der Storage-Boundary mit kanonischer `realpath`-Containment-Prüfung.

### Tests

- **+29 Tests** (RED→GREEN TDD): 22 `path_safety`-Unit-Tests + 7 `ArtifactStore`-Integration-Tests (Traversal-Ablehnung + positive Normal-Cases + IPC-Subdir).
- Alle 30 bestehenden `test_artifact_store.py`-Tests bestehen (keine Regression).

### Nicht-Ziele

- Die verbleibenden 71 `py/path-injection`-Alerts in anderen Storage-Call-Sites (`run_state_store`, `run_registry`, `json_io`, `simulation_profiles` etc.) sind Follow-up-Slices — dieser PR etabliert die wiederverwendbare Boundary-Utility.
- Keine Änderung an Pydantic-Verträgen (Pattern-Ergänzung wäre ein separater, breiterer Eingriff).

### 7.7/7.4a-Konflikt

Kein Konflikt — `artifact_store.py` ist Storage-Layer, nicht Profiles/Settings.

### Rollback-Risiko

Niedrig. `validate_path_id` erlaubt `[A-Za-z0-9_-]+` — deckt alle realen Agora-IDs (`sim_<hex>`, UUID-Derivate). Falls eine ID ein unerwartetes Format hat, wirft sie `PathTraversalError` (statt still zu traversieren).

### Gate

`bash scripts/pre-push-gate.sh backend` — ALL GREEN.