### PR TITLE
fix(frontend): routing-defaults-Response mit ai_route-Anreicherung parsen

### DIFF
--- a/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
+++ b/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
@@ -77,21 +77,30 @@ describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)',
   })
 })
 
-describe('llmRoutingDefaults api client — Pfade und Payloads', () => {
+describe('llmRoutingDefaults api client — Request-Wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('ruft GET /api/llm/routing/defaults ohne Body auf', async () => {
-    serviceMock.get.mockResolvedValueOnce(enrichedEnvelope)
+  const envelope = {
+    data: {
+      global_default: globalDefault,
+      stage_overrides: {},
+      version: 1,
+    },
+  }
+
+  it('getRoutingDefaults ruft GET /api/llm/routing/defaults ohne Body auf', async () => {
+    serviceMock.get.mockResolvedValueOnce(envelope)
 
     await getRoutingDefaults()
 
+    expect(serviceMock.get).toHaveBeenCalledTimes(1)
     expect(serviceMock.get).toHaveBeenCalledWith('/api/llm/routing/defaults')
   })
 
-  it('ruft PUT /api/llm/routing/defaults mit dem vollstaendigen Payload auf', async () => {
-    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+  it('replaceRoutingDefaults sendet PUT /api/llm/routing/defaults mit dem vollen Payload', async () => {
+    serviceMock.put.mockResolvedValueOnce(envelope)
     const payload = { global_default: globalDefault, stage_overrides: {}, version: 1 }
 
     await replaceRoutingDefaults(payload)
@@ -99,94 +108,102 @@ describe('llmRoutingDefaults api client — Pfade und Payloads', () => {
     expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults', payload)
   })
 
-  it('ruft PUT /api/llm/routing/defaults/global mit der Route auf', async () => {
-    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+  it('replaceGlobalDefault sendet PUT /api/llm/routing/defaults/global mit der Route', async () => {
+    serviceMock.put.mockResolvedValueOnce(envelope)
 
     await replaceGlobalDefault(globalDefault)
 
-    expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults/global', globalDefault)
-  })
-
-  it('ruft PATCH /api/llm/routing/defaults/stages/:stageId mit der Route auf', async () => {
-    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
-
-    await patchRoutingDefaultStage('graph_build', globalDefault)
-
-    expect(serviceMock.patch).toHaveBeenCalledWith(
-      '/api/llm/routing/defaults/stages/graph_build',
+    expect(serviceMock.put).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/global',
       globalDefault,
     )
   })
 
-  it('sendet { clear: true } statt eines Route-Body, wenn die Stage-Route null ist', async () => {
-    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+  it('patchRoutingDefaultStage sendet PATCH mit der Route als Body, wenn eine Route übergeben wird', async () => {
+    serviceMock.patch.mockResolvedValueOnce(envelope)
 
-    await patchRoutingDefaultStage('graph_build', null)
+    await patchRoutingDefaultStage('ontology_generation', globalDefault)
 
-    expect(serviceMock.patch).toHaveBeenCalledWith('/api/llm/routing/defaults/stages/graph_build', {
-      clear: true,
-    })
+    expect(serviceMock.patch).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/stages/ontology_generation',
+      globalDefault,
+    )
+  })
+
+  it('patchRoutingDefaultStage sendet { clear: true }, wenn route === null (Stage-Override löschen)', async () => {
+    serviceMock.patch.mockResolvedValueOnce(envelope)
+
+    await patchRoutingDefaultStage('ontology_generation', null)
+
+    expect(serviceMock.patch).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/stages/ontology_generation',
+      { clear: true },
+    )
   })
 })
 
-describe('llmRoutingDefaults api client — unangereicherte Antworten (Backward-Compat)', () => {
+describe('llmRoutingDefaults api client — Response-Schema-Validierung', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  const plainEnvelope = {
-    data: {
-      global_default: globalDefault,
-      stage_overrides: {},
-      updated_at: '2026-07-18T01:08:56.061467Z',
-      version: 1,
-    },
-  }
-
-  it('parst eine Antwort ohne ai_route weiterhin korrekt', async () => {
-    serviceMock.get.mockResolvedValueOnce(plainEnvelope)
+  it('akzeptiert eine Antwort ohne ai_route-Feld (optional, kein enrichment nötig)', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        version: 1,
+      },
+    })
 
     const result = await getRoutingDefaults()
 
-    expect(result).toMatchObject({ version: 1 })
     expect(result.ai_route).toBeUndefined()
-  })
-})
-
-describe('llmRoutingDefaults api client — Schema-Drift (negativ)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+    expect(result.global_default).toMatchObject({ model: 'gpt-5.4-nano' })
   })
 
-  it('wirft einen typisierten Fehler, wenn das Backend global_default weglaesst', async () => {
-    serviceMock.get.mockResolvedValueOnce({ data: { stage_overrides: {}, version: 1 } })
+  it('lehnt eine Antwort ohne global_default mit "schema mismatch" ab', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: { stage_overrides: {}, version: 1 },
+    })
 
-    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/)
   })
 
-  it('wirft einen typisierten Fehler, wenn ai_route dem AiRoute-Vertrag widerspricht', async () => {
+  it('lehnt eine Antwort mit einem fehlerhaften ai_route-Block ab (source fehlt)', async () => {
     serviceMock.get.mockResolvedValueOnce({
       data: {
         global_default: globalDefault,
         stage_overrides: {},
         version: 1,
-        ai_route: { ...aiRoute, source: 'not-a-real-source' },
+        ai_route: { ...aiRoute, source: undefined },
       },
     })
 
-    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/)
   })
 
-  it('wirft einen typisierten Fehler bei unbekannten Top-Level-Keys jenseits von ai_route', async () => {
+  it('lehnt weiterhin unbekannte Top-Level-Felder außerhalb von ai_route ab', async () => {
     serviceMock.get.mockResolvedValueOnce({
       data: {
         global_default: globalDefault,
         stage_overrides: {},
         version: 1,
-        unexpected_field: 'nope',
+        unexpected_field: true,
       },
     })
 
-    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/)
+  })
+
+  it('gibt den ai_route-Block unverändert an den Aufrufer durch, wenn er vorhanden ist', async () => {
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+
+    const result = await replaceGlobalDefault(globalDefault)
+
+    expect(result.ai_route).toMatchObject({
+      source: 'workspace',
+      model_id: 'gpt-5.4-nano',
+    })
   })
 })

--- a/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
+++ b/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
@@ -75,36 +75,22 @@ describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)',
       patchRoutingDefaultStage('ontology_generation', globalDefault),
     ).resolves.toMatchObject({ version: 1 })
   })
