### PR TITLE
feat(frontend): Kanon-First-Modellwahl (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ backend/instance/*.db
 # Screenshot-Drops, persönliche Test-Seed-Dokumente).
 .tmp-*
 test-seed-*.md
+
+# graphify Knowledge-Graph-Output (lokaler Build-Artefakt-Cache)
+graphify-out/

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -267,7 +267,7 @@ class LLMClient:
         )
         return {key: max_tokens}
 
-    def _detect_provider(self) -> Literal["ollama", "cloud", "openai", "google", "unknown"]:
+    def _detect_provider(self) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
         """Infer the LLM provider from base_url and model name.
 
         Siehe ``app.llm.providers.base.detect_provider`` für die Heuristik.

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -251,13 +251,15 @@ class LLMClient:
     def _completion_token_kwargs(
         self, max_tokens: int, model: Optional[str] = None
     ) -> Dict[str, int]:
-        """Wire-Key für das Token-Limit pro Modell.
-
-        Liefert ``{"max_completion_tokens": N}`` für GPT-5/o1/o3/o4 und
-        ``{"max_tokens": N}`` für alle anderen Modelle. ``model`` überschreibt
-        ``self.model`` — nötig im Vision-Pfad, der ein anderes Modell als das
-        Default-Chat-Modell nutzen kann (z. B. ``gemini-3-flash-preview:cloud``
-        bei einer GPT-5-Chat-Session).
+        """
+        Select the token-limit parameter name supported by the target model.
+        
+        Parameters:
+            model (Optional[str]): Model to inspect; defaults to the client's model.
+        
+        Returns:
+            Dict[str, int]: A mapping containing either ``max_completion_tokens`` or
+            ``max_tokens`` with the requested limit.
         """
         target_model = model if model is not None else (self.model or "")
         key = (
@@ -268,9 +270,11 @@ class LLMClient:
         return {key: max_tokens}
 
     def _detect_provider(self) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
-        """Infer the LLM provider from base_url and model name.
-
-        Siehe ``app.llm.providers.base.detect_provider`` für die Heuristik.
+        """
+        Infer the provider associated with the configured base URL and model name.
+        
+        Returns:
+            str: The inferred provider identifier.
         """
         return _provider_base.detect_provider(self.base_url, self.model)
 

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -233,7 +233,7 @@ def is_ollama(base_url: Optional[str]) -> bool:
 
 def detect_provider(
     base_url: Optional[str], model: Optional[str]
-) -> Literal["ollama", "cloud", "openai", "google", "unknown"]:
+) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
     """Infer the LLM provider from base_url and model name.
 
     Delegiert an ``app.llm.providers.registry.detect_provider(mode="http")``

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -234,15 +234,14 @@ def is_ollama(base_url: Optional[str]) -> bool:
 def detect_provider(
     base_url: Optional[str], model: Optional[str]
 ) -> Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]:
-    """Infer the LLM provider from base_url and model name.
-
-    Delegiert an ``app.llm.providers.registry.detect_provider(mode="http")``
-    (Single Source of Truth seit #591). Diese Wrapper-Funktion haelt die
-    alte Signatur fuer bestehende Aufrufer (z. B. ``LLMClient._detect_provider``)
-    aufrecht — die Heuristik-Logik lebt jetzt in der Registry, damit
-    HTTP-Client und OASIS-Subprozess dieselbe Quelle nutzen.
-
-    Siehe ``registry.py`` fuer die dokumentierten Divergenzen zwischen
-    ``mode="http"`` und ``mode="oasis"``.
+    """
+    Identify the LLM provider associated with a base URL and model name.
+    
+    Parameters:
+        base_url (Optional[str]): The provider's base URL.
+        model (Optional[str]): The model name.
+    
+    Returns:
+        Literal["ollama", "cloud", "minimax", "openai", "google", "unknown"]: The inferred provider label.
     """
     return _detect_provider_registry(base_url, model, mode="http")

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -90,23 +90,19 @@ def _is_ollama_cloud_tag(model: str) -> bool:
 
 
 def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedProvider:
-    """Heuristik des Backend-HTTP-Clients (vormals ``LLMClient._detect_provider``).
-
-    Prioritäten:
-    1. Base URL enthält ``ollama.com`` → ``"cloud"`` (Ollama Cloud proxy).
-    2. Ollama-Cloud-Tag ``:cloud`` / ``:<size>-cloud`` → ``"cloud"`` (Cloud-
-       Modelle laufen auch über den lokalen ollama-Proxy — deshalb VOR der
-       Port-Heuristik). Siehe ``_is_ollama_cloud_tag`` (Issue #670).
-    3. Base URL enthält ``api.minimax.io`` → ``"minimax"`` (MiniMax-Modelle
-       wie ``MiniMax-M3``, OpenAI- und Anthropic-kompatibel). Eigener
-       Branch vor der Port-Heuristik und vor ``openai.com``, weil
-       Subdomain-Matchings nichts mit Ollama-Ports zu tun haben und
-       ``api.openai.com`` sonst fälschlich gewinnen würde.
-    4. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
-    5. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
-    6. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
-       ``"google"`` (Gemini-OpenAI-Compat-Layer mit nativem ``tools=``).
-    7. Fallback → ``"unknown"``.
+    """
+    Detects the provider used by the backend HTTP client.
+    
+    Provider detection prioritizes Ollama Cloud URLs and cloud model tags, followed
+    by MiniMax, local Ollama, OpenAI, and Google endpoints. Unrecognized endpoints
+    are classified as ``"unknown"``.
+    
+    Parameters:
+        base_url (Optional[str]): Provider endpoint URL to inspect.
+        model (Optional[str]): Model name whose cloud tag may identify Ollama Cloud.
+    
+    Returns:
+        HttpDetectedProvider: The detected provider identifier.
     """
     model_name = model or ""
     base = (base_url or "").lower()

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -51,7 +51,9 @@ if TYPE_CHECKING:
     from app.llm.providers.base import ProviderAdapter
 
 # Teilmengen von app.contracts.provider_types.ProviderType
-HttpDetectedProvider = Literal["ollama", "cloud", "openai", "google", "unknown"]
+HttpDetectedProvider = Literal[
+    "ollama", "cloud", "minimax", "openai", "google", "unknown"
+]
 OasisDetectedProvider = Literal["google", "ollama", "openai"]
 DetectionMode = Literal["http", "oasis"]
 
@@ -95,11 +97,16 @@ def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedP
     2. Ollama-Cloud-Tag ``:cloud`` / ``:<size>-cloud`` → ``"cloud"`` (Cloud-
        Modelle laufen auch über den lokalen ollama-Proxy — deshalb VOR der
        Port-Heuristik). Siehe ``_is_ollama_cloud_tag`` (Issue #670).
-    3. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
-    4. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
-    5. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
+    3. Base URL enthält ``api.minimax.io`` → ``"minimax"`` (MiniMax-Modelle
+       wie ``MiniMax-M3``, OpenAI- und Anthropic-kompatibel). Eigener
+       Branch vor der Port-Heuristik und vor ``openai.com``, weil
+       Subdomain-Matchings nichts mit Ollama-Ports zu tun haben und
+       ``api.openai.com`` sonst fälschlich gewinnen würde.
+    4. Base URL enthält ``11434`` → ``"ollama"`` (lokales Ollama).
+    5. Base URL enthält ``openai.com`` oder ``api.openai`` → ``"openai"``.
+    6. Base URL enthält ``googleapis.com`` oder ``generativelanguage`` →
        ``"google"`` (Gemini-OpenAI-Compat-Layer mit nativem ``tools=``).
-    6. Fallback → ``"unknown"``.
+    7. Fallback → ``"unknown"``.
     """
     model_name = model or ""
     base = (base_url or "").lower()
@@ -107,6 +114,8 @@ def _detect_http(base_url: Optional[str], model: Optional[str]) -> HttpDetectedP
         return "cloud"
     if _is_ollama_cloud_tag(model_name):
         return "cloud"
+    if "api.minimax.io" in base:
+        return "minimax"
     if "11434" in base:
         return "ollama"
     if "openai.com" in base or "api.openai" in base:

--- a/backend/app/services/runtime_run_config.py
+++ b/backend/app/services/runtime_run_config.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, urlunparse
 from typing import Optional, Dict, Any
 from ..contracts import (
     PROVIDER_GOOGLE,
+    PROVIDER_MINIMAX,
     PROVIDER_OLLAMA_CLOUD,
     PROVIDER_OPENAI,
     PROVIDER_OPENAI_COMPATIBLE,
@@ -78,6 +79,7 @@ def _sanitize_url(value: str) -> str:
 _HTTP_DETECTION_TO_PROVIDER_ID = {
     "cloud": PROVIDER_OLLAMA_CLOUD,
     "google": PROVIDER_GOOGLE,
+    "minimax": PROVIDER_MINIMAX,
     "openai": PROVIDER_OPENAI,
     # "ollama" (local, e.g. port 11434) and "unknown" both fall back to the
     # generic OpenAI-compatible route, matching this function's previous

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -43,6 +43,14 @@ HTTP_CASES = [
     ("https://api.openai.com/v1", "mistral-large-cloud", "openai"),
     # Kein False Positive: `:`-Tag mit `-cloud` OHNE Groessenpraefix (Dritt-Gateway).
     ("https://api.example.com/v1", "custom:experimental-cloud", "unknown"),
+    # MiniMax (MiniMax-M3, ...) — eigener Provider-Branch unter api.minimax.io.
+    # Subdomain-Match vor "11434"-Port und vor "openai.com"-Substring, sonst
+    # landet MiniMax-M3 fälschlich auf api.openai.com (Smoke 2026-07-14).
+    ("https://api.minimax.io/v1", "MiniMax-M3", "minimax"),
+    ("https://api.minimax.io/anthropic", "MiniMax-M3", "minimax"),
+    ("HTTPS://API.MINIMAX.IO/v1", "MiniMax-M3", "minimax"),  # case-insensitive
+    # Kein False Positive: Modellname enthaelt "minimax", Base-URL aber nicht.
+    ("https://api.openai.com/v1", "minimax-mock", "openai"),
 ]
 
 
@@ -110,6 +118,10 @@ DIVERGENT_CASES = [
     ("https://example.com/v1", "some-model", "unknown", "openai"),
     ("", "llama3:latest", "unknown", "ollama"),  # :latest nur im OASIS-Modus ein Signal
     ("http://host:114340/v1", "foo", "ollama", "openai"),  # Substring vs. Port-Regex
+    # MiniMax: HTTP erkennt explizit ("minimax"); OASIS faellt auf
+    # OpenAI-Compat-Fallback zurueck (CAMEL-Dispatcher kennt kein
+    # "minimax"-PlatformType, OpenAI-Compat-Endpoint funktioniert).
+    ("https://api.minimax.io/v1", "MiniMax-M3", "minimax", "openai"),
 ]
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,7 +23,7 @@ Epic-`HANDOVER.md`.
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3335 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3340 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 163 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/epics/frontend-next/HANDOVER-GLM-MMX.md
+++ b/docs/epics/frontend-next/HANDOVER-GLM-MMX.md
@@ -1,0 +1,162 @@
+# Übergabe — Frontend-Next Phase 1+2 an MiniMax M3 / GLM 5.2
+
+**Datum:** 2026-07-17 · **Branch:** `feat/frontend-next-phase12` (von `feat/frontend-next`)
+**Vorgänger-Opus-Session:** siehe `PHASE-1-2-OPUS-HANDOVER.md` und `PHASE-1-DIVERGENZ.md`
+**Auftrag:** Phase 1 (Root-Cause-Fix der Modellwahl) ist **implementiert, uncommittet, ungetestet**. Phase 2 (Onboarding-Port) ist **nicht begonnen**. Diese Übergabe listet den verifizierten Ist-Stand und die nächsten Schritte.
+
+---
+
+## 1. Verifizierter Ist-Stand (Stand 2026-07-17, 23:11)
+
+### Git
+```
+Branch: feat/frontend-next-phase12  (2 Commits ahead von feat/frontend-next: a11y + gitignore)
+Modified (uncommitted):
+  .claude/settings.json                            (37 Zeilen — auto-Mode + bun/gh/docker-Allows, BEWUSST von Alex)
+  frontend/src/components/Step4Report.vue          (40 Zeilen)
+  frontend/src/components/v4/dashboard/HeroNewRun.vue (47 Zeilen)
+  frontend/src/views/Home.vue                      (57 Zeilen)
+  frontend/src/views/Settings/LlmProvidersView.vue (7 Zeilen)
+  frontend/src/views/Settings/SettingsGeneralView.vue (290 Zeilen — Komplettumschreibung)
+  frontend/src/views/SettingsView.vue               (14 Zeilen)
+Untracked:
+  frontend/src/composables/useEffectiveModelSelection.ts        (97 Zeilen — architektonisches Herzstück, von Opus)
+  frontend/src/composables/__tests__/useEffectiveModelSelection.spec.ts (202 Zeilen, 12/12 grün)
+  docs/epics/frontend-next/HANDOVER.md
+  docs/epics/frontend-next/PHASE-1-2-OPUS-HANDOVER.md
+  docs/epics/frontend-next/PHASE-1-DIVERGENZ.md
+  docs/epics/frontend-next/PHASE-5-VERIFICATION-HANDOVER.md
+  (diese Datei)
+Diff-Stat: 7 Dateien, 117 insertions, 375 deletions
+```
+
+### settings.json
+Alex hat `.claude/settings.json` bewusst geändert (defaultMode→"auto", leeres ask[], plus bun/npm/gh/docker-compose-Allows). **Nicht revertieren.** Siehe Diff in `PHASE-1-2-OPUS-HANDOVER.md` §9.
+
+---
+
+## 2. Architekturentscheidung (Phase-1-Root-Cause)
+
+**Problem:** Mehrere Frontend-Flächen schrieben in unabhängige, server-seitig NICHT synchrone Senken. Zwei Backend-Runtime-Pfade lasen verschiedene Quellen:
+- `backend/app/llm/client.py:72` → `use_active_config` → `active-config`-Store
+- `backend/app/services/stage_model_router.py:116` → `routing/defaults.global_default`
+- `backend/app/services/json_mode.py:203` → `active-config`
+
+`llm_active.py` und `llm_routing.py` sind serverseitig **unabhängig persistiert** — nichts synchronisiert sie außer FE-Doppelschreib.
+
+**Kanon-Entscheidung (AGENTS.md-konform):**
+- **Kanon = `routing/defaults.global_default`**, repräsentiert als `AiModelRef` via `useAiModelRefAdapter`.
+- `active-config` wird beim Schreiben **im Gleichschritt mitgezogen** (KEIN Backend-Touch, reiner FE-Sync).
+- Die reinere SSoT (Backend delegiert active-config serverseitig an den Routing-Store) ist ein **bewusst separates Folge-Slice** — nicht in Phase 1 machen.
+
+**Umgesetzt via Composable** `frontend/src/composables/useEffectiveModelSelection.ts`:
+```typescript
+export interface EffectiveModelSelection {
+  effectiveRef: ComputedRef<AiModelRef | null>   // aus global_default via Adapter
+  effectiveRoute: ComputedRef<LlmRoute>          // global_default direkt
+  loading: Ref<boolean>
+  error: Ref<string | null>
+  ensureLoaded: () => Promise<void>              // lädt routing-defaults + connections idempotent (hasLoadedOnce-Guard)
+  setGlobalSelection: (ref: AiModelRef) => Promise<void>  // routing/defaults.global UND active-config im Gleichschritt
+}
+```
+`setGlobalSelection` schreibt **Kanon zuerst** (`defaultsStore.setGlobalDefault(route)`), dann `setActiveLlmConfig({provider_id, model})` für den Gleichschritt.
+
+**5 frühere Persistenz-Senken (alle entfernt/umgeleitet):**
+1. `active-config` (eigene Provider/Modell-Dropdowns in SettingsGeneralView) → **entfernt**, jetzt via Composable
+2. `routing/defaults.global_default` → **Kanon**, via Composable
+3. `STORAGE_HOME_AI_REF` (localStorage `agora.home.aiModelRef`) → **entfernt**
+4. `STORAGE_HERO_AI_REF` → **entfernt** (HeroNewRun: nur noch transienter Run-Override + STORAGE_MODEL-Spiegel für MainView)
+5. `STORAGE_REPORT_AI_REF` → **entfernt**
+
+---
+
+## 3. Geänderte Flächen (Kanon-First-Init Pattern)
+
+Alle Per-Run-Flächen folgen jetzt demselben Muster:
+```typescript
+const effectiveModel = useEffectiveModelSelection()
+onMounted(async () => {
+  await effectiveModel.ensureLoaded()
+  if (!selectedModel.value) selectedModel.value = effectiveModel.effectiveRef.value
+})
+```
+
+| Datei | Änderung |
+|---|---|
+| `SettingsGeneralView.vue` | Komplettumschreibung. Entfernte separate "Active LLM Config"-Sektion. Ein `AiModelPicker` via Composable. |
+| `SettingsView.vue` (classic) | `saveLlmActive` → `effectiveModel.setGlobalSelection(...)`. |
+| `LlmProvidersView.vue` | `setDefault` → `effectiveModel.setGlobalSelection(aiRef)`. |
+| `HeroNewRun.vue` | `onPickModel` = transienter Run-Override (nur STORAGE_MODEL-Spiegel). Kanon-First-Init onMounted. |
+| `Home.vue` | **WICHTIG:** führte `modelOverridden`-Flag ein. Home nutzte `selectedModel !== null` als Proxy für „User hat explizit gewählt" im Ollama-Reachability-Gate. Kanon-Vorbelegung würde das brechen → `servicesReady` nutzt jetzt `modelOverridden.value`. Template-Hinweise `!selectedModel` → `!modelOverridden`. |
+| `Step4Report.vue` | Kanon-First-Init. Entfernte STORAGE_REPORT_AI_REF, resolveInitialReportRoute, reportRoute-watch-Persistenz. `llmProfileId`/STORAGE_REPORT_PROFILE_ID (Preset) bleibt. |
+
+### Bewusst NICHT geändert
+- `LlmRoutingView.vue` — Run-Scoped (`props.runId`, getRunLlmRouting/updateRunLlmRouting), berührt weder active-config noch Workspace-Defaults → keine Divergenzquelle.
+- `EnvSetupModelPanel.vue` — reine Präsentationskomponente (nur Props+Emits, kein eigener State, keine Senke). Echte Konsolidierung erfordert Eltern-Container-Bau (useEnvForm/STORAGE_MODEL/Parent) → siehe §5 offener Punkt.
+- `ActiveModelBadge.vue`, `LlmProfilePicker.vue` — unkritisch.
+
+---
+
+## 4. Tests — Status
+
+**Grün:**
+- `useEffectiveModelSelection.spec.ts` — 12/12 (vom Sonnet-Subagent geschrieben; testet Spiegelung, setGlobalSelection ruft setGlobalDefault + setActiveLlmConfig, Kanon-VOR-active-config-Reihenfolge, ensureLoaded-Idempotenz, Fehler-Propagation).
+
+**NOCH NICHT GELAUFEN (Pflicht vor Commit):**
+- `cd frontend && bun run check` (typecheck) — die 6 geänderten Flächen-Dateien sind nicht typecheck-geprüft.
+- `cd frontend && bun run test -- --run` — **existierende Specs müssen auf Kanon-First-Verhalten umgeschrieben werden**, weil sie das entfernte localStorage-Verhalten spiegeln:
+  - `SettingsGeneralView.spec.ts`
+  - `LlmProvidersView.spec.ts`
+  - `HeroNewRun.spec.ts`
+  - Home-Specs
+  - `ReportModelControls.spec.ts` (bzw. Step4Report-zugehörige)
+- `bash scripts/pre-push-gate.sh frontend` — finales Gate.
+
+**Memory-Regel beachten:** „Subagent pre-existing failures verifizieren" — Refactor-induzierte Test-Brüche tarnen sich gerne als Pre-Existing. Wenn Specs rot sind: prüfen, ob der Bruch durch den Phase-1-Refactor kam oder schon vorher rot war (`git stash` + Spec-Run auf HEAD zur Unterscheidung).
+
+---
+
+## 5. Offene Punkte (Reihenfolge = Priorität)
+
+### 5.1 Verifikation + Gates (Pflicht, vor Commit)
+1. `cd frontend && bun run check` — typecheck
+2. Bestehende Specs auf Kanon-First umschreiben (siehe §4 Liste). RED → GREEN.
+3. `cd frontend && bun run test -- --run`
+4. `bash scripts/pre-push-gate.sh frontend`
+
+### 5.2 EnvSetupModelPanel / step2-Legacy-Profil-Pfad konsolidieren
+Q3-Entscheidung (Alex): „Auf AiModelRef umstellen." EnvSetupModelPanel ist reine Präsentationskomponente — Eltern-Container (useEnvForm/STORAGE_MODEL/Parent) muss gefunden und migriert werden. Profile → optionale Presets, keine eigene aktive Selektionsquelle. **Größter verbleibender Schritt.** CRG nutzen, um Parent zu finden: `query_graph pattern="callers_of" target="EnvSetupModelPanel"`.
+
+### 5.3 PR erstellen (nach Gates)
+PR + 90 s warten + Gemini-Findings sichten, dann mergen (Memory: `feedback_pr_gemini_workflow`). Niemals direkt FF-pushen.
+
+### 5.4 Phase 2 — Onboarding React→Vue portieren
+**Design-Konflikt klären mit Alex, NICHT autonom portieren:** Vue-Onboarding nutzt bewusst „Statusschritte" (verlinken in Settings) statt React-Inline-Flow. Ein Port würde diese Designentscheidung überschreiben. Jede Modellwahl im Onboarding muss den Phase-1-Composable nutzen. Siehe `PHASE-1-2-OPUS-HANDOVER.md` für Details.
+
+---
+
+## 6. Hard Constraints (gelten weiter)
+
+- **NIE** API-Keys/Secrets in Code, Logs, Fixtures, Doku.
+- **NIE** `--no-verify`, `--force`, `--no-gpg-sign` ohne explizite User-Anweisung.
+- **NIE** Edits auf `main`. PR-Workflow ist Default. Branch: `feat/frontend-next-phase12`.
+- **NIE** `curl`/`wget` in Bash (Hook geblockt) — `ctx_fetch_and_index`/`WebFetch`.
+- **NIE** `cat`/`head`/`tail`/`sed`/`echo` für Dateioperationen — `Read`/`Edit`/`Write`.
+- context-mode Hook-Decisions sind bindend.
+- Evidence-Gating-Hartanker (ADR-0002) NIE ohne `docs/decisions/0002-supersedes.md` + User-Sign-off schwächen. **Phase 1+2 berührt diese nicht** — keine Backend-Prompt-/Validator-Änderungen.
+- Pre-Push-Gate Pflicht: `bash scripts/pre-push-gate.sh frontend`.
+- Frontend-Toolchain: **`bun` ist Canon** (`bun run <script>`), NICHT pnpm/npm (Memory: `agora-frontend-toolchain`).
+- **Keine Anthropic-Subagents** (Memory: `feedback_no_anthropic_subagents`) — Workflow/Agent: `model`/`agentType` weglassen → Session-Modell erben; keine Claude-Varianten.
+- `.claude/settings.json`-Änderung war beabsichtigt von Alex — nicht revertieren.
+
+---
+
+## 7. Erster Schritt der Folge-Session
+
+1. `cd /Volumes/T7/Projekte/agora && git status` verifizieren (sollte §1 entsprechen).
+2. `cd frontend && bun run check` laufen lassen — typecheck-Brüche in den 6 Flächen fixen.
+3. Bestehende Specs umschreiben (§4) — RED → GREEN.
+4. Dann §5.2 (EnvSetupModelPanel-Parent) via CRG angehen.
+5. Gates + PR (§5.1/§5.3).
+6. Phase 2 nur nach Alex-Klärung (§5.4).

--- a/docs/epics/frontend-next/HANDOVER.md
+++ b/docs/epics/frontend-next/HANDOVER.md
@@ -1,0 +1,115 @@
+# Übergabe-Prompt — Agora Frontend-Next (Lovable React-Redesign)
+
+Session-Kontext ist fast voll. Diesen Prompt 1:1 in eine neue Claude-Code-Session
+in `/Volumes/T7/Projekte/agora` (Branch `feat/frontend-next`) einfügen, um nahtlos
+weiterzumachen.
+
+## Was das Projekt ist
+
+Redesign des Agora-Frontends (Flask-Backend bleibt unverändert) als eigenständige
+React+TanStack-Start-SPA über Lovable. Vollständiger Architektur-Brief liegt unter
+`docs/epics/frontend-next/brief.md` (committed, Commit `674f698a`, **noch nicht
+gepusht**). Lies den Brief zuerst für den kompletten Kontext (Auth, SSE-Ticket-Flow,
+Contracts, API-Routen, Baureihenfolge).
+
+## Lovable-Projekt
+
+- Projekt-ID: `a061f7f7-294f-4380-935d-a8f0eb4110a3`
+- Editor: https://lovable.dev/projects/a061f7f7-294f-4380-935d-a8f0eb4110a3
+- Preview: https://id-preview--a061f7f7-294f-4380-935d-a8f0eb4110a3.lovable.app
+- Workspace-ID: `ywW2AknvnOdwQW1Yt23P` ("Alexander's Lovable")
+- Projektwissen (Auth/SSE/Contracts/Baureihenfolge) ist bereits über
+  `set_project_knowledge` dauerhaft im Lovable-Projekt hinterlegt — nicht nötig,
+  das bei neuen `send_message`-Calls zu wiederholen.
+- GitHub-Sync aktiv: https://github.com/arn0ld87/agora-runs-dashboard.git (Branch
+  `main`, bidirektional — Lovable pusht eigene Edits automatisch, externe Pushes
+  werden von Lovable zurückgesynct).
+
+## Lokaler Klon (für Real-API-Tests)
+
+- Pfad: `/Volumes/T7/Projekte/agora-runs-dashboard`
+- Stack: React 19 + TanStack Start/Router + Vite 8 + Tailwind + shadcn/ui, `bun`
+  als Package-Manager, MSW bereits als Dependency (für Mock-Mode).
+- `vite.config.ts` wurde um einen `/api`-Proxy zu `http://localhost:5001` ergänzt
+  (Commit `a4af152`, bereits gepusht) — Dev-Server läuft same-origin gegen das
+  lokale Agora-Backend, kein CORS nötig.
+- Dev-Server-Start: `cd /Volumes/T7/Projekte/agora-runs-dashboard && bun run dev`
+  (läuft auf Port 8080).
+
+## Bereits fertiggestellte Slices (in Lovable gebaut, live in der Preview)
+
+1. **Slice 1** — Projekt-Skeleton, Contracts-Ordner, API-Client mit
+   `X-Agora-Token`-Header + Envelope-Unwrapping, MSW-Mock-Infra, Runs-Dashboard +
+   Run-Detail, App-Shell mit Sidebar.
+2. **Slice 2** — Onboarding-Wizard (7 Steps: welcome, profile, providers,
+   chat_model, embeddings, privacy, summary), Step-Indicator, Mock-State.
+3. **Slice 3** — Simulation-Seite: Persona-Review-Grid (Approve/Reject/Regenerate,
+   Filter nach review_status), Quoten-Übersicht (target vs. actual), Branch-Button,
+   Live-Feed-Tab als Platzhalter.
+4. History/Compare-Seiten wurden laut letztem Dashboard-Commit
+   (`5e9c918 History & Compare-Seiten angelegt`) ebenfalls schon angelegt — Stand
+   prüfen, bevor Slice 7 nochmal angestoßen wird (evtl. schon (teilweise) erledigt).
+
+## Offene Slices — fertige Copy-Paste-Prompts
+
+Die exakten Prompts für Slice 4 (SSE-Live-Feed), 5 (Report+Interaction), 6
+(Settings), 7 (Compare/History), 8 (Real-API-Wiring) wurden bereits einmal im
+Chat formuliert und an den Nutzer ausgegeben — falls das Chat-Log verloren geht,
+im Zweifel aus `docs/epics/frontend-next/brief.md` Abschnitt 10 (Baureihenfolge)
+neu ableiten oder den Nutzer fragen, ob er die Prompts noch hat. Kernpunkte pro
+Slice stehen im Brief.
+
+**Wichtig für Slice 8 (Real-API-Wiring):** NICHT blind ausführen. Setzt voraus,
+dass der lokale Dev-Server (Port 8080) gegen das lokale Backend läuft (siehe unten).
+
+## Laufende lokale Infrastruktur (Stand: Übergabe-Zeitpunkt)
+
+- `agora-neo4j` (Docker, healthy, Bolt auf `127.0.0.1:7687`)
+- `agora-redis` (Docker, healthy, **kein Host-Port-Mapping** — nur im
+  Compose-Netzwerk erreichbar, daher MUSS das Backend ebenfalls dockerisiert
+  laufen, nicht nativ via `uv run python run.py`)
+- `docker compose up -d --build` (voller Dev-Stack inkl. `agora`-Service mit
+  HMR-Mounts aus `docker-compose.override.yml`) lief beim Session-Ende noch —
+  Status prüfen: `docker ps` (fehlt `agora`-Container in der Liste → Build lief
+  noch oder ist fehlgeschlagen, dann Build-Log/Fehler checken und ggf. neu
+  anstoßen: `docker compose up -d --build`).
+- `AGORA_AUTH_TOKEN` wurde vom Nutzer selbst in `backend/.env` gesetzt (per
+  `!`-Bash-Prefix, da `.env`-Zugriff für den Agenten hart geblockt ist — das
+  bitte respektieren, nicht versuchen zu umgehen).
+- Nach erfolgreichem `docker compose up`: Log prüfen auf
+  `Neo4jStorage initialization failed` — sollte NICHT mehr auftreten, wenn der
+  `agora`-Container läuft (DNS-Namen `neo4j`/`redis` sind dann im
+  Compose-Netzwerk auflösbar).
+
+## Wichtige Leitplanken aus dieser Session (bitte respektieren)
+
+- **`.env`/Secrets:** Bash-Zugriff auf `.env`-Pfade ist hart per Hook geblockt,
+  auch nach expliziter Nutzer-Freigabe im Chat. Bei Bedarf dem Nutzer den exakten
+  `!`-Prefix-Befehl geben, den er selbst ausführt — nicht versuchen, über andere
+  Tools (Read, ctx_execute) auszuweichen.
+- **Keine Secrets in Lovable:** Lovable-"Secrets" sind für Supabase-Edge-Functions
+  gedacht; dieses Projekt hat explizit kein Lovable Cloud/Supabase. Keine Tokens
+  dort eintragen.
+- **`curl`/`wget` in Bash sind geblockt** (Hook) — für HTTP-Checks `ctx_execute`
+  oder `WebFetch` nutzen (WebFetch kann aber keine `localhost`-URLs).
+- Repo `agora`: nicht direkt auf `main` arbeiten, PR-Workflow. Aktueller Branch
+  `feat/frontend-next`. Der Brief-Commit (`674f698a`) ist noch ungepusht.
+- Repo `agora-runs-dashboard`: eigenständiges Repo, kein Teil des `agora`-Repos,
+  liegt als Sibling-Verzeichnis unter `/Volumes/T7/Projekte/`.
+- `frontend-next/` (Vue-Scaffold-Altlast) wurde bereits gelöscht — falls sie
+  wieder auftaucht, ist das nicht die Zielarchitektur (React, nicht Vue).
+- Pre-existing uncommitted changes im `agora`-Repo (`AiModelPicker.vue`,
+  `Field.vue`, `SettingsSectionPanel.vue`, `golden-gate-accessibility.spec.ts`,
+  `frontend/test-results/`, `graphify-out/`) stammen NICHT aus dieser Session —
+  nicht anfassen, nicht committen, gehören zu anderer laufender Arbeit.
+
+## Nächster Schritt für die neue Session
+
+1. `docker ps` prüfen, ob `agora`-Container läuft (Build könnte fertig sein).
+2. Falls ja: Backend-Log auf saubere Neo4j/Redis-Verbindung prüfen.
+3. Falls Dev-Server auf Port 8080 nicht mehr läuft: `cd agora-runs-dashboard &&
+   bun run dev` neu starten.
+4. Mit Slice 4 (SSE-Live-Feed) oder dem nächsten offenen Slice weitermachen,
+   je nachdem was der Nutzer zuletzt in Lovable direkt angestoßen hat — vorher
+   kurz `get_project`/`list_messages` auf das Lovable-Projekt prüfen, um den
+   tatsächlichen Stand zu verifizieren, statt blind vom Brief auszugehen.

--- a/docs/epics/frontend-next/PHASE-1-2-OPUS-HANDOVER.md
+++ b/docs/epics/frontend-next/PHASE-1-2-OPUS-HANDOVER.md
@@ -1,0 +1,257 @@
+# Übergabe-Brief — Agora Frontend-Next, Phase 1+2 (Opus-Session)
+
+Diesen Brief in eine **neue Claude-Code-Session mit Opus als Lead-Modell** pasten
+(effort=**high**, nicht xhigh — ausdrückliche Vorgabe Alex'). Arbeitsverzeichnis:
+`/Volumes/T7/Projekte/agora`, Repo `arn0ld87/agora`.
+
+Vollständiger Plan liegt unter
+`~/.claude/plans/sieh-dir-volumes-t7-projekte-agora-runs-swift-spark.md`
+(same machine). Dieser Brief ist die **verifizierte, korrigierte Eingangsinformation** für
+Phase 1+2 — er ersetzt nicht den Plan, er verifiziert/korrigiert seine Annahmen.
+
+---
+
+## Entschluss vorab (richtet alle folgenden Schritte aus)
+
+Das React-Lovable-Dashboard (`agora-runs-dashboard`) wird **nicht weiterverfolgt** —
+das produktive Vue-3-Frontend (`agora/frontend/`) deckt die 5 „Weiter sinnvoll"-Punkte
+der alten Übergabe bereits ab. Das React-Repo dient **nur noch als Vorlage** für zwei
+Dinge: (a) die Onboarding-Step-Struktur, (b) das Provider-Connection-Modell für die
+Modellwahl. Portiert wird **nach Vue**, gegen dieselben, bereits verifizierten
+Flask-Endpunkte. Die alte `docs/epics/frontend-next/HANDOVER.md` beschreibt die
+verworfenen React-Slices — **nicht** weiterverfolgen; `frontend-next/`-Scaffold wurde
+bereits gelöscht.
+
+Alex' tatsächlicher Schmerzpunkt: **inkonsistente Modellauswahl** im Vue-Frontend
+(mehrere parallel existierende State-Quellen, die nicht dieselbe Quelle spiegeln).
+Phase 1+2 ist der Kernschmerz und reasoning-intensiv — deshalb Opus-Lead.
+
+---
+
+## Modell- & Session-Strategie (Alex' Vorgabe)
+
+- **Lead: Opus, effort=high** (NICHT xhigh).
+- **Subagents: Sonnet** via Workflow-Tool (`agent()` mit `model: "sonnet"`).
+  Workflows halten den Hauptkontext sauber — Subagents machen die mechanische
+  Implementierung, Opus-Lead macht die State-Konsolidierungs-Entscheidungen und
+  verifiziert.
+- **Pro Phase eigenes Fenster.** Diese Opus-Session führt **nur Phase 1+2** aus.
+  Phase 3 (Kill-Switch), Phase 4 (Graph-Lücken), Phase 5 (Verifikation) werden in
+  jeweils eigenen Sessions gemacht — nicht hier.
+
+---
+
+## Verifizierte Fakten aus der glm-Discovery (Korrekturen zum Plan)
+
+### 1. Branch `feat/frontend-next` ist 2 ahead, 0 behind `main`
+
+`git log main..feat/frontend-next` →
+`674f698a docs(frontend-next): Frontend-Next-Brief`, `67ad63da feat(registry):
+detect MiniMax provider via api.minimax.io base URL`. Strikt voran, kein Merge
+nötig. Plan-Option „von main" vs „von feat/frontend-next (WIP mitnehmen)" —
+
+### 2. Uncommitteter WIP ist Accessibility-Polish, NICHT Modellwahl
+
+`git diff` zeigt 4 Dateien, 11 insertions / 6 deletions:
+
+| Datei | Änderung | Natur |
+|---|---|---|
+| `components/v4/forms/AiModelPicker.vue` | +1 Zeile `:aria-label="placeholderText"` | a11y |
+| `components/v4/forms/Field.vue` | `div`→`label`/`span` Wrapping | a11y (Label-Assoziation) |
+| `components/v4/forms/SettingsSectionPanel.vue` | 4× `:aria-label="field.key"` | a11y |
+| `tests/e2e/golden-gate-accessibility.spec.ts` | 2 Zeilen | a11y-Test |
+
+Der Plan interpretierte dies als „unfertiger Modellwahl-WIP" — **falsch**. Es ist ein
+a11y-Fix. Alt-`HANDOVER.md` Zeile 100–104 bestätigt: WIP stammt aus *anderer* laufender
+Arbeit, nicht anfassen/committen.
+
+**Empfehlung:** diesen WIP als **eigenen kleinen a11y-Commit** sichern (z. B.
+`fix(a11y): aria-label für v4 Forms`), **bevor** der Phase-1+2-Branch entsteht. Nicht
+mit Phase-1-Code vermischen. `frontend/test-results/` und `graphify-out/` gehören in
+`.gitignore` (Build-/Test-Artefakte), nicht committen.
+
+### 3. Vue hat bereits einen Onboarding-Flow — Port muss migrieren, nicht ersetzen
+
+- `frontend/src/views/onboarding/OnboardingView.vue` (+ Test)
+- `frontend/src/router/onboardingGuard.ts` (+ Test)
+- `frontend/src/api/` hat `llmProfiles.ts`, und Backend hat `onboarding.py`,
+  `llm_active.py`, `llm_providers.py`, `llm_routing.py`, `llm_profiles.py`,
+  `user_profile.py`.
+
+Plan sagte „Vue hat vermutlich älteren/anderen Flow — Ist-Stand gegenchecken". Ist
+bestätigt: der Port **darf nicht blind ersetzen**. Erst `OnboardingView.vue` lesen,
+vergleichen mit React-`contracts/onboarding.ts`-Step-Reihenfolge
+(`welcome→profile→providers→chat_model→embeddings→privacy→summary`), dann
+migrieren/erweitern. Risiko-Quelle laut Plan: Onboarding-Fortschritt ist bereits
+serverseitig persistiert — nicht regressen.
+
+### 4. AiModelPicker.vue hat schon Logik — Mock-These verifizieren
+
+`query_graph file_summary` auf `AiModelPicker.vue` (686 Zeilen) liefert Funktionen:
+`refresh`, `deriveSource`, `fallbackReason`, `onUpdate`, `providerStatusLabel`,
+`statusTone`, `isDisabled`. `deriveSource`/`onUpdate` deuten auf **bereits
+begonnene** Store-/Quellen-Anbindung — der Plan-Claim „noch Mock-Daten, keine
+Store-Anbindung (Slice 5.0/5.1)" ist vermutlich **teilweise obsolet**. Der Kopf-Kommentar
+der Datei sagt selbst, 5.2 bringe `useAvailableModels()`-Anbindung. **Erster
+Schritt der Opus-Session:** Datei lesen, Ist-Stand der Anbindung feststellen, dann
+entscheiden was wirklich fehlt (nicht vom Plan-Claim ausgehen).
+
+### 5. CRG deckt das Frontend vollständig — richtig nutzen
+
+`list_graph_stats`: 992 Dateien, 9643 Knoten, 82320 Kanten, Sprachen
+`python, javascript, typescript, vue, bash`, Graph zuletzt 2026-07-17 22:33
+aktualisiert, **7768 Knoten mit Embeddings** (semantic search verfügbar).
+
+**Stolperfalle:** `semantic_search_nodes` mit *langen* Phrasen („AiModelPicker
+model selection") lieferte 0 Treffer. Funktioniert mit **kurzen, präzisen**
+Queries. `query_graph` mit Pattern `file_summary` / `callers_of` / `callees_of` /
+`tests_for` funktioniert zuverlässig.
+
+**Discovery-Pfad für Phase 1+2 (CRG zuerst, dann gezieltes Read):**
+
+- `query_graph pattern="file_summary" target="frontend/src/components/v4/forms/AiModelPicker.vue"`
+- `query_graph pattern="callers_of" target="useAiModelRefAdapter"` und
+  `target="useAvailableModels"` → wer konsumiert die Adapter?
+- `query_graph pattern="tests_for" target="AiModelPicker"` / `"useAiModelRefAdapter"`
+  → bestehende Coverage
+- `get_impact_radius` für die Dateien, die geändert werden sollen
+- `semantic_search_nodes query="AiModelRef"` / `"active-config"` / `"routing defaults"`
+  (kurze Queries) → kanonische Quelle identifizieren
+
+### 6. Vollständiges Inventar der Modellwahl-Konsumenten (Frontend)
+
+Contracts: `contracts/aiModelRef.ts`, `contracts/modelActiveContract.ts`,
+`contracts/llmProfileContract.ts`.
+Stores: `store/aiModels.ts`, `store/useActiveModelStore.ts`.
+Composables/Adapter: `composables/useAiModelRefAdapter.ts`,
+`composables/useAvailableModels.ts`.
+API: `api/llmProfiles.ts`.
+Komponenten: `components/v4/forms/AiModelPicker.vue`,
+`components/v4/forms/LlmProfileManager.vue`,
+`components/v4/forms/StepModelOverrideChip.vue`,
+`components/llm/LlmProfilePicker.vue`, `components/ActiveModelBadge.vue`,
+`components/step4/ReportModelControls.vue`, `components/step2/EnvSetupModelPanel.vue`
+(Plan nannte fälschlich `Step2EnvSetup.vue`), `views/agora2026/components/ModelPill.vue`.
+
+**Tests (jede Konsument-Datei hat einen Spec):** `useAiModelRefAdapter.spec.ts`,
+`useAvailableModels.connection.spec.ts`, `aiModels.spec.ts`,
+`useActiveModelStore.spec.ts`, `ActiveModelBadge.spec.ts`,
+`LlmProfilePicker.spec.ts`, `ReportModelControls.spec.ts`, `AiModelPicker.spec.ts`,
+`AiModelPicker.discovery.spec.ts`, `LlmProfileManager.spec.ts`,
+`StepModelOverrideChip.spec.ts`. Die Opus-Session **musst** diese Specs als
+Regressionsschutz laufen lassen.
+
+**Divergenz-Tabelle** (welche Quelle liest/schreibt jeder Konsument) ist der erste
+Deliverable von Phase 1 — aus den oben verifizierten Dateien per CRG + gezieltem Read
+aufzubauen. Kannonische Quelle klären: `GET /api/llm/active-config` vs
+`GET /api/llm/routing/defaults` (Plan lässt das Schritt 1 klären).
+
+### 7. Backend-Endpunkte (Referenz, keine Änderung nötig)
+
+`backend/app/api/`: `onboarding.py`, `llm_active.py`, `llm_providers.py`,
+`llm_routing.py`, `llm_profiles.py`, `user_profile.py`, `llm.py`. Alle vorhanden
+(Plan-Annahme bestätigt). **Kein neues Backend** — nur Vue-Schicht gegen bestehende
+Endpunkte.
+
+**Zu klärendes Backend-Konzept:** `llm_profiles.py` (Profile) vs React's reinem
+Provider-Connection-Modell. Plan-Risiko: klären ob Profile obsolet werden oder
+koexistieren — sonst entsteht die *nächste* Parallel-Quelle (genau das zu behebende
+Problem). Provider-Detection-SSoT: `backend/app/llm/providers/registry.py::detect_provider`
+(laut CLAUDE.md) — keine neue Heuristik pflegen.
+
+---
+
+## Branch-Strategie
+
+1. WIP als a11y-Commit sichern (s. o.).
+2. Phase-1+2-Branch von `feat/frontend-next` (nimmt die 2 Commits + sauberen a11y-Stand
+   mit) ODER von `main` (sauberer, aber verliert Frontend-Next-Brief-Commit — nicht
+   kritisch da `docs/`). **Empfehlung:** von `feat/frontend-next` nach a11y-Commit —
+   der Frontend-Next-Brief (`674f698a`) ist der Kontext für diesen Slice und sollte im
+   Branch bleiben.
+3. PR-Workflow Pflicht (AGENTS.md): kein Direkt-push auf `main`, PR + Gemini-Sichtung
+   (90 s warten) vor Merge.
+
+---
+
+## Phasen-1+2 Aufgabe (präzisiert)
+
+### Phase 1 — Modellwahl-Diagnose & Root-Cause-Fix
+
+1. Bestandsaufnahme aller Konsumenten (Inventar s. o.) → Divergenz-Tabelle (liest/schreibt
+   jeder `active-config`, `routing/defaults`, `llm_profiles`, oder eigenen State?).
+2. Ziel-Modell aus React übernehmen: ein `AiModelRef` (Provider-Connection-ID +
+   Modellname), eine kanonische Quelle, Live-Discovery über
+   `GET /api/llm/provider-connections/<kind>/models` (Muster `discoverChatModels`).
+3. `AiModelPicker.vue` auf kanonische Quelle umstellen — **aber erst Ist-Stand lesen**
+   (`deriveSource`/`onUpdate` existieren schon, s. Punkt 4).
+4. Parallele/legacy Pfade (`useEnvForm.defaultModel`, `LlmProfilePicker` falls
+   redundant) auf Adapter umstellen oder deprecated markieren — kein zweiter Konsument
+   mit eigenem State.
+5. Test: `useAiModelRefAdapter.spec.ts` + neue/erweiterte Tests dass Picker, Settings
+   und Run-Start **dieselbe** Auswahl sehen (Regressionsschutz gegen genau das
+   gemeldete Problem).
+
+### Phase 2 — Onboarding aus React nach Vue portieren
+
+1. Step-Struktur wie React `contracts/onboarding.ts`:
+   `welcome→profile→providers→chat_model→embeddings→privacy→summary`, serverseitig
+   via `GET/PUT /api/onboarding`, `/api/onboarding/step`, `/api/onboarding/complete`.
+   **Aber:** `OnboardingView.vue` existiert schon — migrieren/erweitern, nicht ersetzen.
+2. Provider-Schritt: pro Provider API-Key + Base-URL →
+   `PUT /api/llm/provider-connections/<kind>`.
+3. Chat-Model-Schritt: Live-Modell-Discovery via `GET .../models` nach
+   Provider-Speicherung, Auswahl setzt `active-config`.
+4. Embeddings-Schritt analog, gegen Embedding-Endpunkte (ADR-0007: Embedding-Config
+   lebt in Neo4j, Pfade über `embedding_service.py`/`embedding_migration.py`).
+5. Onboarding-Fortschritt bleibt serverseitig (nicht regressen).
+6. Nach Abschluss: `AiModelPicker`/Onboarding nutzen denselben `AiModelRef`-Adapter
+   aus Phase 1 — keine zweite Modell-Auswahl-Implementierung.
+
+---
+
+## Verifikation & Gates (AGENTS.md)
+
+```bash
+cd frontend && npm run check          # bzw. bun run check (frontend = bun, s. Memory)
+cd frontend && npm test -- --run
+bash scripts/pre-push-gate.sh frontend
+```
+
+Frontend-Toolchain-Hinweis (Memory): `bun.lock` ist Canon, `bun run <script>`
+statt `pnpm`/`npm` (npm-Befehle in AGENTS.md funktionieren, bun ist bevorzugt).
+
+**Manueller Flow (Kernkriterium für den behobenen Bug):** Onboarding komplett
+durchlaufen (Provider → Live-Modell-Discovery → Chat-Model → Embeddings) → Modell in
+Settings ändern → Run starten → **dieselbe Modellwahl überall sichtbar** (Picker,
+Settings, Run-Start, ActiveModelBadge).
+
+## Evidence-Gating-Hartanker (ADR-0002)
+
+Nicht berührt von Phase 1+2 — aber falls irgendwo Modellwahl mit Report-Confidence
+kreuzt: die 5 Hartanker in `backend/app/services/report_prompts.py`,
+`snapshots/evidence-gating-hedge-words.txt`, `EvidenceSourceKind`,
+`cross_stakeholder_for_high`, `reject_inferred_in_high_confidence` dürfen nicht
+geschwächt werden.
+
+## Risiken (aus Plan + verifiziert)
+
+- Onboarding-Port bricht bestehenden serverseitig persistierten Vue-Flow, falls
+  Struktur stark abweicht — Ist-Stand vor Port genau lesen (Punkt 3).
+- `llm_profiles.py` vs Provider-Connection-Modell: Profile obsolet oder koexistieren?
+  Sonst nächste Parallel-Quelle.
+- AiModelPicker-„Mock"-These evtl. obsolet — Ist-Stand mit `deriveSource`/`onUpdate`
+  zuerst lesen (Punkt 4).
+- Uncommitteter a11y-WIP nicht mit Phase-1-Code vermischen (Punkt 2).
+
+## Nächster Schritt für die Opus-Session
+
+1. WIP als a11y-Commit sichern (`git add` der 4 Dateien + spec, eigener Commit).
+2. Branch von `feat/frontend-next` für Phase 1+2.
+3. CRG-Discovery (Punkt 5) — Divergenz-Tabelle der Konsumenten bauen.
+4. `AiModelPicker.vue` + `useAiModelRefAdapter.ts` + `store/aiModels.ts`/
+   `useActiveModelStore.ts` + `contracts/aiModelRef.ts`/`modelActiveContract.ts`
+   lesen — kanonische Quelle festlegen.
+5. Workflow mit Sonnet-Subagents für die Umstellung der einzelnen Konsumenten
+   fahren; Opus-Lead verifiziert nach jedem Subagent die State-Konsistenz.
+6. Tests grün, Pre-Push-Gate frontend, PR.

--- a/docs/epics/frontend-next/PHASE-1-DIVERGENZ.md
+++ b/docs/epics/frontend-next/PHASE-1-DIVERGENZ.md
@@ -1,0 +1,43 @@
+# Phase 1 — Divergenz-Tabelle Modellauswahl (verifiziert)
+
+Erstellt in der Opus-Phase-1+2-Session via CRG + gezieltem Read. Belegt die
+gemeldete „inkonsistente Modellauswahl" als Divergenz über **fünf unabhängige,
+nicht gespiegelte Quellen**.
+
+## Kernbefund
+
+Der `AiModelPicker.vue` ist **bereits kanonisch** verdrahtet (`useAvailableModels`
+→ Provider-Connections-Discovery, emittiert `AiModelRef`). Die These „Picker auf
+Mock-Daten" aus dem Plan ist **obsolet**. Die Divergenz sitzt **nicht im Picker**,
+sondern in den **Eltern-Flächen**, die jede in eine andere Senke schreiben/lesen.
+
+## Quellen-Inventar (Writer / Reader)
+
+| # | Quelle | Persistenz | Writer | Reader (Runtime) |
+|---|---|---|---|---|
+| 1 | `active-config` (`/api/llm/active-config`) | `instance/active_llm_config.json` (eigen) | `SettingsView.vue`, `SettingsGeneralView.vue` | **`llm/client.py:72`** (`use_active_config=True`), `json_mode.py:203` |
+| 2 | `routing/defaults` global+stages | Workspace-Routing-Store (eigen) | `SettingsGeneralView.vue`, `LlmProvidersView.vue`, `StepModelOverrideChip.vue` | **`stage_model_router.py:116`** (`global_default`), `llm_routing_seed.py` |
+| 3 | `localStorage['agora.hero.aiModelRef']` | Client-only | `HeroNewRun.vue` (Run-Start) | HeroNewRun (init aus localStorage) |
+| 4 | `localStorage['agora.home.aiModelRef']` | Client-only | `Home.vue` | Home |
+| 5 | `localStorage['agora.report.aiModelRef']` | Client-only | `Step4Report.vue` | Step4Report |
+| L | Legacy `llm_profiles` | Server | `EnvSetupModelPanel`/`LlmProfilePicker`, `LlmProfileManager` | Profil-Auflösung |
+| R | SSE `model-stream` | — (read-only) | — | `ActiveModelBadge` (nur Anzeige, benign) |
+
+## Warum es divergiert
+
+- **Zwei Server-Wahrheiten (#1 vs #2):** server-seitig nicht synchron. Nur
+  `SettingsGeneralView` schreibt beide (Doppelschreib). `SettingsView` schreibt
+  **nur** #1, `LlmProvidersView` schreibt **nur** #2 → je nach Screen driftet es.
+- **Zwei Runtime-Pfade lesen verschiedene Quellen:** stage-geroutete Simulation →
+  #2; generische/Fallback-LLM-Calls → #1. Beide müssen übereinstimmen, nichts
+  erzwingt das.
+- **Drei client-seitige localStorage-Keys (#3/#4/#5):** Run-Start/Home/Report
+  halten je eine eigene Auswahl, komplett vom Server entkoppelt. HeroNewRun liest
+  beim Init **nie** den Server-Default → „gleiche Auswahl überall" bricht hier.
+- **Legacy-Profil-Pfad (L):** parallele sechste Selektionswelt in step2.
+
+## Kanonische-Quelle-Frage (offen, Entscheidung erforderlich)
+
+`active-config` (flaches Single-Model, Runtime-Fallback) vs
+`routing/defaults.global_default` (reich, per-stage, hat `AiModelRef`-Adapter,
+AGENTS.md-Kanon). Beide backend-relevant. Siehe Entscheidungs-Vorlage an Alex.

--- a/docs/epics/frontend-next/PHASE-2-ONBOARDING-HANDOVER.md
+++ b/docs/epics/frontend-next/PHASE-2-ONBOARDING-HANDOVER.md
@@ -27,9 +27,9 @@ Diese Entscheidung widerspricht dem React-Original (das einen Inline-Wizard hatt
 
 **Kurz: nichts direkt — aber alles indirekt.**
 
-- Die 3 Onboarding-Statusschritte (`providers`, `chat_model`, `embeddings`) verlinken auf `SettingsLlmProviders` und `SettingsEmbedding`. **Diese Flächen wurden in Phase 1 auf den kanonischen Composable umgestellt.** → Der Status, den Onboarding anzeigt, ist nach Phase 1 *zuverlässig* (vorher konnte er divergieren).
-- Wenn der User im Onboarding auf "Provider konfigurieren" klickt, in SettingsLlmProviders einen Provider setzt, zurück ins Onboarding kommt und auf "Weiter" klickt: `store.onboarding.requirements.chat_model_configured` ist jetzt wahr (weil routing/defaults + active-config im Gleichschritt sind, und der Backend-Status-Check beide lesen kann).
-- Phase 1 hat das Onboarding also nicht direkt berührt, aber seine Funktionalität stillschweigend repariert.
+- Die 3 Onboarding-Statusschritte (`providers`, `chat_model`, `embeddings`) verlinken auf `SettingsLlmProviders` und `SettingsEmbedding`. **Diese Flächen wurden in Phase 1 auf den kanonischen Composable umgestellt.** → Der User sieht und schreibt nun konsistent `routing/defaults.global_default` + `active-config` (die beiden Frontend-facing-Senken).
+- `store.onboarding.requirements.chat_model_configured` wird jedoch **weiterhin** in `compute_onboarding_requirements()` aus `settings.llm_model_name` berechnet (Zeile 232–234 in `onboarding_state_store.py`). Phase-1-Schreibpfade (`PUT /api/llm/routing/defaults/global`, `PUT /api/llm/active-config`) ändern `settings.llm_model_name` nicht — dieser Pydantic-Settings-Wert stammt aus Env-Variablen und ist zur Laufzeit effektiv immutabel.
+- **Integration-Gap:** `chat_model_configured` reflektiert die Phase-1-Modellwahl nur, wenn `settings.llm_model_name` unabhängig gesetzt wurde (z. B. via `.env`), oder beim nächsten `/api/onboarding`-Reload nachdem `settings.llm_model_name` extern geändert wurde. Ein Phase-1-Write allein führt nicht zu einem synchronen `chat_model_configured = true`. Phase 2 (oder ein Folge-Slice) muss klären, ob `compute_onboarding_requirements()` stattdessen `routing/defaults.global_default` oder `active-config` prüfen soll.
 
 ---
 

--- a/docs/epics/frontend-next/PHASE-2-ONBOARDING-HANDOVER.md
+++ b/docs/epics/frontend-next/PHASE-2-ONBOARDING-HANDOVER.md
@@ -1,0 +1,90 @@
+# Phase-2-Übergabe — Onboarding React→Vue
+
+**Datum:** 2026-07-17 · **Phase-1-Stand:** PR #752 offen, gemerged noch nicht
+**Vorgänger-Phase:** Phase 1 = Root-Cause-Fix Modellwahl (`bf4c81a7`, Composable `useEffectiveModelSelection`, 6 Flächen migriert). PR: https://github.com/arn0ld87/agora/pull/752
+**Verwandte Docs:** `PHASE-1-2-OPUS-HANDOVER.md`, `PHASE-1-DIVERGENZ.md`, `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md`, `HANDOVER-GLM-MMX.md`
+
+---
+
+## 1. Ausgangslage — Vue-Onboarding existiert bereits
+
+`frontend/src/views/onboarding/OnboardingView.vue` ist bereits eine Vue-3-Implementierung mit `vue-i18n`, `vue-router`, `userProfileStore` und `onboardingGuard.ts`. **Es ist NICHT von Grund auf zu portieren.**
+
+**Architektur (bereits da):**
+- 7 Steps laut `ONBOARDING_STEP_ORDER`: `welcome`, `profile`, `providers`, `chat_model`, `embeddings`, `privacy`, `summary`
+- Steps `providers` / `chat_model` / `embeddings` sind **ehrliche Statusschritte**: zeigen `store.onboarding.requirements?.chat_model_configured` und verlinken via `RouterLink` auf die bestehenden Settings-Routen (`SettingsLlmProviders`, `SettingsEmbedding`). Keine eigene Konfigurationslogik im Onboarding.
+- Welcome wählt Operating-Mode (`local`/`hybrid`/`server`); Profile nutzt `ProfileForm`; Embedding-Step hat Legacy-Hint wenn `embedding_source === 'legacy'`.
+- Spec: `frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts`.
+
+**Design-Entscheidung (bewusst):**
+> *"providers/chat_model/embeddings sind bewusst ehrliche Statusschritte: sie zeigen den realen `requirements`-Status und verlinken auf die bestehenden Settings-Routen. Die geführte Einrichtung folgt in einem späteren Update — hier gibt es keine Attrappen."* — Doc-Kommentar im File.
+
+Diese Entscheidung widerspricht dem React-Original (das einen Inline-Wizard hatte). Der Inline-Pattern wurde **bewusst NICHT** portiert — Phase 1 hat die Settings-Flächen stattdessen kanonisch gemacht.
+
+---
+
+## 2. Was Phase 1 für das Onboarding bedeutet
+
+**Kurz: nichts direkt — aber alles indirekt.**
+
+- Die 3 Onboarding-Statusschritte (`providers`, `chat_model`, `embeddings`) verlinken auf `SettingsLlmProviders` und `SettingsEmbedding`. **Diese Flächen wurden in Phase 1 auf den kanonischen Composable umgestellt.** → Der Status, den Onboarding anzeigt, ist nach Phase 1 *zuverlässig* (vorher konnte er divergieren).
+- Wenn der User im Onboarding auf "Provider konfigurieren" klickt, in SettingsLlmProviders einen Provider setzt, zurück ins Onboarding kommt und auf "Weiter" klickt: `store.onboarding.requirements.chat_model_configured` ist jetzt wahr (weil routing/defaults + active-config im Gleichschritt sind, und der Backend-Status-Check beide lesen kann).
+- Phase 1 hat das Onboarding also nicht direkt berührt, aber seine Funktionalität stillschweigend repariert.
+
+---
+
+## 3. Verbleibende Phase-2-Arbeit — Klärung mit Alex erforderlich
+
+### 3.1 Design-Konflikt: Inline-Flow oder Statusschritt?
+Das React-Original hatte einen geführten Inline-Wizard (Form-Felder direkt im Onboarding-Step). Das aktuelle Vue-Onboarding hat **bewusst** Statusschritte. Zwei mögliche Wege:
+
+| Option | Was | Trade-off |
+|---|---|---|
+| **A (aktuell)** | Statusschritt beibehalten, nur Settings-Link | Ehrlich, keine Duplikat-Wahrheit, weniger FE-Code. Aber User muss Onboarding verlassen → zurück → weiter. UX-Reibung. |
+| **B (React-Stil)** | Inline-Wizard nachportieren | Besserer UX-Flow, aber **AiModelPicker müsste zweimal existieren** (im Onboarding und in Settings). Divergenz-Risiko — genau das, was Phase 1 gerade behoben hat. **Vermutlich nicht der richtige Weg.** |
+| **C (Hybrid)** | Statusschritt bleibt, aber Inline-Mini-Picker pro Step mit Kanon-Composable | Mittelweg. Erfordert neue Spec/Architektur. |
+
+**Frage an Alex:** Soll Phase 2 das Onboarding bei Statusschritten belassen, oder doch auf Inline umstellen? Ich empfehle **A** (Status quo) oder **C** (Hybrid), **nicht B**.
+
+### 3.2 Optionale Verfeinerungen (unabhängig vom Design-Konflikt)
+Falls bei A geblieben wird, sind diese Verbesserungen denkbar:
+1. **`Step-Status-Granularität verbessern`** — Aktuell nur `chat_model_configured` ja/nein. Wäre `providers` (alle konfiguriert) vs. `chat_model` (genau eins gewählt) vs. `embeddings` getrennt aussagekräftiger? Aktuell sind `providers` und `chat_model` redundant (beide prüfen `chat_model_configured`).
+2. **Embedding-Legacy-Hint bereinigen** — sobald `embedding_service.py` final Gemini-Re-Embedding unterstützt (Phase-F-Restpunkt).
+3. **Wizard-Progress-Bar mit echten Prozenten** statt nur 7-Step-Liste.
+4. **„Skip"-Button** auf Statusschritten ausblenden, wenn der Step noch nicht `configured` ist (sonst irreführend).
+
+### 3.3 Phase-1-Berührung im Onboarding (optional)
+Wenn gewünscht, könnte der Welcome-Step den aktuellen Default via `useEffectiveModelSelection().effectiveRef` anzeigen (rein informativ, kein Write). Mini-Migration, isoliert.
+
+---
+
+## 4. Hard Constraints (gelten weiter)
+
+- **KEIN** zweiter `AiModelPicker` im Onboarding (Divergenz-Risiko). Wenn überhaupt, dann `<AiModelPicker :model-value="effectiveModel.effectiveRef.value" :readonly="true" />` als reinen Status.
+- **KEINE** zusätzlichen localStorage-Senken für Modellwahl (Phase-1-Bann).
+- **i18n** via `vue-i18n` (keine hartkodierten Texte).
+- **Composable `useEffectiveModelSelection`** ist die einzige Quelle für Modell-Schreibzugriffe.
+- Profile → optionale Presets, **kein** eigener aktiver State.
+- Keine Anthropic-Subagents (Memory).
+- bun-Toolchain (`bun run check`, `bun run test`).
+- Pre-Push-Gate frontend.
+
+---
+
+## 5. Erster Schritt der Folge-Session (Phase 2)
+
+1. **Design-Konflikt klären** (siehe §3.1). Frage an Alex direkt, nicht autonom entscheiden.
+2. Bei A (Status quo): Spec erweitern → §3.2 Verfeinerungen priorisieren.
+3. Bei B/C: Neuer Sub-Slice-Brief analog zu `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` schreiben.
+4. Branch von `feat/frontend-next-phase12` (oder direkt von `main`, falls Phase 1 gemerged ist).
+5. Wie immer: typecheck → specs → lint → pre-push-gate → PR + 90s Gemini-Sichtung → Merge.
+
+---
+
+## 6. PR #752 — Phase-1-Merge abwarten
+
+PR #752 ist **offen, nicht gemerged**. Vor Phase-2-Beginn:
+- Gemini-/CodeRabbit-Findings sichten (Memory: `feedback_pr_gemini_workflow` — 90s warten).
+- Findings adressieren oder bewusst zurückstellen.
+- Dann mergen.
+- Erst danach Phase-2-Branch von `main` (oder von `feat/frontend-next-phase12`, falls Alex das so will) starten.

--- a/docs/epics/frontend-next/PHASE-5-VERIFICATION-HANDOVER.md
+++ b/docs/epics/frontend-next/PHASE-5-VERIFICATION-HANDOVER.md
@@ -1,0 +1,124 @@
+# Übergabe-Prompt — Agora Frontend-Next, Phase 5 (Formale Verifikation)
+
+Diesen Prompt in eine **neue Claude-Code-Session** pasten. Arbeitsverzeichnis:
+`/Volumes/T7/Projekte/agora`, Repo `arn0ld87/agora`.
+
+Vollständiger Plan: `~/.claude/plans/sieh-dir-volumes-t7-projekte-agora-runs-swift-spark.md`.
+Phase-1+2-Handover: `docs/epics/frontend-next/PHASE-1-2-OPUS-HANDOVER.md` (Opus-Session,
+läuft parallel). Dieser Brief hier deckt **nur Phase 5** ab.
+
+---
+
+## Was Phase 5 ist
+
+Formale Verifikation der **5 Übergabe-Punkte** gegen die **laufende** Vue-App. Nichts
+neu bauen — nur Feinschliff wo nötig. Phase 5 ist der Abschluss-Check des gesamten
+Frontend-Next-Slices.
+
+### Vorbedingung: Phase 3+4 ist ausgeliefert
+
+Phase 3 (Kill-Switch) + Phase 4 (Graph-Lücken) wurden in einer glm-Session gebaut und
+auf Branch `feat/phase3-4-killswitch-graph` committet. **Erst prüfen, ob dieser Branch
+gemerged ist** (`git log origin/main --oneline | grep phase3-4` o.ä.). Falls nicht gemerged:
+entweder Branch lokal auschecken für die Verifikation, oder PR mergen lassen. Die
+Verifikation muss gegen den Stand laufen, der Phase 3+4 enthält.
+
+Branch nach Merge: auf `main` (oder `feat/frontend-next` falls dort hin gemerged).
+
+---
+
+## Die 5 Verifikations-Punkte (alle gegen laufenden Stack)
+
+1. **SSE-Reconnect real auslösen.** Backend kurz stoppen (`docker compose stop agora`
+   oder Backend-Prozess killen) → Frontend-EventStream muss Backoff zeigen
+   (500ms→8s exponentiell, `MAX_RECONNECT_ATTEMPTS=5` in
+   `frontend/src/composables/useEventStream.ts`) → kein Endlos-Loop, sauberes Close +
+   frisches Ticket bei Fehler. Backend wieder hochfahren → Reconnect greift.
+2. **Pause/Resume/Stop im Step3-Wizard end-to-end.** `api/simulation.ts`
+   (`pauseSimulation`/`resumeSimulation`/`stopSimulation`) + `Step3Simulation.vue`,
+   `runStatus.paused`-Sync prüfen.
+3. **Run-Kill aus der Übersicht (NEU aus Phase 3).** Dashboard `ActiveRunsCard.vue`
+   hat pro Run einen Stop-Button (Actions-Slot), unabhängig vom Step3-Wizard. Stop
+   aus der Übersicht auslösen → Run endet, optimistisches UI-Update, Run-Liste
+   refresht. **Zusätzlich:** falls Step3-Wizard für denselben Run offen ist, muss er
+   konsistent aktualisiert werden (Re-Fetch bei Fokus / gemeinsamer State). Backend:
+   `POST /api/runs/{runId}/stop` über `api/runs.ts::stopRun` (nicht `stopSimulation`).
+4. **Persona-Zustände** (Vorbereitung/leer/Fehler) optisch prüfen in
+   `step2/PersonaCardGrid.vue` + `composables/usePersonaReview.ts`/`usePersonaFilter.ts`
+   — ggf. minimale Text-/State-Klarstellung. **Quota-Editor + Ready-Gate** vor Start:
+   `composables/usePersonaQuota.ts` + `contracts/personaQuotaContract.ts` (Editor,
+   localStorage, Zod-Validierung).
+5. **Graph: Legende/Suche/Zoom/Pan/Drag + NEUE Pin-Persistenz + Mini-Map (Phase 4).**
+   - Node verschieben (Drag-Ende) → Position in
+     `localStorage["agora:graph-layout:"+graph_id]` gesichert (`useGraphRender.ts`).
+   - Reload → Position erhalten (`fx`/`fy` auf passende Nodes angewendet vor
+     `forceSimulation`-Start).
+   - Reset-Button vorhanden.
+   - Mini-Map (`components/graph/GraphMiniMap.vue`): Bounding-Box aller Nodes +
+     Viewport-Rechteck (aus Zoom-Transform), Klick/Drag verschiebt Haupt-Viewport.
+
+---
+
+## Stack lokal hochfahren
+
+```bash
+cd /Volumes/T7/Projekte/agora
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  -f deploy/compose/docker-compose.prod-with-proxy.yml up -d --build
+curl -fsS http://localhost/healthz
+# alternativ Dev-Stack: docker compose up -d --build (mit HMR-Mounts)
+```
+
+Frontend-Dev-Server (falls nötig): `cd frontend && bun run dev`.
+
+**Hinweise aus der Vorgänger-Session (Handover.md):**
+- `agora-redis` hat kein Host-Port-Mapping → Backend muss dockerisiert laufen (nicht
+  nativ `uv run python run.py`).
+- `AGORA_AUTH_TOKEN` liegt in `backend/.env` (User hat selbst via `!`-Prefix gesetzt —
+  `.env`-Zugriff für Agent geblockt, nicht umgehen).
+- Neo4j/Redis-Verbindung im Backend-Log prüfen (DNS `neo4j`/`redis` nur im
+  Compose-Netzwerk auflösbar).
+
+---
+
+## Manueller Flow (Kernkriterium)
+
+Onboarding komplett durchlaufen (Provider → Live-Modell-Discovery → Chat-Model →
+Embeddings) → Modell in Settings ändern → Run starten → **dieselbe Modellwahl überall
+sichtbar** (Picker, Settings, Run-Start, ActiveModelBadge) → **Run aus der Übersicht
+stoppen, nicht aus dem Wizard** → Graph: Node verschieben → Reload → Position erhalten
+→ Mini-Map nutzen.
+
+**Achtung:** der Onboarding-Teil und die Modellwahl-Konsistenz sind Phase 1+2 (Opus).
+Falls Phase 1+2 noch nicht ausgeliefert ist, ist Punkt „dieselbe Modellwahl überall" noch
+nicht verifizierbar — dann auf den Opus-Merge warten oder diesen Teilschritt überspringen
+und nur Phase-3/4-Punkte verifizieren.
+
+---
+
+## Gates
+
+```bash
+cd frontend && bun run check          # typecheck + tests
+cd frontend && bun test -- --run      # Suite (frontend = bun, bun.lock Canon)
+bash scripts/pre-push-gate.sh frontend
+```
+
+Bestehende Specs, die grün bleiben müssen: `useGraphRender.pinLayout.spec.ts` (NEU,
+Phase 4), `useGraphRender.spec.ts`, `ActiveRunsCard.spec.ts` (NEU, Phase 3),
+`useAiModelRefAdapter.spec.ts`, `usePersonaQuota.spec.ts`, `useEventStream`-Specs.
+
+---
+
+## Deliverable
+
+Kurzer Verifikations-Report pro Punkt (PASS/FAIL + Beweis: Screenshot/Log-Auszug/Spec).
+Bei FAIL: minimaler Fix (kein Scope-Creep — nur Feinschliff). Keine neuen Features, kein
+Refactor. Evidence-Gating-Hartanker (ADR-0002) nicht berühren.
+
+## Risiken
+
+- Stack bootet nicht sauber → Backend-Log auf Neo4j/Redis-Verbindung prüfen.
+- Phase-1+2 noch nicht gemerged → Modellwahl-Konsistenz noch nicht verifizierbar.
+- Pin-Persistenz hängt am `graph_id` → falls Graph ohne `graph_id` geladen wird,
+  greift Persistenz nicht (Ist-Stand prüfen).

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -1,0 +1,149 @@
+# Slice 5.2 — EnvSetupModelPanel/Step2EnvSetup auf Kanon-AiModelRef (Folge-PR)
+
+**Status:** nicht begonnen · **Vorgänger:** Phase 1 (PR feat/frontend-next-phase12) ·
+**Datum:** 2026-07-17 · **Quelle:** Scout-Workflow `frontend-next-scout` (CRG + Spec-Gap-Analyse) + Alex-Entscheidung 2026-07-17.
+
+> Dieser Slice ist aus Phase 1 ausgegliedert (Alex-Entscheidung: Atomic Slicing, separates
+> PR). Phase 1 (Kanon-First-Root-Cause-Fix der Modellwahl) ist ohne EnvSetupModelPanel
+> gemergt. Dieser Slice konsolidiert die letzte verbleibende Persistenz-Senke im
+> Onboarding-Step2 auf den Kanon.
+
+---
+
+## 1. Alex-Entscheidungen (2026-07-17)
+
+- **Q1 — Scope:** Phase 1 + Specs werden **zuvor** als eigener PR gemergt. **§5.2 ist ein
+  separates Folge-PR/Issue.** Begründung: Atomic Slicing, sauberer Review, der
+  Backend-Payload-Vertrag (`triggerPrepare`) bekommt eigenen Fokus.
+- **Q2 — Backend-Payload:** `triggerPrepare.llm_model` **und** `llm_profile_id` **entfallen**
+  (kein Backend-Touch). Reiner FE-Sync via `useEffectiveModelSelection.setGlobalSelection`
+  (schreibt `routing/defaults.global` + `active-config` im Gleichschritt).
+  Profile → optionale Presets (schlagen dem `AiModelPicker` nur einen Wert vor, kein
+  Override, kein eigenes Payload-Feld).
+
+---
+
+## 2. Verifizierter Ist-Stand (Scout)
+
+- **Eltern-Container:** `frontend/src/components/Step2EnvSetup.vue` (561 LOC).
+- **Präsentationskomponente:** `frontend/src/components/step2/EnvSetupModelPanel.vue` (235 LOC).
+- **Composable:** `frontend/src/composables/useEnvForm.ts` (312 LOC).
+- **Kanon-Composable:** `frontend/src/composables/useEffectiveModelSelection.ts` (97 LOC, aus Phase 1).
+
+### Doppelselektionsquellen in Step2EnvSetup (genau diese werden konsolidiert)
+1. **localStorage-Modell** via `useEnvForm`: `modelOption` (`'default'|preset|'custom'`) +
+   `customModel` + `effectiveModel()`, persistiert via `STORAGE_MODEL='agora.lastModel'` +
+   `STORAGE_CUSTOM_MODEL='agora.lastCustomModel'`.
+2. **v3-Profil** via `llmProfileId`-Ref (init aus `props.projectData.llm_profile_id`, watch
+   mit `userPickedProfile`-Guard) → `v-model:llm-profile-id` an `EnvSetupModelPanel` →
+   `LlmProfilePicker` (deprecated v3, `useLlmProfilesStore`). Profil überschreibt Model
+   visuell (`is-overridden-by-profile`, `step2.llmProfile.modelIgnored`).
+
+### useEnvForm — was bleibt, was entfällt
+- **BLEIBT** (Metadaten-Loader via `getAvailableModels()`): `ollamaModels`,
+  `presetModels`, `defaultModel`, `defaultProvider`, `serverDefaultRequiresOllama`,
+  `ollamaReachable`, `agentToolsEnabled`, `maxToolCallsPerAction`, `loadingModels`,
+  `language` (+ `STORAGE_LANG='agora.agentLanguage'`), `loadModels()`. Die
+  `runtimeProvider`-Override-Logik (OASIS-Runtime-Provider) muss erhalten oder
+  sauber auf `AiModelRef`-Ebene abgebildet werden — **Pflicht-Verifikation vor Edit**
+  (siehe §4 Risiko C).
+- **ENTFÄLLT** (Modell-Selektions-Senke): `modelOption`, `customModel`, `modelOptions`,
+  `effectiveModel`, `STORAGE_MODEL`/`STORAGE_CUSTOM_MODEL`-Persistenz,
+  `storedEffectiveModel`. `useEnvForm` reduziert sich auf einen reinen Metadaten-Loader.
+
+---
+
+## 3. Migrationsplan (7 Schritte, kein Backend-Touch, reiner FE-Sync)
+
+### (a) `Step2EnvSetup.vue` — useEnvForm ersetzen für MODELL-Auswahl
+- `const { effectiveRef, effectiveRoute, ensureLoaded, setGlobalSelection, loading } = useEffectiveModelSelection()`
+- `onMounted`: `ensureLoaded()` statt `loadModels()` für die Selektion.
+  `loadModels()` bleibt für Metadaten (Ollama-Reachability, Agent-Tools, Default-Display).
+- `llmProfileId`-Ref + `watch`/`userPickedProfile`-Guard entfallen als **aktive
+  Selektionsquelle**; `effectiveRef` wird einzige Wahrheit.
+- `serverDefaultRequiresOllama`/`ollamaReachable`/`defaultProvider`/`agentToolsFlags`
+  bleiben aus `useEnvForm` (reine Read-only-Flags).
+
+### (b) `EnvSetupModelPanel.vue` — kanonischen `AiModelPicker` einbauen
+- Props `modelOption`/`customModel`/`modelOptions`/`loadingModels` entfallen; stattdessen
+  `:model-value="effectiveRef" @update:model-value="setGlobalSelection"`.
+- `is-overridden-by-profile`-Logik + `step2.llmProfile.modelIgnored`-Hint entfallen.
+- `LlmProfilePicker` (deprecated v3) wird **ENTFERNT**. Profile → optionale Presets: ein
+  Preset schlägt dem `AiModelPicker` nur einen Wert vor (via `setGlobalSelection` mit
+  `source='explicit'` o.ä.), keine eigene aktive Senke.
+
+### (c) `STORAGE_MODEL`/`STORAGE_CUSTOM_MODEL` entfallen
+- Selektion lebt in `routing/defaults.global_default` (`useLlmRoutingDefaultsStore`),
+  server-seitig persistiert; localStorage-Persistenz entfällt.
+- `STORAGE_LANG='agora.agentLanguage'` bleibt unangetastet (Sprache orthogonal zur
+  Modell-Auswahl).
+
+### (d) `triggerPrepare` (`Step2EnvSetup.vue:232-264`) — Payload konsolidieren
+- `payload.llm_model = effectiveModel()` **ENTFÄLLT** (Q2). Backend
+  `stage_model_router.py:116` liest `routing/defaults.global_default` direkt, via
+  `setGlobalSelection`-Gleichschritt synchron gehalten → kein doppelter `llm_model`-Payload.
+- `payload.llm_profile_id` **ENTFÄLLT** als Override (Q2). Profile sind nur Presets; kein
+  eigenes Payload-Feld.
+- `runtimePayload()` (Override-Provider) bleibt orthogonal; Override ist kein Profil,
+  sondern connection-basiert.
+
+### (e) State/Store-Übersicht
+- Ersetzt wird: `modelOption`/`customModel`/`effectiveModel`-Block aus `useEnvForm.ts` +
+  `llmProfileId`-Ref-Block aus `Step2EnvSetup.vue`.
+- Kanonische Senke ab Migration: `useLlmRoutingDefaultsStore.globalDefault` (`LlmRoute`) +
+  `useLlmProvidersStore` (connections), gekapselt in `useEffectiveModelSelection`.
+- Vor Entfernen von `useEnvForm`-Code Aufrufer-Prüfung:
+  `grep -rn "STORAGE_MODEL\|storedEffectiveModel\|effectiveModel\b" frontend/src`
+
+### (f) Kompatibilität/Hygiene
+- `LlmProfilePicker` ist bereits `@deprecated` (Slice 5.5, „keine neuen Importeure");
+  Entfernung ist der dokumentierte Folge-Schritt.
+- `AiModelPicker` ist der kanonische Picker laut AGENTS.md.
+- Zod-Spiegel `AiModelRefSchema` (`frontend/src/contracts/aiModelRef.ts`) validiert
+  `effectiveRef` bereits.
+- Kein Backend-Touch — `setGlobalSelection` schreibt bereits
+  `routing/defaults.global_default` + `active-config` im Gleichschritt, sodass beide
+  Runtime-Leser (`llm/client.py::use_active_config`,
+  `stage_model_router.py::routing/defaults.global_default`) konsistent bleiben.
+
+### (g) Reihenfolge
+1. `useEffectiveModelSelection` in `Step2EnvSetup` verdrahten.
+2. `AiModelPicker` in `EnvSetupModelPanel` einbauen.
+3. `LlmProfilePicker` + `llmProfileId`-Override entfernen.
+4. `useEnvForm` ausdünnen (Metadaten-Loader bleibt).
+5. `STORAGE_MODEL`-Keys + `storedEffectiveModel` entfernen (nach grep-Prüfung).
+6. Specs anpassen: `frontend/src/composables/__tests__/useEnvForm.spec.ts`,
+   `frontend/src/components/__tests__/Step2EnvSetup.spec.ts` (falls vorhanden),
+   `useEffectiveModelSelection.spec.ts` erweitern, E2E-Smoke `AiModelPicker` (Issue #739)
+   prüfen.
+
+---
+
+## 4. Risiken (Pflicht-Verifikation vor Edit)
+
+- **A — Backend-Payload:** Vor Streichen von `triggerPrepare.llm_model`/`llm_profile_id`
+  per CRG/Code-Read verifizieren, dass `stage_model_router.py` und ggf. weitere Consumer
+  (`backend/app/api/simulation.py` o.ä.) `routing/defaults.global_default` wirklich
+  direkt lesen und `llm_model` im Payload nicht als zwingenden Fallback brauchen.
+  Cross-Check mit Backend-Contract (`backend/app/contracts/`).
+- **B — OASIS-Runtime-Provider:** `useEnvForm` hat `runtimeProvider`-Override-Logik
+  (`defaultRuntimeModelForProvider`, `isRuntimeModelForProvider`,
+  `runtimeModelOptionsForProvider` aus `useRuntimeLlmOptions`). Der `AiModelRef`-Kanon ist
+  connection-basiert und kennt kein `runtimeProvider`-Konzept direkt. Vor Edit klären, wie
+  der Runtime-Provider-Override auf `AiModelRef` abgebildet wird (oder ob er orthogonal als
+  Run-Override via `runtimePayload()` erhalten bleibt). **Nicht blind migrieren.**
+- **C — LlmProfilePicker-Removal:** `useLlmProfilesStore`-Abhängigkeit prüfen — wenn
+  Step2EnvSetup noch andere Profil-Verbraucher hat, Teil-Entfernung statt Komplett-Removal.
+- **D — Spec pre-existing failures:** Memory `feedback_subagent_failure_attribution` —
+  `useEnvForm.spec.ts`-Brüche sind refactor-induziert, nicht pre-existing; nicht abschwächen.
+
+---
+
+## 5. Hard Constraints (gelten weiter)
+
+- Kein Backend-Touch ohne separaten Slice + User-Sign-off (Q2 bestätigt: kein Backend-Touch).
+- Keine Anthropic-Subagents (Workflow/Agent: `model`/`agentType` weglassen).
+- Frontend-Toolchain: `bun` (nicht pnpm/npm).
+- Kein `--no-verify`, keine Edits auf `main`.
+- Pre-Push-Gate: `bash scripts/pre-push-gate.sh frontend`.
+- `useEnvForm.spec.ts`-Assertions nicht abschwächen (AGENTS.md Regel 6).

--- a/docs/epics/frontend-next/brief.md
+++ b/docs/epics/frontend-next/brief.md
@@ -1,0 +1,224 @@
+# Frontend-Next-Brief — Agora React-Redesign
+
+**Status:** Entwurf / Analyse-Ergebnis, noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet.
+**Erstellt:** 2026-07-16, Branch `feat/frontend-next`.
+**Quelle:** code-review-graph + gezielte Datei-Reads gegen `main`-Stand von `frontend/`, `backend/app/api/`, `backend/app/contracts/`, `docs/auth.md`, `README.md`, `deploy/nginx/agora.conf`.
+
+Zielarchitektur laut Auftrag: eigenständige React-Vite-SPA (TypeScript strict) als Lovable-Projekt,
+kein Lovable Cloud, kein Supabase, keine neue DB, kein eigener Backend-Code, Zugriff nur relativ
+über `/api`, Mock-API mit Umschaltung auf echte Agora-API, keine fest eingebauten Tokens/Secrets im
+Bundle, späterer Betrieb hinter dem vorhandenen nginx-Reverse-Proxy. Bestehendes Flask/Neo4j/Redis/
+Ollama-Backend bleibt unverändert; das alte Vue-Frontend bleibt als Referenz/Fallback bestehen.
+
+## 0. Vorab-Befund: `frontend-next/`-Namenskollision
+
+Im Repo liegt bereits ein untracked `frontend-next/`-Verzeichnis — es ist ausschließlich das
+unveränderte `npm create vite@latest -- vue-ts`-Scaffold (`package.json` mit `"vue": "^3.5.39"`,
+Default-`main.ts`, Boilerplate-README, keine eigene Logik). Kollidiert im Namen, nicht im Inhalt,
+mit der geplanten React-SPA. Da Lovable-Projekte remote in Lovables Cloud-Infrastruktur leben, ist
+diese lokale Ordnerkollision funktional folgenlos — sie ist nur ein Dokumentations-/Mental-Model-
+Stolperstein. Keine Aktion vorgenommen; falls ein lokaler Sync-Ordner mit demselben Namen später
+gebraucht wird, vorher entscheiden: löschen, umbenennen oder ignorieren.
+
+## 1. Benutzerabläufe (User Flows)
+
+| Flow | Schritte | Primäre Views (Ist-Zustand) |
+|---|---|---|
+| Onboarding | Welcome → Profil → Provider wählen → Chat-Modell → Embedding-Modell → Privacy → Summary. Resumierbar über `OnboardingState.current_step`, Pflicht-Steps: `profile, chat_model, embeddings`. | `views/onboarding/OnboardingView.vue` |
+| Projekt/Input anlegen | Dokument(e) hochladen (Multipart) → Ontologie generieren → Graph bauen (Task-Polling) | `views/MainView.vue` (`/process/:projectId`) |
+| Persona-Erzeugung & Review | Quoten planen → Personas generieren → einzeln approven/rejecten/regenerieren, Branching möglich | `views/SimulationView.vue`, `simulation_profiles.py` (17 Routen) |
+| Simulation starten & verfolgen | Start → Live-Feed via SSE (`post_created`) → Pause/Resume/Stop → Timeline/Agent-Stats | `views/SimulationRunView.vue`, `views/v4/steps/StepSimulationFeedView.vue` |
+| Report generieren & lesen | Generate (mode: strict/balanced/explorative) → Progress-Poll → Sections/Evidence/Claims lesen → Chat mit Report-Agent | `views/ReportView.vue`, `views/InteractionView.vue` |
+| Export/Download | Report als PDF/ZIP/CSV, Simulation-Config/Script als signierter Download | `report.py::/export`, `/download`; `simulation_profiles.py::/config/download`, `/script/.../download` |
+| Runs-Dashboard | Liste aller Runs (Graph-Build, Simulation, Report), Filter nach Status, Live-Updates via SSE | `views/RunsView.vue` (`/runs`), `views/RunDetailView.vue` (`/runs/:id`) |
+| Compare | Zwei Runs/Graph-Versionen gegenüberstellen (Diff) | `views/v4/CompareView.vue`, `graph_data.py::/diff` |
+| Settings — Provider/Modelle | Provider-Connections anlegen/testen, Modelle je Stage routen, Embedding-Konfiguration + Migration | `Settings/LlmProvidersView.vue`, `LlmRoutingView.vue`, `EmbeddingConfigurationsView.vue` |
+| Settings — Profil/API-Keys/Audit | Avatar, Sprache, Theme, Privacy; Workspace-API-Keys erzeugen/widerrufen; Audit-Log einsehen | `SettingsProfileView.vue`, `SettingsApiKeysView.vue`, `SettingsAuditLogsView.vue` |
+| Auth-Bootstrap | Kein Login-Flow (Single-User) — Token wird einmalig gesetzt (Env/localStorage/Memory), Router-Guard blockt `requiresAuth`-Routen ohne Token | `router/index.ts:1355` |
+
+**Strukturbefund:** Es existieren drei parallele View-Generationen im selben Baum — Flat-Legacy
+(`views/*.vue`), `views/v4/*` (App-Shell-Redesign) und `views/agora2026/*` (weiterer Prototyp).
+Vor Umsetzungsbeginn klären, welche Generation als fachliche Referenz gilt (vermutlich `v4`,
+da zuletzt aktiv weiterentwickelt — unverifizierte Annahme).
+
+## 2. Benötigte Seiten (React-Zielstruktur, aus Routen abgeleitet)
+
+| Route | Zweck |
+|---|---|
+| `/` → Dashboard | Runs-Übersicht, Health/Status |
+| `/onboarding` | Setup-Wizard |
+| `/process/:projectId` | Upload + Graph-Build |
+| `/simulation/:id` | Persona-Review, Branching |
+| `/simulation/:id/start` | Live-Run + Feed |
+| `/report/:reportId` | Report-Lesen, Evidence-Drilldown |
+| `/interaction/:reportId` | Chat mit Report-Agent |
+| `/runs`, `/runs/:id` | Runs-Liste/-Detail |
+| `/compare/:simulationId` | Graph-/Report-Diff |
+| `/history` | Historische Runs |
+| `/settings/*` | general, integrations, profile, api-keys, audit-logs, llm-routing, llm-providers, embedding-configurations |
+| 404 | Fallback |
+
+## 3. Vom Frontend verwendete API-Endpunkte (vollständig, nach Blueprint)
+
+Alle Prefixe aus `backend/app/__init__.py:345-357`:
+
+| Blueprint | Prefix | Kernrouten (Auswahl der für Flows relevanten) |
+|---|---|---|
+| `auth_bp` | `/api/auth` | `POST /ticket` |
+| `onboarding_bp` | `/api/onboarding` | `GET ""`, `PUT /step`, `POST /complete`, `POST /dismiss`, `POST /reopen` |
+| `graph_bp` | `/api/graph` | `POST /ontology/generate` (Multipart-Upload), `POST /build`, `GET /task/:id`, `GET /tasks`, `GET /data/:graph_id`, `GET /:graph_id/diff`, `GET /:graph_id/export`, `GET/DELETE /project/*` |
+| `simulation_bp` | `/api/simulation` | `GET /available-models`, `POST /create`, `GET /:id`, `GET /list`, `POST /prepare[/status]`, `POST /start`, `POST /stop`, `POST /:id/pause\|resume`, `GET /:id/run-status[/detail]`, `GET /:id/stream` (SSE), `GET /:id/timeline`, `GET /:id/agent-stats`, `GET /:id/compare`, 17 Profile-Routen (`/:id/profiles*`, `/persona-library*`), `GET /:id/metrics[/export]`, `GET /:id/config[/download]`, `GET /script/:name/download` |
+| `report_bp` | `/api/report` | `POST /generate`, `GET /:id`, `GET /by-simulation/:simId`, `GET /list`, `GET /:id/evidence[...]`, `GET /:id/export`, `GET /:id/download`, `POST /chat`, `GET /:id/progress`, `GET /:id/sections`, `GET /:id/agent-log[/stream]`, `GET /:id/console-log[/stream]` |
+| `runs_bp` | `/api/runs` | `GET ""`, `GET /:id`, `GET /:id/events`, `POST /:id/stop\|cancel\|resume`, `GET/PUT /:id/llm-routing[/stages/:id]` |
+| `status_bp` | `/api/status` | `GET ""` |
+| `logs_bp` | `/api/logs` | `GET ""`, `GET /stream` (SSE) |
+| `settings_bp` | `/api/settings` | `GET/PUT ""`, `GET /schema`, `PUT /secrets`, `GET /stream` (SSE) |
+| `llm_bp` | `/api/llm` | `GET /model-stream` (SSE), `GET/PUT /active-config`, `GET/PUT/DELETE /provider-connections[/:id]`, `POST .../test`, `GET .../models`, Legacy `/providers*`, `GET/PUT /routing/defaults[...]`, `GET/POST .../embedding/configurations*`, `GET/POST .../embedding/migrations*` |
+| `llm_profiles_bp` | `/api/settings/llm-profiles` | CRUD + `/:id/default` |
+| `api_keys_bp` | `/api/api-keys` | `GET/POST ""`, `DELETE /:id` |
+| `user_profile_bp` | `/api/profile` | `GET/PUT ""`, `POST/GET/DELETE /avatar` |
+
+**Doppelte Provider-API:** `llm_providers.py` exponiert sowohl den kanonischen Pfad
+`/provider-connections` als auch einen Legacy-Pfad `/providers` parallel — im Rewrite nur
+`provider-connections` + `AiRoute`/`AiModel` (kanonischer Contract) verwenden.
+
+## 4. Request-/Response-Verträge (Kernmodelle)
+
+Backend = Pydantic v2 (`backend/app/contracts/`, größtenteils `extra="forbid"`), Frontend-Spiegel =
+Zod (`frontend/src/contracts/`). Zwei Contracts sind kein 1:1-Spiegel:
+
+- **`ReportV3`** (`report_v3.py` ↔ `reportV3Contract.ts`): 1:1, `schema_version: 3`, 11 fachliche
+  Listen (Personas, Segments, Claims, Multipliers, FrictionPoints, TrustSignals,
+  ChangeRecommendations, ProjectImpacts, PositioningVariants, ContentIdeas, DataGaps) +
+  `hypotheses[]` (eigener Slot, MAI-03) + `model_attribution[]` + `red_team_findings[]` (max 10).
+  `Claim.evidence_refs` ist Pflicht (min_length=1) — Kernanker von ADR-0002.
+- **`RunDetail`/`RunsListResponse`** (`runs_contract.py` ↔ `runsContract.ts`): bewusst
+  `extra="allow"` (Zod `.passthrough()`), `RunStatus` genau 6 Werte
+  (`pending|processing|paused|completed|failed|stopped`).
+- **`AiRoute`/`AiModel`/`ProviderConnection`** (`ai_provider_contract.py`, kanonisch laut AGENTS.md)
+  vs. **`AiModelRef`** (`aiModelRef.ts`, bewusst entkoppelt, eigenes `AiModelSourceSchema`-Enum mit
+  Bindestrich-Naming statt Unterstrich). Entscheidung nötig: kanonischen `AiRoute` direkt übernehmen
+  (empfohlen — weniger Adapter-Schulden) oder `AiModelRef` + Adapter neu bauen.
+- **`OnboardingStatusResponse`**: Abweichung — Backend `embedding_source: str` (offen), Frontend
+  `z.enum(['store','legacy','none'])` (geschlossen). Frontend ist strenger als Backend.
+- **`PostCreatedEvent`** (`post_event_contract.py`, `frozen=True`): SSE-Payload für Live-Posts,
+  `sentiment: float|None (-1..1)`, `sim_time` muss tz-aware sein.
+- **`/api/status`**: kein Pydantic-Contract im Backend — nur lose Zod-`.passthrough()`-Hülle im
+  Frontend. Response-Form im Rewrite nicht als stabil annehmen.
+- **`settings_contract.py`**: dynamisch zur Laufzeit aus `settings_schema.py` generiert
+  (`pydantic.create_model`), kein statisches Schema — Frontend bildet 13 Sektionen
+  (`llm, neo4j, embedding, ontology, hybrid_search, agent_tools, event_bus, logging, locale, ui,
+  webtools, oasis, security`) manuell nach.
+
+## 5. Authentifizierung (X-Agora-Token)
+
+Quelle: `docs/auth.md`, `frontend/src/api/index.ts`.
+
+- **Header:** `X-Agora-Token: <token>` (primär, Axios-Interceptor hängt ihn automatisch an),
+  Fallback `Authorization: Bearer <token>`. Backend-Vergleich timing-safe (`hmac.compare_digest`).
+- **Storage-Modi** (`VITE_AGORA_TOKEN_STORAGE`):
+  - `localStorage` (Dev-Default) — überlebt Reload, XSS-Risiko.
+  - `memory` (Prod-Empfehlung) — nur JS-Heap, kein Reload-Überleben, räumt aktiv
+    `localStorage.agora_token` weg.
+  - HttpOnly-Cookie — nicht implementiert, nur Zielarchitektur (kein `/api/auth/login`, kein CSRF).
+- **Kein Login-Endpoint.** Single-User-Modell: Token wird extern gesetzt.
+- **Router-Guard:** ohne Token bei `requiresAuth`-Route → Redirect mit `?authRequired=1&next=<path>`.
+- **Response-Envelope:** `success:false` (auch in 2xx-Hülle) → `ApiError{code, status, message,
+  details}`. Sollte im React-Data-Layer 1:1 übernommen werden.
+
+## 6. Signierter Ticket-Flow für SSE
+
+Quelle: `backend/app/api/auth.py`, `useApiAuth.ts`, `stream.ts`.
+
+1. `POST /api/auth/ticket` mit Header-Auth (`X-Agora-Token`), Body `{scope, ttl_seconds}`.
+2. Erlaubte Scope-Präfixe: `sse:`, `settings-stream`, `download:report:`,
+   `download:simulation_config:`, `download:simulation_script:`, `logs:stream`, `llm-stream`.
+3. TTL: Default 60s, Max 300s. Rate-Limit (429 + `Retry-After`).
+4. Response: `{ticket: "v1.<exp>.<scope>.<sig>", exp: <unix>}` — HMAC-signiert mit `SECRET_KEY`.
+5. Client hängt `?ticket=<signed>` an die URL an. Backend prüft Signatur, Scope, Single-Use (Redis,
+   Multi-Worker-safe, In-Memory-Fallback).
+6. Client-Cache pro Scope, 5s-Vorlauf vor `exp`, In-Flight-Dedup.
+7. 401-Retry: einmaliger Cache-Invalidate + Refetch, zweites 401 propagiert.
+8. `?token=<bearer>` ist deprecated aber noch aktiv (Warning-Log) — im Rewrite nicht neu verwenden.
+
+## 7. SSE-Eventtypen
+
+| Event | Payload | Quelle |
+|---|---|---|
+| `hello` | `{simulation_id, ts}` | einmalig bei Connect |
+| `ping` | `{ts}` | Heartbeat alle ~15s |
+| `state` | `{type, simulation_id, payload, ts}` — Run-State-Snapshot | Backend-dokumentiert |
+| `control` | `{type, simulation_id, payload, ts}` — `{paused, stop_requested, ...}` | Backend-dokumentiert |
+| `post_created` | `PostCreatedEvent` (Zod-validiert, Envelope wird ausgepackt) | Slice 5-pre, OASIS-Runner |
+| `error` (kein Named-Event) | `source.onerror` | Standard-EventSource |
+
+Transport: `Last-Event-ID` wird geloggt, aber kein Replay. Response-Header:
+`Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`, `Connection: keep-alive`.
+nginx hat einen eigenen `location /api/simulation/`-Block vor `location /api/` mit
+`proxy_buffering off`, `proxy_read_timeout 600s` — bei neuem Reverse-Proxy-Setup übernehmen.
+
+## 8. Upload-/Download-Abläufe
+
+**Upload** (`POST /api/graph/ontology/generate`, `backend/app/api/graph_build.py:83-152`):
+- Multipart-Feld `files` (mehrere Dateien, `request.files.getlist('files')`).
+- Form-Felder: `simulation_requirement` (Pflicht), `project_name` (Default `"Unnamed Project"`),
+  `additional_context`, optional `llm_model`, `llm_provider` (JSON-String), `llm_profile_id`.
+- Größenlimit pro Datei: `Config.AGORA_MAX_UPLOAD_SIZE_MB` → `413 UPLOAD_TOO_LARGE` bei Überschreitung
+  (Projekt wird dabei automatisch wieder gelöscht). nginx-seitig zusätzlich `client_max_body_size 50M`.
+- Rate-Limit über `AGORA_UPLOAD_RATE_LIMIT_MAX`/`_WINDOW_SECONDS`.
+- Fehlerfälle: `400 VALIDATION_FAILED` (fehlende Requirement/Dateien, ungültiges `llm_provider`-JSON),
+  `400 UNSUPPORTED_FORMAT` (keine Datei erfolgreich verarbeitet).
+
+**Downloads** (Ticket-scoped, siehe Abschnitt 6):
+- `download:report:` → `GET /api/report/:id/export`, `GET /api/report/:id/download`
+- `download:simulation_config:` → `GET /api/simulation/:id/config/download`
+- `download:simulation_script:` → `GET /api/simulation/script/:name/download`
+- CSV-Export (`ReportExportService.build_csv_export`) und gestreamtes ZIP-Bundle mit
+  Größen-Schwellen (`_ZIP_STREAM_THRESHOLD_BYTES`, `_ZIP_HARD_CAP_BYTES`) für große Reports.
+- Browser können keine Custom-Header an `<a href>`/Downloads anhängen → derselbe Ticket-Mechanismus
+  wie SSE.
+
+## 9. Fehlercodes und Loading-States
+
+| Code | Bedeutung | Quelle |
+|---|---|---|
+| `429` | Rate-Limit (Ticket-Endpoint, Report-Generate/Chat, Upload) | `json_error(RATE_LIMITED, 429, extra={retry_after_seconds})` + `Retry-After`-Header |
+| `400` | `invalid_scope`, `invalid_ttl` (Ticket), `VALIDATION_FAILED`, `UNSUPPORTED_FORMAT` (Upload) | `auth.py`, `graph_build.py` |
+| `401` | Token ungültig/abgelaufen → einmaliger Ticket-Refresh, danach propagiert | `useApiAuth._is401` |
+| `413` | `UPLOAD_TOO_LARGE` | `graph_build.py` |
+| `500` | `no_secret` (SECRET_KEY fehlt) | `auth.py` |
+| `INVALID_ID` | ungültiges `simulation_id`-Format | `simulation_stream.py` |
+| `timeout` / `service_unavailable` (Client-Codes) | Timeout bzw. Network Error ohne Backend-Envelope | `api/index.ts` |
+
+**Retry-Logik** (`requestWithRetry`): nur `timeout`, `service_unavailable`, `5xx` sind retry-fähig
+(3 Versuche, exponentielles Backoff `1000 * 2^i`). 4xx bubbeln sofort (Doppel-Create-Vermeidung bei
+non-idempotenten POSTs) — 1:1 in den React-Data-Layer übernehmen (z. B. React-Query `retry`-Callback).
+
+**Loading-States:** kein zentrales State-Machine-Contract gefunden. Graph-Build/Ontologie-Generierung
+nutzt Task-Polling (`GET /graph/task/:id`), Runs nutzen `RunStatus`-Enum + SSE-Push, Report nutzt
+`/progress`-Polling **und** `/agent-log/stream` SSE parallel.
+
+## 10. Empfohlene Umsetzungsreihenfolge
+
+1. **Contracts-Schicht zuerst**: Backend-Pydantic-Modelle 1:1 nach TS/Zod übertragen — beginnend mit
+   `ReportV3`, `RunDetail`/`RunsListResponse`, `AiRoute`/`AiModel`/`ProviderConnection` (kanonisch,
+   nicht `AiModelRef` neu erfinden), `PostCreatedEvent`, `UserProfile`/`OnboardingState`. Klärt den
+   `embedding_source`-Enum-Drift und ob `/api/status` einen echten Contract bekommt.
+2. **Auth + Ticket-Client**: Fetch/Axios-Wrapper mit `X-Agora-Token`-Interceptor + Error-Envelope-
+   Unwrapping, dann `fetchTicket`/`withFreshTicket`-Äquivalent (Cache + In-Flight-Dedup + 401-Retry).
+3. **Mock-Mode-Umschaltung**: MSW o. ä. gegen dieselben Zod-Schemas aus Schritt 1, damit die
+   Lovable-Preview ohne Backend lauffähig ist und später nahtlos auf `/api` (relativ) umschaltet.
+4. **Runs-Dashboard + Run-Detail**: kleinster geschlossener Flow mit Read-Only-SSE (`state`/`control`),
+   `RunDetailView.vue` gibt bereits ein sauberes Contract-first-Muster vor.
+5. **Onboarding**: reine REST-Calls, keine SSE — validiert Contract-Layer + Routing-Guard-Pattern.
+6. **Simulation-Flow** (Start → Live-Feed → Persona-Review): größte SSE-Oberfläche, danach
+   Ticket-Flow vollständig verifiziert.
+7. **Report + Interaction (Chat)**: hängt von Simulation-Flow ab, bringt Export/Download-Flow mit.
+8. **Settings** (Provider/Routing/Embedding): komplexeste Contracts, bewusst spät — Legacy-Adapter
+   (`llm_profile_to_canonical` etc.) sind laut AGENTS.md noch in Migration (Phase F, #669–#671 offen).
+9. **Compare/History**: nice-to-have, keine harten Abhängigkeiten.
+
+**Offene Punkte vor Umsetzungsstart:**
+- Ob `AiModelRef` (Frontend-eigen) oder `AiRoute` (Backend-kanonisch) die Zielabstraktion für React wird.
+- Schicksal von `views/agora2026/*` — dritter Prototyp, unklar ob aktiv oder tot.
+- Schicksal von `frontend-next/`-Namenskollision (Abschnitt 0).

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Playwright/Vitest Test-Artefakte
+test-results/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -19,7 +19,7 @@ import ReportLiveLogPane from './step4/ReportLiveLogPane.vue'
 import ReportFinalView from './step4/ReportFinalView.vue'
 import { useReportExports } from '../composables/useReportExports'
 import type { AiModelRef } from '../contracts/aiModelRef'
-import { AiModelRefSchema } from '../contracts/aiModelRef'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import { parseAgentEntry } from '../utils/reportAgentLog'
 import { parseSourceAnchor } from '../utils/sourceAnchor'
 import {
@@ -99,25 +99,16 @@ function recordSchemaError(where: string, error: unknown): void {
 }
 
 const resolvedSimulationId = ref(props.simulationId || null)
-// Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.report.route` wird NICHT mehr
-// gelesen; er wird beim Mount und beim Speichern defensiv aus localStorage
-// entfernt. Persistenz läuft nur noch über den neuen Key agora.report.aiModelRef.
-const STORAGE_REPORT_AI_REF = 'agora.report.aiModelRef'
+// Phase-1 Konsolidierung: Das Report-Modell wird aus dem Kanon
+// (routing/defaults.global via useEffectiveModelSelection) initialisiert, nicht
+// mehr aus einem eigenen agora.report.aiModelRef-Key. Ein Picker-Pick ist ein
+// transienter Report-Override (nur diese Regenerierung), nicht persistiert.
+// Slice 7.6c (Storage-Cut): Legacy-Key agora.report.route wird defensiv entfernt.
 const STORAGE_REPORT_ROUTE_LEGACY = 'agora.report.route'
 
-function resolveInitialReportRoute(): AiModelRef | null {
-  // Slice 7.6c (Storage-Cut): nur noch der neue AiModelRef-Key wird gelesen.
-  const raw = localStorage.getItem(STORAGE_REPORT_AI_REF)
-  if (!raw) return null
-  try {
-    const parsed = AiModelRefSchema.safeParse(JSON.parse(raw))
-    return parsed.success ? parsed.data : null
-  } catch {
-    return null
-  }
-}
+const effectiveModel = useEffectiveModelSelection()
 
-const reportRoute = ref<AiModelRef | null>(resolveInitialReportRoute())
+const reportRoute = ref<AiModelRef | null>(null)
 const isRegenerating = ref(false)
 
 const STORAGE_REPORT_PROFILE_ID = 'agora.report.llmProfileId'
@@ -126,16 +117,6 @@ watch(llmProfileId, (val) => {
   if (val) localStorage.setItem(STORAGE_REPORT_PROFILE_ID, val)
   else localStorage.removeItem(STORAGE_REPORT_PROFILE_ID)
 })
-
-watch(reportRoute, (val) => {
-  if (val?.provider_connection_id && val?.model_id) {
-    localStorage.setItem(STORAGE_REPORT_AI_REF, JSON.stringify(val))
-    localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
-  } else {
-    localStorage.removeItem(STORAGE_REPORT_AI_REF)
-    localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
-  }
-}, { deep: true })
 
 const STORAGE_REPORT_MODE = 'agora.reportMode'
 function resolveStoredReportMode(): ReportMode {
@@ -361,6 +342,11 @@ function goConversation() {
 onMounted(async () => {
   // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
   localStorage.removeItem(STORAGE_REPORT_ROUTE_LEGACY)
+  // Phase-1 Konsolidierung: Report-Modell aus dem Kanon initialisieren.
+  effectiveModel
+    .ensureLoaded()
+    .then(() => { if (!reportRoute.value) reportRoute.value = effectiveModel.effectiveRef.value })
+    .catch(() => { /* Kanon nicht ladbar: Backend nutzt active-config */ })
   await pollStatus()
   if (!isComplete.value) {
     if (props.reportId) { phase.value = 1; startPolling() }

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -63,10 +63,46 @@ vi.mock('../../composables/useIncrementalLogPolling', async () => {
   }
 })
 
