### PR TITLE
fix(e2e): make smoke stack boot (Alpine CDN resilient + AGORA_SECRET_KEY fallback)

### DIFF
--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -3,6 +3,8 @@ name: e2e-smokes
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -3,8 +3,6 @@ name: e2e-smokes
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,17 @@ FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e
 # Alpine-Pakete auf Repo-Stand heben, solange das Base-Image hinterherhinkt:
 # CVE-2026-33630 (c-ares < 1.34.8-r0), CVE-2026-56407/-56408/-56131
 # (libexpat < 2.8.2-r0) — Trivy-Gate scannt HIGH/CRITICAL mit exit-code 1.
-RUN apk upgrade --no-cache
+#
+# Resilienz: GitHub-Runner-Netzwerk liefert zu dl-cdn.alpinelinux.org gelegentlich
+# persistente I/O-Errors (APKINDEX fetch exit 99 "stale/unavailable repositories"),
+# die jeden E2E-Smoke-Job reißen. Erst retry-basiert (3× mit Backoff), bei
+# anhaltendem Ausfall Fallback auf den sekundären dl-4-Mirror — ein CDN-Edge-Ausfall
+# darf den Build (und damit pull_request-getriggerte E2E-Smokes) nicht blockieren.
+RUN for i in 1 2 3; do \
+      apk upgrade --no-cache && break; \
+      echo "apk upgrade attempt $i failed, retrying in 5s…"; sleep 5; \
+    done || \
+    (sed -i 's#dl-cdn.alpinelinux.org#dl-4.alpinelinux.org#g' /etc/apk/repositories && \
+     apk upgrade --no-cache)
 COPY deploy/nginx/agora.conf /etc/nginx/conf.d/default.conf
 COPY --from=frontend-build /app/frontend/dist /usr/share/nginx/html

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -28,6 +28,26 @@ if [[ ! -f "${REPO_ROOT}/.env" ]]; then
   fi
 fi
 
+# Slice 5.6: Fernet-Master-Key für den LLM-Provider-Secrets-Store
+# (llm_provider_secrets_store.py, env AGORA_SECRET_KEY). Wird beim Seeden
+# von Provider-Connections MIT api_key benötigt (frontend/tests/e2e/
+# global-setup.ts seed). Ohne diesen Key schlägt _secrets_store.upsert mit
+# RuntimeError fehl → API 503 store_unavailable beim e2e-globalSetup, jeder
+# Smoke-Job reißt. Wert muss ein gültiger Fernet-Key sein (urlsafe base64,
+# 32 Bytes).
+#
+# Pre-existing Gap (sichtbar geworden, seit e2e-smokes auch auf pull_request
+# läuft): das e2e-smokes-Workflow generiert AGORA_SECRET_KEY in keinem der 6
+# Jobs (nur AGORA_AUTH_TOKEN/SECRET_KEY/NEO4J_PASSWORD). Früher lief e2e nur
+# auf push:main, dort war das gleiche 503 also unsichtbar. Fallback hier
+# statt im Workflow: self-contained für alle 6 Jobs + lokale Dev-Runs.
+# E2E-seeded Provider-Connections werden nicht zwischen Runs persistiert,
+# ein pro-Run-ephemeraler Key ist semantisch korrekt.
+if [[ -z "${AGORA_SECRET_KEY:-}" ]]; then
+  AGORA_SECRET_KEY="$(python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')"
+  echo "[e2e-up] AGORA_SECRET_KEY not set in env — generated ephemeral Fernet key for this run" >&2
+fi
+
 # Kritische Werte aus dem Runner-Env in die .env appenden — docker compose
 # variable substitution liest .env mit Vorrang vor Process-Env, daher reicht
 # Export auf Runner-Ebene NICHT. Letzte Definition gewinnt; das überschreibt
