### PR TITLE
docs(slice-7.6): picker migration matrix + 7.6d scope/plan

### DIFF
--- a/docs/epics/onboarding-provider-unification/slice-7.6-picker-migration-matrix.md
+++ b/docs/epics/onboarding-provider-unification/slice-7.6-picker-migration-matrix.md
@@ -1,0 +1,75 @@
+# Slice 7.6 — Picker-Migrationsmatrix
+
+Stand: 2026-07-14 (nach PR #727 / #728, gegen `origin/main`).
+
+Diese Matrix präzisiert die Pickernutzung, den internen Typ, den Backend-Payload
+und die Persistenz je Surface — und ersetzt die leicht widersprüchlichen
+Angaben in den PR-Beschreibungen #727/#728 (»migriert« vs. »doch nicht
+migriert«) durch eine verifizierte Ist-Aufnahme.
+
+## Verifikationsmethode
+
+Alle Zellen per `grep`/`Read` gegen den aktuellen Code auf `origin/main`
+verifiziert (CRG + `ctx_execute`). Persistenz = tatsächliches
+`localStorage.setItem(...)` mit dem `…aiModelRef`-Key, nicht nur eine
+konstantendefinition.
+
+## Matrix
+
+| Bereich (Datei) | Picker-Komponente | interner Typ | Backend-Payload | Persistenz | Status |
+|---|---|---|---|---|---|
+| **Hero** (`v4/dashboard/HeroNewRun.vue`) | `AiModelPicker` | `AiModelRef` | `LlmRoute` via `adapter.toLlmRoute()` | `localStorage['agora.hero.aiModelRef']` (JSON, Zod-validiert); Legacy `agora.hero.route` wird nicht mehr gelesen und beim Schreiben entfernt | **fertig, persistiert** |
+| **Home** (`views/Home.vue`) | `AiModelPicker` | `AiModelRef` | `LlmRoute` | `localStorage['agora.home.aiModelRef']`; Legacy `agora.home.route` entfernt | **fertig, persistiert** |
+| **Report-Auswahl** (`Step4Report.vue`) | `AiModelPicker` (im Kind `step4/ReportModelControls.vue`) | `AiModelRef` | `LlmRoute` | `localStorage['agora.report.aiModelRef']`; Legacy `agora.report.route` entfernt | **fertig, persistiert** |
+| **ReportModelControls** (`step4/ReportModelControls.vue`) | `AiModelPicker` | `AiModelRef` | — (controlled child, `emit('update:modelValue')`) | keine eigene — Persistenz obliegt dem Parent `Step4Report.vue` | **fertig** (controlled child, korrekt) |
+| **StepModelOverrideChip** (`v4/forms/StepModelOverrideChip.vue`) | `AiModelPicker` | `AiModelRef` | per-Run-Override im Run-Snapshot | run-bounded (kein `localStorage`; Override lebt im Run, nicht pro-Surface) | **fertig** |
+| **LlmRoutingView** (`LlmRouting/LlmRoutingView.vue`) | `AiModelPicker` | `AiModelRef` / `LlmRoute` | `LlmRoute` (`/api/llm-routing`) | server-seitig (RuntimeLlmRouting, Pydantic-SSoT) | **fertig** |
+| **SettingsGeneralView** | `AiModelPicker` | `AiModelRef` | `LlmRoute` | server-seitig | **fertig** |
+| **LlmProvidersView** | `AiModelPicker` | `AiModelRef` | `LlmRoute` | server-seitig | **fertig** |
+| **LlmProfileManager** (`v4/forms/LlmProfileManager.vue`) | **legacy `./ModelPicker.vue`** (line 13 import, line 347 `<ModelPicker>`) | `LlmProfile` (provider-basiert) | `LlmProfile` | `localStorage` (Profile-Store) | **OFFEN — 7.6d** |
+| **v4-Legacy-Picker** (`v4/forms/ModelPicker.vue`, 160 LoC) | — | `{ provider_id, model_id }` | — | — | **OFFEN — 7.6d: löschen** (einziger Importer ist `LlmProfileManager`) |
+
+## Aufklärung der P1-Annahme »temporär / session-only«
+
+Die Annahme, 7.6c habe für Home / Step4Report / Report-Auswahl nur eine
+**session-only**-Auswahl hinterlassen (nicht dauerhaft gespeichert), trifft auf
+den aktuellen Code **nicht** zu:
+
+- `Home.vue:70` — `localStorage.setItem(STORAGE_HOME_AI_REF, JSON.stringify(aiRef))`
+- `Step4Report.vue:132` — `localStorage.setItem(STORAGE_REPORT_AI_REF, JSON.stringify(val))`
+- `HeroNewRun.vue:209` — `writeLocal(STORAGE_HERO_AI_REF, JSON.stringify(aiRef))`
+
+Alle drei Surfaces persistieren die Auswahl nach `localStorage` unter dem
+neuen `…aiModelRef`-Key und entfernen den Legacy-`…route`-Key beim Schreiben.
+`ReportModelControls.vue` persistiert bewusst nicht selbst — es ist ein
+controlled child (`emit('update:modelValue')`); die Persistenz liegt beim Parent
+`Step4Report.vue`. Das ist die korrekte Architektur, keine Lücke.
+
+Falls die PR-#728-Beschreibung ein »session-only, Persistenz in 7.6d«
+angedeutet hat, war das konservativer als die tatsächliche Implementierung:
+die Persistenz ist bereits in `origin/main` geschlossen.
+
+## Echter verbleibender 7.6d-Scope
+
+Gegen `docs/epics/onboarding-provider-unification/slice-7-subplan.md` §7.6d:
+
+1. **`LlmProfileManager.vue` auf `AiModelPicker` migrieren** (646 LoC).
+   Letzter Produktionsimporter des legacy `ModelPicker.vue`. Mapping
+   `ModelPicker.provider_id` (Runtime) ⇄ `LlmProfile.provider` (Storage) wird
+   durch die connection-basierte `AiModelPicker`-Abbildung ersetzt. Flows:
+   Profil erstellen/bearbeiten/default setzen, unbekannte Connection als
+   validierten Fehler, Picker komplett per Tastatur. Spec
+   `__tests__/LlmProfileManager.spec.ts` mitziehen.
+2. **`v4/forms/ModelPicker.vue` + ggf. Spec löschen** — nach 1. ist die Datei
+   Dead Code (einziger Importer war `LlmProfileManager`). Vor Löschung
+   `rg`-Nachweis, dann `bun run typecheck` + targeted Spec grün.
+
+Der ursprünglich für 7.6d genannte »Picker-Spiegel für Home / ReportModelControls«
+ist durch 7.6b (PR #727) bereits erledigt — keine Doppel-Migration.
+
+## Akzeptanz für 7.6d (nach Sub-Plan)
+
+- `grep -r "AiModelPicker"` ist der einzige Produktionspicker.
+- `v4/forms/ModelPicker.vue` entfernt, kein Import mehr.
+- Keine neue Contract-Klasse.
+- `LlmProfileManager.spec.ts` + Build grün; `pre-push-gate.sh frontend` grün.

--- a/docs/epics/onboarding-provider-unification/slice-7.6d-llm-profile-manager-migration-plan.md
+++ b/docs/epics/onboarding-provider-unification/slice-7.6d-llm-profile-manager-migration-plan.md
@@ -1,0 +1,98 @@
+# Slice 7.6d — Migrationsplan: LlmProfileManager → AiModelPicker
+
+Stand: 2026-07-14. Konkreter Umsetzungsplan für den letzten offenen
+7.6d-Scope (siehe `slice-7.6-picker-migration-matrix.md`). Wurde gegen den
+aktuellen Code auf `origin/main` verifiziert, nicht gegen die Sub-Plan-Prosa.
+
+## Ist-Zustand (verifiziert)
+
+`frontend/src/components/v4/forms/LlmProfileManager.vue` (646 LoC):
+
+- CRUD-Panel für **provider-zentrische** `LlmProfile` (`@/contracts/llmProfileContract`):
+  Felder `name`, `provider` (`LlmProvider`: openai/ollama/gemini/anthropic/…),
+  `baseUrl`, `model`, `api_key`. Store: `useLlmProfilesStore` (`@/store/aiModels`)
+  mit `create / update / remove / setDefault / fetch`.
+- Nutzt legacy `./ModelPicker.vue` (line 13, `<ModelPicker>` line 347,
+  `:model-value="pickerValue" @update:model-value="onPickerChange"`).
+- `RUNTIME_TO_PROFILE_PROVIDER` (line 24) mapt `ModelPicker.provider_id`
+  (Runtime-Provider-String) → `{ provider, baseUrl }`.
+- `pickerValue` (line ~130) baut aus `formProvider`/`formModel` ein
+  route-ähnliches Objekt `{ provider_id, model_id, provider_options: {} }`.
+- `onPickerChange` (line ~153) übersetzt eingehenden `route.provider_id`
+  zurück nach `formProvider`/`formBaseUrl`.
+- Spec `__tests__/LlmProfileManager.spec.ts` (188 LoC) stubt `ModelPicker`
+  (`ModelPickerStub` line 80), testet: rendert Profile, `store.create`-Payload,
+  `store.setDefault`. Kein ApiKey-/Fehler-Flow-Test.
+
+`v4/forms/ModelPicker.vue` (160 LoC) ist **der einzige Importer** von
+`LlmProfileManager.vue` (relativer Import `./ModelPicker.vue`); keine eigene Spec.
+
+## Semantischer Shift (Kernschwierigkeit)
+
+`ModelPicker` ist **provider-id-basiert** (`provider_id` = Runtime-String wie
+`"openai"`). `AiModelPicker` ist **connection-basiert** (`AiModelRef` mit
+`provider_connection_id` = UUID aus `ProviderConnectionStore`, plus `model_id`).
+
+Die bisherige Abbildung `provider_id ⇄ LlmProfile.provider` wird ersetzt durch
+**`ProviderConnection → LlmProfile`**:
+
+- Ein `ProviderConnection` trägt selbst `provider` + `base_url` (zu prüfen gegen
+  `ProviderConnectionStore` / `contracts/providerConnectionContract`).
+- Pick im `AiModelPicker` → `AiModelRef{ provider_connection_id, model_id }`
+  → lookup der Connection → `formProvider`/`formBaseUrl`/`formModel` ableiten.
+- Edit/Load (bestehendes Profil) → aus `profile.provider` eine passende Connection
+  best-effort finden. **Unbekannte/fehlende Connection = validierter Fehler**
+  (kein silentes Default), wie §7.6d fordert.
+
+Diese Abbildung muss vor der Codierung geklärt + getestet sein — sie ist der
+Risikokern, kein reines Find-and-Replace.
+
+## Dateien
+
+| Datei | Änderung |
+|---|---|
+| `components/v4/forms/LlmProfileManager.vue` | `import ModelPicker` → `import AiModelPicker`; `<ModelPicker>` → `<AiModelPicker>`; `RUNTIME_TO_PROFILE_PROVIDER` ersetzen durch Connection-Lookup (`useProviderConnections` o. ä.); `pickerValue` → `AiModelRef`-Builder; `onPickerChange` → Connection→Profile-Mapping + unknown-connection-Fehler |
+| `components/v4/forms/__tests__/LlmProfileManager.spec.ts` | `ModelPickerStub` → `AiModelPickerStub`; `store.create`-Payload-Test an Connection-Mapping anpassen; **neu**: unknown-connection → Fehler (kein create); a11y-Tastatur-Smoke für den Picker |
+| `components/v4/forms/ModelPicker.vue` | **löschen** (nach Commit 1, wenn kein Importer mehr) |
+
+## TDD-Reihenfolge
+
+1. **RED** — Spec auf `AiModelPicker` + Connection-Mapping umstellen;
+   `unknown-connection`-Fall als neuer Test (erwartet Fehler/anzeige, kein
+   `store.create`-Aufruf). Build schlägt fehl (ModelPicker noch da, Spec
+   erwartet AiModelPicker).
+2. **GREEN** — `LlmProfileManager.vue` auf `AiModelPicker` migrieren;
+   Mapping implementieren; Spec grün; `bun run typecheck` grün.
+3. **DELETE** — `rg "forms/ModelPicker"` leer → `ModelPicker.vue` löschen;
+   `bun run typecheck` + targeted Spec grün.
+4. **Doku-Sync** — Matrix + dieser Plan: Status auf »done«; `AGENTS.md` /
+   `docs/STATUS.md` / `CHANGELOG.md` (LlmProfileManager retired).
+
+## Akzeptanz
+
+- `grep -r "AiModelPicker" frontend/src` = einziger Produktionspicker.
+- `grep -rln "v4/forms/ModelPicker" frontend/src` = leer; Datei entfernt.
+- `LlmProfileManager.spec.ts` grün (inkl. unknown-connection + a11y).
+- `bun run typecheck` + `bun run build` grün; `pre-push-gate.sh frontend` grün.
+- Keine neue Contract-Klasse.
+
+## Risiken / Offenpunkte (vor Codierung klären)
+
+- Hat `ProviderConnection` wirklich `provider` + `base_url`? (gegen
+  `contracts/providerConnectionContract` + Store verifizieren — nicht
+  angenommen). Wenn nicht, ist die Abbildung Connection→Profile nicht
+  verlustfrei und braucht eine explizite Selektion im Form.
+- `LlmProfile.api_key` vs. Connection-Secrets: Profile verwalten ihr eigenes
+  `api_key`; Connections haben separate Secrets. Migration darf das
+  Secret-Modell nicht vermischen — nur Provider/BasisURL/Modell mappen.
+- Mapping-Implikation für **bestehende Profile** (persistiert im
+  Profile-Store): ein Profil mit `provider="ollama"` ohne hinterlegte
+  Connection darf im Picker nicht crashen → best-effort-Anzeige + klare
+  Aufforderung, eine Connection auszuwählen.
+
+## Empfehlung
+
+Eigener fokussierter PR (`feat/slice-7.6d-llm-profile-manager-ai-picker`),
+2 Commits (migrate / delete), dedizierter Frontend-Worker, der nur targeted
+Specs laufen lässt (kein Full-Suite-Loop). Nicht am Ende einer langen Session
+in Eile — die Connection↔Profile-Abbildung verdient eine eigene Aufmerksamkeitsspanne.


### PR DESCRIPTION
## What

Two docs for the ongoing Onboarding/Provider-Unification Slice 7.6 wave, verified against current code on `origin/main` (grep/Read via CRG + ctx, not PR descriptions):

1. **`slice-7.6-picker-migration-matrix.md`** — precise matrix per surface (Picker | interner Typ | Backend-Payload | Persistenz | Status). Resolves the #727/#728 description drift ("migriert" vs "doch nicht migriert").
2. **`slice-7.6d-llm-profile-manager-migration-plan.md`** — concrete plan for the last open 7.6d scope (LlmProfileManager → AiModelPicker + delete legacy ModelPicker.vue).

## Key findings

- **Hero/Home/Report all use `AiModelPicker` + persist `AiModelRef` to `localStorage` under `agora.<scope>.aiModelRef`** — verified via actual `localStorage.setItem` calls (Home.vue:70, Step4Report.vue:132, HeroNewRun.vue:209). The P1 assumption "session-only / nicht dauerhaft gespeichert" does **not** hold against current code; persistence is already closed. `ReportModelControls` is a controlled child (`emit('update:modelValue')`); `Step4Report` persists — correct architecture, not a gap.
- `StageLLMRoute` is gone from non-spec frontend `src/` (7.6c acceptance met).
- **Real remaining 7.6d scope** = migrate `LlmProfileManager.vue` (646 LoC, last importer of legacy `ModelPicker.vue`) to `AiModelPicker`, then delete `v4/forms/ModelPicker.vue`. The "Picker-Spiegel for Home/ReportModelControls" originally listed for 7.6d is already done by 7.6b — no double migration.
- The 7.6d plan flags the semantic shift (provider-id → connection-based), the `ProviderConnection → LlmProfile` mapping design (incl. unknown-connection validated error), TDD sequence, acceptance, and open questions to resolve before coding.

Docs-only PR; no code/schema/STATUS impact. `pre-push-gate.sh backend` green on rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)