-// Slice 7.6c: Step4Report liest die Report-Modell-Auswahl direkt aus
-// `agora.report.aiModelRef` (Zod-validiert) und nutzt den useAiModelRefAdapter
-// nicht mehr; der frühere Adapter-Mock entfällt. ReportModelControls ist ohnehin
-// vollständig gestubbt (siehe oben).
+// Phase-1 Kanon-First: Step4Report initialisiert reportRoute in onMounted aus
+// dem Kanon (routing/defaults.global_default via useEffectiveModelSelection.
+// effectiveRef); Picker-Picks sind transient (KEIN setGlobalSelection, nicht
+// persistiert). STORAGE_REPORT_AI_REF (agora.report.aiModelRef) ist entfernt,
+// STORAGE_REPORT_ROUTE_LEGACY (agora.report.route) wird nur noch defensiv
+// gelöscht. ReportModelControls bleibt gestubbt. Der Mock ersetzt das Composable
+// (das Pinia-Stores instanziiert) mit steuerbaren Refs, damit die Specs ohne
+// Pinia-Setup mounten.
+import { ref as mockRef, type Ref as MockRef } from 'vue'
+import type { AiModelRef } from '../../contracts/aiModelRef'
+
+// Steuerbarer Kanon-Stub. Defaults: leerer Kanon (effectiveRef=null), wie er
+// von useEffectiveModelSelection vor ensureLoaded/Routing-Load geliefert wird.
+const mockEffectiveRef: MockRef<AiModelRef | null> = mockRef<AiModelRef | null>(null)
+const mockEffectiveRoute: MockRef<unknown> = mockRef<unknown>(null)
+const mockLoading: MockRef<boolean> = mockRef<boolean>(false)
+const mockError: MockRef<string | null> = mockRef<string | null>(null)
+const mockEnsureLoaded = vi.fn().mockResolvedValue(undefined)
+const mockSetGlobalSelection = vi.fn().mockResolvedValue(undefined)
+
+function resetMockSelection(): void {
+  mockEffectiveRef.value = null
+  mockEffectiveRoute.value = null
+  mockLoading.value = false
+  mockError.value = null
+  mockEnsureLoaded.mockResolvedValue(undefined)
+  mockSetGlobalSelection.mockReset()
+  mockSetGlobalSelection.mockResolvedValue(undefined)
+}
+
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: mockEffectiveRef,
+    effectiveRoute: mockEffectiveRoute,
+    loading: mockLoading,
+    error: mockError,
+    ensureLoaded: mockEnsureLoaded,
+    setGlobalSelection: mockSetGlobalSelection,
+  }),
+}))
 
 import { generateReport, getReport, getReportStatus, getReportEvidence } from '../../api/report'
 import { useIncrementalLogPolling } from '../../composables/useIncrementalLogPolling'
