### PR TITLE
fix(e2e): Minimalreport-Smoke grün via Onboarding-Dismiss + Outline-Sync aus Report-Contract

### DIFF
--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -244,7 +244,11 @@ async function pollStatus() {
         try {
           const full = (await getReport(resolvedId)) as ApiResult
           if (full?.success) {
-            try { fullReport.value = ReportSchema.parse(full.data) } catch (err) { recordSchemaError('report', err); fullReport.value = null }
+            try {
+              const parsed = ReportSchema.parse(full.data)
+              fullReport.value = parsed
+              syncOutlineFromReport(parsed)
+            } catch (err) { recordSchemaError('report', err); fullReport.value = null }
             await loadEvidence()
           }
         } catch { /* report not yet flushed */ }
@@ -301,6 +305,19 @@ async function loadEvidence() {
   } catch (err) { recordSchemaError('evidence', err) }
 }
 
+// Sub-Slice 2 von 5 (Issue #739): synchronisiere reportOutline aus
+// fullReport.outline. Wenn /report/<id> nach completed-Status betreten wird
+// (Direct-Page-Goto, Refresh oder Regenerate-Stream), liefert der
+// Status-Endpoint oft kein `outline`-Feld — das Outline hängt aber am
+// Report-Contract. Setzt reportOutline idempotent, damit ReportOutlinePanel
+// auch ohne vorherige Status-Poll-Outline-Daten rendert.
+function syncOutlineFromReport(report: Report | null) {
+  if (!report?.outline || reportOutline.value) return
+  try {
+    reportOutline.value = ReportOutlineSchema.parse(report.outline)
+  } catch (err) { recordSchemaError('outline', err) }
+}
+
 const {
   copyMarkdown,
   downloadCombinedJson,
@@ -355,7 +372,11 @@ onMounted(async () => {
     try {
       const full = (await getReport(props.reportId!)) as ApiResult
       if (full?.success) {
-        try { fullReport.value = ReportSchema.parse(full.data) } catch (err) { recordSchemaError('report', err); fullReport.value = null }
+        try {
+          const parsed = ReportSchema.parse(full.data)
+          fullReport.value = parsed
+          syncOutlineFromReport(parsed)
+        } catch (err) { recordSchemaError('report', err); fullReport.value = null }
         await loadEvidence()
       }
     } catch { /* swallow */ }

--- a/frontend/tests/e2e/minimal-report.spec.ts
+++ b/frontend/tests/e2e/minimal-report.spec.ts
@@ -279,6 +279,20 @@ test.describe('M11.4c · Minimalreport-Smoke', () => {
         // aufruft und ReportSchema.parse() ausführt.
         // Bei status="completed" wird fullReport gesetzt und reportHtml gerendert.
         // ===================================================================
+        // Sub-Slice 2/5 (Issue #739): Onboarding-Wizard wegräumen.
+        // backend/app/api/onboarding.py::dismiss_onboarding setzt state.status='dismissed',
+        // onboardingGuard (router/onboardingGuard.ts:32) lässt dann jede Route durch.
+        // Notwendig, weil der Smoke-Spec aus M11.4c (Mai 2026) vor dem Onboarding-Feature
+        // (PR #684, Juni 2026) entstand und keine Onboarding-Bypass-Logik enthält.
+        // Dismiss ist idempotent — sicher bei mehrfachem Run.
+        const dismissRes = await apiCtx.post(`${baseURL}/api/onboarding/dismiss`, {
+          headers,
+        });
+        expect(
+          dismissRes.ok(),
+          `POST /api/onboarding/dismiss fehlgeschlagen (${dismissRes.status()}): ${await dismissRes.text()}`,
+        ).toBe(true);
+
         // M11.4b-Followup-3: waitUntil: 'domcontentloaded' statt 'networkidle'.
         // SPAs mit Pinia-State-Polling erreichen niemals networkidle (>=500 ms ohne Request).
         // 'domcontentloaded': HTML-Parser durch, Inline-Scripts ausgeführt — deterministisch.


### PR DESCRIPTION
## Summary

Sub-Slice 2/5 aus Issue #739 — `minimal-report-smoke` lokal + CI verifizierbar.

## Diagnose (gegen main verifiziert)

Epic-Hypothese `Step4Report.vue:255 try/catch schluckt ReportOutlineSchema.parse`-Fehler` reproduziert sich auf aktuellem main **nicht**. Der echte Break liegt upstream:

- **Onboarding-Guard blockt den Spec-Goto:** PR #684 (Juni 2026) hat den Onboarding-Wizard eingeführt; `router/onboardingGuard.ts:32` blockt jeden Route-Zugriff solange `state.status !== 'dismissed'`. Der minimal-report-Spec stammt aus M11.4c (Mai 2026) und enthält keine Onboarding-Bypass-Logik → `page.goto('/report/<id>')` wird redirected, `pollReportReady` sah zwar API-grün aus, aber die UI erreichte nie die Outline-Panel-Mount-Bedingung.
- **Outline-Sync-Lücke:** Selbst nach Onboarding-Dismiss würde `v-if="reportOutline"` (`Step4Report.vue:436`) falsch bleiben, weil der Status-Poll im Direct-Goto-Fall kein `st.outline` liefert — `reportOutline.value` blieb `null`, `ReportOutlinePanel.vue:55` mountete nicht.

## Fix

- **`frontend/tests/e2e/minimal-report.spec.ts`** — `POST /api/onboarding/dismiss` vor dem `page.goto` in Schritt 10. Idempotent, kein Selektor geändert.
- **`frontend/src/components/Step4Report.vue`** — `syncOutlineFromReport(parsed)` nach `ReportSchema.parse(full.data)` in beiden Mount-/Poll-Pfaden. Parst `ReportOutlineSchema.parse(report.outline)` idempotent (nur wenn noch nicht gesetzt) → `ReportOutlinePanel` rendert auch ohne vorherigen Status-Poll-Outline-Daten.

Beide Spec-Anker (`ol.outline`/`span.outline-title`/`div.report-body.markdown-body`) bleiben unverändert. ADR-0002 Evidence-Gating-Hartanker in `backend/app/services/report_prompts.py` unangetastet.

## Test-Bestätigung

- 2/2 lokale Playwright-Läufe grün (24.2s, 2.8s), kein Flake.
- `pre-push-gate.sh`: ALL GREEN (Backend + Frontend + Schemas).

## Sliced off Concerns

- Epic §3 spekulierte auf Schema-Drift oder Stub-Backend-Outline-Lücke — beides traf nicht zu. Echte Ursachen waren (a) fehlende Onboarding-Bypass-Logik im Spec und (b) Outline-Sync-Lücke bei Direct-Goto ohne vorherigen Status-Poll.
- Die anderen 4 Specs (Upload+Graph, Report-Modes, Golden-Gate-A11y) brauchen dieselbe Onboarding-Dismiss-Behandlung — wird in den Folgeslices (3-5) jeweils am Spec-Anker eingebaut, nicht als Cross-Cutting-Utility extrahiert (Slice-Granularität).

Refs #739