### PR TITLE
fix(scripts): define run_schemas in pre-push-gate.sh

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -63,6 +63,22 @@ run_backend() {
 }
 
 # ---------------------------------------------------------------------------
+# Schema-Gates (Drift + STATUS-Sync) — eigenes Scope fuer den schnellen
+# Schema-Check ohne Backend-Test-Suite. Spiegel genau die beiden letzten
+# run_backend-Steps (dump_schemas --check + sync-status --check).
+# ---------------------------------------------------------------------------
+run_schemas() {
+  step "Schema-Drift (dump_schemas --check)"
+  (cd backend && uv run python -m app.contracts.dump_schemas --check) \
+    || fail "schema drift — run 'cd backend && uv run python -m app.contracts.dump_schemas' locally and commit"
+
+  step "Backend: sync-status --check"
+  bash scripts/sync-status.sh --check \
+    || fail "STATUS.md drift — run 'bash scripts/sync-status.sh' locally and commit"
+  ok "schema gates green"
+}
+
+# ---------------------------------------------------------------------------
 # Frontend-Gates
 # ---------------------------------------------------------------------------
 run_frontend() {
@@ -103,7 +119,7 @@ case "$SCOPE" in
   all)      run_backend; run_frontend ;;
   backend)  run_backend ;;
   frontend) run_frontend ;;
-  schemas)  run_schemas && ok "schema gates green" ;;
+  schemas)  run_schemas ;;
   *)        echo "usage: $0 [all|backend|frontend|schemas]" >&2; exit 2 ;;
 esac
 


### PR DESCRIPTION
## Problem

`bash scripts/pre-push-gate.sh schemas` brach mit `run_schemas: command not found` ab — der `schemas)`-Case im Routing rief `run_schemas` auf, die Funktion war nie definiert. Geflaggt in der Session als offener Punkt 5.

## Fix

- `run_schemas()` definiert: spiegelt genau die beiden letzten `run_backend`-Steps (`dump_schemas --check` + `sync-status.sh --check`) als eigenes Scope. Passend zum Usage-Kommentar (Zeile 13) und AGENTS.md („schemas: nur Schema-Drift + STATUS-Sync").
- Doppelt-ok entfernt: der `schemas)`-Case rief zuvor `run_schemas && ok "schema gates green"` — `run_schemas` setzt `ok` selbst, also erschien die Meldung zweimal. Case jetzt schlank wie `backend)`/`frontend)`.

## Verification

- `bash -n scripts/pre-push-gate.sh` → SYNTAX OK
- `bash scripts/pre-push-gate.sh schemas` → 46 Schemas matchen, STATUS.md in sync, single „schema gates green", ALL GREEN.
- `backend`/`frontend`-Scopes unberührt.

## Risk

Minimal — eine fehlende Funktionsdefinition nachgetragen, keine Logikänderung an bestehenden Scopes. Kein Layer-Touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)