### PR TITLE
docs(security): consolidate PYSEC-2026-597 tracking into #672

### DIFF
--- a/docs/dependency-risk-exceptions.json
+++ b/docs/dependency-risk-exceptions.json
@@ -7,12 +7,12 @@
       "package": "nltk",
       "version_constraint": "==3.9.4",
       "severity": "unknown",
-      "reason": "Kein Upstream-Fix released; PYSEC-2026-597 hat keine gefixte Version in der Advisory-DB — Upgrade behebt das Finding derzeit nicht.",
+      "reason": "Kein Upstream-Fix released; PYSEC-2026-597 hat keine gefixte Version in der Advisory-DB — Upgrade behebt das Finding derzeit nicht. Tracking konsolidiert in #672 (2026-07-14).",
       "blocker": "nltk upstream: https://github.com/nltk/nltk/releases",
       "target_version": "nltk mit gepatchter Advisory-DB-Version",
       "owner": "nltk",
       "deadline": "2026-09-28",
-      "issue": "https://github.com/arn0ld87/agora/issues/661",
+      "issue": "https://github.com/arn0ld87/agora/issues/672",
       "status": "open"
     },
     {

--- a/docs/dependency-risk-register.md
+++ b/docs/dependency-risk-register.md
@@ -48,7 +48,7 @@ Ohne erfüllte Bedingungen gilt: sofort fixen, kein Register-Eintrag.
 
 | CVE | Paket | Schweregrad | Fix verfügbar? | Owner | Frist | Status | Issue | Upstream-Release-Watch |
 |---|---|---|---|---|---|---|---|---|
-| PYSEC-2026-597 | `nltk` | unbekannt | Nein (kein Upstream-Fix released) | NLTK | 2026-09-28 | open | [#661](https://github.com/arn0ld87/agora/issues/661) | [nltk/nltk/releases](https://github.com/nltk/nltk/releases) |
+| PYSEC-2026-597 | `nltk` | unbekannt | Nein (kein Upstream-Fix released) | NLTK | 2026-09-28 | open (konsolidiert in #672) | [#672](https://github.com/arn0ld87/agora/issues/672) | [nltk/nltk/releases](https://github.com/nltk/nltk/releases) |
 | GHSA-p4gq-832x-fm9v | `nltk` | High | Nein (kein Upstream-Fix in 3.9.x) | NLTK | 2026-09-28 | open | [#672](https://github.com/arn0ld87/agora/issues/672) | [nltk/nltk/releases](https://github.com/nltk/nltk/releases) |
 
 ## Trivy Container Scan Baseline (Hardstop 2026-08-30)


### PR DESCRIPTION
## Doku-Konsistenz: nltk-Advisory-Tracking

**Inkonsistenz:** Issue #661 (PYSEC-2026-597) war seit 2026-07-05 closed (completed), aber `dependency-risk-exceptions.json` und `dependency-risk-register.md` referenzierten es weiterhin mit `status: "open"`.

**Fix:** Beide nltk-Advisories (PYSEC-2026-597 + GHSA-p4gq-832x-fm9v) sind jetzt unter **#672** konsolidiert — gleiches Paket, gleicher Blocker (kein Upstream-Fix), gleicher Hardstop (2026-09-28), gleicher Owner (nltk).

**Geändert:**
- `exceptions.json`: PYSEC-2026-597 `issue` → #672, `reason` ergänzt um Konsolidierungsvermerk
- `register.md`: PYSEC-2026-597 `status` → "open (konsolidiert in #672)", Issue-Link → #672

**Keine Änderung an:** Deadline, Owner, Blocker, `--ignore-vuln`-Flags, CI/cve-monitor.