### PR TITLE
fix(routing): preserve canonical AiRoute in lock_stage (P0)

### DIFF
--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -37,6 +37,14 @@ class StageModelRouter:
     def __init__(self, run_id: str):
         self.run_id = run_id
         self.config_service = RuntimeRunConfig(run_id)
+        # Kanonischer AiRoute, den ``resolve()`` beim frischen Auflösen
+        # berechnet hat — bewahrt die echten Auswahl-Inputs (project_route,
+        # workspace_route, required_capabilities, resolved_at) für
+        # ``lock_stage()``. Ohne diesen Cache müsste ``lock_stage()`` die
+        # kanonische Route neu auflösen und würde dabei die Original-Inputs
+        # verlieren (P0: Audit-Snapshot konnte von der ausgeführten Route
+        # abweichen). Lebensdauer: genau ein resolve→lock-Fenster pro Stage.
+        self._pending_canonical: dict[StageId, AiRoute] = {}
 
     def resolve(
         self,
@@ -74,6 +82,11 @@ class StageModelRouter:
             project_route=project_route,
             workspace_route=workspace_route,
         )
+        # Bewahre den kanonischen AiRoute für das unmittelbar folgende
+        # ``lock_stage()`` — die Legacy-``ResolvedRoute`` trägt keine
+        # ``source``/``fallback_reason``/``validated_capabilities``, ein
+        # späterer Re-Resolve mit leeren Inputs würde diese verlieren.
+        self._pending_canonical[stage_id] = canonical
         return self._resolved_route_from_ai_route(stage_id, canonical, cfg.routing_version)
 
     def _resolve_canonical(
@@ -186,22 +199,38 @@ class StageModelRouter:
     def lock_stage(self, stage_id: StageId, resolved_route: ResolvedRoute) -> ResolvedRoute:
         """Lock the route for a stage by persisting the snapshot.
 
-        The canonical snapshot is rebuilt through the same resolver so its
-        ``source`` reflects the real winning level (stage/run/workspace/
-        provider-fallback) rather than a heuristic, and it carries the
-        validated capabilities and fallback reason recorded in the audit.
+        The canonical snapshot for the audit is the AiRoute that ``resolve()``
+        actually computed for this stage — never a re-resolved copy. A
+        re-resolve would lose the original selection inputs
+        (``required_capabilities``, ``project_route``, ``workspace_route``,
+        the real ``resolved_at``) and could record a route whose
+        ``source``/``model_id`` differ from what is executed and persisted
+        in the stage snapshot (P0: Audit-Log / Snapshot-Wiederaufnahme
+        divergence). If no fresh canonical is pending (snapshot-hit path,
+        resume, or external caller without prior ``resolve()``), fall back
+        to the already-persisted canonical snapshot; only as a last resort
+        re-resolve with the same empty inputs the caller would have used.
         """
         winner = self.config_service.save_stage_snapshot(
             stage_id, resolved_route.model_dump(mode="json")
         )
         stored = ResolvedRoute.model_validate(winner)
-        config = self.config_service.load_config()
-        canonical_route = self._resolve_canonical(
-            stage_id,
-            config,
-            required_capabilities=(),
-            resolved_at=self._parse_started_at(stored.started_at),
-        )
+        canonical_route = self._pending_canonical.pop(stage_id, None)
+        if canonical_route is None:
+            # Kein frischer Resolve vorausgegangen: die bereits persistierte
+            # kanonische Route wiederverwenden (stimmt garantiert mit der
+            # ausgeführten überein), statt mit leeren Inputs neu aufzulösen.
+            existing = self.config_service.load_ai_route_snapshot(stage_id)
+            if existing is not None:
+                canonical_route = existing
+            else:
+                config = self.config_service.load_config()
+                canonical_route = self._resolve_canonical(
+                    stage_id,
+                    config,
+                    required_capabilities=(),
+                    resolved_at=self._parse_started_at(stored.started_at),
+                )
         canonical = self.config_service.save_ai_route_snapshot(stage_id, canonical_route)
         AiRouteAudit(self.run_id).record_routing_resolved(stage_id, canonical)
         return self._resolved_from_snapshot(stage_id, winner)

--- a/backend/tests/services/test_llm_routing_logic.py
+++ b/backend/tests/services/test_llm_routing_logic.py
@@ -94,6 +94,62 @@ def test_stage_model_router_snapshot_isolation(temp_run_dir):
     assert resolved_other.routing_version == 2
 
 
+def test_lock_stage_audit_reflects_resolved_project_route_not_lossy_reresolve(temp_run_dir):
+    """P0 (lock_stage-Re-Resolve-Verlust): ``lock_stage()`` darf den
+    kanonischen ``AiRoute`` fürs Audit NICHT neu auflösen. Ein Re-Resolve mit
+    leeren Inputs (``required_capabilities=()``, ``project_route=None``,
+    ``workspace_route=None``) verliert die beim ursprünglichen Resolve
+    verwendete Auswahlquelle.
+
+    Setup: Run-Level-Default ohne Modell → Run-Kandidat ist ``None`` → der
+    kanonische Resolver wählt die ``project_route`` (source="project_route").
+    Vor dem Fix re-resolvierte ``lock_stage()`` mit ``project_route=None`` und
+    fiel bis auf den Provider-Fallback zurück → Audit-Snapshot beschrieb ein
+    *anderes* Modell/eine *andere* Quelle als die tatsächlich ausgeführte und
+    im Stage-Snapshot persistierte Route. Audit-Log, Snapshot und
+    Wiederaufnahme konnten widersprüchlich werden.
+
+    Nach dem Fix nutzt ``lock_stage()`` den kanonischen ``AiRoute``, den
+    ``resolve()`` berechnet und zwischengespeichert hat — Audit und ausgeführte
+    Route stimmen überein.
+    """
+    service = RuntimeRunConfig(temp_run_dir)
+    # Run-Level-Default bewusst OHNE Modell → Run-Kandidat ist None, damit die
+    # project_route gewinnt (Priorität Stage > Run > Projekt > … > Fallback).
+    service.save_config(RuntimeLlmRouting(
+        global_default=StageLLMRoute(provider_id="conn-run", model=""),
+        routing_version=1,
+    ))
+    router = StageModelRouter(temp_run_dir)
+
+    project_route = AiRoute(
+        provider_connection_id="conn-proj",
+        model_id="model-proj",
+        source="project",
+        routing_version=1,
+    )
+    resolved = router.resolve("graph_build", project_route=project_route)
+    # Die ausgeführte Route IST die project_route.
+    assert resolved.provider_id == "conn-proj"
+    assert resolved.model == "model-proj"
+
+    # Provider-Fallback deterministisch machen, damit der alte (verlustbehaftete)
+    # Pfad ein bekanntes Ergebnis liefert statt env-abhängig zu sein oder zu
+    # raisen — der Test soll die Divergenz assertionsbasiert nachweisen.
+    with patch("app.config.Config.LLM_MODEL_NAME", "env-fallback-model"), \
+         patch("app.config.Config.LLM_BASE_URL", ""):
+        router.lock_stage("graph_build", resolved)
+
+    canonical = service.load_ai_route_snapshot("graph_build")
+    assert canonical is not None
+    # Audit-Snapshot beschreibt DIESELBE Route wie ausgeführt — kein Verlust
+    # durch Re-Resolve mit project_route=None (sonst source="provider_fallback"
+    # und model_id="env-fallback-model").
+    assert canonical.provider_connection_id == "conn-proj"
+    assert canonical.model_id == "model-proj"
+    assert canonical.source == "project"
+
+
 def test_resolve_from_canonical_snapshot_yields_iso8601_started_at(temp_run_dir):
     """Regression für PR-#700-Review-Finding #2: Wird nur ein kanonischer
     ``AiRoute``-Snapshot gespeichert (kein Legacy-Stage-Snapshot), muss

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,8 +19,8 @@ Stand: 2026-07-14 (Onboarding/Provider-Unification Slice 5 final + Slice-7-Serie
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3334 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 161 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 3335 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 163 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 _Hinweise: 2 Redis-Integrationstests skippen sauber ohne `TEST_REDIS_URL` und sind in der Backend-Summe enthalten (sie zählen als collected, werden aber zur Laufzeit übersprungen)._


### PR DESCRIPTION
## Problem (P0)

`StageModelRouter.lock_stage()` re-resolved the canonical `AiRoute` for the audit with lossy inputs — `required_capabilities=()` and `project_route=None` / `workspace_route=None` — discarding the real selection context that `resolve()` had used. The audit snapshot (`source` / `fallback_reason` / `validated_capabilities` / `model_id`) and the resume route could then describe a **different route than the one actually executed** and persisted in the stage snapshot → contradictory audit log vs. snapshot vs. resume route.

The divergence is **latent today** (no production caller passes `project_route` / `workspace_route` / `required_capabilities` to `resolve()` — verified via CRG), but structural: any future caller passing those inputs would immediately produce a divergent audit.

## Fix

Removes the lossy re-resolve:
- `resolve()` stashes the canonical `AiRoute` it computed (with the real inputs) per stage on the router instance.
- `lock_stage()` pops that stashed canonical and uses it for the audit snapshot — the audit now records exactly what was executed.
- Fallbacks when no fresh canonical is pending (snapshot-hit path, resume, or lock without prior `resolve()`): reuse the already-persisted canonical snapshot; only as a last resort re-resolve with the same empty inputs the caller would have used.

## TDD

New regression test `test_lock_stage_audit_reflects_resolved_project_route_not_lossy_reresolve`: `project_route` wins over an empty run default; asserts the audit canonical matches the executed route (`source="project"`, `model-proj`), not a `provider_fallback`. Existing snapshot / iso8601 / secret-free tests stay green.

## Gates

- `pre-push-gate.sh backend` green (ruff, mypy, contracts 377, schema-drift, STATUS sync).
- STATUS.md synced (3335 backend / 163 frontend — the frontend count corrects pre-existing main drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)