### PR TITLE
docs: Stand auf Slice 7.6b/7.6c aktualisieren

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ Dokument hochladen → Wissensgraph extrahieren → Personas spawnen → OASIS-S
 **Single-User**, lokal oder hybrid, **kein öffentliches SaaS** ([ADR-0001](./docs/decisions/0001-auth-model.md)).
 
 **Status:** v1.0.0 (Release 2026-05-11). Layer 0–6 grün, 7–8 teilweise, 9–10 grün. M11 Phase 1–5b durch.
-Aktive Welle: **Onboarding & Provider-Unification** (Phase 1 Slices 1–4.3.4 gemerged, Phase 2 Slice 5 läuft —
-Sub-Slice 5.0/5.1 gemerged, 5.2 in Arbeit). Roadmap: [`PLAN.md`](PLAN.md).
+Aktive Welle: **Onboarding & Provider-Unification** (Phase 1 Slices 1–4.3.4 + Phase 2 Slice 5
+gemerged; Slice-7-Serie: 7.6b Consumer-Migration auf AiModelPicker/AiModelRef gemerged, 7.6c
+`StageLLMRoute`-Entfernung + Legacy-Route-Storage-Cut in PR). Roadmap: [`PLAN.md`](PLAN.md).
 Layer-Detail: [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.md).
 
 ## Sofort wichtig
@@ -159,15 +160,19 @@ und [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.m
 - Lokale Provider-Detection-Heuristiken — `backend/app/llm/providers/registry.py::detect_provider` ist SSoT
   (Phase F, #669/#670/#671 delegieren bestehende Stellen dorthin)
 
-## Aktive Epics (Stand 2026-07-13)
+## Aktive Epics (Stand 2026-07-14)
 
 - **Onboarding & Provider-Unification** (laufende Welle):
   - **Phase 1 (gemerged):** Slices 1–4.3.4 — kanonische Provider-/Modell-/Embedding-Verträge,
     User-Profile + resumierbares Onboarding-Grundgerüst, Provider-Discovery, Embedding-Configuration-
     Service, Embedding-Migration-Lifecycle, Frontend-Store/View, **echte Neo4j-Re-Embedding-Engine
     mit Resume-Cursor**, zentrales `pre-push-gate.sh`, F401-Cleanup. PRs #683 → #694.
-  - **Phase 2 (Slice 5, läuft):** Unified Model Picker (Sub-Slice 5.0 Sub-Plan + ADR-0009 gemerged,
-    5.1 `AiModelPicker.vue` mit reka-ui gemerged, 5.2 in Arbeit). Branch: `codex/onboarding-model-picker`.
+  - **Phase 2 (Slice 5, gemerged):** Unified Model Picker (ADR-0009) — `AiModelPicker.vue` als SSoT.
+  - **Slice-7-Serie (StageLLMRoute-Abbau):** 7.6b Consumer-Migration (Home/Step4Report/ReportModelControls
+    auf AiModelPicker/AiModelRef, PR #727) gemerged. **7.6c** entfernt den Frontend-Type `StageLLMRoute` +
+    `StageLLMRouteSchema` (Nachfolger `LlmRoute`), streicht den `migrateStoredRoute`-Helper und macht den
+    **Legacy-Route-Storage-Cut** (`agora.<scope>.route` wird nicht mehr gelesen) — PR #728. Picker-
+    Spiegel-Restarbeiten laufen in 7.6d.
   - Detail: [`docs/epics/onboarding-provider-unification/`](docs/epics/onboarding-provider-unification/).
 - **Design Language v4 — App-Shell-Port:** Slices A–E durch, **F + G1 (Settings General/Integrations)
   + G2 (API Keys real) gemerged**. Branch `feat/design-v4-epic`. Vendoriert in [`design/v3-source/`](design/v3-source/).

--- a/README.md
+++ b/README.md
@@ -348,8 +348,10 @@ Aktive Wellen (Detail in [`PLAN.md`](./PLAN.md) und [`ROADMAP.md`](./ROADMAP.md)
   Phase 1 (Slices 1–4.3.4) abgeschlossen — kanonische Provider-/Modell-/Embedding-Verträge,
   User-Profile, Provider-Discovery mit Test, Embedding-Configuration-Service, Migrations-
   Lifecycle, Frontend-Store/View, **echte Neo4j-Re-Embedding-Engine mit Resume**. Phase 2
-  (Unified Model Picker, [ADR-0009](./docs/decisions/0009-unified-model-picker.md)) läuft —
-  AiModelPicker.vue mit reka-ui gemerged, weitere Schritte offen.
+  (Unified Model Picker, [ADR-0009](./docs/decisions/0009-unified-model-picker.md)) gemerged —
+  `AiModelPicker.vue` ist SSoT. Slice-7-Serie: 7.6b Consumer-Migration gemerged (PR #727),
+  **7.6c** entfernt `StageLLMRoute` und liest den Legacy-Key `agora.<scope>.route` nicht mehr
+  (BREAKING; Nachfolger `LlmRoute`, PR #728).
 - **Design Language v4 — App-Shell-Port:** Slices A–E sowie F, G1 (Settings General/Integrations)
   und G2 (API Keys real) gemerged. Branch `feat/design-v4-epic`.
 - **v1.0-Output-Vertrag** ([`PLAN.md`](./PLAN.md)) — offene Schritte: P3.2, P4.1, P4.3, P4.4

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Agora — Status (Single Source of Truth)
 
-Stand: 2026-07-13 (Onboarding/Provider-Unification Slice 5.6 final gemergt; armserver-Verifikation ausstehend, v1.0.0)
+Stand: 2026-07-14 (Onboarding/Provider-Unification Slice 5 final + Slice-7-Serie: 7.6b Consumer-Migration gemergt, 7.6c StageLLMRoute-Entfernung + Legacy-Route-Storage-Cut in PR #728; v1.0.0)
 
 **Aktualisiert via `scripts/sync-status.sh`.** README, CLAUDE.md und ROADMAP verweisen auf diese Datei — Versionsstände und Test-Counts werden nicht mehr inline kopiert.
 


### PR DESCRIPTION
Docs-Sync nach dem Merge von Slice 7.6b (#727) und 7.6c (#728).

- **AGENTS.md** — Status-Zeile + Aktive Epics (Stand 2026-07-14): Phase 2 Slice 5 gemerged; Slice-7-Serie (7.6b Consumer-Migration, 7.6c StageLLMRoute-Entfernung + Legacy-Route-Storage-Cut).
- **README.md** — Onboarding-Epic-Abschnitt: Model-Picker gemerged, 7.6c BREAKING (`StageLLMRoute` raus, `agora.<scope>.route` wird nicht mehr gelesen; Nachfolger `LlmRoute`).
- **docs/STATUS.md** — Stand-Zeile aktualisiert (Prosa; Autogen-Blöcke unangetastet).

Reine Doku, kein Code. CLAUDE.md bewusst unverändert (nicht veraltet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)