@@ -36,14 +56,7 @@ fi
 {
   [[ -n "${AGORA_AUTH_TOKEN:-}" ]] && echo "AGORA_AUTH_TOKEN=${AGORA_AUTH_TOKEN}"
   [[ -n "${SECRET_KEY:-}" ]] && echo "SECRET_KEY=${SECRET_KEY}"
-  # Slice 5.6: Fernet-Master-Key für den LLM-Provider-Secrets-Store
-  # (llm_provider_secrets_store.py, env AGORA_SECRET_KEY). Wird beim Seeden
-  # von Provider-Connections MIT api_key benötigt (frontend/tests/e2e/
-  # global-setup.ts seed). Ohne diesen Key schlägt _secrets_store.upsert mit
-  # RuntimeError fehl → API 503 store_unavailable. Wert muss ein gültiger
-  # Fernet-Key sein (urlsafe base64, 32 Bytes); im Runner generieren via
-  #   python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
-  [[ -n "${AGORA_SECRET_KEY:-}" ]] && echo "AGORA_SECRET_KEY=${AGORA_SECRET_KEY}"
+  echo "AGORA_SECRET_KEY=${AGORA_SECRET_KEY}"
   [[ -n "${NEO4J_PASSWORD:-}" ]] && echo "NEO4J_PASSWORD=${NEO4J_PASSWORD}"
   [[ -n "${AGORA_PROXY_PORT:-}" ]] && echo "AGORA_PROXY_PORT=${AGORA_PROXY_PORT}"
   # Ollama gibt es im CI-Stack nicht — Backend-Boot würde sonst an der


### PR DESCRIPTION
## What

Two infra fixes that make the e2e-smoke **stack actually boot** for the first time on \`push:main\` / \`schedule\`. Previously every e2e-smoke run (and the nightly schedule) failed before a single test executed.

## Fixes

### 1. Alpine CDN I/O resilience (Dockerfile proxy stage)
\`apk upgrade --no-cache\` (CVE refresh for c-ares / libexpat) failed on the runner with a persistent I/O error fetching \`dl-cdn.alpinelinux.org/alpine/v3.23/main\` → apk exit 99 ("stale/unavailable repositories"). Now retries 3× with backoff, then falls back to the secondary \`dl-4\` mirror.

### 2. AGORA_SECRET_KEY fallback (scripts/e2e-up.sh)
e2e-globalSetup seeds provider-connections with an api_key, which the LLM-Provider-Secrets-Store encrypts with the \`AGORA_SECRET_KEY\` Fernet master key (Slice 5.6). Without it, \`_secrets_store.upsert\` raised RuntimeError → seed API answered **503 store_unavailable** and every smoke job died in \`beforeEach\`. The workflow generates \`AGORA_AUTH_TOKEN\`/\`SECRET_KEY\`/\`NEO4J_PASSWORD\` in all 6 jobs but **never** \`AGORA_SECRET_KEY\`; \`e2e-up.sh\` only forwarded it when already set, so the backend booted without a Fernet key. Now \`e2e-up.sh\` generates an ephemeral urlsafe-base64 Fernet key via python3 if unset (self-contained for all 6 jobs + local dev runs; e2E-seeded connections are not persisted across runs).

## Verification (run 29309606742)
**Health-Smoke: success** ✅ — stack boots, provider-connections seed, backend healthy. This is the first green e2e-smoke job ever; before this PR all 6 died at build/seed.

## Not in this PR: pull_request trigger + 5 spec bugs
The branch originally added a \`pull_request: branches:[main]\` trigger (commit 0431f045, now reverted in 4a4fb0d0). That trigger exposed a deeper truth: **5 of 6 smoke specs are pre-existing broken** (independent root causes — UI-drift on \`/settings/llm-routing\` from the 7.6 migration, report/graph stub-pipeline gaps, a11y violations). They never failed before because e2e only ran on \`push:main\`/\`schedule\`, where it died at build/seed before reaching the specs.

Merging the pull_request trigger now would block **every future PR** on 5 independent spec bugs. The trigger is therefore reverted from this PR and will be re-added in a follow-up once the specs are green. The 5 spec bugs should be tracked as a separate epic.

Co-Authored-By: Claude <noreply@anthropic.com>