### PR TITLE
fix(contracts): sync model-active provider vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Issue #750 — 2026-07-18)
+
+- **MiniMax-Provider-Contract synchronisiert**: Der Frontend-Zod-Spiegel für
+  `ModelActiveEvent.provider` akzeptiert jetzt das vom Backend publizierte
+  `minimax`; ein Contract-Test fixiert den SSE-Pfad. Das dokumentierte
+  HTTP-Provider-Vokabular in `registry.detect_provider` enthält MiniMax nun
+  ebenfalls. Die bereits auf `main` vorhandene hostname-basierte Erkennung
+  bleibt durch die Backend-Registry-Regressionstests abgesichert.
+
 ### Internal (Slice 7.6d — 2026-07-14)
 
 - **Frontend**: `LlmProfileManager.vue` vom legacy `ModelPicker.vue` auf den

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ### Fixed (Issue #750 — 2026-07-18)
 
-- **MiniMax-Provider-Contract synchronisiert**: Der Frontend-Zod-Spiegel für
-  `ModelActiveEvent.provider` akzeptiert jetzt das vom Backend publizierte
-  `minimax`; ein Contract-Test fixiert den SSE-Pfad. Das dokumentierte
-  HTTP-Provider-Vokabular in `registry.detect_provider` enthält MiniMax nun
-  ebenfalls. Die bereits auf `main` vorhandene hostname-basierte Erkennung
-  bleibt durch die Backend-Registry-Regressionstests abgesichert.
+- **MiniMax-/Google-Provider-Contract synchronisiert**: Der Frontend-Zod-Spiegel
+  für `ModelActiveEvent.provider` akzeptiert jetzt die vom Backend publizierten
+  Werte `minimax` und `google`; Contract-Tests fixieren den SSE-Pfad. Das
+  dokumentierte HTTP-Provider-Vokabular in `registry.detect_provider` und
+  `registry.get_adapter` enthält MiniMax nun ebenfalls. Die bereits auf `main`
+  vorhandene hostname-basierte Erkennung bleibt durch die
+  Backend-Registry-Regressionstests abgesichert.
 
 ### Internal (Slice 7.6d — 2026-07-14)
 

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -209,8 +209,8 @@ def get_adapter(
 ) -> "ProviderAdapter":
     """Liefert den passenden :class:`ProviderAdapter` fuer einen Provider-String.
 
-    Mappt das Vokabular beider Detection-Modi (``http``: ollama/cloud/openai/
-    google/unknown; ``oasis``: google/ollama/openai) auf die konkreten
+    Mappt das Vokabular beider Detection-Modi (``http``: ollama/cloud/minimax/
+    openai/google/unknown; ``oasis``: google/ollama/openai) auf die konkreten
     Adapter-Klassen:
 
     - ``ollama``, ``cloud`` und ``ollama_cloud`` ->

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -190,7 +190,7 @@ def detect_provider(
 ) -> Union[HttpDetectedProvider, OasisDetectedProvider]:
     """Erkennt den LLM-Provider aus Base-URL + Modellname.
 
-    ``mode="http"``  — Vokabular ``ollama|cloud|openai|google|unknown``;
+    ``mode="http"``  — Vokabular ``ollama|cloud|minimax|openai|google|unknown``;
     nutzt der OpenAI-kompatible Backend-HTTP-Client (``LLMClient``).
 
     ``mode="oasis"`` — Vokabular ``google|ollama|openai``; nutzt das

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,7 +28,7 @@ Die Manifest-Versionen bilden noch den früheren, zu optimistischen Release-Stan
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3350 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 167 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:

--- a/frontend/src/contracts/__tests__/modelActiveContract.spec.ts
+++ b/frontend/src/contracts/__tests__/modelActiveContract.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseModelActiveEvent } from '../modelActiveContract'
+
+describe('parseModelActiveEvent', () => {
+  it('akzeptiert ein vom Backend publiziertes MiniMax-Event', () => {
+    const event = {
+      model: 'MiniMax-M3',
+      context: 'chat',
+      provider: 'minimax',
+      ts: 1_752_800_000,
+      extra: null,
+    }
+
+    expect(parseModelActiveEvent(event)).toEqual({ ok: true, data: event })
+  })
+})

