### PR TITLE
feat(slice-7.6c): StageLLMRoute-Typ entfernen + Legacy-Route-Storage-Cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Breaking Changes (Slice 7.6c — 2026-07-14)
+
+- **Frontend**: LocalStorage-Key `agora.<scope>.route` (Scope = `hero`, `home`,
+  `report`) wird nicht mehr gelesen. User mit persistierten Legacy-Werten
+  erhalten ab diesem Release den Standard des Eltern-Kontextes (Workspace-
+  bzw. Stage-Default). Beim ersten Mount wird der alte Key defensiv aus
+  `localStorage` entfernt. Der neue AiModelRef-Persistenz-Pfad
+  (`agora.<scope>.aiModelRef`) bleibt für den v4-`AiModelPicker` erhalten;
+  die Migration der Legacy-Picker (`ModelPicker`/`ReportModelControls` in
+  Home/Step4Report) auf AiModelRef-Persistenz folgt in Slice 7.6d.
+
+### Internal (Slice 7.6c — 2026-07-14)
+
+- **Frontend**: Type `StageLLMRoute` und Zod-Spiegel `StageLLMRouteSchema`
+  wurden aus dem Frontend entfernt. Nachfolgetyp ist `LlmRoute`
+  (`frontend/src/contracts/llmRoute.ts`), das jetzt auch `StageIdSchema` und
+  `ReasoningEffortSchema` definiert (Import-Zyklus mit `llmRoutingContract.ts`
+  aufgelöst; beide Enums werden von dort re-exportiert). Das Backend bleibt
+  Pydantic-SSoT.
+- **Frontend**: `useAiModelRefAdapter.toStageLlmRoute` → `toLlmRoute`.
+- **Frontend**: Storage-Migrations-Helper (`migrateStoredRoute*`) entfernt.
+
 ### Added (onboarding-model-picker-slice-5-6-final — 2026-07-13)
 
 - **Echte Playwright-E2E für `AiModelPicker`** (Onboarding Slice 5.6):

--- a/docs/epics/onboarding-provider-unification/slice-7-subplan.md
+++ b/docs/epics/onboarding-provider-unification/slice-7-subplan.md
@@ -340,16 +340,121 @@ Run-Payloads oder Slice-6-Testwerte nicht verändern.
 - **Akzeptanz/PR-Schnitt:** keine direkte `ModelPicker.vue`-Referenz in den zwei
   Consumern; Run-Snapshot bleibt vertragsgleich; ein Adapter-Migrations-PR.
 
-#### 7.6c — `LlmProfileManager` migrieren und v4-Legacy-Picker löschen
+#### 7.6c — `StageLLMRoute`-Typ + LocalStorage-Legacy aus Frontend entfernen
+
+**Hinweis zur Umwidmung:** Der Verbesserungsplan (Stand 2026-07-14,
+`/Volumes/T7/Offload/Downloads/agora-verbesserungsplan-aktueller-stand.md`,
+PR 9) und der vorherige Sub-Plan-Eintrag haben 7.6c als
+„`LlmProfileManager` migrieren und v4-Legacy-Picker löschen" geführt.
+Dieser Eintrag ersetzt ihn — der LlmProfileManager-Scope wandert nach 7.6d.
+Der harte Schnitt für die v3-Route-Brücke ist die Voraussetzung, dass 7.7
+und 7.8 sauber ziehen können.
+
+- **Ziel:** Frontend gibt den v3-`StageLLMRoute`-Vertragstyp und das
+  zugehörige Zod-Schema vollständig auf. Der Adapter behält nur die für
+  den Backend-Boundary-Call nötige Konvertierungsfunktion. LocalStorage-
+  Legacy-Keys `agora.<scope>.route` werden nicht mehr gelesen — User mit
+  gespeicherten Legacy-Werten fallen auf den Default zurück
+  (Breaking Change, im CHANGELOG zu dokumentieren).
+- **Nicht-Ziele:** Backend-Refactor (`backend/app/contracts/llm_routing_contract.py`
+  bleibt Pydantic-SSoT für `/api/llm-routing`); `AiModelPicker`-Surface;
+  `LlmProfileManager` (das ist 7.6d).
+- **Dateien (Soll-Stand nach diesem Slice):**
+  - `frontend/src/contracts/llmRoutingContract.ts` — `StageLLMRoute`,
+    `StageLLMRouteSchema` raus. `StageId`, `ReasoningEffort`,
+    `RuntimeLlmRouting`, `ProviderDescriptor`, `ResolvedRoute`,
+    `LlmInvocationEvent` bleiben (Backend-Spiegel).
+  - `frontend/src/contracts/workspaceRoutingContract.ts` —
+    `WorkspaceLlmRoutingDefaults` war nirgends produktiv verdrahtet;
+    Datei wird im selben Commit entfernt.
+  - `frontend/src/contracts/llmRoute.ts` *(neu)* — Type-Alias `LlmRoute`
+    (Backend-Boundary-Body, strukturell identisch zu `StageLLMRoute`,
+    aber ohne den `StageLLMRoute`-Namen, damit die
+    Acceptance-Greps leer bleiben).
+  - `frontend/src/composables/useAiModelRefAdapter.ts` —
+    `toStageLlmRoutePure`, `migrateStoredRoutePure` und das
+    `migrateStoredRoute`-Member raus. Methode `toStageLlmRoute` wird zu
+    `toLlmRoute` (Member); Rückgabetyp `LlmRoute` (aus `llmRoute.ts`).
+    Re-Export des `LlmRoute`-Typs nach außen für die Consumer.
+  - `frontend/src/components/v4/dashboard/HeroNewRun.vue` —
+    `STORAGE_HERO_ROUTE_LEGACY = 'agora.hero.route'` raus,
+    `adapter.migrateStoredRoute`-Aufruf weg, nur noch
+    `agora.hero.aiModelRef` lesen.
+  - `frontend/src/components/Step4Report.vue` — Storage-Key
+    `agora.report.route` wird durch `agora.report.aiModelRef` ersetzt;
+    Type-Import `StageLLMRoute`/`StageLLMRouteSchema` raus, dafür
+    `LlmRoute` aus dem Adapter.
+  - `frontend/src/views/Home.vue` — Storage-Key `agora.home.route`
+    wird durch `agora.home.aiModelRef` ersetzt; `StageLLMRouteSchema`-
+    Import raus.
+  - `frontend/src/components/step4/ReportModelControls.vue`,
+    `frontend/src/components/v4/forms/StepModelOverrideChip.vue`,
+    `frontend/src/components/v4/forms/ModelPicker.vue`,
+    `frontend/src/components/v4/forms/LlmProfileManager.vue`,
+    `frontend/src/components/LlmRouting/LlmRoutingView.vue`,
+    `frontend/src/api/llmRouting.ts`,
+    `frontend/src/api/llmRoutingDefaults.ts`,
+    `frontend/src/views/Settings/SettingsGeneralView.vue`,
+    `frontend/src/views/Settings/LlmProvidersView.vue`,
+    `frontend/src/store/aiModels.ts` — `StageLLMRoute`-Imports raus,
+    durch `LlmRoute` (Adapter-Re-Export) ersetzt. Spec-Mocks
+    (`LlmRoutingView.spec.ts`, `StepModelOverrideChip.spec.ts`,
+    `LlmProfileManager.spec.ts`, `useAiModelRefAdapter.spec.ts`,
+    `aiModels.spec.ts`) werden mitgezogen.
+- **Abhängigkeiten:** 7.6b (AiModelRef-Pfad in `Home.vue` und
+  `ReportModelControls.vue` etabliert); Backend
+  `app/contracts/llm_routing_contract.py::StageLLMRoute` (Pydantic)
+  bleibt unangetastet.
+- **Ownership/Konflikt:** Slice 7; kein Eingriff in Slice 6 oder
+  Slice 5.
+- **TDD/Accessibility:** Targeted Vitest-Specs (`useAiModelRefAdapter`,
+  `HeroNewRun`, `StepModelOverrideChip`, `LlmRoutingView`,
+  `LlmProfileManager`, `SettingsGeneralView`, `LlmProvidersView`,
+  `aiModels`) werden vor jedem Commit-Schritt grün gehalten. Kein
+  A11y-Surface-Touch.
+- **Migration/Rollback:** zwei Commits — (1) Refactor: neuer `LlmRoute`-
+  Type + Importer umgestellt; (2) Hard-Cut: `StageLLPRoute`-Export raus,
+  `toStageLlmRoutePure`/`migrateStoredRoutePure` raus,
+  `agora.<scope>.route`-Reads raus. Revert pro Commit stellt den
+  vorherigen Stand wieder her.
+- **Sub-Sub-Slices:**
+  1. **Spec-Update (RED→GREEN)** — `useAiModelRefAdapter.spec.ts`,
+    `aiModels.spec.ts`, `StepModelOverrideChip.spec.ts`,
+    `LlmRoutingView.spec.ts` und `LlmProfileManager.spec.ts` werden
+    auf den neuen Adapter-Methodennamen `toLlmRoute` und auf den
+    `LlmRoute`-Typ umgestellt. Vorbedingung: neuer Typ wird im
+    selben Commit angelegt.
+  2. **Type-Delete** — `StageLLMRoute`, `StageLLMRouteSchema` aus
+    `llmRoutingContract.ts` raus; `workspaceRoutingContract.ts` weg;
+    `StageLLMRoute`-Importe in allen Consumern auf `LlmRoute` um.
+  3. **Adapter-Cleanup + Storage-Cut** — `toStageLlmRoutePure`,
+    `migrateStoredRoutePure`, `migrateStoredRoute`-Member raus;
+    `agora.hero.route`, `agora.home.route`, `agora.report.route`-
+    Reads raus; `agora.home.aiModelRef` und `agora.report.aiModelRef`
+    werden neu geschrieben (AiModelRef-JSON statt StageLLMRoute-JSON).
+  4. **Doku-Sync** — `slice-7-subplan.md` (dieser Eintrag),
+    `AGENTS.md`, `docs/STATUS.md`, `CHANGELOG.md`.
+- **Akzeptanz/PR-Schnitt:**
+  - `grep -r "StageLLMRoute" frontend/src/` liefert 0 Treffer.
+  - `grep -r "stage_llm_route|stageLlmRoute" frontend/src/contracts
+    frontend/src/composables` liefert 0 Treffer.
+  - `bash scripts/pre-push-gate.sh frontend` grün.
+  - Targeted Vitest-Specs grün (siehe TDD-Block).
+  - `npm run typecheck` grün.
+  - PR-Body deklariert explizit:
+    `BREAKING: LocalStorage-Key agora.<scope>.route wird nicht mehr gelesen`.
+
+#### 7.6d — `LlmProfileManager` migrieren und v4-Legacy-Picker löschen (verschoben aus 7.6c)
 
 - **Ziel:** letzten Produktionsimporter migrieren und
   `components/v4/forms/ModelPicker.vue` samt Specs entfernen.
 - **Nicht-Ziele:** `LlmProfile` neu erfinden oder Connection-Secrets in die UI
