### PR TITLE
test(frontend): stabilize parallel-flaky router + accessibility specs

### DIFF
--- a/frontend/src/router/__tests__/index.spec.ts
+++ b/frontend/src/router/__tests__/index.spec.ts
@@ -35,6 +35,30 @@ vi.mock('../../i18n/index', () => ({
   setLocale: vi.fn(),
 }))
 
+// Die Produktion-Routen referenzieren ihre Views als lazy `() => import(...)`.
+// vue-router löst diese Async-Components bei jedem `router.push()` auf (nicht
+// erst beim Render). Isoliert kostet das ~0,5 s pro erstem Routen-Besuch
+// (View-Transform); im parallelen Full-Suite-Lauf ballt sich die Transform-
+// Last auf >10 s pro Navigation → der beforeAll-Hook überschreitet das
+// Default-hookTimeout (10 s) und der ganze File flakt. Dieser Spec testet
+// ausschließlich Routen-Resolution/Redirects/Guards/meta-Flags — es wird keine
+// Komponente gerendert. Also stubben wir die besuchten Views auf einen Noop,
+// damit `push()` deterministisch ~1 ms bleibt. Assertions bleiben unberührt.
+const VIEW_STUB = vi.hoisted(() => ({
+  default: { name: 'ViewStub', render: () => null },
+}))
+vi.mock('../../views/v4/DashboardView.vue', () => VIEW_STUB)
+vi.mock('../../views/v4/RunsAppShellView.vue', () => VIEW_STUB)
+vi.mock('../../views/v4/CompareView.vue', () => VIEW_STUB)
+vi.mock('../../views/Home.vue', () => VIEW_STUB)
+vi.mock('../../views/NotFoundView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/SettingsGeneralView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/SettingsIntegrationsView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/SettingsApiKeysView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/SettingsAuditLogsView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/LlmRoutingView.vue', () => VIEW_STUB)
+vi.mock('../../views/Settings/LlmProvidersView.vue', () => VIEW_STUB)
+
 import router from '../index'
 import { getAgoraToken } from '../../api/index'
 

--- a/frontend/tests/accessibility-helpers.spec.ts
+++ b/frontend/tests/accessibility-helpers.spec.ts
@@ -1,6 +1,26 @@
 import type { Page } from '@playwright/test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// @axe-core/playwright ist ein E2E-only-Dep (nur in `runAxe` + Type-Positionen
+// des Helpers genutzt, nicht in den hier getesteten Pure-Functions). Unter
+// paralleler Full-Suite-Last rast Vites Lazy-Resolver beim Auflösen dieses
+// CJS-Pakets gelegentlich und der File flakt mit "Failed to resolve import
+// @axe-core/playwright". Stub auf einen Noop-Default — die getesteten
+// Funktionen (diffFocusStyle/parseMaxDuration/checkFocusVisible/
+// checkReducedMotion) rufen `runAxe` nicht auf, `@playwright/test`'s `expect`
+// bleibt echt (in checkFocusVisible genutzt).
+vi.mock('@axe-core/playwright', () => ({
+  default: class AxeBuilder {
+    constructor() {}
+    options() {
+      return this;
+    }
+    analyze() {
+      return Promise.resolve({});
+    }
+  },
+}));
+
 import {
   checkFocusVisible,
   checkReducedMotion,


### PR DESCRIPTION
## Problem

Two specs passed isolated but flaked under parallel full-suite load
(`pre-push-gate.sh frontend` / CI frontend gate), so the gate was
non-deterministic. Root cause in both cases: **parallel transform/resolver
contention**, not a logic bug.

## Root causes

### `router/__tests__/index.spec.ts`
vue-router resolves lazy `() => import(...)` view components on every
`router.push()` (not only on render). Isolated ~0.5 s per first route visit;
under parallel load this balloons past the 10 s `beforeAll` hookTimeout →
the whole file times out.

This spec tests route resolution/redirects/guards/meta **only** — no
component is rendered — so stub the 11 visited views via `vi.hoisted()`
Noop mocks. `push()` drops to ~1 ms, deterministic. **Assertions
(name/params/query/meta) unchanged.**

### `tests/accessibility-helpers.spec.ts`
`@axe-core/playwright` is an e2e-only dep used only in type positions and
the untested `runAxe` helper; Vite's lazy resolver raced on this CJS
package under parallel load and failed with
`Failed to resolve import @axe-core/playwright`. Stub to a Noop
`AxeBuilder` default — tested pure functions
(`diffFocusStyle`/`parseMaxDuration`/`checkFocusVisible`/`checkReducedMotion`)
don't call `runAxe`; `@playwright/test`'s `expect` stays real.

## Verification
- Isolated: both files green (router 21/21).
- Parallel full-suite (`pre-push-gate.sh frontend`): **ALL GREEN**.

No assertion weakened, no test skipped.