### PR TITLE
fix(e2e): Upload+Graph-Smoke grün via Onboarding-Dismiss (Sub-Slice 3/5, Issue #739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Issue #739 — 2026-07-18)
+
+- **Upload + Graph E2E-Smoke lokal grün**: Der `upload-graph`-Smoke wurde durch
+  den in PR #684 eingeführten Onboarding-Guard (`router/onboardingGuard.ts`)
+  blockiert — `page.goto('/process/<projectId>')` wurde zu `/onboarding`
+  umgeleitet, `.graph-view` mountete nie. Der Spec räumt den Wizard jetzt per
+  idempotentem `POST /api/onboarding/dismiss` vor dem `page.goto` weg. Kein
+  Selektor und keine State-Verkettung geändert; die vorgelagerte
+  `GET /api/graph/data`-Assertion war stets grün. Folgearbeit (Trigger-Readd,
+  restliche Smokes) unter Issue #739.
+
 ### Fixed (Issue #750 — 2026-07-18)
 
 - **MiniMax-/Google-Provider-Contract synchronisiert**: Der Frontend-Zod-Spiegel

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -60,7 +60,7 @@ Der Stack bootet im GitHub-Runner. Der Health-Smoke ist grün; fünf Kern-Smokes
 | Smoke | Status | Hauptbefund |
 |---|---|---|
 | Health | grün | Stack, Auth und Provider-Seeding funktionieren |
-| Upload + Graph | rot | API erfolgreich, UI-/Store-Pfad rendert `graphData` nicht zuverlässig |
+| Upload + Graph | grün (lokal, Sub-Slice 3/5) | Onboarding-Guard blockierte `/process/<id>`, nicht die State-Verkettung; Fix per Onboarding-Dismiss vor `page.goto` |
 | Minimalreport | rot | Report beendet, Outline/Zod-Spiegel nicht stabil |
 | Report-Modi | rot | `force_regenerate` und Mode-Transition erreichen nicht stabil `completed` |
 | Golden-Gate Accessibility | rot | mindestens eine Route verletzt das strikte A11y-Gate |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -55,7 +55,7 @@ Der Stand ist dennoch Technical Preview, weil die Kernpipeline im E2E-Gate noch 
 
 ## E2E-Smokes
 
-Der Stack bootet im GitHub-Runner. Der Health-Smoke ist grün; fünf Kern-Smokes erreichen den eigentlichen Test und sind rot.
+Der Stack bootet im GitHub-Runner. Der Health-Smoke ist grün. Von den fünf Kern-Smokes ist Upload + Graph lokal grün (Sub-Slice 3/5); die übrigen vier erreichen den eigentlichen Test und sind noch rot.
 
 | Smoke | Status | Hauptbefund |
 |---|---|---|

--- a/frontend/tests/e2e/upload-graph.spec.ts
+++ b/frontend/tests/e2e/upload-graph.spec.ts
@@ -154,6 +154,21 @@ test.describe('M11.4b · Upload + Graph-Smoke', () => {
       // ruft loadGraph(graph_id) auf, sobald project.graph_id vorhanden ist.
       // 'domcontentloaded' als waitUntil — networkidle wäre Anti-Pattern für SPAs mit Polling.
       // =================================================================
+      // Sub-Slice 3/5 (Issue #739): Onboarding-Wizard wegräumen.
+      // backend/app/api/onboarding.py::dismiss_onboarding setzt state.status='dismissed',
+      // onboardingGuard (router/onboardingGuard.ts:32) lässt dann jede Route durch.
+      // Notwendig, weil der Smoke-Spec aus M11.4b (Mai 2026) vor dem Onboarding-Feature
+      // (PR #684, Juni 2026) entstand und keine Onboarding-Bypass-Logik enthält — sonst
+      // redirected page.goto('/process/<projectId>') zu '/onboarding', .graph-view mountet nie.
+      // Dismiss ist idempotent — sicher bei mehrfachem Run.
+      const dismissRes = await apiCtx.post(`${baseURL}/api/onboarding/dismiss`, {
+        headers,
+      });
+      expect(
+        dismissRes.ok(),
+        `POST /api/onboarding/dismiss fehlgeschlagen (${dismissRes.status()}): ${await dismissRes.text()}`,
+      ).toBe(true);
+
       // M11.4b-Followup-3: waitUntil: 'domcontentloaded' statt 'networkidle'.
       // SPAs mit Polling/SSE erreichen niemals den networkidle-State (>=500 ms ohne Request).
       // 'domcontentloaded' ist deterministisch: HTML-Parser durch, Inline-Scripts ausgeführt.


### PR DESCRIPTION
## Summary

Sub-Slice 3/5 aus Issue #739 — `upload-graph-smoke` lokal + CI verifizierbar.

## Diagnose (gegen main verifiziert)

Die Epic-Hypothese (§2) — unterbrochene State-Verkettung `/process/<projectId>` → `project.graph_id` → `loadGraph` → `GraphCanvas.graphData` — reproduziert sich auf aktuellem main **nicht**. Der echte Blocker ist derselbe wie in Sub-Slice 2 (**Cross-Cutting-Fund**):

- **Onboarding-Guard blockt den Spec-Goto:** PR #684 (Juni 2026) führte den Onboarding-Wizard ein; `router/onboardingGuard.ts:32` redirected jeden Route-Zugriff zu `/onboarding`, solange `onboarding-state.status !== 'dismissed'`. Der upload-graph-Spec stammt aus M11.4b (Mai 2026) und hat keine Bypass-Logik → `page.goto('/process/<projectId>')` landet auf `/onboarding`, `.graph-view` mountet nie. Die vorgelagerte API-Assertion (`GET /api/graph/data`, Schritt 6) war immer grün — der Backend-Flow war nie das Problem.

## Fix

- **`frontend/tests/e2e/upload-graph.spec.ts`** — idempotentes `POST /api/onboarding/dismiss` vor dem `page.goto`. Kein Selektor geändert, keine State-Verkettungs-Änderung nötig (die funktioniert, sobald die Route erreichbar ist).
- **`docs/STATUS.md`** — Smoke-Tabelle: Upload+Graph rot → grün (lokal, Sub-Slice 3/5).

## Test-Bestätigung

- 2/2 lokale Playwright-Läufe grün (7.6s, 4.7s), kein Flake.
- `pre-push-gate.sh`: ALL GREEN (Backend + Frontend + Schemas).

## Sliced off Concerns

- Epic §2 spekulierte auf design-v4-AppShell-State-Verkettung — traf nicht zu. Sobald der Onboarding-Guard weg ist, rendert `.graph-view` korrekt. Die State-Verkettung ist intakt.

Refs #739