### PR TITLE
docs(status): E2E-Smoke-Tabelle für gemergte Sub-Slices 1-3 nachziehen

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -55,16 +55,16 @@ Der Stand ist dennoch Technical Preview, weil die Kernpipeline im E2E-Gate noch 
 
 ## E2E-Smokes
 
-Der Stack bootet im GitHub-Runner. Der Health-Smoke ist grün. Von den fünf Kern-Smokes ist Upload + Graph lokal grün (Sub-Slice 3/5); die übrigen vier erreichen den eigentlichen Test und sind noch rot.
+Der Stack bootet im GitHub-Runner. Der Health-Smoke ist grün. Von den fünf Kern-Smokes sind AiModelPicker, Minimalreport und Upload + Graph lokal grün (Sub-Slices 1–3/5); die übrigen zwei (Report-Modi, Golden-Gate Accessibility) erreichen den eigentlichen Test und sind noch rot.
 
 | Smoke | Status | Hauptbefund |
 |---|---|---|
 | Health | grün | Stack, Auth und Provider-Seeding funktionieren |
 | Upload + Graph | grün (lokal, Sub-Slice 3/5) | Onboarding-Guard blockierte `/process/<id>`, nicht die State-Verkettung; Fix per Onboarding-Dismiss vor `page.goto` |
-| Minimalreport | rot | Report beendet, Outline/Zod-Spiegel nicht stabil |
+| Minimalreport | grün (lokal, Sub-Slice 2/5) | Onboarding-Guard blockierte `/report/<id>`; Fix per Onboarding-Dismiss + Outline-Sync aus dem Report-Contract (PR #771) |
 | Report-Modi | rot | `force_regenerate` und Mode-Transition erreichen nicht stabil `completed` |
 | Golden-Gate Accessibility | rot | mindestens eine Route verletzt das strikte A11y-Gate |
-| AiModelPicker | rot | Route-/UI-Drift nach der Picker-Migration |
+| AiModelPicker | grün (lokal, Sub-Slice 1/5) | mock-models-Seed-URL via `AGORA_E2E_MOCK_MODELS_BASE` lokal überschreibbar; CI-Verhalten unverändert (PR #769) |
 
 Tracking: [Issue #739](https://github.com/arn0ld87/agora/issues/739)
 
@@ -79,7 +79,7 @@ Der `pull_request`-Trigger des E2E-Workflows bleibt deaktiviert, bis alle sechs 
 | Backend Full Tests + Coverage | `push:main` oder Label |
 | Frontend Full Tests + Coverage | `push:main` oder Label |
 | Schemas und Contract-Spiegel | vorhanden |
-| E2E-Kernpipeline | 1/6 grün, noch nicht verpflichtend |
+| E2E-Kernpipeline | 4/6 lokal grün (Health + Sub-Slices 1–3/5), noch nicht verpflichtend |
 
 Lokale Befehle:
 

--- a/docs/epics/e2e-smoke-specs/README.md
+++ b/docs/epics/e2e-smoke-specs/README.md
@@ -4,6 +4,14 @@ Status: **Draft** — 2026-07-14
 Owner: —
 Verwandt: `.github/workflows/e2e-smokes.yml`, `frontend/tests/e2e/`
 
+> **Statusquelle:** Dieses Epic ist ein **Diagnose-Dokument mit Stand
+> 2026-07-14** und keine Live-Statusquelle. Der aktuelle, verifizierte
+> Smoke-Status wird in [`docs/STATUS.md`](../../STATUS.md) und
+> [Issue #739](https://github.com/arn0ld87/agora/issues/739) geführt (per
+> `AGENTS.md`-Dokumentationshierarchie). Die Root-Cause-Analysen unten bleiben
+> gültige Referenz; die Status-Spalten spiegeln den Draft-Stand, nicht den
+> Merge-Fortschritt.
+
 ## Ziel
 
 Sechs E2E-Smoke-Specs sind in `.github/workflows/e2e-smokes.yml` verdrahtet. Davon
@@ -31,6 +39,9 @@ als parallele Jobs definiert, jeder mit eigenem Playwright-Run
 (`npx playwright test <spec>.spec.ts --reporter=list,github`).
 
 ## Spec-Übersicht
+
+_Status-Spalte = Diagnose-Stand 2026-07-14 (historisch). Live-Status:
+[`docs/STATUS.md`](../../STATUS.md) + [Issue #739](https://github.com/arn0ld87/agora/issues/739)._
 
 | # | Spec | Pfad | Status |
 |---|------|------|--------|


### PR DESCRIPTION
## Summary

Hält `docs/STATUS.md` mit dem realen Merge-Stand von Issue #739 konsistent. AiModelPicker (#769), Minimalreport (#771) und Upload+Graph (#773) sind gemergt und lokal grün, aber die STATUS.md-Smoke-Tabelle zeigte AiModelPicker und Minimalreport noch als `rot` — nur Upload+Graph war in #773 nachgezogen worden.

## Änderungen (reine Doku)

- **Smoke-Tabelle:** AiModelPicker + Minimalreport `rot` → `grün (lokal)` mit PR-Referenz und Kurzbefund
- **Zusammenfassungstext:** 3/5 Kern-Smokes lokal grün (Sub-Slices 1–3), 2 verbleibend rot (Report-Modi, Golden-Gate A11y)
- **Quality-Gate-Zeile:** E2E-Kernpipeline `1/6` → `4/6 lokal grün (Health + Sub-Slices 1–3/5)`

Keine Code-, Schema- oder AUTOGEN-Marker-Änderung. "stabil grün" im formalen Sinn (3 grüne Schedule-Läufe auf main) bleibt für den Trigger-Readd-PR reserviert — hier wird nur der lokale/PR-verifizierte Stand dokumentiert.

Refs #739