### PR TITLE
refactor(0.9): Provider-, Secret- und Routing-SSoT abschließen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Embedding-Erkennung bleibt gemäß ADR-0007 eigenständig und ist über den
   öffentlichen `EmbeddingService.embed()`-Pfad testfixiert.
 - **Legacy-HTTP-Pfade terminiert**: `/api/settings/llm-profiles/*` und
-  `/api/llm/providers/*` liefern `Deprecation: true`, den kanonischen
-  Nachfolger und `X-Agora-Removal-Version: 1.0.0`. Ein RFC-`Sunset`-Datum folgt
-  erst, sobald ein belastbares Release-Datum feststeht.
+  `/api/llm/providers/*` liefern RFC 9745-konforme `Deprecation`-Header
+  (Structured Field Date), den kanonischen Nachfolger und
+  `X-Agora-Removal-Version: 1.0.0`. Ein RFC-`Sunset`-Datum folgt erst, sobald
+  ein belastbares Release-Datum feststeht.
 
 ### Fixed (Issue #750 — 2026-07-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   `GET /api/graph/data`-Assertion war stets grün. Folgearbeit (Trigger-Readd,
   restliche Smokes) unter Issue #739.
 
+### Changed (Issue #761 — 2026-07-18)
+
+- **Provider-, Secret- und Routing-SSoT abgeschlossen**: Explizit aufgelöste
+  `AiRoute`-Snapshots gewinnen in Ontologie- und Graph-Build-Pfaden vor
+  Legacy-Profilen. Cloud-Secrets werden ausschließlich aus einer passenden,
+  aktivierten `ProviderConnection` gelesen; eingebettete Profil-Keys sind kein
+  Fallback mehr.
+- **Provider-Erkennung konsolidiert**: `/api/simulation/available-models`
+  delegiert an `registry.detect_provider(mode="http")`. Die getrennte
+  Embedding-Erkennung bleibt gemäß ADR-0007 eigenständig und ist über den
+  öffentlichen `EmbeddingService.embed()`-Pfad testfixiert.
+- **Legacy-HTTP-Pfade terminiert**: `/api/settings/llm-profiles/*` und
+  `/api/llm/providers/*` liefern `Deprecation: true`, den kanonischen
+  Nachfolger und `X-Agora-Removal-Version: 1.0.0`. Ein RFC-`Sunset`-Datum folgt
+  erst, sobald ein belastbares Release-Datum feststeht.
+
 ### Fixed (Issue #750 — 2026-07-18)
 
 - **MiniMax-/Google-Provider-Contract synchronisiert**: Der Frontend-Zod-Spiegel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,9 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Embedding-Erkennung bleibt gemäß ADR-0007 eigenständig und ist über den
   öffentlichen `EmbeddingService.embed()`-Pfad testfixiert.
 - **Legacy-HTTP-Pfade terminiert**: `/api/settings/llm-profiles/*` und
-  `/api/llm/providers/*` liefern RFC 9745-konforme `Deprecation`-Header
-  (Structured Field Date), den kanonischen Nachfolger und
-  `X-Agora-Removal-Version: 1.0.0`. Ein RFC-`Sunset`-Datum folgt erst, sobald
-  ein belastbares Release-Datum feststeht.
+  `/api/llm/providers/*` liefern gemäß RFC 9745 `Deprecation: @1784332800`, den
+  kanonischen Nachfolger und `X-Agora-Removal-Version: 1.0.0`. Ein
+  RFC-`Sunset`-Datum folgt erst, sobald ein belastbares Release-Datum feststeht.
 
 ### Fixed (Issue #750 — 2026-07-18)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,11 +85,11 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 
 ### Provider und Routing
 
-- [ ] `ProviderConnection`, `AiRoute` und `AiModelPicker` sind die kanonischen Pfade
-- [ ] Legacy-Profile greifen nicht mehr bevorzugt auf eigene Secrets oder Routingwerte zu
-- [ ] explizite Provider-Konfiguration gewinnt vor URL-/Modell-Heuristiken
-- [ ] Frontend- und Backend-Provider-Vokabular sind synchron
-- [ ] Chat-Routing und Embedding-Konfiguration bleiben getrennt
+- [x] `ProviderConnection`, `AiRoute` und `AiModelPicker` sind die kanonischen Pfade
+- [x] Legacy-Profile greifen nicht mehr bevorzugt auf eigene Secrets oder Routingwerte zu
+- [x] explizite Provider-Konfiguration gewinnt vor URL-/Modell-Heuristiken
+- [x] Frontend- und Backend-Provider-Vokabular sind synchron
+- [x] Chat-Routing und Embedding-Konfiguration bleiben getrennt
 
 ### Betrieb und Supply Chain
 

--- a/backend/app/api/deprecation.py
+++ b/backend/app/api/deprecation.py
@@ -2,10 +2,14 @@
 
 from flask import Response
 
+# RFC 9745 Structured Field Date representing when this deprecation was announced.
+# Fixed timestamp (2026-07-15 12:00:00 UTC) for deterministic tests.
+_DEPRECATION_DATE = "@1752624000"
+
 
 def add_legacy_deprecation_headers(response: Response) -> Response:
     """Mark a legacy response and point clients at the canonical successor."""
-    response.headers["Deprecation"] = "true"
+    response.headers["Deprecation"] = _DEPRECATION_DATE
     response.headers["X-Agora-Removal-Version"] = "1.0.0"
     response.headers["Link"] = '</api/llm/provider-connections>; rel="successor-version"'
     return response

--- a/backend/app/api/deprecation.py
+++ b/backend/app/api/deprecation.py
@@ -7,7 +7,12 @@ _DEPRECATION_DATE = "@1784332800"
 
 
 def add_legacy_deprecation_headers(response: Response) -> Response:
-    """Mark a legacy response and point clients at the canonical successor."""
+    """
+    Mark a legacy response and identify its canonical successor.
+    
+    Returns:
+        Response: The response with deprecation metadata and successor location headers.
+    """
     response.headers["Deprecation"] = _DEPRECATION_DATE
     response.headers["X-Agora-Removal-Version"] = "1.0.0"
     response.headers["Link"] = '</api/llm/provider-connections>; rel="successor-version"'

--- a/backend/app/api/deprecation.py
+++ b/backend/app/api/deprecation.py
@@ -1,0 +1,11 @@
+"""Shared response headers for legacy HTTP API routes."""
+
+from flask import Response
+
+
+def add_legacy_deprecation_headers(response: Response) -> Response:
+    """Mark a legacy response and point clients at the canonical successor."""
+    response.headers["Deprecation"] = "true"
+    response.headers["X-Agora-Removal-Version"] = "1.0.0"
+    response.headers["Link"] = '</api/llm/provider-connections>; rel="successor-version"'
+    return response

--- a/backend/app/api/deprecation.py
+++ b/backend/app/api/deprecation.py
@@ -2,9 +2,8 @@
 
 from flask import Response
 
-# RFC 9745 Structured Field Date representing when this deprecation was announced.
-# Fixed timestamp (2026-07-15 12:00:00 UTC) for deterministic tests.
-_DEPRECATION_DATE = "@1752624000"
+# RFC 9745 Structured Field Date for the 2026-07-18 deprecation announcement.
+_DEPRECATION_DATE = "@1784332800"
 
 
 def add_legacy_deprecation_headers(response: Response) -> Response:

--- a/backend/app/api/llm_profiles.py
+++ b/backend/app/api/llm_profiles.py
@@ -23,7 +23,12 @@ logger = get_logger("agora.api.llm_profiles")
 
 @llm_profiles_bp.after_request
 def add_profile_deprecation_headers(response):
-    """Mark every legacy profile response with its canonical successor."""
+    """
+    Add deprecation headers identifying the canonical successor for profile responses.
+    
+    Returns:
+        The response with deprecation headers added.
+    """
     return add_legacy_deprecation_headers(response)
 
 

--- a/backend/app/api/llm_profiles.py
+++ b/backend/app/api/llm_profiles.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from flask import Blueprint, request
 from pydantic import ValidationError
 
+from .deprecation import add_legacy_deprecation_headers
 from ..contracts.llm_profile_contract import LlmProfileCreateRequest, LlmProfileListResponse
 from ..services.llm_profiles_store import get_llm_profiles_store
 from ..utils.api_responses import handle_api_errors, json_error, json_success
@@ -18,6 +19,12 @@ from ..utils.logger import get_logger
 
 llm_profiles_bp = Blueprint("llm_profiles", __name__)
 logger = get_logger("agora.api.llm_profiles")
+
+
+@llm_profiles_bp.after_request
+def add_profile_deprecation_headers(response):
+    """Mark every legacy profile response with its canonical successor."""
+    return add_legacy_deprecation_headers(response)
 
 
 @llm_profiles_bp.route("", methods=["GET"])

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -46,7 +46,15 @@ _LEGACY_PROVIDER_VIEW_NAMES = frozenset(
 
 @llm_bp.after_request
 def add_provider_deprecation_headers(response):
-    """Mark only legacy ``/providers`` responses, never canonical connections."""
+    """
+    Add deprecation headers to legacy provider responses.
+    
+    Parameters:
+    	response: The Flask response to process.
+    
+    Returns:
+    	The response with legacy deprecation headers when applicable.
+    """
     view_name = (request.endpoint or "").rsplit(".", maxsplit=1)[-1]
     if view_name in _LEGACY_PROVIDER_VIEW_NAMES:
         return add_legacy_deprecation_headers(response)

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -50,10 +50,10 @@ def add_provider_deprecation_headers(response):
     Add deprecation headers to legacy provider responses.
     
     Parameters:
-    	response: The Flask response to process.
+        response: The Flask response to process.
     
     Returns:
-    	The response with legacy deprecation headers when applicable.
+        The response with legacy deprecation headers when applicable.
     """
     view_name = (request.endpoint or "").rsplit(".", maxsplit=1)[-1]
     if view_name in _LEGACY_PROVIDER_VIEW_NAMES:

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -30,11 +30,25 @@ from ..utils.logger import get_logger
 logger = get_logger("agora.api.llm_providers")
 provider_registry = LlmProviderRegistry()
 
+_LEGACY_PROVIDER_VIEW_NAMES = frozenset(
+    {
+        "list_providers",
+        "list_provider_models",
+        "test_provider",
+        "list_provider_api_keys",
+        "get_provider_api_key",
+        "upsert_provider_api_key",
+        "provider_has_key",
+        "delete_provider_api_key",
+    }
+)
+
 
 @llm_bp.after_request
 def add_provider_deprecation_headers(response):
     """Mark only legacy ``/providers`` responses, never canonical connections."""
-    if request.path.startswith("/api/llm/providers"):
+    view_name = (request.endpoint or "").rsplit(".", maxsplit=1)[-1]
+    if view_name in _LEGACY_PROVIDER_VIEW_NAMES:
         return add_legacy_deprecation_headers(response)
     return response
 

--- a/backend/app/api/llm_providers.py
+++ b/backend/app/api/llm_providers.py
@@ -6,6 +6,7 @@ from pydantic import SecretStr, ValidationError
 from typing import cast
 
 from . import llm_bp
+from .deprecation import add_legacy_deprecation_headers
 from ..contracts.ai_provider_contract import (
     ProviderConnection,
     ProviderConnectionProviderKind,
@@ -28,6 +29,14 @@ from ..utils.logger import get_logger
 
 logger = get_logger("agora.api.llm_providers")
 provider_registry = LlmProviderRegistry()
+
+
+@llm_bp.after_request
+def add_provider_deprecation_headers(response):
+    """Mark only legacy ``/providers`` responses, never canonical connections."""
+    if request.path.startswith("/api/llm/providers"):
+        return add_legacy_deprecation_headers(response)
+    return response
 
 
 _store_instance: ProviderConnectionStore | None = None

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -318,7 +318,7 @@ class AiRoute(BaseModel):
         Validate fallback and connection-only route requirements.
         
         Returns:
-        	AiRoute: The validated route.
+            AiRoute: The validated route.
         """
         if self.source == "provider_fallback" and not (
             self.fallback_reason and self.fallback_reason.strip()

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -314,6 +314,12 @@ class AiRoute(BaseModel):
 
     @model_validator(mode="after")
     def validate_provider_fallback_reason(self) -> AiRoute:
+        """
+        Validate fallback and connection-only route requirements.
+        
+        Returns:
+        	AiRoute: The validated route.
+        """
         if self.source == "provider_fallback" and not (
             self.fallback_reason and self.fallback_reason.strip()
         ):

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -281,7 +281,23 @@ class AiRoute(BaseModel):
                         },
                         "required": ["fallback_reason"],
                     },
-                }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "provider_options": {
+                                "properties": {"connection_only": {"const": True}},
+                                "required": ["connection_only"],
+                            }
+                        },
+                        "required": ["provider_options"],
+                    },
+                    "then": {
+                        "properties": {
+                            "provider_options": {"required": ["secret_ref"]}
+                        }
+                    },
+                },
             ]
         },
     )
@@ -302,6 +318,10 @@ class AiRoute(BaseModel):
             self.fallback_reason and self.fallback_reason.strip()
         ):
             raise ValueError("provider_fallback requires a non-blank fallback_reason")
+        if self.provider_options.get("connection_only") is True and not self.provider_options.get(
+            "secret_ref"
+        ):
+            raise ValueError("connection_only requires secret_ref")
         return self
 
 

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -315,8 +315,8 @@ class AiRoute(BaseModel):
     @model_validator(mode="after")
     def validate_provider_fallback_reason(self) -> AiRoute:
         """
-        Validate fallback and connection-only route requirements.
-        
+        Validate that provider_fallback routes have a non-blank fallback_reason.
+
         Returns:
             AiRoute: The validated route.
         """
@@ -324,6 +324,16 @@ class AiRoute(BaseModel):
             self.fallback_reason and self.fallback_reason.strip()
         ):
             raise ValueError("provider_fallback requires a non-blank fallback_reason")
+        return self
+
+    @model_validator(mode="after")
+    def validate_connection_only_requirements(self) -> AiRoute:
+        """
+        Validate that connection_only routes have a secret_ref.
+
+        Returns:
+            AiRoute: The validated route.
+        """
         if self.provider_options.get("connection_only") is True and not self.provider_options.get(
             "secret_ref"
         ):

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -153,6 +153,8 @@ class AiProviderOptions(TypedDict, total=False, closed=True):  # type: ignore[ca
 
     base_url: PublicBaseUrl | LocalOllamaBaseUrl | None
     num_ctx: Annotated[int, Field(gt=0)]
+    secret_ref: Annotated[str, Field(min_length=1)]
+    connection_only: bool
     __legacy_stage_route__: LegacyStageRouteOptions
 
 

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -43,6 +43,13 @@ from .tool_calls import _chat_with_tools
 logger = get_logger("agora.llm_client")
 
 
+def get_llm_provider_secrets_store() -> Any:
+    """Load the secrets store lazily to avoid the services package import cycle."""
+    from ..services.llm_provider_secrets_store import get_llm_provider_secrets_store as get_store
+
+    return get_store()
+
+
 class LLMClient:
     """LLM Client"""
 
@@ -60,6 +67,7 @@ class LLMClient:
         route_provider_id: Optional[str] = None,
         use_active_config: bool = True,
         api_key_source: Optional[str] = None,
+        allow_api_key_fallback: bool = True,
     ):
         # When no explicit model is set, fall back to the user's active
         # provider/model selection (Settings → LLM-Auswahl). Falls back to
@@ -105,10 +113,12 @@ class LLMClient:
         if api_key:
             self.api_key = api_key
             # resolved_source bleibt erhalten (passed_in oder vom Resolver)
-        else:
+        elif allow_api_key_fallback:
             self.api_key = Config.LLM_API_KEY
             if self.api_key:
                 resolved_source = "config_fallback"
+        else:
+            self.api_key = None
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
         self.reasoning_effort = reasoning_effort or "none"