+})
 
-  it('calls the expected backend routes with the expected payloads', async () => {
+describe('llmRoutingDefaults api client — Pfade und Payloads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('ruft GET /api/llm/routing/defaults ohne Body auf', async () => {
     serviceMock.get.mockResolvedValueOnce(enrichedEnvelope)
-    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
-    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
 
     await getRoutingDefaults()
-    await replaceGlobalDefault(globalDefault)
-    await patchRoutingDefaultStage('ontology_generation', globalDefault)
 
     expect(serviceMock.get).toHaveBeenCalledWith('/api/llm/routing/defaults')
-    expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults/global', globalDefault)
-    expect(serviceMock.patch).toHaveBeenCalledWith(
-      '/api/llm/routing/defaults/stages/ontology_generation',
-      globalDefault,
-    )
   })
 
-  it('sends { clear: true } when patching a stage default to null', async () => {
-    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
-
-    await patchRoutingDefaultStage('ontology_generation', null)
-
-    expect(serviceMock.patch).toHaveBeenCalledWith(
-      '/api/llm/routing/defaults/stages/ontology_generation',
-      { clear: true },
-    )
-  })
-
-  it('calls PUT /api/llm/routing/defaults with the full payload for replaceRoutingDefaults', async () => {
+  it('ruft PUT /api/llm/routing/defaults mit dem vollstaendigen Payload auf', async () => {
     serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
     const payload = { global_default: globalDefault, stage_overrides: {}, version: 1 }
 
@@ -113,51 +99,93 @@ describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)',
     expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults', payload)
   })
 
-  it('still parses a response without the ai_route enrichment (backward compatible)', async () => {
-    const plainEnvelope = {
-      data: {
-        global_default: globalDefault,
-        stage_overrides: {},
-        updated_at: '2026-07-18T01:08:56.061467Z',
-        version: 1,
-      },
-    }
+  it('ruft PUT /api/llm/routing/defaults/global mit der Route auf', async () => {
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+
+    await replaceGlobalDefault(globalDefault)
+
+    expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults/global', globalDefault)
+  })
+
+  it('ruft PATCH /api/llm/routing/defaults/stages/:stageId mit der Route auf', async () => {
+    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+
+    await patchRoutingDefaultStage('graph_build', globalDefault)
+
+    expect(serviceMock.patch).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/stages/graph_build',
+      globalDefault,
+    )
+  })
+
+  it('sendet { clear: true } statt eines Route-Body, wenn die Stage-Route null ist', async () => {
+    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+
+    await patchRoutingDefaultStage('graph_build', null)
+
+    expect(serviceMock.patch).toHaveBeenCalledWith('/api/llm/routing/defaults/stages/graph_build', {
+      clear: true,
+    })
+  })
+})
+
+describe('llmRoutingDefaults api client — unangereicherte Antworten (Backward-Compat)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const plainEnvelope = {
+    data: {
+      global_default: globalDefault,
+      stage_overrides: {},
+      updated_at: '2026-07-18T01:08:56.061467Z',
+      version: 1,
+    },
+  }
+
+  it('parst eine Antwort ohne ai_route weiterhin korrekt', async () => {
     serviceMock.get.mockResolvedValueOnce(plainEnvelope)
 
     const result = await getRoutingDefaults()
+
+    expect(result).toMatchObject({ version: 1 })
     expect(result.ai_route).toBeUndefined()
-    expect(result).toMatchObject({ version: 1, global_default: { model: 'gpt-5.4-nano' } })
+  })
+})
+
+describe('llmRoutingDefaults api client — Schema-Drift (negativ)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('rejects with a schema-mismatch error when a non-ai_route key is unrecognized', async () => {
-    serviceMock.get.mockResolvedValueOnce({
-      data: {
-        global_default: globalDefault,
-        stage_overrides: {},
-        version: 1,
-        ai_route: aiRoute,
-        unexpected_field: 'boom',
-      },
-    })
-
-    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
-  })
-
-  it('rejects with a schema-mismatch error when ai_route itself is malformed', async () => {
-    serviceMock.get.mockResolvedValueOnce({
-      data: {
-        global_default: globalDefault,
-        stage_overrides: {},
-        version: 1,
-        ai_route: { ...aiRoute, source: 'not_a_valid_source' },
-      },
-    })
-
-    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
-  })
-
-  it('rejects with a schema-mismatch error when global_default is missing', async () => {
+  it('wirft einen typisierten Fehler, wenn das Backend global_default weglaesst', async () => {
     serviceMock.get.mockResolvedValueOnce({ data: { stage_overrides: {}, version: 1 } })
+
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+  })
+
+  it('wirft einen typisierten Fehler, wenn ai_route dem AiRoute-Vertrag widerspricht', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        version: 1,
+        ai_route: { ...aiRoute, source: 'not-a-real-source' },
+      },
+    })
+
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+  })
+
+  it('wirft einen typisierten Fehler bei unbekannten Top-Level-Keys jenseits von ai_route', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        version: 1,
+        unexpected_field: 'nope',
+      },
+    })
 
     await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
   })

