### PR TITLE
docs(slice7): PLAN Slice-7-Stand korrigiert

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -409,7 +409,7 @@ Source of Truth:
 | 4.3.2 | Frontend-Store + View + Onboarding-Anbindung | offen |
 | 5 | Gemeinsamer Model-Picker und Routing | 🟡 5.1–5.3 implementiert; 5.4–5.6 offen |
 | 6 | Persona-Count-End-to-End-Invariante | offen |
-| 7 | Golden-Gate-Designsystem und Informationsarchitektur | 🟡 7.1 (Token-Fundament + Focus/Motion/Dark-Readiness-Vertrag, `tokens-v3.css` + `designTokens.spec.ts`) auf main; 7.2+ offen |
+| 7 | Golden-Gate-Designsystem und Informationsarchitektur | 🟡 weitgehend auf main: 7.1 Token-Fundament, 7.3 Gates/Drawer-A11y/Routing (PR #723), 7.5 Onboarding (PR #725), 7.6a–c AiModelPicker-Migration/StageLLMRoute-Cut (PR #726–#728); offen: 7.6d, responsive/Regressionen, --agora-*-Token-Wechsel |
 | 8+ | Projekte, Datensätze, Vorlagen, Monitoring als einzelne MVPs | offen |
 
 Baseline: Backend 3130 passed / 9 skipped / 7 deselected; Frontend 154
@@ -430,7 +430,7 @@ validation_error_payload`. Wirkt zentral für alle API-Routen, die
 
 ---
 
-*Zuletzt aktualisiert: 2026-07-14 — Slice 7.1 (Golden-Gate-Token-Fundament + Focus/Motion/Dark-Readiness-Vertrag) auf main nachgetragen; Slice 4.1 verifiziert; Slice 3 (PR #685) gemergt.*
+*Zuletzt aktualisiert: 2026-07-14 — Slice-7-Stand korrigiert: 7.1 Tokens, 7.3 Gates/Drawer/Routing (PR #723), 7.5 Onboarding (PR #725), 7.6a–c Picker-Migration (PR #726–#728) auf main; offen 7.6d + responsive + --agora-*-Token-Wechsel; Slice 3 (PR #685) gemergt.*
 *Provider-Detection-SSoT: `backend/app/llm/providers/registry.py`.*
 *Embedding-Provider-Restriktion: `backend/app/contracts/embedding_contract.py::provider_kind_supports_embeddings`.*
 *Heuristik-SSoT: `docs/plans/plan.heuristic-2026-05-17.md`.*


### PR DESCRIPTION
## Was

PR #735 hatte die Slice-7-Zeile in PLAN.md untertrieben: »🟡 7.1 auf main; 7.2+ offen«. Tatsächlich liegt deutlich mehr Slice-7-Arbeit auf main.

## Korrektur (verifiziert gegen origin/main)

Slice 7 → **🟡 weitgehend auf main**:
- 7.1 Token-Fundament (`tokens-v3.css` + `designTokens.spec.ts`)
- 7.3 Gates/Drawer-A11y/Routing (PR #723)
- 7.5 Onboarding (PR #725)
- 7.6a–c AiModelPicker-Migration/StageLLMRoute-Cut (PR #726–#728)

**Offen:**
- 7.6d (LlmProfileManager→AiModelPicker + Delete ModelPicker.vue — nur Plan-Doku via PR #732 auf main, Code fehlt)
- responsive/Regressionen
- `--agora-*`-Token-Wechsel (eigenes Slice 7, `agora-tokens.css` aus Pack + `designTokens.spec.ts`-Anpassung)

## Scope

Docs-only — nur PLAN.md (1 Datei, 2 Zeilen: Tabellenzeile + Fußnote). Kein Code, keine Schema-Änderung.

## Gates

- `bash scripts/pre-push-gate.sh backend` → ALL GREEN (46 Schemas matchen, STATUS in sync)

Refs: golden-gate-workbench.md (via #735), e2e-smoke-specs-README (via #735).