### PR TITLE
fix(security): apply path-boundary validation to storage utilities

### DIFF
--- a/backend/app/services/run_registry.py
+++ b/backend/app/services/run_registry.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 from ..config import Config
 from ..utils.json_io import read_json_file, write_json_atomic
 from ..utils.logger import get_logger
+from ..utils.path_safety import safe_join_within_root, validate_path_id
 
 logger = get_logger("agora.run_registry")
 
@@ -67,7 +68,8 @@ class RunRegistry:
         return mapping.get(value, "pending")
 
     def _run_path(self, run_id: str) -> str:
-        return os.path.join(self.REGISTRY_DIR, f"{run_id}.json")
+        validate_path_id(run_id, field_name="run_id")
+        return safe_join_within_root(self.REGISTRY_DIR, f"{run_id}.json")
 
     def _read_run(self, run_id: str) -> Optional[Dict[str, Any]]:
         if run_id in self._cache:

--- a/backend/app/services/sim/run_state_store.py
+++ b/backend/app/services/sim/run_state_store.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ...utils.logger import get_logger
+from ...utils.path_safety import safe_join_within_root, validate_path_id
 
 logger = get_logger("agora.run_state_store")
 
@@ -298,7 +299,7 @@ def save_run_state(
     """
     from ...services.artifact_store import resolve_default_store
 
-    sim_dir = os.path.join(str(base_dir), state.simulation_id)
+    sim_dir = safe_join_within_root(str(base_dir), validate_path_id(state.simulation_id, field_name="simulation_id"))
     os.makedirs(sim_dir, exist_ok=True)  # keep dir for log-pipe / shutil consumers
 
     data = state.to_detail_dict()
@@ -341,7 +342,7 @@ def read_console_log(
         Lines with trailing newlines stripped.  Empty list on missing file or
         read error.
     """
-    log_path = os.path.join(str(base_dir), run_id, "simulation.log")
+    log_path = safe_join_within_root(str(base_dir), validate_path_id(run_id, field_name="run_id"), "simulation.log")
 
     if not os.path.exists(log_path):
         return []
@@ -386,7 +387,7 @@ def cleanup_run_logs(
     dict
         ``{"success": bool, "cleaned_files": list[str], "errors": list[str] | None}``
     """
-    sim_dir = os.path.join(str(base_dir), run_id)
+    sim_dir = safe_join_within_root(str(base_dir), validate_path_id(run_id, field_name="run_id"))
 
     if not os.path.exists(sim_dir):
         return {"success": True, "message": "Simulation directory does not exist, no cleanup needed"}

--- a/backend/app/utils/artifact_locator.py
+++ b/backend/app/utils/artifact_locator.py
@@ -8,6 +8,7 @@ import os
 from typing import Any, Dict, Optional
 
 from ..config import Config
+from .path_safety import safe_join_within_root, validate_path_id
 
 
 class ArtifactLocator:
@@ -25,11 +26,13 @@ class ArtifactLocator:
 
     @classmethod
     def simulation_dir(cls, simulation_id: str) -> str:
-        return os.path.join(cls.simulations_dir(), simulation_id)
+        validate_path_id(simulation_id, field_name="simulation_id")
+        return safe_join_within_root(cls.simulations_dir(), simulation_id)
 
     @classmethod
     def report_dir(cls, report_id: str) -> str:
-        return os.path.join(cls.reports_dir(), report_id)
+        validate_path_id(report_id, field_name="report_id")
+        return safe_join_within_root(cls.reports_dir(), report_id)
 
     @classmethod
     def runs_dir(cls) -> str:
@@ -41,7 +44,8 @@ class ArtifactLocator:
 
     @classmethod
     def run_dir(cls, run_id: str) -> str:
-        return os.path.join(cls.runs_dir(), run_id)
+        validate_path_id(run_id, field_name="run_id")
+        return safe_join_within_root(cls.runs_dir(), run_id)
 
     @classmethod
     def simulation_file(cls, simulation_id: str, filename: str) -> str:


### PR DESCRIPTION
## SEC-1 Follow-up: Path-Boundary-Validierung für Storage-Utilities

**Betroffene Alerts:** CodeQL `py/path-injection` #8, #26, #72–#77, #302–#303 (~10 Alerts)

### Fix

Die in PR #717 eingeführte `path_safety`-Utility (`validate_path_id` + `safe_join_within_root`) wird auf weitere Storage-Call-Sites angewendet:

| Datei | Methode(n) | ID-Typ |
|---|---|---|
| `artifact_locator.py` | `simulation_dir`, `report_dir`, `run_dir` | simulation_id, report_id, run_id |
| `run_state_store.py` | `save_state`, `read_log`, `cleanup_sim_dir` | simulation_id, run_id |
| `run_registry.py` | `_run_path` | run_id |

### Tests

- 59 `test_path_safety` + `test_artifact_store` ✅
- 18 Modultests (run_registry, run_state, simulation_runner) ✅
- `pre-push-gate.sh backend` ALL GREEN ✅

### 7.7/7.4a-Konflikt

Kein Konflikt — reine Storage-Utilities, nicht Profiles/Settings.