--- a/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
+++ b/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const serviceMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+}))
+
+vi.mock('../index', () => ({
+  default: serviceMock,
+}))
+
+import {
+  getRoutingDefaults,
+  patchRoutingDefaultStage,
+  replaceGlobalDefault,
+  replaceRoutingDefaults,
+} from '../llmRoutingDefaults'
+
+const globalDefault = {
+  provider_id: 'openai',
+  model: 'gpt-5.4-nano',
+  reasoning_effort: 'none' as const,
+  provider_options: {},
+}
+
+// Das Backend reichert JEDE routing/defaults-Antwort via `_with_ai_route()`
+// (backend/app/api/llm_routing.py) um einen Top-Level-`ai_route`-Key an. Der
+// Frontend-Response-Parser muss diese Anreicherung akzeptieren, statt strikt
+// mit `unrecognized_keys` abzubrechen (Regression: LlmProvidersView-Crash bei
+// Load und beim Speichern des Workspace-Defaults).
+const aiRoute = {
+  stage: null,
+  provider_connection_id: 'openai',
+  model_id: 'gpt-5.4-nano',
+  source: 'workspace',
+  validated_capabilities: {},
+  provider_options: {},
+  routing_version: 1,
+  resolved_at: null,
+  fallback_reason: null,
+}
+
+const enrichedEnvelope = {
+  data: {
+    global_default: globalDefault,
+    stage_overrides: {},
+    updated_at: '2026-07-18T01:08:56.061467Z',
+    version: 1,
+    ai_route: aiRoute,
+  },
+}
+
+describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('parst die ai_route-angereicherte Antwort ohne "schema mismatch"', async () => {
+    serviceMock.get.mockResolvedValueOnce(enrichedEnvelope)
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+
+    await expect(getRoutingDefaults()).resolves.toMatchObject({
+      global_default: { model: 'gpt-5.4-nano' },
+    })
+    await expect(replaceGlobalDefault(globalDefault)).resolves.toMatchObject({
+      version: 1,
+    })
+    await expect(
+      replaceRoutingDefaults({ global_default: globalDefault, stage_overrides: {}, version: 1 }),
+    ).resolves.toMatchObject({ version: 1 })
+    await expect(
+      patchRoutingDefaultStage('ontology_generation', globalDefault),
+    ).resolves.toMatchObject({ version: 1 })
+  })
+})

--- a/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
+++ b/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
@@ -64,16 +64,24 @@ describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)',
 
     await expect(getRoutingDefaults()).resolves.toMatchObject({
       global_default: { model: 'gpt-5.4-nano' },
+      ai_route: { model_id: 'gpt-5.4-nano', source: 'workspace' },
     })
     await expect(replaceGlobalDefault(globalDefault)).resolves.toMatchObject({
       version: 1,
+      ai_route: { model_id: 'gpt-5.4-nano', source: 'workspace' },
     })
     await expect(
       replaceRoutingDefaults({ global_default: globalDefault, stage_overrides: {}, version: 1 }),
-    ).resolves.toMatchObject({ version: 1 })
+    ).resolves.toMatchObject({
+      version: 1,
+      ai_route: { model_id: 'gpt-5.4-nano', source: 'workspace' },
+    })
     await expect(
       patchRoutingDefaultStage('ontology_generation', globalDefault),
-    ).resolves.toMatchObject({ version: 1 })
+    ).resolves.toMatchObject({
+      version: 1,
+      ai_route: { model_id: 'gpt-5.4-nano', source: 'workspace' },
+    })
   })
 })
 

--- a/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
+++ b/frontend/src/api/__tests__/llmRoutingDefaults.spec.ts
@@ -75,4 +75,90 @@ describe('llmRoutingDefaults api client — ai_route-Anreicherung (Regression)',
       patchRoutingDefaultStage('ontology_generation', globalDefault),
     ).resolves.toMatchObject({ version: 1 })
   })
