### PR TITLE
feat(frontend): Onboarding Phase 2 — Statusschritt-Granularität + Skip-Button

### DIFF
--- a/frontend/src/views/onboarding/OnboardingView.vue
+++ b/frontend/src/views/onboarding/OnboardingView.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
 /**
- * OnboardingView — resumierbarer Erst-Einrichtungs-Wizard (Onboarding Slice 2).
+ * OnboardingView — resumierbarer Erst-Einrichtungs-Wizard (Onboarding Slice 2
+ * + Phase-2-Verfeinerung frontend-next).
  *
  * `providers`/`chat_model`/`embeddings` sind bewusst ehrliche Statusschritte:
- * sie zeigen den realen `requirements`-Status und verlinken auf die
+ * sie zeigen den realen Konfigurations-Status und verlinken auf die
  * bestehenden Settings-Routen. Die geführte Einrichtung folgt in einem
  * späteren Update — hier gibt es keine Attrappen.
+ *
+ * Phase 2 Granularität (§3.2.1): `providers` wertet den Connection-Store
+ * aus (mindestens eine ProviderConnection existiert), nicht das
+ * `chat_model_configured`-Flag. `chat_model` und `embeddings` bleiben am
+ * Backend-Requirements-Flag. Damit sind `providers` und `chat_model`
+ * nicht mehr redundant und der Status entspricht der echten Konfiguration.
+ *
+ * Phase 2 Skip-Button (§3.2.4): Auf Statusschritten wird der "Weiter"-
+ * Button ausgeblendet, solange der jeweilige Step nicht `configured()` ist.
+ * Sonst markiert ein voreilig geklickter "Weiter"-Button den Step als
+ * completed, obwohl keine Einrichtung stattgefunden hat. Der "Später
+ * einrichten"-Footer bleibt sichtbar als ehrlicher Ausweg.
  */
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -17,6 +30,7 @@ import Button from '@/components/v4/forms/Button.vue'
 import ProfileForm from '@/components/v4/forms/ProfileForm.vue'
 import { isApiError } from '@/api/envelope'
 import { useUserProfileStore } from '@/store/userProfile'
