### PR TITLE
feat(slice-7.6b): migrate StageLLMRoute consumers to AiModelPicker

### DIFF
--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -18,7 +18,9 @@ import ReportOutlinePanel from './step4/ReportOutlinePanel.vue'
 import ReportLiveLogPane from './step4/ReportLiveLogPane.vue'
 import ReportFinalView from './step4/ReportFinalView.vue'
 import { useReportExports } from '../composables/useReportExports'
-import { StageLLMRouteSchema, type StageLLMRoute } from '../contracts/llmRoutingContract'
+import type { AiModelRef } from '../contracts/aiModelRef'
+import { AiModelRefSchema } from '../contracts/aiModelRef'
+import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
 import { parseAgentEntry } from '../utils/reportAgentLog'
 import { parseSourceAnchor } from '../utils/sourceAnchor'
 import {
@@ -98,20 +100,25 @@ function recordSchemaError(where: string, error: unknown): void {
 }
 
 const resolvedSimulationId = ref(props.simulationId || null)
-const STORAGE_REPORT_ROUTE = 'agora.report.route'
+const STORAGE_REPORT_AI_REF = 'agora.report.aiModelRef'
+const STORAGE_REPORT_ROUTE_LEGACY = 'agora.report.route'
 
-function resolveInitialReportRoute(): StageLLMRoute | null {
-  const raw = localStorage.getItem(STORAGE_REPORT_ROUTE)
-  if (!raw) return null
+const adapter = useAiModelRefAdapter()
+
+function resolveInitialReportRoute(): AiModelRef | null {
   try {
-    const parsed = StageLLMRouteSchema.safeParse(JSON.parse(raw))
-    if (!parsed.success) return null
-    if (!parsed.data.provider_id || !parsed.data.model) return null
-    return parsed.data
-  } catch { return null }
+    const rawAiRef = localStorage.getItem(STORAGE_REPORT_AI_REF)
+    const rawLegacy = localStorage.getItem(STORAGE_REPORT_ROUTE_LEGACY)
+    const migrated = adapter.migrateStoredRoute(rawAiRef, rawLegacy)
+    if (!migrated) return null
+    const parsed = AiModelRefSchema.safeParse(migrated)
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
 }
 
-const reportRoute = ref<StageLLMRoute | null>(resolveInitialReportRoute())
+const reportRoute = ref<AiModelRef | null>(resolveInitialReportRoute())
 const isRegenerating = ref(false)
 
 const STORAGE_REPORT_PROFILE_ID = 'agora.report.llmProfileId'
@@ -122,8 +129,13 @@ watch(llmProfileId, (val) => {
 })
 
 watch(reportRoute, (val) => {
-  if (val?.provider_id && val?.model) localStorage.setItem(STORAGE_REPORT_ROUTE, JSON.stringify(val))
-  else localStorage.removeItem(STORAGE_REPORT_ROUTE)
+  if (val?.provider_connection_id && val?.model_id) {
+    localStorage.setItem(STORAGE_REPORT_AI_REF, JSON.stringify(val))
+    localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
+  } else {
+    localStorage.removeItem(STORAGE_REPORT_AI_REF)
+    localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
+  }
 }, { deep: true })
 
 const STORAGE_REPORT_MODE = 'agora.reportMode'
@@ -139,7 +151,7 @@ const reportMode = ref<ReportMode>(resolveStoredReportMode())
 watch(reportMode, (val) => { localStorage.setItem(STORAGE_REPORT_MODE, val) })
 
 function effectiveReportModel(): string | null {
-  const m = reportRoute.value?.model
+  const m = reportRoute.value?.model_id
   return m && m.trim() ? m.trim() : null
 }
 

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -63,6 +63,23 @@ vi.mock('../../composables/useIncrementalLogPolling', async () => {
   }
 })
 
+// Slice 7.6b: useAiModelRefAdapter mocken, weil Step4Report den Adapter
+// im setup() fuer resolveInitialReportRoute() braucht und der Adapter selbst
+// useLlmProvidersStore() aufruft. Pinia-Setup ist hier nicht noetig, weil
+// der eigentliche Routing-Workflow im Fokus steht — die Adapter-Migration
+// ist separat in ReportModelControls.spec.ts und useAiModelRefAdapter.spec.ts
+// getestet.
+const adapterMock = {
+  toStageLlmRoute: vi.fn(),
+  toAiModelRef: vi.fn(),
+  toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
+  migrateStoredRoute: vi.fn(() => null),
+  buildLookup: vi.fn(() => new Map()),
+}
+vi.mock('@/composables/useAiModelRefAdapter', () => ({
+  useAiModelRefAdapter: () => adapterMock,
+}))
+
 import { generateReport, getReport, getReportStatus, getReportEvidence } from '../../api/report'
 import { useIncrementalLogPolling } from '../../composables/useIncrementalLogPolling'
 import Step4Report from '../Step4Report.vue'

--- a/frontend/src/components/step4/ReportModelControls.vue
+++ b/frontend/src/components/step4/ReportModelControls.vue
@@ -2,29 +2,25 @@
 /**
  * ReportModelControls — Auswahl des LLM-Modells für die Report-Regenerierung.
  *
- * Slice A1 (2026-05-17): Migrationsendzustand. Nutzt projektweit denselben
- * ModelPicker wie das Workspace-Default-Dropdown unter `/settings/llm-providers`.
- * Provider+API-Key+Base-URL werden NICHT mehr inline gepflegt — Keys laufen
- * über den ``LlmProviderSecretsStore`` (Settings-Seite), das Backend zieht
- * sie via ``SecretResolver`` und ``build_route_subprocess_env`` automatisch.
- * Lokale Ollama-Modelle erscheinen, sobald ein Ollama- oder
- * OpenAI-kompatibler Provider mit passender ``base_url`` in
- * ``/settings/llm-providers`` hinterlegt ist.
+ * Slice 7.6b: Migration auf den kanonischen AiModelPicker (v4/forms/AiModelPicker).
+ * Der Vertrag ist jetzt AiModelRef (provider_connection_id + model_id). Der Parent
+ * (Step4Report) konvertiert via useAiModelRefAdapter, wenn er den llm_model-String
+ * an das Backend uebergibt (Run-Snapshot bleibt vertragsgleich).
  */
 import { useI18n } from 'vue-i18n'
 import Button from '@/components/v4/forms/Button.vue'
-import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
 
 const { t } = useI18n()
 
 defineProps<{
-  modelValue: StageLLMRoute | null
+  modelValue: AiModelRef | null
   isRegenerating: boolean
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: StageLLMRoute | null]
+  'update:modelValue': [value: AiModelRef | null]
   regenerate: []
 }>()
 </script>
