### PR TITLE
feat(frontend): Run-Kill-Switch + Graph Pin-Persistenz/Mini-Map (Phase 3+4)

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -252,14 +252,14 @@ class LLMClient:
         self, max_tokens: int, model: Optional[str] = None
     ) -> Dict[str, int]:
         """
-        Select the token-limit parameter name supported by the target model.
+        Build the token-limit parameter for the selected model.
         
         Parameters:
-            model (Optional[str]): Model to inspect; defaults to the client's model.
+            max_tokens (int): Maximum number of completion tokens.
+            model (Optional[str]): Model used to select the token-limit parameter; defaults to the client's model.
         
         Returns:
-            Dict[str, int]: A mapping containing either ``max_completion_tokens`` or
-            ``max_tokens`` with the requested limit.
+            Dict[str, int]: A mapping containing either ``max_completion_tokens`` or ``max_tokens`` with the requested limit.
         """
         target_model = model if model is not None else (self.model or "")
         key = (
@@ -271,10 +271,11 @@ class LLMClient:
 
     def _detect_provider(self) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
         """
-        Infer the provider associated with the configured base URL and model name.
+        Identify the LLM provider associated with the configured endpoint and model.
         
         Returns:
-            str: The inferred provider identifier.
+            str: The provider name: ``"ollama"``, ``"cloud"``, ``"minimax"``,
+                ``"openai"``, ``"google"``, or ``"unknown"``.
         """
         return _provider_base.detect_provider(self.base_url, self.model)
 

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -235,13 +235,13 @@ def detect_provider(
     base_url: Optional[str], model: Optional[str]
 ) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
     """
-    Identify the LLM provider associated with a base URL and model name.
+    Infer the LLM provider from a base URL and model name.
     
     Parameters:
-        base_url (Optional[str]): The provider's base URL.
-        model (Optional[str]): The model name.
+        base_url (Optional[str]): The provider endpoint URL.
+        model (Optional[str]): The model identifier.
     
     Returns:
-        Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]: The inferred provider label.
+        Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]: The inferred provider.
     """
     return _detect_provider_registry(base_url, model, mode="http")

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING, Literal, Optional, Union, overload
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from app.llm.providers.base import ProviderAdapter
@@ -110,7 +111,17 @@ def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedP
         return "cloud"
     if _is_ollama_cloud_tag(model_name):
         return "cloud"
-    if "api.minimax.io" in base:
+    # CodeQL #750 — match the URL hostname exactly (suffix) instead of a raw
+    # substring, which would also match `api.minimax.io.attacker.test` or
+    # paths/query containing the text and misroute requests through
+    # PROVIDER_MINIMAX. Consistent hostname-based detection for all providers
+    # (ollama.com, openai.com, googleapis.com) is tracked in Phase F (#671)
+    # / #750 — this PR only fixes the NEW minimax branch.
+    _minimax_host = urlparse(base).hostname
+    if _minimax_host and (
+        _minimax_host == "api.minimax.io"
+        or _minimax_host.endswith(".api.minimax.io")
+    ):
         return "minimax"
     if "11434" in base:
         return "ollama"

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -91,15 +91,15 @@ def _is_ollama_cloud_tag(model: str) -> bool:
 
 def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedProvider:
     """
-    Detects the provider used by the backend HTTP client.
+    Detect the provider used by the backend HTTP client.
     
-    Provider detection prioritizes Ollama Cloud URLs and cloud model tags, followed
-    by MiniMax, local Ollama, OpenAI, and Google endpoints. Unrecognized endpoints
-    are classified as ``"unknown"``.
+    Provider detection follows a fixed priority order: Ollama Cloud URLs and
+    cloud model tags, MiniMax URLs, local Ollama ports, OpenAI URLs, and Google
+    URLs. Inputs that match none of these patterns are classified as unknown.
     
     Parameters:
-        base_url (Optional[str]): Provider endpoint URL to inspect.
-        model (Optional[str]): Model name whose cloud tag may identify Ollama Cloud.
+        base_url (Optional[str]): The provider endpoint URL.
+        model (Optional[str]): The model identifier, including any provider tag.
     
     Returns:
         HttpDetectedProvider: The detected provider identifier.

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -49,6 +49,14 @@ HTTP_CASES = [
     ("https://api.minimax.io/v1", "MiniMax-M3", "minimax"),
     ("https://api.minimax.io/anthropic", "MiniMax-M3", "minimax"),
     ("HTTPS://API.MINIMAX.IO/v1", "MiniMax-M3", "minimax"),  # case-insensitive
+    # Issue #750 — Subdomain unter api.minimax.io erkannt (Suffix-Match).
+    ("https://foo.api.minimax.io/v1", "MiniMax-M3", "minimax"),
+    # CodeQL #750 — kein Substring-False-Positive: Host `api.minimax.io.attacker.test`
+    # enthaelt den Text, ist aber nicht der MiniMax-Host → unknown (vorher: minimax).
+    ("https://api.minimax.io.attacker.test/v1", "MiniMax-M3", "unknown"),
+    # CodeQL #750 — kein Path-False-Positive: `api.minimax.io` im Path eines
+    # anderen Hosts → openai (vorher: minimax via Substring).
+    ("https://api.openai.com/proxy/api.minimax.io", "MiniMax-M3", "openai"),
     # Kein False Positive: Modellname enthaelt "minimax", Base-URL aber nicht.
     ("https://api.openai.com/v1", "minimax-mock", "openai"),
 ]

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -8,6 +8,7 @@
       @refresh="$emit('refresh')"
       @toggle-maximize="$emit('toggle-maximize')"
       @toggle-pause="canvasRef?.togglePause()"
+      @reset-layout="canvasRef?.resetLayout()"
       @download-graphml="canvasRef?.downloadGraphml()"
       @download-svg="canvasRef?.downloadSvg()"
       @download-png="canvasRef?.downloadPng()"

--- a/frontend/src/components/graph/GraphCanvas.vue
+++ b/frontend/src/components/graph/GraphCanvas.vue
@@ -18,6 +18,15 @@
         @close="closeDetailPanel"
         @toggle-self-loop="toggleSelfLoop"
       />
+
+      <!-- Issue #744 Phase 4b — Mini-Map overlay. -->
+      <GraphMiniMap
+        v-if="minimapNodes.length > 0"
+        :nodes="minimapNodes"
+        :viewport="minimapViewport"
+        :title="t('graph.ui.minimapTitle')"
+        @seek="onMinimapSeek"
+      />
     </div>
 
     <!-- Loading State -->
@@ -49,6 +58,7 @@ import { useI18n } from 'vue-i18n'
 
 import GraphDetailPanel from './GraphDetailPanel.vue'
 import GraphHints from './GraphHints.vue'
+import GraphMiniMap from './GraphMiniMap.vue'
 import { useGraphRender } from '../../composables/useGraphRender'
 import { exportGraphMl } from '../../api/graph'
 
@@ -82,7 +92,16 @@ const expandedSelfLoops = ref(new Set())
 // The prop is typed as Object (plain JS script), but useGraphRender accepts
 // MaybeRefOrGetter<BuildProgressDetail | null> — the shape is compatible.
 const batchSignalRef = computed(() => props.batchSignal ?? null)
-const { selectedItem, render, isPaused, togglePause } = useGraphRender({
+const {
+  selectedItem,
+  render,
+  isPaused,
+  togglePause,
+  resetLayout,
+  minimapNodes,
+  minimapViewport,
+  panToGraphPoint,
+} = useGraphRender({
   svgRef: graphSvg,
   containerRef: graphContainer,
   graphData: toRef(props, 'graphData'),
@@ -91,6 +110,11 @@ const { selectedItem, render, isPaused, togglePause } = useGraphRender({
   translateLabel: t,
   batchSignal: batchSignalRef,
 })
+
+// Issue #744 Phase 4b — Mini-Map click/drag centers the main viewport.
+function onMinimapSeek(g) {
+  panToGraphPoint(g.gx, g.gy)
+}
 
 // Locale-Wechsel: Edge-Labels frisch durch i18n laufen lassen.
 watch(locale, () => {
@@ -290,6 +314,7 @@ defineExpose({
   downloadHtml,
   isPaused,
   togglePause,
+  resetLayout,
 })
 </script>
 

--- a/frontend/src/components/graph/GraphMiniMap.vue
+++ b/frontend/src/components/graph/GraphMiniMap.vue
@@ -10,11 +10,15 @@
       class="minimap-svg"
       :viewBox="`0 0 ${MINIMAP_W} ${MINIMAP_H}`"
       preserveAspectRatio="xMidYMid meet"
+      tabindex="0"
+      :aria-label="title"
+      role="application"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
       @pointercancel="onPointerUp"
       @pointerleave="onPointerLeave"
+      @keydown="onKeydown"
     >
       <!-- Graph bounds frame -->
       <rect
@@ -199,6 +203,50 @@ function onPointerUp(event) {
 
 function onPointerLeave() {
   // Do NOT cancel on leave — pointer capture keeps the drag alive.
+}
+
+// Issue #744 Phase 4b — keyboard-operable minimap. Arrow keys pan the main
+// viewport in 20 % steps of the currently visible region, Home/End jump to
+// the horizontal bounds. CodeRabbit Major (F2): same seek functionality
+// without a mouse.
+const ARROW_MAP = {
+  ArrowLeft: [-1, 0],
+  ArrowRight: [1, 0],
+  ArrowUp: [0, -1],
+  ArrowDown: [0, 1],
+}
+
+function stepSeek(dx, dy) {
+  const vp = props.viewport
+  if (!vp || !vp.k || vp.k <= 0) return
+  // Visible region in graph space: left = -tx/k, top = -ty/k,
+  // w = width/k, h = height/k.
+  const cx = (-vp.x + vp.width / 2) / vp.k
+  const cy = (-vp.y + vp.height / 2) / vp.k
+  const stepX = (vp.width / vp.k) * 0.2
+  const stepY = (vp.height / vp.k) * 0.2
+  emit('seek', { gx: cx + dx * stepX, gy: cy + dy * stepY })
+}
+
+function onKeydown(event) {
+  const m = ARROW_MAP[event.key]
+  if (m) {
+    event.preventDefault()
+    stepSeek(m[0], m[1])
+    return
+  }
+  if (event.key === 'Home') {
+    event.preventDefault()
+    const b = graphBounds.value
+    emit('seek', { gx: b.minX, gy: (b.minY + b.maxY) / 2 })
+    return
+  }
+  if (event.key === 'End') {
+    event.preventDefault()
+    const b = graphBounds.value
+    emit('seek', { gx: b.maxX, gy: (b.minY + b.maxY) / 2 })
+    return
+  }
 }
 </script>
 

--- a/frontend/src/components/graph/GraphMiniMap.vue
+++ b/frontend/src/components/graph/GraphMiniMap.vue
@@ -1,0 +1,250 @@
+<template>
+  <div
+    v-if="nodes.length > 0"
+    class="graph-minimap"
+    :aria-label="title"
+    role="region"
+  >
+    <svg
+      ref="miniSvg"
+      class="minimap-svg"
+      :viewBox="`0 0 ${MINIMAP_W} ${MINIMAP_H}`"
+      preserveAspectRatio="xMidYMid meet"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+      @pointerleave="onPointerLeave"
+    >
+      <!-- Graph bounds frame -->
+      <rect
+        :x="padX"
+        :y="padY"
+        :width="Math.max(0, innerW)"
+        :height="Math.max(0, innerH)"
+        class="minimap-frame"
+        rx="2"
+      />
+
+      <!-- Nodes (scaled) -->
+      <circle
+        v-for="n in minimapNodePoints"
+        :key="n.id"
+        :cx="n.mx"
+        :cy="n.my"
+        :r="1.4"
+        class="minimap-node"
+      />
+
+      <!-- Viewport rectangle (what the main canvas currently shows) -->
+      <rect
+        v-if="viewportRect"
+        :x="viewportRect.x"
+        :y="viewportRect.y"
+        :width="viewportRect.w"
+        :height="viewportRect.h"
+        class="minimap-viewport"
+        rx="1"
+      />
+    </svg>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  /**
+   * Mirror of node positions from useGraphRender.minimapNodes.
+   * Shape: Array<{ id: string; x: number; y: number }>
+   */
+  nodes: { type: Array, default: () => [] },
+  /**
+   * Mirror of the main viewport's d3.zoom transform + container dims.
+   * Shape: { x, y, k, width, height } where (x,y,k) is the zoom transform
+   * (translate tx/ty + scale k) and width/height are the main canvas size.
+   */
+  viewport: {
+    type: Object,
+    default: () => ({ x: 0, y: 0, k: 1, width: 0, height: 0 }),
+  },
+  /** Accessible label (i18n-provided). */
+  title: { type: String, default: 'Minimap' },
+})
+
+const emit = defineEmits(['seek'])
+
+const MINIMAP_W = 168
+const MINIMAP_H = 116
+const PAD = 8
+
+const padX = PAD
+const padY = PAD
+const innerW = MINIMAP_W - PAD * 2
+const innerH = MINIMAP_H - PAD * 2
+
+const miniSvg = ref(null)
+const isDragging = ref(false)
+
+// Graph-space bounding box of all nodes (with a small degenerate fallback).
+const graphBounds = computed(() => {
+  const ns = props.nodes
+  if (!ns || ns.length === 0) {
+    return { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+  }
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const n of ns) {
+    if (!Number.isFinite(n.x) || !Number.isFinite(n.y)) continue
+    if (n.x < minX) minX = n.x
+    if (n.y < minY) minY = n.y
+    if (n.x > maxX) maxX = n.x
+    if (n.y > maxY) maxY = n.y
+  }
+  if (!Number.isFinite(minX)) return { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+  // Guard against degenerate (single-point / colinear) bounds.
+  if (maxX - minX < 1) { minX -= 0.5; maxX += 0.5 }
+  if (maxY - minY < 1) { minY -= 0.5; maxY += 0.5 }
+  return { minX, minY, maxX, maxY }
+})
+
+const scale = computed(() => {
+  const b = graphBounds.value
+  const sx = innerW / Math.max(1e-6, b.maxX - b.minX)
+  const sy = innerH / Math.max(1e-6, b.maxY - b.minY)
+  // Uniform scale, fit-inside (use the smaller axis).
+  return Math.min(sx, sy)
+})
+
+// Graph → Mini-Map pixel mapping.
+function toMini(gx, gy) {
+  const b = graphBounds.value
+  const s = scale.value
+  // Center within inner box (for the unused axis).
+  const usedW = (b.maxX - b.minX) * s
+  const usedH = (b.maxY - b.minY) * s
+  const offX = padX + (innerW - usedW) / 2
+  const offY = padY + (innerH - usedH) / 2
+  return { mx: offX + (gx - b.minX) * s, my: offY + (gy - b.minY) * s }
+}
+
+// Mini-Map pixel → Graph-space (inverse of toMini).
+function toGraph(mx, my) {
+  const b = graphBounds.value
+  const s = scale.value || 1e-6
+  const usedW = (b.maxX - b.minX) * s
+  const usedH = (b.maxY - b.minY) * s
+  const offX = padX + (innerW - usedW) / 2
+  const offY = padY + (innerH - usedH) / 2
+  return { gx: (mx - offX) / s + b.minX, gy: (my - offY) / s + b.minY }
+}
+
+const minimapNodePoints = computed(() => {
+  return props.nodes.map(n => {
+    const p = toMini(n.x, n.y)
+    return { id: n.id, mx: p.mx, my: p.my }
+  })
+})
+
+// Viewport rectangle in graph space, then mapped to Mini-Map pixels.
+// Visible graph region: left = -tx/k, top = -ty/k, w = width/k, h = height/k.
+const viewportRect = computed(() => {
+  const vp = props.viewport
+  if (!vp || !vp.k || vp.k <= 0) return null
+  const left = -vp.x / vp.k
+  const top = -vp.y / vp.k
+  const w = vp.width / vp.k
+  const h = vp.height / vp.k
+  const tl = toMini(left, top)
+  const br = toMini(left + w, top + h)
+  return {
+    x: Math.min(tl.mx, br.mx),
+    y: Math.min(tl.my, br.my),
+    w: Math.abs(br.mx - tl.mx),
+    h: Math.abs(br.my - tl.my),
+  }
+})
+
+function pointerToGraph(event) {
+  const el = miniSvg.value
+  if (!el) return null
+  const rect = el.getBoundingClientRect()
+  // Map client coords into the SVG's viewBox coordinate space.
+  const mx = ((event.clientX - rect.left) / rect.width) * MINIMAP_W
+  const my = ((event.clientY - rect.top) / rect.height) * MINIMAP_H
+  return toGraph(mx, my)
+}
+
+function onPointerDown(event) {
+  isDragging.value = true
+  if (event.target && typeof event.target.setPointerCapture === 'function') {
+    event.target.setPointerCapture(event.pointerId)
+  }
+  const g = pointerToGraph(event)
+  if (g) emit('seek', g)
+}
+
+function onPointerMove(event) {
+  if (!isDragging.value) return
+  const g = pointerToGraph(event)
+  if (g) emit('seek', g)
+}
+
+function onPointerUp(event) {
+  if (!isDragging.value) return
+  isDragging.value = false
+  if (event.target && typeof event.target.releasePointerCapture === 'function') {
+    event.target.releasePointerCapture(event.pointerId)
+  }
+}
+
+function onPointerLeave() {
+  // Do NOT cancel on leave — pointer capture keeps the drag alive.
+}
+</script>
+
+<style scoped>
+.graph-minimap {
+  position: absolute;
+  bottom: var(--s-5);
+  right: var(--s-5);
+  width: 168px;
+  height: 116px;
+  background: var(--surface-translucent, var(--bg));
+  border: 1px solid var(--hairline, var(--rule));
+  border-radius: var(--r-5, var(--r-1));
+  box-shadow: var(--shadow-2, none);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  z-index: 10;
+  overflow: hidden;
+}
+
+.minimap-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.minimap-frame {
+  fill: var(--bg-elevated, var(--bg));
+  fill-opacity: 0.35;
+  stroke: var(--hairline, var(--rule));
+  stroke-width: 0.5;
+}
+
+.minimap-node {
+  fill: var(--accent);
+  fill-opacity: 0.8;
+}
+
+.minimap-viewport {
+  fill: var(--accent);
+  fill-opacity: 0.08;
+  stroke: var(--accent);
+  stroke-width: 1;
+  stroke-opacity: 0.9;
+  pointer-events: none;
+}
+</style>

--- a/frontend/src/components/graph/GraphToolbar.vue
+++ b/frontend/src/components/graph/GraphToolbar.vue
@@ -22,6 +22,15 @@
         <span class="btn-text">{{ isPaused ? $t('graph.ui.resumeLayout') : $t('graph.ui.pauseLayout') }}</span>
       </button>
       <button
+        v-if="hasGraphData"
+        class="tool-btn"
+        :title="$t('graph.ui.resetLayout')"
+        @click="$emit('reset-layout')"
+      >
+        <span class="icon-reset">⟲</span>
+        <span class="btn-text">{{ $t('graph.ui.resetLayout') }}</span>
+      </button>
+      <button
         v-if="hasGraphId"
         class="tool-btn"
         title="Export as GraphML"
@@ -88,6 +97,7 @@ defineEmits([
   'download-html',
   'toggle-maximize',
   'toggle-pause',
+  'reset-layout',
   'close-graph',
 ])
 </script>

--- a/frontend/src/components/graph/__tests__/GraphCanvas.downloadHtml.spec.ts
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.downloadHtml.spec.ts
@@ -18,6 +18,10 @@ vi.mock('../../../composables/useGraphRender', () => ({
     render: vi.fn(),
     isPaused: ref(false),
     togglePause: vi.fn(),
+    resetLayout: vi.fn(),
+    minimapNodes: ref([]),
+    minimapViewport: ref({ x: 0, y: 0, k: 1, width: 0, height: 0 }),
+    panToGraphPoint: vi.fn(),
   }),
 }))
 

--- a/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
+++ b/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
@@ -165,15 +165,25 @@ async function doStop(row: Row) {
 // Stale stopping-Flags abräumen, sobald die betroffene Run die aktive Menge
 // verlässt (status → stopped/completed/failed). Wird durch den Parent-Re-Poll
 // nach emit('refresh') gespeist. CodeRabbit Minor (F3).
-watch(activeRuns, (now) => {
+//
+// Wichtig: auf `props.runs` (ungefiltert) schauen, NICHT auf `activeRuns` —
+// letzteres ist für die Tabelle auf 8 Rows gecappt, sonst würden bei >8
+// aktiven Runs die stoppingIds der Rows 9+ vorzeitig gecleart (CodeRabbit
+// 21:53Z Re-Review). Die aktive Menge wird hier ohne Cap aus ACTIVE_STATUSES
+// bestimmt.
+watch(() => props.runs, (runs) => {
   if (stoppingIds.value.size === 0) return
-  const activeIds = new Set(now.map(r => r.run_id))
+  const activeIds = new Set(
+    runs
+      .filter(r => (ACTIVE_STATUSES as readonly string[]).includes(r.status))
+      .map(r => r.run_id),
+  )
   const next = new Set(stoppingIds.value)
   for (const id of stoppingIds.value) {
     if (!activeIds.has(id)) next.delete(id)
   }
   if (next.size !== stoppingIds.value.size) stoppingIds.value = next
-})
+}, { deep: true })
 </script>
 
 <template>

--- a/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
+++ b/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
@@ -5,14 +5,22 @@
  * Workbench-These: kompakte Tabelle, Mono für IDs/Project-Slugs, Phase als
  * Tone-Pill (graph_build=teal, simulation_prepare=purple, simulation_run=blue,
  * report_generate=orange).
+ *
+ * Phase 3: Globaler Kill-Switch pro Run. Nutzt stopRun(runId) aus api/runs
+ * (generischer Run-Registry-Stop, key=run_id) — nicht stopSimulation, da auf
+ * der Übersicht Runs aller Phasen (graph_build/report_generate) stehen, die
+ * keine simulation_id tragen. Bestätigungsdialog via vue-i18n, optimistisches
+ * Loading-State, danach emit('refresh') für sofortigen Re-Poll der Liste.
  */
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Card from '../forms/Card.vue'
 import Badge from '../forms/Badge.vue'
+import Button from '../forms/Button.vue'
 import DataTable, { type DataTableColumn } from '../data/DataTable.vue'
 import EmptyState from '../data/EmptyState.vue'
+import { stopRun } from '@/api/runs'
 import type { RunDetail } from '../../../contracts/runsContract'
 
 const props = defineProps<{
@@ -34,6 +42,10 @@ const activeRuns = computed<RunDetail[]>(() =>
   props.runs.filter(r => (ACTIVE_STATUSES as readonly string[]).includes(r.status))
     .slice(0, 8),
 )
+
+// Optimistische Stop-States: run_ids, deren Stop-Aufruf aussteht.
+const stoppingIds = ref<Set<string>>(new Set())
+const stopError = ref('')
 
 const columns: DataTableColumn[] = [
   { key: 'run_id', label: t('dashboard.active.columns.runId'), mono: true, width: '180px' },
@@ -80,6 +92,10 @@ function relTime(iso: string): string {
   return new Date(ts).toLocaleDateString()
 }
 
+function isStopping(runId: string): boolean {
+  return stoppingIds.value.has(runId)
+}
+
 interface Row extends Record<string, unknown> {
   id: string
   run_id: string
@@ -109,6 +125,28 @@ const rows = computed<Row[]>(() =>
 function openRun(row: Row) {
   router.push({ name: 'RunDetail', params: { id: row.run_id } })
 }
+
+async function doStop(row: Row) {
+  if (isStopping(row.run_id)) return
+  if (typeof window !== 'undefined' && !window.confirm(t('dashboard.active.stopConfirm'))) return
+  stoppingIds.value = new Set(stoppingIds.value).add(row.run_id)
+  stopError.value = ''
+  try {
+    await stopRun(row.run_id)
+    // Sofortigen Re-Poll triggern — Parent (DashboardView::useRunsPolling)
+    // aktualisiert die Liste; der nächste 5s-Tick und ein ggf. offener
+    // Step3-Wizard (eigenes Polling) ziehen den neuen Status nach.
+    emit('refresh')
+  } catch (err) {
+    stopError.value = t('dashboard.active.stopError', {
+      message: err instanceof Error ? err.message : String(err),
+    })
+  } finally {
+    const next = new Set(stoppingIds.value)
+    next.delete(row.run_id)
+    stoppingIds.value = next
+  }
+}
 </script>
 
 <template>
@@ -126,20 +164,25 @@ function openRun(row: Row) {
       </button>
     </div>
 
-    <template v-else-if="rows.length === 0">
+    <template v-else>
+      <div v-if="stopError" class="ar-stoperror">
+        <Badge tone="red">{{ $t('dashboard.active.errorLabel') }}</Badge>
+        <span class="ar-stoperror__msg">{{ stopError }}</span>
+      </div>
+
       <EmptyState
+        v-if="rows.length === 0"
         :title="$t('dashboard.active.emptyTitle')"
         :subtitle="$t('dashboard.active.emptyHint')"
       />
-    </template>
 
-    <DataTable
-      v-else
-      :columns="columns"
-      :rows="rows"
-      :row-click="openRun"
-      compact
-    >
+      <DataTable
+        v-else
+        :columns="columns"
+        :rows="rows"
+        :row-click="openRun"
+        compact
+      >
       <template #cell-run_id="{ row }">
         <span class="ar-id">{{ (row as Row).run_id_display }}</span>
       </template>
@@ -149,7 +192,20 @@ function openRun(row: Row) {
       <template #cell-progress="{ row }">
         <span class="ar-progress">{{ (row as Row).progress }}<span class="ar-progress__unit">%</span></span>
       </template>
+      <template #actions="{ row }">
+        <Button
+          class="ar-stop"
+          variant="danger"
+          size="sm"
+          icon
+          :aria-label="$t('dashboard.active.stopLabel')"
+          :loading="isStopping((row as Row).run_id)"
+          :disabled="isStopping((row as Row).run_id)"
+          @click.stop="doStop(row as Row)"
+        />
+      </template>
     </DataTable>
+    </template>
   </Card>
 </template>
 
@@ -160,14 +216,16 @@ function openRun(row: Row) {
   color: var(--text-tertiary);
 }
 
-.ar-error {
+.ar-error,
+.ar-stoperror {
   display: flex;
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
 }
 
-.ar-error__msg {
+.ar-error__msg,
+.ar-stoperror__msg {
   font-family: var(--font-sans);
   font-size: 13px;
   color: var(--text-secondary);
@@ -200,5 +258,11 @@ function openRun(row: Row) {
 
 .ar-progress__unit {
   color: var(--text-tertiary);
+}
+
+/* Stop-Button in der Actions-Spalte — darf den Row-Klick nicht triggern. */
+.ar-stop {
+  /* kleines Target, aber über v4-state-interactive voll fokussierbar */
+  --v4-state-hover-bg: var(--danger-tint-bg, rgba(220, 38, 38, 0.12));
 }
 </style>

--- a/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
+++ b/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
@@ -12,7 +12,7 @@
  * keine simulation_id tragen. Bestätigungsdialog via vue-i18n, optimistisches
  * Loading-State, danach emit('refresh') für sofortigen Re-Poll der Liste.
  */
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Card from '../forms/Card.vue'
@@ -146,16 +146,34 @@ async function doStop(row: Row) {
     // aktualisiert die Liste; der nächste 5s-Tick und ein ggf. offener
     // Step3-Wizard (eigenes Polling) ziehen den neuen Status nach.
     emit('refresh')
+    // stoppingIds bewusst NICHT hier clearen: der Button bleibt disabled,
+    // bis der Parent refreshed props liefert und die Row aus activeRuns
+    // verschwindet (status → stopped). Verhindert doppelte Stop-Requests
+    // im Gap zwischen stopRun-Resolve und dem nächsten Polling-Tick.
+    // CodeRabbit Minor (F3).
   } catch (err) {
     stopError.value = t('dashboard.active.stopError', {
       message: err instanceof Error ? err.message : String(err),
     })
-  } finally {
+    // Bei Fehler freigeben, damit der User retryen kann.
     const next = new Set(stoppingIds.value)
     next.delete(row.run_id)
     stoppingIds.value = next
   }
 }
+
+// Stale stopping-Flags abräumen, sobald die betroffene Run die aktive Menge
+// verlässt (status → stopped/completed/failed). Wird durch den Parent-Re-Poll
+// nach emit('refresh') gespeist. CodeRabbit Minor (F3).
+watch(activeRuns, (now) => {
+  if (stoppingIds.value.size === 0) return
+  const activeIds = new Set(now.map(r => r.run_id))
+  const next = new Set(stoppingIds.value)
+  for (const id of stoppingIds.value) {
+    if (!activeIds.has(id)) next.delete(id)
+  }
+  if (next.size !== stoppingIds.value.size) stoppingIds.value = next
+})
 </script>
 
 <template>

--- a/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
+++ b/frontend/src/components/v4/dashboard/ActiveRunsCard.vue
@@ -96,6 +96,15 @@ function isStopping(runId: string): boolean {
   return stoppingIds.value.has(runId)
 }
 
+// Nur Simulation-Runs unterstützen den generischen Stop (Backend returnt 409
+// für andere run_types — s. backend test_runs_resume_stop.py:
+// test_resume_unsupported_run_type_returns_409). graph_build/report_generate
+// haben keinen killbaren Hintergrund-Task; ein Stop-Call würde immer failen.
+const STOPPABLE_RUN_TYPE = 'simulation_run'
+function canStopRun(runType: string): boolean {
+  return runType === STOPPABLE_RUN_TYPE
+}
+
 interface Row extends Record<string, unknown> {
   id: string
   run_id: string
@@ -194,6 +203,7 @@ async function doStop(row: Row) {
       </template>
       <template #actions="{ row }">
         <Button
+          v-if="canStopRun((row as Row).raw.run_type)"
           class="ar-stop"
           variant="danger"
           size="sm"

--- a/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
@@ -89,13 +89,13 @@ describe('ActiveRunsCard', () => {
   })
 
   it('zeigt pro aktivem Run einen Stop-Button', async () => {
-    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })])
     expect(w.find('.ar-stop').exists()).toBe(true)
   })
 
   it('ruft stopRun(runId) auf nach Bestätigung und emit refresh', async () => {
     stopRunMock.mockResolvedValue({ data: { run_id: 'aaaaaaaa-bbbb', status: 'stopped' } })
-    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })])
     await w.find('.ar-stop').trigger('click')
     await flushPromises()
     expect(stopRunMock).toHaveBeenCalledTimes(1)
@@ -105,7 +105,7 @@ describe('ActiveRunsCard', () => {
 
   it('ohne Bestätigung keinen stopRun-Aufruf', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false)
-    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })])
     await w.find('.ar-stop').trigger('click')
     await flushPromises()
     expect(stopRunMock).not.toHaveBeenCalled()
@@ -115,7 +115,7 @@ describe('ActiveRunsCard', () => {
   it('zeigt optimistischen Loading-State während stopRun aussteht', async () => {
     let resolveStop!: (v: unknown) => void
     stopRunMock.mockReturnValue(new Promise((r) => { resolveStop = r as (v: unknown) => void }))
-    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })])
     const btn = w.find('.ar-stop')
     await btn.trigger('click')
     await flushPromises()
@@ -129,7 +129,7 @@ describe('ActiveRunsCard', () => {
 
   it('leitet Stop-Fehler nicht weiter und bleibt stabil (kein Crash)', async () => {
     stopRunMock.mockRejectedValue(new Error('boom'))
-    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })])
     await w.find('.ar-stop').trigger('click')
     await flushPromises()
     expect(stopRunMock).toHaveBeenCalled()
@@ -143,7 +143,7 @@ describe('ActiveRunsCard', () => {
     const router = makeRouter()
     await router.push('/dashboard')
     const w = mount(ActiveRunsCard, {
-      props: { runs: [run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })], loading: false, error: '' },
+      props: { runs: [run({ run_id: 'aaaaaaaa-bbbb', status: 'processing', run_type: 'simulation_run' })], loading: false, error: '' },
       global: { plugins: [makeI18n(), router] },
     })
     const stopBtn = w.find('.ar-stop')
@@ -151,5 +151,24 @@ describe('ActiveRunsCard', () => {
     await flushPromises()
     // Kein Route-Push nach RunDetail durch den Stop-Klick
     expect(router.currentRoute.value.name).toBe('Dashboard')
+  })
+
+  // CodeRabbit/codex P1: Stop-Button darf nur für simulation_run rendern —
+  // POST /api/runs/{id}/stop returnt 409 für andere run_types (s. backend
+  // test_runs_resume_stop.py::test_resume_unsupported_run_type_returns_409),
+  // ein Kill-Switch der immer failt ist schlimmer als keiner.
+  it('rendert keinen Stop-Button für graph_build (nicht stoppbar)', async () => {
+    const w = await mountCard([run({ run_id: 'graph-aaaaaaaa', status: 'processing', run_type: 'graph_build' })])
+    expect(w.find('.ar-stop').exists()).toBe(false)
+  })
+
+  it('rendert keinen Stop-Button für report_generate (nicht stoppbar)', async () => {
+    const w = await mountCard([run({ run_id: 'report-aaaaaa', status: 'processing', run_type: 'report_generate' })])
+    expect(w.find('.ar-stop').exists()).toBe(false)
+  })
+
+  it('rendert Stop-Button nur für simulation_run', async () => {
+    const w = await mountCard([run({ run_id: 'sim-aaaaaaaa', status: 'processing', run_type: 'simulation_run' })])
+    expect(w.find('.ar-stop').exists()).toBe(true)
   })
 })

--- a/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/ActiveRunsCard.spec.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import ActiveRunsCard from '../ActiveRunsCard.vue'
 import { makeI18n, makeRouter } from './dashTestHelpers'
 import type { RunDetail } from '../../../../contracts/runsContract'
+
+const { stopRunMock } = vi.hoisted(() => ({ stopRunMock: vi.fn() }))
+vi.mock('../../../../api/runs', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  stopRun: stopRunMock,
+}))
 
 function run(over: Partial<RunDetail>): RunDetail {
   return {
@@ -34,30 +40,31 @@ function run(over: Partial<RunDetail>): RunDetail {
   } as RunDetail
 }
 
+async function mountCard(runs: RunDetail[] = []) {
+  const router = makeRouter()
+  await router.push('/dashboard')
+  const w = mount(ActiveRunsCard, {
+    props: { runs, loading: false, error: '' },
+    global: { plugins: [makeI18n(), router] },
+  })
+  return w
+}
+
 describe('ActiveRunsCard', () => {
+  beforeEach(() => {
+    stopRunMock.mockReset()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
   it('rendert aktive Run-Zeilen mit ID und Progress', async () => {
-    const router = makeRouter()
-    await router.push('/dashboard')
-    const w = mount(ActiveRunsCard, {
-      props: {
-        runs: [run({ run_id: 'aaaaaaaa-bbbb-cccc', status: 'processing', progress: 33 })],
-        loading: false,
-        error: '',
-      },
-      global: { plugins: [makeI18n(), router] },
-    })
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb-cccc', status: 'processing', progress: 33 })])
     expect(w.find('.dt-table').exists()).toBe(true)
     expect(w.text()).toContain('aaaaaaaa')
     expect(w.text()).toContain('33')
   })
 
   it('rendert EmptyState ohne aktive Runs', async () => {
-    const router = makeRouter()
-    await router.push('/dashboard')
-    const w = mount(ActiveRunsCard, {
-      props: { runs: [], loading: false, error: '' },
-      global: { plugins: [makeI18n(), router] },
-    })
+    const w = await mountCard([])
     expect(w.find('.es-root').exists()).toBe(true)
   })
 
@@ -74,19 +81,75 @@ describe('ActiveRunsCard', () => {
   })
 
   it('filtert nicht-aktive Status raus', async () => {
+    const w = await mountCard([
+      run({ run_id: 'completed-1', status: 'completed' }),
+      run({ run_id: 'failed-1', status: 'failed' }),
+    ])
+    expect(w.find('.es-root').exists()).toBe(true)
+  })
+
+  it('zeigt pro aktivem Run einen Stop-Button', async () => {
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    expect(w.find('.ar-stop').exists()).toBe(true)
+  })
+
+  it('ruft stopRun(runId) auf nach Bestätigung und emit refresh', async () => {
+    stopRunMock.mockResolvedValue({ data: { run_id: 'aaaaaaaa-bbbb', status: 'stopped' } })
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    await w.find('.ar-stop').trigger('click')
+    await flushPromises()
+    expect(stopRunMock).toHaveBeenCalledTimes(1)
+    expect(stopRunMock).toHaveBeenCalledWith('aaaaaaaa-bbbb')
+    expect(w.emitted('refresh')).toBeTruthy()
+  })
+
+  it('ohne Bestätigung keinen stopRun-Aufruf', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    await w.find('.ar-stop').trigger('click')
+    await flushPromises()
+    expect(stopRunMock).not.toHaveBeenCalled()
+    expect(w.emitted('refresh')).toBeFalsy()
+  })
+
+  it('zeigt optimistischen Loading-State während stopRun aussteht', async () => {
+    let resolveStop!: (v: unknown) => void
+    stopRunMock.mockReturnValue(new Promise((r) => { resolveStop = r as (v: unknown) => void }))
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    const btn = w.find('.ar-stop')
+    await btn.trigger('click')
+    await flushPromises()
+    // Button ist während des Aufrufs deaktiviert (loading)
+    expect(btn.attributes('aria-busy')).toBe('true')
+    expect(btn.attributes('disabled')).toBeDefined()
+    resolveStop({ data: { run_id: 'aaaaaaaa-bbbb', status: 'stopped' } })
+    await flushPromises()
+    expect(w.emitted('refresh')).toBeTruthy()
+  })
+
+  it('leitet Stop-Fehler nicht weiter und bleibt stabil (kein Crash)', async () => {
+    stopRunMock.mockRejectedValue(new Error('boom'))
+    const w = await mountCard([run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })])
+    await w.find('.ar-stop').trigger('click')
+    await flushPromises()
+    expect(stopRunMock).toHaveBeenCalled()
+    // Nach Fehler kein refresh-Event (Status unbekannt) und Komponente noch intakt
+    expect(w.find('.dt-table').exists()).toBe(true)
+    expect(w.emitted('refresh')).toBeFalsy()
+  })
+
+  it('stoppt nicht die Row-Navigation beim Klick auf Stop', async () => {
+    stopRunMock.mockResolvedValue({ data: { run_id: 'aaaaaaaa-bbbb', status: 'stopped' } })
     const router = makeRouter()
     await router.push('/dashboard')
     const w = mount(ActiveRunsCard, {
-      props: {
-        runs: [
-          run({ run_id: 'completed-1', status: 'completed' }),
-          run({ run_id: 'failed-1', status: 'failed' }),
-        ],
-        loading: false,
-        error: '',
-      },
+      props: { runs: [run({ run_id: 'aaaaaaaa-bbbb', status: 'processing' })], loading: false, error: '' },
       global: { plugins: [makeI18n(), router] },
     })
-    expect(w.find('.es-root').exists()).toBe(true)
+    const stopBtn = w.find('.ar-stop')
+    await stopBtn.trigger('click')
+    await flushPromises()
+    // Kein Route-Push nach RunDetail durch den Stop-Klick
+    expect(router.currentRoute.value.name).toBe('Dashboard')
   })
 })

--- a/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
@@ -112,6 +112,12 @@ vi.mock('d3', () => {
       scale: vi.fn().mockReturnThis(),
     },
     __captured: captured,
+    // CodeRabbit Minor (F5): captured handlers + last-node array survive
+    // across cases otherwise — a failed render could reuse a previous
+    // handler and pass. Reset between tests.
+    __resetCaptured: () => {
+      for (const k of Object.keys(captured)) delete captured[k]
+    },
   }
 })
 
@@ -210,6 +216,10 @@ function mountHarness(graphDataValue: unknown): Harness {
   })
 
   const wrapper = mount(Comp)
+  // CodeRabbit Minor (F5): track every mounted harness so afterEach can unmount
+  // — otherwise resize listeners + composable scope work stay active across
+  // cases and captured handlers leak between tests.
+  mountedWrappers.push(wrapper)
   return {
     minimapNodes: exposed!.minimapNodes,
     minimapViewport: exposed!.minimapViewport,
@@ -218,6 +228,17 @@ function mountHarness(graphDataValue: unknown): Harness {
     unmount: () => wrapper.unmount(),
   }
 }
+
+// CodeRabbit Minor (F5): shared cleanup — unmount every harness and reset
+// captured d3 handlers between cases so a failed render can't reuse a prior
+// case's handlers and pass.
+const mountedWrappers: Array<ReturnType<typeof mount>> = []
+afterEach(() => {
+  mountedWrappers.splice(0).forEach((w) => {
+    try { w.unmount() } catch { /* already unmounted */ }
+  })
+  d3Mock.__resetCaptured()
+})
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
@@ -1,0 +1,417 @@
+// Issue #744 Phase 4a/4b — useGraphRender Pin-Persistenz & Mini-Map Tests.
+//
+// Diese Specs ergänzen die Auto-Freeze-Suite (useGraphRender.spec.ts) um:
+//   4a. Pin-Persistenz:
+//     - Drag-End sichert Node-Positionen in localStorage pro graph_id.
+//     - render() wendet gespeichertes Layout als fx/fy an (vor Simulation).
+//     - resetLayout() leert den Key und re-rendert.
+//   4b. Mini-Map:
+//     - minimapNodes wird auf Tick-Updates gespiegelt (via rAF-Flush).
+//     - minimapViewport wird beim Zoom-Event aktualisiert.
+//     - panToGraphPoint treibt den zoom programmatisch (Call-Spy auf
+//       selection.call(zoom.transform, ...)).
+//
+// D3 wird gemockt — die Handler werden direkt mit synthetischen Events
+// aufgerufen, um das Verhalten ohne echtes SVG zu verifizieren.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, ref, type Ref } from 'vue'
+
+// ---------------------------------------------------------------------------
+// Mock D3 — vi.mock factory must NOT reference top-level variables (hoisting).
+// ---------------------------------------------------------------------------
+vi.mock('d3', () => {
+  // Captured handlers per render() so tests can invoke them.
+  const captured: Record<string, unknown> = {}
+
+  const makeSim = () => {
+    const sim: Record<string, unknown> = {}
+    sim['force'] = vi.fn().mockReturnValue(sim)
+    sim['stop'] = vi.fn()
+    sim['restart'] = vi.fn()
+    sim['alpha'] = vi.fn().mockReturnValue(sim)
+    sim['alphaTarget'] = vi.fn().mockReturnValue(sim)
+    // Capture tick handler so tests can fire it.
+    sim['on'] = vi.fn((ev: string, cb: unknown) => {
+      if (ev === 'tick') captured.tick = cb
+      return sim
+    })
+    return sim
+  }
+
+  const makeSel = (): Record<string, unknown> => {
+    const sel: Record<string, unknown> = {}
+    sel['attr'] = vi.fn().mockReturnValue(sel)
+    sel['style'] = vi.fn().mockReturnValue(sel)
+    sel['selectAll'] = vi.fn().mockReturnValue(sel)
+    sel['append'] = vi.fn().mockReturnValue(sel)
+    sel['remove'] = vi.fn().mockReturnValue(sel)
+    sel['data'] = vi.fn().mockReturnValue(sel)
+    sel['enter'] = vi.fn().mockReturnValue(sel)
+    sel['text'] = vi.fn().mockReturnValue(sel)
+    sel['on'] = vi.fn().mockReturnValue(sel)
+    // `.call(zoomBehavior)` — capture zoom behavior; `.call(d3.drag()...)` — capture drag handlers.
+    sel['call'] = vi.fn((target: unknown) => {
+      // Heuristic: d3.drag() returns { on: fn } (has `.on`), zoom behavior has `.transform`.
+      const t = target as Record<string, unknown>
+      if (t && typeof t.on === 'function' && typeof t.transform === 'undefined') {
+        // drag behavior — already captured via .on() below
+      } else if (t && typeof t.transform === 'function') {
+        captured.zoomBehavior = t
+        captured.svgSelection = sel
+      }
+      return sel
+    })
+    sel['filter'] = vi.fn().mockReturnValue(sel)
+    sel['each'] = vi.fn().mockReturnValue(sel)
+    sel['nodes'] = vi.fn().mockReturnValue([])
+    return sel
+  }
+
+  // Zoom behavior factory: capture 'zoom' handler and expose .transform spy.
+  const zoom = () => {
+    const zb: Record<string, unknown> = {
+      extent: vi.fn().mockReturnThis(),
+      scaleExtent: vi.fn().mockReturnThis(),
+      on: vi.fn((ev: string, cb: unknown) => {
+        if (ev === 'zoom') captured.zoom = cb
+        return zb
+      }),
+      transform: vi.fn(),
+    }
+    return zb
+  }
+
+  // Drag behavior factory: capture start/drag/end handlers.
+  const drag = () => {
+    const db: Record<string, unknown> = { on: vi.fn().mockReturnThis() }
+    // We intercept .on('start'|'drag'|'end', cb) by overriding on to capture.
+    db['on'] = vi.fn((ev: string, cb: unknown) => {
+      if (ev === 'start') captured.dragStart = cb
+      else if (ev === 'drag') captured.dragDrag = cb
+      else if (ev === 'end') captured.dragEnd = cb
+      return db
+    })
+    return db
+  }
+
+  return {
+    forceSimulation: () => makeSim(),
+    forceLink: () => ({ id: vi.fn().mockReturnThis(), distance: vi.fn().mockReturnThis() }),
+    forceManyBody: () => ({ strength: vi.fn().mockReturnThis() }),
+    forceCenter: vi.fn(),
+    forceCollide: () => ({ radius: vi.fn().mockReturnThis() }),
+    forceX: () => ({ strength: vi.fn().mockReturnThis() }),
+    forceY: () => ({ strength: vi.fn().mockReturnThis() }),
+    zoom,
+    drag,
+    select: () => makeSel(),
+    zoomIdentity: {
+      translate: vi.fn().mockReturnThis(),
+      scale: vi.fn().mockReturnThis(),
+    },
+    __captured: captured,
+  }
+})
+
+vi.mock('../../components/graph/graphPanelData', () => {
+  // Capture the last returned nodes so tests can assert post-render mutations
+  // (e.g. fx/fy applied from a saved layout) without overriding forceSimulation.
+  let lastNodes: Record<string, unknown>[] = []
+  const buildGraphRenderData = (data: { nodes?: Record<string, unknown>[] }) => {
+    lastNodes = (data.nodes ?? []).map((n) => ({ ...n, x: 0, y: 0, rawData: {} }))
+    return { nodes: lastNodes, edges: [], getColor: () => '#ccc' }
+  }
+  return {
+    buildGraphRenderData,
+    __getLastNodes: () => lastNodes,
+  }
+})
+
+vi.mock('../../components/graph/edgeLabelI18n', () => ({
+  formatEdgeLabel: (key: string) => key,
+}))
+
+vi.mock('../../components/graph/graphPanelGeometry', () => ({
+  getLinkMidpoint: () => ({ x: 0, y: 0 }),
+  getLinkPath: () => '',
+}))
+
+// Import composable + mocked d3 AFTER mocks are registered.
+import { useGraphRender } from '../useGraphRender'
+import * as d3MockStar from 'd3'
+import * as graphDataMock from '../../components/graph/graphPanelData'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const d3Mock: any = d3MockStar
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// jsdom in this vitest setup does not expose `localStorage` as a global, so we
+// install a minimal in-memory stub. The composable reads/writes `localStorage`
+// directly (module-scope helpers), so the stub must live on globalThis.
+function installLocalStorageStub() {
+  const store = new Map<string, string>()
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k) as string : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  }
+  ;(globalThis as Record<string, unknown>).localStorage = stub
+  return stub
+}
+
+function makeSvgRef(): Ref<SVGSVGElement | null> {
+  const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as unknown as SVGSVGElement
+  return ref(svgEl)
+}
+
+function makeContainerRef(w = 800, h = 600): Ref<HTMLElement | null> {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'clientWidth', { value: w, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { value: h, configurable: true })
+  return ref(el)
+}
+
+interface Harness {
+  minimapNodes: Ref<Array<{ id: string; x: number; y: number }>>
+  minimapViewport: Ref<{ x: number; y: number; k: number; width: number; height: number }>
+  resetLayout: () => void
+  panToGraphPoint: (gx: number, gy: number) => void
+  unmount: () => void
+}
+
+function mountHarness(graphDataValue: unknown): Harness {
+  let exposed: ReturnType<typeof useGraphRender> | undefined
+  const svgRef = makeSvgRef()
+  const containerRef = makeContainerRef()
+  const showEdgeLabels = ref(true)
+  // The composable accepts MaybeRefOrGetter<RawGraphData | null>; the test data
+  // carries an extra graph_id field, so cast through any.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const graphData: any = ref(graphDataValue)
+
+  const Comp = defineComponent({
+    setup() {
+      exposed = useGraphRender({
+        svgRef,
+        containerRef,
+        graphData,
+        entityTypes: ref([]),
+        showEdgeLabels,
+      })
+      return () => h('div')
+    },
+  })
+
+  const wrapper = mount(Comp)
+  return {
+    minimapNodes: exposed!.minimapNodes,
+    minimapViewport: exposed!.minimapViewport,
+    resetLayout: () => exposed!.resetLayout(),
+    panToGraphPoint: (gx: number, gy: number) => exposed!.panToGraphPoint(gx, gy),
+    unmount: () => wrapper.unmount(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useGraphRender — Pin-Persistenz (Phase 4a)', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('Drag-End sichert Node-Position in localStorage pro graph_id', async () => {
+    const graphData = { graph_id: 'g-123', nodes: [{ id: 'n1' }, { id: 'n2' }], edges: [] }
+    mountHarness(graphData)
+    await flushPromises()
+
+    // Use the real node object the composable closed over so saveNodeLayout
+    // iterates the same array we mutate.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nodes = (graphDataMock as any).__getLastNodes() as Array<Record<string, unknown>>
+    const n1 = nodes.find((n) => n.id === 'n1') as Record<string, unknown>
+
+    const captured = d3Mock.__captured
+    // Start handler sets fx/fy + drag-tracking fields.
+    captured.dragStart?.({ x: 5, y: 5 }, n1)
+    // Drag moves the node and flags _isDragging.
+    captured.dragDrag?.({ x: 100, y: 120 }, n1)
+    // Simulate the tick having updated d.x/d.y to the drop position.
+    n1.x = 100
+    n1.y = 120
+    // End handler must persist the layout (reads n1.x/n1.y → saveNodeLayout).
+    captured.dragEnd?.({}, n1)
+
+    const raw = localStorage.getItem('agora:graph-layout:g-123')
+    expect(raw, 'layout key must be written').not.toBeNull()
+    const parsed = JSON.parse(raw as string)
+    expect(parsed.n1).toEqual({ x: 100, y: 120 })
+  })
+
+  it('render() wendet gespeichertes Layout als fx/fy an (vor Simulation)', async () => {
+    // Seed a saved layout for graph_id 'g-layout'.
+    localStorage.setItem(
+      'agora:graph-layout:g-layout',
+      JSON.stringify({ n1: { x: 42, y: 77 } }),
+    )
+    const graphData = { graph_id: 'g-layout', nodes: [{ id: 'n1' }, { id: 'n2' }], edges: [] }
+    mountHarness(graphData)
+    await flushPromises()
+
+    // The graphPanelData mock captured the node objects; the composable
+    // mutated them in place (x/y/fx/fy) before starting the simulation.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nodes = (graphDataMock as any).__getLastNodes() as Record<string, unknown>[]
+    const n1 = nodes.find((n) => n.id === 'n1')
+    const n2 = nodes.find((n) => n.id === 'n2')
+    expect(n1?.fx).toBe(42)
+    expect(n1?.fy).toBe(77)
+    expect(n1?.x).toBe(42)
+    expect(n1?.y).toBe(77)
+    // Unpinned node keeps fx/fy undefined.
+    expect(n2?.fx).toBeUndefined()
+    expect(n2?.fy).toBeUndefined()
+  })
+
+  it('resetLayout() leert den localStorage-Key und re-rendert', async () => {
+    const graphData = { graph_id: 'g-reset', nodes: [{ id: 'n1' }], edges: [] }
+    const harness = mountHarness(graphData)
+    await flushPromises()
+
+    // Seed via drag-end so there is something to clear.
+    const captured = d3Mock.__captured
+    const node = { id: 'n1', x: 5, y: 6 }
+    captured.dragStart?.({ x: 1, y: 1 }, node)
+    captured.dragDrag?.({ x: 50, y: 60 }, node)
+    node.x = 50
+    node.y = 60
+    captured.dragEnd?.({}, node)
+    expect(localStorage.getItem('agora:graph-layout:g-reset')).not.toBeNull()
+
+    harness.resetLayout()
+    await flushPromises()
+    expect(localStorage.getItem('agora:graph-layout:g-reset')).toBeNull()
+  })
+
+  it('ohne graph_id wird kein localStorage-Key geschrieben', async () => {
+    const graphData = { nodes: [{ id: 'n1' }], edges: [] } // no graph_id
+    mountHarness(graphData)
+    await flushPromises()
+
+    const captured = d3Mock.__captured
+    const node = { id: 'n1', x: 0, y: 0 }
+    captured.dragStart?.({ x: 1, y: 1 }, node)
+    captured.dragDrag?.({ x: 30, y: 40 }, node)
+    node.x = 30
+    node.y = 40
+    captured.dragEnd?.({}, node)
+
+    // No key under the agora prefix should exist.
+    let hasKey = false
+    for (let i = 0; i < localStorage.length; i++) {
+      if ((localStorage.key(i) ?? '').startsWith('agora:graph-layout:')) {
+        hasKey = true
+        break
+      }
+    }
+    expect(hasKey).toBe(false)
+  })
+
+  it('Drag-End ohne echte Bewegung (Klick) pinnt nicht und schreibt keinen Key', async () => {
+    const graphData = { graph_id: 'g-click', nodes: [{ id: 'n1' }], edges: [] }
+    mountHarness(graphData)
+    await flushPromises()
+
+    const captured = d3Mock.__captured
+    const node: Record<string, unknown> = { id: 'n1', x: 10, y: 10 }
+    captured.dragStart?.({ x: 10, y: 10 }, node)
+    // No drag event — _isDragging stays false.
+    captured.dragEnd?.({}, node)
+    expect(node.fx).toBeNull()
+    expect(node.fy).toBeNull()
+    expect(localStorage.getItem('agora:graph-layout:g-click')).toBeNull()
+  })
+})
+
+describe('useGraphRender — Mini-Map (Phase 4b)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('minimapViewport wird beim Zoom-Event aktualisiert', async () => {
+    const graphData = { graph_id: 'g-zoom', nodes: [{ id: 'n1' }], edges: [] }
+    const harness = mountHarness(graphData)
+    await flushPromises()
+
+    const captured = d3Mock.__captured
+    const zoomCb = captured.zoom as ((event: { transform: { x: number; y: number; k: number } }) => void) | undefined
+    expect(zoomCb, 'zoom handler must be wired').toBeDefined()
+    zoomCb!({ transform: { x: 120, y: 80, k: 2 } })
+    expect(harness.minimapViewport.value).toMatchObject({ x: 120, y: 80, k: 2, width: 800, height: 600 })
+  })
+
+  it('minimapNodes wird nach rAF-Flush aus dem Tick-Handler aktualisiert', async () => {
+    vi.useRealTimers()
+    const graphData = { graph_id: 'g-tick', nodes: [{ id: 'n1' }, { id: 'n2' }], edges: [] }
+    const harness = mountHarness(graphData)
+    await flushPromises()
+    expect(harness.minimapNodes.value).toEqual([])
+
+    const captured = d3Mock.__captured
+    const tickCb = captured.tick as (() => void) | undefined
+    expect(tickCb, 'tick handler must be wired').toBeDefined()
+    tickCb!()
+    // Flush the rAF the composable scheduled.
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await flushPromises()
+    expect(harness.minimapNodes.value.length).toBe(2)
+    expect(harness.minimapNodes.value.map((n) => n.id).sort()).toEqual(['n1', 'n2'])
+  })
+
+  it('panToGraphPoint ruft zoom.transform programmatisch auf', async () => {
+    const graphData = { graph_id: 'g-pan', nodes: [{ id: 'n1' }], edges: [] }
+    const harness = mountHarness(graphData)
+    await flushPromises()
+
+    const captured = d3Mock.__captured
+    const zb = captured.zoomBehavior as { transform: ReturnType<typeof vi.fn> } | undefined
+    expect(zb, 'zoom behavior must be captured').toBeDefined()
+    const transformFn = zb!.transform
+    // Set a known viewport scale via zoom event so _currentTransform.k is set.
+    ;(captured.zoom as (event: { transform: { x: number; y: number; k: number } }) => void)!({
+      transform: { x: 0, y: 0, k: 1.5 },
+    })
+    // The svg selection's .call spy is the dispatch surface used by
+    // panToGraphPoint: `svgSelection.call(zoomBehavior.transform, newTransform)`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const svgCallSpy = (captured.svgSelection as any).call as ReturnType<typeof vi.fn>
+    svgCallSpy.mockClear()
+    d3Mock.zoomIdentity.translate.mockReturnValue(d3Mock.zoomIdentity)
+    d3Mock.zoomIdentity.scale.mockReturnValue(d3Mock.zoomIdentity)
+    harness.panToGraphPoint(100, 200)
+    expect(svgCallSpy).toHaveBeenCalled()
+    // Last call's first arg must be the zoom behavior's transform method.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const calls = (svgCallSpy as any).mock.calls as unknown[]
+    const lastCall = calls[calls.length - 1] as unknown[]
+    expect(lastCall?.[0]).toBe(transformFn)
+    // Second arg is the new transform (built via zoomIdentity.translate().scale()).
+    expect(lastCall?.[1]).toBeDefined()
+  })
+})

--- a/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphRender.pinLayout.spec.ts
@@ -261,6 +261,40 @@ describe('useGraphRender — Pin-Persistenz (Phase 4a)', () => {
     expect(parsed.n1).toEqual({ x: 100, y: 120 })
   })
 
+  it('Drag-End persistiert die Drop-Position (d.fx/fy) auch wenn d.x/d.y stale sind', async () => {
+    // CodeRabbit/codex P2: läst der User zwischen Simulation-Ticks los, sind
+    // d.x/d.y noch die vorige Tick-Position (stale), während d.fx/d.fy bereits
+    // die Drop-Position halten. Persistiert werden muss die Drop-Position
+    // (sonst snap-back beim Restore). d.x/d.y müssen auf d.fx/d.fy gesynced
+    // werden, damit saveNodeLayout (liest n.x/n.y) den echten Drop-Punkt schreibt.
+    const graphData = { graph_id: 'g-stale', nodes: [{ id: 'n1' }], edges: [] }
+    mountHarness(graphData)
+    await flushPromises()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nodes = (graphDataMock as any).__getLastNodes() as Array<Record<string, unknown>>
+    const n1 = nodes.find((n) => n.id === 'n1') as Record<string, unknown>
+
+    const captured = d3Mock.__captured
+    captured.dragStart?.({ x: 5, y: 5 }, n1)
+    // drag handler setzt d.fx/d.fy = event.x/event.y (Drop-Position 100/120).
+    captured.dragDrag?.({ x: 100, y: 120 }, n1)
+    // d.x/d.y bleiben auf der vorigen Tick-Position (stale) — User lässt
+    // zwischen Ticks los, der letzte Tick hat d.x/d.y noch nicht auf fx/fy gezogen.
+    n1.x = 50
+    n1.y = 60
+    captured.dragEnd?.({}, n1)
+
+    const raw = localStorage.getItem('agora:graph-layout:g-stale')
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw as string)
+    // Drop-Position (100/120 via fx/fy), NICHT stale d.x/d.y (50/60).
+    expect(parsed.n1).toEqual({ x: 100, y: 120 })
+    // Node-Position wurde auf Drop-Punkt gesynced (verhindert snap-back).
+    expect(n1.x).toBe(100)
+    expect(n1.y).toBe(120)
+  })
+
   it('render() wendet gespeichertes Layout als fx/fy an (vor Simulation)', async () => {
     // Seed a saved layout for graph_id 'g-layout'.
     localStorage.setItem(

--- a/frontend/src/composables/useGraphRender.ts
+++ b/frontend/src/composables/useGraphRender.ts
@@ -93,10 +93,22 @@ export interface UseGraphRenderReturn {
 
 const GRAPH_LAYOUT_STORAGE_PREFIX = 'agora:graph-layout:'
 
+/**
+ * Creates the local storage key for a graph's saved layout.
+ *
+ * @param graphId - The graph identifier
+ * @returns The local storage key associated with the graph
+ */
 function layoutStorageKey(graphId: string): string {
   return GRAPH_LAYOUT_STORAGE_PREFIX + graphId
 }
 
+/**
+ * Loads persisted node positions for a graph.
+ *
+ * @param graphId - Identifier of the graph whose layout should be loaded
+ * @returns The saved node positions, or `null` when no valid layout is available
+ */
 function loadSavedLayout(graphId: string): Record<string, { x: number; y: number }> | null {
   if (typeof localStorage === 'undefined') return null
   try {
@@ -110,6 +122,12 @@ function loadSavedLayout(graphId: string): Record<string, { x: number; y: number
   }
 }
 
+/**
+ * Persists valid node positions for a graph in local storage.
+ *
+ * @param graphId - Identifier of the graph whose node layout is being saved
+ * @param nodes - Nodes and their current positions
+ */
 function saveNodeLayout(
   graphId: string,
   nodes: ReadonlyArray<{ id: string; x: number; y: number }>,
@@ -128,6 +146,11 @@ function saveNodeLayout(
   }
 }
 
+/**
+ * Removes the persisted node layout for a graph.
+ *
+ * @param graphId - The identifier of the graph whose saved layout should be removed
+ */
 function clearNodeLayout(graphId: string): void {
   if (typeof localStorage === 'undefined') return
   try {
@@ -145,6 +168,19 @@ type D3Selection = d3.Selection<any, any, any, any>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type D3Simulation = d3.Simulation<any, any>
 
+/**
+ * Manages force-directed graph rendering and exposes graph interaction controls.
+ *
+ * @param svgRef - Reference to the SVG element used for rendering
+ * @param containerRef - Reference to the element that determines the graph dimensions
+ * @param graphData - Reactive graph data to render
+ * @param entityTypes - Reactive entity type definitions used for node colors
+ * @param showEdgeLabels - Controls edge label visibility
+ * @param translateLabel - Optional function for translating edge labels
+ * @param batchSignal - Optional reactive signal used to trigger temporary auto-freezing
+ * @param autoFreezeMs - Duration of automatic freezing after a new batch, in milliseconds
+ * @returns Reactive selection, pause, layout, and Mini-Map state with graph control functions
+ */
 export function useGraphRender({
   svgRef,
   containerRef,

--- a/frontend/src/composables/useGraphRender.ts
+++ b/frontend/src/composables/useGraphRender.ts
@@ -63,6 +63,78 @@ export interface UseGraphRenderReturn {
   pauseSimulation: () => void
   resumeSimulation: () => void
   togglePause: () => void
+  /**
+   * Issue #744 Phase 4a — clears the persisted node-pinch layout for the
+   * current graph_id and re-renders without fixed positions (fx/fy = null).
+   */
+  resetLayout: () => void
+  /**
+   * Issue #744 Phase 4b — reactive mirror of node positions for the Mini-Map.
+   * Updated (throttled via rAF) on every Force-Simulation tick.
+   */
+  minimapNodes: Ref<Array<{ id: string; x: number; y: number }>>
+  /**
+   * Issue #744 Phase 4b — reactive mirror of the main viewport's d3.zoom
+   * transform plus container dimensions, so the Mini-Map can draw the
+   * viewport rectangle and convert Mini-Map clicks back to graph coords.
+   */
+  minimapViewport: Ref<{ x: number; y: number; k: number; width: number; height: number }>
+  /**
+   * Issue #744 Phase 4b — pans the main viewport so that the given graph-space
+   * point is centered. Used by the Mini-Map click/drag handler.
+   */
+  panToGraphPoint: (gx: number, gy: number) => void
+}
+
+// ---------------------------------------------------------------------------
+// Issue #744 Phase 4a — localStorage persistence for per-graph node pinch.
+// Layouts are keyed by graph_id so different graphs keep independent layouts.
+// ---------------------------------------------------------------------------
+
+const GRAPH_LAYOUT_STORAGE_PREFIX = 'agora:graph-layout:'
+
+function layoutStorageKey(graphId: string): string {
+  return GRAPH_LAYOUT_STORAGE_PREFIX + graphId
+}
+
+function loadSavedLayout(graphId: string): Record<string, { x: number; y: number }> | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(layoutStorageKey(graphId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    return parsed as Record<string, { x: number; y: number }>
+  } catch {
+    return null
+  }
+}
+
+function saveNodeLayout(
+  graphId: string,
+  nodes: ReadonlyArray<{ id: string; x: number; y: number }>,
+): void {
+  if (typeof localStorage === 'undefined') return
+  const map: Record<string, { x: number; y: number }> = {}
+  for (const n of nodes) {
+    if (n && typeof n.id === 'string' && Number.isFinite(n.x) && Number.isFinite(n.y)) {
+      map[n.id] = { x: n.x, y: n.y }
+    }
+  }
+  try {
+    localStorage.setItem(layoutStorageKey(graphId), JSON.stringify(map))
+  } catch {
+    // ignore quota / serialization errors — pin persistence is best-effort
+  }
+}
+
+function clearNodeLayout(graphId: string): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.removeItem(layoutStorageKey(graphId))
+  } catch {
+    // ignore
+  }
 }
 
 // reason: d3 v7 ships types via @types/d3; its internal Selection/Simulation generics require
@@ -107,6 +179,28 @@ export function useGraphRender({
   let _autoFreezeActive = false
   let _autoFreezeTimer: ReturnType<typeof setTimeout> | null = null
 
+  // Issue #744 Phase 4a — graph_id of the currently rendered graph, tracked
+  // so resetLayout() can clear the matching localStorage key without re-reading
+  // the raw data shape, and so the drag-end handler can persist positions.
+  let currentGraphId: string | null = null
+
+  // Issue #744 Phase 4b — refs/state consumed by the Mini-Map.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let _zoomBehavior: any = null
+  let _svgSelection: D3Selection | null = null
+  let _currentTransform: { x: number; y: number; k: number } = { x: 0, y: 0, k: 1 }
+  let _containerWidth = 0
+  let _containerHeight = 0
+  let _minimapRafHandle: number | null = null
+  const minimapNodes = ref<Array<{ id: string; x: number; y: number }>>([])
+  const minimapViewport = ref<{ x: number; y: number; k: number; width: number; height: number }>({
+    x: 0,
+    y: 0,
+    k: 1,
+    width: 0,
+    height: 0,
+  })
+
   const render = () => {
     const svgEl = svgRef.value
     const data = toValue(graphData)
@@ -134,6 +228,27 @@ export function useGraphRender({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { nodes, edges, getColor } = buildGraphRenderData(data, types) as { nodes: any[]; edges: any[]; getColor: (type: string) => string }
     if (nodes.length === 0) return
+
+    // Issue #744 Phase 4a — track graph_id for localStorage pin persistence.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rawGraphId = (data as any)?.graph_id
+    currentGraphId = typeof rawGraphId === 'string' && rawGraphId.length > 0 ? rawGraphId : null
+
+    // Issue #744 Phase 4a — restore persisted pinch layout BEFORE the simulation
+    // starts. Nodes with a saved position get x/y + fx/fy so the Force layout
+    // leaves them in place instead of recomputing them.
+    const savedLayout = currentGraphId ? loadSavedLayout(currentGraphId) : null
+    if (savedLayout) {
+      for (const n of nodes) {
+        const pos = savedLayout[n.id]
+        if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) {
+          n.x = pos.x
+          n.y = pos.y
+          n.fx = pos.x
+          n.fy = pos.y
+        }
+      }
+    }
 
     // reason: nodes/edges come from a JS module; cast to any[] is required to satisfy d3 overloads
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -166,16 +281,41 @@ export function useGraphRender({
     // reason: d3.zoom() requires Selection<Element,...> but d3.select(svgEl) returns
     // Selection<SVGSVGElement,...>; cast is safe because SVGSVGElement extends Element.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(svg as any).call(d3.zoom().extent([[0, 0], [width, height]]).scaleExtent([0.1, 4]).on('zoom', (event: any) => {
-      g.attr('transform', event.transform)
-      const wantsHide = event.transform.k < EDGE_LABEL_AUTO_HIDE_ZOOM
-      if (wantsHide !== _zoomedOut) {
-        _zoomedOut = wantsHide
-        const visible = showEdgeLabels.value && !_zoomedOut
-        if (linkLabelsRef) linkLabelsRef.style('display', visible ? 'block' : 'none')
-        if (linkLabelBgRef) linkLabelBgRef.style('display', visible ? 'block' : 'none')
-      }
-    }))
+    const zoomBehavior = (d3.zoom() as any)
+      .extent([[0, 0], [width, height]])
+      .scaleExtent([0.1, 4])
+      .on('zoom', (event: any) => {
+        _currentTransform = event.transform
+        g.attr('transform', event.transform)
+        const wantsHide = event.transform.k < EDGE_LABEL_AUTO_HIDE_ZOOM
+        if (wantsHide !== _zoomedOut) {
+          _zoomedOut = wantsHide
+          const visible = showEdgeLabels.value && !_zoomedOut
+          if (linkLabelsRef) linkLabelsRef.style('display', visible ? 'block' : 'none')
+          if (linkLabelBgRef) linkLabelBgRef.style('display', visible ? 'block' : 'none')
+        }
+        // Issue #744 Phase 4b — mirror viewport transform for the Mini-Map.
+        minimapViewport.value = {
+          x: event.transform.x,
+          y: event.transform.y,
+          k: event.transform.k,
+          width,
+          height,
+        }
+      })
+
+    // Issue #744 Phase 4b — keep refs so panToGraphPoint() can drive the zoom
+    // programmatically (Mini-Map click/drag → center main viewport).
+    _zoomBehavior = zoomBehavior
+    _svgSelection = svg
+    _containerWidth = width
+    _containerHeight = height
+    // The initial viewport matches an untransformed view.
+    _currentTransform = { x: 0, y: 0, k: 1 }
+    minimapViewport.value = { x: 0, y: 0, k: 1, width, height }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(svg as any).call(zoomBehavior)
 
     const linkGroup = g.append('g').attr('class', 'links')
 
@@ -292,9 +432,17 @@ export function useGraphRender({
         .on('end', (event: any, d: any) => {
           if (d._isDragging) {
             simulation.alphaTarget(0)
+            // Issue #744 Phase 4a — keep the node pinned at the dropped
+            // position (fx/fy) and persist the full layout to localStorage
+            // so it survives re-renders and is restored on next render().
+            d.fx = d.x
+            d.fy = d.y
+            if (currentGraphId) saveNodeLayout(currentGraphId, nodes)
+          } else {
+            // Click without drag → release the temporary pin set in 'start'.
+            d.fx = null
+            d.fy = null
           }
-          d.fx = null
-          d.fy = null
           d._isDragging = false
         }),
       )
@@ -378,6 +526,11 @@ export function useGraphRender({
       nodeLabels
         .attr('x', d => d.x)
         .attr('y', d => d.y)
+
+      // Issue #744 Phase 4b — throttled rAF mirror of node positions for the
+      // Mini-Map. Coalescing per animation frame avoids Vue-reactivity overhead
+      // on every Force-Simulation tick (which fires far more often than 60 Hz).
+      scheduleMinimapNodesUpdate(nodes)
     })
 
     svg.on('click', () => {
@@ -452,6 +605,47 @@ export function useGraphRender({
   }
 
   /**
+   * Issue #744 Phase 4a — clear the persisted pinch layout for the current
+   * graph and re-render so all nodes float freely again (fx/fy = null because
+   * no saved layout is applied). Auto-Freeze / manual-pause state is left
+   * untouched; render() re-creates the simulation regardless.
+   */
+  function resetLayout() {
+    if (currentGraphId) clearNodeLayout(currentGraphId)
+    render()
+  }
+
+  /**
+   * Issue #744 Phase 4b — throttle Mini-Map node updates to one per animation
+   * frame. Forces a fresh array so Vue reactivity actually triggers.
+   */
+  function scheduleMinimapNodesUpdate(
+    nodes: ReadonlyArray<{ id: string; x: number; y: number }>,
+  ) {
+    if (_minimapRafHandle !== null) return
+    _minimapRafHandle = requestAnimationFrame(() => {
+      _minimapRafHandle = null
+      minimapNodes.value = nodes.map(n => ({ id: n.id, x: n.x, y: n.y }))
+    })
+  }
+
+  /**
+   * Issue #744 Phase 4b — pan the main viewport so the given graph-space point
+   * is centered. Drives the stored d3.zoom behavior programmatically, which
+   * fires the zoom handler and thereby re-renders the Mini-Map viewport rect.
+   */
+  function panToGraphPoint(gx: number, gy: number) {
+    if (!_svgSelection || !_zoomBehavior) return
+    const k = _currentTransform.k || 1
+    const tx = _containerWidth / 2 - gx * k
+    const ty = _containerHeight / 2 - gy * k
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const newTransform = (d3.zoomIdentity as any).translate(tx, ty).scale(k)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(_svgSelection as any).call(_zoomBehavior.transform, newTransform)
+  }
+
+  /**
    * Internal-only auto-freeze: pauses the simulation without setting the
    * manual-pause flag. After `autoFreezeMs` the simulation auto-resumes
    * unless the user has manually paused in the meantime.
@@ -502,6 +696,10 @@ export function useGraphRender({
       clearTimeout(_autoFreezeTimer)
       _autoFreezeTimer = null
     }
+    if (_minimapRafHandle !== null) {
+      cancelAnimationFrame(_minimapRafHandle)
+      _minimapRafHandle = null
+    }
   })
 
   return {
@@ -511,5 +709,9 @@ export function useGraphRender({
     pauseSimulation,
     resumeSimulation,
     togglePause,
+    resetLayout,
+    minimapNodes,
+    minimapViewport,
+    panToGraphPoint,
   }
 }

--- a/frontend/src/composables/useGraphRender.ts
+++ b/frontend/src/composables/useGraphRender.ts
@@ -471,8 +471,16 @@ export function useGraphRender({
             // Issue #744 Phase 4a — keep the node pinned at the dropped
             // position (fx/fy) and persist the full layout to localStorage
             // so it survives re-renders and is restored on next render().
-            d.fx = d.x
-            d.fy = d.y
+            // d.fx/d.fy hold the final pointer position from the last drag
+            // event; d.x/d.y are only updated to fx/fy on force-simulation
+            // ticks, so on a release between ticks they still hold the prior
+            // tick's coordinates. Sync d.x/d.y to d.fx/d.fy so the rendered
+            // position matches the drop point and saveNodeLayout (which reads
+            // n.x/n.y) persists the actual released position instead of a
+            // stale tick coordinate (which would snap the node back on
+            // restore). CodeRabbit/codex P2 finding.
+            d.x = d.fx
+            d.y = d.fy
             if (currentGraphId) saveNodeLayout(currentGraphId, nodes)
           } else {
             // Click without drag → release the temporary pin set in 'start'.

--- a/frontend/src/composables/useGraphRender.ts
+++ b/frontend/src/composables/useGraphRender.ts
@@ -258,12 +258,30 @@ export function useGraphRender({
 
     svg.selectAll('*').remove()
 
+    // Issue #744 Phase 4b — reset the minimap mirror on every render. A
+    // render while paused (or a render of a graph whose simulation never
+    // ticks) produces no tick, so without a reset the prior graph's nodes
+    // would linger in the minimap. Cancelling a pending rAF also prevents a
+    // stale callback from publishing nodes captured before this render.
+    // CodeRabbit Major (F8).
+    if (_minimapRafHandle !== null) {
+      cancelAnimationFrame(_minimapRafHandle)
+      _minimapRafHandle = null
+    }
+    minimapNodes.value = []
+
     const types = toValue(entityTypes) || []
     // reason: buildGraphRenderData is a JS function; the result types are inferred
     // as JSDoc-only and are not compatible with d3 SimulationNodeDatum generics.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { nodes, edges, getColor } = buildGraphRenderData(data, types) as { nodes: any[]; edges: any[]; getColor: (type: string) => string }
-    if (nodes.length === 0) return
+    if (nodes.length === 0) {
+      // Issue #744 Phase 4 — empty graph: drop the graph identity so the
+      // still-visible reset action can't delete a *previous* graph's
+      // persisted layout. CodeRabbit Major (F6).
+      currentGraphId = null
+      return
+    }
 
     // Issue #744 Phase 4a — track graph_id for localStorage pin persistence.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -632,7 +632,9 @@
       "pauseLayout": "Layout pausieren",
       "resumeLayout": "Layout fortsetzen",
       "closePanel": "Graph-Panel schließen",
-      "exportHtml": "Als standalone HTML exportieren"
+      "exportHtml": "Als standalone HTML exportieren",
+      "resetLayout": "Layout zurücksetzen",
+      "minimapTitle": "Minimap"
     },
     "edgeLabels": {
       "RELATES_TO": "verbunden mit",
@@ -1248,6 +1250,9 @@
       "emptyTitle": "Keine aktiven Runs",
       "emptyHint": "Starte oben einen neuen Run aus einer Quelle.",
       "errorLabel": "Fehler",
+      "stopLabel": "Lauf stoppen",
+      "stopConfirm": "Lauf wirklich stoppen? Bisherige Daten bleiben erhalten.",
+      "stopError": "Stoppen fehlgeschlagen: {message}",
       "columns": {
         "runId": "Run-ID",
         "project": "Projekt",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -632,7 +632,9 @@
       "pauseLayout": "Pause layout",
       "resumeLayout": "Resume layout",
       "closePanel": "Close graph panel",
-      "exportHtml": "Export as standalone HTML"
+      "exportHtml": "Export as standalone HTML",
+      "resetLayout": "Reset layout",
+      "minimapTitle": "Minimap"
     },
     "edgeLabels": {
       "RELATES_TO": "relates to",
@@ -1248,6 +1250,9 @@
       "emptyTitle": "No active runs",
       "emptyHint": "Start a new run from a source above.",
       "errorLabel": "Error",
+      "stopLabel": "Stop run",
+      "stopConfirm": "Really stop this run? Existing data is preserved.",
+      "stopError": "Stop failed: {message}",
       "columns": {
         "runId": "Run ID",
         "project": "Project",


### PR DESCRIPTION
## Phase 3 — Runs jederzeit beenden

`ActiveRunsCard.vue` bekommt pro Run einen Stop-Button (Actions-Slot), unabhängig vom Step3-Wizard.
- `stopRun(runId)` via `POST /api/runs/{runId}/stop` (aus `api/runs.ts`, nicht `stopSimulation` — Runs haben verschiedene Phasen)
- Confirm-Dialog (`dashboard.active.stopConfirm`), optimistisches UI-Update + `emit('refresh')`, Stop-Fehler-Banner
- i18n `dashboard.active.stopLabel/stopConfirm/stopError` (de/en)

## Phase 4 — Graph-Lücken

**Pin-Persistenz** in `useGraphRender.ts`:
- Drag-Ende sichert `fx`/`fy` in `localStorage["agora:graph-layout:"+graph_id]`
- `render()` wendet gespeicherte Positionen vor `forceSimulation`-Start an
- Reset-Button

**Mini-Map** (`components/graph/GraphMiniMap.vue`, neu):
- Bounding-Box aller Nodes + Viewport-Rechteck (aus Zoom-Transform)
- Klick/Drag verschiebt Haupt-Viewport

## Tests

- `ActiveRunsCard.spec.ts` (+6 neue, 10/10 grün)
- `useGraphRender.pinLayout.spec.ts` (neu, 8/8 grün)
- `GraphCanvas.downloadHtml.spec.ts` angepasst
- Suite: **1437 passed**, typecheck (`vue-tsc --noEmit`) grün

## Pre-Push-Gate-Hinweis

`scripts/pre-push-gate.sh frontend` scheitert an **pre-existing transienten Flakes**, nicht an Phase-3/4-Code:
- AppShell/HistoryView `EnvironmentTeardownError` (Worker-Race beim Teardown)
- `DropdownMenu.reka.spec.ts` Timeout (5000ms, reka-UI-Render)
Jeweils *verschiedene* Specs pro Lauf, keine von Phase 3/4 berührt. Lokaler sauberer Run (post `rm -rf coverage node_modules/.vite`): **1437 passed, exit 0**. Flake-Beseitigung ist separates Issue, nicht Teil dieses Slices.

## Doku

`docs/epics/frontend-next/PHASE-5-VERIFICATION-HANDOVER.md` — Übergabe-Prompt für formale Verifikation (Phase 5, eigenes Fenster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)