### PR TITLE
feat(settings): converge v4 settings and redirect classic route (Slice 7.4a)

### DIFF
--- a/frontend/src/router/__tests__/index.spec.ts
+++ b/frontend/src/router/__tests__/index.spec.ts
@@ -58,6 +58,7 @@ describe('Router – Routen-Resolution', () => {
     ['/dashboard', 'Dashboard'],
     ['/runs', 'Runs'],
     ['/settings/general', 'SettingsGeneral'],
+    ['/settings/integrations', 'SettingsIntegrations'],
     ['/home', 'Home'],
   ])('löst %s → %s auf', async (path, name) => {
     await pushAndSettle(path)
@@ -80,9 +81,17 @@ describe('Router – Redirects', () => {
     ['/', 'Dashboard'],
     ['/v4/dashboard', 'Dashboard'],
     ['/settings', 'SettingsGeneral'],
+    ['/settings-classic', 'SettingsGeneral'],
   ])('%s → %s', async (from, to) => {
     await pushAndSettle(from)
     expect(router.currentRoute.value.name).toBe(to)
+  })
+
+  it('hält /settings-classic nur als expliziten benannten Redirect', () => {
+    const classicRoute = router.getRoutes().find((route) => route.path === '/settings-classic')
+
+    expect(classicRoute?.redirect).toEqual({ name: 'SettingsGeneral' })
+    expect(classicRoute?.components).toBeUndefined()
   })
 })
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -49,7 +49,7 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/onboarding/OnboardingView.vue'),
   },
 
-  // Settings — klassische View bleibt aktiv; /settings redirect auf /settings/general
+  // Settings — /settings und der klassische Deep-Link konvergieren auf General.
   {
     path: '/settings',
     name: 'Settings',
@@ -109,11 +109,10 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/Settings/EmbeddingConfigurationsView.vue'),
     meta: { requiresAuth: true },
   },
-  // Klassische SettingsView bleibt erreichbar fuer Slice-G-Migration
+  // Legacy-Deep-Link bleibt fuer einen Release-Zyklus als Redirect erhalten.
   {
     path: '/settings-classic',
-    name: 'SettingsClassic',
-    component: () => import('../views/SettingsView.vue'),
+    redirect: { name: 'SettingsGeneral' },
   },
 
   // Legacy-Prozess-Routen

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -18,11 +18,19 @@ import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
+import Button from '@/components/v4/forms/Button.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
 import LlmProfileManager from '@/components/v4/forms/LlmProfileManager.vue'
 import { useLlmRoutingDefaultsStore } from '@/store/aiModels'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
 import type { AiModelRef } from '@/contracts/aiModelRef'
+import {
+  getActiveLlmConfig,
+  listLlmProviders,
+  listProviderModels,
+  setActiveLlmConfig,
+} from '@/api/llmRouting'
+import { GENERAL_SETTINGS_SECTIONS } from './settingsSections'
 
 const { t } = useI18n()
 
@@ -31,11 +39,6 @@ const BREADCRUMBS = [
   { label: 'General' },
 ]
 
-// .env-Sektionen, die das Laufzeit-Verhalten der Agora-App selbst beschreiben.
-// Externe Systeme (Neo4j, Embedding, OASIS, ...) gehoeren in den
-// Integrations-Tab und werden dort gerendert.
-const ALLOWED_SECTIONS = ['llm', 'logging', 'locale', 'ui', 'event_bus', 'security'] as const
-
 const defaultsStore = useLlmRoutingDefaultsStore()
 const adapter = useAiModelRefAdapter()
 
@@ -43,6 +46,92 @@ const adapter = useAiModelRefAdapter()
 const selectedModel = ref<AiModelRef | null>(
   defaultsStore.globalDefault ? adapter.toAiModelRef(defaultsStore.globalDefault) : null,
 )
