### PR TITLE
feat(registry): detect MiniMax provider via api.minimax.io base URL

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -267,7 +267,7 @@ class LLMClient:
         )
         return {key: max_tokens}
 
-    def _detect_provider(self) -> Literal["ollama", "cloud", "openai", "google", "unknown"]:
+    def _detect_provider(self) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
         """Infer the LLM provider from base_url and model name.
 
         Siehe ``app.llm.providers.base.detect_provider`` für die Heuristik.

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -233,7 +233,7 @@ def is_ollama(base_url: Optional[str]) -> bool:
 
 def detect_provider(
     base_url: Optional[str], model: Optional[str]
-) -> Literal["ollama", "cloud", "openai", "google", "unknown"]:
+) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
     """Infer the LLM provider from base_url and model name.
 
     Delegiert an ``app.llm.providers.registry.detect_provider(mode="http")``

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -51,7 +51,9 @@ if TYPE_CHECKING:
     from app.llm.providers.base import ProviderAdapter
 
 # Teilmengen von app.contracts.provider_types.ProviderType
-HttpDetectedProvider = Literal["ollama", "cloud", "openai", "google", "unknown"]
+HttpDetectedProvider = Literal[
+    "ollama", "cloud", "minimax", "openai", "google", "unknown"
+]
 OasisDetectedProvider = Literal["google", "ollama", "openai"]
 DetectionMode = Literal["http", "oasis"]
 
@@ -95,11 +97,16 @@ def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedP
     2. Ollama-Cloud-Tag ``:cloud`` / ``:<size>-cloud`` → ``"cloud"`` (Cloud-
        Modelle laufen auch über den lokalen ollama-Proxy — deshalb VOR der
        Port-Heuristik). Siehe ``_is_ollama_cloud_tag`` (Issue #670).
-    3. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
-    4. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
-    5. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
+    3. Base URL enthält ``api.minimax.io`` → ``"minimax"`` (MiniMax-Modelle
+       wie ``MiniMax-M3``, OpenAI- und Anthropic-kompatibel). Eigener
+       Branch vor der Port-Heuristik und vor ``openai.com``, weil
+       Subdomain-Matchings nichts mit Ollama-Ports zu tun haben und
+       ``api.openai.com`` sonst fälschlich gewinnen würde.
+    4. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
+    5. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
+    6. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
        ``"google"`` (Gemini-OpenAI-Compat-Layer mit nativem ``tools=``).
-    6. Fallback → ``"unknown"``.
+    7. Fallback → ``"unknown"``.
     """
     model_name = model or ""
     base = (base_url or "").lower()
@@ -107,6 +114,8 @@ def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedP
         return "cloud"
     if _is_ollama_cloud_tag(model_name):
         return "cloud"
+    if "api.minimax.io" in base:
+        return "minimax"
     if "11434" in base:
         return "ollama"
     if "openai.com" in base or "api.openai" in base:

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, urlunparse
 from typing import Optional, Dict, Any
 from ..contracts import (
     PROVIDER_GOOGLE,
+    PROVIDER_MINIMAX,
     PROVIDER_OLLAMA_CLOUD,
     PROVIDER_OPENAI,
     PROVIDER_OPENAI_COMPATIBLE,
@@ -78,6 +79,7 @@ def _sanitize_url(value: str) -> str:
 _HTTP_DETECTION_TO_PROVIDER_ID = {
     "cloud": PROVIDER_OLLAMA_CLOUD,
     "google": PROVIDER_GOOGLE,
+    "minimax": PROVIDER_MINIMAX,
     "openai": PROVIDER_OPENAI,
     # "ollama" (local, e.g. port 11434) and "unknown" both fall back to the
     # generic OpenAI-compatible route, matching this function's previous

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -43,6 +43,14 @@ HTTP_CASES = [
     ("https://api.openai.com/v1", "mistral-large-cloud", "openai"),
     # Kein False Positive: `:`-Tag mit `-cloud` OHNE Groessenpraefix (Dritt-Gateway).
     ("https://api.example.com/v1", "custom:experimental-cloud", "unknown"),
+    # MiniMax (MiniMax-M3, ...) — eigener Provider-Branch unter api.minimax.io.
+    # Subdomain-Match vor "11434"-Port und vor "openai.com"-Substring, sonst
+    # landet MiniMax-M3 fälschlich auf api.openai.com (Smoke 2026-07-14).
+    ("https://api.minimax.io/v1", "MiniMax-M3", "minimax"),
+    ("https://api.minimax.io/anthropic", "MiniMax-M3", "minimax"),
+    ("HTTPS://API.MINIMAX.IO/v1", "MiniMax-M3", "minimax"),  # case-insensitive
+    # Kein False Positive: Modellname enthaelt "minimax", Base-URL aber nicht.
+    ("https://api.openai.com/v1", "minimax-mock", "openai"),
 ]
 
 
@@ -110,6 +118,10 @@ DIVERGENT_CASES = [
     ("https://example.com/v1", "some-model", "unknown", "openai"),
     ("", "llama3:latest", "unknown", "ollama"),  # :latest nur im OASIS-Modus ein Signal
     ("http://host:114340/v1", "foo", "ollama", "openai"),  # Substring vs. Port-Regex
+    # MiniMax: HTTP erkennt explizit ("minimax"); OASIS faellt auf
+    # OpenAI-Compat-Fallback zurueck (CAMEL-Dispatcher kennt kein
+    # "minimax"-PlatformType, OpenAI-Compat-Endpoint funktioniert).
+    ("https://api.minimax.io/v1", "MiniMax-M3", "minimax", "openai"),
 ]
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,7 +23,7 @@ Epic-`HANDOVER.md`.
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3335 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3340 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 163 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
Adds MiniMax (`api.minimax.io`) to the central provider detection Single Source of Truth (`backend/app/llm/providers/registry.py::detect_provider`, `mode="http"`). Previously MiniMax-M3 fell through to the OpenAI fallback and POSTed to `api.openai.com` → 404.

## Why
Live smoke 2026-07-14 on armserver: ontology generation with `MiniMax-M3 @ https://api.minimax.io/v1` returned HTTP 500 because the backend dispatched to `api.openai.com`. The fix was a working UI override (`provider=custom_openai`); this PR generalizes the recognition at the detection layer.

## What
- `registry._detect_http`: substring check on `api.minimax.io` → `"minimax"`, placed before the `"11434"` port heuristic and before `"openai.com"`.
- `HttpDetectedProvider` Literal extended with `"minimax"`. `OasisDetectedProvider` deliberately unchanged — CAMEL has no `minimax` PlatformType; documented as divergent in tests.
- `runtime_run_config._HTTP_DETECTION_TO_PROVIDER_ID`: `"minimax" → PROVIDER_MINIMAX`.
- `base.detect_provider` + `client.LLMClient._detect_provider`: Return-Type Literal extended so the delegation chain stays type-consistent under mypy.
- 5 new tests (4 positive + 1 negative + 1 divergent) in `tests/llm/test_provider_registry.py`.
- `docs/STATUS.md`: test counter sync 3335 → 3340.

## Validation
- Targeted: `tests/llm/test_provider_registry.py` — 46 passed.
- Backend pre-push-gate: 377 tests passed, ruff + mypy clean, schema-dump + STATUS-sync OK.

## Out of scope (follow-up)
- `mode="oasis"` MiniMax branch — CAMEL needs a `minimax` PlatformType first.
- `parse_runtime_llm_config` UI alias for `provider="minimax"` — needs a default base URL + key-prefix decision; current `provider="custom_openai"` path works.