+
+  it('calls the expected backend routes with the expected payloads', async () => {
+    serviceMock.get.mockResolvedValueOnce(enrichedEnvelope)
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+
+    await getRoutingDefaults()
+    await replaceGlobalDefault(globalDefault)
+    await patchRoutingDefaultStage('ontology_generation', globalDefault)
+
+    expect(serviceMock.get).toHaveBeenCalledWith('/api/llm/routing/defaults')
+    expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults/global', globalDefault)
+    expect(serviceMock.patch).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/stages/ontology_generation',
+      globalDefault,
+    )
+  })
+
+  it('sends { clear: true } when patching a stage default to null', async () => {
+    serviceMock.patch.mockResolvedValueOnce(enrichedEnvelope)
+
+    await patchRoutingDefaultStage('ontology_generation', null)
+
+    expect(serviceMock.patch).toHaveBeenCalledWith(
+      '/api/llm/routing/defaults/stages/ontology_generation',
+      { clear: true },
+    )
+  })
+
+  it('calls PUT /api/llm/routing/defaults with the full payload for replaceRoutingDefaults', async () => {
+    serviceMock.put.mockResolvedValueOnce(enrichedEnvelope)
+    const payload = { global_default: globalDefault, stage_overrides: {}, version: 1 }
+
+    await replaceRoutingDefaults(payload)
+
+    expect(serviceMock.put).toHaveBeenCalledWith('/api/llm/routing/defaults', payload)
+  })
+
+  it('still parses a response without the ai_route enrichment (backward compatible)', async () => {
+    const plainEnvelope = {
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        updated_at: '2026-07-18T01:08:56.061467Z',
+        version: 1,
+      },
+    }
+    serviceMock.get.mockResolvedValueOnce(plainEnvelope)
+
+    const result = await getRoutingDefaults()
+    expect(result.ai_route).toBeUndefined()
+    expect(result).toMatchObject({ version: 1, global_default: { model: 'gpt-5.4-nano' } })
+  })
+
+  it('rejects with a schema-mismatch error when a non-ai_route key is unrecognized', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        version: 1,
+        ai_route: aiRoute,
+        unexpected_field: 'boom',
+      },
+    })
+
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+  })
+
+  it('rejects with a schema-mismatch error when ai_route itself is malformed', async () => {
+    serviceMock.get.mockResolvedValueOnce({
+      data: {
+        global_default: globalDefault,
+        stage_overrides: {},
+        version: 1,
+        ai_route: { ...aiRoute, source: 'not_a_valid_source' },
+      },
+    })
+
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+  })
+
+  it('rejects with a schema-mismatch error when global_default is missing', async () => {
+    serviceMock.get.mockResolvedValueOnce({ data: { stage_overrides: {}, version: 1 } })
+
+    await expect(getRoutingDefaults()).rejects.toThrow(/schema mismatch/i)
+  })
 })

--- a/frontend/src/api/llmRoutingDefaults.ts
+++ b/frontend/src/api/llmRoutingDefaults.ts
@@ -9,46 +9,47 @@
 import service from "./index";
 import {
   WorkspaceLlmRoutingDefaults,
-  WorkspaceLlmRoutingDefaultsSchema,
+  WorkspaceLlmRoutingDefaultsResponse,
+  WorkspaceLlmRoutingDefaultsResponseSchema,
 } from "../contracts/workspaceRoutingContract";
 import { StageId } from "../contracts/llmRoutingContract";
 import type { LlmRoute } from "../contracts/llmRoute";
 import { ApiSuccessEnvelope } from "./envelope";
 import { unwrapAndParse } from "./parse";
 
-export async function getRoutingDefaults(): Promise<WorkspaceLlmRoutingDefaults> {
+export async function getRoutingDefaults(): Promise<WorkspaceLlmRoutingDefaultsResponse> {
   const resp = await service.get<ApiSuccessEnvelope<unknown>>("/api/llm/routing/defaults");
-  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsSchema);
+  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
 export async function replaceRoutingDefaults(
   payload: WorkspaceLlmRoutingDefaults,
-): Promise<WorkspaceLlmRoutingDefaults> {
+): Promise<WorkspaceLlmRoutingDefaultsResponse> {
   const resp = await service.put<ApiSuccessEnvelope<unknown>>(
     "/api/llm/routing/defaults",
     payload,
   );
-  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsSchema);
+  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
 export async function patchRoutingDefaultStage(
   stageId: StageId,
   route: LlmRoute | null,
-): Promise<WorkspaceLlmRoutingDefaults> {
+): Promise<WorkspaceLlmRoutingDefaultsResponse> {
   const body = route === null ? { clear: true } : route;
   const resp = await service.patch<ApiSuccessEnvelope<unknown>>(
     `/api/llm/routing/defaults/stages/${stageId}`,
     body,
   );
-  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsSchema);
+  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
 export async function replaceGlobalDefault(
   route: LlmRoute,
-): Promise<WorkspaceLlmRoutingDefaults> {
+): Promise<WorkspaceLlmRoutingDefaultsResponse> {
   const resp = await service.put<ApiSuccessEnvelope<unknown>>(
     "/api/llm/routing/defaults/global",
     route,
   );
-  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsSchema);
+  return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }

--- a/frontend/src/api/llmRoutingDefaults.ts
+++ b/frontend/src/api/llmRoutingDefaults.ts
@@ -17,11 +17,22 @@ import type { LlmRoute } from "../contracts/llmRoute";
 import { ApiSuccessEnvelope } from "./envelope";
 import { unwrapAndParse } from "./parse";
 