@@ -187,13 +197,25 @@ class LLMClient:
         falling back to sanitized/config defaults if no resolver is provided.
         """
         base_url = route.base_url_sanitized
-        api_key = api_key_override
-        api_key_source: Optional[str] = "passed_in" if api_key_override else None
+        connection_only = route.provider_options.get("connection_only") is True
+        if connection_only:
+            from ..services.secret_resolver import get_bound_store_api_key
+
+            raw_secret_ref = route.provider_options.get("secret_ref")
+            secret_ref = raw_secret_ref if isinstance(raw_secret_ref, str) else ""
+            api_key = get_bound_store_api_key(
+                secret_ref,
+                secrets_store=get_llm_provider_secrets_store(),
+            )
+            api_key_source: Optional[str] = "store" if api_key else None
+        else:
+            api_key = api_key_override
+            api_key_source = "passed_in" if api_key_override else None
 
         # If a secret resolver is provided, we try to get the real secrets.
         # This prevents leaking them into ResolvedRoute but allows LLMClient
         # to use them.
-        if secret_resolver:
+        if secret_resolver and not connection_only:
             # We need to know the provider type to resolve the key correctly.
             # ResolvedRoute only has provider_id.
             # In a full implementation, we'd look up the provider descriptor.
@@ -224,6 +246,8 @@ class LLMClient:
             route_stage=route.stage,
             route_provider_id=route.provider_id,
             api_key_source=api_key_source,
+            use_active_config=not connection_only,
+            allow_api_key_fallback=not connection_only,
         )
 
     def _is_ollama(self) -> bool:

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -101,16 +101,15 @@ def build_client_from_profile(
     Build an LLM client from a persisted profile and its provider connection settings.
     
     Parameters:
-        profile (LlmProfile): Profile containing the provider, credentials, endpoint, and model.
+        profile (LlmProfile): Profile specifying the provider, endpoint, and model.
         run_id (Optional[str]): Optional identifier associated with the client run.
         timeout (float): Request timeout in seconds.
     
     Returns:
-        LLMClient: Configured client using the matching connection-store key,
-        or local no-auth credentials for local providers.
+        LLMClient: Configured client using the resolved connection credentials and endpoint.
     
     Raises:
-        ValueError: If no API key is available for a non-local provider.
+        ValueError: If no API key is available for a non-local endpoint.
     """
     connection_key, connection_id, connection_base_url = _resolve_connection_secret(profile)
     api_key = connection_key

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -42,17 +42,24 @@ def _is_local_base_url(url: str | None) -> bool:
 
 def _resolve_connection_secret(
     profile: "LlmProfile",
-) -> tuple[Optional[str], Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """
-    Resolve the API key associated with a profile's enabled provider connection.
-    
+    Resolve the enabled provider connection bound to a profile and its API key.
+
+    Die aufgelöste Connection (``connection_id``, ``base_url``, ``auth_mode``) wird
+    unabhängig vom Secret zurückgegeben, damit die autoritative Route auch für
+    No-Auth-Connections erhalten bleibt. Der Hostname ist kein Authentifizierungs-
+    modell — maßgeblich ist der explizite ``auth_mode`` der ProviderConnection.
+
     Parameters:
         profile (LlmProfile): Profile whose provider or base URL identifies the connection.
-    
+
     Returns:
-        tuple[Optional[str], Optional[str], Optional[str]]: The plaintext API key,
-        connection ID and canonical connection URL, or three ``None`` values when
-        no matching secret is available or resolution fails.
+        tuple[Optional[str], Optional[str], Optional[str], Optional[str]]: The plaintext
+        API key, connection ID, canonical connection URL and connection ``auth_mode``.
+        Alle vier sind ``None``, wenn keine Connection aufgelöst wird oder der Lesepfad
+        fehlschlägt. Bei einer aufgelösten api_key-Connection ohne hinterlegtes Secret
+        ist der Key ``None``, ID/URL/auth_mode bleiben jedoch gesetzt.
     """
     try:
         from ..services.provider_connection_store import ProviderConnectionStore
@@ -66,20 +73,24 @@ def _resolve_connection_secret(
             getattr(profile, "id", "?"),
             exc,
         )
-        return None, None, None
+        return None, None, None, None
 
     from ..services.profile_connection_resolver import resolve_profile_connection
 
     resolved = resolve_profile_connection(profile, connections)
     if resolved is None:
-        return None, None, None
+        return None, None, None, None
+
+    match = resolved.connection
+    # Explizite No-Auth-Connection: autoritative Route ohne erwartetes Secret.
+    if match.auth_mode == "none":
+        return None, match.id, resolved.base_url, match.auth_mode
 
     try:
         from ..services.llm_provider_secrets_store import (
             get_llm_provider_secrets_store,
         )
 
-        match = resolved.connection
         key = get_llm_provider_secrets_store().get_plaintext(match.secret_ref or match.id)
     except Exception as exc:  # noqa: BLE001 — caller handles unavailable connection secrets
         logger.warning(
@@ -87,8 +98,10 @@ def _resolve_connection_secret(
             getattr(profile, "id", "?"),
             exc,
         )
-        return None, None, None
-    return (key, match.id, resolved.base_url) if key else (None, None, None)
+        # Route (ID/URL/auth_mode) bleibt erhalten, damit der Aufrufer den
+        # fehlenden Key als harten Fehler statt als Dummy-Key behandeln kann.
+        return None, match.id, resolved.base_url, match.auth_mode
+    return (key or None), match.id, resolved.base_url, match.auth_mode
 
 
 def build_client_from_profile(
@@ -111,19 +124,31 @@ def build_client_from_profile(
     Raises:
         ValueError: If no API key is available for a non-local endpoint.
     """
-    connection_key, connection_id, connection_base_url = _resolve_connection_secret(profile)
+    connection_key, connection_id, connection_base_url, connection_auth_mode = (
+        _resolve_connection_secret(profile)
+    )
     api_key = connection_key
     api_key_source = "connection_store" if connection_key else "local_no_auth"
 
-    is_local = _is_local_base_url(profile.base_url)
-    if not api_key and not is_local:
+    resolved_via_connection = connection_id is not None
+    connection_no_auth = connection_auth_mode == "none"
+    effective_base_url = connection_base_url or profile.base_url
+
+    # No-Auth ist nur erlaubt, wenn die aufgelöste Connection es explizit vorsieht
+    # (auth_mode="none") ODER — ohne passende Connection — der Endpunkt lokal ist
+    # (Legacy-Profile ohne ProviderConnection). Eine api_key-Connection ohne Secret
+    # fällt NICHT auf den Dummy-Key zurück, auch nicht bei lokalem Hostnamen.
+    no_auth_allowed = connection_no_auth or (
+        not resolved_via_connection and _is_local_base_url(effective_base_url)
+    )
+    if not api_key and not no_auth_allowed:
         raise ValueError(
             f"LLM-Profil {profile.id!r}: api_key fehlt; kein Secret aus einer passenden "
             f"aktivierten ProviderConnection für Provider {profile.provider!r}"
         )
     return LLMClient(
         api_key=api_key or "ollama",
-        base_url=connection_base_url or profile.base_url,
+        base_url=effective_base_url,
         model=profile.model_name,
         timeout=timeout,
         run_id=run_id,

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -5,7 +5,9 @@ Extracted verbatim from ``app/utils/llm_client.py`` as part of issue #582
 (mechanical split — no behavior change).
 """
 
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlsplit
 
 from .client import LLMClient
 from ..utils.logger import get_logger
@@ -19,6 +21,23 @@ logger = get_logger("agora.llm.factory")
 def _normalize_base_url(url: Optional[str]) -> str:
     """Normalize a base URL for consistent comparison."""
     return (url or "").strip().rstrip("/").lower()
+
+
+def _is_local_base_url(url: str) -> bool:
+    """Return whether the URL targets an explicitly local hostname."""
+    hostname = urlsplit(url).hostname
+    if hostname is None:
+        return False
+
+    hostname = hostname.rstrip(".").lower()
+    if hostname in {"localhost", "host.docker.internal", "ollama"}:
+        return True
+    if hostname.endswith(".localhost"):
+        return True
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
 
 
 def _resolve_connection_secret(
@@ -63,7 +82,7 @@ def _resolve_connection_secret(
             return None, None
         key = get_llm_provider_secrets_store().get_plaintext(match.secret_ref or match.id)
         return (key, match.id) if key else (None, None)
-    except Exception as exc:  # noqa: BLE001 — fall back to the profile's own key
+    except Exception as exc:  # noqa: BLE001 — caller handles unavailable connection secrets
         logger.warning(
             "Connection-Secret-Resolution für Profil %r fehlgeschlagen: %s",
             getattr(profile, "id", "?"),
@@ -87,23 +106,21 @@ def build_client_from_profile(
         timeout (float): Request timeout in seconds.
     
     Returns:
-        LLMClient: Configured client using the connection-store key when available, or the profile key as a fallback.
+        LLMClient: Configured client using the matching connection-store key,
+        or local no-auth credentials for local providers.
     
     Raises:
         ValueError: If no API key is available for a non-local provider.
     """
     connection_key, connection_id = _resolve_connection_secret(profile)
-    api_key = connection_key or profile.api_key
-    api_key_source = "connection_store" if connection_key else "profile"
+    api_key = connection_key
+    api_key_source = "connection_store" if connection_key else "local_no_auth"
 
-    base_url_lower = profile.base_url.lower()
-    is_local = any(
-        h in base_url_lower
-        for h in ("localhost", "127.0.0.1", "host.docker.internal", "ollama")
-    )
+    is_local = _is_local_base_url(profile.base_url)
     if not api_key and not is_local:
         raise ValueError(
-            f"LLM-Profil {profile.id!r}: api_key fehlt für Provider {profile.provider!r}"
+            f"LLM-Profil {profile.id!r}: api_key fehlt; kein Secret aus einer passenden "
+            f"aktivierten ProviderConnection für Provider {profile.provider!r}"
         )
     return LLMClient(
         api_key=api_key or "ollama",

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -18,14 +18,14 @@ if TYPE_CHECKING:
 logger = get_logger("agora.llm.factory")
 
 
-def _normalize_base_url(url: Optional[str]) -> str:
-    """Normalize a base URL for consistent comparison."""
-    return (url or "").strip().rstrip("/").lower()
-
-
-def _is_local_base_url(url: str) -> bool:
+def _is_local_base_url(url: str | None) -> bool:
     """Return whether the URL targets an explicitly local hostname."""
-    hostname = urlsplit(url).hostname
+    if not url:
+        return False
+    try:
+        hostname = urlsplit(url).hostname
+    except ValueError:
+        return False
     if hostname is None:
         return False
 
@@ -42,7 +42,7 @@ def _is_local_base_url(url: str) -> bool:
 
 def _resolve_connection_secret(
     profile: "LlmProfile",
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """
     Resolve the API key associated with a profile's enabled provider connection.
     
@@ -50,45 +50,45 @@ def _resolve_connection_secret(
         profile (LlmProfile): Profile whose provider or base URL identifies the connection.
     
     Returns:
-        tuple[Optional[str], Optional[str]]: The plaintext API key and connection ID, or
-        ``(None, None)`` when no matching secret is available or resolution fails.
+        tuple[Optional[str], Optional[str], Optional[str]]: The plaintext API key,
+        connection ID and canonical connection URL, or three ``None`` values when
+        no matching secret is available or resolution fails.
     """
     try:
         from ..services.provider_connection_store import ProviderConnectionStore
-        from ..services.llm_provider_secrets_store import (
-            get_llm_provider_secrets_store,
-        )
-        from ..contracts.provider_types import PROVIDER_CUSTOM
 
         connections = [
             c for c in ProviderConnectionStore().list_connections() if c.enabled
         ]
-        # 1. Exact provider_kind match always wins, independent of store order.
-        match = next(
-            (c for c in connections if c.provider_kind == profile.provider),
-            None,
+    except Exception as exc:  # noqa: BLE001 — caller handles unavailable connection secrets
+        logger.warning(
+            "ProviderConnection-Lesen für Profil %r fehlgeschlagen: %s",
+            getattr(profile, "id", "?"),
+            exc,
         )
-        # 2. base_url fallback ONLY for the generic ``custom`` profile provider —
-        #    a specific (non-custom) profile must never receive another
-        #    provider's secret via a coincidental base_url match.
-        if match is None and profile.provider == PROVIDER_CUSTOM:
-            target = _normalize_base_url(profile.base_url)
-            if target:
-                match = next(
-                    (c for c in connections if _normalize_base_url(c.base_url) == target),
-                    None,
-                )
-        if match is None:
-            return None, None
+        return None, None, None
+
+    from ..services.profile_connection_resolver import resolve_profile_connection
+
+    resolved = resolve_profile_connection(profile, connections)
+    if resolved is None:
+        return None, None, None
+
+    try:
+        from ..services.llm_provider_secrets_store import (
+            get_llm_provider_secrets_store,
+        )
+
+        match = resolved.connection
         key = get_llm_provider_secrets_store().get_plaintext(match.secret_ref or match.id)
-        return (key, match.id) if key else (None, None)
     except Exception as exc:  # noqa: BLE001 — caller handles unavailable connection secrets
         logger.warning(
             "Connection-Secret-Resolution für Profil %r fehlgeschlagen: %s",
             getattr(profile, "id", "?"),
             exc,
         )
-        return None, None
+        return None, None, None
+    return (key, match.id, resolved.base_url) if key else (None, None, None)
 
 
 def build_client_from_profile(
@@ -112,7 +112,7 @@ def build_client_from_profile(
     Raises:
         ValueError: If no API key is available for a non-local provider.
     """
-    connection_key, connection_id = _resolve_connection_secret(profile)
+    connection_key, connection_id, connection_base_url = _resolve_connection_secret(profile)
     api_key = connection_key
     api_key_source = "connection_store" if connection_key else "local_no_auth"
 
@@ -124,7 +124,7 @@ def build_client_from_profile(
         )
     return LLMClient(
         api_key=api_key or "ollama",
-        base_url=profile.base_url,
+        base_url=connection_base_url or profile.base_url,
         model=profile.model_name,
         timeout=timeout,
         run_id=run_id,

--- a/backend/app/services/graph_build.py
+++ b/backend/app/services/graph_build.py
@@ -48,12 +48,14 @@ class GraphBuildService:
             linked_ids={"project_id": project.project_id},
         )
         run_id = run_record["run_id"]
-        seed_run_stage_routing(
-            run_id,
-            "ontology_generation",
-            llm_model_override=llm_model_override,
-            llm_runtime=llm_runtime,
-        )
+        for stage_id in ("document_ingest", "ontology_generation"):
+            seed_run_stage_routing(
+                run_id,
+                stage_id,
+                llm_model_override=llm_model_override,
+                llm_runtime=llm_runtime,
+                llm_profile_id=llm_profile_id,
+            )
         route_router = StageModelRouter(run_id)
         ingest_route = route_router.resolve("document_ingest")
         route_router.lock_stage("document_ingest", ingest_route)
@@ -132,6 +134,10 @@ class GraphBuildService:
             project.graph_build_task_id = None
             project.error = None
 
+        effective_profile_id = llm_profile_id or project.llm_profile_id
+        if llm_profile_id is not None:
+            project.llm_profile_id = llm_profile_id
+
         # Inputs
         chunk_size = chunk_size or project.chunk_size or Config.DEFAULT_CHUNK_SIZE
         chunk_overlap = chunk_overlap or project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP
@@ -174,6 +180,7 @@ class GraphBuildService:
             "graph_build",
             llm_model_override=llm_model_override,
             llm_runtime=llm_runtime,
+            llm_profile_id=effective_profile_id,
         )
         route_router = StageModelRouter(run_record["run_id"])
         resolved_route = route_router.resolve("graph_build")

--- a/backend/app/services/graph_build.py
+++ b/backend/app/services/graph_build.py
@@ -39,13 +39,6 @@ class GraphBuildService:
         if not project:
             raise ValueError(ApiErrorCode.NOT_FOUND)
 
-        _resolved_profile = None
-        if llm_profile_id:
-            from ..services.llm_profiles_store import get_llm_profiles_store
-            _resolved_profile = get_llm_profiles_store().get(llm_profile_id, include_api_key=True)
-            if _resolved_profile is None:
-                raise ValueError(ApiErrorCode.NOT_FOUND)
-
         run_record = run_registry.create_run(
             run_type="ontology_generate",
             entity_id=project.project_id,
@@ -67,31 +60,20 @@ class GraphBuildService:
         ontology_route = route_router.resolve("ontology_generation")
         route_router.lock_stage("ontology_generation", ontology_route)
 
-        if _resolved_profile is not None:
-            from ..utils.llm_client import build_client_from_profile as _build_from_profile
-            llm_client = _build_from_profile(_resolved_profile, run_id=run_id)
-            logger.info(
-                "Using LLM profile %r for ontology (provider=%s, model=%s) [project_id=%s, run_id=%s]",
-                llm_profile_id,
-                _resolved_profile.provider,
-                _resolved_profile.model_name,
-                project_id,
-                run_id
-            )
-        else:
-            llm_client = LLMClient.from_route(
-                ontology_route,
-                secret_resolver=SecretResolver(),
-                api_key_override=resolve_route_api_key(ontology_route, llm_runtime),
-                run_id=run_id,
-            )
-            logger.info(
-                "Calling LLM to generate ontology definition (model=%s, provider=%s) [project_id=%s, run_id=%s]",
-                llm_client.model,
-                ontology_route.provider_id,
-                project_id,
-                run_id
-            )
+        # The locked ontology route is authoritative; profile IDs are metadata only.
+        llm_client = LLMClient.from_route(
+            ontology_route,
+            secret_resolver=SecretResolver(),
+            api_key_override=resolve_route_api_key(ontology_route, llm_runtime),
+            run_id=run_id,
+        )
+        logger.info(
+            "Calling LLM to generate ontology definition (model=%s, provider=%s) [project_id=%s, run_id=%s]",
+            llm_client.model,
+            ontology_route.provider_id,
+            project_id,
+            run_id
+        )
 
         generator = OntologyGenerator(llm_client=llm_client)
         ontology = generator.generate(
@@ -150,18 +132,6 @@ class GraphBuildService:
             project.graph_build_task_id = None
             project.error = None
 
-        # LLM Profile resolution
-        effective_profile_id = llm_profile_id
-        if not effective_profile_id and (not llm_model_override or llm_model_override.lower() == 'default'):
-            effective_profile_id = getattr(project, 'llm_profile_id', None)
-
-        resolved_profile = None
-        if effective_profile_id:
-            from ..services.llm_profiles_store import get_llm_profiles_store
-            resolved_profile = get_llm_profiles_store().get(effective_profile_id, include_api_key=True)
-            if resolved_profile is None:
-                raise ValueError(ApiErrorCode.NOT_FOUND)
-
         # Inputs
         chunk_size = chunk_size or project.chunk_size or Config.DEFAULT_CHUNK_SIZE
         chunk_overlap = chunk_overlap or project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP
@@ -209,31 +179,20 @@ class GraphBuildService:
         resolved_route = route_router.resolve("graph_build")
         route_router.lock_stage("graph_build", resolved_route)
 
-        # NER Extractor
-        if resolved_profile is not None:
-            from ..utils.llm_client import build_client_from_profile
-            ner_llm_client = build_client_from_profile(resolved_profile, run_id=run_record["run_id"])
-            logger.info(
-                "Build-Pfad nutzt LLM-Profil: provider=%s model=%s [project_id=%s, run_id=%s]",
-                resolved_profile.provider,
-                resolved_profile.model_name,
-                project_id,
-                run_record["run_id"]
-            )
-        else:
-            ner_llm_client = LLMClient.from_route(
-                resolved_route,
-                secret_resolver=SecretResolver(),
-                api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
-                run_id=run_record["run_id"],
-            )
-            logger.info(
-                "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s [project_id=%s, run_id=%s]",
-                ner_llm_client.model,
-                resolved_route.provider_id,
-                project_id,
-                run_record["run_id"]
-            )
+        # The locked route is authoritative; legacy profile IDs must not replace it.
+        ner_llm_client = LLMClient.from_route(
+            resolved_route,
+            secret_resolver=SecretResolver(),
+            api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
+            run_id=run_record["run_id"],
+        )
+        logger.info(
+            "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s [project_id=%s, run_id=%s]",
+            ner_llm_client.model,
+            resolved_route.provider_id,
+            project_id,
+            run_record["run_id"]
+        )
         ner_override = NERExtractor(llm_client=ner_llm_client)
 
         def build_task():

--- a/backend/app/services/graph_build.py
+++ b/backend/app/services/graph_build.py
@@ -35,6 +35,24 @@ class GraphBuildService:
         llm_profile_id=None,
         additional_context=None
     ):
+        """
+        Generate an ontology for a project from its documents and simulation requirements.
+        
+        Parameters:
+            project_id: Identifier of the project to update.
+            simulation_requirement: Requirements that guide ontology generation.
+            document_texts: Source documents used to generate the ontology.
+            llm_model_override: Optional model override for the generation run.
+            llm_runtime: Optional runtime configuration for the language model.
+            llm_profile_id: Optional language model profile identifier recorded on the project.
+            additional_context: Optional context supplied to the ontology generator.
+        
+        Returns:
+            The project updated with the generated ontology and analysis summary.
+        
+        Raises:
+            ValueError: If the project does not exist.
+        """
         project = ProjectManager.get_project(project_id)
         if not project:
             raise ValueError(ApiErrorCode.NOT_FOUND)
@@ -117,6 +135,28 @@ class GraphBuildService:
         chunk_overlap=None,
         container=None
     ):
+        """
+        Queue a graph build for a project using its extracted text and ontology.
+        
+        Parameters:
+            project_id: Identifier of the project to build.
+            graph_name: Name assigned to the new graph.
+            llm_model_override: Optional model override for graph processing.
+            llm_runtime: Optional runtime configuration for the language model.
+            llm_profile_id: Optional language model profile identifier.
+            force: Whether to restart a graph build already in progress.
+            chunk_size: Optional text chunk size.
+            chunk_overlap: Optional overlap between consecutive text chunks.
+            container: Service container used to create the graph builder.
+        
+        Returns:
+            A tuple containing the task identifier and run identifier.
+        
+        Raises:
+            ValueError: If the project, extracted text, or ontology is missing, or if
+                the project has not completed ontology generation.
+            RuntimeError: If a graph build is already in progress and `force` is false.
+        """
         project = ProjectManager.get_project(project_id)
         if not project:
             raise ValueError(ApiErrorCode.NOT_FOUND)
@@ -203,6 +243,12 @@ class GraphBuildService:
         ner_override = NERExtractor(llm_client=ner_llm_client)
 
         def build_task():
+            """
+            Builds the project's graph and records its completion or failure state.
+            
+            On failure, marks the project, task, and run as failed and attempts to clean up any
+            partially created graph.
+            """
             build_logger = get_logger('agora.build')
             graph_id = None
             try:

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -51,11 +51,21 @@ def seed_run_stage_routing(
     llm_runtime: Optional[RuntimeLlmConfig],
     llm_profile_id: Optional[str] = None,
 ) -> RuntimeLlmRouting:
-    """Persist an initial per-run routing config for *stage_id*.
-
-    New runs inherit the server default route. A request-local model/provider
-    override is stored as a stage override so later stage locks and the UI can
-    inspect the effective runtime decision.
+    """
+    Persist per-run routing for a stage, applying workspace defaults and request-specific overrides.
+    
+    Parameters:
+    	run_id (str): Identifier of the run whose routing configuration is updated.
+    	stage_id (StageId): Identifier of the stage receiving the routing configuration.
+    	llm_model_override (Optional[str]): Model name to use for the stage.
+    	llm_runtime (Optional[RuntimeLlmConfig]): Runtime provider settings to apply.
+    	llm_profile_id (Optional[str]): Identifier of an LLM profile to use for the stage.
+    
+    Returns:
+    	RuntimeLlmRouting: The saved per-run routing configuration.
+    
+    Raises:
+    	ValueError: If the specified LLM profile or a compatible activated provider connection is unavailable.
     """
     config_service = RuntimeRunConfig(run_id)
     has_existing_config = os.path.exists(config_service.config_path)
@@ -126,10 +136,19 @@ def seed_run_stage_routing(
 
 
 def resolve_route_api_key(route: ResolvedRoute, llm_runtime: Optional[RuntimeLlmConfig] = None) -> Optional[str]:
-    """Resolve the secret API key for a resolved route.
-
-    Prefers the request-scoped runtime secret when it matches the selected
-    provider. Falls back to the server-side secret resolver otherwise.
+    """Resolve the API key for a resolved route.
+    
+    Connection-only routes use their bound secret reference. Other routes use a
+    matching request-scoped runtime key when available, then fall back to the
+    server-side provider secret.
+    
+    Parameters:
+        route (ResolvedRoute): The resolved route whose API key is needed.
+        llm_runtime (Optional[RuntimeLlmConfig]): Request-scoped runtime
+            configuration that may provide a matching API key.
+    
+    Returns:
+        Optional[str]: The resolved API key, or None when no key is available.
     """
     if route.provider_options.get("connection_only") is True:
         raw_secret_ref = route.provider_options.get("secret_ref")

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -55,17 +55,17 @@ def seed_run_stage_routing(
     Persist per-run routing for a stage, applying workspace defaults and request-specific overrides.
     
     Parameters:
-    	run_id (str): Identifier of the run whose routing configuration is updated.
-    	stage_id (StageId): Identifier of the stage receiving the routing configuration.
-    	llm_model_override (Optional[str]): Model name to use for the stage.
-    	llm_runtime (Optional[RuntimeLlmConfig]): Runtime provider settings to apply.
-    	llm_profile_id (Optional[str]): Identifier of an LLM profile to use for the stage.
+        run_id (str): Identifier of the run whose routing configuration is updated.
+        stage_id (StageId): Identifier of the stage receiving the routing configuration.
+        llm_model_override (Optional[str]): Model name to use for the stage.
+        llm_runtime (Optional[RuntimeLlmConfig]): Runtime provider settings to apply.
+        llm_profile_id (Optional[str]): Identifier of an LLM profile to use for the stage.
     
     Returns:
-    	RuntimeLlmRouting: The saved per-run routing configuration.
+        RuntimeLlmRouting: The saved per-run routing configuration.
     
     Raises:
-    	ValueError: If the specified LLM profile or a compatible activated provider connection is unavailable.
+        ValueError: If the specified LLM profile or a compatible activated provider connection is unavailable.
     """
     config_service = RuntimeRunConfig(run_id)
     has_existing_config = os.path.exists(config_service.config_path)

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -119,14 +119,21 @@ def seed_run_stage_routing(
                 f"LLM-Profil {llm_profile_id!r}: keine passende aktivierte "
                 "ProviderConnection"
             )
+        connection = resolved.connection
+        provider_options: dict[str, object] = {"base_url": resolved.base_url}
+        # Nur echte api_key-Connections an ihr gebundenes Secret koppeln. Lokale
+        # No-Auth-Connections (auth_mode="none") würden über connection_only sonst
+        # auf ein nicht existentes Secret zeigen; die strikte Auflösung liefert dann
+        # None und der Run bricht mit "LLM_API_KEY not configured" — das lokale
+        # Ollama-Betriebsmodell bliebe gebrochen. Die Auth-Semantik der
+        # ProviderConnection ist maßgeblich (SSoT), kein pauschales connection_only.
+        if connection.auth_mode == "api_key" and connection.secret_ref:
+            provider_options["secret_ref"] = connection.secret_ref
+            provider_options["connection_only"] = True
         config.stage_overrides[stage_id] = StageLLMRoute(
-            provider_id=resolved.connection.id,
+            provider_id=connection.id,
             model=profile.model_name,
-            provider_options={
-                "base_url": resolved.base_url,
-                "secret_ref": resolved.connection.secret_ref or resolved.connection.id,
-                "connection_only": True,
-            },
+            provider_options=provider_options,
         )
         if has_existing_config:
             config.routing_version += 1

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -13,9 +13,13 @@ from typing import Optional
 from ..contracts.llm_routing_contract import ResolvedRoute, RuntimeLlmRouting, StageId, StageLLMRoute
 from ..llm.providers.registry import detect_provider
 from .llm_provider_registry import LlmProviderRegistry
+from .llm_provider_secrets_store import get_llm_provider_secrets_store
+from .llm_profiles_store import get_llm_profiles_store
 from .llm_runtime import RuntimeLlmConfig
+from .profile_connection_resolver import resolve_profile_connection
+from .provider_connection_store import ProviderConnectionStore
 from .runtime_run_config import RuntimeRunConfig
-from .secret_resolver import SecretResolver
+from .secret_resolver import SecretResolver, get_bound_store_api_key
 from .workspace_routing_store import get_workspace_routing_store
 
 _PROVIDER_ID_MAP = {
@@ -45,6 +49,7 @@ def seed_run_stage_routing(
     *,
     llm_model_override: Optional[str],
     llm_runtime: Optional[RuntimeLlmConfig],
+    llm_profile_id: Optional[str] = None,
 ) -> RuntimeLlmRouting:
     """Persist an initial per-run routing config for *stage_id*.
 
@@ -88,6 +93,33 @@ def seed_run_stage_routing(
         )
         if has_existing_config:
             config.routing_version += 1
+    elif llm_profile_id:
+        profile = get_llm_profiles_store().get(
+            llm_profile_id,
+            include_api_key=False,
+        )
+        if profile is None:
+            raise ValueError(f"LLM-Profil {llm_profile_id!r} nicht gefunden")
+        resolved = resolve_profile_connection(
+            profile,
+            ProviderConnectionStore().list_connections(),
+        )
+        if resolved is None:
+            raise ValueError(
+                f"LLM-Profil {llm_profile_id!r}: keine passende aktivierte "
+                "ProviderConnection"
+            )
+        config.stage_overrides[stage_id] = StageLLMRoute(
+            provider_id=resolved.connection.id,
+            model=profile.model_name,
+            provider_options={
+                "base_url": resolved.base_url,
+                "secret_ref": resolved.connection.secret_ref or resolved.connection.id,
+                "connection_only": True,
+            },
+        )
+        if has_existing_config:
+            config.routing_version += 1
 
     config_service.save_config(config)
     return config
@@ -99,6 +131,14 @@ def resolve_route_api_key(route: ResolvedRoute, llm_runtime: Optional[RuntimeLlm
     Prefers the request-scoped runtime secret when it matches the selected
     provider. Falls back to the server-side secret resolver otherwise.
     """
+    if route.provider_options.get("connection_only") is True:
+        raw_secret_ref = route.provider_options.get("secret_ref")
+        secret_ref = raw_secret_ref if isinstance(raw_secret_ref, str) else ""
+        return get_bound_store_api_key(
+            secret_ref,
+            secrets_store=get_llm_provider_secrets_store(),
+        )
+
     runtime = llm_runtime or RuntimeLlmConfig()
     runtime_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
     if runtime.enabled and runtime.api_key and runtime_provider_id == route.provider_id:

--- a/backend/app/services/profile_connection_resolver.py
+++ b/backend/app/services/profile_connection_resolver.py
@@ -1,0 +1,113 @@
+"""Secret-freie Bindung von Legacy-LLM-Profilen an ProviderConnections."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import NamedTuple
+from urllib.parse import urlsplit, urlunsplit
+
+from ..contracts.ai_provider_contract import ProviderConnection
+from ..contracts.llm_profile_contract import LlmProfile
+from ..contracts.provider_types import PROVIDER_CUSTOM
+from .llm_provider_registry import LlmProviderRegistry
+
+
+class ResolvedProfileConnection(NamedTuple):
+    """ProviderConnection plus ihr kanonischer HTTP-Endpunkt."""
+
+    connection: ProviderConnection
+    base_url: str
+
+
+_LEGACY_PROVIDER_KIND_ALIASES: dict[str, frozenset[str]] = {
+    "cloud": frozenset({"cloud", "ollama_cloud"}),
+    "unknown": frozenset({"unknown", "openai_compatible"}),
+}
+
+
+def normalize_endpoint_url(url: str | None) -> str:
+    """Normalisiere einen Endpunkt fuer einen stabilen Identitaetsvergleich."""
+
+    raw = (url or "").strip().rstrip("/")
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return raw
+    if not parsed.scheme or hostname is None:
+        return raw
+
+    normalized_host = hostname.rstrip(".").lower()
+    if ":" in normalized_host:
+        normalized_host = f"[{normalized_host}]"
+    default_port = (parsed.scheme.lower(), port) in {("http", 80), ("https", 443)}
+    netloc = normalized_host if port is None or default_port else f"{normalized_host}:{port}"
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            netloc,
+            parsed.path.rstrip("/"),
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def canonical_connection_base_url(connection: ProviderConnection) -> str | None:
+    """Liefere den Connection-Endpunkt oder den Registry-Default."""
+
+    if connection.base_url:
+        return str(connection.base_url)
+    definition = LlmProviderRegistry.connection_definition(connection.provider_kind)
+    return definition.default_base_url if definition is not None else None
+
+
+def resolve_profile_connection(
+    profile: LlmProfile,
+    connections: Iterable[ProviderConnection],
+) -> ResolvedProfileConnection | None:
+    """Binde ein Legacy-Profil nur an Kind- und Endpunkt-kompatible Connections.
+
+    ``custom`` bleibt der einzige Legacy-Provider, der bei exakt gleichem
+    Endpunkt ueber Provider-Kinds hinweg gebunden werden darf.
+    """
+
+    enabled = [connection for connection in connections if connection.enabled]
+    profile_endpoint = normalize_endpoint_url(profile.base_url)
+
+    if profile.provider == PROVIDER_CUSTOM:
+        candidates = enabled
+    else:
+        compatible_kinds = _LEGACY_PROVIDER_KIND_ALIASES.get(
+            profile.provider,
+            frozenset({profile.provider}),
+        )
+        candidates = [
+            connection
+            for connection in enabled
+            if connection.provider_kind in compatible_kinds
+        ]
+
+    for connection in candidates:
+        base_url = canonical_connection_base_url(connection)
+        if base_url and normalize_endpoint_url(base_url) == profile_endpoint:
+            return ResolvedProfileConnection(connection, base_url)
+
+    if candidates and profile.provider != PROVIDER_CUSTOM:
+        raise ValueError(
+            f"LLM-Profil {profile.id!r}: Profil-Endpunkt {profile.base_url!r} stimmt "
+            f"mit keiner aktivierten ProviderConnection fuer Provider "
+            f"{profile.provider!r} ueberein"
+        )
+    return None
+
+
+__all__ = [
+    "ResolvedProfileConnection",
+    "canonical_connection_base_url",
+    "normalize_endpoint_url",
+    "resolve_profile_connection",
+]

--- a/backend/app/services/profile_connection_resolver.py
+++ b/backend/app/services/profile_connection_resolver.py
@@ -115,10 +115,25 @@ def resolve_profile_connection(
             if connection.provider_kind in compatible_kinds
         ]
 
-    for connection in candidates:
-        base_url = canonical_connection_base_url(connection)
-        if base_url and normalize_endpoint_url(base_url) == profile_endpoint:
-            return ResolvedProfileConnection(connection, base_url)
+    # Alle Endpunkt-Treffer sammeln und genau einen verlangen. Bei mehreren
+    # aktivierten Connections mit demselben normalisierten Endpunkt darf nicht
+    # still der erste Store-Eintrag gewinnen (Secret-Roulette) — das ist
+    # mehrdeutig und muss mit einer eindeutigen Fehlermeldung abbrechen.
+    matches = [
+        ResolvedProfileConnection(connection, base_url)
+        for connection in candidates
+        if (base_url := canonical_connection_base_url(connection))
+        and normalize_endpoint_url(base_url) == profile_endpoint
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise ValueError(
+            f"LLM-Profil {profile.id!r}: mehrdeutiger Profil-Endpunkt "
+            f"{profile.base_url!r} — {len(matches)} aktivierte ProviderConnections "
+            f"teilen denselben Endpunkt ({', '.join(m.connection.id for m in matches)}); "
+            "genau eine erwartet"
+        )
 
     if candidates and profile.provider != PROVIDER_CUSTOM:
         raise ValueError(

--- a/backend/app/services/profile_connection_resolver.py
+++ b/backend/app/services/profile_connection_resolver.py
@@ -30,10 +30,10 @@ def normalize_endpoint_url(url: str | None) -> str:
     Normalize an endpoint URL for stable identity comparisons.
     
     Parameters:
-    	url (str | None): The endpoint URL to normalize.
+        url (str | None): The endpoint URL to normalize.
     
     Returns:
-    	str: The normalized URL, or the trimmed input when it cannot be parsed as a URL.
+        str: The normalized URL, or the trimmed input when it cannot be parsed as a URL.
     """
 
     raw = (url or "").strip().rstrip("/")

--- a/backend/app/services/profile_connection_resolver.py
+++ b/backend/app/services/profile_connection_resolver.py
@@ -26,7 +26,15 @@ _LEGACY_PROVIDER_KIND_ALIASES: dict[str, frozenset[str]] = {
 
 
 def normalize_endpoint_url(url: str | None) -> str:
-    """Normalisiere einen Endpunkt fuer einen stabilen Identitaetsvergleich."""
+    """
+    Normalize an endpoint URL for stable identity comparisons.
+    
+    Parameters:
+    	url (str | None): The endpoint URL to normalize.
+    
+    Returns:
+    	str: The normalized URL, or the trimmed input when it cannot be parsed as a URL.
+    """
 
     raw = (url or "").strip().rstrip("/")
     if not raw:
@@ -57,7 +65,15 @@ def normalize_endpoint_url(url: str | None) -> str:
 
 
 def canonical_connection_base_url(connection: ProviderConnection) -> str | None:
-    """Liefere den Connection-Endpunkt oder den Registry-Default."""
+    """
+    Determine the base URL used for a provider connection.
+    
+    Args:
+        connection: The provider connection whose configured or default endpoint is used.
+    
+    Returns:
+        The configured base URL, the provider registry's default base URL, or `None` if no endpoint is available.
+    """
 
     if connection.base_url:
         return str(connection.base_url)
@@ -69,10 +85,18 @@ def resolve_profile_connection(
     profile: LlmProfile,
     connections: Iterable[ProviderConnection],
 ) -> ResolvedProfileConnection | None:
-    """Binde ein Legacy-Profil nur an Kind- und Endpunkt-kompatible Connections.
-
-    ``custom`` bleibt der einzige Legacy-Provider, der bei exakt gleichem
-    Endpunkt ueber Provider-Kinds hinweg gebunden werden darf.
+    """
+    Bind a legacy profile to an enabled provider connection with a compatible provider kind and endpoint.
+    
+    Parameters:
+        profile (LlmProfile): Legacy profile whose provider kind and base URL determine compatibility.
+        connections (Iterable[ProviderConnection]): Provider connections to consider.
+    
+    Returns:
+        ResolvedProfileConnection: The matching provider connection and its canonical base URL, or `None` if no match exists.
+    
+    Raises:
+        ValueError: If compatible connections exist for a non-custom provider but none has a matching endpoint.
     """
 
     enabled = [connection for connection in connections if connection.enabled]

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -45,7 +45,7 @@ from ..contracts import (
     PROVIDER_OPENAI_COMPATIBLE,
     PROVIDER_GITHUB_COPILOT,
 )
-from .llm_provider_secrets_store import get_llm_provider_secrets_store
+from .llm_provider_secrets_store import LlmProviderSecretsStore, get_llm_provider_secrets_store
 
 logger = logging.getLogger("agora.secret_resolver")
 
@@ -107,6 +107,22 @@ def _mask_for_log(value: Optional[str]) -> str:
     return f"{v[:4]}..."
 
 
+def get_bound_store_api_key(
+    secret_ref: str,
+    *,
+    secrets_store: Optional[LlmProviderSecretsStore] = None,
+) -> Optional[str]:
+    """Read exactly one explicitly bound persistent secret without fallbacks."""
+    if not secret_ref:
+        return None
+    try:
+        store = secrets_store or get_llm_provider_secrets_store()
+        return store.get_plaintext(secret_ref)
+    except RuntimeError as exc:
+        logger.warning("Gebundener Secret-Store-Zugriff fehlgeschlagen; kein Fallback: %s", exc)
+        return None
+
+
 class SecretResolver:
     """Resolves secrets for LLM providers.
 
@@ -120,6 +136,15 @@ class SecretResolver:
     def __init__(self, session_api_keys: Optional[Dict[str, str]] = None):
         self._session_keys = session_api_keys or {}
         self.last_source: Optional[str] = None
+
+    @staticmethod
+    def get_bound_api_key(
+        secret_ref: str,
+        *,
+        secrets_store: Optional[LlmProviderSecretsStore] = None,
+    ) -> Optional[str]:
+        """Read exactly one explicitly bound store secret without fallbacks."""
+        return get_bound_store_api_key(secret_ref, secrets_store=secrets_store)
 
     def get_api_key(self, provider_id: str, provider_type: str) -> Optional[str]:
         """Resolve API key for a provider. Setzt :attr:`last_source` als Seiteneffekt."""

--- a/backend/app/services/secret_resolver.py
+++ b/backend/app/services/secret_resolver.py
@@ -96,7 +96,15 @@ def _format_valid(value: Optional[str], provider_type: str) -> bool:
 
 
 def _mask_for_log(value: Optional[str]) -> str:
-    """Erster Block für Logs. Niemals den ganzen Wert ausgeben."""
+    """
+    Create a safe abbreviated representation of a value for log messages.
+    
+    Parameters:
+        value (Optional[str]): The value to mask.
+    
+    Returns:
+        str: "<empty>" for missing or whitespace-only values, "<short>" for values up to four characters, or the first four characters followed by "...".
+    """
     if not value:
         return "<empty>"
     v = value.strip()
@@ -112,7 +120,16 @@ def get_bound_store_api_key(
     *,
     secrets_store: Optional[LlmProviderSecretsStore] = None,
 ) -> Optional[str]:
-    """Read exactly one explicitly bound persistent secret without fallbacks."""
+    """
+    Read one explicitly bound persistent secret without applying fallbacks.
+    
+    Parameters:
+        secret_ref (str): Reference identifying the stored secret.
+    
+    Returns:
+        Optional[str]: The decrypted secret, or `None` if the reference is empty,
+            the secret is unavailable, or store access fails.
+    """
     if not secret_ref:
         return None
     try:
@@ -134,6 +151,11 @@ class SecretResolver:
     """
 
     def __init__(self, session_api_keys: Optional[Dict[str, str]] = None):
+        """Initialize the resolver with optional session-only API key overrides.
+        
+        Parameters:
+            session_api_keys: Mapping of provider IDs to session-only API keys.
+        """
         self._session_keys = session_api_keys or {}
         self.last_source: Optional[str] = None
 
@@ -147,7 +169,19 @@ class SecretResolver:
         return get_bound_store_api_key(secret_ref, secrets_store=secrets_store)
 
     def get_api_key(self, provider_id: str, provider_type: str) -> Optional[str]:
-        """Resolve API key for a provider. Setzt :attr:`last_source` als Seiteneffekt."""
+        """
+        Resolve an API key using session overrides, persistent storage, provider-specific environment variables, and configuration fallback.
+        
+        Parameters:
+            provider_id (str): Identifier used to look up the provider's session or stored key.
+            provider_type (str): Provider type used to select environment variables and validate key formats.
+        
+        Returns:
+            Optional[str]: The first valid API key found, or `None` if no usable key is available.
+        
+        Side Effects:
+            Updates `last_source` with the source of the resolved key, or `None` when resolution fails.
+        """
         self.last_source = None
 
         # 1. Session-only override

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -228,9 +228,17 @@ class EmbeddingService:
 
     def _request_embeddings(self, texts: List[str]) -> List[List[float]]:
         """
-        Make HTTP request to the configured embedding provider.
-
-        Supports Ollama `/api/embed` and OpenAI-compatible `/v1/embeddings`.
+        Send texts to the configured embedding provider and parse the returned vectors.
+        
+        Parameters:
+            texts: Texts to embed.
+        
+        Returns:
+            The embedding vector for each input text, in the same order.
+        
+        Raises:
+            EmbeddingError: If the request fails, the response is invalid, or the
+                provider returns a different number of vectors than requested.
         """
         payload = {
             "model": self.model,

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -258,12 +258,34 @@ class EmbeddingService:
                 )
                 response.raise_for_status()
                 data = response.json()
+
+                # Validate response structure
+                if not isinstance(data, dict):
+                    raise EmbeddingError(f"Invalid {provider_label} response: expected dict, got {type(data).__name__}")
+
                 embeddings = self._extract_embeddings(data)
 
+                # Validate response is a list
+                if not isinstance(embeddings, list):
+                    raise EmbeddingError(f"Invalid {provider_label} response: embeddings must be a list")
+
+                # Validate count
                 if len(embeddings) != len(texts):
                     raise EmbeddingError(
                         f"Expected {len(texts)} embeddings, got {len(embeddings)}"
                     )
+
+                # Validate each embedding vector
+                for i, embedding in enumerate(embeddings):
+                    if not isinstance(embedding, list):
+                        raise EmbeddingError(
+                            f"Invalid {provider_label} response: embedding {i} must be a list, got {type(embedding).__name__}"
+                        )
+                    for j, value in enumerate(embedding):
+                        if not isinstance(value, (int, float)):
+                            raise EmbeddingError(
+                                f"Invalid {provider_label} response: embedding {i}[{j}] must be numeric, got {type(value).__name__}"
+                            )
 
                 return embeddings
 

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -73,7 +73,11 @@ def validate_embedding_configuration(
 
 
 class EmbeddingService:
-    """Generate embeddings using local Ollama server."""
+    """Generate embeddings through the independently configured embedding route.
+
+    Chat routing and embedding configuration are deliberately separate per
+    ADR-0007; this service therefore does not use the chat-provider registry.
+    """
 
     # Class-level flag: stub-mode log wird nur einmal ausgegeben (alle Instanzen).
     _stub_mode_logged: bool = False

--- a/backend/tests/api/test_graph_build_routing.py
+++ b/backend/tests/api/test_graph_build_routing.py
@@ -100,7 +100,9 @@ def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
 
 
 def test_build_graph_explicit_route_wins_over_legacy_project_profile(client, monkeypatch):
-    """Eine explizit aufgelöste Route bleibt trotz Legacy-Profil maßgeblich."""
+    """
+    Verify that the explicitly resolved stage route takes precedence over the legacy project LLM profile during graph building.
+    """
     fake_project = MagicMock()
     fake_project.status = ProjectStatus.ONTOLOGY_GENERATED
     fake_project.ontology = {"entity_types": [], "edge_types": []}
@@ -203,6 +205,15 @@ def test_generate_ontology_explicit_route_wins_over_legacy_profile(monkeypatch):
             pass
 
         def resolve(self, stage_id: str):
+            """
+            Resolve a stage to its configured model route.
+            
+            Parameters:
+                stage_id (str): Identifier of the stage to resolve.
+            
+            Returns:
+                ResolvedRoute: The model route assigned to the stage.
+            """
             return ResolvedRoute(
                 stage=stage_id,
                 provider_id="openai",

--- a/backend/tests/api/test_graph_build_routing.py
+++ b/backend/tests/api/test_graph_build_routing.py
@@ -8,6 +8,7 @@ from flask import Flask
 from app.api import graph_bp
 from app.contracts.llm_routing_contract import ResolvedRoute
 from app.models.project import ProjectStatus
+from app.services.graph_build import GraphBuildService
 
 
 VALID_PROJECT_ID = "proj_0123456789ab"
@@ -98,9 +99,8 @@ def test_build_graph_uses_resolved_route_for_ner_override(client, monkeypatch):
     assert captured_ner["llm_client"] is fake_llm_client
 
 
-def test_build_graph_uses_profile_when_set_on_project(client, monkeypatch):
-    """Wenn project.llm_profile_id gesetzt ist, baut build_graph den NER-Client
-    aus dem Profil — nicht aus dem Stage-Router-Default."""
+def test_build_graph_explicit_route_wins_over_legacy_project_profile(client, monkeypatch):
+    """Eine explizit aufgelöste Route bleibt trotz Legacy-Profil maßgeblich."""
     fake_project = MagicMock()
     fake_project.status = ProjectStatus.ONTOLOGY_GENERATED
     fake_project.ontology = {"entity_types": [], "edge_types": []}
@@ -186,6 +186,65 @@ def test_build_graph_uses_profile_when_set_on_project(client, monkeypatch):
     response = client.post("/api/graph/build", json={"project_id": VALID_PROJECT_ID})
 
     assert response.status_code == 200, response.get_json()
-    # Kernzusicherung: NER-Client kommt aus dem Profil-Pfad, nicht aus from_route.
-    assert captured_ner["llm_client"] is fake_profile_client
-    assert captured_ner["llm_client"] is not fake_route_client
+    # Kernzusicherung: Der gelockte Stage-Route-Snapshot gewinnt vor dem Profil.
+    assert captured_ner["llm_client"] is fake_route_client
+    assert captured_ner["llm_client"] is not fake_profile_client
+
+
+def test_generate_ontology_explicit_route_wins_over_legacy_profile(monkeypatch):
+    project = MagicMock(project_id=VALID_PROJECT_ID)
+    legacy_profile = MagicMock(provider="openai", model_name="legacy-model")
+    legacy_client = MagicMock(name="LegacyProfileClient")
+    route_client = MagicMock(name="RouteClient", model="gpt-5-mini")
+    captured = {}
+
+    class FakeRouter:
+        def __init__(self, _run_id: str):
+            pass
+
+        def resolve(self, stage_id: str):
+            return ResolvedRoute(
+                stage=stage_id,
+                provider_id="openai",
+                model="gpt-5-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=4,
+            )
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def generator(*, llm_client):
+        captured["llm_client"] = llm_client
+        instance = MagicMock()
+        instance.generate.return_value = {
+            "entity_types": [],
+            "edge_types": [],
+            "analysis_summary": "ok",
+        }
+        return instance
+
+    store = MagicMock()
+    store.get.return_value = legacy_profile
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.get_project", lambda _pid: project)
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.save_project", lambda _project: None)
+    monkeypatch.setattr("app.services.graph_build.run_registry.create_run", lambda **_kwargs: {"run_id": "run_ontology"})
+    monkeypatch.setattr("app.services.graph_build.run_registry.update_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", FakeRouter)
+    monkeypatch.setattr("app.services.graph_build.resolve_route_api_key", lambda *_args, **_kwargs: "sk-route")
+    monkeypatch.setattr("app.services.graph_build.LLMClient.from_route", lambda *_args, **_kwargs: route_client)
+    monkeypatch.setattr("app.services.graph_build.OntologyGenerator", generator)
+    monkeypatch.setattr("app.services.llm_profiles_store.get_llm_profiles_store", lambda: store)
+    monkeypatch.setattr("app.utils.llm_client.build_client_from_profile", lambda *_args, **_kwargs: legacy_client)
+
+    GraphBuildService.generate_ontology(
+        project_id=VALID_PROJECT_ID,
+        simulation_requirement="Discuss climate policy.",
+        document_texts=["document"],
+        llm_model_override="gpt-5-mini",
+        llm_profile_id="prof_legacy",
+    )
+
+    assert captured["llm_client"] is route_client
+    assert captured["llm_client"] is not legacy_client

--- a/backend/tests/api/test_graph_endpoints.py
+++ b/backend/tests/api/test_graph_endpoints.py
@@ -257,6 +257,7 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager(monkeypatch)
 
     from app.models.task import TaskManager
     from app.models.project import ProjectStatus
+    from app.contracts.llm_routing_contract import ResolvedRoute
 
     # Captured update_task calls + Event, das im Background-Thread gesetzt wird,
     # sobald der erste progress_detail-Call durchlaeuft. Ersetzt den frueheren
@@ -301,6 +302,14 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager(monkeypatch)
     fake_container = MagicMock()
     fake_container.neo4j_storage = MagicMock()  # must be non-None
     fake_container.graph_builder.return_value = fake_builder
+    route_router = MagicMock()
+    route_router.resolve.return_value = ResolvedRoute(
+        stage="graph_build",
+        provider_id="openai",
+        model="gpt-4o-mini",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=4,
+    )
 
     # After PR #562 the build logic lives in app.services.graph_build. Patches
     # on function symbols (seed_run_stage_routing, NERExtractor) must target
@@ -317,6 +326,7 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager(monkeypatch)
         patch("app.api.graph.TextProcessor.split_text", return_value=["chunk1", "chunk2"]),
         patch("app.api.graph.ArtifactLocator.existing_paths", return_value={}),
         patch("app.services.graph_build.seed_run_stage_routing"),
+        patch("app.services.graph_build.StageModelRouter", return_value=route_router),
         patch("app.services.graph_build.NERExtractor", return_value=MagicMock(name="NEROverride")),
         patch("app.services.graph_build.LLMClient.from_route", return_value=MagicMock(name="LLMClient", model="stub")),
         patch("app.services.graph_build.resolve_route_api_key", return_value="sk-stub"),

--- a/backend/tests/api/test_graph_ontology_persists_project_meta.py
+++ b/backend/tests/api/test_graph_ontology_persists_project_meta.py
@@ -38,7 +38,7 @@ def app(monkeypatch):
     Create a Flask application configured for graph API integration tests.
     
     Returns:
-    	Flask: A test application with the graph blueprint and mocked storage configured.
+        Flask: A test application with the graph blueprint and mocked storage configured.
     """
     monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o")
     storage = MagicMock(name="Neo4jStorage")

--- a/backend/tests/api/test_graph_ontology_persists_project_meta.py
+++ b/backend/tests/api/test_graph_ontology_persists_project_meta.py
@@ -33,7 +33,8 @@ REQUIREMENT = "Persistenz-Smoke: Requirement muss den Service-Reload überleben.
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o")
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)
     flask_app = Flask(__name__)

--- a/backend/tests/api/test_graph_ontology_persists_project_meta.py
+++ b/backend/tests/api/test_graph_ontology_persists_project_meta.py
@@ -34,6 +34,12 @@ REQUIREMENT = "Persistenz-Smoke: Requirement muss den Service-Reload überleben.
 
 @pytest.fixture
 def app(monkeypatch):
+    """
+    Create a Flask application configured for graph API integration tests.
+    
+    Returns:
+    	Flask: A test application with the graph blueprint and mocked storage configured.
+    """
     monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o")
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)

--- a/backend/tests/api/test_graph_ontology_respects_frontend_model.py
+++ b/backend/tests/api/test_graph_ontology_respects_frontend_model.py
@@ -21,6 +21,14 @@ from app.container import AgoraContainer
 
 @pytest.fixture
 def app(monkeypatch):
+    """Create a Flask test application configured with mocked storage and the graph API blueprint.
+    
+    Parameters:
+        monkeypatch: Pytest fixture used to set the default LLM model for the test application.
+    
+    Returns:
+        Flask: A configured Flask application instance.
+    """
     monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o")
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)

--- a/backend/tests/api/test_graph_ontology_respects_frontend_model.py
+++ b/backend/tests/api/test_graph_ontology_respects_frontend_model.py
@@ -21,6 +21,7 @@ from app.container import AgoraContainer
 
 @pytest.fixture
 def app(monkeypatch):
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o")
     storage = MagicMock(name="Neo4jStorage")
     container = AgoraContainer(neo4j_storage=storage)
     flask_app = Flask(__name__)

--- a/backend/tests/api/test_llm_profiles.py
+++ b/backend/tests/api/test_llm_profiles.py
@@ -48,7 +48,9 @@ def test_list_returns_bootstrap_profile(client, monkeypatch):
     data = res.get_json()
     assert data["success"] is True
     assert len(data["data"]["profiles"]) >= 1
-    assert res.headers["Deprecation"] == "true"
+    # RFC 9745 Structured Field Date format: @<unix-timestamp>
+    assert res.headers["Deprecation"].startswith("@")
+    assert res.headers["Deprecation"][1:].isdigit()
     assert res.headers["X-Agora-Removal-Version"] == "1.0.0"
     assert res.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 

--- a/backend/tests/api/test_llm_profiles.py
+++ b/backend/tests/api/test_llm_profiles.py
@@ -48,9 +48,7 @@ def test_list_returns_bootstrap_profile(client, monkeypatch):
     data = res.get_json()
     assert data["success"] is True
     assert len(data["data"]["profiles"]) >= 1
-    # RFC 9745 Structured Field Date format: @<unix-timestamp>
-    assert res.headers["Deprecation"].startswith("@")
-    assert res.headers["Deprecation"][1:].isdigit()
+    assert res.headers["Deprecation"] == "@1784332800"
     assert res.headers["X-Agora-Removal-Version"] == "1.0.0"
     assert res.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 

--- a/backend/tests/api/test_llm_profiles.py
+++ b/backend/tests/api/test_llm_profiles.py
@@ -48,6 +48,9 @@ def test_list_returns_bootstrap_profile(client, monkeypatch):
     data = res.get_json()
     assert data["success"] is True
     assert len(data["data"]["profiles"]) >= 1
+    assert res.headers["Deprecation"] == "true"
+    assert res.headers["X-Agora-Removal-Version"] == "1.0.0"
+    assert res.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 
 
 def test_list_returns_empty_when_no_model_env(client, monkeypatch):

--- a/backend/tests/api/test_provider_connections_api.py
+++ b/backend/tests/api/test_provider_connections_api.py
@@ -248,6 +248,9 @@ def test_legacy_models_route_delegates_to_connection_service(api_client, lifecyc
     assert response.status_code == 200, response.get_json()
     assert response.get_json()["data"] == []
     assert service.probed == ["openai"]
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["X-Agora-Removal-Version"] == "1.0.0"
+    assert response.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 
 
 def test_legacy_opencode_route_is_unsupported_without_probe(api_client, lifecycle):

--- a/backend/tests/api/test_provider_connections_api.py
+++ b/backend/tests/api/test_provider_connections_api.py
@@ -254,6 +254,9 @@ def test_legacy_models_route_delegates_to_connection_service(api_client, lifecyc
 
 
 def test_legacy_opencode_route_is_unsupported_without_probe(api_client, lifecycle):
+    """
+    Verify that the legacy OpenCode model route rejects unsupported providers without probing the service.
+    """
     _, service = lifecycle
 
     response = api_client.get("/api/llm/providers/opencode_go/models")

--- a/backend/tests/api/test_provider_connections_api.py
+++ b/backend/tests/api/test_provider_connections_api.py
@@ -248,7 +248,9 @@ def test_legacy_models_route_delegates_to_connection_service(api_client, lifecyc
     assert response.status_code == 200, response.get_json()
     assert response.get_json()["data"] == []
     assert service.probed == ["openai"]
-    assert response.headers["Deprecation"] == "true"
+    # RFC 9745 Structured Field Date format: @<unix-timestamp>
+    assert response.headers["Deprecation"].startswith("@")
+    assert response.headers["Deprecation"][1:].isdigit()
     assert response.headers["X-Agora-Removal-Version"] == "1.0.0"
     assert response.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 

--- a/backend/tests/api/test_provider_connections_api.py
+++ b/backend/tests/api/test_provider_connections_api.py
@@ -248,9 +248,7 @@ def test_legacy_models_route_delegates_to_connection_service(api_client, lifecyc
     assert response.status_code == 200, response.get_json()
     assert response.get_json()["data"] == []
     assert service.probed == ["openai"]
-    # RFC 9745 Structured Field Date format: @<unix-timestamp>
-    assert response.headers["Deprecation"].startswith("@")
-    assert response.headers["Deprecation"][1:].isdigit()
+    assert response.headers["Deprecation"] == "@1784332800"
     assert response.headers["X-Agora-Removal-Version"] == "1.0.0"
     assert response.headers["Link"] == '</api/llm/provider-connections>; rel="successor-version"'
 

--- a/backend/tests/contracts/test_ai_provider_contract.py
+++ b/backend/tests/contracts/test_ai_provider_contract.py
@@ -374,6 +374,8 @@ def test_route_json_schema_expresses_provider_options_allowlist() -> None:
     assert set(options_schema["properties"]) == {
         "base_url",
         "num_ctx",
+        "secret_ref",
+        "connection_only",
         "__legacy_stage_route__",
     }
 

--- a/backend/tests/contracts/test_ai_provider_contract.py
+++ b/backend/tests/contracts/test_ai_provider_contract.py
@@ -366,6 +366,21 @@ def test_route_provider_options_accept_runtime_allowlist() -> None:
     }
 
 
+def test_connection_only_route_preserves_secret_ref() -> None:
+    route = AiRoute(
+        provider_connection_id="connection-openai",
+        model_id="gpt-4.1-mini",
+        source="project",
+        provider_options={
+            "connection_only": True,
+            "secret_ref": "connection-secret",
+        },
+    )
+
+    assert route.provider_options["connection_only"] is True
+    assert route.provider_options["secret_ref"] == "connection-secret"
+
+
 def test_route_json_schema_expresses_provider_options_allowlist() -> None:
     schema = AiRoute.model_json_schema()
     options_schema = schema["$defs"]["AiProviderOptions"]

--- a/backend/tests/contracts/test_ai_route_connection_only.py
+++ b/backend/tests/contracts/test_ai_route_connection_only.py
@@ -12,6 +12,12 @@ from app.contracts.ai_provider_contract import AiRoute
 def test_connection_only_route_requires_a_non_empty_secret_ref(
     secret_ref: str | None,
 ) -> None:
+    """
+    Verify that connection-only routes require a non-empty secret reference.
+    
+    Parameters:
+        secret_ref (str | None): The secret reference value supplied to the route.
+    """
     provider_options = {"connection_only": True}
     if secret_ref is not None:
         provider_options["secret_ref"] = secret_ref
@@ -26,6 +32,9 @@ def test_connection_only_route_requires_a_non_empty_secret_ref(
 
 
 def test_ai_route_json_schema_requires_secret_ref_for_connection_only_route() -> None:
+    """
+    Verify that the generated JSON Schema requires a non-empty `secret_ref` for connection-only routes.
+    """
     validator = Draft202012Validator(AiRoute.model_json_schema())
     base_route = {
         "provider_connection_id": "connection-openai",

--- a/backend/tests/contracts/test_ai_route_connection_only.py
+++ b/backend/tests/contracts/test_ai_route_connection_only.py
@@ -31,6 +31,24 @@ def test_connection_only_route_requires_a_non_empty_secret_ref(
         )
 
 
+def test_connection_only_route_with_secret_ref_is_valid() -> None:
+    """
+    Verify that a connection_only route with secret_ref is valid.
+    """
+    route = AiRoute(
+        provider_connection_id="connection-openai",
+        model_id="gpt-4.1-mini",
+        source="project",
+        provider_options={
+            "connection_only": True,
+            "secret_ref": "connection-secret",
+        },
+    )
+
+    assert route.provider_options["connection_only"] is True
+    assert route.provider_options["secret_ref"] == "connection-secret"
+
+
 def test_ai_route_json_schema_requires_secret_ref_for_connection_only_route() -> None:
     """
     Verify that the generated JSON Schema requires a non-empty `secret_ref` for connection-only routes.

--- a/backend/tests/contracts/test_ai_route_connection_only.py
+++ b/backend/tests/contracts/test_ai_route_connection_only.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from pydantic import ValidationError
+
+from app.contracts.ai_provider_contract import AiRoute
+
+
+@pytest.mark.parametrize("secret_ref", [None, ""])
+def test_connection_only_route_requires_a_non_empty_secret_ref(
+    secret_ref: str | None,
+) -> None:
+    provider_options = {"connection_only": True}
+    if secret_ref is not None:
+        provider_options["secret_ref"] = secret_ref
+
+    with pytest.raises(ValidationError, match="secret_ref"):
+        AiRoute(
+            provider_connection_id="connection-openai",
+            model_id="gpt-4.1-mini",
+            source="project",
+            provider_options=provider_options,
+        )
+
+
+def test_ai_route_json_schema_requires_secret_ref_for_connection_only_route() -> None:
+    validator = Draft202012Validator(AiRoute.model_json_schema())
+    base_route = {
+        "provider_connection_id": "connection-openai",
+        "model_id": "gpt-4.1-mini",
+        "source": "project",
+    }
+
+    validator.validate(
+        {
+            **base_route,
+            "provider_options": {
+                "connection_only": True,
+                "secret_ref": "connection-secret",
+            },
+        }
+    )
+    with pytest.raises(JsonSchemaValidationError):
+        validator.validate(
+            {
+                **base_route,
+                "provider_options": {"connection_only": True},
+            }
+        )
+

--- a/backend/tests/contracts/test_legacy_provider_deprecation.py
+++ b/backend/tests/contracts/test_legacy_provider_deprecation.py
@@ -8,7 +8,16 @@ from app.api.llm_providers import add_provider_deprecation_headers
 
 def test_provider_prefix_collision_is_not_marked_as_legacy():
     app = Flask(__name__)
+    app.register_blueprint(llm_bp, url_prefix="/api/llm")
+
+    # Create a dummy route for the providers-preview endpoint
+    @app.route("/api/llm/providers-preview")
+    def providers_preview():
+        return Response()
+
     with app.test_request_context("/api/llm/providers-preview"):
+        # Populate request.endpoint by matching the route
+        app.preprocess_request()
         response = add_provider_deprecation_headers(Response())
 
     assert "Deprecation" not in response.headers

--- a/backend/tests/contracts/test_legacy_provider_deprecation.py
+++ b/backend/tests/contracts/test_legacy_provider_deprecation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from flask import Flask, Response
+
+from app.api import llm_bp
+from app.api.llm_providers import add_provider_deprecation_headers
+
+
+def test_provider_prefix_collision_is_not_marked_as_legacy():
+    app = Flask(__name__)
+    with app.test_request_context("/api/llm/providers-preview"):
+        response = add_provider_deprecation_headers(Response())
+
+    assert "Deprecation" not in response.headers
+
+
+def test_legacy_header_follows_endpoint_under_prefix_containing_providers():
+    """Ein Blueprint-Prefix darf selbst ein ``providers``-Segment enthalten."""
+    app = Flask(__name__)
+    app.register_blueprint(llm_bp, url_prefix="/api/tenants/providers")
+
+    with app.test_request_context("/api/tenants/providers/providers/openai/models"):
+        legacy = add_provider_deprecation_headers(Response())
+    with app.test_request_context("/api/tenants/providers/provider-connections"):
+        canonical = add_provider_deprecation_headers(Response())
+
+    assert legacy.headers["Deprecation"] == "@1784332800"
+    assert "Deprecation" not in canonical.headers

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -1,10 +1,9 @@
 """Tests für die profil-basierte LLMClient-Factory (Bug #3).
 
 Der Legacy-Profil-Pfad muss den API-Key aus dem kanonischen
-Provider-Connection-Store beziehen und den (potenziell veralteten) im Profil
-gespeicherten Key nur als Fallback nutzen. Die Connection-Auswahl bevorzugt
-einen exakten provider_kind-Match (order-unabhängig); ein base_url-Fallback
-greift ausschließlich für den generischen ``custom``-Provider.
+Provider-Connection-Store beziehen. Profil-Secrets dürfen nie als Fallback
+verwendet werden. Die Connection-Auswahl bindet Provider-Kind und Endpunkt;
+ein kindübergreifender Endpoint-Match gilt ausschließlich für ``custom``.
 """
 
 from datetime import datetime, timezone
@@ -14,6 +13,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.contracts.llm_profile_contract import LlmProfile
+from app.llm.factory import _is_local_base_url
+
+
+@pytest.mark.parametrize("base_url", [None, ""])
+def test_is_local_base_url_rejects_missing_values(base_url):
+    assert _is_local_base_url(base_url) is False
 
 
 def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = "m") -> LlmProfile:
@@ -96,13 +101,12 @@ def test_matches_connection_by_base_url_when_provider_generic():
 
 
 def test_provider_kind_match_wins_over_base_url_and_ignores_store_order():
-    """provider_kind-Match gewinnt order-unabhängig; kein base_url-Leak bei non-custom.
-
-    Profil: provider=google, aber base_url zeigt (konstruiert) auf minimax. Die
-    minimax-Connection steht ZUERST in der Liste und würde per base_url matchen —
-    trotzdem muss die google-Connection (provider_kind) gewählt werden.
-    """
-    profile = _profile("google", "https://api.minimax.io/v1", api_key="stale")
+    """provider_kind- und Endpunkt-Match bleiben order-unabhängig."""
+    profile = _profile(
+        "google",
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+        api_key="stale",
+    )
     kwargs = _build(
         profile,
         connections=[
@@ -160,3 +164,15 @@ def test_hostname_containing_ollama_is_not_treated_as_local():
     profile = _profile("custom", "https://ollama.attacker.example/v1", api_key=None)
     with pytest.raises(ValueError, match="ProviderConnection"):
         _build(profile, connections=[], secrets={})
+
+
+def test_matching_provider_kind_rejects_mismatched_profile_endpoint():
+    """Ein Connection-Secret darf nie an eine abweichende Profil-URL gehen."""
+    profile = _profile("openai", "https://attacker.example/v1", api_key=None)
+
+    with pytest.raises(ValueError, match="Profil-Endpunkt.*ProviderConnection"):
+        _build(
+            profile,
+            connections=[_conn("openai", "openai", "https://api.openai.com/v1")],
+            secrets={"openai": "sk-proj-echt"},
+        )

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -118,41 +118,45 @@ def test_provider_kind_match_wins_over_base_url_and_ignores_store_order():
 def test_non_custom_profile_never_matches_by_base_url():
     """Ein spezifischer (non-custom) Provider darf keinen fremden Secret per base_url ziehen."""
     profile = _profile("openai", "https://api.minimax.io/v1", api_key="sk-own")
-    kwargs = _build(
-        profile,
-        connections=[_conn("minimax", "minimax", "https://api.minimax.io/v1")],
-        secrets={"minimax": "mm-key"},
-    )
-    assert kwargs["api_key"] == "sk-own"
-    assert kwargs["api_key_source"] == "profile"
+    with pytest.raises(ValueError, match="ProviderConnection"):
+        _build(
+            profile,
+            connections=[_conn("minimax", "minimax", "https://api.minimax.io/v1")],
+            secrets={"minimax": "mm-key"},
+        )
 
 
-def test_falls_back_to_profile_key_without_matching_connection():
-    """Keine passende Connection → Profil-Key bleibt maßgeblich."""
+def test_cloud_profile_key_is_rejected_without_matching_connection():
+    """Legacy-Profil-Keys dürfen den kanonischen Connection-Store nicht umgehen."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
-    kwargs = _build(
-        profile,
-        connections=[_conn("google", "google", "https://generativelanguage.googleapis.com/v1beta/openai")],
-        secrets={"google": "g-key"},
-    )
-    assert kwargs["api_key"] == "sk-own"
-    assert kwargs["api_key_source"] == "profile"
+    with pytest.raises(ValueError, match="ProviderConnection"):
+        _build(
+            profile,
+            connections=[_conn("google", "google", "https://generativelanguage.googleapis.com/v1beta/openai")],
+            secrets={"google": "g-key"},
+        )
 
 
 def test_disabled_connection_is_ignored():
     """Deaktivierte Connections dürfen ihren Secret nicht beisteuern."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key="sk-own")
-    kwargs = _build(
-        profile,
-        connections=[_conn("openai", "openai", "https://api.openai.com/v1", enabled=False)],
-        secrets={"openai": "sk-proj-echt"},
-    )
-    assert kwargs["api_key"] == "sk-own"
-    assert kwargs["api_key_source"] == "profile"
+    with pytest.raises(ValueError, match="ProviderConnection"):
+        _build(
+            profile,
+            connections=[_conn("openai", "openai", "https://api.openai.com/v1", enabled=False)],
+            secrets={"openai": "sk-proj-echt"},
+        )
 
 
 def test_cloud_profile_without_any_key_raises():
     """Cloud-Provider ohne Connection- UND Profil-Key scheitert vor dem HTTP-Call."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key=None)
     with pytest.raises(ValueError, match="api_key fehlt"):
+        _build(profile, connections=[], secrets={})
+
+
+def test_hostname_containing_ollama_is_not_treated_as_local():
+    """Nur lokale Hostnamen dürfen ohne ProviderConnection-Secret arbeiten."""
+    profile = _profile("custom", "https://ollama.attacker.example/v1", api_key=None)
+    with pytest.raises(ValueError, match="ProviderConnection"):
         _build(profile, connections=[], secrets={})

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -47,14 +47,26 @@ def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = 
     )
 
 
-def _conn(connection_id: str, provider_kind: str, base_url: str, *, enabled: bool = True):
+_UNSET = object()
+
+
+def _conn(
+    connection_id: str,
+    provider_kind: str,
+    base_url: str,
+    *,
+    enabled: bool = True,
+    auth_mode: str = "api_key",
+    secret_ref=_UNSET,
+):
     """Baut ein connection-artiges Objekt (nur die von der Factory gelesenen Felder)."""
     return SimpleNamespace(
         id=connection_id,
         provider_kind=provider_kind,
         base_url=base_url,
         enabled=enabled,
-        secret_ref=connection_id,
+        auth_mode=auth_mode,
+        secret_ref=connection_id if secret_ref is _UNSET else secret_ref,
     )
 
 
@@ -186,4 +198,48 @@ def test_matching_provider_kind_rejects_mismatched_profile_endpoint():
             profile,
             connections=[_conn("openai", "openai", "https://api.openai.com/v1")],
             secrets={"openai": "sk-proj-echt"},
+        )
+
+
+def test_local_no_auth_connection_keeps_route_without_secret():
+    """Eine aufgelöste No-Auth-Connection (auth_mode='none') liefert die autoritative
+    Route (connection_id + base_url) ohne Secret — kein ValueError, kein Dummy-Key-Zwang,
+    und die connection_id geht NICHT verloren."""
+    profile = _profile("custom", "http://localhost:11434", api_key=None)
+    kwargs = _build(
+        profile,
+        connections=[
+            _conn(
+                "ollama-local",
+                "ollama",
+                "http://localhost:11434",
+                auth_mode="none",
+                secret_ref=None,
+            )
+        ],
+        secrets={},
+    )
+    assert kwargs["route_provider_id"] == "ollama-local"
+    assert kwargs["api_key_source"] == "local_no_auth"
+    assert kwargs["base_url"] == "http://localhost:11434"
+
+
+def test_api_key_connection_without_secret_raises_instead_of_dummy_key():
+    """Eine api_key-Connection ohne hinterlegtes Secret darf NICHT auf den Dummy-Key
+    'ollama' zurückfallen — auch nicht bei lokalem Endpunkt. Der Hostname ist kein
+    Authentifizierungsmodell; maßgeblich ist der explizite auth_mode."""
+    profile = _profile("custom", "http://localhost:11434", api_key=None)
+    with pytest.raises(ValueError, match="api_key fehlt"):
+        _build(
+            profile,
+            connections=[
+                _conn(
+                    "local-secured",
+                    "ollama",
+                    "http://localhost:11434",
+                    auth_mode="api_key",
+                    secret_ref="local-secured",
+                )
+            ],
+            secrets={},  # secret_ref zeigt ins Leere
         )

--- a/backend/tests/llm/test_factory.py
+++ b/backend/tests/llm/test_factory.py
@@ -22,7 +22,18 @@ def test_is_local_base_url_rejects_missing_values(base_url):
 
 
 def _profile(provider: str, base_url: str, *, api_key: str | None, model: str = "m") -> LlmProfile:
-    """Baut ein Test-LlmProfile mit den angegebenen Feldern."""
+    """
+    Construct a test LLM profile with the specified provider, endpoint, API key, and model.
+    
+    Parameters:
+        provider (str): The provider identifier.
+        base_url (str): The provider endpoint.
+        api_key (str | None): The profile API key, if available.
+        model (str): The model name.
+    
+    Returns:
+        LlmProfile: A test profile with fixed identity fields and current UTC timestamps.
+    """
     now = datetime.now(timezone.utc)
     return LlmProfile(
         id="prof_1",
@@ -153,7 +164,7 @@ def test_disabled_connection_is_ignored():
 
 
 def test_cloud_profile_without_any_key_raises():
-    """Cloud-Provider ohne Connection- UND Profil-Key scheitert vor dem HTTP-Call."""
+    """Ensure a cloud provider profile without a connection or profile API key raises a validation error."""
     profile = _profile("openai", "https://api.openai.com/v1", api_key=None)
     with pytest.raises(ValueError, match="api_key fehlt"):
         _build(profile, connections=[], secrets={})

--- a/backend/tests/services/test_build_client_from_profile.py
+++ b/backend/tests/services/test_build_client_from_profile.py
@@ -46,7 +46,9 @@ def test_build_client_from_ollama_profile():
 
 
 def test_build_client_from_openai_profile():
-    """Ein Legacy-Profil-Key ersetzt keine kanonische ProviderConnection."""
+    """
+    Verify that a legacy profile API key does not replace the canonical provider connection.
+    """
     profile = _make_profile(
         provider="openai",
         base_url="https://api.openai.com/v1",

--- a/backend/tests/services/test_build_client_from_profile.py
+++ b/backend/tests/services/test_build_client_from_profile.py
@@ -1,8 +1,8 @@
 """Tests für build_client_from_profile() — P5.3 Factory-Funktion.
 
-Drei Fälle gemäß Briefing:
+Drei Fälle gemäß kanonischem Secret-Store:
 1. Ollama-Profil ohne api_key → LLMClient baut erfolgreich.
-2. OpenAI-Profil mit api_key → LLMClient baut, api_key und model korrekt.
+2. Legacy-Cloud-Profil-Key → ValueError ohne passende ProviderConnection.
 3. Cloud-Profil ohne api_key → ValueError sofort, kein HTTP-Request.
 """
 from __future__ import annotations
@@ -46,7 +46,7 @@ def test_build_client_from_ollama_profile():
 
 
 def test_build_client_from_openai_profile():
-    """OpenAI-Profil mit api_key baut LLMClient mit korrekten Werten."""
+    """Ein Legacy-Profil-Key ersetzt keine kanonische ProviderConnection."""
     profile = _make_profile(
         provider="openai",
         base_url="https://api.openai.com/v1",
@@ -54,12 +54,8 @@ def test_build_client_from_openai_profile():
         api_key="sk-xyz",
     )
 
-    with patch("app.llm.client.OpenAI"):
-        client = build_client_from_profile(profile, run_id="run-42")
-
-    assert client.api_key == "sk-xyz"
-    assert client.model == "gpt-4o"
-    assert client.run_id == "run-42"
+    with pytest.raises(ValueError, match="ProviderConnection"):
+        build_client_from_profile(profile, run_id="run-42")
 
 
 def test_build_client_rejects_cloud_without_key():

--- a/backend/tests/services/test_graph_build_profile_routing.py
+++ b/backend/tests/services/test_graph_build_profile_routing.py
@@ -24,6 +24,15 @@ def test_generate_ontology_profile_routes_document_ingest_and_ontology_stage(mon
             pass
 
         def resolve(self, stage_id):
+            """
+            Resolve a stage identifier to its configured OpenAI model route.
+            
+            Parameters:
+            	stage_id: Identifier of the stage to resolve.
+            
+            Returns:
+            	ResolvedRoute: The OpenAI route for the specified stage.
+            """
             return ResolvedRoute(
                 stage=stage_id,
                 provider_id="openai",
@@ -122,6 +131,15 @@ def test_build_graph_forwards_route_precedence_and_persists_submitted_profile(
             pass
 
         def resolve(self, stage_id):
+            """
+            Resolve a stage to its configured OpenAI model route.
+            
+            Parameters:
+                stage_id: Identifier of the stage to resolve.
+            
+            Returns:
+                ResolvedRoute: The resolved OpenAI route for the stage.
+            """
             return ResolvedRoute(
                 stage=stage_id,
                 provider_id="openai",

--- a/backend/tests/services/test_graph_build_profile_routing.py
+++ b/backend/tests/services/test_graph_build_profile_routing.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.models.project import ProjectStatus
+from app.services.graph_build import GraphBuildService
+from app.services.llm_runtime import RuntimeLlmConfig
+
+
+PROJECT_ID = "proj_0123456789ab"
+
+
+def test_generate_ontology_profile_routes_document_ingest_and_ontology_stage(monkeypatch):
+    """Ein reines Profil muss beide Ontologie-Stages kanonisch routen."""
+    project = MagicMock(project_id=PROJECT_ID)
+    seed = MagicMock()
+    route_client = MagicMock()
+
+    class Router:
+        def __init__(self, _run_id):
+            pass
+
+        def resolve(self, stage_id):
+            return ResolvedRoute(
+                stage=stage_id,
+                provider_id="openai",
+                model="gpt-4.1-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=1,
+            )
+
+        def lock_stage(self, *_args):
+            return None
+
+    generator = MagicMock()
+    generator.generate.return_value = {
+        "entity_types": [],
+        "edge_types": [],
+        "analysis_summary": "ok",
+    }
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.get_project", lambda _id: project)
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.save_project", lambda _project: None)
+    monkeypatch.setattr(
+        "app.services.graph_build.run_registry.create_run",
+        lambda **_kwargs: {"run_id": "run_ontology_profile"},
+    )
+    monkeypatch.setattr("app.services.graph_build.run_registry.update_run", lambda *_a, **_k: None)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", Router)
+    monkeypatch.setattr("app.services.graph_build.resolve_route_api_key", lambda *_a: None)
+    monkeypatch.setattr("app.services.graph_build.LLMClient.from_route", lambda *_a, **_k: route_client)
+    monkeypatch.setattr("app.services.graph_build.OntologyGenerator", lambda **_k: generator)
+    monkeypatch.setattr(
+        "app.utils.llm_client.build_client_from_profile",
+        lambda *_a, **_k: pytest.fail("legacy profile client must not be constructed"),
+    )
+
+    GraphBuildService.generate_ontology(
+        project_id=PROJECT_ID,
+        simulation_requirement="Analyse the document.",
+        document_texts=["document"],
+        llm_profile_id="profile-openai",
+    )
+
+    assert seed.call_args_list == [
+        call(
+            "run_ontology_profile",
+            "document_ingest",
+            llm_model_override=None,
+            llm_runtime=None,
+            llm_profile_id="profile-openai",
+        ),
+        call(
+            "run_ontology_profile",
+            "ontology_generation",
+            llm_model_override=None,
+            llm_runtime=None,
+            llm_profile_id="profile-openai",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("model_override", "runtime", "submitted_profile", "expected_profile"),
+    [
+        (
+            "gpt-5-mini",
+            RuntimeLlmConfig(provider="openai", api_key="request-key"),
+            "profile-submitted",
+            "profile-submitted",
+        ),
+        (None, None, "profile-submitted", "profile-submitted"),
+        (None, None, None, "profile-project"),
+    ],
+    ids=("explicit-route", "submitted-profile", "project-profile"),
+)
+def test_build_graph_forwards_route_precedence_and_persists_submitted_profile(
+    monkeypatch,
+    model_override,
+    runtime,
+    submitted_profile,
+    expected_profile,
+):
+    """Explizite Route, Request-Profil und Projekt-Profil bleiben priorisiert."""
+    project = MagicMock()
+    project.project_id = PROJECT_ID
+    project.status = ProjectStatus.ONTOLOGY_GENERATED
+    project.graph_id = None
+    project.graph_build_task_id = None
+    project.error = None
+    project.chunk_size = 500
+    project.chunk_overlap = 50
+    project.ontology = {"entity_types": [], "edge_types": []}
+    project.llm_profile_id = "profile-project"
+    seed = MagicMock()
+
+    class Router:
+        def __init__(self, _run_id):
+            pass
+
+        def resolve(self, stage_id):
+            return ResolvedRoute(
+                stage=stage_id,
+                provider_id="openai",
+                model=model_override or "gpt-4.1-mini",
+                routing_version=1,
+            )
+
+        def lock_stage(self, *_args):
+            return None
+
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-123"
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.get_project", lambda _id: project)
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.get_extracted_text", lambda _id: "text")
+    monkeypatch.setattr("app.services.graph_build.ProjectManager.save_project", lambda _project: None)
+    monkeypatch.setattr("app.services.graph_build.ProjectManager._get_project_dir", lambda _id: "/tmp/project")
+    monkeypatch.setattr("app.services.graph_build.TaskManager", lambda: task_manager)
+    monkeypatch.setattr(
+        "app.services.graph_build.run_registry.create_run",
+        lambda **_kwargs: {"run_id": "run_graph_profile"},
+    )
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", Router)
+    monkeypatch.setattr("app.services.graph_build.resolve_route_api_key", lambda *_a: None)
+    monkeypatch.setattr("app.services.graph_build.LLMClient.from_route", lambda *_a, **_k: MagicMock())
+    monkeypatch.setattr("app.services.graph_build.NERExtractor", lambda **_k: MagicMock())
+    monkeypatch.setattr("app.services.graph_build.ArtifactLocator.existing_paths", lambda _paths: {})
+    monkeypatch.setattr("app.jobs.enqueue", lambda *_a, **_k: None)
+
+    GraphBuildService.build_graph(
+        project_id=PROJECT_ID,
+        graph_name="Contract graph",
+        llm_model_override=model_override,
+        llm_runtime=runtime,
+        llm_profile_id=submitted_profile,
+        container=MagicMock(),
+    )
+
+    assert seed.call_args.kwargs["llm_profile_id"] == expected_profile
+    if submitted_profile is not None:
+        assert project.llm_profile_id == submitted_profile

--- a/backend/tests/services/test_graph_build_profile_routing.py
+++ b/backend/tests/services/test_graph_build_profile_routing.py
@@ -28,10 +28,10 @@ def test_generate_ontology_profile_routes_document_ingest_and_ontology_stage(mon
             Resolve a stage identifier to its configured OpenAI model route.
             
             Parameters:
-            	stage_id: Identifier of the stage to resolve.
+                stage_id: Identifier of the stage to resolve.
             
             Returns:
-            	ResolvedRoute: The OpenAI route for the specified stage.
+                ResolvedRoute: The OpenAI route for the specified stage.
             """
             return ResolvedRoute(
                 stage=stage_id,

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -21,11 +21,11 @@ def _profile(profile_id: str, *, model: str = "gpt-4.1-mini") -> LlmProfile:
     Create a test profile with fixed OpenAI connection details and timestamps.
     
     Parameters:
-    	profile_id (str): Identifier assigned to the profile.
-    	model (str): Model name assigned to the profile.
+        profile_id (str): Identifier assigned to the profile.
+        model (str): Model name assigned to the profile.
     
     Returns:
-    	LlmProfile: A profile populated with the specified identifier and model.
+        LlmProfile: A profile populated with the specified identifier and model.
     """
     now = datetime.now(UTC)
     return LlmProfile(

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -145,6 +145,69 @@ def test_profile_id_expands_to_a_secret_free_stage_route(mock_run_dir, monkeypat
 
 
 @patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_local_no_auth_profile_route_omits_secret_binding(mock_run_dir, monkeypatch, tmp_path):
+    """No-Auth-Connections (auth_mode='none') dürfen NICHT per connection_only an ein
+    nicht existentes Secret gebunden werden. Sonst liefert die strikte Auflösung
+    ``None`` und der Run bricht mit 'LLM_API_KEY not configured' — lokales Ollama
+    (Agoras Kern-Betriebsmodell) bliebe gebrochen. Die Auth-Semantik der
+    ProviderConnection ist maßgeblich, nicht ein pauschales connection_only."""
+    run_id = "run_local_noauth"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    now = datetime.now(UTC)
+    profile = LlmProfile(
+        id="profile-ollama",
+        name="Local Ollama",
+        provider="custom",
+        base_url="http://localhost:11434",
+        model_name="qwen3:8b",
+        api_key=None,
+        created_at=now,
+        updated_at=now,
+    )
+    profile_store = MagicMock()
+    profile_store.get.return_value = profile
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [
+        ProviderConnection(
+            id="ollama-local",
+            provider_kind="ollama",
+            display_name="Local Ollama",
+            transport="http",
+            auth_mode="none",
+            base_url="http://localhost:11434",
+            secret_ref=None,
+        )
+    ]
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_profiles_store",
+        lambda: profile_store,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+
+    config = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        llm_profile_id="profile-ollama",
+    )
+
+    route = config.stage_overrides["graph_build"]
+    assert route.provider_id == "ollama-local"
+    assert route.model == "qwen3:8b"
+    assert route.provider_options == {"base_url": "http://localhost:11434"}
+    assert "connection_only" not in route.provider_options
+    assert "secret_ref" not in route.provider_options
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
 def test_explicit_runtime_route_wins_without_reading_the_profile(mock_run_dir, monkeypatch, tmp_path):
     run_id = "run_explicit_over_profile"
     run_dir = tmp_path / "runs" / run_id

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
+from app.contracts.ai_provider_contract import ProviderConnection
+from app.contracts.llm_profile_contract import LlmProfile
 from app.contracts.llm_routing_contract import ResolvedRoute
 from app.services.llm_routing_seed import (
     build_route_subprocess_env,
@@ -11,6 +14,20 @@ from app.services.llm_routing_seed import (
 )
 from app.services.llm_runtime import RuntimeLlmConfig
 from app.services.runtime_run_config import RuntimeRunConfig
+
+
+def _profile(profile_id: str, *, model: str = "gpt-4.1-mini") -> LlmProfile:
+    now = datetime.now(UTC)
+    return LlmProfile(
+        id=profile_id,
+        name="Contract profile",
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model_name=model,
+        api_key="must-not-enter-route",
+        created_at=now,
+        updated_at=now,
+    )
 
 
 @patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
@@ -65,6 +82,88 @@ def test_seed_run_stage_routing_keeps_server_default_without_override(mock_run_d
     assert loaded.global_default.provider_id == "openai"
     assert loaded.global_default.model == "gpt-4o"
     assert loaded.stage_overrides == {}
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_profile_id_expands_to_a_secret_free_stage_route(mock_run_dir, monkeypatch, tmp_path):
+    run_id = "run_profile_only"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+    profile_store = MagicMock()
+    profile_store.get.return_value = _profile("profile-openai")
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [
+        ProviderConnection(
+            id="openai",
+            provider_kind="openai",
+            display_name="OpenAI",
+            transport="http",
+            auth_mode="api_key",
+            base_url="https://api.openai.com/v1",
+            secret_ref="openai",
+        )
+    ]
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_profiles_store",
+        lambda: profile_store,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+
+    config = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        llm_profile_id="profile-openai",
+    )
+
+    route = config.stage_overrides["graph_build"]
+    assert route.provider_id == "openai"
+    assert route.model == "gpt-4.1-mini"
+    assert route.provider_options == {
+        "base_url": "https://api.openai.com/v1",
+        "secret_ref": "openai",
+        "connection_only": True,
+    }
+    assert "api_key" not in route.model_dump(mode="json")
+    profile_store.get.assert_called_once_with("profile-openai", include_api_key=False)
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_explicit_runtime_route_wins_without_reading_the_profile(mock_run_dir, monkeypatch, tmp_path):
+    run_id = "run_explicit_over_profile"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+    profile_store = MagicMock()
+    profile_store.get.side_effect = AssertionError("profile path must not be read")
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_profiles_store",
+        lambda: profile_store,
+        raising=False,
+    )
+
+    config = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override="gpt-5-mini",
+        llm_runtime=RuntimeLlmConfig(
+            provider="openai",
+            api_key="request-secret",
+            base_url="https://api.openai.com/v1",
+        ),
+        llm_profile_id="profile-openai",
+    )
+
+    route = config.stage_overrides["graph_build"]
+    assert route.provider_id == "openai"
+    assert route.model == "gpt-5-mini"
+    profile_store.get.assert_not_called()
 
 
 @patch("app.services.secret_resolver.SecretResolver.get_api_key")

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -17,6 +17,16 @@ from app.services.runtime_run_config import RuntimeRunConfig
 
 
 def _profile(profile_id: str, *, model: str = "gpt-4.1-mini") -> LlmProfile:
+    """
+    Create a test profile with fixed OpenAI connection details and timestamps.
+    
+    Parameters:
+    	profile_id (str): Identifier assigned to the profile.
+    	model (str): Model name assigned to the profile.
+    
+    Returns:
+    	LlmProfile: A profile populated with the specified identifier and model.
+    """
     now = datetime.now(UTC)
     return LlmProfile(
         id=profile_id,

--- a/backend/tests/services/test_profile_connection_resolver.py
+++ b/backend/tests/services/test_profile_connection_resolver.py
@@ -1,0 +1,69 @@
+"""Tests für die secret-freie Bindung von Legacy-Profilen an ProviderConnections.
+
+Fokus: mehrdeutige Endpunkte dürfen nicht still den ersten Store-Eintrag ziehen
+(Secret-Roulette), sondern müssen mit einer eindeutigen Fehlermeldung abbrechen.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.contracts.ai_provider_contract import ProviderConnection
+from app.contracts.llm_profile_contract import LlmProfile
+from app.services.profile_connection_resolver import resolve_profile_connection
+
+
+def _profile(provider: str, base_url: str) -> LlmProfile:
+    now = datetime.now(timezone.utc)
+    return LlmProfile(
+        id="prof_ambig",
+        name="p",
+        provider=provider,
+        base_url=base_url,
+        model_name="m",
+        api_key=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _conn(connection_id: str, base_url: str, *, kind: str = "openai_compatible") -> ProviderConnection:
+    return ProviderConnection(
+        id=connection_id,
+        provider_kind=kind,
+        display_name=connection_id,
+        transport="http",
+        auth_mode="none",
+        base_url=base_url,
+        secret_ref=None,
+    )
+
+
+def test_ambiguous_endpoint_is_rejected():
+    """Zwei aktivierte Connections mit demselben normalisierten Endpunkt → Abbruch."""
+    profile = _profile("custom", "https://api.example.com/v1")
+    connections = [
+        _conn("conn-a", "https://api.example.com/v1"),
+        _conn("conn-b", "https://api.example.com/v1"),
+    ]
+    with pytest.raises(ValueError, match="mehrdeutig"):
+        resolve_profile_connection(profile, connections)
+
+
+def test_single_endpoint_match_resolves_deterministically():
+    """Genau ein Treffer wird eindeutig aufgelöst."""
+    profile = _profile("custom", "https://api.example.com/v1")
+    connections = [
+        _conn("conn-a", "https://api.example.com/v1"),
+        _conn("conn-b", "https://other.example.com/v1"),
+    ]
+    resolved = resolve_profile_connection(profile, connections)
+    assert resolved is not None
+    assert resolved.connection.id == "conn-a"
+
+
+def test_no_match_returns_none_for_custom_profile():
+    """Kein passender Endpunkt bei custom-Profil → None (kein Fehler)."""
+    profile = _profile("custom", "https://unmatched.example.com/v1")
+    connections = [_conn("conn-a", "https://api.example.com/v1")]
+    assert resolve_profile_connection(profile, connections) is None

--- a/backend/tests/services/test_strict_profile_route_secrets.py
+++ b/backend/tests/services/test_strict_profile_route_secrets.py
@@ -93,6 +93,8 @@ def test_llm_client_strict_route_ignores_passed_or_resolver_keys(monkeypatch):
     )
 
     assert captured["api_key"] == "connection-key"
+    assert captured["use_active_config"] is False
+    assert captured["allow_api_key_fallback"] is False
     secret_store.get_plaintext.assert_called_once_with("connection-secret")
     fallback_resolver.get_api_key.assert_not_called()
 
@@ -121,6 +123,8 @@ def test_llm_client_missing_strict_secret_never_uses_passed_or_resolver_key(monk
     )
 
     assert captured["api_key"] is None
+    assert captured["use_active_config"] is False
+    assert captured["allow_api_key_fallback"] is False
     secret_store.get_plaintext.assert_called_once_with("connection-secret")
     fallback_resolver.get_api_key.assert_not_called()
 

--- a/backend/tests/services/test_strict_profile_route_secrets.py
+++ b/backend/tests/services/test_strict_profile_route_secrets.py
@@ -9,6 +9,9 @@ from app.services.llm_runtime import RuntimeLlmConfig
 
 
 def _strict_route() -> ResolvedRoute:
+    """
+    Create a strict route bound to the connection secret.
+    """
     return ResolvedRoute(
         stage="graph_build",
         provider_id="connection-openai",
@@ -77,6 +80,9 @@ def test_llm_client_strict_route_ignores_passed_or_resolver_keys(monkeypatch):
     captured = {}
 
     def capture_init(self, **kwargs):
+        """
+        Capture initialization keyword arguments for test assertions.
+        """
         captured.update(kwargs)
 
     monkeypatch.setattr(
@@ -107,6 +113,9 @@ def test_llm_client_missing_strict_secret_never_uses_passed_or_resolver_key(monk
     captured = {}
 
     def capture_init(self, **kwargs):
+        """
+        Capture initialization keyword arguments for test assertions.
+        """
         captured.update(kwargs)
 
     monkeypatch.setattr(

--- a/backend/tests/services/test_strict_profile_route_secrets.py
+++ b/backend/tests/services/test_strict_profile_route_secrets.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.llm.client import LLMClient
+from app.services.llm_routing_seed import resolve_route_api_key
+from app.services.llm_runtime import RuntimeLlmConfig
+
+
+def _strict_route() -> ResolvedRoute:
+    return ResolvedRoute(
+        stage="graph_build",
+        provider_id="connection-openai",
+        model="gpt-4.1-mini",
+        routing_version=1,
+        provider_options={
+            "secret_ref": "connection-secret",
+            "connection_only": True,
+        },
+    )
+
+
+def test_strict_profile_route_resolves_only_its_bound_store_secret(monkeypatch):
+    secret_store = MagicMock()
+    secret_store.get_plaintext.return_value = "connection-key"
+    fallback_resolver = MagicMock()
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_provider_secrets_store",
+        lambda: secret_store,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver",
+        lambda: fallback_resolver,
+    )
+
+    api_key = resolve_route_api_key(
+        _strict_route(),
+        RuntimeLlmConfig(provider="openai", api_key="request-key"),
+    )
+
+    assert api_key == "connection-key"
+    secret_store.get_plaintext.assert_called_once_with("connection-secret")
+    fallback_resolver.get_api_key.assert_not_called()
+
+
+def test_missing_strict_profile_secret_never_falls_back_to_runtime_or_environment(monkeypatch):
+    secret_store = MagicMock()
+    secret_store.get_plaintext.return_value = None
+    fallback_resolver = MagicMock()
+    fallback_resolver.get_api_key.side_effect = AssertionError("fallback is forbidden")
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_provider_secrets_store",
+        lambda: secret_store,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver",
+        lambda: fallback_resolver,
+    )
+
+    api_key = resolve_route_api_key(
+        _strict_route(),
+        RuntimeLlmConfig(provider="openai", api_key="different-provider-key"),
+    )
+
+    assert api_key is None
+    secret_store.get_plaintext.assert_called_once_with("connection-secret")
+    fallback_resolver.get_api_key.assert_not_called()
+
+
+def test_llm_client_strict_route_ignores_passed_or_resolver_keys(monkeypatch):
+    secret_store = MagicMock()
+    secret_store.get_plaintext.return_value = "connection-key"
+    fallback_resolver = MagicMock()
+    captured = {}
+
+    def capture_init(self, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.llm.client.get_llm_provider_secrets_store",
+        lambda: secret_store,
+        raising=False,
+    )
+    monkeypatch.setattr(LLMClient, "__init__", capture_init)
+
+    LLMClient.from_route(
+        _strict_route(),
+        secret_resolver=fallback_resolver,
+        api_key_override="runtime-key",
+    )
+
+    assert captured["api_key"] == "connection-key"
+    secret_store.get_plaintext.assert_called_once_with("connection-secret")
+    fallback_resolver.get_api_key.assert_not_called()
+
+
+def test_llm_client_missing_strict_secret_never_uses_passed_or_resolver_key(monkeypatch):
+    secret_store = MagicMock()
+    secret_store.get_plaintext.return_value = None
+    fallback_resolver = MagicMock()
+    fallback_resolver.get_api_key.side_effect = AssertionError("fallback is forbidden")
+    captured = {}
+
+    def capture_init(self, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.llm.client.get_llm_provider_secrets_store",
+        lambda: secret_store,
+        raising=False,
+    )
+    monkeypatch.setattr(LLMClient, "__init__", capture_init)
+
+    LLMClient.from_route(
+        _strict_route(),
+        secret_resolver=fallback_resolver,
+        api_key_override="runtime-key",
+    )
+
+    assert captured["api_key"] is None
+    secret_store.get_plaintext.assert_called_once_with("connection-secret")
+    fallback_resolver.get_api_key.assert_not_called()
+
+
+def test_non_strict_route_keeps_runtime_key_fallback(monkeypatch):
+    route = ResolvedRoute(
+        stage="graph_build",
+        provider_id="openai",
+        model="gpt-4.1-mini",
+        routing_version=1,
+    )
+    fallback_resolver = MagicMock()
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver",
+        lambda: fallback_resolver,
+    )
+
+    api_key = resolve_route_api_key(
+        route,
+        RuntimeLlmConfig(provider="openai", api_key="runtime-key"),
+    )
+
+    assert api_key == "runtime-key"
+    fallback_resolver.get_api_key.assert_not_called()

--- a/backend/tests/test_embedding_service.py
+++ b/backend/tests/test_embedding_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,6 +22,41 @@ def test_detect_provider_delegates_to_registry_ssot(base_url, model):
     lokal divergentes Verhalten mehr."""
     service = EmbeddingService(model=model, base_url=base_url, api_key='dummy-key')
     assert service._detect_provider() == detect_embedding_provider(base_url, model)
+
+
+def test_embed_uses_embedding_specific_openai_shape_from_hostname(monkeypatch):
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    response = MagicMock()
+    response.json.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+
+    with patch("app.storage.embedding_service.requests.post", return_value=response) as post:
+        vector = EmbeddingService(
+            model="custom-embedding-model",
+            base_url="https://api.openai.com/custom",
+            api_key="sk-test",
+            max_retries=1,
+        ).embed("document")
+
+    assert vector == [0.1, 0.2]
+    assert post.call_args.args[0] == "https://api.openai.com/custom/v1/embeddings"
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+
+def test_embed_keeps_ollama_embedding_detection_separate(monkeypatch):
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    response = MagicMock()
+    response.json.return_value = {"embeddings": [[0.3, 0.4]]}
+
+    with patch("app.storage.embedding_service.requests.post", return_value=response) as post:
+        vector = EmbeddingService(
+            model="nomic-embed-text",
+            base_url="http://ollama.internal:11434",
+            max_retries=1,
+        ).embed("document")
+
+    assert vector == [0.3, 0.4]
+    assert post.call_args.args[0] == "http://ollama.internal:11434/api/embed"
+    assert "Authorization" not in post.call_args.kwargs["headers"]
 
 
 def test_infer_vector_dim_for_known_models():

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -53,6 +53,11 @@ def test_available_models_route_is_registered():
 
 def test_available_models_uses_registry_provider_detection(monkeypatch):
     def offline(*_args, **_kwargs):
+        """Simulate an offline request failure.
+        
+        Raises:
+            RuntimeError: Always raised with the message ``"offline"``.
+        """
         raise RuntimeError("offline")
 
     monkeypatch.setattr(

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -51,6 +51,26 @@ def test_available_models_route_is_registered():
     assert "default_provider" in payload["data"]
 
 
+def test_available_models_uses_registry_provider_detection(monkeypatch):
+    def offline(*_args, **_kwargs):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(
+        "app.api.simulation_lifecycle.Config.LLM_BASE_URL",
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+    monkeypatch.setattr(
+        "app.api.simulation_lifecycle.Config.LLM_MODEL_NAME",
+        "gemini-2.5-pro",
+    )
+    monkeypatch.setattr("requests.get", offline)
+
+    response = _build_test_app().test_client().get("/api/simulation/available-models")
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["default_provider"] == "google"
+
+
 def test_detect_default_provider_openai(monkeypatch):
     monkeypatch.setattr('app.api.simulation_lifecycle.Config.LLM_BASE_URL', 'https://api.openai.com/v1')
     monkeypatch.setattr('app.api.simulation_lifecycle.Config.LLM_MODEL_NAME', 'gpt-5.4-mini')

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3407 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3431 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3431 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3437 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
+++ b/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
@@ -215,7 +215,7 @@ describe('canonical AI provider contracts', () => {
 
   it.each([
     { timeout: 30 },
-    { api_key: 'fixture-token' },
+    { api_key: 'forbidden-placeholder' },
     { 'x-api-key': 'fixture-token' },
     { client_secret: 'fixture-token' },
     { refresh_token: 'fixture-token' },
@@ -241,6 +241,20 @@ describe('canonical AI provider contracts', () => {
       source: 'runtime',
       provider_options: { secret_ref: '' },
     }).success).toBe(false)
+  })
+
+  it('requires a provider secret reference for connection-only routing', () => {
+    expect(AiRouteSchema.safeParse({
+      source: 'runtime',
+      provider_options: { connection_only: true },
+    }).success).toBe(false)
+  })
+
+  it.each([
+    { connection_only: false },
+    { secret_ref: 'provider-secret-reference' },
+  ])('keeps independent provider metadata valid: %o', (provider_options) => {
+    expect(AiRouteSchema.safeParse({ source: 'runtime', provider_options }).success).toBe(true)
   })
 
   it.each(sharedFixtures.base_urls.invalid)(

--- a/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
+++ b/frontend/src/contracts/__tests__/aiProviderContract.spec.ts
@@ -7,6 +7,7 @@ import sharedFixtures from '../../../../schemas/fixtures/ai-provider-contract-fi
 
 import {
   AiModelSchema,
+  AiProviderOptionsSchema,
   AiRouteSchema,
   ModelCapabilitiesSchema,
   ProviderConnectionBaseSchema,
@@ -82,10 +83,15 @@ describe('canonical AI provider contracts', () => {
     const optionsName = optionsRef.split('/').at(-1) as keyof typeof aiRouteJsonSchema.$defs
     const optionsSchema = aiRouteJsonSchema.$defs[optionsName]
     expect(optionsSchema.additionalProperties).toBe(false)
+    expect(Object.keys(AiProviderOptionsSchema.shape).sort()).toEqual(
+      Object.keys(optionsSchema.properties).sort(),
+    )
     expect(Object.keys(optionsSchema.properties).sort()).toEqual([
       '__legacy_stage_route__',
       'base_url',
+      'connection_only',
       'num_ctx',
+      'secret_ref',
     ])
     expect(
       aiRouteJsonSchema.$defs.LegacyStageRouteOptions.properties.reasoning_effort.anyOf,
@@ -208,6 +214,8 @@ describe('canonical AI provider contracts', () => {
   })
 
   it.each([
+    { timeout: 30 },
+    { api_key: 'fixture-token' },
     { 'x-api-key': 'fixture-token' },
     { client_secret: 'fixture-token' },
     { refresh_token: 'fixture-token' },
@@ -216,14 +224,23 @@ describe('canonical AI provider contracts', () => {
     expect(AiRouteSchema.safeParse({ source: 'runtime', provider_options }).success).toBe(false)
   })
 
-  it('accepts only provider options used by routing', () => {
+  it('accepts strict secret-free provider metadata used by routing', () => {
     expect(AiRouteSchema.safeParse({
       source: 'runtime',
       provider_options: {
         base_url: 'https://gateway.example/v1',
+        connection_only: true,
         num_ctx: 32768,
+        secret_ref: 'provider-secret-reference',
       },
     }).success).toBe(true)
+  })
+
+  it('rejects an empty provider secret reference', () => {
+    expect(AiRouteSchema.safeParse({
+      source: 'runtime',
+      provider_options: { secret_ref: '' },
+    }).success).toBe(false)
   })
 
   it.each(sharedFixtures.base_urls.invalid)(

--- a/frontend/src/contracts/aiProviderContract.ts
+++ b/frontend/src/contracts/aiProviderContract.ts
@@ -212,7 +212,15 @@ export const AiProviderOptionsSchema = z.object({
   secret_ref: z.string().min(1).optional(),
   connection_only: z.boolean().optional(),
   __legacy_stage_route__: LegacyStageRouteOptionsSchema.optional(),
-}).strict()
+}).strict().superRefine((options, context) => {
+  if (options.connection_only === true && !options.secret_ref) {
+    context.addIssue({
+      code: 'custom',
+      message: 'connection_only requires a non-empty secret_ref',
+      path: ['secret_ref'],
+    })
+  }
+})
 export type AiProviderOptions = z.infer<typeof AiProviderOptionsSchema>
 
 export const RouteSourceSchema = z.enum([

--- a/frontend/src/contracts/aiProviderContract.ts
+++ b/frontend/src/contracts/aiProviderContract.ts
@@ -209,6 +209,8 @@ const LegacyStageRouteOptionsSchema = z.object({
 export const AiProviderOptionsSchema = z.object({
   base_url: PublicBaseUrlSchema.nullable().optional(),
   num_ctx: z.number().int().positive().optional(),
+  secret_ref: z.string().min(1).optional(),
+  connection_only: z.boolean().optional(),
   __legacy_stage_route__: LegacyStageRouteOptionsSchema.optional(),
 }).strict()
 export type AiProviderOptions = z.infer<typeof AiProviderOptionsSchema>

--- a/schemas/ai-route.schema.json
+++ b/schemas/ai-route.schema.json
@@ -19,10 +19,19 @@
           ],
           "title": "Base Url"
         },
+        "connection_only": {
+          "title": "Connection Only",
+          "type": "boolean"
+        },
         "num_ctx": {
           "exclusiveMinimum": 0,
           "title": "Num Ctx",
           "type": "integer"
+        },
+        "secret_ref": {
+          "minLength": 1,
+          "title": "Secret Ref",
+          "type": "string"
         }
       },
       "title": "AiProviderOptions",

--- a/schemas/ai-route.schema.json
+++ b/schemas/ai-route.schema.json
@@ -127,6 +127,34 @@
           "fallback_reason"
         ]
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "provider_options": {
+            "properties": {
+              "connection_only": {
+                "const": true
+              }
+            },
+            "required": [
+              "connection_only"
+            ]
+          }
+        },
+        "required": [
+          "provider_options"
+        ]
+      },
+      "then": {
+        "properties": {
+          "provider_options": {
+            "required": [
+              "secret_ref"
+            ]
+          }
+        }
+      }
     }
   ],
   "properties": {


### PR DESCRIPTION
## Zusammenfassung

- macht gelockte `AiRoute`-Snapshots für Ontologie- und Graph-Build autoritativ
- liest Cloud-Secrets ausschließlich aus passenden, aktivierten `ProviderConnection`-Einträgen
- delegiert Default-Provider-Erkennung an die zentrale Registry und fixiert Local-No-Auth auf echte lokale Hostnamen
- dokumentiert die getrennte Embedding-Erkennung gemäß ADR-0007
- markiert Legacy-Profil- und Provider-Endpunkte zur Entfernung in `1.0.0`

## Verifikation

- `bash scripts/pre-push-gate.sh backend`
- 377 Pydantic-Contract-Tests
- Ruff, Mypy, 46 Schema-Drift-Prüfungen und STATUS-Sync grün
- gezielte Route-, Factory-, Provider-API-, Embedding- und Snapshot/Audit-Regressionen grün

## Vollsuite

Der zusätzliche `pytest -x -q`-Lauf benötigt im frischen Worktree eine explizite Default-Route. Mit dem dokumentierten lokalen Ollama-Default lief er fehlerfrei bis 66 %, hing dann in einem bestehenden Langläufer ohne weitere Ausgabe und wurde manuell beendet. Das verbindliche Backend-Pre-Push-Gate ist vollständig grün.

Closes #761