+import { useLlmProvidersStore } from '@/store/aiModels'
 import { ONBOARDING_STEP_ORDER } from '@/contracts/userProfileContract'
 import type {
   OnboardingStepId,
@@ -27,6 +41,7 @@ import type {
 const { t } = useI18n()
 const router = useRouter()
 const store = useUserProfileStore()
+const providersStore = useLlmProvidersStore()
 
 const OPERATING_MODES: readonly OperatingMode[] = ['local', 'hybrid', 'server']
 
@@ -73,7 +88,11 @@ const statusSteps = computed<StatusStepConfig[]>(() => [
     futureNoticeKey: 'onboarding.providers.futureNotice',
     settingsLinkKey: 'onboarding.providers.settingsLink',
     settingsRouteName: 'SettingsLlmProviders',
-    configured: () => store.onboarding.requirements?.chat_model_configured ?? false,
+    // Phase 2 §3.2.1: providers zeigt Connection-Store-Status (mindestens
+    // eine ProviderConnection existiert), nicht das redundante
+    // `chat_model_configured`-Flag. Voraussetzung: onMounted ruft
+    // `providersStore.loadConnections()` (fail-open per .catch).
+    configured: () => Object.keys(providersStore.connections).length > 0,
   },
   {
     step: 'chat_model',
@@ -247,7 +266,15 @@ async function handleDismiss(): Promise<void> {
 }
 
 onMounted(async () => {
-  await store.ensureLoaded()
+  // Phase 2 §3.2.1: `providers.configured()` braucht den Connection-Store.
+  // Parallel zu `ensureLoaded()` laden, fail-open per `.catch` (bei
+  // Provider-Endpoint-Fehler bleibt `connections = {}` und der providers-
+  // Step zeigt ehrlich "pending" — der User klickt sich dann zu den
+  // Settings und sieht dort den realen Stand).
+  await Promise.all([
+    store.ensureLoaded(),
+    providersStore.loadConnections().catch(() => undefined),
+  ])
   viewStep.value = store.onboarding.state?.current_step ?? 'welcome'
   selectedOperatingMode.value = store.onboarding.state?.operating_mode ?? null
 })
@@ -431,7 +458,7 @@ onMounted(async () => {
           </Button>
 
           <Button
-            v-else-if="activeStatusStep"
+            v-else-if="activeStatusStep && activeStatusStep.configured()"
             variant="primary"
             type="button"
             :disabled="busy"

--- a/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
+++ b/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
@@ -20,6 +20,7 @@ import { ApiError } from '@/api/envelope'
 import de from '@/i18n/locales/de.json'
 import en from '@/i18n/locales/en.json'
 import type { OnboardingState, OnboardingStatusResponse, UserProfile } from '@/contracts/userProfileContract'
+import type { ProviderConnection } from '@/contracts/aiProviderContract'
 
 vi.mock('@/api/profile', () => ({
   getProfile: vi.fn(),
@@ -70,7 +71,7 @@ const _getOnboardingStatus = getOnboardingStatus as unknown as MockFn
 const _completeOnboardingStep = completeOnboardingStep as unknown as MockFn
 const _completeOnboarding = completeOnboarding as unknown as MockFn
 const _dismissOnboarding = dismissOnboarding as unknown as MockFn
-const _listProviderConnections = listProviderConnections as unknown as MockFn
+const _listProviderConnections = vi.mocked(listProviderConnections)
 
 function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
   return {
@@ -114,6 +115,26 @@ function makeOnboardingStatus(
       embedding_source: 'none',
     },
     onboarding_required: true,
+    ...overrides,
+  }
+}
+
+function makeProviderConnection(overrides: Partial<ProviderConnection> = {}): ProviderConnection {
+  return {
+    id: 'test-connection-1',
+    provider_kind: 'ollama',
+    display_name: 'Test Ollama',
+    transport: 'local',
+    auth_mode: 'none',
+    base_url: null,
+    enabled: true,
+    status: 'connected',
+    status_message: null,
+    secret_ref: null,
+    capabilities: {},
+    created_at: null,
+    updated_at: null,
+    last_tested_at: null,
     ...overrides,
   }
 }
@@ -367,7 +388,7 @@ describe('OnboardingView', () => {
       }),
     )
     // … aber es existiert (noch) keine konfigurierte Provider-Connection.
-    _listProviderConnections.mockResolvedValue({ items: [] })
+    _listProviderConnections.mockResolvedValue({ items: [], total: 0 })
 
     const { wrapper } = await mountView()
     // providers.configured() wertet connections aus, nicht chat_model_configured.
@@ -389,7 +410,7 @@ describe('OnboardingView', () => {
         }),
       }),
     )
-    _listProviderConnections.mockResolvedValue({ items: [] })
+    _listProviderConnections.mockResolvedValue({ items: [], total: 0 })
 
     const { wrapper } = await mountView()
     const nextBtn = wrapper
@@ -409,7 +430,7 @@ describe('OnboardingView', () => {
         }),
       }),
     )
-    _listProviderConnections.mockResolvedValue({ items: [{ id: 'p1' }] })
+    _listProviderConnections.mockResolvedValue({ items: [makeProviderConnection({ id: 'p1' })], total: 1 })
 
     const { wrapper } = await mountView()
     const nextBtn = wrapper

--- a/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
+++ b/frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts
@@ -35,6 +35,10 @@ vi.mock('@/api/profile', () => ({
   avatarUrl: vi.fn(() => null),
 }))
 
+vi.mock('@/api/providerConnections', () => ({
+  listProviderConnections: vi.fn(),
+}))
+
 vi.mock('@/components/v4/shell/AppShell.vue', () => ({
   default: {
     name: 'AppShell',
@@ -57,6 +61,7 @@ import {
   getOnboardingStatus,
   getProfile,
 } from '@/api/profile'
+import { listProviderConnections } from '@/api/providerConnections'
 import OnboardingView from '../OnboardingView.vue'
 
 type MockFn = ReturnType<typeof vi.fn>
@@ -65,6 +70,7 @@ const _getOnboardingStatus = getOnboardingStatus as unknown as MockFn
 const _completeOnboardingStep = completeOnboardingStep as unknown as MockFn
 const _completeOnboarding = completeOnboarding as unknown as MockFn
 const _dismissOnboarding = dismissOnboarding as unknown as MockFn
+const _listProviderConnections = listProviderConnections as unknown as MockFn
 
 function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
   return {
@@ -334,5 +340,81 @@ describe('OnboardingView', () => {
     expect(document.activeElement).toBe(heading.element)
     wrapper.unmount()
     host.remove()
+  })
+
+  // Phase 2 Onboarding-Verfeinerung: Granularität + Skip-Button.
+  //
+  // Granularität: providers zeigt den Connection-Store-Status (nicht
+  // chat_model_configured). chat_model und embeddings bleiben am
+  // Backend-Requirements-Flag. providers und chat_model sind damit
+  // nicht mehr redundant.
+  it('Test 11: providers-Step zeigt pending, wenn keine Connections geladen — auch wenn chat_model_configured=true', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'providers',
+          completed_steps: ['welcome'],
+          operating_mode: 'local',
+        }),
+        requirements: {
+          profile_valid: false,
+          // Model ist bereits global gesetzt …
+          chat_model_configured: true,
+          embedding_configured: false,
+          embedding_source: 'none',
+        },
+      }),
+    )
+    // … aber es existiert (noch) keine konfigurierte Provider-Connection.
+    _listProviderConnections.mockResolvedValue({ items: [] })
+
+    const { wrapper } = await mountView()
+    // providers.configured() wertet connections aus, nicht chat_model_configured.
+    expect(wrapper.text()).toContain(de.onboarding.providers.notConfigured)
+    expect(wrapper.text()).not.toContain(de.onboarding.providers.configured)
+  })
+
+  // Skip-Button: auf Statusschritten nur sichtbar, wenn der Step
+  // tatsächlich configured ist. Sonst markiert ein voreilig geklickter
+  // "Weiter"-Button den Step als completed, obwohl nichts eingerichtet ist.
+  it('Test 12: providers-Step blendet Weiter-Button aus, solange providers.configured() === false', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'providers',
+          completed_steps: ['welcome'],
+          operating_mode: 'local',
+        }),
+      }),
+    )
+    _listProviderConnections.mockResolvedValue({ items: [] })
+
+    const { wrapper } = await mountView()
+    const nextBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text() === de.onboarding.wizard.nextBtn)
+    expect(nextBtn).toBeFalsy()
+  })
+
+  it('Test 13: providers-Step zeigt Weiter-Button, sobald Connections geladen sind', async () => {
+    _getProfile.mockResolvedValue(null)
+    _getOnboardingStatus.mockResolvedValue(
+      makeOnboardingStatus({
+        state: makeOnboardingState({
+          current_step: 'providers',
+          completed_steps: ['welcome'],
+          operating_mode: 'local',
+        }),
+      }),
+    )
+    _listProviderConnections.mockResolvedValue({ items: [{ id: 'p1' }] })
+
+    const { wrapper } = await mountView()
+    const nextBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text() === de.onboarding.wizard.nextBtn)
+    expect(nextBtn).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Phase 2 — Onboarding-Verfeinerung (frontend-next)

Vue-Onboarding Phase 2 nach PHASE-2-ONBOARDING-HANDOVER.md §3.2. Design-Entscheidung
**A (Statusschritt beibehalten)** — kein zweiter AiModelPicker, keine Inline-Wizard-
Nachportierung. Handover-Übergabe: docs/epics/frontend-next/PHASE-2-ONBOARDING-HANDOVER.md.

### Was

**§3.2.1 Granularität:** providers wertet jetzt `useLlmProvidersStore().connections`
aus (≥ 1 Connection), statt das redundante `chat_model_configured`-Flag.
providers und chat_model sind damit nicht mehr derselbe Status.

**§3.2.4 Skip-Button:** Auf Statusschritten wird `Weiter` ausgeblendet, solange
`configured() === false`. Sonst markiert ein voreilig geklickter `Weiter` den
Step als completed, ohne dass Konfiguration stattfand. `Später einrichten`
(„dismiss") bleibt als ehrlicher Ausweg sichtbar.

### Hard Rules (frontend-next)

- KEIN zweiter AiModelPicker — Verfeinerung bleibt rein im Status-/Footer-
  Conditional. Composable `useEffectiveModelSelection` bleibt die einzige
  Schreibquelle für Modellwahlen; diese Änderung schreibt **nichts**.
- KEINE localStorage-Senken.
- i18n via vue-i18n — keine neuen Keys nötig (Visibility-only-Änderung).
- Profile-Form bleibt unverändert.

### Loading

`onMounted` lädt Profil/Onboarding-Status und Provider-Connections parallel.
Connection-Load `fail-open` per `.catch` — bei Endpoint-Fehler zeigt
providers ehrlich `pending`. Kein neues Backend-Endpoint, kein neues Pinia-
Store-Action.

### Geänderte Dateien

- `frontend/src/views/onboarding/OnboardingView.vue`
- `frontend/src/views/onboarding/__tests__/OnboardingView.spec.ts`

### Tests

- 3 neue Cases (Phase 2): Granularität, Skip-Button-Verbergung,
  Skip-Button-Sichtbarkeit.
- `bun run test`: 166/166 Files, **1444/1444 Tests** grün.
- `bun run lint`: grün.
- `bun run typecheck` (vue-tsc --noEmit): grün.
- `bun run build`: grün.
- `bash scripts/pre-push-gate.sh frontend`: **ALL GREEN — safe to push**.

### Out of Scope (bewusst)

- §3.2.2 Embedding-Legacy-Hint-Bereinigung → wartet auf
  `embedding_service.py` Gemini-Re-Embedding (Phase-F-Restpunkt #671).
- §3.2.3 Progress-Bar in % → separater Folge-Slice, baut auf §3.2.1 auf.
- §3.3 Welcome-Step zeigt effektive Auswahl (read-only) → nicht im
  aktuellen Slice; pure Modus-Auswahl bleibt unverändert.
- Inline-Mini-Picker pro Step (Option C) → bewusst nicht portiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)