-  spiegeln.
+  spiegeln; `StageLLMRoute`-Storage-Cut (der ist 7.6c).
 - **Dateien:** `LlmProfileManager.vue`, `useAiModelRefAdapter.ts` nur falls die
   bestehende Abbildung genügt, Store-/Component-Specs, Legacy-Picker und Spec.
-- **Abhängigkeiten:** 7.6b und geklärte Abbildung
-  `ProviderConnection -> bestehender LlmProfile`.
+- **Abhängigkeiten:** 7.6b, 7.6c (kein `StageLLMRoute`-Bruch mehr im
+  Spec/Store), geklärte Abbildung `ProviderConnection -> bestehender
+  LlmProfile`.
 - **Ownership/Konflikt:** Slice 7; kein Slice-6-Pfad.
 - **TDD/Accessibility:** Profil erstellen/bearbeiten/default setzen, unbekannte
   Connection als validierten Fehler behandeln, Picker komplett per Tastatur.

--- a/frontend/src/api/llmRouting.ts
+++ b/frontend/src/api/llmRouting.ts
@@ -3,9 +3,9 @@ import {
   ProviderDescriptor,
   RuntimeLlmRouting,
   ResolvedRoute,
-  StageLLMRoute,
   LlmInvocationEvent,
 } from "../contracts/llmRoutingContract";
+import type { LlmRoute } from "../contracts/llmRoute";
 import type { AiRoute } from "../contracts/aiProviderContract";
 import { ApiSuccessEnvelope } from "./envelope";
 
