### PR TITLE
refactor(#671): Embedding-Detection in Registry-SSoT vereinheitlichen

### DIFF
--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -232,12 +232,12 @@ def detect_embedding_provider(
        Server mit nativer ``/api/embed``-Route).
     """
     normalized_base = (base_url or "").lower()
-    host = urlparse(normalized_base).netloc
+    host = urlparse(normalized_base).hostname or ""
     model_name = model or ""
     if (
         normalized_base.endswith("/v1")
         or normalized_base.endswith("/v1/")
-        or "api.openai.com" in host
+        or host == "api.openai.com"
         or model_name.startswith("text-embedding-")
     ):
         return "openai"

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -204,6 +204,46 @@ def detect_provider(
     return _detect_oasis(base_url, model)
 
 
+EmbeddingDetectedProvider = Literal["openai", "ollama"]
+
+
+def detect_embedding_provider(
+    base_url: Optional[str], model: Optional[str]
+) -> EmbeddingDetectedProvider:
+    """Erkennt die Embeddings-API-Shape (Issue #671), vormals
+    ``EmbeddingService._detect_provider`` in ``app/storage/embedding_service.py``.
+
+    Bewusst KEINE Delegation an :func:`detect_provider` (``mode="http"``):
+    beide Funktionen loesen unterschiedliche Probleme mit unterschiedlichem
+    Vokabular. ``detect_provider`` entscheidet, welcher Chat-``ProviderAdapter``
+    (Dispatch) genutzt wird; ``detect_embedding_provider`` entscheidet nur,
+    welche Request-/Response-Shape die Embeddings-API hat
+    (``POST /v1/embeddings`` + Bearer-Header vs. ``POST /api/embed``). Die
+    Signale divergieren entsprechend — z. B. reicht hier ein blosses
+    ``/v1``-Suffix der Base-URL fuer ``"openai"``, waehrend ``mode="http"``
+    dafuer ``"unknown"`` liefert (dort ist ``/v1`` allein kein Signal).
+    Eine Zusammenfuehrung waere eine Verhaltensaenderung an einer
+    testfixierten Heuristik.
+
+    Prioritaet (first match wins):
+    1. ``"openai"`` — Base-URL endet auf ``/v1``/``/v1/``, Host ist
+       ``api.openai.com``, oder Modellname beginnt mit ``text-embedding-``.
+    2. ``"ollama"`` — Fallback fuer alles andere (z. B. lokaler/Cloud-Ollama-
+       Server mit nativer ``/api/embed``-Route).
+    """
+    normalized_base = (base_url or "").lower()
+    host = urlparse(normalized_base).netloc
+    model_name = model or ""
+    if (
+        normalized_base.endswith("/v1")
+        or normalized_base.endswith("/v1/")
+        or "api.openai.com" in host
+        or model_name.startswith("text-embedding-")
+    ):
+        return "openai"
+    return "ollama"
+
+
 def get_adapter(
     provider: str, *, num_ctx: Optional[int] = None, think: bool = False
 ) -> "ProviderAdapter":

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -17,11 +17,11 @@ import os
 import time
 import logging
 from typing import List, Optional
-from urllib.parse import urlparse
 
 import requests
 
 from ..config import Config, infer_vector_dim_for_model
+from ..llm.providers.registry import detect_embedding_provider
 
 logger = logging.getLogger('agora.embedding')
 
@@ -291,17 +291,12 @@ class EmbeddingService:
         )
 
     def _detect_provider(self) -> str:
-        """Infer which embeddings API shape to use from the configured base URL/model."""
-        normalized_base = self.base_url.lower()
-        host = urlparse(normalized_base).netloc
-        if (
-            normalized_base.endswith('/v1')
-            or normalized_base.endswith('/v1/')
-            or 'api.openai.com' in host
-            or self.model.startswith('text-embedding-')
-        ):
-            return 'openai'
-        return 'ollama'
+        """Infer which embeddings API shape to use from the configured base URL/model.
+
+        Delegiert an ``detect_embedding_provider`` (SSoT-Registry,
+        ``app/llm/providers/registry.py``, Issue #671). Verhalten unveraendert.
+        """
+        return detect_embedding_provider(self.base_url, self.model)
 
     def _build_embed_url(self) -> str:
         if self._provider == 'openai':

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.llm.providers.registry import detect_provider
+from app.llm.providers.registry import detect_embedding_provider, detect_provider
 
 # ---------------------------------------------------------------------------
 # mode="http" — Verhalten von LLMClient._detect_provider (testfixiert in
@@ -137,3 +137,29 @@ DIVERGENT_CASES = [
 def test_documented_divergences(base_url, model, expected_http, expected_oasis):
     assert detect_provider(base_url, model, mode="http") == expected_http
     assert detect_provider(base_url, model, mode="oasis") == expected_oasis
+
+
+# ---------------------------------------------------------------------------
+# detect_embedding_provider — Embeddings-API-Shape (Issue #671), vormals
+# ``EmbeddingService._detect_provider`` (app/storage/embedding_service.py).
+# Bewusst eigenes Vokabular/eigene Logik statt Delegation an detect_provider
+# (mode="http"): unterschiedlicher Zweck (Request/Response-Shape der
+# Embeddings-API vs. Chat-Adapter-Dispatch) und unterschiedliche Signale
+# (z. B. reicht ein blosses "/v1"-Suffix hier fuer "openai", waehrend
+# mode="http" dafuer "unknown" liefert).
+# ---------------------------------------------------------------------------
+
+EMBEDDING_CASES = [
+    # (base_url, model, expected)
+    ("http://localhost:11434/v1", "nomic-embed-text", "openai"),  # /v1-Suffix
+    ("http://localhost:11434/v1/", "nomic-embed-text", "openai"),  # /v1/-Suffix
+    ("https://api.openai.com", "some-model", "openai"),  # Host api.openai.com
+    ("http://localhost:11434", "text-embedding-3-small", "openai"),  # Modell-Prefix
+    ("http://localhost:11434", "nomic-embed-text", "ollama"),  # Default-Fallback
+    ("https://ollama.com", "qwen3-embedding:4b", "ollama"),
+]
+
+
+@pytest.mark.parametrize(("base_url", "model", "expected"), EMBEDDING_CASES)
+def test_detect_embedding_provider(base_url, model, expected):
+    assert detect_embedding_provider(base_url, model) == expected

--- a/backend/tests/llm/test_provider_registry.py
+++ b/backend/tests/llm/test_provider_registry.py
@@ -157,6 +157,10 @@ EMBEDDING_CASES = [
     ("http://localhost:11434", "text-embedding-3-small", "openai"),  # Modell-Prefix
     ("http://localhost:11434", "nomic-embed-text", "ollama"),  # Default-Fallback
     ("https://ollama.com", "qwen3-embedding:4b", "ollama"),
+    # Lookalike-Hosts duerfen NICHT auf die OpenAI-Shape (Bearer + /v1/embeddings)
+    # fallen — exakter Host-Match statt Substring (CodeQL #370, PR #783).
+    ("https://api.openai.com.evil.com", "some-model", "ollama"),
+    ("https://notapi.openai.com", "some-model", "ollama"),
 ]
 
 

--- a/backend/tests/test_embedding_service.py
+++ b/backend/tests/test_embedding_service.py
@@ -3,7 +3,25 @@ from unittest.mock import patch
 import pytest
 
 from app.config import Config, infer_vector_dim_for_model
+from app.llm.providers.registry import detect_embedding_provider
 from app.storage.embedding_service import EmbeddingError, EmbeddingService, validate_embedding_configuration
+
+
+@pytest.mark.parametrize(
+    ("base_url", "model"),
+    [
+        ("http://localhost:11434/v1", "nomic-embed-text"),
+        ("http://localhost:11434", "nomic-embed-text"),
+        ("https://api.openai.com", "text-embedding-3-small"),
+        ("http://localhost:11434", "text-embedding-3-small"),
+    ],
+)
+def test_detect_provider_delegates_to_registry_ssot(base_url, model):
+    """Issue #671 — EmbeddingService._detect_provider MUSS byte-genau das
+    liefern, was detect_embedding_provider() (SSoT-Registry) liefert. Kein
+    lokal divergentes Verhalten mehr."""
+    service = EmbeddingService(model=model, base_url=base_url, api_key='dummy-key')
+    assert service._detect_provider() == detect_embedding_provider(base_url, model)
 
 
 def test_infer_vector_dim_for_known_models():

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3405 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3407 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3395 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3405 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Closes #671.

Verschiebt die Embedding-Provider-Detection aus `EmbeddingService._detect_provider` in eine dedizierte SSoT-Funktion `detect_embedding_provider(base_url, model)` in `app/llm/providers/registry.py`. Bewusst KEIN Zusammenführen mit der Chat-`detect_provider(mode="http")` — unterschiedlicher Zweck (Embeddings-API-Shape /v1/embeddings vs. /api/embed, mit eigener Vokabular-Semantik) und unterschiedlicher Rückgabe-Literal (`Literal["openai","ollama"]`). Verhalten byte-genau identisch: bestehende Tests grün, neuer RED-Test (`test_detect_provider_delegates_to_registry_ssot`) nagelt die Delegation fest.

Verification (Worktree):
- uv run pytest tests/test_embedding_service.py tests/llm/test_provider_registry.py → 73 passed
- uv run pytest tests/ → 3383 passed, 6 pre-existing fails in tests/api/test_graph_ontology_respects_frontend_model.py (no_api_key, identisch auf main HEAD 0c33533e)
- dump_schemas --check → 46 schemas match
- ruff check app/ tests/ → all checks passed
- mypy app → no issues found in 228 source files
- pre-push-gate schemas → ALL GREEN

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>