--- a/frontend/src/contracts/__tests__/modelActiveContract.spec.ts
+++ b/frontend/src/contracts/__tests__/modelActiveContract.spec.ts
@@ -14,4 +14,16 @@ describe('parseModelActiveEvent', () => {
 
     expect(parseModelActiveEvent(event)).toEqual({ ok: true, data: event })
   })
+
+  it('akzeptiert ein vom Backend publiziertes Google-Event', () => {
+    const event = {
+      model: 'gemini-3-flash-preview',
+      context: 'chat_json',
+      provider: 'google',
+      ts: 1_752_800_001,
+      extra: null,
+    }
+
+    expect(parseModelActiveEvent(event)).toEqual({ ok: true, data: event })
+  })
 })

--- a/frontend/src/contracts/modelActiveContract.ts
+++ b/frontend/src/contracts/modelActiveContract.ts
@@ -17,7 +17,14 @@ export const ModelContextSchema = z.enum([
 ])
 export type ModelContext = z.infer<typeof ModelContextSchema>
 
-export const ModelProviderSchema = z.enum(['ollama', 'cloud', 'minimax', 'openai', 'unknown'])
+export const ModelProviderSchema = z.enum([
+  'ollama',
+  'cloud',
+  'minimax',
+  'openai',
+  'google',
+  'unknown',
+])
 export type ModelProvider = z.infer<typeof ModelProviderSchema>
 
 export const ModelActiveEventSchema = z

--- a/frontend/src/contracts/modelActiveContract.ts
+++ b/frontend/src/contracts/modelActiveContract.ts
@@ -17,7 +17,7 @@ export const ModelContextSchema = z.enum([
 ])
 export type ModelContext = z.infer<typeof ModelContextSchema>
 
-export const ModelProviderSchema = z.enum(['ollama', 'cloud', 'openai', 'unknown'])
+export const ModelProviderSchema = z.enum(['ollama', 'cloud', 'minimax', 'openai', 'unknown'])
 export type ModelProvider = z.infer<typeof ModelProviderSchema>
 
 export const ModelActiveEventSchema = z


### PR DESCRIPTION
## Summary

- ergänzt `minimax` und `google` im Frontend-Zod-Vertrag für `ModelActiveEvent.provider`
- fixiert beide produktiven SSE-Parser-Pfade mit gezielten Contract-Tests
- synchronisiert das HTTP-Provider-Vokabular in den `detect_provider`- und `get_adapter`-Docstrings
- aktualisiert `docs/STATUS.md` und `CHANGELOG.md`

## Root cause

Das Backend kann `provider: "minimax"` und `provider: "google"` über `ModelActiveEvent` publizieren, während der Frontend-Spiegel beide Werte nicht vollständig akzeptierte. Dadurch wurden gültige MiniMax- beziehungsweise Google/Gemini-SSE-Events verworfen. Der hostname-basierte MiniMax-Security-Fix und seine Backend-Regressionstests sind bereits über #749 auf `main`; der konflikthafte PR #744 deckt den Frontend-Vertrag nicht ab.

## Review follow-ups

- Gemini: fehlendes `google`-Literal im Frontend-Contract ergänzt und testfixiert
- CodeRabbit: `minimax` in der `get_adapter`-Vokabular-Dokumentation ergänzt; Adapter-Laufzeitverhalten unverändert

## Impact

MiniMax- und Google/Gemini-Modelle werden im Active-Model-SSE-Pfad als bekannte Provider akzeptiert. Andere Provider und der OASIS-Dispatch bleiben unverändert.

## Validation

- `bun run test -- src/contracts/__tests__/modelActiveContract.spec.ts` — 2 passed
- `uv run pytest -q tests/llm/test_provider_registry.py` — 49 passed
- `bash scripts/pre-push-gate.sh backend` — ALL GREEN
- `bash scripts/pre-push-gate.sh frontend` — ALL GREEN, 170 Testdateien / 1.489 Tests
- Standards-Review: keine Findings
- Spec-Review: keine Findings

Closes #750