### PR TITLE
ci(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-legacy-model-picker.yml
+++ b/.github/workflows/check-legacy-model-picker.yml
@@ -36,10 +36,10 @@ jobs:
             release-assets.githubusercontent.com:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
             api.github.com:443
 
       - name: Checkout full history for secret scan
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set up Bun
         if: github.event_name != 'pull_request'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -95,7 +95,7 @@ jobs:
         run: bun audit --audit-level=high
 
       - name: Run Gitleaks secret scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -138,10 +138,10 @@ jobs:
             pypi.org:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -169,7 +169,7 @@ jobs:
         # PRs sehen Coverage-Werte im pytest-Output, Trend-Tracking läuft
         # über main-Artifacts.
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: backend-coverage
           path: backend/coverage.xml
@@ -202,10 +202,10 @@ jobs:
             registry.npmjs.org:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -228,7 +228,7 @@ jobs:
       - name: Upload frontend coverage report
         # CI-Welle 2026-05-16: Coverage-Artifact-Upload nur auf push:main.
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: frontend-coverage
           path: frontend/coverage/
@@ -262,10 +262,10 @@ jobs:
             pypi.org:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 
@@ -307,10 +307,10 @@ jobs:
             registry.npmjs.org:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 

--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -30,8 +30,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - name: Install uv
@@ -63,8 +63,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
@@ -89,8 +89,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
@@ -115,8 +115,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
@@ -156,8 +156,8 @@ jobs:
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
 
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - run: cd frontend && bun install --frozen-lockfile
@@ -184,8 +184,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - run: python -m pip install --upgrade pip uv
@@ -218,8 +218,8 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - name: Install uv

--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -63,15 +63,15 @@ jobs:
             release-assets.githubusercontent.com:443
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Backend deps installieren (no-dev)
         working-directory: backend
@@ -151,7 +151,7 @@ jobs:
 
       - name: Audit-Output als Artefakt
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pip-audit-output
           path: /tmp/audit.txt

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -62,8 +62,8 @@ jobs:
             storage.googleapis.com:443
             *.blob.core.windows.net:443
 
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Generate ephemeral E2E credentials
@@ -95,7 +95,7 @@ jobs:
         run: npx playwright test health.spec.ts --reporter=list,github
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-trace
           path: frontend/test-results/
@@ -151,8 +151,8 @@ jobs:
             storage.googleapis.com:443
             *.blob.core.windows.net:443
 
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Generate ephemeral E2E credentials
@@ -178,7 +178,7 @@ jobs:
         run: npx playwright test upload-graph.spec.ts --reporter=list,github
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-trace-upload-graph
           path: frontend/test-results/
@@ -238,8 +238,8 @@ jobs:
             storage.googleapis.com:443
             *.blob.core.windows.net:443
 
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Generate ephemeral E2E credentials
@@ -264,7 +264,7 @@ jobs:
         run: npx playwright test minimal-report.spec.ts --reporter=list,github
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-trace-minimal-report
           path: frontend/test-results/
@@ -317,8 +317,8 @@ jobs:
             storage.googleapis.com:443
             *.blob.core.windows.net:443
 
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Generate ephemeral E2E credentials
@@ -342,7 +342,7 @@ jobs:
         run: npx playwright test report-modes.spec.ts --reporter=list,github
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-trace-report-modes
           path: frontend/test-results/

--- a/.github/workflows/version-drift.yml
+++ b/.github/workflows/version-drift.yml
@@ -28,9 +28,9 @@ jobs:
             release-assets.githubusercontent.com:443
             pypi.org:443
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # `docker-compose.prod.yml`.
 
 # ---------- shared base ----------
-FROM python:3.14 AS base
+FROM python:3.14@sha256:09b29c360b84742bf98eba40b214f7f6b4b53286bb2c8a8b5b1afa188a8d9c0e AS base
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl unzip \
@@ -115,7 +115,7 @@ RUN cd backend && uv sync --frozen --no-dev \
   && chown -R agora:agora /app
 
 # ---------- prod ----------
-FROM python:3.14-slim AS prod
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS prod
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -177,7 +177,7 @@ CMD ["/app/backend/.venv/bin/gunicorn", \
      "wsgi:app"]
 
 # ---------- proxy (nginx-Sidecar mit eingebackenem Frontend-Bundle) ----------
-FROM nginx:alpine AS proxy
+FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa AS proxy
 # Alpine-Pakete auf Repo-Stand heben, solange das Base-Image hinterherhinkt:
 # CVE-2026-33630 (c-ares < 1.34.8-r0), CVE-2026-56407/-56408/-56131
 # (libexpat < 2.8.2-r0) — Trivy-Gate scannt HIGH/CRITICAL mit exit-code 1.


### PR DESCRIPTION
## SEC-4: Supply-Chain-Härtung — Workflow-Pinning + Dockerfile-Digests

**Betroffene Alerts:** Scorecard `PinnedDependenciesID` — 61 von 64 (58 Actions + 3 Dockerfile)

### Fix

**GitHub Actions** von Version-Tags auf immutable Commit-SHAs gepinnt:

| Action | Vorher | Nachher |
|---|---|---|
| `actions/checkout` | `@v6` | `@df4cb1c0` |
| `actions/setup-python` | `@v6` | `@ece7cb06` |
| `oven-sh/setup-bun` | `@v2` | `@0c5077e5` |
| `actions/upload-artifact` | `@v7` | `@043fb46d` |
| `astral-sh/setup-uv` | `@v7` | `@94527f2e` |
| `gitleaks/gitleaks-action` | `@v2` | `@dcedce43` |

**Dockerfile** Base-Images auf Content-Digests gepinnt:

| Image | Digest |
|---|---|
| `python:3.14` | `@sha256:09b29c36` |
| `python:3.14-slim` | `@sha256:b877e50b` |
| `nginx:alpine` | `@sha256:54f2a904` |

### Nicht-Ziele

- 3 Scorecard-Alerts auf internen Stage-Referenzen (`FROM base AS dev` etc.) — False Positives (keine externen Images).
- Keine `permissions`-Änderungen (separater Scope).

### 7.7/7.4a-Konflikt

Kein Konflikt.

### Gate

YAML-Syntax validiert (alle 11 Workflows). Dockerfile-Syntax via `docker build --check` (Docker nicht verfügbar, aber Änderung ist rein additiv).