### PR TITLE
fix(#669): simulation_lifecycle._detect_default_provider an registry.detect_provider delegieren

### DIFF
--- a/backend/app/api/simulation_lifecycle.py
+++ b/backend/app/api/simulation_lifecycle.py
@@ -9,6 +9,7 @@ from opentelemetry import trace
 
 from . import simulation_bp
 from ..config import Config
+from ..llm.providers.registry import detect_provider
 from ..models.project import ProjectManager
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..utils.api_errors import ApiErrorCode
@@ -22,21 +23,14 @@ _tracer = trace.get_tracer(__name__)
 def _detect_default_provider() -> str:
     """Infer the configured server-side LLM provider for UI gating.
 
-    Matches the heuristics used by ``LLMClient._detect_provider``:
-    - model suffix ``:cloud`` => Ollama Cloud
-    - base URL contains ``11434`` => local Ollama
-    - base URL contains ``openai.com`` or ``api.openai`` => OpenAI
-    - otherwise => unknown
+    Delegiert an die Provider-Detection-SSoT
+    ``app.llm.providers.registry.detect_provider`` im ``mode="http"``
+    (Issue #669) statt eine lokale Heuristik zu pflegen. Vokabular:
+    ``ollama|cloud|minimax|openai|google|unknown``.
     """
     model_name = (Config.LLM_MODEL_NAME or '').strip()
     base_url = (Config.LLM_BASE_URL or '').strip()
-    if model_name.endswith(':cloud'):
-        return 'cloud'
-    if '11434' in base_url:
-        return 'ollama'
-    if 'openai.com' in base_url or 'api.openai' in base_url:
-        return 'openai'
-    return 'unknown'
+    return detect_provider(base_url, model_name, mode="http")
 
 
 @simulation_bp.route('/available-models', methods=['GET'])

--- a/backend/tests/test_simulation_api_routes.py
+++ b/backend/tests/test_simulation_api_routes.py
@@ -66,6 +66,26 @@ def test_detect_default_provider_ollama_cloud(monkeypatch):
     assert _detect_default_provider() == 'cloud'
 
 
+def test_detect_default_provider_ollama_com_base_url_without_cloud_tag(monkeypatch):
+    # Issue #669: Delegation an die Registry-SSoT erkennt ollama.com auch ohne
+    # ":cloud"-Modell-Tag — die alte lokale Heuristik lieferte hier "unknown".
+    monkeypatch.setattr('app.api.simulation_lifecycle.Config.LLM_BASE_URL', 'https://ollama.com/v1')
+    monkeypatch.setattr('app.api.simulation_lifecycle.Config.LLM_MODEL_NAME', 'gpt-oss:20b')
+
+    assert _detect_default_provider() == 'cloud'
+
+
+def test_detect_default_provider_google(monkeypatch):
+    # Issue #669: Google/Gemini-Base-URLs waren der alten lokalen Heuristik
+    # unbekannt und fielen auf "unknown" zurueck.
+    monkeypatch.setattr(
+        'app.api.simulation_lifecycle.Config.LLM_BASE_URL',
+        'https://generativelanguage.googleapis.com/v1beta',
+    )
+    monkeypatch.setattr('app.api.simulation_lifecycle.Config.LLM_MODEL_NAME', 'gemini-2.5-pro')
+
+    assert _detect_default_provider() == 'google'
+
 
 def test_available_models_surfaces_startup_neo4j_error():
     app = _build_test_app()

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3383 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3395 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Closes #669.

Ersetzt die lokal kopierte Provider-Heuristik in `simulation_lifecycle._detect_default_provider` durch Delegation an die SSoT (`app.llm.providers.registry.detect_provider`, mode=http). Dadurch werden ollama.com-Base-URLs (auch ohne :cloud-Tag), MiniMax und Google/Gemini-Endpunkte korrekt erkannt statt auf unknown zu fallen.

RED: zwei neue Regressionstests (ollama.com ohne Cloud-Tag, Google via generativelanguage.googleapis.com) schlugen mit der alten Heuristik fehl.
GREEN: Delegation implementiert, alle vier Tests inkl. der bestehenden openai/:cloud-Fälle grün.

Sibling-Issue #670 war bereits durch PR #675/#676 abgedeckt (siehe `scripts/_sim_common.py::_is_ollama_route`); #671 läuft parallel.

Verification (Worktree):
- uv run pytest tests/test_simulation_api_routes.py → 34 passed
- uv run pytest tests/ → 3383 passed, 6 pre-existing fails in tests/api/test_graph_ontology_respects_frontend_model.py (no_api_key, identisch auf main HEAD 0c33533e)
- dump_schemas --check → 46 schemas match
- ruff check app/ tests/ → all checks passed
- mypy app → no issues found in 228 source files
- pre-push-gate schemas → PASS (nach Sync von STATUS.md-Test-Count)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>