### PR TITLE
fix(backend): Profil-Client-Factory löst API-Key aus Connection-Store (Bug #3)

### DIFF
--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -39,21 +39,26 @@ def _resolve_connection_secret(
         from ..services.llm_provider_secrets_store import (
             get_llm_provider_secrets_store,
         )
+        from ..contracts.provider_types import PROVIDER_CUSTOM
 
-        connections = ProviderConnectionStore().list_connections()
-        target = _normalize_base_url(profile.base_url)
+        connections = [
+            c for c in ProviderConnectionStore().list_connections() if c.enabled
+        ]
+        # 1. Exact provider_kind match always wins, independent of store order.
         match = next(
-            (
-                c
-                for c in connections
-                if c.enabled
-                and (
-                    c.provider_kind == profile.provider
-                    or (target and _normalize_base_url(c.base_url) == target)
-                )
-            ),
+            (c for c in connections if c.provider_kind == profile.provider),
             None,
         )
+        # 2. base_url fallback ONLY for the generic ``custom`` profile provider —
+        #    a specific (non-custom) profile must never receive another
+        #    provider's secret via a coincidental base_url match.
+        if match is None and profile.provider == PROVIDER_CUSTOM:
+            target = _normalize_base_url(profile.base_url)
+            if target:
+                match = next(
+                    (c for c in connections if _normalize_base_url(c.base_url) == target),
+                    None,
+                )
         if match is None:
             return None, None
         key = get_llm_provider_secrets_store().get_plaintext(match.secret_ref or match.id)

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -17,25 +17,22 @@ logger = get_logger("agora.llm.factory")
 
 
 def _normalize_base_url(url: Optional[str]) -> str:
+    """Normalize a base URL for consistent comparison."""
     return (url or "").strip().rstrip("/").lower()
 
 
 def _resolve_connection_secret(
     profile: "LlmProfile",
 ) -> tuple[Optional[str], Optional[str]]:
-    """Resolve the profile's API key from the canonical provider-connection store.
-
-    Bug #3: ``build_client_from_profile`` historically trusted the key persisted
-    inside the legacy profile and never consulted the connection secret store.
-    A stale profile key (e.g. an old ``…-dummy`` placeholder) then produced 401s
-    even though a valid key was configured via the UI provider connection.
-
-    Matches a connection by ``provider_kind`` first, then by ``base_url`` — the
-    profile's ``provider`` may be the generic ``"custom"`` while the connection
-    id is provider-specific (e.g. ``"minimax"``). Only enabled connections are
-    considered. Returns ``(key, connection_id)`` or ``(None, None)`` when no
-    matching connection secret exists. Never raises: on any failure the caller
-    falls back to the profile's own key, preserving pure-profile setups.
+    """
+    Resolve the API key associated with a profile's enabled provider connection.
+    
+    Parameters:
+        profile (LlmProfile): Profile whose provider or base URL identifies the connection.
+    
+    Returns:
+        tuple[Optional[str], Optional[str]]: The plaintext API key and connection ID, or
+        ``(None, None)`` when no matching secret is available or resolution fails.
     """
     try:
         from ..services.provider_connection_store import ProviderConnectionStore
@@ -76,17 +73,19 @@ def build_client_from_profile(
     run_id: Optional[str] = None,
     timeout: float = 300.0,
 ) -> LLMClient:
-    """P5.3: LLMClient aus persistiertem LLM-Profil bauen (überschreibt Config).
-
-    Bug #3: Der API-Key wird bevorzugt aus dem kanonischen
-    Provider-Connection-Store aufgelöst (gleiche Quelle wie der
-    connection-basierte Routing-Pfad via ``resolve_route_api_key``); der im
-    Profil gespeicherte Key ist nur noch Fallback für reine Profil-Setups ohne
-    passende Connection.
-
-    Ollama-Provider (localhost oder 'ollama' in base_url) dürfen api_key leer
-    lassen — der Dummy-Wert 'ollama' wird gesetzt. Cloud-Provider ohne Key
-    scheitern sofort mit einem ValueError, bevor ein HTTP-Request entsteht.
+    """
+    Build an LLM client from a persisted profile and its provider connection settings.
+    
+    Parameters:
+        profile (LlmProfile): Profile containing the provider, credentials, endpoint, and model.
+        run_id (Optional[str]): Optional identifier associated with the client run.
+        timeout (float): Request timeout in seconds.
+    
+    Returns:
+        LLMClient: Configured client using the connection-store key when available, or the profile key as a fallback.
+    
+    Raises:
+        ValueError: If no API key is available for a non-local provider.
     """
     connection_key, connection_id = _resolve_connection_secret(profile)
     api_key = connection_key or profile.api_key

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -8,9 +8,66 @@ Extracted verbatim from ``app/utils/llm_client.py`` as part of issue #582
 from typing import TYPE_CHECKING, Optional
 
 from .client import LLMClient
+from ..utils.logger import get_logger
 
 if TYPE_CHECKING:
     from ..contracts.llm_profile_contract import LlmProfile
+
+logger = get_logger("agora.llm.factory")
+
+
+def _normalize_base_url(url: Optional[str]) -> str:
+    return (url or "").strip().rstrip("/").lower()
+
+
+def _resolve_connection_secret(
+    profile: "LlmProfile",
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve the profile's API key from the canonical provider-connection store.
+
+    Bug #3: ``build_client_from_profile`` historically trusted the key persisted
+    inside the legacy profile and never consulted the connection secret store.
+    A stale profile key (e.g. an old ``…-dummy`` placeholder) then produced 401s
+    even though a valid key was configured via the UI provider connection.
+
+    Matches a connection by ``provider_kind`` first, then by ``base_url`` — the
+    profile's ``provider`` may be the generic ``"custom"`` while the connection
+    id is provider-specific (e.g. ``"minimax"``). Only enabled connections are
+    considered. Returns ``(key, connection_id)`` or ``(None, None)`` when no
+    matching connection secret exists. Never raises: on any failure the caller
+    falls back to the profile's own key, preserving pure-profile setups.
+    """
+    try:
+        from ..services.provider_connection_store import ProviderConnectionStore
+        from ..services.llm_provider_secrets_store import (
+            get_llm_provider_secrets_store,
+        )
+
+        connections = ProviderConnectionStore().list_connections()
+        target = _normalize_base_url(profile.base_url)
+        match = next(
+            (
+                c
+                for c in connections
+                if c.enabled
+                and (
+                    c.provider_kind == profile.provider
+                    or (target and _normalize_base_url(c.base_url) == target)
+                )
+            ),
+            None,
+        )
+        if match is None:
+            return None, None
+        key = get_llm_provider_secrets_store().get_plaintext(match.secret_ref or match.id)
+        return (key, match.id) if key else (None, None)
+    except Exception as exc:  # noqa: BLE001 — fall back to the profile's own key
+        logger.warning(
+            "Connection-Secret-Resolution für Profil %r fehlgeschlagen: %s",
+            getattr(profile, "id", "?"),
+            exc,
+        )
+        return None, None
 
 
 def build_client_from_profile(
@@ -21,23 +78,35 @@ def build_client_from_profile(
 ) -> LLMClient:
     """P5.3: LLMClient aus persistiertem LLM-Profil bauen (überschreibt Config).
 
+    Bug #3: Der API-Key wird bevorzugt aus dem kanonischen
+    Provider-Connection-Store aufgelöst (gleiche Quelle wie der
+    connection-basierte Routing-Pfad via ``resolve_route_api_key``); der im
+    Profil gespeicherte Key ist nur noch Fallback für reine Profil-Setups ohne
+    passende Connection.
+
     Ollama-Provider (localhost oder 'ollama' in base_url) dürfen api_key leer
     lassen — der Dummy-Wert 'ollama' wird gesetzt. Cloud-Provider ohne Key
     scheitern sofort mit einem ValueError, bevor ein HTTP-Request entsteht.
     """
+    connection_key, connection_id = _resolve_connection_secret(profile)
+    api_key = connection_key or profile.api_key
+    api_key_source = "connection_store" if connection_key else "profile"
+
     base_url_lower = profile.base_url.lower()
     is_local = any(
         h in base_url_lower
         for h in ("localhost", "127.0.0.1", "host.docker.internal", "ollama")
     )
-    if not profile.api_key and not is_local:
+    if not api_key and not is_local:
         raise ValueError(
             f"LLM-Profil {profile.id!r}: api_key fehlt für Provider {profile.provider!r}"
         )
     return LLMClient(
-        api_key=profile.api_key or "ollama",
+        api_key=api_key or "ollama",
         base_url=profile.base_url,
         model=profile.model_name,
         timeout=timeout,
         run_id=run_id,
+        route_provider_id=connection_id,
+        api_key_source=api_key_source,
     )

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -1,0 +1,122 @@
+"""Tests für die profil-basierte LLMClient-Factory (Bug #3).
+
+Der Legacy-Profil-Pfad muss den API-Key aus dem kanonischen
+Provider-Connection-Store beziehen und den (potenziell veralteten) im Profil
+gespeicherten Key nur als Fallback nutzen.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.contracts.llm_profile_contract import LlmProfile
+
+
+def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = "m") -> LlmProfile:
+    now = datetime.now(timezone.utc)
+    return LlmProfile(
+        id="prof_1",
+        name="p",
+        provider=provider,
+        base_url=base_url,
+        model_name=model,
+        api_key=api_key,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: bool = True):
+    return SimpleNamespace(
+        id=connection_id,
+        provider_kind=provider_kind,
+        base_url=base_url,
+        enabled=enabled,
+        secret_ref=connection_id,
+    )
+
+
+def _build(profile, *, connections, secrets):
+    """Ruft build_client_from_profile mit gemockten Stores + LLMClient auf.
+
+    Gibt die kwargs zurück, mit denen ``LLMClient`` konstruiert worden wäre.
+    """
+    store = MagicMock()
+    store.list_connections.return_value = connections
+    secrets_store = MagicMock()
+    secrets_store.get_plaintext.side_effect = lambda ref: secrets.get(ref)
+
+    with patch(
+        "app.services.provider_connection_store.ProviderConnectionStore",
+        return_value=store,
+    ), patch(
+        "app.services.llm_provider_secrets_store.get_llm_provider_secrets_store",
+        return_value=secrets_store,
+    ), patch("app.llm.factory.LLMClient") as client_cls:
+        from app.llm.factory import build_client_from_profile
+
+        build_client_from_profile(profile)
+        assert client_cls.call_count == 1
+        return client_cls.call_args.kwargs
+
+
+def test_prefers_connection_secret_over_stale_profile_key():
+    """provider_kind-Match: veralteter Profil-Key wird durch Connection-Key ersetzt."""
+    profile = _profile("openai", "https://api.openai.com/v1", api_key="agora-local-ollama-dummy")
+    kwargs = _build(
+        profile,
+        connections=[_conn("openai", "openai", "https://api.openai.com/v1")],
+        secrets={"openai": "sk-proj-echt"},
+    )
+    assert kwargs["api_key"] == "sk-proj-echt"
+    assert kwargs["api_key_source"] == "connection_store"
+    assert kwargs["route_provider_id"] == "openai"
+
+
+def test_matches_connection_by_base_url_when_provider_generic():
+    """provider='custom' matcht die minimax-Connection über die base_url."""
+    profile = _profile("custom", "https://api.minimax.io/v1", api_key="stale")
+    kwargs = _build(
+        profile,
+        connections=[
+            _conn("openai", "openai", "https://api.openai.com/v1"),
+            _conn("minimax", "minimax", "https://api.minimax.io/v1"),
+        ],
+        secrets={"minimax": "mm-real-key"},
+    )
+    assert kwargs["api_key"] == "mm-real-key"
+    assert kwargs["api_key_source"] == "connection_store"
+    assert kwargs["route_provider_id"] == "minimax"
+
+
+def test_falls_back_to_profile_key_without_matching_connection():
+    """Keine passende Connection → Profil-Key bleibt maßgeblich."""
+    profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
+    kwargs = _build(
+        profile,
+        connections=[_conn("google", "google", "https://generativelanguage.googleapis.com/v1beta/openai")],
+        secrets={"google": "g-key"},
+    )
+    assert kwargs["api_key"] == "sk-own"
+    assert kwargs["api_key_source"] == "profile"
+
+
+def test_disabled_connection_is_ignored():
+    """Deaktivierte Connections dürfen ihren Secret nicht beisteuern."""
+    profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
+    kwargs = _build(
+        profile,
+        connections=[_conn("openai", "openai", "https://api.openai.com/v1", enabled=False)],
+        secrets={"openai": "sk-proj-echt"},
+    )
+    assert kwargs["api_key"] == "sk-own"
+    assert kwargs["api_key_source"] == "profile"
+
+
+def test_cloud_profile_without_any_key_raises():
+    """Cloud-Provider ohne Connection- UND Profil-Key scheitert vor dem HTTP-Call."""
+    profile = _profile("openai", "https://api.openai.com/v1", api_key=None)
+    with pytest.raises(ValueError, match="api_key fehlt"):
+        _build(profile, connections=[], secrets={})

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -2,7 +2,9 @@
 
 Der Legacy-Profil-Pfad muss den API-Key aus dem kanonischen
 Provider-Connection-Store beziehen und den (potenziell veralteten) im Profil
-gespeicherten Key nur als Fallback nutzen.
+gespeicherten Key nur als Fallback nutzen. Die Connection-Auswahl bevorzugt
+einen exakten provider_kind-Match (order-unabhängig); ein base_url-Fallback
+greift ausschließlich für den generischen ``custom``-Provider.
 """
 
 from datetime import datetime, timezone
@@ -15,18 +17,7 @@ from app.contracts.llm_profile_contract import LlmProfile
 
 
 def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = "m") -> LlmProfile:
-    """
-    Create a test LLM profile with the specified provider, endpoint, model, and API key.
-    
-    Parameters:
-    	provider (str): The provider identifier.
-    	base_url (str): The provider endpoint URL.
-    	api_key (str | None): The profile API key, if available.
-    	model (str): The model name.
-    
-    Returns:
-    	LlmProfile: The configured LLM profile.
-    """
+    """Baut ein Test-LlmProfile mit den angegebenen Feldern."""
     now = datetime.now(timezone.utc)
     return LlmProfile(
         id="prof_1",
@@ -41,18 +32,7 @@ def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = 
 
 
 def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: bool = True):
-    """
-    Create a mock provider connection for factory tests.
-    
-    Parameters:
-        connection_id (str): Identifier and secret reference for the connection.
-        provider_kind (str): Provider type associated with the connection.
-        base_url (str): Base URL exposed by the connection.
-        enabled (bool): Whether the connection is available for use.
-    
-    Returns:
-        SimpleNamespace: A connection-like object with the supplied attributes.
-    """
+    """Baut ein connection-artiges Objekt (nur die von der Factory gelesenen Felder)."""
     return SimpleNamespace(
         id=connection_id,
         provider_kind=provider_kind,
@@ -63,16 +43,9 @@ def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: boo
 
 
 def _build(profile, *, connections, secrets):
-    """
-    Build a client from a profile using mocked connection and secret stores.
-    
-    Parameters:
-        profile: The LLM profile used to build the client.
-        connections: Provider connections available to the factory.
-        secrets: Mapping of secret references to plaintext API keys.
-    
-    Returns:
-        The keyword arguments passed to the mocked LLMClient constructor.
+    """Ruft build_client_from_profile mit gemockten Stores + LLMClient auf.
+
+    Gibt die kwargs zurück, mit denen ``LLMClient`` konstruiert worden wäre.
     """
     store = MagicMock()
     store.list_connections.return_value = connections
@@ -107,9 +80,7 @@ def test_prefers_connection_secret_over_stale_profile_key():
 
 
 def test_matches_connection_by_base_url_when_provider_generic():
-    """
-    Verify that a generic provider profile matches the connection with the same base URL and uses its secret.
-    """
+    """provider='custom' matcht die minimax-Connection über die base_url."""
     profile = _profile("custom", "https://api.minimax.io/v1", api_key="stale")
     kwargs = _build(
         profile,
@@ -124,10 +95,40 @@ def test_matches_connection_by_base_url_when_provider_generic():
     assert kwargs["route_provider_id"] == "minimax"
 
 
+def test_provider_kind_match_wins_over_base_url_and_ignores_store_order():
+    """provider_kind-Match gewinnt order-unabhängig; kein base_url-Leak bei non-custom.
+
+    Profil: provider=google, aber base_url zeigt (konstruiert) auf minimax. Die
+    minimax-Connection steht ZUERST in der Liste und würde per base_url matchen —
+    trotzdem muss die google-Connection (provider_kind) gewählt werden.
+    """
+    profile = _profile("google", "https://api.minimax.io/v1", api_key="stale")
+    kwargs = _build(
+        profile,
+        connections=[
+            _conn("minimax", "minimax", "https://api.minimax.io/v1"),
+            _conn("google", "google", "https://generativelanguage.googleapis.com/v1beta/openai"),
+        ],
+        secrets={"minimax": "mm-key", "google": "g-real"},
+    )
+    assert kwargs["api_key"] == "g-real"
+    assert kwargs["route_provider_id"] == "google"
+
+
+def test_non_custom_profile_never_matches_by_base_url():
+    """Ein spezifischer (non-custom) Provider darf keinen fremden Secret per base_url ziehen."""
+    profile = _profile("openai", "https://api.minimax.io/v1", api_key="sk-own")
+    kwargs = _build(
+        profile,
+        connections=[_conn("minimax", "minimax", "https://api.minimax.io/v1")],
+        secrets={"minimax": "mm-key"},
+    )
+    assert kwargs["api_key"] == "sk-own"
+    assert kwargs["api_key_source"] == "profile"
+
+
 def test_falls_back_to_profile_key_without_matching_connection():
-    """
-    Uses the profile API key when no connection matches the profile configuration.
-    """
+    """Keine passende Connection → Profil-Key bleibt maßgeblich."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
     kwargs = _build(
         profile,
@@ -139,9 +140,7 @@ def test_falls_back_to_profile_key_without_matching_connection():
 
 
 def test_disabled_connection_is_ignored():
-    """
-    Verify that disabled connections do not override the profile API key.
-    """
+    """Deaktivierte Connections dürfen ihren Secret nicht beisteuern."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
     kwargs = _build(
         profile,
@@ -153,9 +152,7 @@ def test_disabled_connection_is_ignored():
 
 
 def test_cloud_profile_without_any_key_raises():
-    """
-    Ensure a cloud profile without an API key or matching connection raises a `ValueError`.
-    """
+    """Cloud-Provider ohne Connection- UND Profil-Key scheitert vor dem HTTP-Call."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key=None)
     with pytest.raises(ValueError, match="api_key fehlt"):
         _build(profile, connections=[], secrets={})

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -15,6 +15,18 @@ from app.contracts.llm_profile_contract import LlmProfile
 
 
 def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = "m") -> LlmProfile:
+    """
+    Create a test LLM profile with the specified provider, endpoint, model, and API key.
+    
+    Parameters:
+    	provider (str): The provider identifier.
+    	base_url (str): The provider endpoint URL.
+    	api_key (str | None): The profile API key, if available.
+    	model (str): The model name.
+    
+    Returns:
+    	LlmProfile: The configured LLM profile.
+    """
     now = datetime.now(timezone.utc)
     return LlmProfile(
         id="prof_1",
@@ -29,6 +41,18 @@ def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = 
 
 
 def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: bool = True):
+    """
+    Create a mock provider connection for factory tests.
+    
+    Parameters:
+        connection_id (str): Identifier and secret reference for the connection.
+        provider_kind (str): Provider type associated with the connection.
+        base_url (str): Base URL exposed by the connection.
+        enabled (bool): Whether the connection is available for use.
+    
+    Returns:
+        SimpleNamespace: A connection-like object with the supplied attributes.
+    """
     return SimpleNamespace(
         id=connection_id,
         provider_kind=provider_kind,
@@ -39,9 +63,16 @@ def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: boo
 
 
 def _build(profile, *, connections, secrets):
-    """Ruft build_client_from_profile mit gemockten Stores + LLMClient auf.
-
-    Gibt die kwargs zurück, mit denen ``LLMClient`` konstruiert worden wäre.
+    """
+    Build a client from a profile using mocked connection and secret stores.
+    
+    Parameters:
+        profile: The LLM profile used to build the client.
+        connections: Provider connections available to the factory.
+        secrets: Mapping of secret references to plaintext API keys.
+    
+    Returns:
+        The keyword arguments passed to the mocked LLMClient constructor.
     """
     store = MagicMock()
     store.list_connections.return_value = connections
@@ -76,7 +107,9 @@ def test_prefers_connection_secret_over_stale_profile_key():
 
 
 def test_matches_connection_by_base_url_when_provider_generic():
-    """provider='custom' matcht die minimax-Connection über die base_url."""
+    """
+    Verify that a generic provider profile matches the connection with the same base URL and uses its secret.
+    """
     profile = _profile("custom", "https://api.minimax.io/v1", api_key="stale")
     kwargs = _build(
         profile,
@@ -92,7 +125,9 @@ def test_matches_connection_by_base_url_when_provider_generic():
 
 
 def test_falls_back_to_profile_key_without_matching_connection():
-    """Keine passende Connection → Profil-Key bleibt maßgeblich."""
+    """
+    Uses the profile API key when no connection matches the profile configuration.
+    """
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
     kwargs = _build(
         profile,
@@ -104,7 +139,9 @@ def test_falls_back_to_profile_key_without_matching_connection():
 
 
 def test_disabled_connection_is_ignored():
-    """Deaktivierte Connections dürfen ihren Secret nicht beisteuern."""
+    """
+    Verify that disabled connections do not override the profile API key.
+    """
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
     kwargs = _build(
         profile,
@@ -116,7 +153,9 @@ def test_disabled_connection_is_ignored():
 
 
 def test_cloud_profile_without_any_key_raises():
-    """Cloud-Provider ohne Connection- UND Profil-Key scheitert vor dem HTTP-Call."""
+    """
+    Ensure a cloud profile without an API key or matching connection raises a `ValueError`.
+    """
     profile = _profile("openai", "https://api.openai.com/v1", api_key=None)
     with pytest.raises(ValueError, match="api_key fehlt"):
         _build(profile, connections=[], secrets={})

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,8 +23,8 @@ Epic-`HANDOVER.md`.
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3340 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 163 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 3348 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 167 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,7 +23,7 @@ Epic-`HANDOVER.md`.
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3348 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3350 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 167 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Problem

Beim lokalen Docker-Run scheiterten Ontologie-/NER- und Report-LLM-Calls mit `401 Unauthorized` (bzw. lieferten stumm 0 Entitäten), obwohl über die UI gültige Provider-Connections mit echten Keys konfiguriert waren.

Ursache: `build_client_from_profile()` ([`backend/app/llm/factory.py`](backend/app/llm/factory.py)) baute den `LLMClient` mit `api_key=profile.api_key` — dem im **Legacy-LLM-Profil** persistierten Klartext-Key — und konsultierte den kanonischen Provider-Connection-Store **nie**. Der connection-basierte Pfad ([`graph_build.py`](backend/app/services/graph_build.py) → `resolve_route_api_key` → `SecretResolver`) macht es korrekt; der Profil-Pfad hatte aber Vorrang (`project.llm_profile_id` wird vom Frontend beim Upload gesendet). Ein veralteter Profil-Key (`…-dummy`) gewann so gegen den echten Connection-Key.

Log-Signatur: `LLMClient initialized provider_id=unknown … api_key_source=unknown`.

## Fix (chirurgisch)

`build_client_from_profile` löst den Key jetzt **bevorzugt aus dem Connection-Store** auf — dieselbe Quelle wie der connection-basierte Routing-Pfad:

- Match per `provider_kind`, sonst per `base_url` (Profil-`provider` kann generisch `custom` sein, während die Connection-ID provider-spezifisch ist, z. B. `minimax`).
- Nur **aktive** Connections zählen.
- Der Profil-Key bleibt **Fallback** für reine Profil-Setups ohne passende Connection.
- Auflösung wirft nie (graceful fallback), `api_key_source` wird korrekt annotiert (`connection_store` | `profile`).

## Tests

Neuer `tests/llm/test_factory.py` (5 Tests): Connection-Key schlägt veralteten Profil-Key (provider_kind-Match), base_url-Match bei generischem `custom`-Provider, Fallback ohne Connection, Ignorieren deaktivierter Connections, ValueError für Cloud-Provider ganz ohne Key.

Backend-Pre-Push-Gate: ALL GREEN (ruff, mypy, contracts, Schema-Drift, STATUS-Sync). `test_graph_build_routing` unverändert grün.

## Scope / Folge

Das ist der **chirurgische** Teil der mit dem Maintainer abgestimmten Zwei-Stufen-Lösung. Die vollständige Ablösung des Legacy-Profil-Vorrangs zugunsten der connection-basierten Route (Slice-7.6d-Linie: Backend ignoriert `llm_profile_id` für Key/Route, Frontend sendet es nicht mehr) folgt als **eigenes Slice mit ADR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)