@@ -33,8 +29,9 @@ const emit = defineEmits<{
   <div class="model-row">
     <div class="model-cell model-cell--picker">
       <label class="field-label">{{ t('step4.model.reportLabel') }}</label>
-      <ModelPicker
+      <AiModelPicker
         :model-value="modelValue"
+        mode="chat"
         :placeholder="t('step4.model.placeholder')"
         @update:model-value="(value) => emit('update:modelValue', value)"
       />

--- a/frontend/src/components/step4/__tests__/ReportModelControls.spec.ts
+++ b/frontend/src/components/step4/__tests__/ReportModelControls.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * ReportModelControls — minimaler Migrations-Spec fuer Slice 7.6b.
+ *
+ * Drei essenzielle Pruefungen:
+ *  - Picker-Anbindung: AiModelPicker gerendert, ModelPicker (v4 legacy) NICHT
+ *  - v-model: AiModelRef wird durchgereicht
+ *  - null-Pfad: emit('update:modelValue', null) funktioniert
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import ReportModelControls from '../ReportModelControls.vue'
+
+const aiPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template:
+    '<div data-testid="ai-model-picker-stub" '
+    + '@click="$emit(\'update:modelValue\', { provider_connection_id: \'conn-openai-1\', model_id: \'gpt-4o-mini\', source: \'explicit\' })">picker</div>',
+}
+const legacyModelPickerStub = {
+  name: 'ModelPicker',
+  props: ['modelValue', 'placeholder', 'disabled'],
+  emits: ['update:modelValue'],
+  template: '<select data-testid="legacy-model-picker-stub" disabled></select>',
+}
+const buttonStub = { name: 'Button', template: '<button><slot /></button>' }
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  fallbackLocale: 'de',
+  messages: { de: { step4: { model: { reportLabel: 'Report-Modell', placeholder: 'waehlen', regenerate: 'Neu' } } } },
+})
+
+function mountRMC(modelValue = null) {
+  return mount(ReportModelControls, {
+    props: { modelValue, isRegenerating: false },
+    global: {
+      plugins: [i18n],
+      stubs: { AiModelPicker: aiPickerStub, ModelPicker: legacyModelPickerStub, Button: buttonStub },
+    },
+  })
+}
+
+describe('ReportModelControls (Slice 7.6b, minimal)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('rendert AiModelPicker, nicht ModelPicker (v4 legacy)', async () => {
+    const w = mountRMC()
+    await flushPromises()
+    expect(w.findComponent(aiPickerStub).exists()).toBe(true)
+    expect(w.findComponent(legacyModelPickerStub).exists()).toBe(false)
+  })
+
+  it('reicht modelValue als AiModelRef an AiModelPicker durch', async () => {
+    const aiRef = { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' }
+    const w = mountRMC(aiRef)
+    await flushPromises()
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.props('modelValue')).toEqual(aiRef)
+  })
+
+  it('emit("update:modelValue", null) wird durchgereicht (null-Pfad)', async () => {
+    const w = mountRMC({ provider_connection_id: 'c', model_id: 'm', source: 'explicit' })
+    await flushPromises()
+    const picker = w.findComponent(aiPickerStub)
+    picker.vm.$emit('update:modelValue', null)
+    await flushPromises()
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted![emitted!.length - 1]).toEqual([null])
+  })
+})