@@ -163,6 +199,7 @@ function mountComponent(props = {}) {
 describe('Step4Report — strict-Zod-Parse (Sub-Slice 15)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetMockSelection()
     // Standard-Status: completed + vollstaendiger Payload
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
@@ -309,6 +346,7 @@ describe('Quote + Anchor (Sub-Slice 16b)', () => {
 
   function mountWithEvidence(evidenceData: object) {
     vi.clearAllMocks()
+    resetMockSelection()
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
       data: { status: 'completed', report_id: 'report_test01', simulation_id: 'sim_test01' },
@@ -468,6 +506,10 @@ describe('aggregateSectionConfidence (Sub-Slice 16a)', () => {
 
 // Sub-Slice J.3 (#221): agentLog-Polling-Intervall auf 2500 ms angeglichen
 describe('Step4Report — agentLog-Polling-Intervall (Sub-Slice J.3)', () => {
+  beforeEach(() => {
+    resetMockSelection()
+  })
+
   it('ruft useIncrementalLogPolling für agentLog mit intervalMs=2500 auf', async () => {
     vi.mocked(getReportStatus).mockResolvedValue({
       success: true,
@@ -594,6 +636,7 @@ describe('Step4Report — ConfidenceBadge-Integration (Sub-Slice 16a)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetMockSelection()
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
       data: {
@@ -629,6 +672,7 @@ describe('Step4Report — Report-Modus-Persistenz und API-Übergabe (P4.1)', () 
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.clear()
+    resetMockSelection()
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
       data: { status: 'idle' },
@@ -690,6 +734,7 @@ describe('Step4Report — Confirm-Dialog + Stop-Button', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.clear()
+    resetMockSelection()
   })
 
   it('zeigt Confirm-Dialog wenn kein reportId und Status idle (reportPending=true)', async () => {
@@ -810,3 +855,80 @@ describe('Step4Report — Confirm-Dialog + Stop-Button', () => {
 // `/settings/llm-providers` → `LlmProviderSecretsStore` → SecretResolver.
 // Step4Report sendet nur noch `llm_model`; der Provider wird serverseitig
 // aufgelöst. Siehe PR-Beschreibung Slice A1.
+
+// Phase-1 Kanon-First (frontend-next): reportRoute wird in onMounted aus dem
+// Kanon (useEffectiveModelSelection.effectiveRef) initialisiert. Picker-Picks
+// sind transient und persistieren NICHT (kein setGlobalSelection-Aufruf, keine
+// agora.report.aiModelRef-Senke mehr). Legacy-STORAGE_REPORT_ROUTE_LEGACY wird
+// nur defensiv gelöscht.
+describe('Step4Report — Kanon-First Initialisierung (Phase 1)', () => {
+  const KANON_REF: AiModelRef = {
+    provider_connection_id: 'conn_kanon',
+    model_id: 'kanon-model-1',
+    source: 'workspace-default',
+  } as AiModelRef
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    resetMockSelection()
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { status: 'idle' },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: VALID_REPORT })
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: VALID_EVIDENCE })
+  })
+
+  it('initialisiert reportRoute aus dem Kanon (effectiveRef) in onMounted', async () => {
+    mockEffectiveRef.value = KANON_REF
+
+    const wrapper = mountComponent({ simulationId: 'sim_test01' })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    expect(mockEnsureLoaded).toHaveBeenCalled()
+    const vm = wrapper.vm as unknown as { reportRoute: AiModelRef | null }
+    expect(vm.reportRoute).toEqual(KANON_REF)
+  })
+
+  it('lässt reportRoute null wenn der Kanon leer ist (effectiveRef=null)', async () => {
+    // mockEffectiveRef bleibt null nach resetMockSelection
+    const wrapper = mountComponent({ simulationId: 'sim_test01' })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const vm = wrapper.vm as unknown as { reportRoute: AiModelRef | null }
+    expect(vm.reportRoute).toBeNull()
+  })
+
+  it('ruft setGlobalSelection NICHT beim Picker-Pick auf (Picker ist transient)', async () => {
+    mockEffectiveRef.value = KANON_REF
+
+    const wrapper = mountComponent({ simulationId: 'sim_test01' })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    // Simuliere einen transienten Picker-Pick via ReportModelControls-Stub-emit.
+    const controls = wrapper.findComponent({ name: 'ReportModelControls' })
+    expect(controls.exists()).toBe(true)
+    await controls.vm.$emit('update:modelValue', {
+      provider_connection_id: 'conn_other',
+      model_id: 'picked-model',
+      source: 'explicit',
+    } as AiModelRef)
+    await wrapper.vm.$nextTick()
+
+    // Picker-Pick ändert reportRoute transient, persistiert aber NICHT den Kanon.
+    expect(mockSetGlobalSelection).not.toHaveBeenCalled()
+  })
+
+  it('löscht STORAGE_REPORT_ROUTE_LEGACY (agora.report.route) defensiv in onMounted', async () => {
+    localStorageMock.setItem('agora.report.route', 'some-legacy-route')
+
+    mountComponent({ simulationId: 'sim_test01' })
+    await flushPromises()
+
+    expect(localStorageMock.getItem('agora.report.route')).toBeNull()
+  })
+})

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -18,9 +18,9 @@ import { fetchLlmProfiles } from '../../../api/llmProfiles'
 import { setPendingUpload } from '../../../store/pendingUpload'
 import { STORAGE_LANG, STORAGE_MODEL } from '../../../composables/useEnvForm'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import type { LlmProfile } from '../../../contracts/llmProfileContract'
 import type { AiModelRef } from '@/contracts/aiModelRef'
-import { AiModelRefSchema } from '@/contracts/aiModelRef'
 import { getSystemStatus } from '../../../api/status'
 
 const { t } = useI18n()
@@ -72,10 +72,13 @@ function removeLocal(key: string): void {
  *   - AiModelPicker (rechts, sichtbar wenn kein Profile aktiv): Direkt-Auswahl
  *     aus den unter /settings/llm-providers hinterlegten Provider-Connections.
  *
- * Persistenz: `agora.hero.profileId`, `agora.hero.aiModelRef` (Slice 5.4
- * Zod-validiert). Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route`
- * wird NICHT mehr gelesen; er wird beim Mount und beim Speichern defensiv aus
- * localStorage entfernt. User mit Legacy-Wert bekommen den Picker-Default.
+ * Persistenz: `agora.hero.profileId` (Preset). Phase-1 Konsolidierung: Das
+ * Default-Modell kommt NICHT mehr aus einem eigenen `agora.hero.aiModelRef`-Key,
+ * sondern aus dem Kanon (routing/defaults.global via useEffectiveModelSelection)
+ * — damit der Dashboard-Start dieselbe Auswahl wie Settings zeigt. Ein
+ * Dashboard-Pick ist ein transienter Run-Override (nur STORAGE_MODEL-Spiegel für
+ * MainView). Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route` wird
+ * NICHT mehr gelesen und beim Mount defensiv entfernt.
  *
  * MainView.handleNewProject liest weiterhin den klassischen STORAGE_MODEL-Key
  * via `storedEffectiveModel()` — wir spiegeln `aiModelRef.model_id` dorthin,
@@ -83,26 +86,17 @@ function removeLocal(key: string): void {
  * SecretResolver, vgl. PR #499) ohne Touch in MainView durchgeht.
  */
 const STORAGE_HERO_PROFILE_ID = 'agora.hero.profileId'
-const STORAGE_HERO_AI_REF = 'agora.hero.aiModelRef'
 // Slice 7.6c (Storage-Cut): nur noch als Ziel für defensives removeLocal.
 const STORAGE_HERO_ROUTE_LEGACY = 'agora.hero.route'
 
 const adapter = useAiModelRefAdapter()
-
-function loadStoredModel(): AiModelRef | null {
-  // Slice 7.6c (Storage-Cut): nur noch der neue AiModelRef-Key wird gelesen.
-  const raw = readLocal(STORAGE_HERO_AI_REF)
-  if (!raw) return null
-  try {
-    const parsed = AiModelRefSchema.safeParse(JSON.parse(raw))
-    return parsed.success ? parsed.data : null
-  } catch {
-    return null
-  }
-}
+// Phase-1 Konsolidierung: Default-Modell kommt aus dem Kanon
+// (routing/defaults.global via useEffectiveModelSelection), nicht mehr aus
+// einem eigenen localStorage-Key.
+const effectiveModel = useEffectiveModelSelection()
 
 const selectedProfileId = ref<string | null>(readLocal(STORAGE_HERO_PROFILE_ID))
-const selectedModel = ref<AiModelRef | null>(loadStoredModel())
+const selectedModel = ref<AiModelRef | null>(null)
 const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
 const simulationRequirement = ref('')
 
@@ -204,16 +198,15 @@ function formatBytes(bytes: number): string {
 }
 
 function onPickModel(aiRef: AiModelRef | null) {
+  // Transienter Run-Override: nur STORAGE_MODEL-Spiegel für den Sim-Start
+  // (MainView.handleNewProject). KEINE eigene persistente Modell-Senke mehr —
+  // der Default kommt aus dem Kanon.
   selectedModel.value = aiRef
   if (aiRef) {
-    writeLocal(STORAGE_HERO_AI_REF, JSON.stringify(aiRef))
     // STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default' bei leerer model_id).
     writeLocal(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
-    // Legacy-Key loeschen (Storage-Cut): verhindert, dass ein veralteter
-    // Routen-Eintrag beim naechsten Mount ueberhaupt herumliegt.
     removeLocal(STORAGE_HERO_ROUTE_LEGACY)
   } else {
-    removeLocal(STORAGE_HERO_AI_REF)
     removeLocal(STORAGE_HERO_ROUTE_LEGACY)
     writeLocal(STORAGE_MODEL, 'default')
   }
@@ -261,6 +254,14 @@ async function startSimulation() {
 onMounted(() => {
   // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
   removeLocal(STORAGE_HERO_ROUTE_LEGACY)
+  // Phase-1 Konsolidierung: Default-Modell aus dem Kanon initialisieren, damit
+  // der Dashboard-Start dieselbe Auswahl wie Settings zeigt.
+  effectiveModel
+    .ensureLoaded()
+    .then(() => {
+      if (!selectedModel.value) selectedModel.value = effectiveModel.effectiveRef.value
+    })
+    .catch(() => { /* Kanon nicht ladbar: Picker bleibt leer, Backend nutzt active-config */ })
   fetchLlmProfiles()
     .then(profiles => { llmProfiles.value = profiles })
     .catch(() => { /* Fallback: Profile-Picker bleibt leer, ModelPicker greift */ })

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
@@ -59,6 +59,32 @@ vi.mock('../../../../store/pendingUpload', () => ({
   setPendingUpload: vi.fn(),
 }))
 
+// Phase-1 Kanon-Composable stubben: HeroNewRun initialisiert selectedModel
+// onMounted aus effectiveRef. In den Profile-Tests interessiert nur das
+// Profil-Verhalten — Kanon-Stub mit null/einem Stativ-Route, ensureLoaded
+// resolvt, setGlobalSelection ist hier nicht aktiv (Profile gewinnt).
+vi.mock('@/composables/useEffectiveModelSelection', () => {
+  const stubRoute = {
+    stage: null,
+    provider_id: 'openai',
+    model: 'gpt-4o',
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+  }
+  return {
+    useEffectiveModelSelection: () => ({
+      effectiveRef: { value: null },
+      effectiveRoute: { value: stubRoute },
+      loading: { value: false },
+      error: { value: null },
+      ensureLoaded: vi.fn().mockResolvedValue(undefined),
+      setGlobalSelection: vi.fn().mockResolvedValue(undefined),
+    }),
+  }
+})
+
 import { setPendingUpload } from '../../../../store/pendingUpload'
 import HeroNewRun from '../HeroNewRun.vue'
 

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -1,11 +1,18 @@
 /**
- * HeroNewRun — Spec-Tests fuer Slice 5.4 Migration auf AiModelPicker.
+ * HeroNewRun — Spec-Tests fuer Phase-1 Kanon-First Migration.
  *
  * Die Komponente ist der primaere Aktions-Block des Dashboards:
  * File-Picker, Profile-Dropdown, Modell-Wahl, Sprache, Persona-Count,
- * Rounds, Requirement, Start-CTA. Migration-Fokus ist der Modell-Picker:
- * ModelPicker (alt) -> AiModelPicker (SSoT) mit Adapter-Glue fuer den
- * STORAGE_MODEL-Spiegel. Slice 7.6c: Legacy-Route-Storage wird nicht mehr gelesen.
+ * Rounds, Requirement, Start-CTA.
+ *
+ * Kanon-First (Phase-1): Das Default-Modell kommt aus dem Kanon
+ * (routing/defaults.global via useEffectiveModelSelection), NICHT mehr aus
+ * einem eigenen `agora.hero.aiModelRef`-localStorage-Key. Beim Mount wird
+ * `effectiveModel.ensureLoaded()` gerufen und `selectedModel` aus
+ * `effectiveModel.effectiveRef` initialisiert. Ein Dashboard-Pick ist ein
+ * TRANSIENTER Run-Override: nur STORAGE_MODEL-Spiegel fuer MainView + defensive
+ * Entfernung des Legacy-Keys `agora.hero.route`. KEINE eigene persistente
+ * Modell-Senke mehr.
  *
  * Coverage:
  *  1. mountet ohne Crash
@@ -13,25 +20,26 @@
  *  3. File-Picker-Zone sichtbar
  *  4. Profile-Dropdown sichtbar (Hybrid bleibt)
  *  5. AiModelPicker in Config-Zone sichtbar
- *  6. liest bestehende Auswahl aus `agora.hero.aiModelRef` (neuer Key)
- *  7. Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen
- *  8. onPickRoute: persistiert als `agora.hero.aiModelRef` (neues Format)
- *  9. onPickRoute: setzt STORAGE_MODEL-Spiegel auf model_id
- * 10. onPickRoute: bei null werden beide Keys + STORAGE_MODEL auf 'default'
- * 11. onPickProfile: persistiert Profile-ID, loescht Model-Auswahl
- * 12. canSubmit: false ohne Files, false ohne Requirement
- * 13. startSimulation: bei Profile aktiv wird STORAGE_MODEL='default'
- * 14. startSimulation: ohne Profile wird STORAGE_MODEL=model_id
- * 15. startSimulation: ruft setPendingUpload + router.push
- * 16. i18n-Key: dashboard.hero.modelPlaceholder
- * 17. Capability-Filter: Picker bekommt mode='chat' (Default)
- * 18. Profile-Dropdown aktiv -> AiModelPicker versteckt (Hybrid)
+ *  6. Kanon-First-Init: selectedModel wird onMounted aus effectiveRef initialisiert
+ *  7. Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen, beim Mount entfernt
+ *  8. onPickModel: spiegelt model_id transient nach STORAGE_MODEL (agora.lastModel)
+ *  9. onPickModel(null): STORAGE_MODEL auf 'default', Legacy-Route entfernt
+ * 10. onPickProfile: persistiert Profile-ID (kein Model-Clear mehr)
+ * 11. canSubmit: false ohne Files, false ohne Requirement
+ * 12. startSimulation: bei Profile aktiv wird STORAGE_MODEL='default'
+ * 13. startSimulation: ohne Profile wird Picker-Wahl als STORAGE_MODEL gespiegelt
+ * 14. startSimulation: ruft setPendingUpload + router.push
+ * 15. i18n-Key: dashboard.hero.modelPlaceholder
+ * 16. Capability-Filter: Picker bekommt mode='chat' (Default)
+ * 17. Profile-Dropdown aktiv -> AiModelPicker versteckt (Hybrid)
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
 import HeroNewRun from '../HeroNewRun.vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
+import type { LlmRoute } from '@/contracts/llmRoute'
 
 // AiModelPicker mocken
 const aiPickerStub = {
@@ -62,16 +70,27 @@ const iconPlusStub = { name: 'IconPlus', template: '<span />' }
 // "Cannot access 'X' before initialization". Die geteilten Mock-Objekte
 // werden in mountHero() / beforeEach() resettet und in den Tests über
 // .mockClear()/.mockResolvedValue() gesteuert.
+//
+// effectiveRefHolder ist der steuerbare Kanon-Stub: Tests setzen
+// `.current` auf den gewünschten AiModelRef (oder null) VOR dem Mount. Der
+// Composable-Mock exponiert effectiveRef als Ref-Shape (Getter/Setter auf
+// .value), die Komponente liest `effectiveModel.effectiveRef.value`.
 const {
   fetchLlmProfilesMock,
   getSystemStatusMock,
   setPendingUploadMock,
   routerPushMock,
+  ensureLoadedMock,
+  setGlobalSelectionMock,
+  effectiveRefHolder,
 } = vi.hoisted(() => ({
   fetchLlmProfilesMock: vi.fn(),
   getSystemStatusMock: vi.fn(),
   setPendingUploadMock: vi.fn(),
   routerPushMock: vi.fn(),
+  ensureLoadedMock: vi.fn(),
+  setGlobalSelectionMock: vi.fn(),
+  effectiveRefHolder: { current: null as AiModelRef | null },
 }))
 
 vi.mock('@/api/llmProfiles', () => ({
@@ -89,6 +108,61 @@ vi.mock('@/api/status', () => ({
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: routerPushMock }),
 }))
+
+// Kanon-Composable stubben: effectiveRef wird über den hoisted Holder
+// pro Test steuerbar. effectiveRoute/loading/error sind statisch (HeroNewRun
+// konsumiert nur effectiveRef + ensureLoaded). setGlobalSelection wird hier
+// nur exponiert, damit die Komponente ihn importieren kann — HeroNewRun ruft
+// ihn NICHT auf (Picker-Pick ist transient, kein setGlobalSelection).
+vi.mock('@/composables/useEffectiveModelSelection', () => {
+  const stubRoute: LlmRoute = {
+    stage: null,
+    provider_id: 'openai',
+    model: 'gpt-4o',
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+  }
+  return {
+    useEffectiveModelSelection: () => ({
+      effectiveRef: {
+        get value(): AiModelRef | null {
+          return effectiveRefHolder.current
+        },
+        set value(v: AiModelRef | null) {
+          effectiveRefHolder.current = v
+        },
+      },
+      effectiveRoute: {
+        get value(): LlmRoute {
+          return stubRoute
+        },
+        set value(_v: LlmRoute) {
+          /* noop — HeroNewRun schreibt effectiveRoute nicht */
+        },
+      },
+      loading: {
+        get value(): boolean {
+          return false
+        },
+        set value(_v: boolean) {
+          /* noop */
+        },
+      },
+      error: {
+        get value(): string | null {
+          return null
+        },
+        set value(_v: string | null) {
+          /* noop */
+        },
+      },
+      ensureLoaded: ensureLoadedMock,
+      setGlobalSelection: setGlobalSelectionMock,
+    }),
+  }
+})
 
 // Initial-Defaults (werden in mountHero() vor jedem Test neu gesetzt).
 fetchLlmProfilesMock.mockResolvedValue([])
@@ -133,10 +207,14 @@ const localStorageMock = (() => {
 })()
 
 // jsdom hat ein eigenes localStorage; wir ersetzen es pro Test via
-// vi.stubGlobal, damit die Vue-Komponente (die window.local liest)
+// vi.stubGlobal, damit die Vue-Komponente (die window.localStorage liest)
 // unseren Mock sieht. vi.unstubAllGlobals nach jedem Test.
 function installLocalStorageMock(): void {
   vi.stubGlobal('localStorage', localStorageMock)
+}
+
+function setEffectiveRef(aiRef: AiModelRef | null): void {
+  effectiveRefHolder.current = aiRef
 }
 
 function makeI18n() {
@@ -196,6 +274,11 @@ async function mountHero(seed: Record<string, string> = {}) {
   getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
   adapterMock.toLlmRoute.mockClear()
   adapterMock.toStoredModelString.mockClear()
+  // Kanon-Stub: ensureLoaded muss resolven, damit die Komponente beim Mount
+  // selectedModel aus effectiveRef initialisiert.
+  ensureLoadedMock.mockReset()
+  ensureLoadedMock.mockResolvedValue(undefined)
+  setGlobalSelectionMock.mockReset()
 
   const i18n = makeI18n()
   const pinia = createPinia()
@@ -215,7 +298,7 @@ async function mountHero(seed: Record<string, string> = {}) {
   return wrapper
 }
 
-describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
+describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
   beforeEach(() => {
     // clearAllMocks wuerde auch mockResolvedValue/Mock-Implementierungen loeschen.
     // Wir resetten nur die Call-History, nicht die Mocks selbst.
@@ -223,6 +306,11 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
       m.mockClear()
     }
     installLocalStorageMock()
+    // Kanon-Stub pro Test auf Null zurücksetzen; Tests setzen vor mountHero
+    // via setEffectiveRef den gewuenschten Kanon-Wert.
+    setEffectiveRef(null)
+    fetchLlmProfilesMock.mockReset()
+    fetchLlmProfilesMock.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -258,21 +346,31 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(picker.exists()).toBe(true)
   })
 
-  it('liest bestehende Auswahl aus `agora.hero.aiModelRef` (neuer Key)', async () => {
-    const aiRef = { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' }
-    const w = await mountHero({ 'agora.hero.aiModelRef': JSON.stringify(aiRef) })
+  it('Kanon-First-Init: selectedModel wird onMounted aus effectiveRef initialisiert', async () => {
+    const aiRef: AiModelRef = {
+      provider_connection_id: 'conn-ollama-1',
+      model_id: 'qwen3',
+      source: 'workspace-default',
+    }
+    setEffectiveRef(aiRef)
+    const w = await mountHero()
+    // ensureLoaded wird beim Mount gerufen und resolvt (Kanon-First-Init).
+    expect(ensureLoadedMock).toHaveBeenCalled()
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
-    // Der neue Key wird direkt Zod-validiert an den Picker durchgereicht.
+    // selectedModel wurde aus effectiveRef (Kanon) initialisiert — nicht aus
+    // einem localStorage-Key. Komponente liest agora.hero.aiModelRef NICHT mehr.
     expect(picker.props('modelValue')).toMatchObject({
       provider_connection_id: 'conn-ollama-1',
       model_id: 'qwen3',
     })
   })
 
-  it('Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen', async () => {
+  it('Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen, beim Mount entfernt', async () => {
     // Nur der Legacy-Key ist gesetzt — er darf nach dem Storage-Cut keinen
-    // Wert mehr vorbelegen und wird beim Mount defensiv entfernt.
+    // Wert mehr vorbelegen und wird beim Mount defensiv entfernt. effectiveRef
+    // ist null (kein Kanon-Wert), also bleibt der Picker leer.
+    setEffectiveRef(null)
     const legacyRoute = {
       stage: null, provider_id: 'ollama', model: 'gpt-legacy',
       temperature: null, max_tokens: null, reasoning_effort: 'none', provider_options: {},
@@ -281,58 +379,48 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
     expect(picker.props('modelValue')).toBeNull()
+    // Legacy-Route wird beim Mount defensiv entfernt.
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
+    // Legacy-Route wird NICHT mehr gelesen (kein readLocal auf diesen Key).
+    expect(localStorageMock.getItem).not.toHaveBeenCalledWith('agora.hero.route')
   })
 
-  it('onPickRoute: persistiert als `agora.hero.aiModelRef` (neues Format)', async () => {
+  it('onPickModel: spiegelt model_id transient nach STORAGE_MODEL (agora.lastModel)', async () => {
     const w = await mountHero()
     const picker = w.findComponent(aiPickerStub)
     await picker.trigger('click')
-    expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'agora.hero.aiModelRef',
-      expect.stringContaining('gpt-4o-mini'),
-    )
-  })
-
-  it('onPickRoute: setzt STORAGE_MODEL-Spiegel auf model_id', async () => {
-    const w = await mountHero()
-    const picker = w.findComponent(aiPickerStub)
-    expect(picker.exists()).toBe(true)
-    picker.vm.$emit('update:modelValue', {
-      provider_connection_id: 'conn-openai-1',
-      model_id: 'gpt-4o-mini',
-      source: 'explicit',
-    })
     await flushPromises()
-    expect(adapterMock.toStoredModelString).toHaveBeenCalled()
-    const calls = localStorageMock.setItem.mock.calls
-    const modelCall = calls.find((c) => c[0] === 'agora.lastModel')
-    expect(modelCall).toBeDefined()
-    expect(modelCall?.[1]).toBe('gpt-4o-mini')
+    // Transienter Run-Override: nur STORAGE_MODEL-Spiegel, keine eigene Senke.
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'gpt-4o-mini')
+    // Legacy-Route wird bei jedem Pick defensiv entfernt.
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
+    // Kein Schreiben in die entfernte Senke agora.hero.aiModelRef.
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.hero.aiModelRef', expect.anything())
   })
 
-  it('onPickRoute: bei null werden beide Keys + STORAGE_MODEL entfernt/zurueckgesetzt', async () => {
+  it('onPickModel(null): STORAGE_MODEL auf default, Legacy-Route entfernt', async () => {
     const w = await mountHero()
     const picker = w.findComponent(aiPickerStub)
     // Manuell null emittieren (AiModelRef | null).
     ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', null)
     await flushPromises()
-    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.aiModelRef')
+    // STORAGE_MODEL wird auf 'default' zurueckgesetzt (kein stale Override).
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'default')
+    // Legacy-Route wird entfernt.
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
+    // Kein Schreiben in / kein Entfernen der entfernten Senke agora.hero.aiModelRef.
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.hero.aiModelRef')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.hero.aiModelRef', expect.anything())
   })
 
-  it('onPickProfile: persistiert Profile-ID via store, loscht Model-Auswahl', async () => {
+  it('onPickProfile: persistiert Profile-ID via store', async () => {
     // Smoke: wir setzen selectedProfileId via Pinia und pruefen, dass
     // setItem mit Profile-ID aufgerufen wird. Profil-Options aus dem
-    // async API-Call sind hier zweitrangig.
+    // async API-Call sind hier zweitrangig. onPickProfile cleared selectedModel
+    // nicht mehr (Kanon-First-Init bleibt erhalten).
     const w = await mountHero()
-    // Profil-Dropdown @change direkt: das native change-Event wird vom
-    // heroNewRun onPickProfile-Handler konsumiert, der auf selectedProfileId
-    // ref hoert. Ohne Profile-Options bleibt selectedProfileId null, was
-    // wir hier dokumentieren.
     const select = w.find('#hero-profile')
     expect(select.exists()).toBe(true)
-    // Im nativen DOM dispatch wir das change-Event, der Handler liest
-    // event.target.value. Mit leerer Options-Liste ist value immer ''.
     const sel = select.element as HTMLSelectElement
     sel.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
@@ -365,16 +453,85 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
     // Vollstaendige Profil-Selektion wird in onPickProfile-Test dokumentiert.
   })
 
-  it('startSimulation: ohne Profile bleibt Picker aktiv und Picker-Wahl persistent', async () => {
+  it('startSimulation: bei Profile aktiv wird STORAGE_MODEL auf default gesetzt', async () => {
+    fetchLlmProfilesMock.mockResolvedValue([
+      {
+        id: 'abc',
+        name: 'Mein GPT-4o',
+        provider: 'openai',
+        base_url: 'https://api.openai.com/v1',
+        model_name: 'gpt-4o',
+        api_key: 'sk-test',
+        is_default: true,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
     const w = await mountHero()
-    // Picker klicken
+
+    // Datei setzen
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    // Fragestellung setzen
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    // Profil 'abc' auswählen
+    const select = w.find<HTMLSelectElement>('select#hero-profile')
+    await select.setValue('abc')
+    await flushPromises()
+
+    // Starten
+    const cta = w.find('.hero-cta')
+    expect((cta.element as HTMLButtonElement).disabled).toBe(false)
+    await cta.trigger('click')
+    await flushPromises()
+
+    // Bei aktivem Profile gewinnt das Profile — STORAGE_MODEL wird auf
+    // 'default' zurueckgesetzt, damit MainView keinen stale Override mitsendet.
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'default')
+    expect(setPendingUploadMock).toHaveBeenCalledWith(
+      [file],
+      'Wie reagiert die DACH-Region?',
+      'abc',
+      30,
+      10,
+    )
+    expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+  })
+
+  it('startSimulation: ohne Profile wird Picker-Wahl als STORAGE_MODEL gespiegelt', async () => {
+    const w = await mountHero()
+    // Picker emit aiRef (transienter Run-Override → STORAGE_MODEL-Spiegel)
     const picker = w.findComponent(aiPickerStub)
     await picker.trigger('click')
     await flushPromises()
-    const calls = localStorageMock.setItem.mock.calls
-    const aiCall = calls.find((c) => c[0] === 'agora.hero.aiModelRef')
-    expect(aiCall).toBeDefined()
-    expect((aiCall?.[1] as string)).toContain('gpt-4o-mini')
+
+    // Datei setzen
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    // Fragestellung setzen
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    // Starten (ohne Profil → Picker-Wahl gewinnt, STORAGE_MODEL=model_id)
+    const cta = w.find('.hero-cta')
+    await cta.trigger('click')
+    await flushPromises()
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'gpt-4o-mini')
+    expect(setPendingUploadMock).toHaveBeenCalled()
+    expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
   })
 
   it('startSimulation: setPendingUpload wird ueber Pinia exportiert (Smoke)', async () => {
@@ -399,7 +556,7 @@ describe('HeroNewRun (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(mode === 'chat' || mode === undefined).toBe(true)
   })
 
-  it('Profile-Dropdown aktiv -> AiModelPicker versteckt (Hybrid: i zeigt Picker nur wenn kein Profil)', async () => {
+  it('Profile-Dropdown aktiv -> AiModelPicker versteckt (Hybrid: Picker nur wenn kein Profil)', async () => {
     // Der Hybrid-Mechanismus (v-if="!selectedProfileId") ist Template-Logik
     // und nicht direkt Migration-relevant. Smoke: ohne Profil sichtbar.
     const w = await mountHero()

--- a/frontend/src/components/v4/forms/AiModelPicker.vue
+++ b/frontend/src/components/v4/forms/AiModelPicker.vue
@@ -291,6 +291,7 @@ defineExpose({ filteredOptions, providerGroups, selectedId, selectedLabel, loadi
           autocomplete="off"
           spellcheck="false"
           :data-testid="testIds.input"
+          :aria-label="placeholderText"
         />
         <ComboboxTrigger class="ai-model-picker__trigger" :aria-label="placeholderText" tabindex="-1">
           <span aria-hidden="true">▾</span>

--- a/frontend/src/components/v4/forms/Field.vue
+++ b/frontend/src/components/v4/forms/Field.vue
@@ -5,12 +5,12 @@ defineProps<{
 </script>
 
 <template>
-  <div class="v4-field">
-    <label class="v4-field__label">{{ label }}</label>
-    <div class="v4-field__control">
+  <label class="v4-field">
+    <span class="v4-field__label">{{ label }}</span>
+    <span class="v4-field__control">
       <slot />
-    </div>
-  </div>
+    </span>
+  </label>
 </template>
 
 <style scoped>

--- a/frontend/src/components/v4/forms/SettingsSectionPanel.vue
+++ b/frontend/src/components/v4/forms/SettingsSectionPanel.vue
@@ -218,6 +218,7 @@ function setDraftValue(key: string, value: unknown) {
                 <template v-if="field.secret">
                   <input
                     type="password"
+                    :aria-label="field.key"
                     class="v4-input v4-input--secret"
                     :placeholder="
                       field.is_set
@@ -249,6 +250,7 @@ function setDraftValue(key: string, value: unknown) {
                 </template>
                 <template v-else-if="field.type === 'enum'">
                   <select
+                    :aria-label="field.key"
                     class="v4-input"
                     :value="settingsStore.draft[field.key]"
                     @change="
@@ -266,6 +268,7 @@ function setDraftValue(key: string, value: unknown) {
                 </template>
                 <template v-else-if="field.type === 'int' || field.type === 'float'">
                   <input
+                    :aria-label="field.key"
                     class="v4-input"
                     type="number"
                     :step="field.type === 'float' ? '0.01' : '1'"
@@ -277,6 +280,7 @@ function setDraftValue(key: string, value: unknown) {
                 </template>
                 <template v-else>
                   <input
+                    :aria-label="field.key"
                     class="v4-input"
                     type="text"
                     :value="settingsStore.draft[field.key]"

--- a/frontend/src/composables/__tests__/useEffectiveModelSelection.spec.ts
+++ b/frontend/src/composables/__tests__/useEffectiveModelSelection.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * useEffectiveModelSelection — Spec-Tests für den Phase-1-Root-Cause-Fix
+ * "inkonsistente Modellauswahl" (frontend-next, PHASE-1-DIVERGENZ.md).
+ *
+ * Coverage:
+ *  1. effectiveRoute spiegelt routing/defaults.global_default direkt
+ *  2. effectiveRef leitet AiModelRef via Adapter aus global_default ab
+ *  3. effectiveRef ist null ohne provider_id/model in global_default
+ *  4. setGlobalSelection ruft setGlobalDefault (routing) mit der korrekt
+ *     gemappten LlmRoute (provider_connection_id → provider_id, model_id → model)
+ *  5. setGlobalSelection ruft setActiveLlmConfig (active-config) mit denselben
+ *     Werten im Gleichschritt
+ *  6. setGlobalSelection: Kanon (routing) wird VOR active-config geschrieben
+ *  7. ensureLoaded lädt routing-defaults + connections, wenn noch nicht geladen
+ *  8. ensureLoaded überspringt defaultsStore.load() idempotent bei hasLoadedOnce,
+ *     lädt connections aber weiterhin
+ *  9. ensureLoaded propagiert Fehler aus defaultsStore.load() nach error
+ * 10. ensureLoaded propagiert Fehler aus providersStore.loadConnections() nach error
+ * 11. setGlobalSelection propagiert Fehler aus setGlobalDefault, ruft
+ *     setActiveLlmConfig dann NICHT auf
+ * 12. setGlobalSelection propagiert Fehler aus setActiveLlmConfig
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { LlmRoute } from '@/contracts/llmRoute'
+import type { AiModelRef } from '@/contracts/aiModelRef'
+
+const providersStore = vi.hoisted(() => ({
+  connections: {} as Record<string, any>,
+  loadConnections: vi.fn(),
+}))
+
+const defaultsStore = vi.hoisted(() => ({
+  globalDefault: {
+    stage: null,
+    provider_id: null,
+    model: null,
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+  } as LlmRoute,
+  hasLoadedOnce: false,
+  load: vi.fn(),
+  setGlobalDefault: vi.fn(),
+}))
+
+vi.mock('@/store/aiModels', () => ({
+  useLlmProvidersStore: () => providersStore,
+  useLlmRoutingDefaultsStore: () => defaultsStore,
+}))
+
+const setActiveLlmConfigMock = vi.hoisted(() => vi.fn())
+vi.mock('@/api/llmRouting', () => ({
+  setActiveLlmConfig: setActiveLlmConfigMock,
+}))
+
+import { useEffectiveModelSelection } from '../useEffectiveModelSelection'
+
+function makeRoute(overrides: Partial<LlmRoute> = {}): LlmRoute {
+  return {
+    stage: null,
+    provider_id: 'conn-1',
+    model: 'qwen3',
+    temperature: null,
+    max_tokens: null,
+    reasoning_effort: 'none',
+    provider_options: {},
+    ...overrides,
+  }
+}
+
+function makeRef(overrides: Partial<AiModelRef> = {}): AiModelRef {
+  return {
+    provider_connection_id: 'conn-xyz',
+    model_id: 'gpt-4o',
+    source: 'explicit',
+    ...overrides,
+  }
+}
+
+describe('useEffectiveModelSelection (Phase-1 Kanon-Fix)', () => {
+  beforeEach(() => {
+    providersStore.connections = {}
+    providersStore.loadConnections.mockReset().mockResolvedValue(undefined)
+
+    defaultsStore.globalDefault = makeRoute()
+    defaultsStore.hasLoadedOnce = false
+    defaultsStore.load.mockReset().mockResolvedValue(undefined)
+    defaultsStore.setGlobalDefault.mockReset().mockResolvedValue(undefined)
+
+    setActiveLlmConfigMock.mockReset().mockResolvedValue({})
+  })
+
+  it('effectiveRoute spiegelt global_default direkt', () => {
+    defaultsStore.globalDefault = makeRoute({ provider_id: 'conn-42', model: 'llama3' })
+    const { effectiveRoute } = useEffectiveModelSelection()
+    expect(effectiveRoute.value).toEqual(defaultsStore.globalDefault)
+  })
+
+  it('effectiveRef leitet AiModelRef aus global_default ab (Adapter)', () => {
+    defaultsStore.globalDefault = makeRoute({ provider_id: 'conn-42', model: 'llama3' })
+    const { effectiveRef } = useEffectiveModelSelection()
+    expect(effectiveRef.value).toMatchObject({
+      provider_connection_id: 'conn-42',
+      model_id: 'llama3',
+    })
+  })
+
+  it('effectiveRef ist null, wenn global_default kein Provider/Modell trägt', () => {
+    defaultsStore.globalDefault = makeRoute({ provider_id: null, model: null })
+    const { effectiveRef } = useEffectiveModelSelection()
+    expect(effectiveRef.value).toBeNull()
+  })
+
+  it('setGlobalSelection schreibt routing/defaults.global mit der gemappten Route', async () => {
+    const { setGlobalSelection } = useEffectiveModelSelection()
+    await setGlobalSelection(makeRef({ provider_connection_id: 'conn-xyz', model_id: 'gpt-4o' }))
+
+    expect(defaultsStore.setGlobalDefault).toHaveBeenCalledWith(
+      expect.objectContaining({ provider_id: 'conn-xyz', model: 'gpt-4o' }),
+    )
+  })
+
+  it('setGlobalSelection schreibt active-config im Gleichschritt mit gemappten Feldern', async () => {
+    const { setGlobalSelection } = useEffectiveModelSelection()
+    await setGlobalSelection(makeRef({ provider_connection_id: 'conn-xyz', model_id: 'gpt-4o' }))
+
+    expect(setActiveLlmConfigMock).toHaveBeenCalledWith({
+      provider_id: 'conn-xyz',
+      model: 'gpt-4o',
+    })
+  })
+
+  it('setGlobalSelection schreibt Kanon (routing) VOR active-config', async () => {
+    const order: string[] = []
+    defaultsStore.setGlobalDefault.mockImplementation(async () => {
+      order.push('routing')
+    })
+    setActiveLlmConfigMock.mockImplementation(async () => {
+      order.push('active-config')
+      return {}
+    })
+
+    const { setGlobalSelection } = useEffectiveModelSelection()
+    await setGlobalSelection(makeRef())
+
+    expect(order).toEqual(['routing', 'active-config'])
+  })
+
+  it('ensureLoaded lädt routing-defaults + connections, wenn noch nicht geladen', async () => {
+    defaultsStore.hasLoadedOnce = false
+    const { ensureLoaded } = useEffectiveModelSelection()
+    await ensureLoaded()
+
+    expect(defaultsStore.load).toHaveBeenCalledOnce()
+    expect(providersStore.loadConnections).toHaveBeenCalledOnce()
+  })
+
+  it('ensureLoaded überspringt defaultsStore.load() idempotent, lädt connections aber weiterhin', async () => {
+    defaultsStore.hasLoadedOnce = true
+    const { ensureLoaded } = useEffectiveModelSelection()
+    await ensureLoaded()
+
+    expect(defaultsStore.load).not.toHaveBeenCalled()
+    expect(providersStore.loadConnections).toHaveBeenCalledOnce()
+  })
+
+  it('ensureLoaded propagiert Fehler aus defaultsStore.load() nach error', async () => {
+    defaultsStore.hasLoadedOnce = false
+    defaultsStore.load.mockRejectedValue(new Error('routing-defaults kaputt'))
+    const { ensureLoaded, error, loading } = useEffectiveModelSelection()
+
+    await expect(ensureLoaded()).rejects.toThrow('routing-defaults kaputt')
+    expect(error.value).toBe('routing-defaults kaputt')
+    expect(loading.value).toBe(false)
+  })
+
+  it('ensureLoaded propagiert Fehler aus providersStore.loadConnections() nach error', async () => {
+    providersStore.loadConnections.mockRejectedValue(new Error('connections kaputt'))
+    const { ensureLoaded, error } = useEffectiveModelSelection()
+
+    await expect(ensureLoaded()).rejects.toThrow('connections kaputt')
+    expect(error.value).toBe('connections kaputt')
+  })
+
+  it('setGlobalSelection propagiert Fehler aus setGlobalDefault und ruft active-config NICHT auf', async () => {
+    defaultsStore.setGlobalDefault.mockRejectedValue(new Error('routing-write kaputt'))
+    const { setGlobalSelection, error } = useEffectiveModelSelection()
+
+    await expect(setGlobalSelection(makeRef())).rejects.toThrow('routing-write kaputt')
+    expect(error.value).toBe('routing-write kaputt')
+    expect(setActiveLlmConfigMock).not.toHaveBeenCalled()
+  })
+
+  it('setGlobalSelection propagiert Fehler aus setActiveLlmConfig nach error', async () => {
+    setActiveLlmConfigMock.mockRejectedValue(new Error('active-config kaputt'))
+    const { setGlobalSelection, error } = useEffectiveModelSelection()
+
+    await expect(setGlobalSelection(makeRef())).rejects.toThrow('active-config kaputt')
+    expect(error.value).toBe('active-config kaputt')
+  })
+})

--- a/frontend/src/composables/useEffectiveModelSelection.ts
+++ b/frontend/src/composables/useEffectiveModelSelection.ts
@@ -39,6 +39,11 @@ export interface EffectiveModelSelection {
   setGlobalSelection: (ref: AiModelRef) => Promise<void>
 }
 
+/**
+ * Provides the effective global model selection and synchronizes updates across model configuration stores.
+ *
+ * @returns The effective model reference and route, loading and error state, and actions for loading and updating the global selection
+ */
 export function useEffectiveModelSelection(): EffectiveModelSelection {
   const defaultsStore = useLlmRoutingDefaultsStore()
   const providersStore = useLlmProvidersStore()

--- a/frontend/src/composables/useEffectiveModelSelection.ts
+++ b/frontend/src/composables/useEffectiveModelSelection.ts
@@ -1,0 +1,97 @@
+/**
+ * useEffectiveModelSelection — die EINZIGE Quelle/Senke für die effektive
+ * globale Chat-Modellwahl (Phase-1 Root-Cause-Fix, frontend-next).
+ *
+ * Vor dieser Konsolidierung schrieben mehrere Flächen in unabhängige, server-
+ * seitig NICHT synchrone Senken (`active-config`, `routing/defaults.global`,
+ * drei `agora.*.aiModelRef`-localStorage-Keys, Legacy-Profile). Zwei Runtime-
+ * Pfade lasen verschiedene Quellen: `llm/client.py` (use_active_config) →
+ * `active-config`, `stage_model_router.py` → `routing/defaults.global_default`.
+ * Das war die Ursache der gemeldeten „inkonsistenten Modellauswahl".
+ *
+ * Kanon (AGENTS.md): `routing/defaults.global_default`, repräsentiert als
+ * {@link AiModelRef} über {@link useAiModelRefAdapter}. `active-config` wird
+ * beim Schreiben im Gleichschritt mitgezogen, damit beide Runtime-Leser
+ * konsistente Werte sehen. Das Backend bleibt unangetastet (reiner FE-Sync);
+ * die theoretisch reinere SSoT (active-config delegiert server-seitig an den
+ * Workspace-Routing-Store) ist ein bewusst separates Folge-Slice.
+ */
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import { useLlmProvidersStore, useLlmRoutingDefaultsStore } from '@/store/aiModels'
+import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { setActiveLlmConfig } from '@/api/llmRouting'
+import type { AiModelRef } from '@/contracts/aiModelRef'
+import type { LlmRoute } from '@/contracts/llmRoute'
+
+export interface EffectiveModelSelection {
+  /** Effektive globale Auswahl als AiModelRef (aus global_default via Adapter). */
+  effectiveRef: ComputedRef<AiModelRef | null>
+  /** Effektive globale Auswahl als LlmRoute (global_default direkt). */
+  effectiveRoute: ComputedRef<LlmRoute>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+  /** Lädt Routing-Defaults + Provider-Connections idempotent. */
+  ensureLoaded: () => Promise<void>
+  /**
+   * Kanonischer Schreibpfad: setzt den globalen Default. Aktualisiert
+   * `routing/defaults.global` UND `active-config` im Gleichschritt.
+   */
+  setGlobalSelection: (ref: AiModelRef) => Promise<void>
+}
+
+export function useEffectiveModelSelection(): EffectiveModelSelection {
+  const defaultsStore = useLlmRoutingDefaultsStore()
+  const providersStore = useLlmProvidersStore()
+  const adapter = useAiModelRefAdapter()
+
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const effectiveRoute = computed<LlmRoute>(() => defaultsStore.globalDefault)
+  const effectiveRef = computed<AiModelRef | null>(() =>
+    adapter.toAiModelRef(defaultsStore.globalDefault),
+  )
+
+  async function ensureLoaded(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      await Promise.all([
+        defaultsStore.hasLoadedOnce ? Promise.resolve() : defaultsStore.load(),
+        providersStore.loadConnections(),
+      ])
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function setGlobalSelection(selection: AiModelRef): Promise<void> {
+    error.value = null
+    const route = adapter.toLlmRoute(selection)
+    try {
+      // Kanon zuerst: routing/defaults.global_default.
+      await defaultsStore.setGlobalDefault(route)
+      // Gleichschritt: active-config, damit der generische LLM-Client
+      // (client.py use_active_config) denselben Wert liest.
+      await setActiveLlmConfig({
+        provider_id: selection.provider_connection_id,
+        model: selection.model_id,
+      })
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    }
+  }
+
+  return {
+    effectiveRef,
+    effectiveRoute,
+    loading,
+    error,
+    ensureLoaded,
+    setGlobalSelection,
+  }
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -15,7 +15,7 @@ import { getAvailableModels } from '../api/simulation'
 import { STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
 import { setPendingUpload } from '../store/pendingUpload'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
-import { AiModelRefSchema } from '@/contracts/aiModelRef'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 
 const { t, tm } = useI18n()
 const router = useRouter()
@@ -38,40 +38,31 @@ const neo4jError = ref(null)
 const loadingModels = ref(true)
 const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
 
-// ---- LLM-Auswahl (Slice 7.6b: AiModelPicker + useAiModelRefAdapter). ----
-//   Persistenz: agora.home.aiModelRef (AiModelRef-JSON, Zod-validiert).
-//   Slice 7.6c (Storage-Cut): Der Legacy-Key agora.home.route wird NICHT mehr
-//   gelesen; er wird beim Mount und beim Speichern defensiv aus localStorage
-//   entfernt. Spiegelung auf STORAGE_MODEL für die bestehende Step2/MainView-
-//   Pipeline (Provider+Key resolved das Backend serverseitig via SecretResolver).
-const STORAGE_HOME_AI_REF = 'agora.home.aiModelRef'
+// ---- LLM-Auswahl (Phase-1 Konsolidierung: Kanon-First). ----
+//   Das Default-Modell kommt aus dem Kanon (routing/defaults.global via
+//   useEffectiveModelSelection), NICHT mehr aus einem eigenen
+//   agora.home.aiModelRef-Key — damit Home dieselbe Auswahl wie Settings zeigt.
+//   Ein Picker-Pick ist ein transienter Override nur für diesen Start; er wird
+//   auf STORAGE_MODEL gespiegelt (Step2/MainView-Pipeline, Backend resolved
+//   Provider+Key serverseitig via SecretResolver). Slice 7.6c (Storage-Cut):
+//   Legacy-Key agora.home.route wird defensiv entfernt.
 const STORAGE_HOME_ROUTE_LEGACY = 'agora.home.route'
 
 const adapter = useAiModelRefAdapter()
+const effectiveModel = useEffectiveModelSelection()
 
-function loadStoredModel() {
-  // Slice 7.6c (Storage-Cut): nur noch der neue AiModelRef-Key wird gelesen.
-  const raw = localStorage.getItem(STORAGE_HOME_AI_REF)
-  if (!raw) return null
-  try {
-    const parsed = AiModelRefSchema.safeParse(JSON.parse(raw))
-    return parsed.success ? parsed.data : null
-  } catch (err) {
-    console.warn('[Home] lokal gespeicherte Modell-Auswahl nicht parsbar — Auswahl zurückgesetzt:', err)
-    return null
-  }
-}
-
-const selectedModel = ref(loadStoredModel())
+const selectedModel = ref(null)
+// true, sobald der User im Picker explizit ein Modell wählt (überschreibt den
+// Kanon-Default). Steuert das Ollama-Reachability-Gate und die UI-Hinweise.
+const modelOverridden = ref(false)
 
 function onPickModel(aiRef) {
   selectedModel.value = aiRef
+  modelOverridden.value = aiRef !== null
   if (aiRef) {
-    localStorage.setItem(STORAGE_HOME_AI_REF, JSON.stringify(aiRef))
     localStorage.setItem(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
     localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
   } else {
-    localStorage.removeItem(STORAGE_HOME_AI_REF)
     localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
     localStorage.setItem(STORAGE_MODEL, 'default')
   }
@@ -108,12 +99,11 @@ const llmStatusLabel = computed(() => {
   return 'LLM'
 })
 
-// Wenn der User unter /settings/llm-providers einen anderen Provider als Default
-// gewählt hat (selectedModel !== null), gilt der Ollama-Reachability-Check nicht
-// mehr — der gewählte Provider übernimmt.
+// Wenn der User im Picker explizit ein anderes Modell wählt (modelOverridden),
+// gilt der Ollama-Reachability-Check nicht mehr — der gewählte Provider übernimmt.
 const servicesReady = computed(() => (
   neo4jReachable.value &&
-  (!serverDefaultRequiresOllama.value || ollamaReachable.value || selectedModel.value !== null)
+  (!serverDefaultRequiresOllama.value || ollamaReachable.value || modelOverridden.value)
 ))
 
 const canSubmit = computed(() => {
@@ -170,6 +160,13 @@ async function startSimulation() {
 onMounted(() => {
   // Slice 7.6c (Storage-Cut): Legacy-Route-Key einmalig defensiv entsorgen.
   localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
+  // Phase-1 Konsolidierung: Default-Modell aus dem Kanon initialisieren.
+  effectiveModel
+    .ensureLoaded()
+    .then(() => {
+      if (!modelOverridden.value) selectedModel.value = effectiveModel.effectiveRef.value
+    })
+    .catch(() => { /* Kanon nicht ladbar: Picker bleibt leer, Backend nutzt active-config */ })
   loadStatus()
 })
 
@@ -361,10 +358,10 @@ const differentiators = computed(() => tm('home.differentiators'))
               :placeholder="t('step2.model.placeholder')"
               @update:model-value="onPickModel"
             />
-            <p v-if="!selectedModel && !loadingModels" class="console-meta" style="margin-top: 4px;">
+            <p v-if="!modelOverridden && !loadingModels" class="console-meta" style="margin-top: 4px;">
               {{ t('step2.model.workspaceDefaultHint') }}
             </p>
-            <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !selectedModel" class="console-warning" style="margin-top: 4px;">
+            <p v-if="serverDefaultRequiresOllama && !ollamaReachable && !loadingModels && !modelOverridden" class="console-warning" style="margin-top: 4px;">
               {{ t('step2.model.noOllama') }}
             </p>
           </div>

--- a/frontend/src/views/Settings/LlmProvidersView.vue
+++ b/frontend/src/views/Settings/LlmProvidersView.vue
@@ -30,6 +30,7 @@ import Input from '@/components/v4/forms/Input.vue'
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
 import { useLlmProvidersStore, useLlmRoutingDefaultsStore } from '@/store/aiModels'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import type { ProviderDescriptor } from '@/contracts/llmRoutingContract'
 import type { LlmRoute } from '@/contracts/llmRoute'
 import type { ProviderProbeStatus } from '@/contracts/aiProviderContract'
@@ -40,6 +41,7 @@ const { t } = useI18n()
 const providersStore = useLlmProvidersStore()
 const defaultsStore = useLlmRoutingDefaultsStore()
 const adapter = useAiModelRefAdapter()
+const effectiveModel = useEffectiveModelSelection()
 
 const BREADCRUMBS = [
   { label: 'Settings', to: { name: 'SettingsGeneral' } },
@@ -184,8 +186,9 @@ const defaultAiRef = computed<AiModelRef | null>(() => {
 
 async function setDefault(aiRef: AiModelRef | null): Promise<void> {
   if (!aiRef) return
-  const llmRoute = adapter.toLlmRoute(aiRef)
-  await defaultsStore.setGlobalDefault(llmRoute)
+  // Kanon: routing/defaults.global + active-config im Gleichschritt
+  // (Phase-1 Konsolidierung, PHASE-1-DIVERGENZ.md).
+  await effectiveModel.setGlobalSelection(aiRef)
 }
 
 onMounted(async () => {

--- a/frontend/src/views/Settings/SettingsGeneralView.vue
+++ b/frontend/src/views/Settings/SettingsGeneralView.vue
@@ -2,34 +2,25 @@
 /**
  * SettingsGeneralView — Globale Workspace-Einstellungen.
  *
- * Slice 5.4: Pilot-Abschluss der AiModelPicker-Migration.
- *  - AiModelPicker-Update wird an useLlmRoutingDefaultsStore.setGlobalDefault
- *    durchgereicht (Adapter Uebersetzung AiModelRef -> LlmRoute).
- *  - Initialer Wert kommt aus defaultsStore.globalDefault (via Adapter).
- *  - i18n-Key 'settings.v4.general.workspaceDefaultModel' ersetzt das
- *    generische aiModelPicker.label und macht die Funktion klar.
+ * Phase-1 Konsolidierung (frontend-next): EIN Modell-Picker als einzige
+ * Selektions-UI. Die Auswahl geht durch `useEffectiveModelSelection`, das
+ * `routing/defaults.global` UND `active-config` im Gleichschritt schreibt
+ * (Kanon: PHASE-1-DIVERGENZ.md). Die frühere separate „Active LLM Config"-
+ * Sektion (eigene Provider/Modell-Dropdowns → active-config) wurde entfernt —
+ * sie war die zweite, divergierende Server-Senke.
  *
- * Bewusst KEIN Override-Flow auf Stage-Ebene — dafuer ist
- * StepModelOverrideChip zustaendig. Hier geht es nur um den
- * Workspace-Default.
+ * Bewusst KEIN Override-Flow auf Stage-Ebene — dafür ist
+ * StepModelOverrideChip zuständig. Hier geht es nur um den Workspace-Default.
  */
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
-import Button from '@/components/v4/forms/Button.vue'
 import SettingsSectionPanel from '@/components/v4/forms/SettingsSectionPanel.vue'
 import LlmProfileManager from '@/components/v4/forms/LlmProfileManager.vue'
-import { useLlmRoutingDefaultsStore } from '@/store/aiModels'
-import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import type { AiModelRef } from '@/contracts/aiModelRef'
-import {
-  getActiveLlmConfig,
-  listLlmProviders,
-  listProviderModels,
-  setActiveLlmConfig,
-} from '@/api/llmRouting'
 import { GENERAL_SETTINGS_SECTIONS } from './settingsSections'
 
 const { t } = useI18n()
@@ -39,120 +30,24 @@ const BREADCRUMBS = [
   { label: 'General' },
 ]
 
-const defaultsStore = useLlmRoutingDefaultsStore()
-const adapter = useAiModelRefAdapter()
+const effectiveModel = useEffectiveModelSelection()
 
-// Initialer Wert aus dem Store (via Adapter: LlmRoute -> AiModelRef).
-const selectedModel = ref<AiModelRef | null>(
-  defaultsStore.globalDefault ? adapter.toAiModelRef(defaultsStore.globalDefault) : null,
-)
-
-const activeProviders = ref<Awaited<ReturnType<typeof listLlmProviders>>>([])
-const activeModels = ref<Awaited<ReturnType<typeof listProviderModels>>>([])
-const activeProviderId = ref('')
-const activeModelId = ref('')
-const activeLoadingProviders = ref(false)
-const activeLoadingModels = ref(false)
-const activeSaving = ref(false)
-const activeError = ref('')
-const activeFlash = ref('')
-
-function messageFrom(error: unknown, fallback: string): string {
-  return error instanceof Error && error.message ? error.message : fallback
-}
-
-async function loadActiveProviders(): Promise<void> {
-  activeLoadingProviders.value = true
-  activeError.value = ''
-  try {
-    activeProviders.value = await listLlmProviders()
-  } catch (error) {
-    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadProviders'))
-  } finally {
-    activeLoadingProviders.value = false
-  }
-}
-
-async function loadActiveModels(providerId: string): Promise<void> {
-  if (!providerId) {
-    activeModels.value = []
-    return
-  }
-
-  activeLoadingModels.value = true
-  try {
-    activeModels.value = await listProviderModels(providerId)
-  } catch (error) {
-    activeModels.value = []
-    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadModels'))
-  } finally {
-    activeLoadingModels.value = false
-  }
-}
-
-async function loadActiveSelection(): Promise<void> {
-  try {
-    const config = await getActiveLlmConfig()
-    activeProviderId.value = config.provider_id ?? ''
-    if (activeProviderId.value) {
-      await loadActiveModels(activeProviderId.value)
-    }
-    activeModelId.value = config.model ?? ''
-  } catch (error) {
-    activeError.value = messageFrom(error, t('settings.llmActive.errorLoadActive'))
-  }
-}
-
-async function changeActiveProvider(event: Event): Promise<void> {
-  activeProviderId.value = (event.target as HTMLSelectElement).value
-  activeModelId.value = ''
-  activeFlash.value = ''
-  activeError.value = ''
-  await loadActiveModels(activeProviderId.value)
-}
-
-async function saveActiveSelection(): Promise<void> {
-  if (!activeProviderId.value || !activeModelId.value) {
-    activeError.value = t('settings.llmActive.errorSelectionMissing')
-    return
-  }
-
-  activeSaving.value = true
-  activeError.value = ''
-  activeFlash.value = ''
-  try {
-    await setActiveLlmConfig({
-      provider_id: activeProviderId.value,
-      model: activeModelId.value,
-    })
-    activeFlash.value = t('settings.llmActive.flashSaved')
-  } catch (error) {
-    activeError.value = messageFrom(error, t('settings.llmActive.errorSaveFailed'))
-  } finally {
-    activeSaving.value = false
-  }
-}
+// Initialer Wert aus dem Kanon (routing/defaults.global via Adapter).
+const selectedModel = ref<AiModelRef | null>(effectiveModel.effectiveRef.value)
 
 onMounted(async () => {
   try {
-    await defaultsStore.load()
-    if (defaultsStore.globalDefault) {
-      selectedModel.value = adapter.toAiModelRef(defaultsStore.globalDefault)
-    }
+    await effectiveModel.ensureLoaded()
+    selectedModel.value = effectiveModel.effectiveRef.value
   } catch {
     /* Defaults bleiben leer — Picker zeigt nichts gewaehltes */
   }
 })
 
-onMounted(async () => {
-  await loadActiveProviders()
-  await loadActiveSelection()
-})
-
 async function setWorkspaceDefault(aiRef: AiModelRef | null): Promise<void> {
   if (!aiRef) return
-  const llmRoute = adapter.toLlmRoute(aiRef)
-  await defaultsStore.setGlobalDefault(llmRoute)
+  // Kanonischer Schreibpfad: routing/defaults.global + active-config im Gleichschritt.
+  await effectiveModel.setGlobalSelection(aiRef)
 }
 </script>
 
@@ -175,162 +70,15 @@ async function setWorkspaceDefault(aiRef: AiModelRef | null): Promise<void> {
       />
     </section>
 
-    <section
-      class="settings-general__active"
-      aria-labelledby="settings-active-title"
-    >
-      <header>
-        <h2 id="settings-active-title">{{ t('settings.llmActive.title') }}</h2>
-        <p>{{ t('settings.llmActive.subtitle') }}</p>
-      </header>
-
-      <div class="settings-general__active-fields">
-        <label for="settings-active-provider">{{ t('settings.llmActive.providerLabel') }}</label>
-        <select
-          id="settings-active-provider"
-          :value="activeProviderId"
-          :disabled="activeLoadingProviders"
-          @change="changeActiveProvider"
-        >
-          <option value="" disabled>
-            {{ activeLoadingProviders ? t('settings.llmActive.providerLoading') : t('settings.llmActive.providerPlaceholder') }}
-          </option>
-          <option
-            v-for="provider in activeProviders"
-            :key="provider.id"
-            :value="provider.id"
-          >
-            {{ provider.label || provider.id }}
-          </option>
-        </select>
-
-        <label for="settings-active-model">{{ t('settings.llmActive.modelLabel') }}</label>
-        <select
-          id="settings-active-model"
-          v-model="activeModelId"
-          :disabled="!activeProviderId || activeLoadingModels"
-        >
-          <option value="" disabled>
-            {{
-              !activeProviderId
-                ? t('settings.llmActive.modelNeedsProvider')
-                : activeLoadingModels
-                  ? t('settings.llmActive.modelLoading')
-                  : activeModels.length
-                    ? t('settings.llmActive.modelPlaceholder')
-                    : t('settings.llmActive.modelEmpty')
-            }}
-          </option>
-          <option
-            v-for="model in activeModels"
-            :key="model.id"
-            :value="model.id"
-          >
-            {{ model.id }}{{ model.label && model.label !== model.id ? ` — ${model.label}` : '' }}
-          </option>
-        </select>
-      </div>
-
-      <p
-        v-if="activeFlash"
-        class="settings-general__active-feedback"
-        role="status"
-        aria-live="polite"
-      >
-        {{ activeFlash }}
-      </p>
-      <p
-        v-if="activeError"
-        class="settings-general__active-feedback settings-general__active-feedback--error"
-        role="alert"
-      >
-        {{ activeError }}
-      </p>
-
-      <Button
-        class="settings-general__active-save"
-        variant="accent"
-        :loading="activeSaving"
-        :disabled="!activeProviderId || !activeModelId || activeSaving"
-        @click="saveActiveSelection"
-      >
-        {{ t('settings.llmActive.save') }}
-      </Button>
-    </section>
-
     <SettingsSectionPanel :allowed-sections="GENERAL_SETTINGS_SECTIONS" />
   </AppShell>
 </template>
 
 <style scoped>
-.settings-general__active {
+.settings-general__model-picker {
   display: grid;
-  gap: 16px;
+  gap: 8px;
   min-width: 0;
   margin-bottom: 16px;
-  padding: 20px;
-  border: 1px solid var(--hairline);
-  border-radius: 12px;
-  background: var(--surface-elevated);
-}
-
-.settings-general__active header,
-.settings-general__active header p {
-  margin: 0;
-}
-
-.settings-general__active header {
-  display: grid;
-  gap: 6px;
-}
-
-.settings-general__active-fields {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
-  gap: 10px 16px;
-  align-items: center;
-  min-width: 0;
-}
-
-.settings-general__active-fields select {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-  padding: 10px 12px;
-  border: 1px solid var(--hairline);
-  border-radius: 8px;
-  color: var(--text-primary);
-  background: var(--surface-elevated);
-}
-
-.settings-general__active-fields select:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.settings-general__active-feedback {
-  margin: 0;
-}
-
-.settings-general__active-feedback--error {
-  color: var(--danger);
-}
-
-.settings-general__active-save {
-  justify-self: end;
-}
-
-@media (max-width: 480px) {
-  .settings-general__active {
-    padding: 16px;
-  }
-
-  .settings-general__active-fields {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .settings-general__active-save {
-    justify-self: stretch;
-  }
 }
 </style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -25,14 +25,17 @@ import {
   listLlmProviders,
   listProviderModels,
   getActiveLlmConfig,
-  setActiveLlmConfig,
 } from '../api/llmRouting'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 
 const LLM_ACTIVE_SECTION = '__llm_active__'
 
 const { t } = useI18n()
 const router = useRouter()
 const settingsStore = useSettingsStore()
+// Kanonischer Schreibpfad: schreibt routing/defaults.global + active-config
+// im Gleichschritt (Phase-1 Konsolidierung, PHASE-1-DIVERGENZ.md).
+const effectiveModel = useEffectiveModelSelection()
 const { sections, schema, fields, dirtyKeys, dirtySectionFlags } = storeToRefs(settingsStore)
 
 const activeSection = ref(LLM_ACTIVE_SECTION)
@@ -108,9 +111,12 @@ async function saveLlmActive() {
   llmError.value = ''
   llmFlash.value = ''
   try {
-    await setActiveLlmConfig({
-      provider_id: selectedProviderId.value,
-      model: selectedModel.value,
+    // provider_id == provider_connection_id (seit 7.3.3). Über den Composable
+    // wird routing/defaults.global UND active-config konsistent geschrieben.
+    await effectiveModel.setGlobalSelection({
+      provider_connection_id: selectedProviderId.value,
+      model_id: selectedModel.value,
+      source: 'explicit',
     })
     llmFlash.value = t('settings.llmActive.flashSaved')
   } catch (err) {

--- a/frontend/src/views/__tests__/Home.spec.ts
+++ b/frontend/src/views/__tests__/Home.spec.ts
@@ -1,11 +1,21 @@
 /**
- * Home — minimaler Migrations-Spec fuer Slice 7.6b.
+ * Home — Kanon-First-Spec (Phase-1 Konsolidierung, frontend-next).
  *
- * Drei essenzielle Pruefungen (User-Direktive "nur die noetigste"):
+ * Drei Kanon-First-Pruefungen + zwei Init-Tests:
  *  - Picker-Anbindung: AiModelPicker gerendert, ModelPicker (v4 legacy) NICHT
- *  - LocalStorage-Migration: onPickModel schreibt agora.home.aiModelRef +
- *    STORAGE_MODEL-Spiegel via adapter.toStoredModelString
- *  - null-Pfad: bei null werden beide Keys entfernt + STORAGE_MODEL='default'
+ *  - Picker-Pick ist TRANSIENT (KEIN setGlobalSelection): schreibt nur
+ *    STORAGE_MODEL-Spiegel (agora.lastModel) via adapter.toStoredModelString
+ *    und entfernt defensiv den Legacy-Key agora.home.route.
+ *  - null-Pfad: entfernt agora.home.route + STORAGE_MODEL='default',
+ *    modelOverridden wird wieder false.
+ *  - Kanon-First-Init: selectedModel wird aus effectiveRef vorbelegt, wenn
+ *    der User nichts waehlt (ensureLoaded in onMounted aufgerufen).
+ *  - Nach explizitem Pick (modelOverridden=true) ueberschreibt die
+ *    Kanon-Vorbelegung selectedModel nicht mehr.
+ *
+ * Entfernte Senken, die NICHT mehr assertet werden duerfen:
+ * STORAGE_HOME_AI_REF (agora.home.aiModelRef), saveLlmActive, direktes
+ * setDefault-Store-Geschreibe.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
@@ -45,7 +55,7 @@ const stubs = {
 const setPendingUploadMock = vi.fn()
 const routerPushMock = vi.fn()
 
-vi.mock('../api/simulation', () => ({
+vi.mock('@/api/simulation', () => ({
   getAvailableModels: vi.fn().mockResolvedValue({
     success: true,
     data: { default_provider: 'ollama', ollama_reachable: true, neo4j_reachable: true, default_language: 'de' },
@@ -61,6 +71,38 @@ const adapterMock = {
   toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
 }
 vi.mock('@/composables/useAiModelRefAdapter', () => ({ useAiModelRefAdapter: () => adapterMock }))
+
+// ---- Kanon-Composable-Mock (steuerbar, Kanon-First). ----
+// effectiveRef/effectiveRoute als Plain-Ref-Objekte (.value wird von Home
+// gelesen), ensureLoaded/setGlobalSelection als vi.fns, damit wir Aufruf
+// UND Nicht-Aufruf asserten koennen. vi.hoisted, damit der Mock-Factory die
+// Halter-Referenz schon vor dem Hoisten sieht.
+const effMock = vi.hoisted(() => ({
+  effectiveRefValue: null as unknown,
+  effectiveRouteValue: null as unknown,
+  ensureLoadedImpl: null as ((...a: unknown[]) => Promise<void>) | null,
+  setGlobalSelection: null as ((...a: unknown[]) => Promise<void>) | null,
+  resolveEnsureLoaded: null as (() => void) | null,
+}))
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: { value: effMock.effectiveRefValue },
+    effectiveRoute: { value: effMock.effectiveRouteValue },
+    loading: { value: false },
+    error: { value: null },
+    ensureLoaded: (...args: unknown[]) => effMock.ensureLoadedImpl!(...args),
+    setGlobalSelection: (...args: unknown[]) => effMock.setGlobalSelection!(...args),
+  }),
+}))
+
+// Kanon-Default, der via effectiveRef vorbelegt wird (unterscheidbar vom
+// Picker-Pick gpt-4o-mini, damit Verwechslung auffaellt).
+const kanonAiRef = {
+  provider_connection_id: 'conn-anthropic-1',
+  model_id: 'claude-sonnet-4',
+  source: 'workspace_default',
+}
+const kanonRoute = { provider: 'anthropic', model: 'claude-sonnet-4' }
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -94,13 +136,30 @@ const makeI18n = () => createI18n({
       },
       history: { kicker: '' }, nav: { available: '' }, brand: { name: 'Agora', tagline: '' },
       step2: {
-        model: { label: 'Modell', placeholder: '', workspaceDefaultHint: '', noOllama: '' },
+        // Erkennbarer Text, damit wir modelOverridden===false am gerenderten
+        // workspaceDefaultHint-Paragraph (v-if="!modelOverridden && !loadingModels")
+        // verifizieren koennen.
+        model: { label: 'Modell', placeholder: '', workspaceDefaultHint: 'WORKSPACE_DEFAULT_HINT', noOllama: '' },
         language: { label: '', de: 'DE', en: 'EN', hint: '' },
       },
       common: { refresh: '' }, aiModelPicker: { placeholder: '' },
     },
   },
 })
+
+function resetEffMock(opts: { deferEnsureLoaded?: boolean } = {}) {
+  effMock.effectiveRefValue = kanonAiRef
+  effMock.effectiveRouteValue = kanonRoute
+  effMock.setGlobalSelection = vi.fn().mockResolvedValue(undefined)
+  effMock.resolveEnsureLoaded = null
+  if (opts.deferEnsureLoaded) {
+    effMock.ensureLoadedImpl = vi.fn(() => new Promise<void>((resolve) => {
+      effMock.resolveEnsureLoaded = resolve
+    }))
+  } else {
+    effMock.ensureLoadedImpl = vi.fn().mockResolvedValue(undefined)
+  }
+}
 
 async function mountHome() {
   localStorageMock.clear()
@@ -110,8 +169,11 @@ async function mountHome() {
   return mount(Home, { global: { plugins: [makeI18n()], stubs } })
 }
 
-describe('Home (Slice 7.6b, minimal)', () => {
-  beforeEach(() => { installLocalStorageSafe() })
+describe('Home (Kanon-First, Phase-1)', () => {
+  beforeEach(() => {
+    installLocalStorageSafe()
+    resetEffMock()
+  })
   afterEach(() => { vi.unstubAllGlobals() })
 
   it('rendert AiModelPicker, nicht ModelPicker (v4 legacy)', async () => {
@@ -121,7 +183,7 @@ describe('Home (Slice 7.6b, minimal)', () => {
     expect(w.findComponent(legacyModelPickerStub).exists()).toBe(false)
   })
 
-  it('onPickModel: persistiert aiModelRef + STORAGE_MODEL-Spiegel via Adapter', async () => {
+  it('onPickModel: transienter Override — STORAGE_MODEL-Spiegel + agora.home.route-Entfernung, KEIN setGlobalSelection, KEIN aiModelRef-Storage', async () => {
     const w = await mountHome()
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
@@ -131,24 +193,92 @@ describe('Home (Slice 7.6b, minimal)', () => {
       source: 'explicit',
     })
     await flushPromises()
-    expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'agora.home.aiModelRef',
-      expect.stringContaining('gpt-4o-mini'),
-    )
+
+    // (a) STORAGE_MODEL-Spiegel via Adapter geschrieben.
     const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
     expect(modelCall?.[1]).toBe('gpt-4o-mini')
+
+    // (b) Legacy-Route-Key defensiv entfernt (mindestens beim Pick).
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.route')
+
+    // (c) agora.home.aiModelRef wird weder gelesen noch geschrieben noch entfernt.
+    const aiRefKeyCalls = [
+      ...localStorageMock.getItem.mock.calls,
+      ...localStorageMock.setItem.mock.calls,
+      ...localStorageMock.removeItem.mock.calls,
+    ].filter((c) => c[0] === 'agora.home.aiModelRef')
+    expect(aiRefKeyCalls).toHaveLength(0)
+
+    // (d) Picker-Pick ist transient — Kanon-Schreibpfad wird NICHT beruehrt.
+    expect(effMock.setGlobalSelection).not.toHaveBeenCalled()
   })
 
-  it('onPickModel: bei null werden aiModelRef+Legacy-Key entfernt + STORAGE_MODEL="default"', async () => {
+  it('onPickModel: bei null — agora.home.route entfernt + STORAGE_MODEL="default", modelOverridden===false', async () => {
     const w = await mountHome()
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
     ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', null)
     await flushPromises()
-    expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.aiModelRef')
+
+    // Legacy-Route-Key entfernt (onMounted + beim null-Pick).
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.route')
+    // STORAGE_MODEL auf 'default' zurueckgesetzt.
     const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
     expect(modelCall?.[1]).toBe('default')
+    // Entfernter aiModelRef-Sink wird NICHT angeruehrt.
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.home.aiModelRef')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.home.aiModelRef', expect.anything())
+
+    // modelOverridden===false: workspaceDefaultHint wird wieder gerendert
+    // (v-if="!modelOverridden && !loadingModels", loadingModels=false nach flush).
+    expect(w.html()).toContain('WORKSPACE_DEFAULT_HINT')
+  })
+
+  it('Kanon-First-Init: selectedModel wird aus effectiveRef vorbelegt, wenn User nichts waehlt; ensureLoaded in onMounted aufgerufen, setGlobalSelection NICHT', async () => {
+    resetEffMock()
+    const w = await mountHome()
+    await flushPromises()
+
+    // ensureLoaded wurde in onMounted aufgerufen.
+    expect(effMock.ensureLoadedImpl).toHaveBeenCalledTimes(1)
+
+    // selectedModel wurde aus dem Kanon (effectiveRef) vorbelegt, nicht null.
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.props('modelValue')).toEqual(kanonAiRef)
+
+    // Kanon-Schreibpfad bei reinem Init nicht beruehrt (nur Lese-Pfad).
+    expect(effMock.setGlobalSelection).not.toHaveBeenCalled()
+  })
+
+  it('Nach explizitem Pick (modelOverridden=true) ueberschreibt Kanon-Vorbelegung selectedModel nicht mehr', async () => {
+    // ensureLoaded bewusst verzoegert, damit der Pick vor der Kanon-Then-Resolution passiert.
+    resetEffMock({ deferEnsureLoaded: true })
+    const picked = {
+      provider_connection_id: 'conn-openai-1',
+      model_id: 'gpt-4o-mini',
+      source: 'explicit',
+    }
+
+    const w = mount(Home, { global: { plugins: [makeI18n()], stubs } })
+    // onMounted hat ensureLoaded (pending) + loadStatus angestossen; Pick VOR Resolution.
+    const picker = w.findComponent(aiPickerStub)
+    picker.vm.$emit('update:modelValue', picked)
+    await flushPromises()
+
+    // Jetzt erst Kanon-Ensure aufloesen -> .then prueft modelOverridden und überschreibt NICHT.
+    expect(effMock.resolveEnsureLoaded).not.toBeNull()
+    effMock.resolveEnsureLoaded!()
+    await flushPromises()
+
+    // selectedModel bleibt der explizite Pick, nicht der Kanon-Default.
+    expect(picker.props('modelValue')).toEqual(picked)
+    expect(picker.props('modelValue')).not.toEqual(kanonAiRef)
+
+    // modelOverridden===true: workspaceDefaultHint wird NICHT gerendert.
+    expect(w.html()).not.toContain('WORKSPACE_DEFAULT_HINT')
+
+    // Picker-Pick ist transient — setGlobalSelection nicht beruehrt.
+    expect(effMock.setGlobalSelection).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/views/__tests__/LlmProvidersView.spec.ts
+++ b/frontend/src/views/__tests__/LlmProvidersView.spec.ts
@@ -13,8 +13,8 @@
  *  4. Workspace-Default-Card sichtbar
  *  5. AiModelPicker in der Default-Card
  *  6. defaultRoute computed zeigt aktuelle Route (Provider-ID + Model)
- *  7. AiModelPicker-Update mit AiModelRef → adapter.toLlmRoute → setGlobalDefault
- *  8. AiModelPicker-Update mit null → kein setGlobalDefault-Aufruf
+ *  7. AiModelPicker-Update mit AiModelRef → effectiveModel.setGlobalSelection (setGlobalDefault + setActiveLlmConfig-Gleichschritt)
+ *  8. AiModelPicker-Update mit null → kein setGlobalSelection (kein Schreibpfad)
  *  9. onMounted: loadProviders + loadConnections + defaultsStore.load
  * 10. onBeforeUnmount: loescht alle drafts
  * 11. statusTone: connected → 'green', error → 'red', unsupported → 'gray'
@@ -28,7 +28,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
-import { reactive } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import LlmProvidersView from '../Settings/LlmProvidersView.vue'
 
 // AiModelPicker mocken — Glue-Code, nicht Picker-Logik
@@ -121,6 +121,21 @@ const adapterMock = {
   })),
 }
 
+// Kanon-First-Composable mocken (Option A). Die View ruft beim Picker-Pick
+// ausschliesslich effectiveModel.setGlobalSelection(aiRef); die Internas
+// (adapter.toLlmRoute, defaultsStore.setGlobalDefault, setActiveLlmConfig)
+// werden in useEffectiveModelSelection.spec.ts geprueft, nicht hier.
+// Ohne diesen Mock wuerde setActiveLlmConfig einen echten Network-Call feuern
+// (AxiosError "Backend offline", siehe Scout-Finding F1).
+const effectiveModelMock = {
+  effectiveRef: computed(() => adapterMock.toAiModelRef(defaultsStoreMock.globalDefault ?? { provider_id: null, model: null })),
+  effectiveRoute: computed(() => defaultsStoreMock.globalDefault),
+  loading: ref(false),
+  error: ref<string | null>(null),
+  ensureLoaded: vi.fn().mockResolvedValue(undefined),
+  setGlobalSelection: vi.fn().mockResolvedValue(undefined),
+}
+
 vi.mock('@/store/aiModels', () => ({
   useLlmProvidersStore: () => providersStoreMock,
   useLlmRoutingDefaultsStore: () => defaultsStoreMock,
@@ -128,6 +143,10 @@ vi.mock('@/store/aiModels', () => ({
 
 vi.mock('@/composables/useAiModelRefAdapter', () => ({
   useAiModelRefAdapter: () => adapterMock,
+}))
+
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => effectiveModelMock,
 }))
 
 function makeI18n() {
@@ -202,6 +221,8 @@ async function mountView(initial: {
   defaultsStoreMock.load.mockClear()
   adapterMock.toLlmRoute.mockClear()
   adapterMock.toAiModelRef.mockClear()
+  effectiveModelMock.setGlobalSelection.mockClear()
+  effectiveModelMock.ensureLoaded.mockClear()
 
   const i18n = makeI18n()
   const pinia = createPinia()
@@ -272,32 +293,30 @@ describe('LlmProvidersView (Slice 5.4, AiModelPicker-Migration)', () => {
     expect(defaultSpan.text()).toContain('gpt-4o-mini')
   })
 
-  it('AiModelPicker-Update mit AiModelRef → adapter.toLlmRoute → setGlobalDefault', async () => {
+  it('AiModelPicker-Update -> effectiveModel.setGlobalSelection (Kanon + active-config-Gleichschritt)', async () => {
     const w = await mountView()
     const picker = w.findComponent(aiPickerStub)
     expect(picker.exists()).toBe(true)
     await picker.trigger('click')
-    expect(adapterMock.toLlmRoute).toHaveBeenCalledWith({
+    // Kanon-First: die View delegiert an effectiveModel.setGlobalSelection,
+    // welche intern setGlobalDefault + setActiveLlmConfig im Gleichschritt
+    // ausfuehrt. Composable-Internas werden hier nicht mehr assertiert.
+    expect(effectiveModelMock.setGlobalSelection).toHaveBeenCalledWith({
       provider_connection_id: 'conn-openai-1',
       model_id: 'gpt-4o-mini',
       source: 'explicit',
     })
-    expect(defaultsStoreMock.setGlobalDefault).toHaveBeenCalledWith({
-      stage: null,
-      provider_id: 'openai',
-      model: 'gpt-4o-mini',
-      temperature: null,
-      max_tokens: null,
-      reasoning_effort: 'none',
-      provider_options: {},
-    })
+    // Schreibpfad ausschliesslich ueber den Composable — kein direktes
+    // Store-Geschreibe aus der View heraus.
+    expect(defaultsStoreMock.setGlobalDefault).not.toHaveBeenCalled()
   })
 
-  it('AiModelPicker-Update mit null → kein setGlobalDefault', async () => {
+  it('AiModelPicker-Update mit null -> kein setGlobalSelection (kein Schreibpfad)', async () => {
     const w = await mountView()
     const picker = w.findComponent(aiPickerStub)
     // Emit null direkt (Stub emittiert hardcoded, daher manuell)
     await picker.vm.$emit('update:modelValue', null)
+    expect(effectiveModelMock.setGlobalSelection).not.toHaveBeenCalled()
     expect(defaultsStoreMock.setGlobalDefault).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsGeneralView.spec.ts
@@ -1,36 +1,71 @@
 /**
- * SettingsGeneralView — Spec-Tests fuer Slice 5.4 Pilot-Abschluss.
+ * SettingsGeneralView — Spec-Tests fuer Phase-1 Kanon-First-Konsolidierung.
  *
- * Die View wurde in Slice 5.2 als Pilot auf AiModelPicker migriert, hatte
- * aber keinen Persistenz-Anschluss an den Workspace-Default-Store. Slice
- * 5.4 schliesst das:
- *  - AiModelPicker-Update -> useAiModelRefAdapter -> setGlobalDefault
- *  - Initial-Wert aus defaultsStore.globalDefault (via Adapter)
- *  - i18n-Keys veredelt (settings.v4.general.workspaceDefaultModel)
+ * Phase-1 Root-Cause-Fix (frontend-next): Die View nutzt AUSSCHLIESSLICH
+ * {@link useEffectiveModelSelection} als einzigen Selektions- und Persistenzpfad.
+ * Kanon = `routing/defaults.global_default`, repraesentiert als `AiModelRef`.
+ * `setGlobalSelection` schreibt Kanon zuerst UND `active-config` im Gleichschritt.
+ *
+ * Entfernte Senken, die hier NICHT mehr assertet werden duerfen:
+ *  - `STORAGE_HOME_AI_REF` / `STORAGE_HERO_AI_REF` / `STORAGE_REPORT_AI_REF`
+ *  - `saveLlmActive` / direktes `setDefault`-Store-Geschreibe
+ *  - separate `active-config`-Dropdowns in der View
  *
  * Coverage:
  *  1. mountet ohne Crash
- *  2. zeigt BREADCRUMBS
- *  3. zeigt PageHeader mit title + subtitle
- *  4. LlmProfileManager sichtbar
- *  5. AiModelPicker sichtbar
- *  6. i18n-Key: settings.v4.general.workspaceDefaultModel
- *  7. Capability-Filter: Picker bekommt mode='chat'
- *  8. allowWorkspaceDefault=true
- *  9. onMount: defaultsStore.load()
- * 10. initialer Picker-Wert aus defaultsStore.globalDefault (via Adapter)
- * 11. AiModelPicker-Update mit AiModelRef -> adapter.toLlmRoute -> setGlobalDefault
- * 12. AiModelPicker-Update mit null: keine setGlobalDefault-Aktion
- * 13. AiModelPicker hat eindeutige ID ('settings-general-model-picker')
- * 14. SettingsSectionPanel sichtbar
+ *  2. ensureLoaded wird onMount aufgerufen; View mountet auch bei
+ *     ensureLoaded-reject ohne Crash (selectedModel bleibt null)
+ *  3. zeigt BREADCRUMBS
+ *  4. zeigt PageHeader mit title + subtitle
+ *  5. LlmProfileManager sichtbar
+ *  6. AiModelPicker sichtbar
+ *  7. i18n-Key: settings.v4.general.workspaceDefaultModel
+ *  8. Capability-Filter: Picker bekommt mode='chat'
+ *  9. allowWorkspaceDefault=true
+ * 10. onMount: effectiveModel.ensureLoaded()
+ * 11. initialer Picker-Wert aus effectiveModel.effectiveRef (Kanon)
+ * 12. AiModelPicker-Update -> effectiveModel.setGlobalSelection
+ *     (Kanon + active-config-Gleichschritt)
+ * 13. AiModelPicker-Update mit null: keine setGlobalSelection-Aktion
+ * 14. AiModelPicker hat eindeutige ID ('settings-general-model-picker')
+ * 15. SettingsSectionPanel sichtbar
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
-import { ref, reactive } from 'vue'
-import { listLlmProviders } from '@/api/llmRouting'
+import { ref } from 'vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
 import SettingsGeneralView from '../Settings/SettingsGeneralView.vue'
+
+// --- Composable-Mock (Kanon-First). Die View beruehrt Store/Adapter/llmRouting
+//     NICHT direkt — alles geht durch useEffectiveModelSelection. Daher mocken
+//     wir ausschliesslich das Composable mit steuerbarem State.
+const ensureLoadedMock = vi.fn()
+const setGlobalSelectionMock = vi.fn()
+const effectiveRef = ref<AiModelRef | null>(null)
+const effectiveRoute = ref({
+  stage: null,
+  provider_id: 'openai',
+  model: 'gpt-4o-mini',
+  temperature: null,
+  max_tokens: null,
+  reasoning_effort: 'none',
+  provider_options: {},
+})
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef,
+    effectiveRoute,
+    loading,
+    error,
+    ensureLoaded: ensureLoadedMock,
+    setGlobalSelection: setGlobalSelectionMock,
+  }),
+}))
 
 // AiModelPicker mocken
 const aiPickerStub = {
@@ -56,50 +91,6 @@ const settingsSectionPanelStub = {
   props: ['allowedSections'],
   template: '<div data-testid="settings-section-panel" />',
 }
-
-const loadMock = vi.fn()
-const setGlobalDefaultMock = vi.fn()
-let globalDefaultRef: unknown = null
-
-vi.mock('@/store/aiModels', () => ({
-  useLlmRoutingDefaultsStore: () => ({
-    get globalDefault() { return globalDefaultRef },
-    load: loadMock,
-    setGlobalDefault: setGlobalDefaultMock,
-  }),
-}))
-
-const adapterMock = {
-  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
-    stage: null,
-    provider_id: 'openai',
-    model: aiRef.model_id,
-    temperature: null,
-    max_tokens: null,
-    reasoning_effort: 'none',
-    provider_options: {},
-  })),
-  toAiModelRef: vi.fn((route: { provider_id?: string | null; model?: string | null }) => ({
-    provider_connection_id: route.provider_id ?? 'conn-fallback',
-    model_id: route.model ?? '',
-    source: 'workspace-default' as const,
-  })),
-}
-
-vi.mock('@/composables/useAiModelRefAdapter', () => ({
-  useAiModelRefAdapter: () => adapterMock,
-}))
-
-vi.mock('@/api/llmRouting', () => ({
-  listLlmProviders: vi.fn().mockResolvedValue([
-    { id: 'ollama', label: 'Ollama' },
-  ]),
-  listProviderModels: vi.fn().mockResolvedValue([
-    { id: 'qwen3', label: 'Qwen 3' },
-  ]),
-  getActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'ollama', model: 'qwen3' }),
-  setActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'ollama', model: 'qwen3' }),
-}))
 
 function makeI18n() {
   return createI18n({
@@ -142,14 +133,12 @@ function makeI18n() {
   })
 }
 
-async function mountSettingsGeneral(initial: { globalDefault?: unknown } = {}) {
-  globalDefaultRef = initial.globalDefault ?? null
-  loadMock.mockClear()
-  loadMock.mockResolvedValue(undefined)
-  setGlobalDefaultMock.mockClear()
-  setGlobalDefaultMock.mockResolvedValue(undefined)
-  adapterMock.toLlmRoute.mockClear()
-  adapterMock.toAiModelRef.mockClear()
+async function mountSettingsGeneral(initial: { effectiveRef?: AiModelRef | null } = {}) {
+  effectiveRef.value = initial.effectiveRef ?? null
+  ensureLoadedMock.mockClear()
+  ensureLoadedMock.mockResolvedValue(undefined)
+  setGlobalSelectionMock.mockClear()
+  setGlobalSelectionMock.mockResolvedValue(undefined)
 
   const i18n = makeI18n()
   const pinia = createPinia()
@@ -170,9 +159,10 @@ async function mountSettingsGeneral(initial: { globalDefault?: unknown } = {}) {
   return wrapper
 }
 
-describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () => {
+describe('SettingsGeneralView (Phase-1, Kanon-First via useEffectiveModelSelection)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    effectiveRef.value = null
   })
 
   it('mountet ohne Crash', async () => {
@@ -180,12 +170,14 @@ describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () =
     expect(w.exists()).toBe(true)
   })
 
-  it('behält den Provider-Discovery-Fehler, wenn active-config und Modelle laden', async () => {
-    vi.mocked(listLlmProviders).mockRejectedValueOnce(new Error('Provider-Discovery fehlgeschlagen'))
-
+  it('ensureLoaded wird onMount aufgerufen; View mountet auch bei ensureLoaded-reject ohne Crash', async () => {
+    ensureLoadedMock.mockRejectedValueOnce(new Error('ensureLoaded fehlgeschlagen'))
     const w = await mountSettingsGeneral()
-
-    expect(w.get('[role="alert"]').text()).toContain('Provider-Discovery fehlgeschlagen')
+    expect(w.exists()).toBe(true)
+    expect(ensureLoadedMock).toHaveBeenCalled()
+    // Bei Reject bleibt selectedModel null (Picker zeigt nichts gewaehltes).
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.props('modelValue')).toBeNull()
   })
 
   it('zeigt BREADCRUMBS via AppShell', async () => {
@@ -230,48 +222,42 @@ describe('SettingsGeneralView (Slice 5.4, Pilot-Abschluss mit Persistenz)', () =
     expect(picker.props('allowWorkspaceDefault')).toBe(true)
   })
 
-  it('onMount: defaultsStore.load()', async () => {
+  it('onMount: effectiveModel.ensureLoaded()', async () => {
     await mountSettingsGeneral()
-    expect(loadMock).toHaveBeenCalled()
+    expect(ensureLoadedMock).toHaveBeenCalled()
   })
 
-  it('initialer Picker-Wert aus defaultsStore.globalDefault (via Adapter)', async () => {
-    const w = await mountSettingsGeneral({
-      globalDefault: { provider_id: 'ollama', model: 'qwen3', temperature: null, max_tokens: null, reasoning_effort: 'none', provider_options: {} },
-    })
-    const picker = w.findComponent(aiPickerStub)
-    expect(picker.exists()).toBe(true)
-    // adapter.toAiModelRef wurde fuer die Initial-Konvertierung aufgerufen
-    expect(adapterMock.toAiModelRef).toHaveBeenCalled()
-  })
-
-  it('AiModelPicker-Update mit AiModelRef -> adapter.toLlmRoute -> setGlobalDefault', async () => {
-    const w = await mountSettingsGeneral()
-    const picker = w.findComponent(aiPickerStub)
-    ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', {
+  it('initialer Picker-Wert aus effectiveModel.effectiveRef (Kanon)', async () => {
+    const initial: AiModelRef = {
       provider_connection_id: 'conn-openai-1',
       model_id: 'gpt-4o-mini',
       source: 'workspace-default',
-    })
-    await flushPromises()
-    expect(adapterMock.toLlmRoute).toHaveBeenCalled()
-    expect(setGlobalDefaultMock).toHaveBeenCalledWith({
-      stage: null,
-      provider_id: 'openai',
-      model: 'gpt-4o-mini',
-      temperature: null,
-      max_tokens: null,
-      reasoning_effort: 'none',
-      provider_options: {},
-    })
+    }
+    const w = await mountSettingsGeneral({ effectiveRef: initial })
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.exists()).toBe(true)
+    expect(picker.props('modelValue')).toEqual(initial)
   })
 
-  it('AiModelPicker-Update mit null: keine setGlobalDefault-Aktion', async () => {
+  it('AiModelPicker-Update -> effectiveModel.setGlobalSelection (Kanon + active-config-Gleichschritt)', async () => {
+    const w = await mountSettingsGeneral()
+    const picker = w.findComponent(aiPickerStub)
+    const emitted: AiModelRef = {
+      provider_connection_id: 'conn-openai-1',
+      model_id: 'gpt-4o-mini',
+      source: 'workspace-default',
+    }
+    ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', emitted)
+    await flushPromises()
+    expect(setGlobalSelectionMock).toHaveBeenCalledWith(emitted)
+  })
+
+  it('AiModelPicker-Update mit null: keine setGlobalSelection-Aktion', async () => {
     const w = await mountSettingsGeneral()
     const picker = w.findComponent(aiPickerStub)
     ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', null)
     await flushPromises()
-    expect(setGlobalDefaultMock).not.toHaveBeenCalled()
+    expect(setGlobalSelectionMock).not.toHaveBeenCalled()
   })
 
   it('AiModelPicker hat eindeutige ID', async () => {

--- a/frontend/src/views/__tests__/SettingsSubViews.spec.ts
+++ b/frontend/src/views/__tests__/SettingsSubViews.spec.ts
@@ -14,10 +14,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
 import { SettingsSectionSchema } from '@/contracts/settingsContract'
-import {
-  getActiveLlmConfig,
-  setActiveLlmConfig,
-} from '@/api/llmRouting'
+import type { AiModelRef } from '@/contracts/aiModelRef'
 
 import de from '@/i18n/locales/de.json'
 import en from '@/i18n/locales/en.json'
@@ -81,6 +78,22 @@ vi.mock('@/api/llmRouting', () => ({
   setActiveLlmConfig: vi.fn().mockResolvedValue({ provider_id: 'openai', model: 'gpt-4o-mini' }),
 }))
 
+const ensureLoadedMock = vi.fn().mockResolvedValue(undefined)
+const setGlobalSelectionMock = vi.fn().mockResolvedValue(undefined)
+const effectiveGeneralRef: { value: AiModelRef | null } = {
+  value: { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3', source: 'workspace-default' },
+}
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: effectiveGeneralRef,
+    effectiveRoute: { value: { provider_connection_id: 'conn-ollama-1', model_id: 'qwen3' } },
+    loading: { value: false },
+    error: { value: null },
+    ensureLoaded: ensureLoadedMock,
+    setGlobalSelection: setGlobalSelectionMock,
+  }),
+}))
+
 import SettingsGeneralView from '../Settings/SettingsGeneralView.vue'
 import SettingsIntegrationsView from '../Settings/SettingsIntegrationsView.vue'
 import SettingsUsersTeamsView from '../Settings/SettingsUsersTeamsView.vue'
@@ -129,23 +142,17 @@ describe('Settings-Section-Parität (Slice 7.4a)', () => {
     expect([...new Set(mappedSections)].sort()).toEqual([...SettingsSectionSchema.options].sort())
   })
 
-  it('erhält den separaten active-config-Lade- und Speicherpfad im General-Surface', async () => {
+  it('erhält den Kanon-First-Initialisierungs- und Speicherpfad im General-Surface', async () => {
     const w = await mountView(SettingsGeneralView, '/settings/general')
 
-    expect(getActiveLlmConfig).toHaveBeenCalled()
-    expect((w.get('#settings-active-provider').element as HTMLSelectElement).value).toBe('ollama')
-    expect((w.get('#settings-active-model').element as HTMLSelectElement).value).toBe('qwen3')
-
-    await w.get('#settings-active-provider').setValue('openai')
-    await flushPromises()
-    await w.get('#settings-active-model').setValue('gpt-4o-mini')
-    await w.get('.settings-general__active-save').trigger('click')
-    await flushPromises()
-
-    expect(setActiveLlmConfig).toHaveBeenCalledWith({
-      provider_id: 'openai',
-      model: 'gpt-4o-mini',
-    })
+    // Kanon-First-Init: effectiveModel.ensureLoaded() wird beim Mount aufgerufen
+    expect(ensureLoadedMock).toHaveBeenCalled()
+    // Entfernte separate Active-LLM-Config-Sektion existiert nicht mehr
+    expect(w.find('#settings-active-provider').exists()).toBe(false)
+    expect(w.find('#settings-active-model').exists()).toBe(false)
+    expect(w.find('.settings-general__active-save').exists()).toBe(false)
+    // Stattdessen: kanonischer AiModelPicker ist sichtbar
+    expect(w.find('.ai-model-picker-stub').exists()).toBe(true)
   })
 })
 

--- a/frontend/src/views/v4/__tests__/HistoryView.spec.ts
+++ b/frontend/src/views/v4/__tests__/HistoryView.spec.ts
@@ -6,7 +6,7 @@
  * 2. PageHeader rendert title="Verlauf" + subtitle.
  * 3. HistoryDatabase wird eingebunden.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
@@ -42,9 +42,24 @@ const router = makeTestRouter([
 const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
 
 describe('HistoryView (v4)', () => {
+  // Still async console-output (Vue/jdom warnings) during jsdom environment
+  // teardown. Without this, a pending console callback at worker-rpc close can
+  // trigger a flaky "EnvironmentTeardownError: Closing rpc while onUserConsoleLog
+  // was pending" race in the full suite. Test assertions are unaffected.
+  let consoleSpies: Array<ReturnType<typeof vi.spyOn>> = []
+
   beforeEach(() => {
     lsMock.clear()
     setActivePinia(createPinia())
+    consoleSpies = [
+      vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      vi.spyOn(console, 'error').mockImplementation(() => {}),
+    ]
+  })
+
+  afterEach(() => {
+    consoleSpies.forEach((s) => s.mockRestore())
+    consoleSpies = []
   })
 
   it('mountet ohne Crash', async () => {

--- a/frontend/tests/e2e/golden-gate-accessibility.spec.ts
+++ b/frontend/tests/e2e/golden-gate-accessibility.spec.ts
@@ -79,7 +79,7 @@ test.describe('Slice 7.2 · Golden-Gate Accessibility Gates', () => {
       await page.getByTestId(LlmRoutingTestId.runId).fill('run_e2e_accessibility');
 
       // Warte bis Picker gerendert ist
-      await page.getByTestId('ai-model-picker').waitFor({ timeout: 5000 });
+      await page.getByTestId('ai-model-picker').first().waitFor({ timeout: 5000 });
 
       // axe-core
       const axeResults = await runAxe(page);


### PR DESCRIPTION
## Root-Cause-Fix der divergierenden Modellwahl-Senken

**Problem:** Mehrere Frontend-Flächen schrieben in unabhängige, server-seitig NICHT synchrone Senken (`active-config`, `routing/defaults.global`, drei `agora.*.aiModelRef`-localStorage-Keys). Zwei Runtime-Pfade lasen verschiedene Quellen — `llm/client.py` → `active-config`, `stage_model_router.py` → `routing/defaults.global_default`.

**Kanon:** `routing/defaults.global_default` als `AiModelRef` via neues `useEffectiveModelSelection`-Composable. `active-config` wird beim Schreiben im Gleichschritt mitgezogen (kein Backend-Touch, reiner FE-Sync). Reinere SSoT (Backend-Delegation) ist separates Folge-Slice.

## Änderungen

- **Neues Composable** `frontend/src/composables/useEffectiveModelSelection.ts` — `effectiveRef/effectiveRoute/ensureLoaded/setGlobalSelection`. Schreibpfad: Kanon zuerst (`setGlobalDefault`), dann `setActiveLlmConfig` für Gleichschritt.
- **6 Flächen auf Kanon-First-Init umgestellt:** `SettingsGeneralView.vue` (Komplettumschreibung, separate Active-LLM-Config-Sektion entfernt), `SettingsView.vue`, `LlmProvidersView.vue`, `HeroNewRun.vue`, `Home.vue`, `Step4Report.vue`.
- **Entfernte Senken:** `STORAGE_HOME_AI_REF`, `STORAGE_HERO_AI_REF`, `STORAGE_REPORT_AI_REF`, separate Active-LLM-Config-Dropdowns, `saveLlmActive`.
- **`Home.vue`:** `modelOverridden`-Flag statt `selectedModel !== null` als Proxy für „User hat explizit gewählt" im Ollama-Reachability-Gate (Kanon-Vorbelegung würde den alten Proxy brechen).

## Verifikation

- `bun run typecheck` — exit 0
- `bun run lint` — exit 0
- 101/101 Specs grün (`useEffectiveModelSelection` 12 + 8 Flächen-Specs umgeschrieben)
- 22 test gaps identifiziert (CRG) — nicht alle durch Specs abgedeckt, aber kein Verhaltensbruch

## Docs

- `docs/epics/frontend-next/PHASE-1-DIVERGENZ.md` — Divergenz-Tabelle der 5 Senken + 2 Runtime-Pfade
- `docs/epics/frontend-next/HANDOVER.md` — Übergabe-Kontext
- `docs/epics/frontend-next/PHASE-1-2-OPUS-HANDOVER.md` — vollständiger Phase-1+2-Brief
- `docs/epics/frontend-next/HANDOVER-GLM-MMX.md` — Übergabe an Folge-Sessions (MiniMax/GLM)
- `docs/epics/frontend-next/PHICE-5-VERIFICATION-HANDOVER.md` — Verifikations-Notizen

## Folge-PR (separat)

- `docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` — `EnvSetupModelPanel.vue`/Step2EnvSetup ist reine Präsentationskomponente, Eltern-Container muss konsolidiert werden (Profile → optionale Presets, kein eigener aktiver State).

## Phase 2 (separater Plan)

Onboarding React→Vue — Design-Konflikt vorab klären (Vue-Onboarding nutzt bewusst „Statusschritte" statt React-Inline-Flow). Jede Modellwahl im Onboarding muss den Phase-1-Composable nutzen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)