+/**
+ * Retrieves the workspace's LLM routing defaults.
+ *
+ * @returns The validated workspace LLM routing defaults.
+ */
 export async function getRoutingDefaults(): Promise<WorkspaceLlmRoutingDefaultsResponse> {
   const resp = await service.get<ApiSuccessEnvelope<unknown>>("/api/llm/routing/defaults");
   return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
+/**
+ * Replaces the workspace's LLM routing defaults.
+ *
+ * @param payload - The routing defaults to apply
+ * @returns The updated workspace LLM routing defaults
+ */
 export async function replaceRoutingDefaults(
   payload: WorkspaceLlmRoutingDefaults,
 ): Promise<WorkspaceLlmRoutingDefaultsResponse> {
@@ -32,6 +43,13 @@ export async function replaceRoutingDefaults(
   return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
+/**
+ * Updates the routing default for a stage.
+ *
+ * @param stageId - The stage whose routing default to update
+ * @param route - The route to assign, or `null` to clear the stage default
+ * @returns The updated workspace LLM routing defaults
+ */
 export async function patchRoutingDefaultStage(
   stageId: StageId,
   route: LlmRoute | null,
@@ -44,6 +62,11 @@ export async function patchRoutingDefaultStage(
   return unwrapAndParse(resp, WorkspaceLlmRoutingDefaultsResponseSchema);
 }
 
+/**
+ * Replaces the workspace-wide default LLM route.
+ *
+ * @returns The updated workspace LLM routing defaults.
+ */
 export async function replaceGlobalDefault(
   route: LlmRoute,
 ): Promise<WorkspaceLlmRoutingDefaultsResponse> {

--- a/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
+++ b/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
@@ -1,5 +1,13 @@
+/**
+ * Tests fuer `WorkspaceLlmRoutingDefaultsResponseSchema`.
+ *
+ * Regression: Das Backend reichert JEDE `/api/llm/routing/defaults*`-Antwort
+ * via `_with_ai_route()` (backend/app/api/llm_routing.py) um einen
+ * aufgelösten Top-Level-`ai_route`-Block an. Das Response-Schema muss diese
+ * additive Anreicherung akzeptieren, ohne den restlichen `.strict()`-Vertrag
+ * (unbekannte Top-Level-Keys weiterhin ablehnen) aufzuweichen.
+ */
 import { describe, expect, it } from 'vitest'
-
 import {
   WorkspaceLlmRoutingDefaultsResponseSchema,
   WorkspaceLlmRoutingDefaultsSchema,
@@ -12,7 +20,14 @@ const globalDefault = {
   provider_options: {},
 }
 
-const aiRoute = {
+const validBase = {
+  global_default: globalDefault,
+  stage_overrides: {},
+  updated_at: '2026-07-18T01:08:56.061467Z',
+  version: 1,
+}
+
+const validAiRoute = {
   stage: null,
   provider_connection_id: 'openai',
   model_id: 'gpt-5.4-nano',
@@ -24,89 +39,77 @@ const aiRoute = {
   fallback_reason: null,
 }
 
-const baseDefaults = {
-  global_default: globalDefault,
-  stage_overrides: {},
-  updated_at: '2026-07-18T01:08:56.061467Z',
-  version: 1,
-}
-
-describe('WorkspaceLlmRoutingDefaultsSchema', () => {
-  it('parses a well-formed defaults payload', () => {
-    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse(baseDefaults)
+describe('WorkspaceLlmRoutingDefaultsResponseSchema', () => {
+  it('parses a bare payload without the ai_route enrichment', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(validBase)
     expect(result.success).toBe(true)
   })
 
-  it('rejects an ai_route-enriched payload (strict store contract)', () => {
-    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse({
-      ...baseDefaults,
-      ai_route: aiRoute,
+  it('parses the ai_route-enriched payload emitted by _with_ai_route()', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...validBase,
+      ai_route: validAiRoute,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.ai_route?.source).toBe('workspace')
+    }
+  })
+
+  it('accepts a minimal ai_route that only carries the required source field', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...validBase,
+      ai_route: { source: 'default' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a payload whose ai_route block violates the AiRoute contract', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...validBase,
+      ai_route: { source: 'not-a-real-source' },
     })
     expect(result.success).toBe(false)
   })
 
-  it('rejects unrecognized top-level keys', () => {
-    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse({
-      ...baseDefaults,
-      unexpected: true,
+  it('rejects provider_fallback ai_route enrichment without a fallback_reason', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...validBase,
+      ai_route: { ...validAiRoute, source: 'provider_fallback', fallback_reason: null },
     })
     expect(result.success).toBe(false)
   })
 
-  it('defaults stage_overrides and version when omitted', () => {
-    const result = WorkspaceLlmRoutingDefaultsSchema.parse({
+  it('still rejects unrecognized top-level keys other than ai_route (stays strict)', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...validBase,
+      unexpected_field: 'should not be accepted',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('still enforces the inherited base-contract validations (missing global_default)', () => {
+    const { global_default, ...withoutGlobalDefault } = validBase
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(withoutGlobalDefault)
+    expect(result.success).toBe(false)
+  })
+
+  it('applies the same defaults as the base schema when optional fields are omitted', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
       global_default: globalDefault,
     })
-    expect(result.stage_overrides).toEqual({})
-    expect(result.version).toBe(1)
-  })
-})
-
-describe('WorkspaceLlmRoutingDefaultsResponseSchema — ai_route enrichment (regression)', () => {
-  it('accepts the backend-enriched payload with a top-level ai_route block', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...baseDefaults,
-      ai_route: aiRoute,
-    })
     expect(result.success).toBe(true)
-    expect(result.data?.ai_route).toEqual(aiRoute)
+    if (result.success) {
+      expect(result.data.stage_overrides).toEqual({})
+      expect(result.data.version).toBe(1)
+      expect(result.data.ai_route).toBeUndefined()
+    }
   })
 
-  it('still accepts a payload without ai_route (field is optional)', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(baseDefaults)
-    expect(result.success).toBe(true)
-    expect(result.data?.ai_route).toBeUndefined()
-  })
-
-  it('rejects an ai_route block that fails AiRouteSchema validation', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...baseDefaults,
-      ai_route: { ...aiRoute, source: undefined },
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects an ai_route block with a provider_fallback source and no reason', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...baseDefaults,
-      ai_route: { ...aiRoute, source: 'provider_fallback', fallback_reason: null },
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('still rejects unrelated unrecognized top-level keys', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...baseDefaults,
-      ai_route: aiRoute,
-      unexpected: true,
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('still requires the base fields (global_default is mandatory)', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ai_route: aiRoute,
-    })
-    expect(result.success).toBe(false)
+  it('remains a superset of the store contract: anything valid for the base schema is valid here', () => {
+    const baseResult = WorkspaceLlmRoutingDefaultsSchema.safeParse(validBase)
+    expect(baseResult.success).toBe(true)
+    const responseResult = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(validBase)
+    expect(responseResult.success).toBe(true)
   })
 })

--- a/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
+++ b/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  WorkspaceLlmRoutingDefaultsResponseSchema,
+  WorkspaceLlmRoutingDefaultsSchema,
+} from '../workspaceRoutingContract'
+
+const globalDefault = {
+  provider_id: 'openai',
+  model: 'gpt-5.4-nano',
+  reasoning_effort: 'none' as const,
+  provider_options: {},
+}
+
+const aiRoute = {
+  stage: null,
+  provider_connection_id: 'openai',
+  model_id: 'gpt-5.4-nano',
+  source: 'workspace' as const,
+  validated_capabilities: {},
+  provider_options: {},
+  routing_version: 1,
+  resolved_at: null,
+  fallback_reason: null,
+}
+
+const baseDefaults = {
+  global_default: globalDefault,
+  stage_overrides: {},
+  updated_at: '2026-07-18T01:08:56.061467Z',
+  version: 1,
+}
+
+describe('WorkspaceLlmRoutingDefaultsSchema', () => {
+  it('parses a well-formed defaults payload', () => {
+    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse(baseDefaults)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an ai_route-enriched payload (strict store contract)', () => {
+    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse({
+      ...baseDefaults,
+      ai_route: aiRoute,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unrecognized top-level keys', () => {
+    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse({
+      ...baseDefaults,
+      unexpected: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('defaults stage_overrides and version when omitted', () => {
+    const result = WorkspaceLlmRoutingDefaultsSchema.parse({
+      global_default: globalDefault,
+    })
+    expect(result.stage_overrides).toEqual({})
+    expect(result.version).toBe(1)
+  })
+})
+
+describe('WorkspaceLlmRoutingDefaultsResponseSchema — ai_route enrichment (regression)', () => {
+  it('accepts the backend-enriched payload with a top-level ai_route block', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...baseDefaults,
+      ai_route: aiRoute,
+    })
+    expect(result.success).toBe(true)
+    expect(result.data?.ai_route).toEqual(aiRoute)
+  })
+
+  it('still accepts a payload without ai_route (field is optional)', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(baseDefaults)
+    expect(result.success).toBe(true)
+    expect(result.data?.ai_route).toBeUndefined()
+  })
+
+  it('rejects an ai_route block that fails AiRouteSchema validation', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...baseDefaults,
+      ai_route: { ...aiRoute, source: undefined },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an ai_route block with a provider_fallback source and no reason', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...baseDefaults,
+      ai_route: { ...aiRoute, source: 'provider_fallback', fallback_reason: null },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('still rejects unrelated unrecognized top-level keys', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ...baseDefaults,
+      ai_route: aiRoute,
+      unexpected: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('still requires the base fields (global_default is mandatory)', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+      ai_route: aiRoute,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
+++ b/frontend/src/contracts/__tests__/workspaceRoutingContract.spec.ts
@@ -1,13 +1,5 @@
-/**
- * Tests fuer `WorkspaceLlmRoutingDefaultsResponseSchema`.
- *
- * Regression: Das Backend reichert JEDE `/api/llm/routing/defaults*`-Antwort
- * via `_with_ai_route()` (backend/app/api/llm_routing.py) um einen
- * aufgelösten Top-Level-`ai_route`-Block an. Das Response-Schema muss diese
- * additive Anreicherung akzeptieren, ohne den restlichen `.strict()`-Vertrag
- * (unbekannte Top-Level-Keys weiterhin ablehnen) aufzuweichen.
- */
 import { describe, expect, it } from 'vitest'
+
 import {
   WorkspaceLlmRoutingDefaultsResponseSchema,
   WorkspaceLlmRoutingDefaultsSchema,
@@ -20,14 +12,10 @@ const globalDefault = {
   provider_options: {},
 }
 
-const validBase = {
-  global_default: globalDefault,
-  stage_overrides: {},
-  updated_at: '2026-07-18T01:08:56.061467Z',
-  version: 1,
-}
-
-const validAiRoute = {
+// Minimal fixture for the ai_route enrichment, cf. `_with_ai_route()` in
+// backend/app/api/llm_routing.py. `source` is the only field on AiRouteSchema
+// without a default.
+const aiRoute = {
   stage: null,
   provider_connection_id: 'openai',
   model_id: 'gpt-5.4-nano',
@@ -39,65 +27,139 @@ const validAiRoute = {
   fallback_reason: null,
 }
 
-describe('WorkspaceLlmRoutingDefaultsResponseSchema', () => {
-  it('parses a bare payload without the ai_route enrichment', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(validBase)
-    expect(result.success).toBe(true)
-  })
+const validPayload = {
+  global_default: globalDefault,
+  stage_overrides: {},
+  updated_at: '2026-07-18T01:08:56.061467Z',
+  version: 1,
+}
 
-  it('parses the ai_route-enriched payload emitted by _with_ai_route()', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...validBase,
-      ai_route: validAiRoute,
-    })
+describe('WorkspaceLlmRoutingDefaultsSchema (store contract)', () => {
+  it('accepts a minimal payload and applies defaults', () => {
+    const result = WorkspaceLlmRoutingDefaultsSchema.safeParse({ global_default: {} })
+
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.ai_route?.source).toBe('workspace')
+      expect(result.data.stage_overrides).toEqual({})
+      expect(result.data.version).toBe(1)
     }
   })
 
-  it('accepts a minimal ai_route that only carries the required source field', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...validBase,
-      ai_route: { source: 'default' },
-    })
+  it('accepts stage overrides keyed by a known stage id', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsSchema.safeParse({
+        global_default: globalDefault,
+        stage_overrides: { ontology_generation: globalDefault },
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an unknown stage id in stage_overrides', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsSchema.safeParse({
+        global_default: globalDefault,
+        stage_overrides: { not_a_real_stage: globalDefault },
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects the ai_route enrichment on the strict store contract', () => {
+    // The store contract stays strict on purpose: `ai_route` is a response-
+    // only enrichment and must never round-trip back into persisted state.
+    expect(
+      WorkspaceLlmRoutingDefaultsSchema.safeParse({
+        ...validPayload,
+        ai_route: aiRoute,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an unrelated unrecognized top-level key', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsSchema.safeParse({
+        ...validPayload,
+        unexpected_field: true,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('requires global_default', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsSchema.safeParse({
+        stage_overrides: {},
+        version: 1,
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('WorkspaceLlmRoutingDefaultsResponseSchema (API response contract)', () => {
+  it('accepts a payload without the ai_route enrichment (optional field)', () => {
+    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(validPayload)
+
     expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.ai_route).toBeUndefined()
+    }
   })
 
-  it('rejects a payload whose ai_route block violates the AiRoute contract', () => {
+  it('accepts the ai_route-enriched payload emitted by _with_ai_route()', () => {
     const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...validBase,
-      ai_route: { source: 'not-a-real-source' },
+      ...validPayload,
+      ai_route: aiRoute,
     })
-    expect(result.success).toBe(false)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.ai_route?.source).toBe('workspace')
+      expect(result.data.ai_route?.model_id).toBe('gpt-5.4-nano')
+    }
   })
 
-  it('rejects provider_fallback ai_route enrichment without a fallback_reason', () => {
+  it('rejects a malformed ai_route block (missing required source)', () => {
+    const { source: _source, ...aiRouteWithoutSource } = aiRoute
+
+    expect(
+      WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+        ...validPayload,
+        ai_route: aiRouteWithoutSource,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an ai_route block with an unrecognized field', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+        ...validPayload,
+        ai_route: { ...aiRoute, unexpected_ai_route_field: true },
+      }).success,
+    ).toBe(false)
+  })
+
+  it('still rejects unrelated unrecognized top-level keys', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+        ...validPayload,
+        unexpected_field: true,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('still requires global_default', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+        stage_overrides: {},
+        version: 1,
+        ai_route: aiRoute,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('applies the same defaults as the store schema', () => {
     const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...validBase,
-      ai_route: { ...validAiRoute, source: 'provider_fallback', fallback_reason: null },
+      global_default: {},
     })
-    expect(result.success).toBe(false)
-  })
 
-  it('still rejects unrecognized top-level keys other than ai_route (stays strict)', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      ...validBase,
-      unexpected_field: 'should not be accepted',
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('still enforces the inherited base-contract validations (missing global_default)', () => {
-    const { global_default, ...withoutGlobalDefault } = validBase
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(withoutGlobalDefault)
-    expect(result.success).toBe(false)
-  })
-
-  it('applies the same defaults as the base schema when optional fields are omitted', () => {
-    const result = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
-      global_default: globalDefault,
-    })
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.stage_overrides).toEqual({})
@@ -106,10 +168,12 @@ describe('WorkspaceLlmRoutingDefaultsResponseSchema', () => {
     }
   })
 
-  it('remains a superset of the store contract: anything valid for the base schema is valid here', () => {
-    const baseResult = WorkspaceLlmRoutingDefaultsSchema.safeParse(validBase)
-    expect(baseResult.success).toBe(true)
-    const responseResult = WorkspaceLlmRoutingDefaultsResponseSchema.safeParse(validBase)
-    expect(responseResult.success).toBe(true)
+  it('rejects an unknown stage id in stage_overrides (inherited from the store schema)', () => {
+    expect(
+      WorkspaceLlmRoutingDefaultsResponseSchema.safeParse({
+        global_default: globalDefault,
+        stage_overrides: { not_a_real_stage: globalDefault },
+      }).success,
+    ).toBe(false)
   })
 })

--- a/frontend/src/contracts/workspaceRoutingContract.ts
+++ b/frontend/src/contracts/workspaceRoutingContract.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 import { StageIdSchema } from "./llmRoutingContract";
 import { LlmRouteSchema } from "./llmRoute";
+import { AiRouteSchema } from "./aiProviderContract";
 
 export const WorkspaceLlmRoutingDefaultsSchema = z
   .object({
@@ -17,3 +18,21 @@ export const WorkspaceLlmRoutingDefaultsSchema = z
   })
   .strict();
 export type WorkspaceLlmRoutingDefaults = z.infer<typeof WorkspaceLlmRoutingDefaultsSchema>;
+
+/**
+ * Response-Variante des Vertrags: Das Backend reichert JEDE
+ * `/api/llm/routing/defaults*`-Antwort über `_with_ai_route()`
+ * (backend/app/api/llm_routing.py) um einen aufgelösten `ai_route`-Block an.
+ * Diese Anreicherung ist rein additiv und gehört nicht zum gespeicherten
+ * Modell — deshalb ein eigenes, streng bleibendes Response-Schema, statt den
+ * Store-Contract aufzuweichen. Ohne dieses Feld bricht `unwrapAndParse` mit
+ * `unrecognized_keys: ["ai_route"]` ab und die LlmProvidersView crasht beim
+ * Laden und beim Speichern des Workspace-Defaults.
+ */
+export const WorkspaceLlmRoutingDefaultsResponseSchema =
+  WorkspaceLlmRoutingDefaultsSchema.extend({
+    ai_route: AiRouteSchema.optional(),
+  });
+export type WorkspaceLlmRoutingDefaultsResponse = z.infer<
+  typeof WorkspaceLlmRoutingDefaultsResponseSchema
+>;


### PR DESCRIPTION
## Problem

Beim Setzen des Workspace-LLM-Defaults (Einstellungen → LLM-Anbieter) crasht die `LlmProvidersView` mit:

```
Error: schema mismatch: [{ "code": "unrecognized_keys", "keys": ["ai_route"], ... }]
  at unwrapAndParse (parse.ts:50)
  at getRoutingDefaults (llmRoutingDefaults.ts:21)   // Load
  at replaceGlobalDefault (llmRoutingDefaults.ts:53) // Save
```

Ursache: Das Backend reichert **jede** `/api/llm/routing/defaults*`-Antwort über `_with_ai_route()` ([`backend/app/api/llm_routing.py`](backend/app/api/llm_routing.py#L66)) um einen aufgelösten `ai_route`-Block an. Der Frontend-Client validierte diese Antworten gegen das strikte `WorkspaceLlmRoutingDefaultsSchema` (`.strict()`), das den Key nicht kennt → `unwrapAndParse` bricht ab.

**Symptom-Folge:** Der Default wird backend-seitig zwar persistiert (`set_global_default` läuft vor der Serialisierung), aber der „active-config im Gleichschritt"-Sync im Frontend läuft nie, weil der Response-Parse vorher wirft. Für den Nutzer sieht es aus, als würde das Speichern nichts tun.

## Fix

Additives `WorkspaceLlmRoutingDefaultsResponseSchema` (Basis-Contract `.extend()` um `ai_route: AiRouteSchema.optional()`). Der **gespeicherte** Store-Contract bleibt unverändert und strikt — nur die Response-Parses in `api/llmRoutingDefaults.ts` nutzen die Response-Variante. Damit bleibt die Drift-Erkennung (#578) für alle anderen Keys erhalten.

## Test

Neuer Regression-Test `llmRoutingDefaults.spec.ts` stellt die reale, `ai_route`-angereicherte Backend-Antwort nach und prüft alle vier Client-Funktionen (`get`/`replace`/`replaceGlobal`/`patchStage`). Reproduziert vor dem Fix exakt den `unrecognized_keys: ["ai_route"]`-Abbruch.

Betroffene Suites grün (94 Tests): `llmRoutingDefaults`, `aiModels`, `useEffectiveModelSelection`, `LlmProvidersView`, `zodParse`, `aiProviderContract`. `pre-push-gate.sh frontend`: ALL GREEN.

## Kontext / Folgearbeit

Gefunden beim Debuggen eines lokalen Docker-Runs (`NoAiRouteCandidateError` → 401). Dieser PR behebt **einen** von zwei Code-Bugs. Der zweite (Legacy-`llm_profile_id` hat im Ingest-Pfad Vorrang vor der connection-basierten Route und trägt einen veralteten Key, [`graph_build.py:154-156`](backend/app/services/graph_build.py#L154)) ist Backend/kritischer Pfad und kommt als eigener PR mit Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)