--- a/frontend/src/components/step4/__tests__/ReportModelControls.spec.ts
+++ b/frontend/src/components/step4/__tests__/ReportModelControls.spec.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import ReportModelControls from '../ReportModelControls.vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
 
 const aiPickerStub = {
   name: 'AiModelPicker',
@@ -34,7 +35,7 @@ const i18n = createI18n({
   messages: { de: { step4: { model: { reportLabel: 'Report-Modell', placeholder: 'waehlen', regenerate: 'Neu' } } } },
 })
 
-function mountRMC(modelValue = null) {
+function mountRMC(modelValue: AiModelRef | null = null) {
   return mount(ReportModelControls, {
     props: { modelValue, isRegenerating: false },
     global: {
@@ -55,7 +56,7 @@ describe('ReportModelControls (Slice 7.6b, minimal)', () => {
   })
 
   it('reicht modelValue als AiModelRef an AiModelPicker durch', async () => {
-    const aiRef = { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' }
+    const aiRef = { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' as const }
     const w = mountRMC(aiRef)
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
@@ -63,7 +64,7 @@ describe('ReportModelControls (Slice 7.6b, minimal)', () => {
   })
 
   it('emit("update:modelValue", null) wird durchgereicht (null-Pfad)', async () => {
-    const w = mountRMC({ provider_connection_id: 'c', model_id: 'm', source: 'explicit' })
+    const w = mountRMC({ provider_connection_id: 'c', model_id: 'm', source: 'explicit' as const })
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
     picker.vm.$emit('update:modelValue', null)

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,11 +10,12 @@ import Kicker from '@/components/v4/data/Kicker.vue'
 import Select from '../components/ui/Select.vue'
 import AgoraGlyph from '../components/ui/AgoraGlyph.vue'
 import AgoraBrand from '../components/brand/AgoraBrand.vue'
-import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
+import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
 import { getAvailableModels } from '../api/simulation'
 import { STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
 import { setPendingUpload } from '../store/pendingUpload'
-import { StageLLMRouteSchema } from '../contracts/llmRoutingContract'
+import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { AiModelRefSchema } from '@/contracts/aiModelRef'
 
 const { t, tm } = useI18n()
 const router = useRouter()
@@ -37,33 +38,43 @@ const neo4jError = ref(null)
 const loadingModels = ref(true)
 const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
 
-// ---- LLM-Route (Slice A3: projektweiter ModelPicker, Slice A1/A2-Pattern). ----
-//   Persistenz: agora.home.route (JSON-serialized, Zod-validiert).
-//   Spiegelung auf STORAGE_MODEL für die bestehende Step2/MainView-Pipeline.
-const STORAGE_HOME_ROUTE = 'agora.home.route'
+// ---- LLM-Auswahl (Slice 7.6b: AiModelPicker + useAiModelRefAdapter). ----
+//   Persistenz: agora.home.aiModelRef (AiModelRef-JSON, Zod-validiert).
+//   Legacy-Key agora.home.route wird via adapter.migrateStoredRoute gelesen
+//   und in eine AiModelRef konvertiert (verlustfreier Roundtrip).
+//   Spiegelung auf STORAGE_MODEL für die bestehende Step2/MainView-Pipeline
+//   (Provider+Key resolved das Backend serverseitig via SecretResolver).
+const STORAGE_HOME_AI_REF = 'agora.home.aiModelRef'
+const STORAGE_HOME_ROUTE_LEGACY = 'agora.home.route'
 
-function loadStoredRoute() {
+const adapter = useAiModelRefAdapter()
+
+function loadStoredModel() {
   try {
-    const raw = localStorage.getItem(STORAGE_HOME_ROUTE)
-    if (!raw) return null
-    const parsed = StageLLMRouteSchema.safeParse(JSON.parse(raw))
-    if (!parsed.success) return null
-    if (!parsed.data.provider_id || !parsed.data.model) return null
-    return parsed.data
+    const rawAiRef = localStorage.getItem(STORAGE_HOME_AI_REF)
+    const rawLegacy = localStorage.getItem(STORAGE_HOME_ROUTE_LEGACY)
+    const migrated = adapter.migrateStoredRoute(rawAiRef, rawLegacy)
+    if (!migrated) return null
+    const parsed = AiModelRefSchema.safeParse(migrated)
+    return parsed.success ? parsed.data : null
   } catch (err) {
-    console.warn('[Home] agora.home.route lokal nicht parsbar — Auswahl zurückgesetzt:', err)
+    console.warn('[Home] lokal gespeicherte Modell-Auswahl nicht parsbar — Auswahl zurückgesetzt:', err)
     return null
   }
 }
 
-const selectedRoute = ref(loadStoredRoute())
+const selectedModel = ref(loadStoredModel())
 
-function onPickRoute(route) {
-  selectedRoute.value = route
-  if (route?.provider_id && route?.model) {
-    localStorage.setItem(STORAGE_HOME_ROUTE, JSON.stringify(route))
+function onPickModel(aiRef) {
+  selectedModel.value = aiRef
+  if (aiRef) {
+    localStorage.setItem(STORAGE_HOME_AI_REF, JSON.stringify(aiRef))
+    localStorage.setItem(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
+    localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
   } else {
-    localStorage.removeItem(STORAGE_HOME_ROUTE)
+    localStorage.removeItem(STORAGE_HOME_AI_REF)
+    localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
+    localStorage.setItem(STORAGE_MODEL, 'default')
   }
 }
 
@@ -99,11 +110,11 @@ const llmStatusLabel = computed(() => {
 })
 
 // Wenn der User unter /settings/llm-providers einen anderen Provider als Default
-// gewählt hat (selectedRoute !== null), gilt der Ollama-Reachability-Check nicht
+// gewählt hat (selectedModel !== null), gilt der Ollama-Reachability-Check nicht
 // mehr — der gewählte Provider übernimmt.
 const servicesReady = computed(() => (
   neo4jReachable.value &&
-  (!serverDefaultRequiresOllama.value || ollamaReachable.value || selectedRoute.value !== null)
+  (!serverDefaultRequiresOllama.value || ollamaReachable.value || selectedModel.value !== null)
 ))
 
 const canSubmit = computed(() => {
@@ -142,11 +153,10 @@ async function startSimulation() {
   loading.value = true
   errorMsg.value = ''
   try {
-    // Spiegele die ModelPicker-Auswahl auf STORAGE_MODEL, damit der bestehende
+    // Spiegele die AiModelPicker-Auswahl auf STORAGE_MODEL, damit der bestehende
     // MainView/Step2-Pfad (storedEffectiveModel → llm_model) sie aufgreift.
     // Provider+Key resolved das Backend serverseitig via SecretResolver (PR #499).
-    const routeModel = selectedRoute.value?.model
-    localStorage.setItem(STORAGE_MODEL, routeModel || 'default')
+    localStorage.setItem(STORAGE_MODEL, adapter.toStoredModelString(selectedModel.value))
     localStorage.setItem(STORAGE_LANG, language.value)
 
     setPendingUpload(files.value, simulationPrompt.value)
@@ -344,15 +354,16 @@ const differentiators = computed(() => tm('home.differentiators'))
         <div class="model-grid">
           <div>
             <label class="home-field-label">{{ t('step2.model.label') }}</label>
-            <ModelPicker
-              :model-value="selectedRoute"
+            <AiModelPicker
+              :model-value="selectedModel"
+              mode="chat"
               :placeholder="t('step2.model.placeholder')"
-              @update:model-value="onPickRoute"
+              @update:model-value="onPickModel"
             />
-            <p v-if="!selectedRoute && !loadingModels" class="console-meta" style="margin-top: 4px;">
+            <p v-if="!selectedModel && !loadingModels" class="console-meta" style="margin-top: 4px;">
               {{ t('step2.model.workspaceDefaultHint') }}
             </p>
-            <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !selectedRoute" class="console-warning" style="margin-top: 4px;">
+            <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !selectedModel" class="console-warning" style="margin-top: 4px;">
               {{ t('step2.model.noOllama') }}
             </p>
           </div>

--- a/frontend/src/views/__tests__/Home.spec.ts
+++ b/frontend/src/views/__tests__/Home.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Home — minimaler Migrations-Spec fuer Slice 7.6b.
+ *
+ * Drei essenzielle Pruefungen (User-Direktive "nur die noetigste"):
+ *  - Picker-Anbindung: AiModelPicker gerendert, ModelPicker (v4 legacy) NICHT
+ *  - LocalStorage-Migration: onPickModel schreibt agora.home.aiModelRef +
+ *    STORAGE_MODEL-Spiegel via adapter.toStoredModelString
+ *  - null-Pfad: bei null werden beide Keys entfernt + STORAGE_MODEL='default'
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createPinia, setActivePinia } from 'pinia'
+import Home from '../Home.vue'
+
+const aiPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template:
+    '<div data-testid="ai-model-picker-stub" '
+    + '@click="$emit(\'update:modelValue\', { provider_connection_id: \'conn-openai-1\', model_id: \'gpt-4o-mini\', source: \'explicit\' })">picker</div>',
+}
+
+const legacyModelPickerStub = {
+  name: 'ModelPicker',
+  props: ['modelValue', 'placeholder', 'disabled'],
+  emits: ['update:modelValue'],
+  template: '<select data-testid="legacy-model-picker-stub" disabled></select>',
+}
+
+const stubs = {
+  AiModelPicker: aiPickerStub,
+  ModelPicker: legacyModelPickerStub,
+  HistoryDatabase: { template: '<div />' },
+  AppFooter: { template: '<div />' },
+  Button: { template: '<button><slot /></button>' },
+  Badge: { template: '<span><slot /></span>' },
+  Kicker: { template: '<span><slot /></span>' },
+  Select: { template: '<select />' },
+  AgoraGlyph: { template: '<span />' },
+  AgoraBrand: { template: '<span />' },
+}
+
+const setPendingUploadMock = vi.fn()
+const routerPushMock = vi.fn()
+
+vi.mock('../api/simulation', () => ({
+  getAvailableModels: vi.fn().mockResolvedValue({
+    success: true,
+    data: { default_provider: 'ollama', ollama_reachable: true, neo4j_reachable: true, default_language: 'de' },
+  }),
+}))
+vi.mock('../store/pendingUpload', () => ({ setPendingUpload: setPendingUploadMock }))
+vi.mock('../composables/useEnvForm', () => ({ STORAGE_LANG: 'agora.lang', STORAGE_MODEL: 'agora.lastModel' }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: routerPushMock }) }))
+
+const adapterMock = {
+  toStageLlmRoute: vi.fn(),
+  toAiModelRef: vi.fn(),
+  toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
+  migrateStoredRoute: vi.fn(() => null),
+}
+vi.mock('@/composables/useAiModelRefAdapter', () => ({ useAiModelRefAdapter: () => adapterMock }))
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((k: string) => store[k] ?? null),
+    setItem: vi.fn((k: string, v: string) => { store[k] = v }),
+    removeItem: vi.fn((k: string) => { delete store[k] }),
+    clear: () => { store = {} },
+  }
+})()
+
+const makeI18n = () => createI18n({
+  legacy: false,
+  locale: 'de',
+  fallbackLocale: 'de',
+  messages: {
+    de: {
+      home: {
+        edition: '', location: '',
+        headline: { line1: '', line2: '', line3Italic: '' },
+        lead: '', tags: { engine: '', version: '' },
+        system: { kicker: '', title: '', desc: '' },
+        metrics: { free: { value: '', label: '' }, private: { value: '', label: '' }, openSource: { value: '', label: '' } },
+        workflow: { kicker: '' },
+        console: {
+          uploadKicker: '', uploadAccepted: '', uploadTitle: '', uploadHint: '',
+          promptKicker: '', engineLabel: '', promptPlaceholder: '',
+          startBtn: 'Start', initializing: 'Init', needFiles: '', needPrompt: '',
+        },
+        steps: [], differentiators: [],
+      },
+      history: { kicker: '' }, nav: { available: '' }, brand: { name: 'Agora', tagline: '' },
+      step2: {
+        model: { label: 'Modell', placeholder: '', workspaceDefaultHint: '', noOllama: '' },
+        language: { label: '', de: 'DE', en: 'EN', hint: '' },
+      },
+      common: { refresh: '' }, aiModelPicker: { placeholder: '' },
+    },
+  },
+})
+
+async function mountHome() {
+  localStorageMock.clear()
+  for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, adapterMock.toStoredModelString, adapterMock.migrateStoredRoute]) m.mockClear()
+  adapterMock.migrateStoredRoute.mockReturnValue(null)
+  vi.stubGlobal('localStorage', localStorageMock)
+  const pinia = createPinia(); setActivePinia(pinia)
+  return mount(Home, { global: { plugins: [makeI18n()], stubs } })
+}
+
+describe('Home (Slice 7.6b, minimal)', () => {
+  beforeEach(() => { installLocalStorageSafe() })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('rendert AiModelPicker, nicht ModelPicker (v4 legacy)', async () => {
+    const w = await mountHome()
+    await flushPromises()
+    expect(w.findComponent(aiPickerStub).exists()).toBe(true)
+    expect(w.findComponent(legacyModelPickerStub).exists()).toBe(false)
+  })
+
+  it('onPickModel: persistiert aiModelRef + STORAGE_MODEL-Spiegel via Adapter', async () => {
+    const w = await mountHome()
+    await flushPromises()
+    const picker = w.findComponent(aiPickerStub)
+    picker.vm.$emit('update:modelValue', {
+      provider_connection_id: 'conn-openai-1',
+      model_id: 'gpt-4o-mini',
+      source: 'explicit',
+    })
+    await flushPromises()
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'agora.home.aiModelRef',
+      expect.stringContaining('gpt-4o-mini'),
+    )
+    const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
+    expect(modelCall?.[1]).toBe('gpt-4o-mini')
+  })
+
+  it('onPickModel: bei null werden aiModelRef+Legacy-Key entfernt + STORAGE_MODEL="default"', async () => {
+    const w = await mountHome()
+    await flushPromises()
+    const picker = w.findComponent(aiPickerStub)
+    ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', null)
+    await flushPromises()
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.aiModelRef')
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.route')
+    const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
+    expect(modelCall?.[1]).toBe('default')
+  })
+})
+
+function installLocalStorageSafe() { vi.stubGlobal('localStorage', localStorageMock) }


### PR DESCRIPTION
## Summary

Slice 7.6b — Migration der verbliebenen StageLLMRoute-Consumer auf den kanonischen AiModelPicker (ADR-0009). Vorletzter Schritt vor 7.6c (StageLLMRoute-Deletion).

## Consumers migriert (2 Commits, atomic reverts)

### 1. Home.vue (refactor(home))
- ModelPicker (v4 legacy) → AiModelPicker (SSoT)
- LocalStorage: `agora.home.route` (StageLLMRoute-JSON) → `agora.home.aiModelRef` (AiModelRef-JSON, Zod-validiert)
- Legacy-Fallback via `adapter.migrateStoredRoute` (verlustfreier Roundtrip)
- STORAGE_MODEL-Spiegel via `adapter.toStoredModelString`
- servicesReady-Check auf `selectedModel` umgestellt
- Picker bekommt `mode='chat'` für konsistenten Capability-Filter
- Neue Spec: `Home.spec.ts` (3 essenzielle Migrationstests)

### 2. ReportModelControls + Step4Report (refactor(step4))
Beide Komponenten werden zusammen migriert (gekoppelt via v-model=`reportRoute`):

- **ReportModelControls**: ModelPicker → AiModelPicker, Vertrag jetzt AiModelRef
- **Step4Report**: 
  - Storage: `agora.report.route` → `agora.report.aiModelRef` mit Legacy-Fallback
  - `effectiveReportModel()`: `reportRoute.value?.model` → `.model_id` (Backend-Payload `llm_model` bleibt vertragsgleich)
- Neue Spec: `ReportModelControls.spec.ts` (3 essenzielle Migrationstests)
- Step4Report-Regression bleibt 24/24 grün (Adapter-Mock analog HeroNewRun-Pattern)

## Test-Coverage

| Spec | Tests | Status |
|---|---|---|
| ReportModelControls.spec.ts | 3/3 | grün |
| Step4Report.spec.ts | 24/24 | grün |
| HeroNewRun.spec.ts | 19/19 | grün |
| Home.spec.ts | 3/3 | grün |
| **Total** | **49/49** | grün |

Plus Type-Fix-Commit: `test(step4)` — expliziter `AiModelRef | null` Typ für mountRMC + `as const` auf source-Felder.

## Constraints / Acceptance

- [x] **StageLLMRoute NICHT gelöscht** — bleibt bis 7.6c am Leben
- [x] Keine Pydantic-Schema-Änderungen
- [x] toStageLlmRoute für Backend-Calls erhalten
- [x] LocalStorage-Migration verlustfrei (Legacy-Fallback via adapter.migrateStoredRoute)
- [x] HeroNewRun.spec.ts bleibt 19/19 grün (Regression-Schutz)
- [x] Targeted Tests (kein voller Suite-Lauf)
- [x] Pre-Push-Gate frontend grün (lint + typecheck + tests + Zod-Spiegel)

## Akzeptanz-Check

```bash
# StageLLMRoute soll nur noch in useAiModelRefAdapter + Migrationspfaden vorkommen
grep -r "StageLLMRoute" frontend/src/ | grep -v "useAiModelRefAdapter" | grep -v "migrate"
# → leer (oder nur Type-Re-Exports)
```

## Sub-Plan

docs/epics/onboarding-provider-unification/slice-7-subplan.md → 7.6b

## Folge-Slice

7.6c — StageLLMRoute-Typ-Deletion (separater PR nach 7.6b-Merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)