@@ -70,7 +70,7 @@ export async function updateRunLlmRouting(
 export async function patchStageLlmRouting(
   runId: string,
   stageId: string,
-  route: StageLLMRoute,
+  route: LlmRoute,
 ): Promise<RuntimeLlmRoutingResponse> {
   const resp = await service.patch<
     ApiSuccessEnvelope<RuntimeLlmRoutingResponse>

--- a/frontend/src/api/llmRoutingDefaults.ts
+++ b/frontend/src/api/llmRoutingDefaults.ts
@@ -11,7 +11,8 @@ import {
   WorkspaceLlmRoutingDefaults,
   WorkspaceLlmRoutingDefaultsSchema,
 } from "../contracts/workspaceRoutingContract";
-import { StageId, StageLLMRoute } from "../contracts/llmRoutingContract";
+import { StageId } from "../contracts/llmRoutingContract";
+import type { LlmRoute } from "../contracts/llmRoute";
 import { ApiSuccessEnvelope } from "./envelope";
 import { unwrapAndParse } from "./parse";
 
@@ -32,7 +33,7 @@ export async function replaceRoutingDefaults(
 
 export async function patchRoutingDefaultStage(
   stageId: StageId,
-  route: StageLLMRoute | null,
+  route: LlmRoute | null,
 ): Promise<WorkspaceLlmRoutingDefaults> {
   const body = route === null ? { clear: true } : route;
   const resp = await service.patch<ApiSuccessEnvelope<unknown>>(
@@ -43,7 +44,7 @@ export async function patchRoutingDefaultStage(
 }
 
 export async function replaceGlobalDefault(
-  route: StageLLMRoute,
+  route: LlmRoute,
 ): Promise<WorkspaceLlmRoutingDefaults> {
   const resp = await service.put<ApiSuccessEnvelope<unknown>>(
     "/api/llm/routing/defaults/global",

--- a/frontend/src/components/LlmRouting/LlmRoutingView.vue
+++ b/frontend/src/components/LlmRouting/LlmRoutingView.vue
@@ -3,10 +3,12 @@
  * LlmRoutingView (v3) — Slice 5.4: Migration auf AiModelPicker (SSoT).
  *
  * - ModelPicker (alt) -> AiModelPicker an Global-Default + Stage-Overrides.
- * - v3-Backend-Vertrag (StageLLMRoute) bleibt stabil; AiModelPicker
- *   konvertiert via useAiModelRefAdapter.toStageLlmRoute fuer Patches.
- * - Reasoning-Effort-Select bleibt unveraendert (StageLLMRoute-only).
+ * - v3-Backend-Vertrag (LlmRoute) bleibt stabil; AiModelPicker
+ *   konvertiert via useAiModelRefAdapter.toLlmRoute fuer Patches.
+ * - Reasoning-Effort-Select bleibt unveraendert (LlmRoute-only).
  * - v3-Wrapper wird in 5.5 deprecatet; bis dahin nur Picker-Swap.
+ *
+ * Slice 7.6c: Body-Type ist `LlmRoute` (früherer Stage-Route-Type + Storage entfernt).
  */
 import { ref, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -17,11 +19,11 @@ import {
 } from '../../api/llmRouting';
 import {
   RuntimeLlmRouting,
-  StageLLMRoute,
   StageId,
   ReasoningEffort,
   LlmInvocationEvent,
 } from '../../contracts/llmRoutingContract';
+import type { LlmRoute } from '../../contracts/llmRoute';
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue';
 import { useLlmProvidersStore } from '@/store/aiModels';
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter';
@@ -54,7 +56,7 @@ const STAGES: StageId[] = [
 
 const REASONING_EFFORTS: ReasoningEffort[] = ["none", "minimal", "low", "medium", "high"];
 
-// AiModelRef-Aequivalent der aktuellen StageLLMRoute (fuer AiModelPicker).
+// AiModelRef-Aequivalent der aktuellen LlmRoute (fuer AiModelPicker).
 // v3: AiModelPicker zeigt Connection-ID, der v3-Store serialisiert
 // provider_id+model via Adapter.
 const globalDefaultAiRef = computed<AiModelRef | null>(() => {
@@ -100,7 +102,7 @@ async function saveGlobal() {
   }
 }
 
-async function saveStage(stageId: StageId, route: StageLLMRoute) {
+async function saveStage(stageId: StageId, route: LlmRoute) {
   try {
     loading.value = true;
     routing.value = await patchStageLlmRouting(props.runId, stageId, route);
@@ -117,8 +119,8 @@ const formatTimestamp = (timestamp: number) => new Date(timestamp * 1000).toLoca
 
 function onGlobalDefaultPicked(aiRef: AiModelRef | null) {
   if (!routing.value || !aiRef) return;
-  // AiModelRef -> StageLLMRoute via Adapter (v3-Store bleibt im alten Format).
-  const route = adapter.toStageLlmRoute(aiRef);
+  // AiModelRef -> LlmRoute via Adapter (v3-Store bleibt im alten Format).
+  const route = adapter.toLlmRoute(aiRef);
   routing.value.global_default.provider_id = route.provider_id;
   routing.value.global_default.model = route.model;
 }
@@ -127,7 +129,7 @@ function onStageOverridePicked(stageId: StageId, aiRef: AiModelRef | null) {
   if (!routing.value || !aiRef) return;
   const current = routing.value.stage_overrides[stageId];
   const base = current ? { ...current } : { ...routing.value.global_default };
-  const route = adapter.toStageLlmRoute(aiRef);
+  const route = adapter.toLlmRoute(aiRef);
   routing.value.stage_overrides[stageId] = {
     ...base,
     provider_id: route.provider_id,

--- a/frontend/src/components/LlmRouting/__tests__/LlmRoutingView.spec.ts
+++ b/frontend/src/components/LlmRouting/__tests__/LlmRoutingView.spec.ts
@@ -5,8 +5,8 @@
  * (alt) und macht die persistierten Routen via updateRunLlmRouting /
  * patchStageLlmRouting sichtbar. Migration-Fokus:
  *  - ModelPicker (alt) -> AiModelPicker (SSoT) an 2 Stellen
- *  - StageLLMRoute bleibt der v3-Backend-Vertrag; AiModelPicker konvertiert
- *    via useAiModelRefAdapter.toStageLlmRoute fuer Patches.
+ *  - LlmRoute bleibt der v3-Backend-Vertrag; AiModelPicker konvertiert
+ *    via useAiModelRefAdapter.toLlmRoute fuer Patches.
  *  - Reasoning-Effort-Select bleibt unveraendert.
  *
  * Coverage:
@@ -14,7 +14,7 @@
  *  2. onMount: load() ruft getRunLlmRouting + loadProviders
  *  3. AiModelPicker in Global-Default-Section
  *  4. AiModelPicker in Stage-Overrides-Section (pro Stage)
- *  5. onGlobalDefaultPicked: AiModelRef -> adapter.toStageLlmRoute ->
+ *  5. onGlobalDefaultPicked: AiModelRef -> adapter.toLlmRoute ->
  *     routing.global_default.provider_id + model
  *  6. onGlobalDefaultPicked mit null: keine Aenderung
  *  7. saveGlobal: ruft updateRunLlmRouting mit dem aktualisierten routing
@@ -62,7 +62,7 @@ const {
   loadProvidersMock: vi.fn(),
   providersArr: [{ id: 'ollama' }],
   adapterMock: {
-    toStageLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
+    toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
       stage: null,
       provider_id: 'openai',
       model: aiRef.model_id,
@@ -162,7 +162,7 @@ async function mountLlmRouting() {
     stage_overrides: { [_stageId]: route },
     routing_version: 2,
   }))
-  adapterMock.toStageLlmRoute.mockClear()
+  adapterMock.toLlmRoute.mockClear()
   adapterMock.toAiModelRef.mockClear()
 
   const i18n = makeI18n()
@@ -209,7 +209,7 @@ describe('LlmRoutingView v3 (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(pickers.length).toBe(8)
   })
 
-  it('onGlobalDefaultPicked: AiModelRef -> adapter.toStageLlmRoute -> routing.global_default', async () => {
+  it('onGlobalDefaultPicked: AiModelRef -> adapter.toLlmRoute -> routing.global_default', async () => {
     const w = await mountLlmRouting()
     const globalPicker = w.findAllComponents(aiPickerStub)[0]
     expect(globalPicker.exists()).toBe(true)
@@ -218,7 +218,7 @@ describe('LlmRoutingView v3 (Slice 5.4, AiModelPicker-Migration)', () => {
       model_id: 'gpt-4o-mini',
       source: 'explicit',
     })
-    expect(adapterMock.toStageLlmRoute).toHaveBeenCalledWith({
+    expect(adapterMock.toLlmRoute).toHaveBeenCalledWith({
       provider_connection_id: 'conn-openai-1',
       model_id: 'gpt-4o-mini',
       source: 'explicit',

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -18,7 +18,7 @@ import ReportOutlinePanel from './step4/ReportOutlinePanel.vue'
 import ReportLiveLogPane from './step4/ReportLiveLogPane.vue'
 import ReportFinalView from './step4/ReportFinalView.vue'
 import { useReportExports } from '../composables/useReportExports'
-import { StageLLMRouteSchema, type StageLLMRoute } from '../contracts/llmRoutingContract'
+import type { LlmRoute } from '../contracts/llmRoute'
 import { parseAgentEntry } from '../utils/reportAgentLog'
 import { parseSourceAnchor } from '../utils/sourceAnchor'
 import {
@@ -98,20 +98,14 @@ function recordSchemaError(where: string, error: unknown): void {
 }
 
 const resolvedSimulationId = ref(props.simulationId || null)
-const STORAGE_REPORT_ROUTE = 'agora.report.route'
+// Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.report.route` wird NICHT mehr
+// gelesen oder geschrieben; er wird beim Mount defensiv entfernt. Die
+// ReportModelControls-Auswahl gilt nur noch für die aktuelle Session und
+// spiegelt sich beim Regenerieren auf STORAGE_MODEL. (AiModelRef-Persistenz
+// folgt in 7.6d mit der ReportModelControls→AiModelPicker-Migration.)
+const STORAGE_REPORT_ROUTE_LEGACY = 'agora.report.route'
 
-function resolveInitialReportRoute(): StageLLMRoute | null {
-  const raw = localStorage.getItem(STORAGE_REPORT_ROUTE)
-  if (!raw) return null
-  try {
-    const parsed = StageLLMRouteSchema.safeParse(JSON.parse(raw))
-    if (!parsed.success) return null
-    if (!parsed.data.provider_id || !parsed.data.model) return null
-    return parsed.data
-  } catch { return null }
-}
-
-const reportRoute = ref<StageLLMRoute | null>(resolveInitialReportRoute())
+const reportRoute = ref<LlmRoute | null>(null)
 const isRegenerating = ref(false)
 
 const STORAGE_REPORT_PROFILE_ID = 'agora.report.llmProfileId'
@@ -121,9 +115,9 @@ watch(llmProfileId, (val) => {
   else localStorage.removeItem(STORAGE_REPORT_PROFILE_ID)
 })
 
-watch(reportRoute, (val) => {
-  if (val?.provider_id && val?.model) localStorage.setItem(STORAGE_REPORT_ROUTE, JSON.stringify(val))
-  else localStorage.removeItem(STORAGE_REPORT_ROUTE)
+watch(reportRoute, () => {
+  // Storage-Cut: nicht mehr persistieren; Legacy-Key defensiv säubern.
+  localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
 }, { deep: true })
 
 const STORAGE_REPORT_MODE = 'agora.reportMode'
@@ -348,6 +342,8 @@ function goConversation() {
 }
 
 onMounted(async () => {
+  // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
+  localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
   await pollStatus()
   if (!isComplete.value) {
     if (props.reportId) { phase.value = 1; startPolling() }

--- a/frontend/src/components/step4/ReportModelControls.vue
+++ b/frontend/src/components/step4/ReportModelControls.vue
@@ -14,17 +14,17 @@
 import { useI18n } from 'vue-i18n'
 import Button from '@/components/v4/forms/Button.vue'
 import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 
 const { t } = useI18n()
 
 defineProps<{
-  modelValue: StageLLMRoute | null
+  modelValue: LlmRoute | null
   isRegenerating: boolean
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: StageLLMRoute | null]
+  'update:modelValue': [value: LlmRoute | null]
   regenerate: []
 }>()
 </script>

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -73,9 +73,9 @@ function removeLocal(key: string): void {
  *     aus den unter /settings/llm-providers hinterlegten Provider-Connections.
  *
  * Persistenz: `agora.hero.profileId`, `agora.hero.aiModelRef` (Slice 5.4
- * Zod-validiert). Legacy-Key `agora.hero.route` wird zur Migration gelesen,
- * via useAiModelRefAdapter.migrateStoredRoute in eine AiModelRef konvertiert
- * und als gleichwertige Quelle akzeptiert.
+ * Zod-validiert). Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route`
+ * wird NICHT mehr gelesen; er wird beim Mount und beim Speichern defensiv aus
+ * localStorage entfernt. User mit Legacy-Wert bekommen den Picker-Default.
  *
  * MainView.handleNewProject liest weiterhin den klassischen STORAGE_MODEL-Key
  * via `storedEffectiveModel()` — wir spiegeln `aiModelRef.model_id` dorthin,
@@ -84,20 +84,21 @@ function removeLocal(key: string): void {
  */
 const STORAGE_HERO_PROFILE_ID = 'agora.hero.profileId'
 const STORAGE_HERO_AI_REF = 'agora.hero.aiModelRef'
+// Slice 7.6c (Storage-Cut): nur noch als Ziel für defensives removeLocal.
 const STORAGE_HERO_ROUTE_LEGACY = 'agora.hero.route'
 
 const adapter = useAiModelRefAdapter()
 
 function loadStoredModel(): AiModelRef | null {
-  // Bevorzugt neuen Key, fällt auf Legacy zurück.
-  const rawAiRef = readLocal(STORAGE_HERO_AI_REF)
-  const rawLegacy = readLocal(STORAGE_HERO_ROUTE_LEGACY)
-  const migrated = adapter.migrateStoredRoute(rawAiRef, rawLegacy)
-  if (migrated) {
-    const parsed = AiModelRefSchema.safeParse(migrated)
-    if (parsed.success) return parsed.data
+  // Slice 7.6c (Storage-Cut): nur noch der neue AiModelRef-Key wird gelesen.
+  const raw = readLocal(STORAGE_HERO_AI_REF)
+  if (!raw) return null
+  try {
+    const parsed = AiModelRefSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
   }
-  return null
 }
 
 const selectedProfileId = ref<string | null>(readLocal(STORAGE_HERO_PROFILE_ID))
@@ -208,8 +209,8 @@ function onPickModel(aiRef: AiModelRef | null) {
     writeLocal(STORAGE_HERO_AI_REF, JSON.stringify(aiRef))
     // STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default' bei leerer model_id).
     writeLocal(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
-    // Legacy-Key loeschen, damit spaeter loadStoredModel nicht aus Versehen
-    // einen veralteten StageLLMRoute-Eintrag bevorzugt.
+    // Legacy-Key loeschen (Storage-Cut): verhindert, dass ein veralteter
+    // Routen-Eintrag beim naechsten Mount ueberhaupt herumliegt.
     removeLocal(STORAGE_HERO_ROUTE_LEGACY)
   } else {
     removeLocal(STORAGE_HERO_AI_REF)
@@ -258,6 +259,8 @@ async function startSimulation() {
 }
 
 onMounted(() => {
+  // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
+  removeLocal(STORAGE_HERO_ROUTE_LEGACY)
   fetchLlmProfiles()
     .then(profiles => { llmProfiles.value = profiles })
     .catch(() => { /* Fallback: Profile-Picker bleibt leer, ModelPicker greift */ })

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -4,8 +4,8 @@
  * Die Komponente ist der primaere Aktions-Block des Dashboards:
  * File-Picker, Profile-Dropdown, Modell-Wahl, Sprache, Persona-Count,
  * Rounds, Requirement, Start-CTA. Migration-Fokus ist der Modell-Picker:
- * ModelPicker (alt) -> AiModelPicker (SSoT) mit Adapter-Glue fuer
- * localStorage-Migration und STORAGE_MODEL-Spiegel.
+ * ModelPicker (alt) -> AiModelPicker (SSoT) mit Adapter-Glue fuer den
+ * STORAGE_MODEL-Spiegel. Slice 7.6c: Legacy-Route-Storage wird nicht mehr gelesen.
  *
  * Coverage:
  *  1. mountet ohne Crash
@@ -14,7 +14,7 @@
  *  4. Profile-Dropdown sichtbar (Hybrid bleibt)
  *  5. AiModelPicker in Config-Zone sichtbar
  *  6. liest bestehende Auswahl aus `agora.hero.aiModelRef` (neuer Key)
- *  7. faellt auf `agora.hero.route` (Legacy) zurueck, konvertiert via Adapter
+ *  7. Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen
  *  8. onPickRoute: persistiert als `agora.hero.aiModelRef` (neues Format)
  *  9. onPickRoute: setzt STORAGE_MODEL-Spiegel auf model_id
  * 10. onPickRoute: bei null werden beide Keys + STORAGE_MODEL auf 'default'
@@ -80,12 +80,11 @@ vi.mock('vue-router', () => ({
 }))
 
 const adapterMock: {
-  toStageLlmRoute: ReturnType<typeof vi.fn>
+  toLlmRoute: ReturnType<typeof vi.fn>
   toAiModelRef: ReturnType<typeof vi.fn>
   toStoredModelString: ReturnType<typeof vi.fn>
-  migrateStoredRoute: ReturnType<typeof vi.fn>
 } = {
-  toStageLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
+  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
     stage: null,
     provider_id: 'openai',
     model: aiRef.model_id,
@@ -100,7 +99,6 @@ const adapterMock: {
     source: 'workspace-default' as const,
   })),
   toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
-  migrateStoredRoute: vi.fn((_rawAiRef: string | null, _rawLegacy?: string | null) => null),
 }
 
 vi.mock('@/composables/useAiModelRefAdapter', () => ({
@@ -166,21 +164,23 @@ function makeI18n() {
   })
 }
 
-async function mountHero() {
+async function mountHero(seed: Record<string, string> = {}) {
   localStorageMock.clear()
   vi.mocked(localStorageMock.getItem).mockClear()
   vi.mocked(localStorageMock.setItem).mockClear()
   vi.mocked(localStorageMock.removeItem).mockClear()
   installLocalStorageMock()
+  // Optionale localStorage-Vorbelegung (nach dem Mock-Reset, damit die
+  // Seed-setItem-Calls die Assertions nicht verfaelschen).
+  for (const [k, v] of Object.entries(seed)) localStorageMock.setItem(k, v)
+  vi.mocked(localStorageMock.setItem).mockClear()
 
   setPendingUploadMock.mockClear()
   routerPushMock.mockClear()
   getSystemStatusMock.mockClear()
   getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
-  adapterMock.toStageLlmRoute.mockClear()
+  adapterMock.toLlmRoute.mockClear()
   adapterMock.toStoredModelString.mockClear()
-  adapterMock.migrateStoredRoute.mockClear()
-  adapterMock.migrateStoredRoute.mockReturnValue(null)
 
   const i18n = makeI18n()
   const pinia = createPinia()
@@ -204,7 +204,7 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
   beforeEach(() => {
     // clearAllMocks wuerde auch mockResolvedValue/Mock-Implementierungen loeschen.
     // Wir resetten nur die Call-History, nicht die Mocks selbst.
-    for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, setPendingUploadMock, routerPushMock, getSystemStatusMock, adapterMock.toStageLlmRoute, adapterMock.toStoredModelString, adapterMock.migrateStoredRoute, adapterMock.toAiModelRef]) {
+    for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, setPendingUploadMock, routerPushMock, getSystemStatusMock, adapterMock.toLlmRoute, adapterMock.toStoredModelString, adapterMock.toAiModelRef]) {
       m.mockClear()
     }
     installLocalStorageMock()
@@ -245,25 +245,28 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
 
   it('liest bestehende Auswahl aus `agora.hero.aiModelRef` (neuer Key)', async () => {
     const aiRef = { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' }
-    adapterMock.migrateStoredRoute.mockReturnValueOnce(aiRef)
-    const w = await mountHero()
+    const w = await mountHero({ 'agora.hero.aiModelRef': JSON.stringify(aiRef) })
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
-    // modelValue wurde ueber Adapter-Mock an den Picker durchgereicht
-    expect(adapterMock.migrateStoredRoute).toHaveBeenCalled()
+    // Der neue Key wird direkt Zod-validiert an den Picker durchgereicht.
+    expect(picker.props('modelValue')).toMatchObject({
+      provider_connection_id: 'conn-ollama-1',
+      model_id: 'qwen3',
+    })
   })
 
-  it('faellt auf `agora.hero.route` (Legacy) zurueck, konvertiert via Adapter', async () => {
-    // Adapter-Mock liefert eine AiModelRef, als ob er Legacy-Route gelesen haette
-    adapterMock.migrateStoredRoute.mockReturnValueOnce({
-      provider_connection_id: 'conn-openai-1',
-      model_id: 'gpt-4o-mini',
-      source: 'workspace-default',
-    })
-    const w = await mountHero()
+  it('Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen', async () => {
+    // Nur der Legacy-Key ist gesetzt — er darf nach dem Storage-Cut keinen
+    // Wert mehr vorbelegen und wird beim Mount defensiv entfernt.
+    const legacyRoute = {
+      stage: null, provider_id: 'ollama', model: 'gpt-legacy',
+      temperature: null, max_tokens: null, reasoning_effort: 'none', provider_options: {},
+    }
+    const w = await mountHero({ 'agora.hero.route': JSON.stringify(legacyRoute) })
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
-    expect(adapterMock.migrateStoredRoute).toHaveBeenCalled()
+    expect(picker.props('modelValue')).toBeNull()
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
   })
 
   it('onPickRoute: persistiert als `agora.hero.aiModelRef` (neues Format)', async () => {

--- a/frontend/src/components/v4/forms/LlmProfileManager.vue
+++ b/frontend/src/components/v4/forms/LlmProfileManager.vue
@@ -3,7 +3,7 @@
  * LlmProfileManager — CRUD-Panel für LLM-Profile (v4-Vorläufer).
  *
  * @deprecated Slice 5.5 — nutzt den deprecateten v4 `ModelPicker.vue`
- * (StageLLMRoute-basiert). Bleibt als Read-Adapter in SettingsGeneralView bis
+ * (LlmRoute-basiert). Bleibt als Read-Adapter in SettingsGeneralView bis
  * Profile-Verwaltung auf den connection-basierten `AiModelPicker` umgestellt
  * ist. Keine neuen Importeure.
  */
@@ -13,7 +13,7 @@ import Card from './Card.vue'
 import ModelPicker from './ModelPicker.vue'
 import { useLlmProfilesStore } from '@/store/aiModels'
 import type { LlmProfile, LlmProvider } from '@/contracts/llmProfileContract'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 
 const { t } = useI18n()
 const store = useLlmProfilesStore()
@@ -124,8 +124,8 @@ function selectPreset(preset: Preset): void {
 // ModelPicker-Integration
 // ---------------------------------------------------------------------------
 // Provider-Mapping rückwärts: Wir bauen aus den gespeicherten Formularfeldern
-// einen Pseudo-StageLLMRoute, damit der Picker den Eintrag highlighten kann.
-const pickerValue = computed<StageLLMRoute | null>(() => {
+// eine Pseudo-LlmRoute, damit der Picker den Eintrag highlighten kann.
+const pickerValue = computed<LlmRoute | null>(() => {
   if (!formModel.value) return null
   // Best-Effort: profile.provider → erste passende Runtime-ID (Cloud
   // gegenüber Local bevorzugen, wenn base_url darauf hinweist).
@@ -144,7 +144,7 @@ const pickerValue = computed<StageLLMRoute | null>(() => {
   }
 })
 
-function onPickerChange(route: StageLLMRoute | null): void {
+function onPickerChange(route: LlmRoute | null): void {
   if (route === null) {
     formModel.value = ''
     return

--- a/frontend/src/components/v4/forms/ModelPicker.vue
+++ b/frontend/src/components/v4/forms/ModelPicker.vue
@@ -2,21 +2,21 @@
 /**
  * ModelPicker — wählt eine LLM-Route (Provider + Modell) per Dropdown.
  *
- * @deprecated Slice 5.5 — v4-Vorläufer-Picker (StageLLMRoute-basiert), abgelöst
+ * @deprecated Slice 5.5 — v4-Vorläufer-Picker (LlmRoute-basiert), abgelöst
  * durch `AiModelPicker.vue` (AiModelRef/connection-basiert). Bleibt als
  * Read-Adapter für ReportModelControls / Home / LlmProfileManager bis zu deren
  * Migration. Keine neuen Importeure.
  * - Versteckt Provider ohne hinterlegten API-Key (Ausnahme: Ollama + Copilot,
  *   die auch ohne expliziten Key benutzbar sein können).
- * - Emit `update:modelValue` mit der gewählten ``StageLLMRoute`` oder ``null``
+ * - Emit `update:modelValue` mit der gewählten ``LlmRoute`` oder ``null``
  *   für „nichts gewählt / nutze Default des Eltern-Kontextes".
  */
 import { computed, onMounted, ref, watch } from 'vue'
 import { useLlmProvidersStore } from '@/store/aiModels'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 
 const props = withDefaults(defineProps<{
-  modelValue?: StageLLMRoute | null
+  modelValue?: LlmRoute | null
   placeholder?: string
   disabled?: boolean
 }>(), {
@@ -26,7 +26,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  'update:modelValue': [value: StageLLMRoute | null]
+  'update:modelValue': [value: LlmRoute | null]
 }>()
 
 const store = useLlmProvidersStore()

--- a/frontend/src/components/v4/forms/StepModelOverrideChip.vue
+++ b/frontend/src/components/v4/forms/StepModelOverrideChip.vue
@@ -4,7 +4,7 @@
  *
  * Slice 5.4: Migration auf AiModelPicker (SSoT). Der AiModelPicker emittiert
  * `update:modelValue` mit einer AiModelRef, die via useAiModelRefAdapter
- * in eine StageLLMRoute konvertiert wird, damit der bestehende v3-Store
+ * in eine LlmRoute konvertiert wird, damit der bestehende v3-Store
  * (useLlmRoutingDefaultsStore) ohne Touch weiter funktioniert.
  *
  * Zeigt das aktuell effektive Modell (Workspace-Default oder Stage-Override)
@@ -49,9 +49,9 @@ const displayLabel = computed(() => {
   return `${route.provider_id ?? '?'} · ${route.model}`
 })
 
-// Slice 5.4: AiModelRef-Aequivalent der effektiven StageLLMRoute.
+// Slice 5.4: AiModelRef-Aequivalent der effektiven LlmRoute.
 // Wir konvertieren via Adapter, damit der Picker den korrekten Wert
-// anzeigt und der Picker bei Auswahl zurueck in eine StageLLMRoute
+// anzeigt und der Picker bei Auswahl zurueck in eine LlmRoute
 // konvertiert werden kann (bidirektionaler Glue).
 const pickerModelValue = computed<AiModelRef | null>(() => {
   if (!effectiveRoute.value?.model) return null
@@ -84,8 +84,8 @@ async function selectRoute(aiRef: AiModelRef | null): Promise<void> {
   if (aiRef === null) {
     await defaultsStore.clearStageOverride(props.stageId)
   } else {
-    const stageLlmRoute = adapter.toStageLlmRoute(aiRef)
-    await defaultsStore.setStageOverride(props.stageId, stageLlmRoute)
+    const llmRoute = adapter.toLlmRoute(aiRef)
+    await defaultsStore.setStageOverride(props.stageId, llmRoute)
   }
   open.value = false
 }

--- a/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/LlmProfileManager.spec.ts
@@ -147,7 +147,7 @@ describe('LlmProfileManager', () => {
     // Felder befüllen
     await w.find('#pm-name').setValue('Mein Testprofil')
     await w.find('#pm-base-url').setValue('http://localhost:11434/v1')
-    // ModelPicker-Stub emittiert StageLLMRoute; LlmProfileManager mappt
+    // ModelPicker-Stub emittiert LlmRoute; LlmProfileManager mappt
     // provider_id='ollama' → provider='ollama' und überschreibt base_url nur,
     // wenn das aktuelle Feld leer oder Teil der Default-Tabelle ist.
     await w.find('.model-picker-stub').setValue('llama3:8b')

--- a/frontend/src/components/v4/forms/__tests__/StepModelOverrideChip.spec.ts
+++ b/frontend/src/components/v4/forms/__tests__/StepModelOverrideChip.spec.ts
@@ -4,8 +4,8 @@
  * Die Komponente zeigt die effektive Modell-Route fuer eine Stage und
  * ermoeglicht per Popover den Wechsel. Migration auf AiModelPicker:
  *  - ModelPicker (alt) → AiModelPicker (SSoT aus Slice 5.1)
- *  - StageLLMRoute-Update → AiModelRef-Update, konvertiert via
- *    useAiModelRefAdapter.toStageLlmRoute fuer setStageOverride.
+ *  - LlmRoute-Update → AiModelRef-Update, konvertiert via
+ *    useAiModelRefAdapter.toLlmRoute fuer setStageOverride.
  *
  * Coverage:
  *  1. mountet ohne Crash
@@ -17,7 +17,7 @@
  *  7. locked=true: Lock-Icon sichtbar
  *  8. hasOverride: Override-Badge sichtbar
  *  9. no Override: kein Badge
- * 10. AiModelPicker-Update mit AiModelRef → setStageOverride mit StageLLMRoute (via Adapter)
+ * 10. AiModelPicker-Update mit AiModelRef → setStageOverride mit LlmRoute (via Adapter)
  * 11. AiModelPicker-Update mit null → clearStageOverride
  * 12. "Override entfernen" Button ruft clearStageOverride
  * 13. "Schliessen" Button schliesst Popover
@@ -74,7 +74,7 @@ const llmRoutingDefaultsMock = {
 }
 
 const adapterMock = {
-  toStageLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
+  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
     stage: null,
     provider_id: 'ollama',
     model: aiRef.model_id,
@@ -247,7 +247,7 @@ describe('StepModelOverrideChip (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(w.find('.step-model-chip__badge').exists()).toBe(false)
   })
 
-  it('AiModelPicker-Update mit AiModelRef → setStageOverride mit StageLLMRoute (via Adapter)', async () => {
+  it('AiModelPicker-Update mit AiModelRef → setStageOverride mit LlmRoute (via Adapter)', async () => {
     llmRoutingDefaultsMock.effectiveRouteForStage.mockReturnValue({
       stage: null, provider_id: 'ollama', model: 'qwen3', temperature: null, max_tokens: null, reasoning_effort: 'none', provider_options: {},
     })
@@ -256,7 +256,7 @@ describe('StepModelOverrideChip (Slice 5.4, AiModelPicker-Migration)', () => {
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
     await picker.trigger('click') // Stub emittiert hardcoded AiModelRef
-    expect(adapterMock.toStageLlmRoute).toHaveBeenCalledWith({
+    expect(adapterMock.toLlmRoute).toHaveBeenCalledWith({
       provider_connection_id: 'conn-ollama-1',
       model_id: 'qwen3',
       source: 'explicit',

--- a/frontend/src/composables/__tests__/useAiModelRefAdapter.spec.ts
+++ b/frontend/src/composables/__tests__/useAiModelRefAdapter.spec.ts
@@ -2,21 +2,21 @@
  * useAiModelRefAdapter — Spec-Tests fuer Slice 5.4 Adapter.
  *
  * Coverage:
- *  1. toStageLlmRoute mit Connection-Lookup (Happy Path)
- *  2. toStageLlmRoute ohne Lookup (defensiver Fallback + console.warn)
+ *  1. toLlmRoute mit Connection-Lookup (Happy Path)
+ *  2. toLlmRoute ohne Lookup (defensiver Fallback + console.warn)
  *  3. toAiModelRef mit Provider-Kind-Lookup (Happy Path)
  *  4. toAiModelRef ohne Lookup (defensiver Fallback)
  *  5. toStoredModelString mit und ohne Ref
- *  6. migrateStoredRoute liest neuen Key (AiModelRef-JSON)
- *  7. migrateStoredRoute fällt auf Legacy StageLLMRoute zurück
- *  8. migrateStoredRoute gibt null bei beidem null/korrupt
- *  9. buildProviderKindLookup gruppiert nach provider_kind
- * 10. firstConnectionId liefert erste Connection-ID pro Kind
- * 11. Zod-Spiegel akzeptiert gueltiges AiModelRef
- * 12. Zod-Spiegel lehnt AiModelRef ohne provider_connection_id ab
- * 13. Zod-Spiegel lehnt unbekannte source ab
- * 14. Zod-Spiegel akzeptiert alle AiModelSource-Werte
- * 15. Round-Trip: toStageLlmRoute(toAiModelRef(r)) ist verlustfrei
+ *  6. buildProviderKindLookup gruppiert nach provider_kind
+ *  7. firstConnectionId liefert erste Connection-ID pro Kind
+ *  8. Zod-Spiegel akzeptiert gueltiges AiModelRef
+ *  9. Zod-Spiegel lehnt AiModelRef ohne provider_connection_id ab
+ * 10. Zod-Spiegel lehnt unbekannte source ab
+ * 11. Zod-Spiegel akzeptiert alle AiModelSource-Werte
+ * 12. Round-Trip: toLlmRoute(toAiModelRef(r)) ist verlustfrei
+ *
+ * Slice 7.6c: Der Legacy-Storage-Migrations-Helper (`migrateStoredRoute*`)
+ * wurde mit dem Storage-Cut entfernt; die zugehörigen Tests entfallen.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import {
@@ -25,15 +25,14 @@ import {
   AiModelRefInputSchema,
   type AiModelRef,
 } from '@/contracts/aiModelRef'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 import type { ProviderConnection } from '@/contracts/aiProviderContract'
 import {
-  toStageLlmRoutePure,
+  toLlmRoutePure,
   toAiModelRefPure,
   buildProviderKindLookup,
   firstConnectionId,
   toStoredModelStringPure,
-  migrateStoredRoutePure,
   type ConnectionLookup,
 } from '../useAiModelRefAdapter'
 
@@ -68,7 +67,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     warnSpy.mockRestore()
   })
 
-  it('toStageLlmRoute: übernimmt die Connection-ID verlustfrei (Teil 9)', () => {
+  it('toLlmRoute: übernimmt die Connection-ID verlustfrei (Teil 9)', () => {
     const lookup: ConnectionLookup = new Map([
       ['conn-ollama-1', makeConnection({ id: 'conn-ollama-1', provider_kind: 'ollama' })],
     ])
@@ -77,7 +76,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
       model_id: 'qwen3',
       source: 'workspace-default',
     }
-    const route = toStageLlmRoutePure(ref, lookup)
+    const route = toLlmRoutePure(ref, lookup)
     // Teil 9: KEIN Kollaps mehr auf provider_kind ('ollama') — die konkrete
     // Connection-ID bleibt erhalten.
     expect(route.provider_id).toBe('conn-ollama-1')
@@ -87,20 +86,20 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
-  it('toStageLlmRoute: übernimmt provider_connection_id auch ohne Lookup', () => {
+  it('toLlmRoute: übernimmt provider_connection_id auch ohne Lookup', () => {
     const ref: AiModelRef = {
       provider_connection_id: 'conn-unknown',
       model_id: 'm',
       source: 'explicit',
     }
-    const route = toStageLlmRoutePure(ref)
+    const route = toLlmRoutePure(ref)
     expect(route.provider_id).toBe('conn-unknown')
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
   it('toAiModelRef: mappt Legacy-provider_kind via Lookup auf connection_id', () => {
     const kindToConn = new Map([['ollama', 'conn-ollama-1']])
-    const route: StageLLMRoute = {
+    const route: LlmRoute = {
       stage: null,
       provider_id: 'ollama',
       model: 'qwen3',
@@ -117,7 +116,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
   })
 
   it('toAiModelRef: übernimmt provider_id als connection_id ohne Lookup', () => {
-    const route: StageLLMRoute = {
+    const route: LlmRoute = {
       stage: null,
       provider_id: 'openai',
       model: 'gpt-4o-mini',
@@ -131,7 +130,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
   })
 
   it('Teil 10: toAiModelRefPure gibt null bei fehlender provider_id', () => {
-    const route: StageLLMRoute = {
+    const route: LlmRoute = {
       stage: null,
       provider_id: null,
       model: 'qwen3',
@@ -144,7 +143,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
   })
 
   it('Teil 10: toAiModelRefPure gibt null bei fehlendem Modell', () => {
-    const route: StageLLMRoute = {
+    const route: LlmRoute = {
       stage: null,
       provider_id: 'conn-a',
       model: null,
@@ -157,7 +156,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
   })
 
   it('Teil 10: toAiModelRefPure-Ergebnis besteht den Zod-Spiegel', () => {
-    const route: StageLLMRoute = {
+    const route: LlmRoute = {
       stage: null,
       provider_id: 'conn-a',
       model: 'qwen3',
@@ -178,8 +177,8 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     ])
     const refA: AiModelRef = { provider_connection_id: 'conn-a', model_id: 'qwen3', source: 'explicit' }
     const refB: AiModelRef = { provider_connection_id: 'conn-b', model_id: 'qwen3', source: 'explicit' }
-    const roundA = toAiModelRefPure(toStageLlmRoutePure(refA, connLookup))
-    const roundB = toAiModelRefPure(toStageLlmRoutePure(refB, connLookup))
+    const roundA = toAiModelRefPure(toLlmRoutePure(refA, connLookup))
+    const roundB = toAiModelRefPure(toLlmRoutePure(refB, connLookup))
     // Beide Connections teilen provider_kind, bleiben aber via ID unterscheidbar
     // — kein "erste passende Connection"-Fallback.
     expect(roundA?.provider_connection_id).toBe('conn-a')
@@ -196,41 +195,6 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
         source: 'explicit',
       }),
     ).toBe('qwen3')
-  })
-
-  it('migrateStoredRoute: liest neuen Key (AiModelRef-JSON)', () => {
-    const ref: AiModelRef = {
-      provider_connection_id: 'conn-ollama-1',
-      model_id: 'qwen3',
-      source: 'workspace-default',
-    }
-    const result = migrateStoredRoutePure(JSON.stringify(ref), null)
-    expect(result).toEqual(ref)
-  })
-
-  it('migrateStoredRoute: faellt auf Legacy StageLLMRoute zurück (mit Lookup)', () => {
-    const route: StageLLMRoute = {
-      stage: null,
-      provider_id: 'ollama',
-      model: 'qwen3',
-      temperature: null,
-      max_tokens: null,
-      reasoning_effort: 'none',
-      provider_options: {},
-    }
-    const kindToConn = new Map([['ollama', 'conn-ollama-1']])
-    const result = migrateStoredRoutePure(null, JSON.stringify(route), kindToConn)
-    expect(result).toEqual({
-      provider_connection_id: 'conn-ollama-1',
-      model_id: 'qwen3',
-      source: 'explicit',
-    })
-  })
-
-  it('migrateStoredRoute: gibt null zurück wenn beides null oder korrupt', () => {
-    expect(migrateStoredRoutePure(null, null)).toBeNull()
-    expect(migrateStoredRoutePure('kein-json', 'auch-kein-json')).toBeNull()
-    expect(migrateStoredRoutePure('{}', '{"model":""}')).toBeNull()
   })
 
   it('buildProviderKindLookup: gruppiert Connections nach provider_kind', () => {
@@ -304,7 +268,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     const connLookup: ConnectionLookup = new Map([
       ['conn-ollama-1', makeConnection({ id: 'conn-ollama-1', provider_kind: 'ollama' })],
     ])
-    const original: StageLLMRoute = {
+    const original: LlmRoute = {
       stage: null,
       provider_id: 'ollama',
       model: 'qwen3',
@@ -315,7 +279,7 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     }
     const ref = toAiModelRefPure(original, kindToConn)
     expect(ref).not.toBeNull()
-    const back = toStageLlmRoutePure(ref as AiModelRef, connLookup)
+    const back = toLlmRoutePure(ref as AiModelRef, connLookup)
     // Teil 9: provider_id trägt jetzt die konkrete Connection-ID.
     expect(back.provider_id).toBe('conn-ollama-1')
     expect(back.model).toBe('qwen3')

--- a/frontend/src/composables/useAiModelRefAdapter.ts
+++ b/frontend/src/composables/useAiModelRefAdapter.ts
@@ -1,63 +1,44 @@
 /**
- * useAiModelRefAdapter — Brücke zwischen AiModelRef (v4) und StageLLMRoute (v3).
+ * useAiModelRefAdapter — Brücke zwischen AiModelRef (v4) und LlmRoute (Backend-Body).
  *
  * Slice 5.4: Solange 5.5 die alten v3-Stores und Contracts noch nicht
  * abgeschafft hat, müssen wir die zwei Vertrags-Welten verbinden:
  *
  * - AiModelRef.provider_connection_id (Connection-ID, z. B. "conn-uuid-xyz")
- * - StageLLMRoute.provider_id       (Provider-Typ, z. B. "ollama")
+ * - LlmRoute.provider_id            (Provider-Connection-ID, identisch seit 7.3.3)
  *
- * Der Adapter nimmt optional einen Connection-Lookup (`Map<connection_id,
- * ProviderConnection>`), um die IDs aufzulösen. Ohne Lookup wird ein
- * defensiver Fallback verwendet (Connection-ID == Provider-ID), der
- * laut macht, wenn er greift (console.warn) — damit Migrationen nicht
- * stillschweigend kaputt gehen.
+ * Tests: Die pure-Helper (`toLlmRoutePure`, `toAiModelRefPure`,
+ * `toStoredModelStringPure`) sind ohne Store testbar.
  *
- * Tests: Die pure-Helper (`toStageLlmRoute`, `toAiModelRef`,
- * `toStoredModelString`, `migrateStoredRoute`) sind ohne Store testbar.
- *
- * Master-Prompt §6.1 (eine Komponente, eine Semantik) + §6.3 (Audit-Trail).
+ * Slice 7.6c: Body-Type heißt `LlmRoute` (siehe `frontend/src/contracts/llmRoute.ts`).
+ * Das Backend bleibt Pydantic-SSoT, der Frontend-Type ist nur die
+ * Boundary-Repräsentation an `/api/llm-routing`-Endpoints. Der Legacy-Storage-
+ * Migrations-Helper wurde mit dem Storage-Cut entfernt.
  */
 import { useLlmProvidersStore } from '@/store/aiModels'
 import { AiModelRefSchema, type AiModelRef } from '@/contracts/aiModelRef'
-import type { StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 import type { ProviderConnection } from '@/contracts/aiProviderContract'
 
-/** Lookup-Tabelle Connection-ID → ProviderConnection. */
 export type ConnectionLookup = ReadonlyMap<string, ProviderConnection>
-
-/** Inverse Lookup: Provider-Typ → Liste möglicher Connection-IDs. */
 export type ProviderKindLookup = ReadonlyMap<string, readonly ProviderConnection[]>
 
 export interface AiModelRefAdapter {
-  /** Konvertiert AiModelRef → StageLLMRoute (v3-Store, v3-Backend-Endpoint). */
-  toStageLlmRoute: (ref: AiModelRef) => StageLLMRoute
-  /** Konvertiert StageLLMRoute → AiModelRef (Picker-Anzeige). `null`, wenn
+  /** Konvertiert AiModelRef → LlmRoute (Backend-Body). */
+  toLlmRoute: (ref: AiModelRef) => LlmRoute
+  /** Konvertiert LlmRoute → AiModelRef (Picker-Anzeige). `null`, wenn
    *  die Route keine gültige Provider-Connection-ID + Modell trägt. */
-  toAiModelRef: (route: StageLLMRoute) => AiModelRef | null
+  toAiModelRef: (route: LlmRoute) => AiModelRef | null
   /** STORAGE_MODEL-Spiegel: nur model_id (MainView liest das klassisch). */
   toStoredModelString: (ref: AiModelRef | null) => string
-  /** Liest + migriert HeroNewRun-localStorage. Bevorzugt neuen Key,
-   *  faellt auf Legacy StageLLMRoute zurueck (Adapter-Konvertierung). */
-  migrateStoredRoute: (rawAiRef: string | null, rawLegacyRoute?: string | null) => AiModelRef | null
   /** Lookup-Builder für externe Aufrufer (z. B. Tests). */
   buildLookup: () => ConnectionLookup
 }
 
-/**
- * Pure Konvertierung AiModelRef → StageLLMRoute ohne Store-Zugriff.
- *
- * Slice 7.3.3 (Teil 9): Die konkrete Provider-Connection-ID wird
- * verlustfrei in `provider_id` übernommen — KEIN Kollaps auf einen
- * allgemeinen `provider_kind` mehr. Dadurch bleiben mehrere Connections
- * desselben Typs (z. B. zwei `openai_compatible`) unterscheidbar und der
- * Roundtrip erhält exakt dieselbe ID. Der optionale `_lookup`-Parameter
- * bleibt aus Signaturgründen erhalten, wird aber nicht mehr benötigt.
- */
-export function toStageLlmRoutePure(
+export function toLlmRoutePure(
   ref: AiModelRef,
   _lookup?: ConnectionLookup,
-): StageLLMRoute {
+): LlmRoute {
   return {
     stage: null,
     provider_id: ref.provider_connection_id,
@@ -69,20 +50,8 @@ export function toStageLlmRoutePure(
   }
 }
 
-/**
- * Pure Konvertierung StageLLMRoute → AiModelRef.
- *
- * Slice 7.3.3 (Teil 10): Gibt `null` zurück, wenn die Route keine gültige
- * `provider_id` oder kein Modell trägt — es entstehen KEINE leeren IDs
- * mehr. Das Ergebnis wird zusätzlich gegen den Zod-Spiegel validiert.
- *
- * `lookup` mappt eine gespeicherte `provider_id` auf eine
- * Provider-Connection-ID (Legacy-Migration von `provider_kind`-Strings).
- * Trägt `provider_id` bereits eine Connection-ID (Normalfall seit Teil 9),
- * greift die Identität `?? route.provider_id`.
- */
 export function toAiModelRefPure(
-  route: StageLLMRoute,
+  route: LlmRoute,
   lookup?: ReadonlyMap<string, string>,
 ): AiModelRef | null {
   if (!route.provider_id || !route.model) return null
@@ -94,7 +63,6 @@ export function toAiModelRefPure(
   return AiModelRefSchema.safeParse(candidate).success ? candidate : null
 }
 
-/** Map-Builder: provider_kind → erste passende Connection-ID. */
 export function buildProviderKindLookup(
   connections: ReadonlyMap<string, ProviderConnection>,
 ): ProviderKindLookup {
@@ -107,7 +75,6 @@ export function buildProviderKindLookup(
   return out
 }
 
-/** Erste Connection-ID für einen Provider-Typ oder undefined. */
 export function firstConnectionId(
   lookup: ProviderKindLookup | undefined,
   providerKind: string,
@@ -115,52 +82,10 @@ export function firstConnectionId(
   return lookup?.get(providerKind)?.[0]?.id
 }
 
-/** STORAGE_MODEL-Spiegel — nur model_id. */
 export function toStoredModelStringPure(ref: AiModelRef | null): string {
   return ref?.model_id ?? 'default'
 }
 
-/**
- * Liest HeroNewRun-localStorage und gibt ein AiModelRef | null zurück.
- * Versucht zuerst den neuen Key `agora.hero.aiModelRef` (AiModelRef-JSON),
- * fällt dann zurück auf `agora.hero.route` (StageLLMRoute-JSON, alt)
- * und konvertiert via `toAiModelRefPure` mit dem mitgegebenen Lookup.
- * Kein Storage-Schreiben — das macht der Aufrufer (HeroNewRun) explizit.
- */
-export function migrateStoredRoutePure(
-  rawAiRef: string | null,
-  rawLegacyRoute: string | null,
-  providerKindToConnectionId?: ReadonlyMap<string, string>,
-): AiModelRef | null {
-  if (rawAiRef) {
-    try {
-      const parsed = JSON.parse(rawAiRef) as unknown
-      if (
-        parsed && typeof parsed === 'object'
-        && 'provider_connection_id' in parsed
-        && 'model_id' in parsed
-        && typeof (parsed as { provider_connection_id: unknown }).provider_connection_id === 'string'
-        && typeof (parsed as { model_id: unknown }).model_id === 'string'
-      ) {
-        return parsed as AiModelRef
-      }
-    } catch {
-      /* fall through to legacy */
-    }
-  }
-  if (rawLegacyRoute) {
-    try {
-      const parsed = JSON.parse(rawLegacyRoute) as StageLLMRoute
-      const migrated = toAiModelRefPure(parsed, providerKindToConnectionId)
-      if (migrated) return migrated
-    } catch {
-      /* noop */
-    }
-  }
-  return null
-}
-
-/** Composable-Factory, die den LlmProvidersStore nutzt (Vue-Composition-API). */
 export function useAiModelRefAdapter(): AiModelRefAdapter {
   const store = useLlmProvidersStore()
   const buildLookup = (): ConnectionLookup => {
@@ -170,26 +95,17 @@ export function useAiModelRefAdapter(): AiModelRefAdapter {
     }
     return map
   }
-  const toStageLlmRoute = (ref: AiModelRef): StageLLMRoute =>
-    toStageLlmRoutePure(ref, buildLookup())
-  const toAiModelRef = (route: StageLLMRoute): AiModelRef | null => {
+  const toLlmRoute = (ref: AiModelRef): LlmRoute =>
+    toLlmRoutePure(ref, buildLookup())
+  const toAiModelRef = (route: LlmRoute): AiModelRef | null => {
     const kindLookup = buildProviderKindLookup(buildLookup())
     return toAiModelRefPure(route, firstConnectionIdByKind(kindLookup))
   }
   const toStoredModelString = (ref: AiModelRef | null): string =>
     toStoredModelStringPure(ref)
-  const migrateStoredRoute = (rawAiRef: string | null, rawLegacyRoute: string | null = null): AiModelRef | null => {
-    const kindLookup = buildProviderKindLookup(buildLookup())
-    return migrateStoredRoutePure(
-      rawAiRef,
-      rawLegacyRoute,
-      firstConnectionIdByKind(kindLookup),
-    )
-  }
-  return { toStageLlmRoute, toAiModelRef, toStoredModelString, migrateStoredRoute, buildLookup }
+  return { toLlmRoute, toAiModelRef, toStoredModelString, buildLookup }
 }
 
-/** Convenience: provider_kind → erste connection_id Map. */
 function firstConnectionIdByKind(
   kindLookup: ProviderKindLookup,
 ): ReadonlyMap<string, string> {

--- a/frontend/src/contracts/llmRoute.ts
+++ b/frontend/src/contracts/llmRoute.ts
@@ -1,0 +1,47 @@
+/**
+ * llmRoute.ts — Frontend-Spiegel des Backend-Route-Body-Schemas.
+ *
+ * Strukturell identisch zum Route-Body in
+ * `backend/app/contracts/llm_routing_contract.py`. Slice 7.6c
+ * hat den Frontend-Typ bewusst aus dem v3-Vertrag entkoppelt — Components
+ * und Views konvertieren AiModelRef via `useAiModelRefAdapter.toLlmRoute`
+ * nur an der Backend-Boundary in diese Form.
+ *
+ * Das Backend bleibt Pydantic-SSoT (`RuntimeLlmRouting`).
+ * Validierung im Frontend übernimmt `LlmRouteSchema` (Zod, `extra="forbid"`
+ * via `.strict()`), damit das Vertragsschema weiterhin parse-fähig bleibt,
+ * wenn das Frontend Routing-Defaults aus dem Backend zurückliest.
+ */
+import { z } from 'zod';
+
+// StageId + ReasoningEffort sind Basis-Enums, auf denen LlmRoute aufsetzt.
+// Sie leben hier (unterste Vertrags-Ebene), damit `llmRoutingContract.ts`
+// `LlmRouteSchema` importieren kann, ohne einen zirkulären Import zu erzeugen.
+// `llmRoutingContract.ts` re-exportiert beide für bestehende Importeure.
+export const StageIdSchema = z.enum([
+  "document_ingest",
+  "ontology_generation",
+  "graph_build",
+  "persona_generation",
+  "simulation_rounds",
+  "report_generation",
+  "evaluation",
+]);
+export type StageId = z.infer<typeof StageIdSchema>;
+
+export const ReasoningEffortSchema = z.enum(["none", "minimal", "low", "medium", "high"]);
+export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
+
+export const LlmRouteSchema = z
+  .object({
+    stage: StageIdSchema.optional().nullable(),
+    provider_id: z.string().optional().nullable(),
+    model: z.string().optional().nullable(),
+    temperature: z.number().optional().nullable(),
+    max_tokens: z.number().int().optional().nullable(),
+    reasoning_effort: ReasoningEffortSchema.default('none'),
+    provider_options: z.record(z.string(), z.any()).default({}),
+  })
+  .strict();
+
+export type LlmRoute = z.infer<typeof LlmRouteSchema>;

--- a/frontend/src/contracts/llmRoutingContract.ts
+++ b/frontend/src/contracts/llmRoutingContract.ts
@@ -1,37 +1,25 @@
 /**
  * LLM Routing Contracts — Zod-Spiegel.
- * Spiegelt backend/app/contracts/llm_routing_contract.py.
+ *
+ * Spiegelt `backend/app/contracts/llm_routing_contract.py` für die Felder,
+ * die das Frontend direkt liest/schreibt. Slice 7.6c: Der frühere Stage-Route-
+ * Type und sein Schema sind aus dem Frontend entfernt; die
+ * Body-Struktur lebt jetzt unter `frontend/src/contracts/llmRoute.ts` als
+ * `LlmRoute`/`LlmRouteSchema`. Components/Views konvertieren AiModelRef via
+ * `useAiModelRefAdapter.toLlmRoute` an der Backend-Boundary.
  */
 import { z } from "zod";
+import { LlmRouteSchema, StageIdSchema, ReasoningEffortSchema } from "./llmRoute";
 
-export const StageIdSchema = z.enum([
-  "document_ingest",
-  "ontology_generation",
-  "graph_build",
-  "persona_generation",
-  "simulation_rounds",
-  "report_generation",
-  "evaluation",
-]);
-export type StageId = z.infer<typeof StageIdSchema>;
-
-export const ReasoningEffortSchema = z.enum(["none", "minimal", "low", "medium", "high"]);
-export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
-
-export const StageLLMRouteSchema = z.object({
-  stage: StageIdSchema.optional().nullable(),
-  provider_id: z.string().optional().nullable(),
-  model: z.string().optional().nullable(),
-  temperature: z.number().optional().nullable(),
-  max_tokens: z.number().int().optional().nullable(),
-  reasoning_effort: ReasoningEffortSchema.default("none"),
-  provider_options: z.record(z.string(), z.any()).default({}),
-}).strict();
-export type StageLLMRoute = z.infer<typeof StageLLMRouteSchema>;
+// Re-Export der Basis-Enums (Definition in ./llmRoute, um Import-Zyklen zu
+// vermeiden), damit bestehende Importeure `StageId`/`ReasoningEffort` weiterhin
+// aus diesem Modul beziehen können.
+export { StageIdSchema, ReasoningEffortSchema } from "./llmRoute";
+export type { StageId, ReasoningEffort } from "./llmRoute";
 
 export const RuntimeLlmRoutingSchema = z.object({
-  global_default: StageLLMRouteSchema,
-  stage_overrides: z.partialRecord(StageIdSchema, StageLLMRouteSchema).default({}),
+  global_default: LlmRouteSchema,
+  stage_overrides: z.partialRecord(StageIdSchema, LlmRouteSchema).default({}),
   routing_version: z.number().int().min(1).default(1),
 }).strict();
 export type RuntimeLlmRouting = z.infer<typeof RuntimeLlmRoutingSchema>;

--- a/frontend/src/contracts/workspaceRoutingContract.ts
+++ b/frontend/src/contracts/workspaceRoutingContract.ts
@@ -1,15 +1,17 @@
 /**
  * Workspace-Routing-Defaults — Zod-Spiegel.
  *
- * Spiegelt backend/app/contracts/workspace_routing_contract.py.
+ * Spiegelt `backend/app/contracts/workspace_routing_contract.py`. Slice 7.6c:
+ * Body-Typ ist `LlmRouteSchema` (früherer Stage-Route-Type entfernt).
  */
 import { z } from "zod";
-import { StageIdSchema, StageLLMRouteSchema } from "./llmRoutingContract";
+import { StageIdSchema } from "./llmRoutingContract";
+import { LlmRouteSchema } from "./llmRoute";
 
 export const WorkspaceLlmRoutingDefaultsSchema = z
   .object({
-    global_default: StageLLMRouteSchema,
-    stage_overrides: z.partialRecord(StageIdSchema, StageLLMRouteSchema).default({}),
+    global_default: LlmRouteSchema,
+    stage_overrides: z.partialRecord(StageIdSchema, LlmRouteSchema).default({}),
     updated_at: z.string().nullable().optional(),
     version: z.number().int().min(1).default(1),
   })

--- a/frontend/src/store/__tests__/aiModels.spec.ts
+++ b/frontend/src/store/__tests__/aiModels.spec.ts
@@ -66,7 +66,7 @@ import {
 
 import type { ProviderConnection, ProviderConnectionTestResult } from '../../contracts/aiProviderContract'
 import type { LlmProfile } from '../../contracts/llmProfileContract'
-import type { StageLLMRoute } from '../../contracts/llmRoutingContract'
+import type { LlmRoute } from '../../contracts/llmRoute'
 import type { WorkspaceLlmRoutingDefaults } from '../../contracts/workspaceRoutingContract'
 
 type MockFn = ReturnType<typeof vi.fn>
@@ -93,7 +93,7 @@ function makeProfile(overrides: Partial<LlmProfile> = {}): LlmProfile {
   } as LlmProfile
 }
 
-function makeRoute(overrides: Partial<StageLLMRoute> = {}): StageLLMRoute {
+function makeRoute(overrides: Partial<LlmRoute> = {}): LlmRoute {
   return {
     stage: null,
     provider_id: 'ollama',
@@ -103,7 +103,7 @@ function makeRoute(overrides: Partial<StageLLMRoute> = {}): StageLLMRoute {
     reasoning_effort: 'none',
     provider_options: {},
     ...overrides,
-  } as StageLLMRoute
+  } as LlmRoute
 }
 
 function makeDefaults(overrides: Partial<WorkspaceLlmRoutingDefaults> = {}): WorkspaceLlmRoutingDefaults {

--- a/frontend/src/store/aiModels.ts
+++ b/frontend/src/store/aiModels.ts
@@ -57,7 +57,8 @@ import type { ApiSuccessEnvelope } from "../api/envelope";
 import { isApiError } from "../api/envelope";
 import { unwrapResponse } from "../api/parse";
 
-import type { ProviderDescriptor, StageId, StageLLMRoute } from "../contracts/llmRoutingContract";
+import type { ProviderDescriptor, StageId } from "../contracts/llmRoutingContract";
+import type { LlmRoute } from "../contracts/llmRoute";
 import type { LlmProviderKeyEntry } from "../contracts/llmProviderKeysContract";
 import type { LlmProfile, LlmProfileCreateRequest } from "../contracts/llmProfileContract";
 import type { WorkspaceLlmRoutingDefaults } from "../contracts/workspaceRoutingContract";
@@ -499,7 +500,7 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
   const globalDefault = computed(() => defaults.value.global_default);
   const stageOverrides = computed(() => defaults.value.stage_overrides);
 
-  function effectiveRouteForStage(stageId: StageId): StageLLMRoute {
+  function effectiveRouteForStage(stageId: StageId): LlmRoute {
     return defaults.value.stage_overrides[stageId] ?? defaults.value.global_default;
   }
 
@@ -517,7 +518,7 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
     }
   }
 
-  async function setGlobalDefault(route: StageLLMRoute): Promise<void> {
+  async function setGlobalDefault(route: LlmRoute): Promise<void> {
     lastError.value = null;
     try {
       defaults.value = await replaceGlobalDefault(route);
@@ -529,7 +530,7 @@ export const useLlmRoutingDefaultsStore = defineStore("llmRoutingDefaults", () =
 
   async function setStageOverride(
     stageId: StageId,
-    route: StageLLMRoute | null,
+    route: LlmRoute | null,
   ): Promise<void> {
     lastError.value = null;
     try {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -14,7 +14,6 @@ import ModelPicker from '@/components/v4/forms/ModelPicker.vue'
 import { getAvailableModels } from '../api/simulation'
 import { STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
 import { setPendingUpload } from '../store/pendingUpload'
-import { StageLLMRouteSchema } from '../contracts/llmRoutingContract'
 
 const { t, tm } = useI18n()
 const router = useRouter()
@@ -38,33 +37,19 @@ const loadingModels = ref(true)
 const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
 
 // ---- LLM-Route (Slice A3: projektweiter ModelPicker, Slice A1/A2-Pattern). ----
-//   Persistenz: agora.home.route (JSON-serialized, Zod-validiert).
-//   Spiegelung auf STORAGE_MODEL für die bestehende Step2/MainView-Pipeline.
-const STORAGE_HOME_ROUTE = 'agora.home.route'
+//   Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.home.route` wird NICHT
+//   mehr gelesen oder geschrieben; er wird beim Mount defensiv entfernt. Die
+//   ModelPicker-Auswahl gilt nur noch für die aktuelle Session und spiegelt
+//   sich beim Start auf STORAGE_MODEL. (Persistenz via AiModelRef folgt in
+//   7.6d mit der ModelPicker→AiModelPicker-Migration.)
+const STORAGE_HOME_ROUTE_LEGACY = 'agora.home.route'
 
-function loadStoredRoute() {
-  try {
-    const raw = localStorage.getItem(STORAGE_HOME_ROUTE)
-    if (!raw) return null
-    const parsed = StageLLMRouteSchema.safeParse(JSON.parse(raw))
-    if (!parsed.success) return null
-    if (!parsed.data.provider_id || !parsed.data.model) return null
-    return parsed.data
-  } catch (err) {
-    console.warn('[Home] agora.home.route lokal nicht parsbar — Auswahl zurückgesetzt:', err)
-    return null
-  }
-}
-
-const selectedRoute = ref(loadStoredRoute())
+const selectedRoute = ref(null)
 
 function onPickRoute(route) {
   selectedRoute.value = route
-  if (route?.provider_id && route?.model) {
-    localStorage.setItem(STORAGE_HOME_ROUTE, JSON.stringify(route))
-  } else {
-    localStorage.removeItem(STORAGE_HOME_ROUTE)
-  }
+  // Storage-Cut: kein Persistieren mehr unter dem Legacy-Key; defensiv säubern.
+  localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
 }
 
 async function loadStatus() {
@@ -159,6 +144,8 @@ async function startSimulation() {
 }
 
 onMounted(() => {
+  // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
+  localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
   loadStatus()
 })
 

--- a/frontend/src/views/Settings/LlmProvidersView.vue
+++ b/frontend/src/views/Settings/LlmProvidersView.vue
@@ -30,7 +30,8 @@ import Input from '@/components/v4/forms/Input.vue'
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
 import { useLlmProvidersStore, useLlmRoutingDefaultsStore } from '@/store/aiModels'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
-import type { ProviderDescriptor, StageLLMRoute } from '@/contracts/llmRoutingContract'
+import type { ProviderDescriptor } from '@/contracts/llmRoutingContract'
+import type { LlmRoute } from '@/contracts/llmRoute'
 import type { ProviderProbeStatus } from '@/contracts/aiProviderContract'
 import type { AiModelRef } from '@/contracts/aiModelRef'
 
@@ -166,16 +167,16 @@ async function disconnect(p: ProviderDescriptor): Promise<void> {
   delete drafts[p.id]
 }
 
-const defaultRoute = computed<StageLLMRoute | null>(() => {
+const defaultRoute = computed<LlmRoute | null>(() => {
   const r = defaultsStore.globalDefault
   if (!r?.provider_id || !r?.model) return null
   return r
 })
 
 // Slice 5.4: AiModelRef-Aequivalent der aktuellen Default-Route.
-// Statt StageLLMRoute → AiModelRef-Konvertierung in der View, nutzen wir
+// Statt LlmRoute → AiModelRef-Konvertierung in der View, nutzen wir
 // den Adapter bidirektional: setDefault empfängt AiModelRef, konvertiert
-// nach StageLLMRoute für den v3-Store. Picker zeigt die AiModelRef-Form.
+// nach LlmRoute für den v3-Store. Picker zeigt die AiModelRef-Form.
 const defaultAiRef = computed<AiModelRef | null>(() => {
   if (!defaultRoute.value) return null
   return adapter.toAiModelRef(defaultRoute.value)
@@ -183,8 +184,8 @@ const defaultAiRef = computed<AiModelRef | null>(() => {
 
 async function setDefault(aiRef: AiModelRef | null): Promise<void> {
   if (!aiRef) return
-  const stageLlmRoute = adapter.toStageLlmRoute(aiRef)
-  await defaultsStore.setGlobalDefault(stageLlmRoute)
+  const llmRoute = adapter.toLlmRoute(aiRef)
+  await defaultsStore.setGlobalDefault(llmRoute)
 }
 
 onMounted(async () => {

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -4,7 +4,7 @@
  *
  * Slice 5.4: Pilot-Abschluss der AiModelPicker-Migration.
  *  - AiModelPicker-Update wird an useLlmRoutingDefaultsStore.setGlobalDefault
- *    durchgereicht (Adapter Uebersetzung AiModelRef -> StageLLMRoute).
+ *    durchgereicht (Adapter Uebersetzung AiModelRef -> LlmRoute).
  *  - Initialer Wert kommt aus defaultsStore.globalDefault (via Adapter).
  *  - i18n-Key 'settings.v4.general.workspaceDefaultModel' ersetzt das
  *    generische aiModelPicker.label und macht die Funktion klar.
@@ -42,7 +42,7 @@ const BREADCRUMBS = [
 const defaultsStore = useLlmRoutingDefaultsStore()
 const adapter = useAiModelRefAdapter()
 
-// Initialer Wert aus dem Store (via Adapter: StageLLMRoute -> AiModelRef).
+// Initialer Wert aus dem Store (via Adapter: LlmRoute -> AiModelRef).
 const selectedModel = ref<AiModelRef | null>(
   defaultsStore.globalDefault ? adapter.toAiModelRef(defaultsStore.globalDefault) : null,
 )
@@ -151,8 +151,8 @@ onMounted(async () => {
 
 async function setWorkspaceDefault(aiRef: AiModelRef | null): Promise<void> {
   if (!aiRef) return
-  const stageLlmRoute = adapter.toStageLlmRoute(aiRef)
-  await defaultsStore.setGlobalDefault(stageLlmRoute)
+  const llmRoute = adapter.toLlmRoute(aiRef)
+  await defaultsStore.setGlobalDefault(llmRoute)
 }
 </script>
 

--- a/frontend/src/views/__tests__/LlmProvidersView.spec.ts
+++ b/frontend/src/views/__tests__/LlmProvidersView.spec.ts
@@ -13,7 +13,7 @@
  *  4. Workspace-Default-Card sichtbar
  *  5. AiModelPicker in der Default-Card
  *  6. defaultRoute computed zeigt aktuelle Route (Provider-ID + Model)
- *  7. AiModelPicker-Update mit AiModelRef → adapter.toStageLlmRoute → setGlobalDefault
+ *  7. AiModelPicker-Update mit AiModelRef → adapter.toLlmRoute → setGlobalDefault
  *  8. AiModelPicker-Update mit null → kein setGlobalDefault-Aufruf
  *  9. onMounted: loadProviders + loadConnections + defaultsStore.load
  * 10. onBeforeUnmount: loescht alle drafts
@@ -105,7 +105,7 @@ const defaultsStoreMock = {
 }
 
 const adapterMock = {
-  toStageLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
+  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
     stage: null,
     provider_id: 'openai',
     model: aiRef.model_id,
@@ -200,7 +200,7 @@ async function mountView(initial: {
   providersStoreMock.removeConnection.mockClear()
   defaultsStoreMock.setGlobalDefault.mockClear()
   defaultsStoreMock.load.mockClear()
-  adapterMock.toStageLlmRoute.mockClear()
+  adapterMock.toLlmRoute.mockClear()
   adapterMock.toAiModelRef.mockClear()
 
   const i18n = makeI18n()
@@ -272,12 +272,12 @@ describe('LlmProvidersView (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(defaultSpan.text()).toContain('gpt-4o-mini')
   })
 
-  it('AiModelPicker-Update mit AiModelRef → adapter.toStageLlmRoute → setGlobalDefault', async () => {
+  it('AiModelPicker-Update mit AiModelRef → adapter.toLlmRoute → setGlobalDefault', async () => {
     const w = await mountView()
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
     await picker.trigger('click')
-    expect(adapterMock.toStageLlmRoute).toHaveBeenCalledWith({
+    expect(adapterMock.toLlmRoute).toHaveBeenCalledWith({
       provider_connection_id: 'conn-openai-1',
       model_id: 'gpt-4o-mini',
       source: 'explicit',

--- a/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
@@ -19,7 +19,7 @@
  *  8. allowWorkspaceDefault=true
  *  9. onMount: defaultsStore.load()
  * 10. initialer Picker-Wert aus defaultsStore.globalDefault (via Adapter)
- * 11. AiModelPicker-Update mit AiModelRef -> adapter.toStageLlmRoute -> setGlobalDefault
+ * 11. AiModelPicker-Update mit AiModelRef -> adapter.toLlmRoute -> setGlobalDefault
  * 12. AiModelPicker-Update mit null: keine setGlobalDefault-Aktion
  * 13. AiModelPicker hat eindeutige ID ('settings-general-model-picker')
  * 14. SettingsSectionPanel sichtbar
@@ -70,7 +70,7 @@ vi.mock('@/store/aiModels', () => ({
 }))
 
 const adapterMock = {
-  toStageLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
+  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
     stage: null,
     provider_id: 'openai',
     model: aiRef.model_id,
@@ -148,7 +148,7 @@ async function mountSettingsGeneral(initial: { globalDefault?: unknown } = {}) {
   loadMock.mockResolvedValue(undefined)
   setGlobalDefaultMock.mockClear()
   setGlobalDefaultMock.mockResolvedValue(undefined)
-  adapterMock.toStageLlmRoute.mockClear()
+  adapterMock.toLlmRoute.mockClear()
   adapterMock.toAiModelRef.mockClear()
 
   const i18n = makeI18n()
@@ -245,7 +245,7 @@ describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () =
     expect(adapterMock.toAiModelRef).toHaveBeenCalled()
   })
 
-  it('AiModelPicker-Update mit AiModelRef -> adapter.toStageLlmRoute -> setGlobalDefault', async () => {
+  it('AiModelPicker-Update mit AiModelRef -> adapter.toLlmRoute -> setGlobalDefault', async () => {
     const w = await mountSettingsGeneral()
     const picker = w.findComponent(aiPickerStub)
     ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', {
@@ -254,7 +254,7 @@ describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () =
       source: 'workspace-default',
     })
     await flushPromises()
-    expect(adapterMock.toStageLlmRoute).toHaveBeenCalled()
+    expect(adapterMock.toLlmRoute).toHaveBeenCalled()
     expect(setGlobalDefaultMock).toHaveBeenCalledWith({
       stage: null,
       provider_id: 'openai',


### PR DESCRIPTION
## Slice 7.6c — StageLLMRoute-Typ + Legacy-Route-Storage aus dem Frontend entfernen

**BREAKING:** LocalStorage-Key `agora.<scope>.route` (Scope = `hero`, `home`, `report`) wird **nicht mehr gelesen**. User mit persistierten Legacy-Werten erhalten ab diesem Release den **Default des Eltern-Kontextes** (Workspace- bzw. Stage-Default). Der alte Key wird beim ersten Mount defensiv aus `localStorage` entfernt.

### Was drin ist
- Frontend-Type `StageLLMRoute` + Zod-Spiegel `StageLLMRouteSchema` komplett entfernt. Nachfolger: `LlmRoute` (`frontend/src/contracts/llmRoute.ts`).
- `StageIdSchema`/`ReasoningEffortSchema` nach `llmRoute.ts` verschoben und aus `llmRoutingContract.ts` re-exportiert — **Import-Zyklus aufgelöst** (`llmRoute` ↔ `llmRoutingContract`), der sonst zu `StageIdSchema is undefined` beim Modul-Init führte.
- `useAiModelRefAdapter.toStageLlmRoute` → `toLlmRoute`; Legacy-Migrations-Helper `migrateStoredRoute*` entfernt.
- Storage-Cut in `HeroNewRun.vue`, `Home.vue`, `Step4Report.vue`: Legacy-Route-Key wird nicht mehr gelesen/geschrieben, nur defensiv entfernt.
- Specs (inkl. HeroNewRun-Legacy-Test → Storage-Cut-Verhalten) + CHANGELOG nachgezogen.

### Scope-Abgrenzung (Stopper §6.2)
Die Legacy-Picker `ModelPicker`/`ReportModelControls` (Home/Step4Report) emittieren weiterhin `LlmRoute`. Ihre Migration auf `AiModelRef`-Persistenz (`agora.<scope>.aiModelRef`) ist **bewusst nach 7.6d verschoben**, um keinen impliziten 3-Komponenten-Refactor in diesen Slice zu ziehen. Für 7.6c bedeutet der Storage-Cut daher: diese beiden Views persistieren die Auswahl vorerst nicht mehr (Session-only) — exakt das dokumentierte BREAKING-Verhalten.

### Verifikation
- `grep -r "StageLLMRoute" frontend/src/` → **0**
- `grep -r "stage_llm_route|stageLlmRoute" frontend/src/contracts frontend/src/composables` → **0**
- Ziel-Tests: **119 passed** (8 Spec-Dateien)
- `bun run lint` + `bun run typecheck` + `bun run build` grün
- `bash scripts/pre-push-gate.sh frontend` → **ALL GREEN**

🤖 Generated with [Claude Code](https://claude.com/claude-code)