+
+const activeProviders = ref<Awaited<ReturnType<typeof listLlmProviders>>>([])
+const activeModels = ref<Awaited<ReturnType<typeof listProviderModels>>>([])
+const activeProviderId = ref('')
+const activeModelId = ref('')
+const activeLoadingProviders = ref(false)
+const activeLoadingModels = ref(false)
+const activeSaving = ref(false)
+const activeError = ref('')
+const activeFlash = ref('')
+
+function messageFrom(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+async function loadActiveProviders(): Promise<void> {
+  activeLoadingProviders.value = true
+  activeError.value = ''
+  try {
+    activeProviders.value = await listLlmProviders()
+  } catch (error) {
+    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadProviders'))
+  } finally {
+    activeLoadingProviders.value = false
+  }
+}
+
+async function loadActiveModels(providerId: string): Promise<void> {
+  if (!providerId) {
+    activeModels.value = []
+    return
+  }
+
+  activeLoadingModels.value = true
+  try {
+    activeModels.value = await listProviderModels(providerId)
+  } catch (error) {
+    activeModels.value = []
+    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadModels'))
+  } finally {
+    activeLoadingModels.value = false
+  }
+}
+
+async function loadActiveSelection(): Promise<void> {
+  try {
+    const config = await getActiveLlmConfig()
+    activeProviderId.value = config.provider_id ?? ''
+    if (activeProviderId.value) {
+      await loadActiveModels(activeProviderId.value)
+    }
+    activeModelId.value = config.model ?? ''
+  } catch (error) {
+    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadActive'))
+  }
+}
+
+async function changeActiveProvider(event: Event): Promise<void> {
+  activeProviderId.value = (event.target as HTMLSelectElement).value
+  activeModelId.value = ''
+  activeFlash.value = ''
+  activeError.value = ''
+  await loadActiveModels(activeProviderId.value)
+}
+
+async function saveActiveSelection(): Promise<void> {
+  if (!activeProviderId.value || !activeModelId.value) {
+    activeError.value = t('settings.llmActive.errorSelectionMissing')
+    return
+  }
+
+  activeSaving.value = true
+  activeError.value = ''
+  activeFlash.value = ''
+  try {
+    await setActiveLlmConfig({
+      provider_id: activeProviderId.value,
+      model: activeModelId.value,
+    })
+    activeFlash.value = t('settings.llmActive.flashSaved')
+  } catch (error) {
+    activeError.value = messageFrom(error, t('settings.llmActive.errorSaveFailed'))
+  } finally {
+    activeSaving.value = false
+  }
+}
 
 onMounted(async () => {
   try {
@@ -53,6 +142,11 @@ onMounted(async () => {
   } catch {
     /* Defaults bleiben leer — Picker zeigt nichts gewaehltes */
   }
+})
+
+onMounted(async () => {
+  await loadActiveProviders()
+  await loadActiveSelection()
 })
 
 async function setWorkspaceDefault(aiRef: AiModelRef | null): Promise<void> {
@@ -80,6 +174,163 @@ async function setWorkspaceDefault(aiRef: AiModelRef | null): Promise<void> {
         @update:model-value="setWorkspaceDefault"
       />
     </section>
-    <SettingsSectionPanel :allowed-sections="ALLOWED_SECTIONS" />
+
+    <section
+      class="settings-general__active"
+      aria-labelledby="settings-active-title"
+    >
+      <header>
+        <h2 id="settings-active-title">{{ t('settings.llmActive.title') }}</h2>
+        <p>{{ t('settings.llmActive.subtitle') }}</p>
+      </header>
+
+      <div class="settings-general__active-fields">
+        <label for="settings-active-provider">{{ t('settings.llmActive.providerLabel') }}</label>
+        <select
+          id="settings-active-provider"
+          :value="activeProviderId"
+          :disabled="activeLoadingProviders"
+          @change="changeActiveProvider"
+        >
+          <option value="" disabled>
+            {{ activeLoadingProviders ? t('settings.llmActive.providerLoading') : t('settings.llmActive.providerPlaceholder') }}
+          </option>
+          <option
+            v-for="provider in activeProviders"
+            :key="provider.id"
+            :value="provider.id"
+          >
+            {{ provider.label || provider.id }}
+          </option>
+        </select>
+
+        <label for="settings-active-model">{{ t('settings.llmActive.modelLabel') }}</label>
+        <select
+          id="settings-active-model"
+          v-model="activeModelId"
+          :disabled="!activeProviderId || activeLoadingModels"
+        >
+          <option value="" disabled>
+            {{
+              !activeProviderId
+                ? t('settings.llmActive.modelNeedsProvider')
+                : activeLoadingModels
+                  ? t('settings.llmActive.modelLoading')
+                  : activeModels.length
+                    ? t('settings.llmActive.modelPlaceholder')
+                    : t('settings.llmActive.modelEmpty')
+            }}
+          </option>
+          <option
+            v-for="model in activeModels"
+            :key="model.id"
+            :value="model.id"
+          >
+            {{ model.id }}{{ model.label && model.label !== model.id ? ` — ${model.label}` : '' }}
+          </option>
+        </select>
+      </div>
+
+      <p
+        v-if="activeFlash"
+        class="settings-general__active-feedback"
+        role="status"
+        aria-live="polite"
+      >
+        {{ activeFlash }}
+      </p>
+      <p
+        v-if="activeError"
+        class="settings-general__active-feedback settings-general__active-feedback--error"
+        role="alert"
+      >
+        {{ activeError }}
+      </p>
+
+      <Button
+        class="settings-general__active-save"
+        variant="accent"
+        :loading="activeSaving"
+        :disabled="!activeProviderId || !activeModelId || activeSaving"
+        @click="saveActiveSelection"
+      >
+        {{ t('settings.llmActive.save') }}
+      </Button>
+    </section>
+
+    <SettingsSectionPanel :allowed-sections="GENERAL_SETTINGS_SECTIONS" />
   </AppShell>
 </template>
+
+<style scoped>
+.settings-general__active {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+  margin-bottom: 16px;
+  padding: 20px;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: var(--surface-elevated);
+}
+
+.settings-general__active header,
+.settings-general__active header p {
+  margin: 0;
+}
+
+.settings-general__active header {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-general__active-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+  gap: 10px 16px;
+  align-items: center;
+  min-width: 0;
+}
+
+.settings-general__active-fields select {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  color: var(--text-primary);
+  background: var(--surface-elevated);
+}
+
+.settings-general__active-fields select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-general__active-feedback {
+  margin: 0;
+}
+
+.settings-general__active-feedback--error {
+  color: var(--danger);
+}
+
+.settings-general__active-save {
+  justify-self: end;
+}
+
+@media (max-width: 480px) {
+  .settings-general__active {
+    padding: 16px;
+  }
+
+  .settings-general__active-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-general__active-save {
+    justify-self: stretch;
+  }
+}
+</style>

--- a/frontend/src/views/Settings/SettingsIntegrationsView.vue
+++ b/frontend/src/views/Settings/SettingsIntegrationsView.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
+import { INTEGRATION_SETTINGS_SECTIONS } from './settingsSections'
 
 const { t } = useI18n()
 
@@ -12,17 +13,6 @@ const BREADCRUMBS = computed(() => [
   { label: t('sidebar.settings.integrations') },
 ])
 
-// Externe Systeme — Neo4j, Embedding-Provider, Ontology-LLM, Hybrid-Search,
-// Agent-Tools, WebTools und OASIS-Runner.
-const ALLOWED_SECTIONS = [
-  'neo4j',
-  'embedding',
-  'ontology',
-  'hybrid_search',
-  'agent_tools',
-  'webtools',
-  'oasis',
-] as const
 </script>
 
 <template>
@@ -32,6 +22,6 @@ const ALLOWED_SECTIONS = [
       :subtitle="t('settings.v4.integrations.subtitle')"
     />
 
-    <SettingsSectionPanel :allowed-sections="ALLOWED_SECTIONS" />
+    <SettingsSectionPanel :allowed-sections="INTEGRATION_SETTINGS_SECTIONS" />
   </AppShell>
 </template>

--- a/frontend/src/views/Settings/settingsSections.ts
+++ b/frontend/src/views/Settings/settingsSections.ts
@@ -1,0 +1,20 @@
+import type { SettingsSection } from '@/contracts/settingsContract'
+
+export const GENERAL_SETTINGS_SECTIONS = [
+  'llm',
+  'logging',
+  'locale',
+  'ui',
+  'event_bus',
+  'security',
+] as const satisfies readonly SettingsSection[]
+
+export const INTEGRATION_SETTINGS_SECTIONS = [
+  'neo4j',
+  'embedding',
+  'ontology',
+  'hybrid_search',
+  'agent_tools',
+  'webtools',
+  'oasis',
+] as const satisfies readonly SettingsSection[]

--- a/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
@@ -29,6 +29,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref, reactive } from 'vue'
+import { listLlmProviders } from '@/api/llmRouting'
 import SettingsGeneralView from '../Settings/SettingsGeneralView.vue'
 
 // AiModelPicker mocken
@@ -89,6 +90,17 @@ vi.mock('@/composables/useAiModelRefAdapter', () => ({
   useAiModelRefAdapter: () => adapterMock,
 }))
 
+vi.mock('@/api/llmRouting', () => ({
+  listLlmProviders: vi.fn().mockResolvedValue([
+    { id: 'ollama', label: 'Ollama' },
+  ]),
+  listProviderModels: vi.fn().mockResolvedValue([
+    { id: 'qwen3', label: 'Qwen 3' },
+  ]),
+  getActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'ollama', model: 'qwen3' }),
+  setActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'ollama', model: 'qwen3' }),
+}))
+
 function makeI18n() {
   return createI18n({
     legacy: false,
@@ -97,6 +109,25 @@ function makeI18n() {
     messages: {
       de: {
         settings: {
+          llmActive: {
+            title: 'Aktiver LLM-Anbieter und Modell',
+            subtitle: 'Backend-Fallback fuer LLM-Aufrufe',
+            providerLabel: 'Provider',
+            modelLabel: 'Modell',
+            providerPlaceholder: 'Provider waehlen',
+            providerLoading: 'Provider werden geladen',
+            modelPlaceholder: 'Modell waehlen',
+            modelLoading: 'Modelle werden geladen',
+            modelEmpty: 'Keine Modelle gefunden',
+            modelNeedsProvider: 'Erst Provider waehlen',
+            save: 'Speichern',
+            flashSaved: 'Auswahl gespeichert',
+            errorSelectionMissing: 'Provider und Modell waehlen',
+            errorLoadProviders: 'Provider konnten nicht geladen werden',
+            errorLoadModels: 'Modelle konnten nicht geladen werden',
+            errorLoadActive: 'Aktive Auswahl konnte nicht geladen werden',
+            errorSaveFailed: 'Speichern fehlgeschlagen',
+          },
           v4: {
             general: {
               title: 'Allgemein',
@@ -147,6 +178,14 @@ describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () =
   it('mountet ohne Crash', async () => {
     const w = await mountSettingsGeneral()
     expect(w.exists()).toBe(true)
+  })
+
+  it('behält den Provider-Discovery-Fehler, wenn active-config und Modelle laden', async () => {
+    vi.mocked(listLlmProviders).mockRejectedValueOnce(new Error('Provider-Discovery fehlgeschlagen'))
+
+    const w = await mountSettingsGeneral()
+
+    expect(w.get('[role="alert"]').text()).toContain('Provider-Discovery fehlgeschlagen')
   })
 
   it('zeigt BREADCRUMBS via AppShell', async () => {

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -13,9 +13,18 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
+import { SettingsSectionSchema } from '@/contracts/settingsContract'
+import {
+  getActiveLlmConfig,
+  setActiveLlmConfig,
+} from '@/api/llmRouting'
 
 import de from '@/i18n/locales/de.json'
 import en from '@/i18n/locales/en.json'
+import {
+  GENERAL_SETTINGS_SECTIONS,
+  INTEGRATION_SETTINGS_SECTIONS,
+} from '../Settings/settingsSections'
 
 vi.mock('@/components/v4/shell/AppShell.vue', () => ({
   default: {
@@ -51,6 +60,26 @@ vi.mock('@/components/v4/forms/LlmProfileManager.vue', () => ({
     template: '<div class="llm-profile-manager-stub" />',
   },
 }))
+vi.mock('@/components/v4/forms/AiModelPicker.vue', () => ({
+  default: {
+    name: 'AiModelPicker',
+    props: ['id', 'modelValue'],
+    template: '<div class="ai-model-picker-stub" :data-id="id" />',
+  },
+}))
+vi.mock('@/api/llmRouting', () => ({
+  listLlmProviders: vi.fn().mockResolvedValue([
+    { id: 'ollama', label: 'Ollama' },
+    { id: 'openai', label: 'OpenAI' },
+  ]),
+  listProviderModels: vi.fn().mockImplementation(async (providerId: string) => (
+    providerId === 'openai'
+      ? [{ id: 'gpt-4o-mini', label: 'GPT-4o mini' }]
+      : [{ id: 'qwen3', label: 'Qwen 3' }]
+  )),
+  getActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'ollama', model: 'qwen3' }),
+  setActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'openai', model: 'gpt-4o-mini' }),
+}))
 
 import SettingsGeneralView from '../Settings/SettingsGeneralView.vue'
 import SettingsIntegrationsView from '../Settings/SettingsIntegrationsView.vue'
@@ -81,6 +110,45 @@ async function mountView(component: object, path: string) {
   return wrapper
 }
 
+describe('Settings-Section-Parität (Slice 7.4a)', () => {
+  it('ordnet jede Schema-Section exakt einer v4-Settings-Seite zu', () => {
+    const mappedSections = [
+      ...GENERAL_SETTINGS_SECTIONS,
+      ...INTEGRATION_SETTINGS_SECTIONS,
+    ]
+    const occurrences = mappedSections.reduce<Record<string, number>>((counts, section) => {
+      counts[section] = (counts[section] ?? 0) + 1
+      return counts
+    }, {})
+
+    expect(
+      Object.entries(occurrences)
+        .filter(([, count]) => count !== 1)
+        .map(([section]) => section),
+    ).toEqual([])
+    expect([...new Set(mappedSections)].sort()).toEqual([...SettingsSectionSchema.options].sort())
+  })
+
+  it('erhält den separaten active-config-Lade- und Speicherpfad im General-Surface', async () => {
+    const w = await mountView(SettingsGeneralView, '/settings/general')
+
+    expect(getActiveLlmConfig).toHaveBeenCalled()
+    expect((w.get('#settings-active-provider').element as HTMLSelectElement).value).toBe('ollama')
+    expect((w.get('#settings-active-model').element as HTMLSelectElement).value).toBe('qwen3')
+
+    await w.get('#settings-active-provider').setValue('openai')
+    await flushPromises()
+    await w.get('#settings-active-model').setValue('gpt-4o-mini')
+    await w.get('.settings-general__active-save').trigger('click')
+    await flushPromises()
+
+    expect(setActiveLlmConfig).toHaveBeenCalledWith({
+      provider_id: 'openai',
+      model: 'gpt-4o-mini',
+    })
+  })
+})
+
 describe('SettingsGeneralView (Slice G1, real)', () => {
   beforeEach(() => vi.clearAllMocks())
 
@@ -106,7 +174,7 @@ describe('SettingsGeneralView (Slice G1, real)', () => {
     const panel = w.findComponent({ name: 'SettingsSectionPanel' })
     expect(panel.exists()).toBe(true)
     const allowed = panel.props('allowedSections') as string[]
-    expect(allowed).toEqual(['llm', 'logging', 'locale', 'ui', 'event_bus', 'security'])
+    expect(allowed).toEqual(GENERAL_SETTINGS_SECTIONS)
   })
 
   it('zeigt keinen "Slice G folgt"-Stub mehr', async () => {
@@ -137,15 +205,7 @@ describe('SettingsIntegrationsView (Slice G1, real)', () => {
     const w = await mountView(SettingsIntegrationsView, '/settings/integrations')
     const panel = w.findComponent({ name: 'SettingsSectionPanel' })
     const allowed = panel.props('allowedSections') as string[]
-    expect(allowed).toEqual([
-      'neo4j',
-      'embedding',
-      'ontology',
-      'hybrid_search',
-      'agent_tools',
-      'webtools',
-      'oasis',
-    ])
+    expect(allowed).toEqual(INTEGRATION_SETTINGS_SECTIONS)
   })
 })
 


### PR DESCRIPTION
## Ziel

Macht die v4-Settings zum einzigen navigierbaren Settings-Einstieg, beweist vollständige Section-Parität und redirectet `/settings-classic` auf die benannte Route `SettingsGeneral`.

## Bewusste Nicht-Ziele

- `SettingsView.vue` bleibt unverändert für Slice 7.4b
- keine Backend-, Contract-, Secret- oder Routing-DTO-Änderung
- keine Picker-Migration aus Slice 7.6
- Slice 7.7 ist PR #720

## Surfaces

- gemeinsame, testbare SSoT für 13 disjunkte Settings-Sections
- General: `llm, logging, locale, ui, event_bus, security`
- Integrationen: `neo4j, embedding, ontology, hybrid_search, agent_tools, webtools, oasis`
- expliziter Redirect `/settings-classic` → `SettingsGeneral`
- Erhalt der separaten `/api/llm/active-config`-Funktion im General-Surface; kein Vermischen mit dem globalen Routing-Default

## TDD-Nachweis

RED:
- fehlende gemeinsame Section-SSoT
- `/settings-classic` lud noch lazy `SettingsView.vue`
- v4-General rief `getActiveLlmConfig` nicht auf
- Provider-Discovery-Fehler wurde durch erfolgreiches Modell-Laden verdeckt

GREEN:
- Router + SettingsSubViews: 36/36
- SettingsGeneralView + SettingsSectionPanel: 19/19
- nach Reviewer-Fix SettingsSubViews + SettingsGeneralView: 30/30
- `git diff --check`: Exit 0
- `graphify update .`: erfolgreich

## Lokales Gate

`bash scripts/pre-push-gate.sh frontend` wurde gestartet. Lint und Typecheck liefen durch; der Full-Vitest-Abschnitt blieb unter paralleler Maschinenlast hängen und wurde auf ausdrückliche User-Anweisung abgebrochen. Kein `--no-verify` und kein Push-Bypass wurden verwendet. Vollständige CI ist deshalb eine harte Merge-Bedingung; der PR bleibt Draft.

## A11y / 320 px

Vorhandene Golden-Gates decken `/settings/general` und `/settings/integrations` ab. Labels, Alert-Kommunikation und responsives lokales Tabellen-/Form-Layout wurden im Diff-Review geprüft; die vollständige Browser-Gate-Ausführung bleibt CI vorbehalten.

## Rollback

Revert stellt die Lazy-Route wieder her. Settings-Daten und beide bestehenden Persistenzverträge bleiben unverändert.
