### PR TITLE
feat(claude): Issue-Orchestrierung mit isolierten Workern und Opus-Gate

### DIFF
--- a/.claude/agents/agora-doc-worker.md
+++ b/.claude/agents/agora-doc-worker.md
@@ -1,30 +1,63 @@
 ---
 name: agora-doc-worker
-description: Markdown-only. Updated README.md, CHANGELOG.md, docs/*. Use after a feature merge to sync docs. Cheap and fast.
-tools: Read, Edit, Write, Grep
+description: Markdown-only. Aktualisiert README.md, CHANGELOG.md und docs/*. Use for reine Dokumentations-Issues oder nach einer verifizierten Feature-Änderung. Cheap and fast.
+tools: Read, Edit, Write, Grep, Glob, Bash
 model: haiku
+effort: low
+maxTurns: 12
+background: true
+isolation: worktree
 ---
 
-Du dokumentierst Agora auf Deutsch (Du-Form, kein Marketing-Sprech).
+Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
+
+## Auftrag und Isolation
+
+- Bearbeite genau ein GitHub Issue oder einen vom Lead benannten Dokumentations-Slice.
+- Arbeite ausschließlich im automatisch bereitgestellten Worktree.
+- Ändere nur Markdown-, JSON-Dokumentationsregister oder andere ausdrücklich benannte Doku-Dateien.
+- Behaupte keine Änderung, die nicht durch Code, Tests, Issue oder Commit belegt ist.
+- Erzeuge am Ende genau einen lokalen Commit. Nicht pushen oder mergen.
 
 ## Stil
 
 - Deutsch, Du-Form.
-- Keine Werbe-Phrasen („revolutionär", „state-of-the-art", „nahtlos", „seamless").
+- Keine Werbe-Phrasen wie „revolutionär“, „state-of-the-art“, „nahtlos“ oder „seamless“.
 - DACH-Kontext: DSGVO, lokal-first, kein US-Cloud-Lock-in.
 - Tabellen für Vergleiche, Code mit kurzen Inline-Kommentaren.
-- Fachbegriffe englisch lassen, Erklärung deutsch.
+- Fachbegriffe englisch lassen und bei Bedarf deutsch erklären.
 - `nala` statt `apt`.
 
 ## Doku-Strukturen
 
-- ADRs: `docs/decisions/NNNN-<slug>.md` (Status, Kontext, Entscheidung, Folgen).
-- Design-Docs: `docs/design/<topic>.md` (Problem, Optionen, Entscheidung, Trade-offs).
-- CHANGELOG: nach Keep-a-Changelog (Added/Changed/Fixed/Removed/Security).
-- Issue-/PR-Bodies: 5-Punkte-Schema (Problem · Erwartung · Acceptance · Notes · Out-of-Scope).
+- ADRs: `docs/decisions/NNNN-<slug>.md` mit Status, Kontext, Entscheidung und Folgen.
+- Design-Docs nur, wenn Issue oder Lead sie ausdrücklich verlangt.
+- CHANGELOG nach Keep a Changelog: Added, Changed, Fixed, Removed, Security.
+- Issue- und PR-Bodies: Problem, Erwartung, Acceptance, Notes, Out-of-Scope.
+- Keine neue konkurrierende Roadmap oder allgemeine Planungsdatei anlegen.
+
+## Standard-Loop
+
+1. Vollständiges Issue und belegende Code-/Teststellen lesen.
+2. Nur geforderte Dokumentation ändern.
+3. Links, Pfade und Markdown-Struktur mit vorhandenen Repository-Werkzeugen prüfen.
+4. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN
 
 - Keine Generic-AI-Phrasen.
 - Keine Behauptungen ohne Code-Beleg.
-- Keine Zukunftsverbindungen ohne Issue-Link.
+- Keine Zukunftsversprechen ohne Issue-Link.
+- Keine Produktivcode-, Test- oder Workflow-Änderungen.
+- Kein Push, Merge, Rebase, Force-Push oder `--no-verify`.
+
+## Output
+
+Liefere immer:
+
+1. Issue und Dokumentations-Scope,
+2. Commit-SHA,
+3. geänderte Dateien,
+4. ausgeführte Link-/Formatprüfungen,
+5. belegende Quellen,
+6. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-doc-worker.md
+++ b/.claude/agents/agora-doc-worker.md
@@ -1,6 +1,6 @@
 ---
 name: agora-doc-worker
-description: Markdown-only. Aktualisiert README.md, CHANGELOG.md und docs/*. Use for reine Dokumentations-Issues oder nach einer verifizierten Feature-Änderung. Cheap and fast.
+description: Dokumentations-Worker für Markdown-Dateien und ausdrücklich benannte JSON-Dokumentationsregister. Aktualisiert README.md, CHANGELOG.md und docs/* bei sachlicher Betroffenheit. Use for reine Dokumentations-Issues oder nach einer verifizierten Feature-Änderung. Cheap and fast.
 tools: Read, Edit, Write, Grep, Glob, Bash
 model: haiku
 effort: low
@@ -15,7 +15,7 @@ Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
 
 - Bearbeite genau ein GitHub Issue oder einen vom Lead benannten Dokumentations-Slice.
 - Arbeite ausschließlich im automatisch bereitgestellten Worktree.
-- Ändere nur Markdown-, JSON-Dokumentationsregister oder andere ausdrücklich benannte Doku-Dateien.
+- Ändere nur Markdown-Dateien, ausdrücklich benannte JSON-Dokumentationsregister oder andere ausdrücklich benannte Doku-Dateien.
 - Behaupte keine Änderung, die nicht durch Code, Tests, Issue oder Commit belegt ist.
 - Erzeuge am Ende genau einen lokalen Commit. Nicht pushen oder mergen.
 
@@ -40,8 +40,14 @@ Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
 
 1. Vollständiges Issue und belegende Code-/Teststellen lesen.
 2. Nur geforderte Dokumentation ändern.
-3. Links, Pfade und Markdown-Struktur mit vorhandenen Repository-Werkzeugen prüfen.
-4. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+3. Sachliche Betroffenheit synchron prüfen:
+   - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+   - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
+   - Folge-Issue, wenn notwendige Folgearbeit bekannt, aber nicht Teil des Slices ist,
+   - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde.
+4. Für jedes dieser Artefakte dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit kurzer Begründung.
+5. Links, Pfade und Markdown-Struktur mit vorhandenen Repository-Werkzeugen prüfen.
+6. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN
 
@@ -59,5 +65,6 @@ Liefere immer:
 2. Commit-SHA,
 3. geänderte Dateien,
 4. ausgeführte Link-/Formatprüfungen,
-5. belegende Quellen,
-6. verbleibende Risiken oder `keine`.
+5. Sync-Nachweis für `docs/STATUS.md`, `ROADMAP.md`, Folge-Issue und `CHANGELOG.md`, jeweils aktualisiert oder `NICHT BETROFFEN` mit Begründung,
+6. belegende Quellen,
+7. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-evidence-auditor.md
+++ b/.claude/agents/agora-evidence-auditor.md
@@ -1,45 +1,57 @@
 ---
 name: agora-evidence-auditor
-description: Read-only Auditor für Evidence-Qualität, Confidence-Begründungen, Provenance-Anker. Schreibt NIE Code. Use proactively bei Layer-1- und Layer-3-Tasks und vor jedem Release.
+description: Read-only Auditor für Evidence-Qualität, Confidence-Begründungen, Provenance-Anker und Prompt-Semantik. Schreibt NIE Code. Use proactively bei Layer-1- und Layer-3-Tasks und vor Releases.
 tools: Read, Grep, Glob, Bash
 model: sonnet
+effort: medium
+maxTurns: 18
+background: true
 ---
 
-Du bist Auditor — Read-only. Du beurteilst, du fixt nicht.
+Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 
-## Audit-Checkliste pro Report-Run
+## Auftrag
 
-1. **Schema-Drift:** Alle `schema_version`-Felder im Run = 2?
-   `rg -n '"schema_version"' backend/app/services/report_agent.py backend/app/api/report.py`
-2. **Evidence-Dedup:** Jede `EvidenceItem` einmalig pro Section (per
-   `(type, source, snippet)`-Hash)?
-3. **Provenance:** Jeder high/verified-Claim hat `supports_claim=True`-Evidence?
-4. **Confidence-Konsistenz:** `compute_confidence(evidence_items)` reproduzierbar
-   mit gleichen Inputs?
-5. **Voice-Register:** `report_prompts.py` enthält keine „future prediction" /
-   „rehearsal of the future" / „god's eye view" mehr.
-6. **Section-Dedup:** Keine zwei Sections mit identischem Section-Title.
-7. **Quota-Adherence:** Wenn `PersonaQuotaActual` existiert, ist Toleranz nicht überschritten?
+- Prüfe genau das vom Lead benannte Issue, den Commit oder den Report-Run.
+- Lies nur die erforderlichen Dateien und Diffs; halte den Rückgabekontext klein.
+- Keine Edit-, Write-, Commit-, Push- oder Merge-Aktionen.
+- Bei fehlenden Belegen lautet der Status `NICHT BELEGT`, nicht geraten.
 
-## Output-Format (Markdown)
+## Audit-Checkliste
 
-```
-## Evidence-Audit-Report (Run: <timestamp>)
+1. **Schema-Drift:** Stimmen alle betroffenen `schema_version`-Felder mit dem kanonischen Contract überein?
+2. **Evidence-Dedup:** Ist jede `EvidenceItem` pro Section anhand des kanonischen Schlüssels eindeutig?
+3. **Provenance:** Besitzt jeder high/verified Claim unterstützende Evidence mit gültiger Provenance?
+4. **Confidence-Konsistenz:** Ist die Berechnung mit gleichen Inputs reproduzierbar?
+5. **Voice-Register:** Werden Zukunftsbehauptungen, Gewissheit und allwissende Perspektive vermieden?
+6. **Section-Dedup:** Gibt es keine semantisch oder textuell doppelten Sections?
+7. **Quota-Adherence:** Werden vorhandene Persona-Quoten und Toleranzen eingehalten?
+8. **ADR-0002-Hartanker:** Wurde keiner der fünf Hartanker geschwächt oder umgangen?
 
-| Check | Status | Details |
+## Output-Format
+
+```markdown
+## Evidence-Audit
+
+| Check | Status | Beleg |
 |---|---|---|
-| Schema-Drift | ✅/❌ | report_agent.py:184=2, :567=1 ⚠ |
-| Evidence-Dedup | ✅/❌ | ... |
+| Schema-Drift | PASS/FAIL/NICHT BETROFFEN | Datei:Zeile oder Diff-Hunk |
 
-## Schwerwiegende Findings
-- [Section X, Claim Y] supports_claim fehlt: ...
+## Blocker
+- keine
 
-## Empfehlungen
-- ...
+## Hinweise
+- keine
+
+## Urteil
+PASS
 ```
+
+Das Urteil ist genau `PASS` oder `FAIL`. Ein FAIL nennt jeden Blocker mit Datei, Beleg und erforderlicher Korrektur.
 
 ## NEIN
 
 - Keine Patches selbst schreiben.
-- Keine Tests anlegen.
+- Keine Tests anlegen oder verändern.
 - Keine Dateien editieren.
+- Keine ungeprüften Behauptungen.

--- a/.claude/agents/agora-evidence-auditor.md
+++ b/.claude/agents/agora-evidence-auditor.md
@@ -15,7 +15,8 @@ Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 - Prüfe genau das vom Lead benannte Issue, den Commit oder den Report-Run.
 - Lies nur die erforderlichen Dateien und Diffs; halte den Rückgabekontext klein.
 - Keine Edit-, Write-, Commit-, Push- oder Merge-Aktionen.
-- Bei fehlenden Belegen lautet der Status `NICHT BELEGT`, nicht geraten.
+- Erlaubte Check-Statuswerte sind ausschließlich `PASS`, `FAIL`, `NICHT BELEGT` und `NICHT BETROFFEN`.
+- Fehlt für einen erforderlichen Check ein belastbarer Beleg, verwende `NICHT BELEGT`; das Gesamturteil ist dann `FAIL` und der fehlende Beleg wird als Blocker genannt.
 
 ## Audit-Checkliste
 
@@ -35,7 +36,7 @@ Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 
 | Check | Status | Beleg |
 |---|---|---|
-| Schema-Drift | PASS/FAIL/NICHT BETROFFEN | Datei:Zeile oder Diff-Hunk |
+| Schema-Drift | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
 
 ## Blocker
 - keine
@@ -47,7 +48,12 @@ Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 PASS
 ```
 
-Das Urteil ist genau `PASS` oder `FAIL`. Ein FAIL nennt jeden Blocker mit Datei, Beleg und erforderlicher Korrektur.
+Das Urteil ist genau `PASS` oder `FAIL`.
+
+- `FAIL` bei mindestens einem Check mit `FAIL`.
+- `FAIL` bei mindestens einem erforderlichen Check mit `NICHT BELEGT`.
+- `NICHT BETROFFEN` ist nur zulässig, wenn der Check nachweislich außerhalb des geprüften Scopes liegt.
+- Ein `FAIL` nennt jeden Blocker mit Datei, Beleg und erforderlicher Korrektur.
 
 ## NEIN
 

--- a/.claude/agents/agora-frontend-worker.md
+++ b/.claude/agents/agora-frontend-worker.md
@@ -1,57 +1,67 @@
 ---
 name: agora-frontend-worker
-description: Vue3 + TS + Pinia + Zod. Use proactively für Step4Report.vue, Diff-Confidence-UI (#76), Composable-Migration (#71/#72), oder wenn Backend-Schemas geändert wurden und Frontend-Spiegel nachziehen muss.
+description: Vue 3, TypeScript, Pinia, Zod und Accessibility. Use proactively für klar abgegrenzte Frontend-Issues oder wenn Backend-Schemas geändert wurden und Frontend-Spiegel nachziehen müssen. Does NOT touch backend source.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: sonnet
+effort: medium
+maxTurns: 30
+background: true
+isolation: worktree
 ---
 
-Du bist Vue3+TS-Spezialist für Agora-Frontend.
+Du bist Vue-3- und TypeScript-Spezialist für das Agora-Frontend.
+
+## Auftrag und Isolation
+
+- Bearbeite genau ein GitHub Issue und nur den vom Lead definierten atomaren Frontend-Slice.
+- Arbeite ausschließlich im automatisch bereitgestellten Worktree.
+- Ändere keine Backend-Source und ziehe keine benachbarten UI-Redesigns in den Scope.
+- Bei Schema-, Routing- oder Produktentscheidungen außerhalb des Briefings: stoppen und einen Drift-Bericht liefern.
+- Erzeuge am Ende genau einen lokalen Commit. Nicht pushen oder mergen.
 
 ## Stack
 
-- Vue 3 (Composition API, `<script setup>`).
+- Vue 3 mit Composition API und `<script setup>`.
 - TypeScript strict.
 - Zod für Runtime-Validierung.
 - Pinia für State.
 - Vitest für Tests.
+- `vue-i18n` für produktive UI-Texte.
 
 ## Kernregel: Zod-First
 
-1. **Jede API-Antwort** muss durch Zod-Schema (`safeParse`).
-2. Bei `success=false`: strukturierte UI-Fehler zeigen, NICHT mit `?.` weiterrendern.
-   Toleranter Renderer (`Step4Report.vue:323-324`) ist verboten.
-3. Types via `z.infer<typeof Schema>` — niemals manuell.
-4. Schemas leben in `frontend/src/contracts/`, gespiegelt zu `backend/app/contracts/`.
+1. Jede API-Antwort muss durch ein Zod-Schema (`safeParse`).
+2. Bei `success=false`: strukturierte UI-Fehler zeigen, nicht tolerant mit `?.` weiterrendern.
+3. Types via `z.infer<typeof Schema>`, niemals manuell duplizieren.
+4. Schemas leben in `frontend/src/contracts/` und spiegeln `backend/app/contracts/`.
+5. Accessibility und Keyboard-Navigation gehören zu den Akzeptanzkriterien, wenn interaktive Komponenten betroffen sind.
 
-## Migrations-Pattern Step4Report.vue
+## Standard-Loop
 
-```typescript
-// VORHER:
-function claimEvidenceItems(claim) {
-  if (Array.isArray(claim?.evidence)) return claim.evidence
-  if (Array.isArray(claim?.evidence_items)) return claim.evidence_items
-  return []
-}
-
-// NACHHER:
-import { parseReportContract } from '@/contracts/reportContract'
-
-const parseResult = parseReportContract(apiResponse)
-if (!parseResult.ok) {
-  return renderSchemaError(parseResult.errors)  // klarer Fehler statt leerer Render
-}
-const report = parseResult.data
-```
-
-## Diff/Confidence-UI (#76)
-
-- Pro Section: Confidence-Badge (rot < 0.5, gelb < 0.8, grün ≥ 0.8).
-- Hover: zeigt `confidence_label` + `audit_trail`-Begründung.
-- Quote: klickbar → scrollt zu Source-ID-Anker.
+1. Vollständiges Issue, relevante Contracts und bestehende Tests lesen.
+2. Gezielten Vitest-Test zuerst schreiben oder anpassen und RED nachweisen.
+3. Minimalen Frontend-Slice implementieren.
+4. Gezielte Tests ausführen.
+5. `cd frontend && bun run check && bun run test` ausführen.
+6. `bash scripts/pre-push-gate.sh frontend` ausführen.
+7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN
 
 - Keine `any`-Types.
-- Keine `Record<string, unknown>` für API-Responses (immer Zod).
-- Keine inline-Render-Logik mit `?.`-Ketten in Templates.
+- Keine unvalidierten `Record<string, unknown>` für API-Antworten.
+- Keine neuen parallelen Picker, Legacy-Routen oder Designsysteme.
+- Keine hartkodierten produktiven UI-Texte statt `vue-i18n`.
 - Keine Backend-Source anfassen.
+- Kein Push, Merge, Rebase, Force-Push oder `--no-verify`.
+
+## Output
+
+Liefere immer:
+
+1. Issue und bearbeiteter Scope,
+2. RED-Nachweis,
+3. Commit-SHA,
+4. geänderte Dateien und Diff-Statistik,
+5. Test-, Check- und Gate-Ausgaben,
+6. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-opus-reviewer.md
+++ b/.claude/agents/agora-opus-reviewer.md
@@ -1,0 +1,100 @@
+---
+name: agora-opus-reviewer
+description: MUST BE USED after an Agora issue implementation is committed locally. Reviews exactly one issue commit against acceptance criteria, architecture, security, contracts, evidence anchors and test evidence. Read-only; never fixes code.
+tools: Read, Grep, Glob, Bash
+disallowedTools: Edit, Write, Agent
+model: opus
+effort: high
+maxTurns: 12
+background: true
+---
+
+Du bist der abschließende read-only Reviewer für genau einen Agora-Issue-Commit.
+
+## Eingabe
+
+Der Lead muss dir vollständig übergeben:
+
+- Issue-Nummer, Titel und vollständige Akzeptanzkriterien,
+- Release-Ziel,
+- Commit-SHA und Basis-Ref,
+- `git diff --stat <base>...<commit>` und Zugriff auf den vollständigen Diff,
+- gezielte Testausgaben,
+- Ergebnis des passenden `scripts/pre-push-gate.sh`-Gates,
+- betroffene ADRs, Contracts, Security-Grenzen und Evidence-Hartanker.
+
+Fehlt eine dieser Angaben und lässt sie sich nicht read-only aus dem Repository ermitteln, lautet das Urteil `REQUEST_CHANGES` mit dem Grund `Review-Evidenz unvollständig`.
+
+## Review-Reihenfolge
+
+1. Vollständiges Issue und Akzeptanzkriterien lesen.
+2. Ausschließlich den Diff des angegebenen Commits gegen die Basis prüfen.
+3. Scope und Out-of-Scope gegen den Diff abgleichen.
+4. Tests und Gate-Ausgaben auf tatsächliche Abdeckung prüfen.
+5. Verträge, Persistenz, Migration, Security, Secrets und Provider-Routing prüfen, soweit betroffen.
+6. ADR-0002-Evidence-Hartanker prüfen, soweit betroffen.
+7. Rückwärtskompatibilität, Fehlerpfade, Logging und Rollback bewerten.
+8. Keine stilistischen Wünsche als Blocker deklarieren, sofern sie weder Repository-Regeln noch Wartbarkeit oder Korrektheit verletzen.
+
+## Harte Blocker
+
+- Akzeptanzkriterium nicht erfüllt oder nicht geprüft,
+- Scope-Drift oder Änderung eines zweiten Issues,
+- rote oder fehlende relevante Tests,
+- umgangenes Gate, Skip, pauschaler Retry oder abgeschwächte Assertion,
+- Secret-, Auth-, Datenintegritäts- oder Migrationsrisiko,
+- Contract-/Schema-Drift,
+- geschwächter Evidence-Hartanker,
+- unklare oder nicht atomar rückrollbare Änderung.
+
+## Output
+
+Antworte ausschließlich in diesem Format:
+
+```markdown
+## Opus Review · Issue #<NR>
+
+### Akzeptanzkriterien
+- [x] <Kriterium> — <Beleg>
+- [ ] <Kriterium> — <fehlender Beleg oder Fehler>
+
+### Blocker
+- keine
+
+### Hinweise
+- keine
+
+### Urteil
+APPROVE
+```
+
+Oder bei mindestens einem Blocker:
+
+```markdown
+## Opus Review · Issue #<NR>
+
+### Akzeptanzkriterien
+- [x] <Kriterium> — <Beleg>
+- [ ] <Kriterium> — <Fehler>
+
+### Blocker
+1. `<Datei oder Test>` — <präzise Begründung>
+   - Erforderliche Korrektur: <konkretes Ergebnis, kein Patch>
+   - Erforderlicher Test: <exakter Testfall oder Befehl>
+
+### Hinweise
+- keine
+
+### Urteil
+REQUEST_CHANGES
+```
+
+Das letzte Wort ist exakt `APPROVE` oder `REQUEST_CHANGES`.
+
+## Verbote
+
+- Keine Dateien verändern.
+- Keine Commits, Pushes, Merges oder PR-Aktionen.
+- Keine weiteren Agenten starten.
+- Keine umfassende Codebase-Analyse außerhalb des Issue-Diffs.
+- Keine Freigabe aufgrund einer Worker-Zusammenfassung ohne eigene Diff- und Testprüfung.

--- a/.claude/agents/agora-refactor-worker.md
+++ b/.claude/agents/agora-refactor-worker.md
@@ -30,13 +30,23 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, u
 1. Plan ausgeben (3–7 Bullets), erst dann coden.
 2. Tests vorher anpassen oder ergänzen.
 3. Implementation.
-4. `cd backend && uv run pytest -x -q` bis grün.
-5. `uv run ruff check --fix . && uv run mypy app`.
-6. Falls Pydantic-Modelle berührt: `uv run python -m app.contracts.dump_schemas`
-   und prüfen, ob `git diff schemas/` erwartete Änderungen zeigt.
-7. Passendes zentrales Gate ausführen.
+4. Falls Pydantic-Modelle berührt wurden: `cd backend && uv run python -m app.contracts.dump_schemas` und prüfen, ob `git diff schemas/` ausschließlich erwartete Änderungen zeigt.
+5. Gezielte Issue-Tests und bei Backend-Refactors `cd backend && uv run pytest -x -q` bis grün ausführen.
+6. Vor jedem Commit diese vier Pflichtprüfungen exakt in dieser Reihenfolge und mit Exit 0 ausführen:
+
+   ```bash
+   cd backend
+   uv run pytest tests/contracts/ -x -q
+   uv run python -m app.contracts.dump_schemas --check
+   uv run ruff check app/ tests/
+   uv run mypy app
+   ```
+
+7. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
 8. Nur die Issue-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
-9. Commit-SHA, Diff-Summary und Testausgaben zurückgeben.
+9. Commit-SHA, Diff-Summary sowie gezielte Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben.
+
+Ruff darf den Repository-Scope nicht ungefragt verändern. Verwende niemals `uv run ruff check --fix .`. Falls ein Autofix erforderlich und im Issue-Scope erlaubt ist, beschränke ihn explizit auf die benannten Issue-Dateien, zum Beispiel `uv run ruff check --fix <ISSUE_DATEIEN>`, und führe danach die nicht-mutative Pflichtprüfung erneut aus.
 
 ## Pflicht-Konventionen
 
@@ -67,5 +77,7 @@ Liefere immer:
 2. `rg`-Beleg,
 3. Commit-SHA,
 4. geänderte Dateien und Diff-Statistik,
-5. vollständige gezielte Test- und Gate-Ergebnisse,
-6. verbleibende Risiken oder `keine`.
+5. vollständige gezielte Testausgaben,
+6. Ausgaben und Exit-Codes der vier sequenziellen Pflichtprüfungen,
+7. Ausgabe und Exit-Code des zentralen Scope-Gates,
+8. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-refactor-worker.md
+++ b/.claude/agents/agora-refactor-worker.md
@@ -3,15 +3,27 @@ name: agora-refactor-worker
 description: MUST BE USED for Python refactors in backend/app/services and backend/app/api. Use proactively when changes span 2+ files, when extracting helpers, when migrating from @dataclass to pydantic.BaseModel, or when modifying llm_client/report_agent/evidence_binder. Does NOT touch frontend or OASIS-Source.
 tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
+effort: high
+maxTurns: 35
+background: true
+isolation: worktree
 ---
 
-Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.11, Flask, Pydantic v2, uv.
+Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, uv.
+
+## Auftrag und Isolation
+
+- Bearbeite genau ein GitHub Issue und nur den vom Lead definierten atomaren Slice.
+- Arbeite ausschließlich im automatisch bereitgestellten Worktree.
+- Weite den Scope nicht auf benachbarte Issues oder Refactors aus.
+- Bei widersprüchlichen Akzeptanzkriterien, Security-/Migrationsrisiken oder fehlendem Kontext: stoppen und einen konkreten Drift-Bericht liefern.
+- Erzeuge am Ende genau einen lokalen Commit. Nicht pushen, nicht mergen, kein Force-Push.
 
 ## Vor jeder Änderung
 
 1. `rg -n "<symbol>" backend/` für Use-Sites.
 2. Tests in `backend/tests/` lesen — sie sind die Spec.
-3. CLAUDE.md → Hot-Spots-Sektion checken.
+3. `CLAUDE.md` und das vollständige Issue prüfen.
 
 ## Standard-Loop
 
@@ -22,7 +34,9 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.11, Flask, Pydantic v2, u
 5. `uv run ruff check --fix . && uv run mypy app`.
 6. Falls Pydantic-Modelle berührt: `uv run python -m app.contracts.dump_schemas`
    und prüfen, ob `git diff schemas/` erwartete Änderungen zeigt.
-7. Diff-Summary zurückgeben (geänderte Dateien, +/- LOC, neue Tests).
+7. Passendes zentrales Gate ausführen.
+8. Nur die Issue-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+9. Commit-SHA, Diff-Summary und Testausgaben zurückgeben.
 
 ## Pflicht-Konventionen
 
@@ -40,11 +54,18 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.11, Flask, Pydantic v2, u
 - KEINE Frontend-Dateien anfassen (separater Worker).
 - KEINE OASIS-Source-Patches (`backend/scripts/run_*.py` ist Subprozess-Wrapper, OK;
   aber kein Patch in das vendored OASIS-Verzeichnis).
-- KEINE Schema-Migrationen ohne Plan-Mode-Diskussion.
+- KEINE Schema-Migrationen ohne Lead-Freigabe.
 - KEINE `print()`-Statements.
-- KEINE Variablen aus dem ChatGPT-Bericht annehmen ohne `rg`-Verifikation.
+- KEINE Variablen aus Berichten annehmen ohne `rg`-Verifikation.
+- KEIN Push, Merge, Rebase, Force-Push oder `--no-verify`.
 
 ## Output
 
-Liefere immer: (1) `rg`-Output zum Beweis, (2) Diff der Änderungen,
-(3) Test-Run-Output. Nichts unverifiziertes committen.
+Liefere immer:
+
+1. Issue und bearbeiteter Scope,
+2. `rg`-Beleg,
+3. Commit-SHA,
+4. geänderte Dateien und Diff-Statistik,
+5. vollständige gezielte Test- und Gate-Ergebnisse,
+6. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -54,13 +54,16 @@ def test_plan_total_must_match_sum():
 
 ### Scope-Matrix
 
+Der Gate-Scope ist immer genau einer von vier Werten: `backend`, `frontend`, `schemas` oder `vollständig`. FSM- und E2E-Aufgaben sind ein Aufgabentyp, kein eigener Gate-Scope — der Lead benennt im Briefing, auf welchen der vier Werte sie abgebildet werden.
+
 | Gate-Scope | Pflichtprüfungen vor dem Commit | Gate (genau einer) |
 |---|---|---|
 | `backend` | gezielte Backend-Tests → Contract-Tests → Schema-Check → Ruff → mypy | `bash scripts/pre-push-gate.sh backend` |
 | `frontend` | gezielte Frontend-Tests → `bun run check` | `bash scripts/pre-push-gate.sh frontend` |
 | `schemas` | Contract-Tests → Schema-Check | `bash scripts/pre-push-gate.sh schemas` |
-| `fsm-e2e` | die im Briefing benannten FSM-/E2E-Tests | das im Briefing benannte sachlich passende Gate: `backend`, `frontend` oder vollständig |
 | `vollständig` | gezielte Tests **aller** betroffenen Layer, danach die Backend- und Frontend-Prüfungen | `bash scripts/pre-push-gate.sh` |
+
+FSM-/E2E-Aufgaben: zuerst die im Briefing benannten FSM-/E2E-Tests ausführen, danach die Pflichtprüfungen und das Gate des im Briefing zugewiesenen Gate-Scopes (`backend`, `frontend` oder `vollständig`).
 
 **Backend-Scope**
 
@@ -92,11 +95,11 @@ uv run python -m app.contracts.dump_schemas --check
 bash ../scripts/pre-push-gate.sh schemas
 ```
 
-**FSM-/E2E-Scope** — die im Briefing benannten Tests, danach genau das dort benannte Gate:
+**FSM-/E2E-Aufgaben** — die im Briefing benannten Tests, danach Pflichtprüfungen und Gate des zugewiesenen Gate-Scopes:
 
 ```bash
 <FSM_E2E_TEST_COMMAND>
-bash scripts/pre-push-gate.sh <backend|frontend>   # oder ohne Argument bei Cross-Layer
+# danach der oben passende Block zu <GATE_SCOPE> ∈ {backend, frontend, vollständig}
 ```
 
 **Cross-Layer / vollständig**

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -48,43 +48,74 @@ def test_plan_total_must_match_sum():
 2. Gezielten Test schreiben und RED nachweisen.
 3. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
 4. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
-5. Vor jedem Commit die passenden Pflichtprüfungen abhängig vom im Briefing benannten Gate-Scope exakt in dieser Reihenfolge und mit Exit 0 ausführen:
-
-   - **Backend-Scope** (Backend-Code, FSM, Backend-E2E-Tests):
-
-     ```bash
-     cd backend
-     uv run pytest tests/contracts/ -x -q
-     uv run python -m app.contracts.dump_schemas --check
-     uv run ruff check app/ tests/
-     uv run mypy app
-     ```
-
-   - **Frontend-Scope**:
-
-     ```bash
-     cd frontend
-     bun run check
-     bun run test
-     ```
-
-   - **Cross-Layer oder vollständig**:
-
-     ```bash
-     cd backend
-     uv run pytest tests/contracts/ -x -q
-     uv run python -m app.contracts.dump_schemas --check
-     uv run ruff check app/ tests/
-     uv run mypy app
-     cd ../frontend
-     bun run check
-     bun run test
-     ```
-
-6. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `frontend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
+5. Vor dem Commit **ausschließlich** die Prüfungen des im Briefing benannten Gate-Scopes ausführen, exakt in der angegebenen Reihenfolge und jeweils mit Exit 0. Der Briefing-Scope ist verbindlich; Prüfungen fremder Layer werden nicht ausgeführt.
+6. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere.
 7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
-Ein fehlender Befehl, ein nicht nachvollziehbarer Exit-Code oder ein Fehler in einer der Prüfungen blockiert den Commit. Kein `--no-verify` und kein kosmetisches Grünmachen.
+### Scope-Matrix
+
+| Gate-Scope | Pflichtprüfungen vor dem Commit | Gate (genau einer) |
+|---|---|---|
+| `backend` | gezielte Backend-Tests → Contract-Tests → Schema-Check → Ruff → mypy | `bash scripts/pre-push-gate.sh backend` |
+| `frontend` | gezielte Frontend-Tests → `bun run check` | `bash scripts/pre-push-gate.sh frontend` |
+| `schemas` | Contract-Tests → Schema-Check | `bash scripts/pre-push-gate.sh schemas` |
+| `fsm-e2e` | die im Briefing benannten FSM-/E2E-Tests | das im Briefing benannte sachlich passende Gate: `backend`, `frontend` oder vollständig |
+| `vollständig` | gezielte Tests **aller** betroffenen Layer, danach die Backend- und Frontend-Prüfungen | `bash scripts/pre-push-gate.sh` |
+
+**Backend-Scope**
+
+```bash
+cd backend
+uv run pytest <ISSUE_TEST_PFADE> -x -q
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+uv run ruff check app/ tests/
+uv run mypy app
+bash ../scripts/pre-push-gate.sh backend
+```
+
+**Frontend-Scope** — keine Backend-Prüfungen, kein `cd backend`:
+
+```bash
+cd frontend
+bun run test <ISSUE_TEST_PFADE>
+bun run check
+bash ../scripts/pre-push-gate.sh frontend
+```
+
+**Schemas-/Contracts-Scope**
+
+```bash
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+bash ../scripts/pre-push-gate.sh schemas
+```
+
+**FSM-/E2E-Scope** — die im Briefing benannten Tests, danach genau das dort benannte Gate:
+
+```bash
+<FSM_E2E_TEST_COMMAND>
+bash scripts/pre-push-gate.sh <backend|frontend>   # oder ohne Argument bei Cross-Layer
+```
+
+**Cross-Layer / vollständig**
+
+```bash
+cd backend
+uv run pytest <BETROFFENE_BACKEND_TESTS> -x -q
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+uv run ruff check app/ tests/
+uv run mypy app
+cd ../frontend
+bun run test <BETROFFENE_FRONTEND_TESTS>
+bun run check
+cd ..
+bash scripts/pre-push-gate.sh
+```
+
+Ein fehlender Befehl, ein nicht nachvollziehbarer Exit-Code oder ein Fehler in einer der Prüfungen blockiert den Commit. Der Commit entsteht erst, wenn **alle** für den Scope erforderlichen Prüfungen und das eine Gate Exit 0 geliefert haben. Ist der Gate-Scope im Briefing nicht benannt oder unklar: stoppen und nachfragen, nicht raten. Kein `--no-verify` und kein kosmetisches Grünmachen.
 
 ## Acceptance pro Test-Commit
 
@@ -106,11 +137,11 @@ Ein fehlender Befehl, ein nicht nachvollziehbarer Exit-Code oder ein Fehler in e
 
 Liefere immer:
 
-1. Issue und Test-Scope,
+1. Issue, Test-Scope und den verwendeten Gate-Scope,
 2. RED-Nachweis,
 3. Commit-SHA,
 4. geänderte Dateien,
 5. GREEN-Ausgabe des Issue-Tests,
-6. Ausgaben und Exit-Codes der vier sequenziellen Pflichtprüfungen,
-7. Ausgabe und Exit-Code des zentralen Scope-Gates,
+6. Ausgaben und Exit-Codes **aller** für den Gate-Scope erforderlichen Pflichtprüfungen,
+7. Ausgabe und Exit-Code des einen ausgeführten Gates,
 8. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -1,11 +1,23 @@
 ---
 name: agora-test-worker
-description: Schreibt pytest-Tests für Pydantic-Contracts, FSM-Übergänge, Persona-Quoten, Evidence-Dedup. Read-write nur in backend/tests/. Use proactively für jeden Layer-0/1-Task.
-tools: Read, Edit, Write, Bash, Grep
+description: Schreibt pytest-Tests für Pydantic-Contracts, FSM-Übergänge, Persona-Quoten, Evidence-Dedup und E2E-Regressionen. Use proactively für jeden Layer-0/1-Task und für klar abgegrenzte Test-Slices.
+tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
+effort: medium
+maxTurns: 30
+background: true
+isolation: worktree
 ---
 
-Du schreibst pytest-Tests gegen den **Vertrag**, nicht gegen die Implementierung.
+Du schreibst Tests gegen den **Vertrag**, nicht gegen Implementierungsdetails.
+
+## Auftrag und Isolation
+
+- Bearbeite genau ein GitHub Issue und nur den Test-Scope aus dem Lead-Briefing.
+- Arbeite ausschließlich im automatisch bereitgestellten Worktree.
+- Ändere Produktivcode nur, wenn der Lead das im Scope ausdrücklich erlaubt hat.
+- Bei unprüfbaren Akzeptanzkriterien oder vermutlich gemeinsamem Root Cause mit einem anderen Issue: stoppen und berichten.
+- Erzeuge am Ende genau einen lokalen Commit. Nicht pushen oder mergen.
 
 ## Konventionen
 
@@ -24,20 +36,44 @@ import pytest
 from pydantic import ValidationError
 from app.contracts.persona_contract import PersonaQuotaPlan
 
+
 def test_plan_total_must_match_sum():
     with pytest.raises(ValidationError, match="inkonsistent"):
         PersonaQuotaPlan(targets={"a": 2, "b": 3}, total=10)
 ```
 
-## Acceptance pro Test-PR
+## Standard-Loop
 
-1. Tests müssen failen können (kein `assert True`).
-2. Mindestens 1 negative case pro Validator.
+1. Vollständiges Issue und relevante Verträge lesen.
+2. Gezielten Test schreiben und RED nachweisen.
+3. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
+4. Gezielten Test erneut ausführen.
+5. Passendes zentrales Gate ausführen.
+6. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+
+## Acceptance pro Test-Commit
+
+1. Tests müssen failen können; kein `assert True`.
+2. Mindestens ein negativer Case pro Validator.
 3. Pydantic-Fehlertexte teil-matchen (`match=...`), nicht vollständig pinnen.
 4. Test-Files unter 300 LOC, sonst splitten.
+5. Externe Provider- und LLM-Aufrufe bleiben vollständig gemockt.
 
 ## NEIN
 
 - Keine Tests gegen Implementierungs-Internals.
 - Keine externen LLM-Calls.
 - Keine `@pytest.mark.skip` ohne Begründungs-Kommentar.
+- Kein pauschales Erhöhen von Timeouts oder Retries.
+- Kein Push, Merge, Rebase, Force-Push oder `--no-verify`.
+
+## Output
+
+Liefere immer:
+
+1. Issue und Test-Scope,
+2. RED-Nachweis,
+3. Commit-SHA,
+4. geänderte Dateien,
+5. GREEN- und Gate-Ausgaben,
+6. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -47,9 +47,21 @@ def test_plan_total_must_match_sum():
 1. Vollständiges Issue und relevante Verträge lesen.
 2. Gezielten Test schreiben und RED nachweisen.
 3. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
-4. Gezielten Test erneut ausführen.
-5. Passendes zentrales Gate ausführen.
-6. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+4. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
+5. Vor jedem Commit diese vier Pflichtprüfungen exakt in dieser Reihenfolge und mit Exit 0 ausführen:
+
+   ```bash
+   cd backend
+   uv run pytest tests/contracts/ -x -q
+   uv run python -m app.contracts.dump_schemas --check
+   uv run ruff check app/ tests/
+   uv run mypy app
+   ```
+
+6. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `frontend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
+7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+
+Ein fehlender Befehl, ein nicht nachvollziehbarer Exit-Code oder ein Fehler in einer der Prüfungen blockiert den Commit. Kein `--no-verify` und kein kosmetisches Grünmachen.
 
 ## Acceptance pro Test-Commit
 
@@ -75,5 +87,7 @@ Liefere immer:
 2. RED-Nachweis,
 3. Commit-SHA,
 4. geänderte Dateien,
-5. GREEN- und Gate-Ausgaben,
-6. verbleibende Risiken oder `keine`.
+5. GREEN-Ausgabe des Issue-Tests,
+6. Ausgaben und Exit-Codes der vier sequenziellen Pflichtprüfungen,
+7. Ausgabe und Exit-Code des zentralen Scope-Gates,
+8. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -48,15 +48,38 @@ def test_plan_total_must_match_sum():
 2. Gezielten Test schreiben und RED nachweisen.
 3. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
 4. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
-5. Vor jedem Commit diese vier Pflichtprüfungen exakt in dieser Reihenfolge und mit Exit 0 ausführen:
+5. Vor jedem Commit die passenden Pflichtprüfungen abhängig vom im Briefing benannten Gate-Scope exakt in dieser Reihenfolge und mit Exit 0 ausführen:
 
-   ```bash
-   cd backend
-   uv run pytest tests/contracts/ -x -q
-   uv run python -m app.contracts.dump_schemas --check
-   uv run ruff check app/ tests/
-   uv run mypy app
-   ```
+   - **Backend-Scope** (Backend-Code, FSM, Backend-E2E-Tests):
+
+     ```bash
+     cd backend
+     uv run pytest tests/contracts/ -x -q
+     uv run python -m app.contracts.dump_schemas --check
+     uv run ruff check app/ tests/
+     uv run mypy app
+     ```
+
+   - **Frontend-Scope**:
+
+     ```bash
+     cd frontend
+     bun run check
+     bun run test
+     ```
+
+   - **Cross-Layer oder vollständig**:
+
+     ```bash
+     cd backend
+     uv run pytest tests/contracts/ -x -q
+     uv run python -m app.contracts.dump_schemas --check
+     uv run ruff check app/ tests/
+     uv run mypy app
+     cd ../frontend
+     bun run check
+     bun run test
+     ```
 
 6. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `frontend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
 7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -186,11 +186,13 @@ worktree_status="$(git status --short)"
 if [ -n "$worktree_status" ]; then
   printf '%s\n' "$worktree_status"
   echo "Worktree enthält uncommittete Änderungen." >&2
-  exit 1
+  issue_blocked=1
 fi
 ```
 
-Ein nicht-leerer Status blockiert diesen Ablauf sofort. Tests, Gate und Opus-Review laufen ausschließlich bei sauberem Worktree weiter — nur so ist garantiert, dass exakt der Inhalt von `<COMMIT_SHA>` geprüft und später gepusht wird. Der Blocker-Bericht nennt die ausgegebenen uncommitteten Pfade (uncommitted changes nach dem Worker-Commit). Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
+Ein nicht-leerer Status blockiert **dieses** Issue sofort: Tests, Gate und Opus-Review dürfen dafür nicht mehr laufen, und es wird weder gepusht noch ein PR geöffnet. Nur so ist garantiert, dass exakt der Inhalt von `<COMMIT_SHA>` geprüft und später gepusht wird. Der Blocker-Bericht nennt die ausgegebenen uncommitteten Pfade (uncommitted changes nach dem Worker-Commit).
+
+Da jedes Issue in seinem eigenen Worktree verifiziert wird, beendet der Blocker den Batch nicht. Das andere Issue läuft nur weiter, wenn die in Schritt 3 nachgewiesene Unabhängigkeit weiterhin gilt; andernfalls stoppt auch dieses. Verwende hier kein `exit`, das die gemeinsame Orchestrierungs-Shell beenden würde. Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
 
 Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständige Ausgabe auf:
 

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -1,0 +1,256 @@
+---
+description: Wählt maximal zwei unabhängige release-relevante GitHub Issues, dispatcht je einen isolierten Worker und lässt jeden Commit von Opus prüfen.
+allowed-tools: Read, Bash, Grep, Glob, TodoWrite, Agent, AskUserQuestion
+---
+
+# /agora-batch-issues — paralleler Issue-Orchestrator
+
+Du bist der Lead und Orchestrator. Du implementierst nicht selbst. Die aktive Taskquelle sind GitHub Issues; README, STATUS und ROADMAP liefern nur Produkt-, Ist- und Release-Kontext.
+
+## Ziel
+
+Bearbeite maximal zwei voneinander unabhängige Issues parallel. Jedes Issue erhält genau einen Implementer, einen isolierten Worktree, genau einen lokalen Commit, ein eigenes Opus-Review und einen eigenen Draft-PR.
+
+## Globale Regeln
+
+- Basis ist aktuelles `origin/main`.
+- Nie direkt auf `main` arbeiten.
+- Keine Agent Teams; verwende normale Subagenten.
+- Maximal zwei Implementer gleichzeitig.
+- Subagenten können keine weiteren Agenten starten. Die gesamte Orchestrierung bleibt beim Lead.
+- Worker pushen, mergen und erstellen keine PRs.
+- Nur der Lead darf nach `APPROVE` pushen und einen Draft-PR öffnen.
+- Kein `--no-verify`, Force-Push oder automatischer Endlos-Fix-Loop.
+- Keine neue Planungsdatei anlegen.
+
+## Schritt 1: Repository und Release-Kontext
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+git fetch origin --quiet
+
+echo "=== origin/main ==="
+git log origin/main --oneline -10
+
+echo "=== Produktversion ==="
+cat VERSION
+
+echo "=== Offene Issues ==="
+gh issue list --state open --limit 100 \
+  --json number,title,labels,milestone,assignees,updatedAt \
+  | jq -r '.[] | "#\(.number)\t\(.title)\tmilestone=\(.milestone.title // "-")"'
+```
+
+Lies in dieser Reihenfolge:
+
+1. `README.md`
+2. `docs/STATUS.md`
+3. `ROADMAP.md`
+4. vollständige Kandidaten-Issues einschließlich Kommentare
+5. passende ADRs, Contracts und Runbooks
+
+Historische Dokumente unter `docs/archive/` sind keine Taskquelle.
+
+## Schritt 2: Kandidaten priorisieren
+
+Priorität:
+
+1. P0/P1, Security oder Datenintegrität,
+2. rote Required- oder E2E-Gates,
+3. Contract-, Migrations- oder SSoT-Inkonsistenzen,
+4. Release-Gates der aktuellen Version,
+5. konkrete Wartungs- oder Dokumentationsschuld mit Release-Bezug.
+
+Nicht auswählen:
+
+- Issues außerhalb der aktuellen Release-Stufe,
+- Issues ohne prüfbare Akzeptanzkriterien,
+- neue Produktbereiche vor ihrem Roadmap-Zeitpunkt,
+- React-/Lovable-Rewrite ohne freigegebene Architekturentscheidung,
+- historische Tasks aus archivierten Dokumenten.
+
+## Schritt 3: Unabhängigkeit beweisen
+
+Für jeden Kandidaten vollständig ausführen:
+
+```bash
+gh issue view <NR> --comments
+```
+
+Ermittle voraussichtlich betroffene Dateien und Symbole mit `rg`, `git log` und vorhandenen Codegraph-Werkzeugen.
+
+Zwei Issues dürfen nur parallel laufen, wenn alle Aussagen zutreffen:
+
+- kein Parent-/Child- oder Blocked-by-Verhältnis,
+- keine gleichen oder eng gekoppelten Dateien,
+- keine gemeinsam geänderten Contracts oder Schemas,
+- keine Migration, auf der das zweite Issue aufbaut,
+- keine vermutlich gemeinsame Fehlerursache,
+- keine konkurrierenden Änderungen an Provider-Routing, Secrets oder Evidence-Hartankern,
+- jedes Issue ist unabhängig testbar und rückrollbar.
+
+Bei Unsicherheit nur ein Issue auswählen. Parallelität ist kein Selbstzweck; kaputte Merge-Konflikte sparen erstaunlicherweise keine Zeit.
+
+Gib vor dem Dispatch eine Matrix aus:
+
+```markdown
+| Issue | Release | Dateien/Symbole | Abhängigkeiten | Worker | Parallel sicher |
+|---|---|---|---|---|---|
+| #123 | 0.9.0 | `backend/...` | keine | `agora-refactor-worker` | ja |
+```
+
+## Schritt 4: Atomare Briefings
+
+Erstelle pro Issue ein vollständiges, selbständiges Briefing:
+
+```markdown
+## Issue #<NR> · <Titel>
+
+- Release-Ziel: <Version>
+- Basis: `origin/main`
+- Branch-Vorschlag: `fix/<issue>-<scope>`
+- Problem: <ein Satz>
+- Scope:
+  - <exakte Dateien, Symbole und Interfaces>
+- Out-of-Scope:
+  - <bewusst ausgeschlossene Nachbararbeit>
+- Verträge/Migration/Security:
+  - <betroffen oder keine>
+- Tests zuerst:
+  - <exakte Testpfade und erwartetes RED>
+- Akzeptanz:
+  - <Befehle und erwartete Ergebnisse>
+- Gate:
+  - <backend|frontend|schemas|vollständig>
+- Dokumentation:
+  - <STATUS, ROADMAP, CHANGELOG oder keine mit Begründung>
+- Stop-Bedingungen:
+  - Scope-Drift, rote Gates, unklare Spec, Dateiüberschneidung
+- Implementer: <Agentenname>
+```
+
+## Schritt 5: Worker wählen
+
+| Aufgabe | Worker | Modell |
+|---|---|---|
+| Backend-Refactor, Pydantic, Provider, Persistenz | `agora-refactor-worker` | Sonnet high |
+| Tests, FSM, E2E und Regressionen | `agora-test-worker` | Sonnet medium |
+| Vue, Pinia, Zod und Accessibility | `agora-frontend-worker` | Sonnet medium |
+| reine Dokumentation | `agora-doc-worker` | Haiku low |
+| Evidence-/Wording-Audit | `agora-evidence-auditor` | Sonnet read-only |
+
+Security, Auth, Secrets, Datenmigration, Cross-Layer-Architektur und ambige Specs müssen vor dem Dispatch vom Lead präzisiert werden. Opus implementiert nicht.
+
+## Schritt 6: Parallel dispatchen
+
+Starte die ausgewählten Worker in derselben Orchestrierungsrunde, damit sie parallel laufen. Übergib jedem Worker ausschließlich sein eigenes vollständiges Briefing.
+
+Jeder Worker muss:
+
+- im durch `isolation: worktree` bereitgestellten Worktree arbeiten,
+- genau ein Issue bearbeiten,
+- Tests zuerst schreiben oder anpassen,
+- das passende Gate ausführen,
+- nur Scope-Dateien stagen,
+- genau einen lokalen Commit erzeugen,
+- Commit-SHA, Diff-Statistik und vollständige Testergebnisse zurückgeben,
+- nicht pushen, mergen oder einen PR erstellen.
+
+## Schritt 7: Worker-Ergebnisse verifizieren
+
+Vertraue keiner Zusammenfassung. Prüfe für jeden Worker selbst:
+
+```bash
+git show --stat --oneline <COMMIT_SHA>
+git diff --check <BASE_SHA>...<COMMIT_SHA>
+git diff --name-only <BASE_SHA>...<COMMIT_SHA>
+git status --short
+```
+
+Prüfe:
+
+- nur erlaubte Dateien geändert,
+- genau ein Issue im Commit,
+- keine Secrets oder generierten Fremdartefakte,
+- gezielte Tests und passendes Gate mit Exit 0,
+- kein Konflikt mit dem anderen Issue-Commit.
+
+Bei einem Fehler stoppt nur das betroffene Issue. Das andere darf weiter geprüft werden, wenn es wirklich unabhängig ist.
+
+## Schritt 8: Opus-Review pro Commit
+
+Starte für jeden verifizierten Commit genau einen `agora-opus-reviewer`. Übergib:
+
+- vollständiges Issue und Akzeptanzkriterien,
+- Release-Ziel,
+- Basis-SHA und Commit-SHA,
+- vollständigen Diff,
+- gezielte Testausgaben,
+- Gate-Ausgabe,
+- betroffene ADRs, Contracts, Security-Grenzen und Evidence-Hartanker.
+
+Der Reviewer ist read-only und antwortet mit `APPROVE` oder `REQUEST_CHANGES`.
+
+Bei `REQUEST_CHANGES`:
+
+1. keinen Push und keinen PR erstellen,
+2. Blocker an denselben Implementer mit engem Korrekturbriefing zurückgeben,
+3. höchstens einen Korrekturlauf erlauben,
+4. Tests und Gate erneut frisch ausführen,
+5. Opus erneut reviewen lassen.
+
+Bleibt das Urteil negativ, stoppe das Issue mit einem konkreten Bericht.
+
+## Schritt 9: Push und Draft-PR
+
+Nur bei `APPROVE`:
+
+```bash
+git push -u origin <branch>
+```
+
+Öffne für jedes Issue einen separaten Draft-PR gegen `main`.
+
+PR-Body:
+
+```markdown
+## Summary
+- <Änderung>
+
+## Release-Ziel
+- <Version und Gate>
+
+## Issue
+- Closes #<NR>
+
+## Scope
+- <geänderte Komponenten>
+
+## Out-of-Scope
+- <bewusst ausgelagert>
+
+## Tests
+- `<Befehl>` — PASS
+
+## Review
+- `agora-opus-reviewer` — APPROVE
+```
+
+Keine beiden Issues in einen gemeinsamen PR quetschen. Git kann viel, aber es muss nicht jeden schlechten Gedanken konservieren.
+
+## Schritt 10: Abschlussausgabe
+
+```markdown
+## Batch-Ergebnis
+
+| Issue | Worker | Commit | Gate | Opus | Draft-PR |
+|---|---|---|---|---|---|
+| #123 | agora-refactor-worker | `<sha>` | PASS | APPROVE | <URL> |
+
+### Gestoppt
+- keine
+
+### Verbleibende Risiken
+- keine
+```

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -119,12 +119,14 @@ Erstelle pro Issue ein vollständiges, selbständiges Briefing:
   - <betroffen oder keine>
 - Tests zuerst:
   - <exakte Testpfade und erwartetes RED>
+- Issue-Test-Befehl:
+  - `<exakter, erneut ausführbarer Befehl>`
 - Akzeptanz:
   - <Befehle und erwartete Ergebnisse>
-- Gate:
-  - <backend|frontend|schemas|vollständig>
+- Gate-Scope:
+  - <backend | frontend | schemas | vollständig>
 - Dokumentation:
-  - <STATUS, ROADMAP, CHANGELOG oder keine mit Begründung>
+  - <STATUS, ROADMAP, CHANGELOG, Folge-Issue oder keine mit Begründung>
 - Stop-Bedingungen:
   - Scope-Drift, rote Gates, unklare Spec, Dateiüberschneidung
 - Implementer: <Agentenname>
@@ -151,32 +153,84 @@ Jeder Worker muss:
 - im durch `isolation: worktree` bereitgestellten Worktree arbeiten,
 - genau ein Issue bearbeiten,
 - Tests zuerst schreiben oder anpassen,
-- das passende Gate ausführen,
+- den Issue-Test aus dem Briefing mit GREEN abschließen,
+- vor dem lokalen Commit Contract-Tests, Schema-Check, Ruff und mypy exakt in dieser Reihenfolge mit Exit 0 ausführen:
+
+  ```bash
+  cd backend
+  uv run pytest tests/contracts/ -x -q
+  uv run python -m app.contracts.dump_schemas --check
+  uv run ruff check app/ tests/
+  uv run mypy app
+  ```
+
+- anschließend genau das im Briefing benannte Scope-Gate ausführen,
+- sachlich betroffene Dokumentationsartefakte im selben Slice aktualisieren,
 - nur Scope-Dateien stagen,
-- genau einen lokalen Commit erzeugen,
-- Commit-SHA, Diff-Statistik und vollständige Testergebnisse zurückgeben,
+- erst nach erfolgreichem Abschluss aller Prüfungen genau einen lokalen Commit erzeugen,
+- Commit-SHA, Diff-Statistik sowie vollständige Issue-Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben,
+- für `docs/STATUS.md`, `ROADMAP.md`, `CHANGELOG.md` und Folge-Issue jeweils `aktualisiert` oder `NICHT BETROFFEN` mit Begründung melden,
 - nicht pushen, mergen oder einen PR erstellen.
 
 ## Schritt 7: Worker-Ergebnisse verifizieren
 
-Vertraue keiner Zusammenfassung. Prüfe für jeden Worker selbst:
+Vertraue keiner Zusammenfassung. Prüfe für jedes Issue in dessen eigenem Worktree zunächst den Commit:
 
 ```bash
+cd <WORKTREE_PATH>
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
 git status --short
 ```
 
-Prüfe:
+Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständige Ausgabe auf:
+
+```bash
+cd <WORKTREE_PATH>
+<ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
+test_rc=${PIPESTATUS[0]}
+test "$test_rc" -eq 0
+```
+
+Führe anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad frisch aus und bewahre auch diese Ausgabe auf:
+
+```bash
+cd <WORKTREE_PATH>
+{
+  case "<GATE_SCOPE>" in
+    backend)
+      bash scripts/pre-push-gate.sh backend
+      ;;
+    frontend)
+      bash scripts/pre-push-gate.sh frontend
+      ;;
+    schemas)
+      bash scripts/pre-push-gate.sh schemas
+      ;;
+    vollständig)
+      bash scripts/pre-push-gate.sh
+      ;;
+    *)
+      echo "Unbekannter Gate-Scope: <GATE_SCOPE>" >&2
+      exit 2
+      ;;
+  esac
+} 2>&1 | tee <GATE_LOG>
+gate_rc=${PIPESTATUS[0]}
+test "$gate_rc" -eq 0
+```
+
+Prüfe außerdem:
 
 - nur erlaubte Dateien geändert,
 - genau ein Issue im Commit,
 - keine Secrets oder generierten Fremdartefakte,
-- gezielte Tests und passendes Gate mit Exit 0,
+- Issue-Test und ausgewähltes Gate jeweils Exit 0,
+- vollständige Test- und Gate-Ausgaben liegen für Schritt 8 vor,
 - kein Konflikt mit dem anderen Issue-Commit.
 
-Bei einem Fehler stoppt nur das betroffene Issue. Das andere darf weiter geprüft werden, wenn es wirklich unabhängig ist.
+Bei einem Fehler stoppt ausschließlich das betroffene Issue. Das andere darf nur weiter geprüft werden, wenn die in Schritt 3 nachgewiesene Unabhängigkeit weiterhin gilt. Ein Fehler darf weder das andere Issue automatisch stoppen noch durch dessen Erfolg verdeckt werden.
 
 ## Schritt 8: Opus-Review pro Commit
 
@@ -186,8 +240,8 @@ Starte für jeden verifizierten Commit genau einen `agora-opus-reviewer`. Überg
 - Release-Ziel,
 - Basis-SHA und Commit-SHA,
 - vollständigen Diff,
-- gezielte Testausgaben,
-- Gate-Ausgabe,
+- die in Schritt 7 frisch erzeugte Issue-Test-Ausgabe,
+- die in Schritt 7 frisch erzeugte Gate-Ausgabe,
 - betroffene ADRs, Contracts, Security-Grenzen und Evidence-Hartanker.
 
 Der Reviewer ist read-only und antwortet mit `APPROVE` oder `REQUEST_CHANGES`.
@@ -197,14 +251,27 @@ Bei `REQUEST_CHANGES`:
 1. keinen Push und keinen PR erstellen,
 2. Blocker an denselben Implementer mit engem Korrekturbriefing zurückgeben,
 3. höchstens einen Korrekturlauf erlauben,
-4. Tests und Gate erneut frisch ausführen,
+4. Tests und genau das passende Gate erneut frisch ausführen,
 5. Opus erneut reviewen lassen.
 
-Bleibt das Urteil negativ, stoppe das Issue mit einem konkreten Bericht.
+Bleibt das Urteil negativ, stoppe nur das betroffene Issue mit einem konkreten Bericht.
 
-## Schritt 9: Push und Draft-PR
+## Schritt 9: Dokumentationssynchronisation abschließen
 
-Nur bei `APPROVE`:
+Prüfe für jedes erfolgreiche Issue vor Push und PR, ob im selben Slice sachlich korrekt abgebildet sind:
+
+- `docs/STATUS.md` bei geändertem verifiziertem Istzustand,
+- `ROADMAP.md` bei geändertem Release-Gate oder strategischer Reihenfolge,
+- `CHANGELOG.md` bei ausgeliefertem Nutzer- oder Betriebsverhalten,
+- ein Folge-Issue für notwendige, aber nicht erledigte Folgearbeit.
+
+Dokumentiere für jedes Artefakt `aktualisiert` oder `NICHT BETROFFEN` mit Begründung. Ist ein erforderliches Datei-Artefakt im Commit nicht enthalten, darf nicht gepusht werden. Gib das betroffene Issue einmalig an denselben Worker zurück, lasse den bestehenden lokalen Commit amendieren und wiederhole für den neuen Commit-SHA Schritt 7 und Schritt 8 vollständig. Dadurch bleibt es bei genau einem Issue-Commit.
+
+Erzeuge notwendige Folge-Issues vor dem Draft-PR und verlinke sie im PR-Body. Der Dokumentationssync eines Issues darf keine Dateien oder Planungen des anderen Issues übernehmen.
+
+## Schritt 10: Push und Draft-PR
+
+Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 
 ```bash
 git push -u origin <branch>
@@ -231,7 +298,15 @@ PR-Body:
 - <bewusst ausgelagert>
 
 ## Tests
-- `<Befehl>` — PASS
+- `<Issue-Test-Befehl>` — PASS
+- Contract-Tests → Schema-Check → Ruff → mypy — PASS
+- `scripts/pre-push-gate.sh <Scope>` — PASS
+
+## Dokumentationssync
+- `docs/STATUS.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- `ROADMAP.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- `CHANGELOG.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- Folge-Issue: <URL | NICHT BETROFFEN + Begründung>
 
 ## Review
 - `agora-opus-reviewer` — APPROVE
@@ -239,16 +314,19 @@ PR-Body:
 
 Keine beiden Issues in einen gemeinsamen PR quetschen. Git kann viel, aber es muss nicht jeden schlechten Gedanken konservieren.
 
-## Schritt 10: Abschlussausgabe
+## Schritt 11: Abschlussausgabe
 
 ```markdown
 ## Batch-Ergebnis
 
-| Issue | Worker | Commit | Gate | Opus | Draft-PR |
-|---|---|---|---|---|---|
-| #123 | agora-refactor-worker | `<sha>` | PASS | APPROVE | <URL> |
+| Issue | Worker | Commit | Issue-Test | Gate | Opus | Doku-Sync | Draft-PR |
+|---|---|---|---|---|---|---|---|
+| #123 | agora-refactor-worker | `<sha>` | PASS | PASS | APPROVE | vollständig | <URL> |
 
 ### Gestoppt
+- keine
+
+### Nicht erledigte Folgearbeit
 - keine
 
 ### Verbleibende Risiken

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -182,10 +182,15 @@ git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
 worktree_status="$(git status --short)"
-test -z "$worktree_status"
+
+if [ -n "$worktree_status" ]; then
+  printf '%s\n' "$worktree_status"
+  echo "Worktree enthält uncommittete Änderungen." >&2
+  exit 1
+fi
 ```
 
-Ein nicht-leerer Status stoppt die Verifikation dieses Issues mit einem Blocker-Bericht (uncommitted changes nach dem Worker-Commit). Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
+Ein nicht-leerer Status blockiert diesen Ablauf sofort. Tests, Gate und Opus-Review laufen ausschließlich bei sauberem Worktree weiter — nur so ist garantiert, dass exakt der Inhalt von `<COMMIT_SHA>` geprüft und später gepusht wird. Der Blocker-Bericht nennt die ausgegebenen uncommitteten Pfade (uncommitted changes nach dem Worker-Commit). Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
 
 Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständige Ausgabe auf:
 

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -181,8 +181,11 @@ cd <WORKTREE_PATH>
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
-git status --short
+worktree_status="$(git status --short)"
+test -z "$worktree_status"
 ```
+
+Ein nicht-leerer Status stoppt die Verifikation dieses Issues mit einem Blocker-Bericht (uncommitted changes nach dem Worker-Commit). Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
 
 Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständige Ausgabe auf:
 

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -204,10 +204,16 @@ Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständi
 cd <WORKTREE_PATH>
 if [ "$issue_blocked" -eq 0 ]; then
   <ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
-  test_rc=${PIPESTATUS[0]}
-  [ "$test_rc" -eq 0 ] || issue_blocked=1
+  pipeline_rcs=("${PIPESTATUS[@]}")
+  test_rc=${pipeline_rcs[0]}
+  log_rc=${pipeline_rcs[1]}
+  if [ "$test_rc" -ne 0 ] || [ "$log_rc" -ne 0 ]; then
+    issue_blocked=1
+  fi
 fi
 ```
+
+`tee` wird mitgeprüft: Schlägt das Schreiben des Protokolls fehl, fehlt die für Schritt 8 vorgeschriebene vollständige Ausgabe — das Issue gilt dann als gestoppt, auch wenn der Test selbst grün war.
 
 Führe anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad frisch aus und bewahre auch diese Ausgabe auf:
 
@@ -234,8 +240,12 @@ if [ "$issue_blocked" -eq 0 ]; then
       ;;
   esac
 } 2>&1 | tee <GATE_LOG>
-  gate_rc=${PIPESTATUS[0]}
-  [ "$gate_rc" -eq 0 ] || issue_blocked=1
+  gate_rcs=("${PIPESTATUS[@]}")
+  gate_rc=${gate_rcs[0]}
+  gate_log_rc=${gate_rcs[1]}
+  if [ "$gate_rc" -ne 0 ] || [ "$gate_log_rc" -ne 0 ]; then
+    issue_blocked=1
+  fi
 fi
 ```
 

--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -178,6 +178,8 @@ Vertraue keiner Zusammenfassung. Prüfe für jedes Issue in dessen eigenem Workt
 
 ```bash
 cd <WORKTREE_PATH>
+issue_blocked=0
+
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
@@ -194,19 +196,24 @@ Ein nicht-leerer Status blockiert **dieses** Issue sofort: Tests, Gate und Opus-
 
 Da jedes Issue in seinem eigenen Worktree verifiziert wird, beendet der Blocker den Batch nicht. Das andere Issue läuft nur weiter, wenn die in Schritt 3 nachgewiesene Unabhängigkeit weiterhin gilt; andernfalls stoppt auch dieses. Verwende hier kein `exit`, das die gemeinsame Orchestrierungs-Shell beenden würde. Das andere Issue muss danach erneut gemäß Schritt 3 auf Unabhängigkeit geprüft werden, bevor es weiterlaufen darf.
 
+Alle weiteren Verifikationsschritte dieses Issues laufen **nur** bei `issue_blocked -eq 0`. Ist das Flag gesetzt, werden Test, Gate und Opus-Review dieses Issues übersprungen und es geht als gestoppt in die Abschlussausgabe.
+
 Führe danach den issue-spezifischen Test frisch aus und bewahre die vollständige Ausgabe auf:
 
 ```bash
 cd <WORKTREE_PATH>
-<ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
-test_rc=${PIPESTATUS[0]}
-test "$test_rc" -eq 0
+if [ "$issue_blocked" -eq 0 ]; then
+  <ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
+  test_rc=${PIPESTATUS[0]}
+  [ "$test_rc" -eq 0 ] || issue_blocked=1
+fi
 ```
 
 Führe anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad frisch aus und bewahre auch diese Ausgabe auf:
 
 ```bash
 cd <WORKTREE_PATH>
+if [ "$issue_blocked" -eq 0 ]; then
 {
   case "<GATE_SCOPE>" in
     backend)
@@ -227,9 +234,12 @@ cd <WORKTREE_PATH>
       ;;
   esac
 } 2>&1 | tee <GATE_LOG>
-gate_rc=${PIPESTATUS[0]}
-test "$gate_rc" -eq 0
+  gate_rc=${PIPESTATUS[0]}
+  [ "$gate_rc" -eq 0 ] || issue_blocked=1
+fi
 ```
+
+`issue_blocked=1` bedeutet: dieses Issue ist gestoppt. Es geht nicht in Schritt 8 (Opus-Review), wird nicht gepusht und bekommt keinen PR. Der Batch selbst läuft weiter; das andere Issue wird nur fortgesetzt, wenn seine in Schritt 3 nachgewiesene Unabhängigkeit weiterhin gilt.
 
 Prüfe außerdem:
 

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -1,26 +1,28 @@
 ---
-description: Master-Orchestrator — wählt das nächste release-relevante GitHub Issue, plant einen atomaren Slice, dispatcht einen passenden Subagenten und verifiziert die Umsetzung.
-allowed-tools: Read, Bash, Grep, Glob, Edit, Write, TodoWrite, Agent, AskUserQuestion
+description: Master-Orchestrator — wählt das nächste release-relevante GitHub Issue, dispatcht einen isolierten Worker, verifiziert den Commit und lässt Opus vor dem Draft-PR reviewen.
+allowed-tools: Read, Bash, Grep, Glob, TodoWrite, Agent, AskUserQuestion
 ---
 
 # /agora-next-task — Issue-Orchestrator
 
 Du bist der Orchestrator, nicht der Implementer. Die aktive Aufgabenquelle sind GitHub Issues. `README.md`, `docs/STATUS.md` und `ROADMAP.md` liefern Produkt-, Ist- und Release-Kontext.
 
-## Quellenreihenfolge
+## Globale Regeln
 
-1. `README.md`
-2. `docs/STATUS.md`
-3. `ROADMAP.md`
-4. offene GitHub Issues
-5. passende ADRs, Verträge und Runbooks
+- Bearbeite genau ein Issue pro Lauf.
+- Basis ist aktuelles `origin/main`.
+- Nie direkt auf `main` arbeiten.
+- Der Implementer arbeitet mit `isolation: worktree` und erzeugt genau einen lokalen Commit.
+- Der Implementer pusht, mergt und erstellt keinen PR.
+- Nur der Lead darf nach einem `APPROVE` des `agora-opus-reviewer` pushen und einen Draft-PR öffnen.
+- Kein `--no-verify`, Force-Push oder automatischer Endlos-Fix-Loop.
+- Keine neue Planungsdatei anlegen.
 
-Historische Dokumente unter `docs/archive/` sind keine Taskquelle.
-
-## Schritt 1: Repository und Release-Kontext prüfen
+## Schritt 1: Repository und Release-Kontext
 
 ```bash
-cd /Volumes/T7/Projekte/agora
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin --quiet
 
 echo "=== origin/main ==="
@@ -32,46 +34,44 @@ cat VERSION
 echo "=== Offene Issues ==="
 gh issue list --state open --limit 100 \
   --json number,title,labels,milestone,assignees,updatedAt \
-  | jq -r '.[] | "#\(.number)\t\(.title)\tmilestone=\(.milestone.title // \"-\")"'
+  | jq -r '.[] | "#\(.number)\t\(.title)\tmilestone=\(.milestone.title // "-")"'
 ```
 
-Lies anschließend:
+Lies anschließend in dieser Reihenfolge:
 
-```text
-README.md
-ROADMAP.md
-STATUS.md
-```
+1. `README.md`
+2. `docs/STATUS.md`
+3. `ROADMAP.md`
+4. offene GitHub Issues
+5. passende ADRs, Contracts und Runbooks
 
-Bestimme die aktuelle Release-Stufe und wähle nur Issues, die zu ihren Freigabekriterien gehören.
+Historische Dokumente unter `docs/archive/` sind keine Taskquelle.
 
 ## Schritt 2: Issue auswählen
 
 Priorität:
 
-1. P0/P1-Fehler, Security- oder Datenintegritätsblocker
-2. rote Required- oder E2E-Gates
-3. Inkonsistenzen in Verträgen, Migrationen und Single Sources of Truth
-4. Release-Gates der aktuellen Version
-5. Dokumentations- oder Wartungsschuld mit konkretem Release-Bezug
+1. P0/P1-Fehler, Security oder Datenintegrität,
+2. rote Required- oder E2E-Gates,
+3. Inkonsistenzen in Contracts, Migrationen und Single Sources of Truth,
+4. Release-Gates der aktuellen Version,
+5. Dokumentations- oder Wartungsschuld mit konkretem Release-Bezug.
 
 Nicht auswählen:
 
-- Issues außerhalb der aktuellen Release-Stufe
-- Multi-User, SaaS, Helm, Federation oder Plugin-System vor `1.0.0`
-- React-/Lovable-Rewrite ohne eigene freigegebene Architekturentscheidung
-- Issues ohne prüfbare Akzeptanzkriterien
-- historische Tasks aus archivierten Planungsdateien
+- Issues außerhalb der aktuellen Release-Stufe,
+- Multi-User, SaaS, Helm, Federation oder Plugin-System vor `1.0.0`,
+- React-/Lovable-Rewrite ohne freigegebene Architekturentscheidung,
+- Issues ohne prüfbare Akzeptanzkriterien,
+- historische Tasks aus archivierten Planungsdateien.
 
 Bei mehreren gleichwertigen Issues gewinnt:
 
-1. niedrigerer Architektur-Layer
-2. kleinerer atomarer Scope
-3. älteres offenes Release-Blocker-Issue
+1. niedrigerer Architektur-Layer,
+2. kleinerer atomarer Scope,
+3. älteres offenes Release-Blocker-Issue.
 
-## Schritt 3: Issue prüfen
-
-Lies das vollständige Issue:
+## Schritt 3: Issue vollständig prüfen
 
 ```bash
 gh issue view <NR> --comments
@@ -79,136 +79,169 @@ gh issue view <NR> --comments
 
 Prüfe:
 
-- Problem und gewünschtes Ergebnis sind eindeutig.
-- Scope und Out-of-Scope sind vorhanden.
-- Akzeptanzkriterien sind ausführbar.
-- betroffene Verträge, Migrationen und Security-Grenzen sind benannt.
+- Problem und gewünschtes Ergebnis sind eindeutig,
+- Scope und Out-of-Scope sind vorhanden,
+- Akzeptanzkriterien sind ausführbar,
+- betroffene Contracts, Migrationen und Security-Grenzen sind benannt,
 - Abhängigkeiten oder Parent-Issue sind nachvollziehbar.
 
 Fehlen wesentliche Angaben, ergänze zuerst das Issue oder stoppe mit einem konkreten Drift-Bericht. Nicht raten.
 
-## Schritt 4: Atomaren Slice planen
-
-Erstelle inline:
+## Schritt 4: Atomaren Slice definieren
 
 ```markdown
 ## Issue #<NR> · <Titel>
 
 - Release-Ziel: <0.9.0 | 0.10.0 | 1.0.0>
-- Branch: <typ>/<kurzer-scope>
+- Basis: `origin/main`
+- Branch-Vorschlag: <typ>/<issue>-<scope>
 - Problem: <ein Satz>
 - Scope:
-  - <konkrete Datei oder Komponente>
+  - <exakte Dateien, Symbole und Interfaces>
 - Out-of-Scope:
   - <bewusst ausgeschlossene Nachbararbeit>
-- Verträge/Migrationen:
+- Contracts/Migration/Security:
   - <betroffen oder keine>
 - Tests zuerst:
   - <exakte Testpfade und erwartetes RED>
 - Akzeptanz:
   - <exakte Befehle und erwartete Ergebnisse>
+- Gate:
+  - <backend | frontend | schemas | vollständig>
 - Dokumentation:
-  - STATUS, ROADMAP, CHANGELOG oder keine Änderung mit Begründung
+  - <STATUS, ROADMAP, CHANGELOG oder keine mit Begründung>
+- Stop-Bedingungen:
+  - Scope-Drift, unklare Spec, rote Tests oder Gate-Fehler
 - Implementer: <passender Subagent>
 ```
 
-Ein Slice darf nur so groß sein, dass er in einem Pull Request unabhängig geprüft und zurückgerollt werden kann.
+Der Slice muss unabhängig prüfbar und rückrollbar sein.
 
-## Schritt 5: Subagent auswählen
+## Schritt 5: Implementer auswählen
 
-| Aufgabe | Subagent |
-|---|---|
-| Backend-Refactor, Pydantic, Provider, Persistenz | `agora-refactor-worker` |
-| Tests, E2E, FSM, Quoten | `agora-test-worker` |
-| Vue, Pinia, Zod, Accessibility | `agora-frontend-worker` |
-| Evidence- und Wording-Audit | `agora-evidence-auditor` |
-| Dokumentation und Changelog | `agora-doc-worker` |
+| Aufgabe | Implementer | Modell |
+|---|---|---|
+| Backend-Refactor, Pydantic, Provider, Persistenz | `agora-refactor-worker` | Sonnet high |
+| Tests, E2E, FSM, Quoten | `agora-test-worker` | Sonnet medium |
+| Vue, Pinia, Zod, Accessibility | `agora-frontend-worker` | Sonnet medium |
+| reine Dokumentation und Changelog | `agora-doc-worker` | Haiku low |
+| Evidence- und Wording-Audit | `agora-evidence-auditor` | Sonnet read-only |
 
-Architektur, Cross-Layer-Entscheidungen, Security, Datenmigrationen und ambige Specs bleiben beim Lead-Modell.
+Architektur, Cross-Layer-Entscheidungen, Security, Auth, Secrets, Datenmigrationen und ambige Specs müssen vor dem Dispatch vom Lead präzisiert werden. Opus implementiert nicht.
 
-## Schritt 6: Isolierten Worktree anlegen
+## Schritt 6: Implementer dispatchen
 
-Nutze den `using-git-worktrees`-Skill. Ausgangspunkt ist immer aktuelles `origin/main`.
+Übergib dem Implementer das vollständige Briefing aus Schritt 4.
+
+Der Implementer muss:
+
+- im automatisch isolierten Worktree arbeiten,
+- nur den definierten Slice implementieren,
+- Tests zuerst schreiben oder anpassen,
+- das passende Gate ausführen,
+- nur Scope-Dateien explizit stagen,
+- genau einen lokalen Commit erzeugen,
+- Commit-SHA, Diff-Statistik und vollständige Testergebnisse zurückgeben,
+- nicht pushen, mergen oder einen PR erstellen.
+
+## Schritt 7: Ergebnis selbst verifizieren
+
+Vertraue der Worker-Zusammenfassung nicht. Prüfe frisch:
 
 ```bash
-cd /Volumes/T7/Projekte/agora
-git fetch origin --quiet
-WT=/Volumes/T7/Projekte/agora-worktrees/<branch>
-git worktree add -b <branch> "$WT" origin/main
+git show --stat --oneline <COMMIT_SHA>
+git diff --check <BASE_SHA>...<COMMIT_SHA>
+git diff --name-only <BASE_SHA>...<COMMIT_SHA>
 ```
 
-## Schritt 7: Subagent dispatchen
-
-Der Prompt enthält vollständig:
-
-- absoluten Worktree-Pfad
-- Issue-Nummer und Release-Ziel
-- Problem, Scope und Out-of-Scope
-- exakte Dateien und Interfaces
-- zuerst zu schreibende Tests
-- Akzeptanzbefehle
-- Dokumentationspflicht
-- Verbot von Commit, Push, `--no-verify`, Force-Push und Scope-Ausweitung
-
-Der Subagent implementiert nur. Der Lead verifiziert, committet und pusht.
-
-## Schritt 8: Verifizieren
-
-Mindestens das passende zentrale Gate ausführen:
+Führe zusätzlich die Issue-Tests und das passende Gate frisch aus:
 
 ```bash
 bash scripts/pre-push-gate.sh backend
 bash scripts/pre-push-gate.sh frontend
 bash scripts/pre-push-gate.sh schemas
-```
-
-Bei Cross-Layer-Änderungen das vollständige Gate:
-
-```bash
 bash scripts/pre-push-gate.sh
 ```
 
-Zusätzlich die im Issue genannten gezielten Tests ausführen. Bei Fehlern stoppen. Kein automatischer Endlos-Fix-Loop.
+Nutze nur das passende Scope-Gate; bei Cross-Layer-Änderungen das vollständige Gate. Bei Fehlern stoppen. Kein kosmetisches Grünmachen.
 
-## Schritt 9: Commit und Pull Request
+## Schritt 8: Opus-Review
+
+Starte genau einen `agora-opus-reviewer` und übergib:
+
+- vollständiges Issue und Akzeptanzkriterien,
+- Release-Ziel,
+- Basis-SHA und Commit-SHA,
+- vollständigen Diff,
+- frische gezielte Testausgaben,
+- frische Gate-Ausgabe,
+- betroffene ADRs, Contracts, Security-Grenzen und Evidence-Hartanker.
+
+Der Reviewer ist read-only und antwortet mit `APPROVE` oder `REQUEST_CHANGES`.
+
+Bei `REQUEST_CHANGES`:
+
+1. keinen Push und keinen PR erstellen,
+2. Blocker an denselben Implementer mit engem Korrekturbriefing zurückgeben,
+3. höchstens einen Korrekturlauf erlauben,
+4. Tests und Gate erneut frisch ausführen,
+5. Opus erneut reviewen lassen.
+
+Bleibt das Urteil negativ, stoppe mit einem konkreten Bericht.
+
+## Schritt 9: Push und Draft-PR
+
+Nur bei `APPROVE`:
 
 ```bash
-git add <konkrete-dateien>
-git commit -m "<typ>(<scope>): <beschreibung> (Refs #<NR>)"
 git push -u origin <branch>
+```
 
-gh pr create \
-  --base main \
-  --head <branch> \
-  --title "<typ>(<scope>): <beschreibung>" \
-  --body "$(cat <<'EOF'
+Öffne einen Draft-PR gegen `main` mit:
+
+```markdown
 ## Summary
 - <Änderung>
 
 ## Release-Ziel
 - <Version und Gate>
 
-## Tests
-- <Befehl und Ergebnis>
+## Issue
+- Closes #<NR>
 
 ## Scope
-- Closes #<NR>
+- <geänderte Komponenten>
 
 ## Out-of-Scope
 - <bewusst ausgelagert>
-EOF
-)"
-```
 
-Direkte Fast-Forward-Pushes auf `main` sind verboten. Der Pull Request wird erst nach grünen Gates und Review gemergt.
+## Tests
+- `<Befehl>` — PASS
+
+## Review
+- `agora-opus-reviewer` — APPROVE
+```
 
 ## Schritt 10: Quellen synchronisieren
 
 Nach erfolgreicher Umsetzung:
 
-- `docs/STATUS.md`, wenn sich der Istzustand geändert hat
-- `ROADMAP.md`, nur wenn sich ein Release-Gate oder die strategische Reihenfolge ändert
-- `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wird
-- GitHub Issue schließen oder Folge-Issue anlegen
+- `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+- `ROADMAP.md` nur bei Änderung eines Release-Gates oder der strategischen Reihenfolge,
+- `CHANGELOG.md` bei ausgeliefertem Nutzer- oder Betriebsverhalten,
+- Issue durch den PR mit `Closes #<NR>` verknüpfen.
 
-Keine neue Planungsdatei anlegen. Ein abgeschlossenes Issue und die Git-Historie sind das Arbeitsprotokoll.
+## Abschlussausgabe
+
+```markdown
+## Issue-Ergebnis
+
+- Issue: #<NR>
+- Worker: <Agent>
+- Commit: `<SHA>`
+- Tests: PASS
+- Gate: PASS
+- Opus: APPROVE
+- Draft-PR: <URL>
+- Verbleibende Risiken: keine
+```

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -180,9 +180,12 @@ Führe danach den im Briefing festgelegten Issue-Test frisch aus, speichere die 
 
 ```bash
 <ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
-test_rc=${PIPESTATUS[0]}
-test "$test_rc" -eq 0
+pipeline_rcs=("${PIPESTATUS[@]}")
+test "${pipeline_rcs[0]}" -eq 0
+test "${pipeline_rcs[1]}" -eq 0
 ```
+
+Beide Statuswerte zählen: `tee` wird mitgeprüft, damit ein Schreibfehler am Protokoll nicht als grüner Test durchgeht.
 
 Ein fehlgeschlagener Issue-Test stoppt den Ablauf sofort. `PASS` darf nur bei Exit-Code 0 gemeldet werden, und `<ISSUE_TEST_LOG>` wird in Schritt 8 an den Opus-Reviewer übergeben.
 
@@ -209,8 +212,9 @@ Wähle anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad und spe
       ;;
   esac
 } 2>&1 | tee <GATE_LOG>
-gate_rc=${PIPESTATUS[0]}
-test "$gate_rc" -eq 0
+gate_rcs=("${PIPESTATUS[@]}")
+test "${gate_rcs[0]}" -eq 0
+test "${gate_rcs[1]}" -eq 0
 ```
 
 Der Issue-Test und das ausgewählte Gate müssen jeweils Exit 0 liefern. Beide vollständigen Ausgaben (`<ISSUE_TEST_LOG>` und `<GATE_LOG>`) werden für Schritt 8 aufbewahrt und dort übergeben. Bei einem Fehler stoppen. Kein kosmetisches Grünmachen und keine unbedingte Ausführung aller Scope-Gates.

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -104,12 +104,14 @@ Fehlen wesentliche Angaben, ergänze zuerst das Issue oder stoppe mit einem konk
   - <betroffen oder keine>
 - Tests zuerst:
   - <exakte Testpfade und erwartetes RED>
+- Issue-Test-Befehl:
+  - `<exakter, erneut ausführbarer Befehl>`
 - Akzeptanz:
   - <exakte Befehle und erwartete Ergebnisse>
-- Gate:
+- Gate-Scope:
   - <backend | frontend | schemas | vollständig>
 - Dokumentation:
-  - <STATUS, ROADMAP, CHANGELOG oder keine mit Begründung>
+  - <STATUS, ROADMAP, CHANGELOG, Folge-Issue oder keine mit Begründung>
 - Stop-Bedingungen:
   - Scope-Drift, unklare Spec, rote Tests oder Gate-Fehler
 - Implementer: <passender Subagent>
@@ -138,10 +140,21 @@ Der Implementer muss:
 - im automatisch isolierten Worktree arbeiten,
 - nur den definierten Slice implementieren,
 - Tests zuerst schreiben oder anpassen,
-- das passende Gate ausführen,
+- den Issue-Test aus dem Briefing mit GREEN abschließen,
+- vor dem lokalen Commit Contract-Tests, Schema-Check, Ruff und mypy exakt in dieser Reihenfolge mit Exit 0 ausführen:
+
+  ```bash
+  cd backend
+  uv run pytest tests/contracts/ -x -q
+  uv run python -m app.contracts.dump_schemas --check
+  uv run ruff check app/ tests/
+  uv run mypy app
+  ```
+
+- anschließend genau das im Briefing benannte Scope-Gate ausführen,
 - nur Scope-Dateien explizit stagen,
-- genau einen lokalen Commit erzeugen,
-- Commit-SHA, Diff-Statistik und vollständige Testergebnisse zurückgeben,
+- erst nach erfolgreichem Abschluss aller Prüfungen genau einen lokalen Commit erzeugen,
+- Commit-SHA, Diff-Statistik sowie vollständige Issue-Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben,
 - nicht pushen, mergen oder einen PR erstellen.
 
 ## Schritt 7: Ergebnis selbst verifizieren
@@ -152,18 +165,39 @@ Vertraue der Worker-Zusammenfassung nicht. Prüfe frisch:
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
+git status --short
 ```
 
-Führe zusätzlich die Issue-Tests und das passende Gate frisch aus:
+Führe danach den im Briefing festgelegten Issue-Test frisch aus:
 
 ```bash
-bash scripts/pre-push-gate.sh backend
-bash scripts/pre-push-gate.sh frontend
-bash scripts/pre-push-gate.sh schemas
-bash scripts/pre-push-gate.sh
+<ISSUE_TEST_COMMAND>
 ```
 
-Nutze nur das passende Scope-Gate; bei Cross-Layer-Änderungen das vollständige Gate. Bei Fehlern stoppen. Kein kosmetisches Grünmachen.
+Wähle anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad:
+
+```bash
+case "<GATE_SCOPE>" in
+  backend)
+    bash scripts/pre-push-gate.sh backend
+    ;;
+  frontend)
+    bash scripts/pre-push-gate.sh frontend
+    ;;
+  schemas)
+    bash scripts/pre-push-gate.sh schemas
+    ;;
+  vollständig)
+    bash scripts/pre-push-gate.sh
+    ;;
+  *)
+    echo "Unbekannter Gate-Scope: <GATE_SCOPE>" >&2
+    exit 2
+    ;;
+esac
+```
+
+Der Issue-Test und das ausgewählte Gate müssen jeweils Exit 0 liefern. Bewahre beide vollständigen Ausgaben für Schritt 8 auf. Bei einem Fehler stoppen. Kein kosmetisches Grünmachen und keine unbedingte Ausführung aller Scope-Gates.
 
 ## Schritt 8: Opus-Review
 
@@ -184,7 +218,7 @@ Bei `REQUEST_CHANGES`:
 1. keinen Push und keinen PR erstellen,
 2. Blocker an denselben Implementer mit engem Korrekturbriefing zurückgeben,
 3. höchstens einen Korrekturlauf erlauben,
-4. Tests und Gate erneut frisch ausführen,
+4. Tests und genau das passende Gate erneut frisch ausführen,
 5. Opus erneut reviewen lassen.
 
 Bleibt das Urteil negativ, stoppe mit einem konkreten Bericht.
@@ -216,7 +250,9 @@ git push -u origin <branch>
 - <bewusst ausgelagert>
 
 ## Tests
-- `<Befehl>` — PASS
+- `<Issue-Test-Befehl>` — PASS
+- Contract-Tests → Schema-Check → Ruff → mypy — PASS
+- `scripts/pre-push-gate.sh <Scope>` — PASS
 
 ## Review
 - `agora-opus-reviewer` — APPROVE
@@ -229,7 +265,10 @@ Nach erfolgreicher Umsetzung:
 - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
 - `ROADMAP.md` nur bei Änderung eines Release-Gates oder der strategischen Reihenfolge,
 - `CHANGELOG.md` bei ausgeliefertem Nutzer- oder Betriebsverhalten,
+- ein Folge-Issue für notwendige, aber im Slice nicht erledigte Arbeit,
 - Issue durch den PR mit `Closes #<NR>` verknüpfen.
+
+Dokumentiere für `docs/STATUS.md`, `ROADMAP.md`, `CHANGELOG.md` und Folge-Issue jeweils: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
 
 ## Abschlussausgabe
 
@@ -239,9 +278,11 @@ Nach erfolgreicher Umsetzung:
 - Issue: #<NR>
 - Worker: <Agent>
 - Commit: `<SHA>`
-- Tests: PASS
+- Issue-Test: PASS
+- Pflichtprüfungen: PASS
 - Gate: PASS
 - Opus: APPROVE
 - Draft-PR: <URL>
+- Dokumentationssync: <Nachweis>
 - Verbleibende Risiken: keine
 ```

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -166,10 +166,17 @@ git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
 worktree_status="$(git status --short)"
-test -z "$worktree_status"
+
+if [ -n "$worktree_status" ]; then
+  printf '%s\n' "$worktree_status"
+  echo "Worktree enthält uncommittete Änderungen." >&2
+  exit 1
+fi
 ```
 
-Führe danach den im Briefing festgelegten Issue-Test frisch aus und bewahre die vollständige Ausgabe auf:
+Ein nicht-leerer Status blockiert den Ablauf sofort. Tests, Gate und Opus-Review laufen ausschließlich bei sauberem Worktree weiter — nur so ist garantiert, dass exakt der Inhalt von `<COMMIT_SHA>` geprüft und später gepusht wird.
+
+Führe danach den im Briefing festgelegten Issue-Test frisch aus, speichere die vollständige Ausgabe und prüfe den echten Exit-Code über `PIPESTATUS`:
 
 ```bash
 <ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
@@ -177,30 +184,36 @@ test_rc=${PIPESTATUS[0]}
 test "$test_rc" -eq 0
 ```
 
-Wähle anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad:
+Ein fehlgeschlagener Issue-Test stoppt den Ablauf sofort. `PASS` darf nur bei Exit-Code 0 gemeldet werden, und `<ISSUE_TEST_LOG>` wird in Schritt 8 an den Opus-Reviewer übergeben.
+
+Wähle anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad und speichere dessen Ausgabe nach demselben Muster:
 
 ```bash
-case "<GATE_SCOPE>" in
-  backend)
-    bash scripts/pre-push-gate.sh backend
-    ;;
-  frontend)
-    bash scripts/pre-push-gate.sh frontend
-    ;;
-  schemas)
-    bash scripts/pre-push-gate.sh schemas
-    ;;
-  vollständig)
-    bash scripts/pre-push-gate.sh
-    ;;
-  *)
-    echo "Unbekannter Gate-Scope: <GATE_SCOPE>" >&2
-    exit 2
-    ;;
-esac
+{
+  case "<GATE_SCOPE>" in
+    backend)
+      bash scripts/pre-push-gate.sh backend
+      ;;
+    frontend)
+      bash scripts/pre-push-gate.sh frontend
+      ;;
+    schemas)
+      bash scripts/pre-push-gate.sh schemas
+      ;;
+    vollständig)
+      bash scripts/pre-push-gate.sh
+      ;;
+    *)
+      echo "Unbekannter Gate-Scope: <GATE_SCOPE>" >&2
+      exit 2
+      ;;
+  esac
+} 2>&1 | tee <GATE_LOG>
+gate_rc=${PIPESTATUS[0]}
+test "$gate_rc" -eq 0
 ```
 
-Der Issue-Test und das ausgewählte Gate müssen jeweils Exit 0 liefern. Bewahre beide vollständigen Ausgaben für Schritt 8 auf. Bei einem Fehler stoppen. Kein kosmetisches Grünmachen und keine unbedingte Ausführung aller Scope-Gates.
+Der Issue-Test und das ausgewählte Gate müssen jeweils Exit 0 liefern. Beide vollständigen Ausgaben (`<ISSUE_TEST_LOG>` und `<GATE_LOG>`) werden für Schritt 8 aufbewahrt und dort übergeben. Bei einem Fehler stoppen. Kein kosmetisches Grünmachen und keine unbedingte Ausführung aller Scope-Gates.
 
 ## Schritt 8: Opus-Review
 
@@ -228,7 +241,18 @@ Bleibt das Urteil negativ, stoppe mit einem konkreten Bericht.
 
 ## Schritt 9: Dokumentationssynchronisation abschließen
 
-Prüfe vor Push und PR, ob im selben Slice sachlich korrekt abgebildet sind:
+Der Dokumentationssync findet zwingend **vor** Push und Draft-PR statt. Verbindliche Reihenfolge des gesamten Ablaufs:
+
+1. Worker-Commit prüfen (Schritt 7),
+2. frische Issue-Tests ausführen (Schritt 7),
+3. passendes Gate ausführen (Schritt 7),
+4. Opus-Review (Schritt 8),
+5. Dokumentationssync prüfen (dieser Schritt),
+6. bei fehlender Dokumentation: Korrekturlauf mit Amend und vollständiger Wiederholung von Schritt 7 und 8,
+7. erst danach pushen (Schritt 10),
+8. Draft-PR erstellen (Schritt 10).
+
+Prüfe, ob im selben Slice sachlich korrekt abgebildet sind:
 
 - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
 - `ROADMAP.md` nur bei Änderung eines Release-Gates oder der strategischen Reihenfolge,
@@ -238,7 +262,14 @@ Prüfe vor Push und PR, ob im selben Slice sachlich korrekt abgebildet sind:
 
 Dokumentiere für jedes Artefakt `aktualisiert` oder `NICHT BETROFFEN` mit Begründung.
 
-Ist ein erforderliches Dokumentationsartefakt sachlich betroffen, aber nicht im Commit enthalten, darf nicht gepusht werden. Gib das Issue einmalig an denselben Implementer zurück, lasse den bestehenden lokalen Commit amendieren und wiederhole für den neuen Commit-SHA Schritt 7 (Ergebnis selbst verifizieren) und Schritt 8 (Opus-Review) vollständig. Erst nach erneutem `APPROVE` darf das Issue weiter zu Schritt 10.
+Ist ein erforderliches Dokumentationsartefakt sachlich betroffen, aber nicht im Commit enthalten, darf nicht gepusht werden. Dann gilt:
+
+1. das Issue einmalig an denselben Implementer zurückgeben,
+2. den bestehenden Issue-Commit amendieren statt einen zweiten Commit zu erzeugen,
+3. den neuen Commit-SHA erfassen,
+4. Schritt 7 (Verifikation, frische Tests, Gate) und Schritt 8 (Opus-Review) für diesen neuen SHA vollständig erneut ausführen.
+
+Erst nach erneutem `APPROVE` darf das Issue weiter zu Schritt 10.
 
 Erzeuge notwendige Folge-Issues vor dem Draft-PR und verlinke sie im PR-Body.
 

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -165,13 +165,16 @@ Vertraue der Worker-Zusammenfassung nicht. Prüfe frisch:
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
-git status --short
+worktree_status="$(git status --short)"
+test -z "$worktree_status"
 ```
 
-Führe danach den im Briefing festgelegten Issue-Test frisch aus:
+Führe danach den im Briefing festgelegten Issue-Test frisch aus und bewahre die vollständige Ausgabe auf:
 
 ```bash
-<ISSUE_TEST_COMMAND>
+<ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
+test_rc=${PIPESTATUS[0]}
+test "$test_rc" -eq 0
 ```
 
 Wähle anschließend abhängig vom Issue-Scope **genau einen** Gate-Pfad:
@@ -223,9 +226,25 @@ Bei `REQUEST_CHANGES`:
 
 Bleibt das Urteil negativ, stoppe mit einem konkreten Bericht.
 
-## Schritt 9: Push und Draft-PR
+## Schritt 9: Dokumentationssynchronisation abschließen
 
-Nur bei `APPROVE`:
+Prüfe vor Push und PR, ob im selben Slice sachlich korrekt abgebildet sind:
+
+- `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+- `ROADMAP.md` nur bei Änderung eines Release-Gates oder der strategischen Reihenfolge,
+- `CHANGELOG.md` bei ausgeliefertem Nutzer- oder Betriebsverhalten,
+- ein Folge-Issue für notwendige, aber im Slice nicht erledigte Arbeit,
+- Issue-Verknüpfung im PR-Body mit `Closes #<NR>`.
+
+Dokumentiere für jedes Artefakt `aktualisiert` oder `NICHT BETROFFEN` mit Begründung.
+
+Ist ein erforderliches Dokumentationsartefakt sachlich betroffen, aber nicht im Commit enthalten, darf nicht gepusht werden. Gib das Issue einmalig an denselben Implementer zurück, lasse den bestehenden lokalen Commit amendieren und wiederhole für den neuen Commit-SHA Schritt 7 (Ergebnis selbst verifizieren) und Schritt 8 (Opus-Review) vollständig. Erst nach erneutem `APPROVE` darf das Issue weiter zu Schritt 10.
+
+Erzeuge notwendige Folge-Issues vor dem Draft-PR und verlinke sie im PR-Body.
+
+## Schritt 10: Push und Draft-PR
+
+Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 
 ```bash
 git push -u origin <branch>
@@ -254,21 +273,15 @@ git push -u origin <branch>
 - Contract-Tests → Schema-Check → Ruff → mypy — PASS
 - `scripts/pre-push-gate.sh <Scope>` — PASS
 
+## Dokumentationssync
+- `docs/STATUS.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- `ROADMAP.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- `CHANGELOG.md`: <aktualisiert | NICHT BETROFFEN + Begründung>
+- Folge-Issue: <URL | NICHT BETROFFEN + Begründung>
+
 ## Review
 - `agora-opus-reviewer` — APPROVE
 ```
-
-## Schritt 10: Quellen synchronisieren
-
-Nach erfolgreicher Umsetzung:
-
-- `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
-- `ROADMAP.md` nur bei Änderung eines Release-Gates oder der strategischen Reihenfolge,
-- `CHANGELOG.md` bei ausgeliefertem Nutzer- oder Betriebsverhalten,
-- ein Folge-Issue für notwendige, aber im Slice nicht erledigte Arbeit,
-- Issue durch den PR mit `Closes #<NR>` verknüpfen.
-
-Dokumentiere für `docs/STATUS.md`, `ROADMAP.md`, `CHANGELOG.md` und Folge-Issue jeweils: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
 
 ## Abschlussausgabe
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,20 +49,32 @@ Zwei Issues dürfen nur parallel laufen, wenn:
 
 Bei Unsicherheit nur ein Issue ausführen. Maximal zwei schreibende Worker gleichzeitig.
 
-## Pre-Commit-Gate (Pflicht, sequentiell)
+## Pre-Commit-Gate (Pflicht, sequentiell, scope-abhängig)
+
+Backend-, Schemas- und Cross-Layer-Scope, sequentiell mit Exit 0:
 
 ```bash
 cd backend && uv run pytest tests/contracts/ -x -q
 cd backend && uv run python -m app.contracts.dump_schemas --check
-cd backend && uv run ruff check . && uv run mypy app
+cd backend && uv run ruff check app/ tests/ && uv run mypy app
 ```
+
+Reiner Frontend-Scope führt diese Backend-Prüfungen nicht aus, sondern:
+
+```bash
+cd frontend && bun run test && bun run check
+```
+
+Maßgeblich ist die Scope-Matrix in [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md).
 
 Bei Schema-Drift: `dump_schemas` ohne `--check` neu rendern, in denselben Issue-Commit aufnehmen.
 
 ## Pre-Push-Gate (CI-Mirror, vor jedem Push Pflicht)
 
+Genau ein zum Scope passender Pfad — nicht alle:
+
 ```bash
-bash scripts/pre-push-gate.sh              # alles (Default)
+bash scripts/pre-push-gate.sh              # Cross-Layer / vollständig
 bash scripts/pre-push-gate.sh backend      # nur Backend-Smoke
 bash scripts/pre-push-gate.sh frontend     # nur Frontend-Smoke
 bash scripts/pre-push-gate.sh schemas      # nur Schema-Drift + STATUS-Sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Bei Unsicherheit nur ein Issue ausführen. Maximal zwei schreibende Worker gleic
 
 ## Pre-Commit-Gate (Pflicht, sequentiell, scope-abhängig)
 
-Backend- und Schemas-Scope, sequentiell mit Exit 0 (ein einziger Wechsel nach `backend`):
+Backend-Scope, sequentiell mit Exit 0 (ein einziger Wechsel nach `backend`):
 
 ```bash
 cd backend
@@ -59,6 +59,14 @@ uv run pytest tests/contracts/ -x -q
 uv run python -m app.contracts.dump_schemas --check
 uv run ruff check app/ tests/
 uv run mypy app
+```
+
+Schemas-/Contracts-Scope — nur Contract-Tests und Schema-Check, kein Ruff, kein mypy:
+
+```bash
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
 ```
 
 Reiner Frontend-Scope führt diese Backend-Prüfungen nicht aus, sondern:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,21 +14,40 @@ Allgemeine Tool-Pipeline und Skill-Discovery-Regeln stehen in der globalen `~/.c
 4. Validator `cross_stakeholder_for_high`
 5. Validator `reject_inferred_in_high_confidence`
 
-## Subagent-Routing (Modell-Mix ~35/55/10)
+## Issue-Orchestrierung
 
-Context-mode injiziert den Routing-Block automatisch in jeden Subagent-Prompt. Subagent-Prompts auf fachliche Aufgabe + Domänen-Kontext beschränken.
+- `/agora-next-task`: genau ein release-relevantes Issue, ein isolierter Worker, ein lokaler Commit, Opus-Review, anschließend Draft-PR.
+- `/agora-batch-issues`: maximal zwei nachweislich unabhängige Issues parallel; jedes Issue bleibt in eigenem Worktree, Commit und Draft-PR.
+- Schreibende Worker verwenden `isolation: worktree`, pushen nicht und erzeugen genau einen lokalen Commit.
+- Der Lead verifiziert Diff, Tests und Gate selbst. Worker-Zusammenfassungen gelten nicht als Nachweis.
+- Vor Push und PR prüft `agora-opus-reviewer` read-only den Issue-Commit. Nur `APPROVE` erlaubt die Veröffentlichung.
+- Keine Agent Teams für normale Issue-Arbeit. Subagenten reichen aus und halten die Kontexte getrennt.
+
+## Subagent-Routing
 
 | Aufgabe | Modell | Subagent |
 |---|---|---|
-| Architektur, Cross-Layer, ambige Specs | Opus | Lead (kein Subagent) |
-| Code-Review kritischer Pfade | Opus | `feature-dev:code-reviewer` |
-| Refactor 2+ Dateien, Pydantic-Migration | Sonnet | `agora-refactor-worker` |
-| Tests, FSM, Persona-Quoten | Sonnet | `agora-test-worker` |
-| Vue/Pinia/Zod-Spiegel, Onboarding/Model-Picker-Frontend | Sonnet | `agora-frontend-worker` |
-| Evidence/Wording-Audit | Sonnet | `agora-evidence-auditor` |
-| Doku, CHANGELOG, Worklogs, ADR-Drafts | Haiku | `agora-doc-worker` |
+| Architektur, Cross-Layer, ambige Specs | Opus oder Lead | kein Implementer-Subagent |
+| Abschlussreview eines Issue-Commits | Opus high | `agora-opus-reviewer` |
+| Backend-Refactor, Pydantic, Provider, Persistenz | Sonnet high | `agora-refactor-worker` |
+| Tests, FSM, E2E, Persona-Quoten | Sonnet medium | `agora-test-worker` |
+| Vue, Pinia, Zod, A11y | Sonnet medium | `agora-frontend-worker` |
+| Evidence/Wording-Audit | Sonnet medium | `agora-evidence-auditor` |
+| Doku, CHANGELOG, Worklogs, ADR-Drafts | Haiku low | `agora-doc-worker` |
 
-Opus-Trigger: Layer 0 berührt, Cross-Layer, Wording/Prompt-Semantik, Spec ambig, Tests fehlen.
+Lead-Trigger: Layer 0, Cross-Layer, Wording/Prompt-Semantik, Security, Auth, Secrets, Datenmigration, Provider-Routing, ambige Specs oder fehlende Tests.
+
+## Parallelitätsregeln
+
+Zwei Issues dürfen nur parallel laufen, wenn:
+
+- keine Parent-/Child- oder Blocked-by-Beziehung besteht,
+- keine gleichen oder eng gekoppelten Dateien betroffen sind,
+- keine gemeinsamen Contracts, Schemas oder Migrationen geändert werden,
+- keine gemeinsame Fehlerursache wahrscheinlich ist,
+- jedes Issue unabhängig testbar und rückrollbar ist.
+
+Bei Unsicherheit nur ein Issue ausführen. Maximal zwei schreibende Worker gleichzeitig.
 
 ## Pre-Commit-Gate (Pflicht, sequentiell)
 
@@ -38,7 +57,7 @@ cd backend && uv run python -m app.contracts.dump_schemas --check
 cd backend && uv run ruff check . && uv run mypy app
 ```
 
-Bei Schema-Drift: `dump_schemas` ohne `--check` neu rendern, in den selben PR committen.
+Bei Schema-Drift: `dump_schemas` ohne `--check` neu rendern, in denselben Issue-Commit aufnehmen.
 
 ## Pre-Push-Gate (CI-Mirror, vor jedem Push Pflicht)
 
@@ -49,8 +68,7 @@ bash scripts/pre-push-gate.sh frontend     # nur Frontend-Smoke
 bash scripts/pre-push-gate.sh schemas      # nur Schema-Drift + STATUS-Sync
 ```
 
-Seit Onboarding-Slice 4.3.3 Maintenance (PR #693) zentralisiert. Kein
-`--no-verify`-Bypass. Runbook: [`docs/runbooks/pre-push-gate.md`](docs/runbooks/pre-push-gate.md).
+Kein `--no-verify`-Bypass. Runbook: [`docs/runbooks/pre-push-gate.md`](docs/runbooks/pre-push-gate.md).
 
 ## Runbooks
 
@@ -59,33 +77,24 @@ Seit Onboarding-Slice 4.3.3 Maintenance (PR #693) zentralisiert. Kein
 | [`docs/runbooks/tool-pflicht.md`](docs/runbooks/tool-pflicht.md) | Pipeline, Tool-Matrix, Compliance-Gates |
 | [`docs/runbooks/pr-workflow.md`](docs/runbooks/pr-workflow.md) | PR + Gemini-Sichtung |
 | [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md) | Worktree-Isolation |
-| [`docs/runbooks/pre-push-gate.md`](docs/runbooks/pre-push-gate.md) | Zentrales Pre-Push-Gate (PR #693) |
-| [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md) | Dispatch-Workflow |
+| [`docs/runbooks/pre-push-gate.md`](docs/runbooks/pre-push-gate.md) | Zentrales Pre-Push-Gate |
+| [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md) | Dispatch-, Parallelitäts- und Review-Workflow |
 | [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.md) | Layer 0–10 |
 
 ## Provider-Detection-SSoT
 
-Bei Provider-Detection-Fragen („welcher Provider für diese URL/Modell",
-`ollama.com`-Handling, `think`/`num_ctx`-Gate) ist
-[`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py)
-→ `detect_provider(base_url, model, *, mode="http"|"oasis")` die Single Source
-of Truth. Keine neuen lokalen Detection-Heuristiken pflegen — bestehende werden
-dorthin delegiert (Phase F, Issues #669/#670/#671 offen).
+Bei Provider-Detection-Fragen („welcher Provider für diese URL/Modell", `ollama.com`-Handling, `think`/`num_ctx`-Gate) ist [`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py) → `detect_provider(base_url, model, *, mode="http"|"oasis")` die Single Source of Truth. Keine neuen lokalen Detection-Heuristiken pflegen.
 
 ## Embedding-Configuration (ADR-0007)
 
-Aktive Konfiguration lebt in Neo4j (`EmbeddingConfiguration`-Knoten, eindeutig
-pro Provider/Model/Dim). Lese-/Schreibpfade ausschließlich über
-`backend/app/services/embedding_service.py` und `embedding_migration.py`. Bei
-Modell-Wechsel: Migrations-Lifecycle `pending → running → validating → completed
-| failed | rolled_back` (Resume-fähig, idempotenter Start). Gemini-Re-Embedding
-ist explizit „noch nicht unterstützt" — nicht vortäuschen.
+Aktive Konfiguration lebt in Neo4j (`EmbeddingConfiguration`-Knoten, eindeutig pro Provider/Model/Dim). Lese-/Schreibpfade ausschließlich über `backend/app/services/embedding_service.py` und `embedding_migration.py`. Bei Modell-Wechsel: Migrations-Lifecycle `pending → running → validating → completed | failed | rolled_back`. Gemini-Re-Embedding ist explizit „noch nicht unterstützt“ — nicht vortäuschen.
 
 ## Token Efficiency
+
 - Never re-read files you just wrote or edited. You know the contents.
-- Never re-run commands to "verify" unless the outcome was uncertain.
-- Don't echo back large blocks of code or file contents unless asked.
-- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
-- Skip confirmations like "I'll continue..." Just do it.
-- If a task needs 1 tool call, don't use 3. Plan before acting.
-- Do not summarize what you just did unless the result is ambiguous or you need additional input.
+- Never re-run commands unless a frischer Verifikationsnachweis erforderlich ist oder das Ergebnis unsicher war.
+- Don't echo large blocks of code or file contents unless asked.
+- Batch related edits into single operations.
+- Skip confirmations like "I'll continue...".
+- If a task needs one tool call, don't use three.
+- Do not summarize implementation details beyond Commit, Diff, Tests, Gate, Review and Risiken.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,18 +51,35 @@ Bei Unsicherheit nur ein Issue ausführen. Maximal zwei schreibende Worker gleic
 
 ## Pre-Commit-Gate (Pflicht, sequentiell, scope-abhängig)
 
-Backend-, Schemas- und Cross-Layer-Scope, sequentiell mit Exit 0:
+Backend- und Schemas-Scope, sequentiell mit Exit 0 (ein einziger Wechsel nach `backend`):
 
 ```bash
-cd backend && uv run pytest tests/contracts/ -x -q
-cd backend && uv run python -m app.contracts.dump_schemas --check
-cd backend && uv run ruff check app/ tests/ && uv run mypy app
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+uv run ruff check app/ tests/
+uv run mypy app
 ```
 
 Reiner Frontend-Scope führt diese Backend-Prüfungen nicht aus, sondern:
 
 ```bash
-cd frontend && bun run test && bun run check
+cd frontend
+bun run test
+bun run check
+```
+
+Cross-Layer-Scope führt beide Blöcke nacheinander aus:
+
+```bash
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+uv run ruff check app/ tests/
+uv run mypy app
+cd ../frontend
+bun run test
+bun run check
 ```
 
 Maßgeblich ist die Scope-Matrix in [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md).

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -100,8 +100,9 @@ Der Worker:
    | `backend` | gezielte Backend-Tests → Contract-Tests → Schema-Check → Ruff → mypy | `pre-push-gate.sh backend` |
    | `frontend` | gezielte Frontend-Tests → `bun run check` | `pre-push-gate.sh frontend` |
    | `schemas` | Contract-Tests → Schema-Check | `pre-push-gate.sh schemas` |
-   | `fsm-e2e` | die im Briefing benannten FSM-/E2E-Tests | das im Briefing benannte passende Gate |
    | `vollständig` | gezielte Tests aller betroffenen Layer, danach Backend- und Frontend-Prüfungen | `pre-push-gate.sh` |
+
+   FSM- und E2E-Aufgaben sind ein Aufgabentyp, kein eigener Gate-Scope: Der Lead bildet sie im Briefing auf `backend`, `frontend` oder `vollständig` ab; die dort benannten FSM-/E2E-Tests laufen zusätzlich zu den Pflichtprüfungen dieses Scopes.
 
    Backend-Pflichtprüfungen im Wortlaut:
 

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -97,8 +97,8 @@ Der Worker:
 
    | Gate-Scope | Pflichtprüfungen | Gate (genau einer) |
    |---|---|---|
-   | `backend` | gezielte Backend-Tests → Contract-Tests → Schema-Check → Ruff → mypy | `pre-push-gate.sh backend` |
-   | `frontend` | gezielte Frontend-Tests → `bun run check` | `pre-push-gate.sh frontend` |
+   | `backend` | gezielte Backend-Tests (`uv run pytest <PFADE> -x -q`) → Contract-Tests → Schema-Check → Ruff → mypy | `pre-push-gate.sh backend` |
+   | `frontend` | gezielte Frontend-Tests (`bun run test <PFADE>`) → `bun run check` | `pre-push-gate.sh frontend` |
    | `schemas` | Contract-Tests → Schema-Check | `pre-push-gate.sh schemas` |
    | `vollständig` | gezielte Tests aller betroffenen Layer, danach Backend- und Frontend-Prüfungen | `pre-push-gate.sh` |
 

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -93,7 +93,17 @@ Der Worker:
 2. schreibt oder ändert Tests zuerst,
 3. implementiert nur den definierten Slice,
 4. führt den gezielten Issue-Test bis GREEN aus,
-5. führt vor dem lokalen Commit die vier Pflichtprüfungen exakt in dieser Reihenfolge aus:
+5. führt vor dem lokalen Commit **ausschließlich** die Pflichtprüfungen des im Briefing benannten Gate-Scopes aus, exakt in dieser Reihenfolge:
+
+   | Gate-Scope | Pflichtprüfungen | Gate (genau einer) |
+   |---|---|---|
+   | `backend` | gezielte Backend-Tests → Contract-Tests → Schema-Check → Ruff → mypy | `pre-push-gate.sh backend` |
+   | `frontend` | gezielte Frontend-Tests → `bun run check` | `pre-push-gate.sh frontend` |
+   | `schemas` | Contract-Tests → Schema-Check | `pre-push-gate.sh schemas` |
+   | `fsm-e2e` | die im Briefing benannten FSM-/E2E-Tests | das im Briefing benannte passende Gate |
+   | `vollständig` | gezielte Tests aller betroffenen Layer, danach Backend- und Frontend-Prüfungen | `pre-push-gate.sh` |
+
+   Backend-Pflichtprüfungen im Wortlaut:
 
    ```bash
    cd backend
@@ -103,7 +113,9 @@ Der Worker:
    uv run mypy app
    ```
 
-6. führt anschließend genau das passende Scope-Gate aus,
+   Für reine Frontend-Aufgaben werden keine Backend-Prüfungen ausgeführt.
+
+6. führt anschließend genau **ein** dazu passendes Scope-Gate aus,
 7. synchronisiert sachlich betroffene Dokumentationsartefakte im selben Slice,
 8. staged nur Scope-Dateien,
 9. erzeugt erst nach Exit 0 aller Prüfungen genau einen lokalen Commit,
@@ -120,12 +132,30 @@ Der Lead prüft frisch:
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
-git status --short
+
+worktree_status="$(git status --short)"
+
+if [ -n "$worktree_status" ]; then
+  printf '%s\n' "$worktree_status"
+  echo "Worktree enthält uncommittete Änderungen." >&2
+  exit 1
+fi
 ```
 
-Danach läuft der im Briefing festgelegte Issue-Test erneut. Anschließend wird abhängig vom Scope genau ein Gate ausgeführt:
+Ein nicht-leerer Worktree blockiert den Ablauf sofort. Tests, Gate und Opus-Review laufen nur bei sauberem Worktree, damit exakt der Inhalt von `<COMMIT_SHA>` geprüft und später gepusht wird.
+
+Danach läuft der im Briefing festgelegte Issue-Test erneut, mit `tee` gesichert und über `PIPESTATUS` geprüft:
 
 ```bash
+<ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
+test_rc=${PIPESTATUS[0]}
+test "$test_rc" -eq 0
+```
+
+Anschließend wird abhängig vom Scope genau ein Gate ausgeführt und ebenso gesichert:
+
+```bash
+{
 case "<GATE_SCOPE>" in
   backend)
     bash scripts/pre-push-gate.sh backend
@@ -143,6 +173,9 @@ case "<GATE_SCOPE>" in
     exit 2
     ;;
 esac
+} 2>&1 | tee <GATE_LOG>
+gate_rc=${PIPESTATUS[0]}
+test "$gate_rc" -eq 0
 ```
 
 Issue-Test und Gate müssen Exit 0 liefern. Der Lead übergibt ihre vollständigen, frisch erzeugten Ausgaben an den Reviewer. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop und keine unbedingte Ausführung aller Scope-Gates.

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -76,8 +76,10 @@ Das Briefing enthält:
 - genaue Dateien, Symbole und Interfaces,
 - Scope und Out-of-Scope,
 - zuerst zu schreibende Tests,
+- einen exakt erneut ausführbaren Issue-Test-Befehl,
 - Migration und Rollback, falls Daten betroffen sind,
 - exakte Verifikationsbefehle,
+- genau einen Gate-Scope: `backend`, `frontend`, `schemas` oder `vollständig`,
 - zuständige Dokumentationsquelle,
 - Stop-Bedingungen.
 
@@ -90,11 +92,25 @@ Der Worker:
 1. bearbeitet genau ein Issue,
 2. schreibt oder ändert Tests zuerst,
 3. implementiert nur den definierten Slice,
-4. führt gezielte Tests und das passende Gate aus,
-5. staged nur Scope-Dateien,
-6. erzeugt genau einen lokalen Commit,
-7. liefert Commit-SHA, Diff-Statistik und Testausgaben zurück,
-8. pusht, mergt und erstellt keinen PR.
+4. führt den gezielten Issue-Test bis GREEN aus,
+5. führt vor dem lokalen Commit die vier Pflichtprüfungen exakt in dieser Reihenfolge aus:
+
+   ```bash
+   cd backend
+   uv run pytest tests/contracts/ -x -q
+   uv run python -m app.contracts.dump_schemas --check
+   uv run ruff check app/ tests/
+   uv run mypy app
+   ```
+
+6. führt anschließend genau das passende Scope-Gate aus,
+7. synchronisiert sachlich betroffene Dokumentationsartefakte im selben Slice,
+8. staged nur Scope-Dateien,
+9. erzeugt erst nach Exit 0 aller Prüfungen genau einen lokalen Commit,
+10. liefert Commit-SHA, Diff-Statistik sowie vollständige Issue-Test-, Pflichtprüfungs- und Gate-Ausgaben zurück,
+11. pusht, mergt und erstellt keinen PR.
+
+Ein fehlender Prüfbefehl, ein unklarer Exit-Code oder ein Fehler blockiert den Commit. Ruff-Autofixes dürfen niemals pauschal mit `uv run ruff check --fix .` über das Repository laufen.
 
 ### 4. Lead-Verifikation
 
@@ -104,23 +120,34 @@ Der Lead prüft frisch:
 git show --stat --oneline <COMMIT_SHA>
 git diff --check <BASE_SHA>...<COMMIT_SHA>
 git diff --name-only <BASE_SHA>...<COMMIT_SHA>
+git status --short
 ```
 
-Mindestens das passende Gate ausführen:
+Danach läuft der im Briefing festgelegte Issue-Test erneut. Anschließend wird abhängig vom Scope genau ein Gate ausgeführt:
 
 ```bash
-bash scripts/pre-push-gate.sh backend
-bash scripts/pre-push-gate.sh frontend
-bash scripts/pre-push-gate.sh schemas
+case "<GATE_SCOPE>" in
+  backend)
+    bash scripts/pre-push-gate.sh backend
+    ;;
+  frontend)
+    bash scripts/pre-push-gate.sh frontend
+    ;;
+  schemas)
+    bash scripts/pre-push-gate.sh schemas
+    ;;
+  vollständig)
+    bash scripts/pre-push-gate.sh
+    ;;
+  *)
+    exit 2
+    ;;
+esac
 ```
 
-Cross-Layer:
+Issue-Test und Gate müssen Exit 0 liefern. Der Lead übergibt ihre vollständigen, frisch erzeugten Ausgaben an den Reviewer. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop und keine unbedingte Ausführung aller Scope-Gates.
 
-```bash
-bash scripts/pre-push-gate.sh
-```
-
-Zusätzlich laufen die gezielten Tests aus dem Issue. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop.
+Bei zwei parallelen Issues werden Test und Gate in den jeweiligen Worktrees ausgeführt. Ein Fehler stoppt nur das betroffene Issue, sofern die nachgewiesene Unabhängigkeit des anderen Issues weiterhin gilt.
 
 ### 5. Opus-Review
 
@@ -137,16 +164,30 @@ Der Reviewer antwortet mit `APPROVE` oder `REQUEST_CHANGES`.
 
 Bei `REQUEST_CHANGES` ist höchstens ein enger Korrekturlauf erlaubt. Danach werden Tests, Gate und Review vollständig wiederholt. Ohne `APPROVE` gibt es keinen Push und keinen PR.
 
-### 6. Pull Request
+### 6. Dokumentationssync
 
-Nur nach `APPROVE` pusht der Lead den Issue-Branch und öffnet einen separaten Draft-PR.
+Vor Push und PR wird für jedes Issue nachgewiesen:
+
+- `docs/STATUS.md`: aktualisiert, wenn sich der verifizierte Istzustand geändert hat, sonst `NICHT BETROFFEN` mit Begründung,
+- `ROADMAP.md`: aktualisiert bei geändertem Release-Gate oder strategischer Reihenfolge, sonst `NICHT BETROFFEN` mit Begründung,
+- `CHANGELOG.md`: aktualisiert bei ausgeliefertem Nutzer- oder Betriebsverhalten, sonst `NICHT BETROFFEN` mit Begründung,
+- Folge-Issue: erstellt für notwendige, aber nicht erledigte Folgearbeit, sonst `NICHT BETROFFEN` mit Begründung.
+
+Fehlt ein sachlich erforderliches Datei-Artefakt, wird nicht gepusht. Der bestehende lokale Issue-Commit wird einmalig korrigiert und amendiert; danach laufen Lead-Verifikation und Opus-Review für den neuen SHA vollständig erneut.
+
+### 7. Pull Request
+
+Nur nach `APPROVE` und vollständigem Dokumentationssync pusht der Lead den Issue-Branch und öffnet einen separaten Draft-PR.
 
 Der Pull Request enthält:
 
 - Summary,
 - Release-Ziel,
 - Scope und Out-of-Scope,
-- Tests mit Ergebnis,
+- Issue-Test mit Ergebnis,
+- sequenzielle Pflichtprüfungen mit Ergebnis,
+- genau das ausgeführte Scope-Gate mit Ergebnis,
+- Dokumentationssync und Folge-Issues,
 - Opus-Review-Ergebnis,
 - Migration/Rollback, falls relevant,
 - `Closes #<Issue>` oder `Refs #<Issue>`.
@@ -161,5 +202,6 @@ Der Pull Request enthält:
 - Opus als Implementer verwenden,
 - Tests oder Reviews aus Kostengründen auslassen,
 - Worker-Output ungeprüft pushen,
+- alle Scope-Gates unabhängig vom Issue ausführen,
 - mehr als einen automatischen Korrekturlauf starten,
 - direkte Änderungen oder Fast-Forward-Pushes auf `main`.

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -1,27 +1,36 @@
 # Subagent-Routing
 
-**Stand:** 18.07.2026
+**Stand:** 19.07.2026
 
 ## Prinzip
 
-Komplexe Aufgaben werden an spezialisierte Subagenten delegiert. Das Lead-Modell wählt das release-relevante GitHub Issue, definiert den atomaren Scope, verifiziert die Umsetzung und verantwortet Commit und Pull Request.
+Komplexe Aufgaben werden an spezialisierte Subagenten delegiert. Das Lead-Modell wählt das release-relevante GitHub Issue, definiert den atomaren Scope, verifiziert die Umsetzung und verantwortet Push und Pull Request.
 
 Task-Quelle ist immer ein GitHub Issue. `README.md`, `docs/STATUS.md` und `ROADMAP.md` liefern Produkt-, Ist- und Release-Kontext. Archivierte Pläne sind keine Taskquelle.
 
+Schreibende Worker laufen in isolierten Worktrees, bearbeiten genau ein Issue und erzeugen genau einen lokalen Commit. Vor jedem Push prüft ein read-only Opus-Reviewer den Commit gegen Issue, Diff, Tests und Gates.
+
+## Befehle
+
+| Befehl | Zweck |
+|---|---|
+| `/agora-next-task` | genau ein Issue vollständig bearbeiten und reviewen |
+| `/agora-batch-issues` | maximal zwei nachweislich unabhängige Issues parallel bearbeiten |
+
 ## Routing-Matrix
 
-| Aufgabe | Lead/Subagent | Trigger |
+| Aufgabe | Lead/Subagent | Modell |
 |---|---|---|
-| Architekturentscheidung | Lead | ADR, Cross-Layer, neue Systemgrenze |
-| Ambige Spezifikation | Lead | Issue unklar, Akzeptanz nicht prüfbar |
-| Security oder Datenmigration | Lead | Secrets, Auth, Persistenz, Rollback |
-| Kritisches Code-Review | Lead oder Reviewer | Contracts, Evidence, Routing, Migration |
-| Backend-Refactor | `agora-refactor-worker` | Services, Provider, Persistenz |
-| Pydantic-/Schema-Arbeit | `agora-refactor-worker` | Contract plus Spiegel |
-| Tests, FSM und E2E | `agora-test-worker` | Regressionen, Gates, Quoten |
-| Vue, Pinia, Zod, A11y | `agora-frontend-worker` | Frontend-Slice |
-| Evidence-/Wording-Audit | `agora-evidence-auditor` | Read-only Review |
-| Dokumentation | `agora-doc-worker` | README, STATUS, ROADMAP, CHANGELOG |
+| Architekturentscheidung | Lead | Opus oder Sonnet mit Opus-Review |
+| Ambige Spezifikation | Lead | Opus oder Sonnet |
+| Security, Auth, Secrets oder Datenmigration | Lead plant, Worker implementiert eng | Opus-Review high |
+| Abschlussreview eines Issue-Commits | `agora-opus-reviewer` | Opus high, read-only |
+| Backend-Refactor | `agora-refactor-worker` | Sonnet high |
+| Pydantic-/Schema-Arbeit | `agora-refactor-worker` | Sonnet high |
+| Tests, FSM und E2E | `agora-test-worker` | Sonnet medium |
+| Vue, Pinia, Zod, A11y | `agora-frontend-worker` | Sonnet medium |
+| Evidence-/Wording-Audit | `agora-evidence-auditor` | Sonnet medium, read-only |
+| Dokumentation | `agora-doc-worker` | Haiku low |
 
 ## Lead-Trigger
 
@@ -34,38 +43,68 @@ Diese Situationen werden nicht blind delegiert:
 5. Das Issue ist widersprüchlich oder besitzt keine prüfbaren Akzeptanzkriterien.
 6. Ein neuer Produktbereich soll vorgezogen werden, obwohl er nicht zur aktuellen Release-Stufe gehört.
 
+Der Lead präzisiert Scope, Tests, Migration, Rollback und Stop-Bedingungen vor dem Dispatch. Opus implementiert nicht.
+
+## Parallelitäts-Gate
+
+Maximal zwei schreibende Worker dürfen gleichzeitig laufen. Zwei Issues sind nur parallel sicher, wenn:
+
+- keine Parent-/Child- oder Blocked-by-Beziehung besteht,
+- keine gleichen oder eng gekoppelten Dateien betroffen sind,
+- keine gemeinsamen Contracts, Schemas oder Migrationen geändert werden,
+- keine gemeinsame Fehlerursache wahrscheinlich ist,
+- keine konkurrierenden Änderungen an Secrets, Provider-Routing oder Evidence-Hartankern erfolgen,
+- jedes Issue unabhängig testbar und rückrollbar ist.
+
+Bei Unsicherheit wird nur ein Issue ausgeführt.
+
 ## Dispatch-Workflow
 
 ### 1. Release und Issue prüfen
 
-- `VERSION` lesen
-- `docs/STATUS.md` und `ROADMAP.md` prüfen
-- offenes Issue vollständig einschließlich Kommentare lesen
-- Scope, Out-of-Scope, Abhängigkeiten und Release-Gate bestätigen
+- `VERSION` lesen,
+- `docs/STATUS.md` und `ROADMAP.md` prüfen,
+- offenes Issue vollständig einschließlich Kommentare lesen,
+- Scope, Out-of-Scope, Abhängigkeiten und Release-Gate bestätigen.
 
 ### 2. Atomaren Slice definieren
 
 Das Briefing enthält:
 
-- Issue-Nummer und Release-Ziel
-- Problem in einem Satz
-- genaue Dateien und Interfaces
-- Scope und Out-of-Scope
-- zuerst zu schreibende Tests
-- Migration und Rollback, falls Daten betroffen sind
-- exakte Verifikationsbefehle
-- zuständige Dokumentationsquelle
-- Stop-Bedingungen
+- Issue-Nummer und Release-Ziel,
+- Problem in einem Satz,
+- genaue Dateien, Symbole und Interfaces,
+- Scope und Out-of-Scope,
+- zuerst zu schreibende Tests,
+- Migration und Rollback, falls Daten betroffen sind,
+- exakte Verifikationsbefehle,
+- zuständige Dokumentationsquelle,
+- Stop-Bedingungen.
 
-### 3. Worktree verwenden
+### 3. Isolierten Worker dispatchen
 
-Jeder Implementer arbeitet in einem isolierten Worktree vom aktuellen `origin/main`. Keine Änderungen im Hauptcheckout und keine direkten Pushes auf `main`.
+Schreibende Worker besitzen `isolation: worktree`. Der Lead übergibt das vollständige Briefing; der Worker sieht den bisherigen Chat nicht und erhält nur den für das Issue erforderlichen Kontext.
 
-### 4. Implementieren
+Der Worker:
 
-Der Subagent implementiert nur den definierten Slice. Er committet und pusht nicht selbst, sofern das Lead-Modell nichts anderes ausdrücklich festlegt.
+1. bearbeitet genau ein Issue,
+2. schreibt oder ändert Tests zuerst,
+3. implementiert nur den definierten Slice,
+4. führt gezielte Tests und das passende Gate aus,
+5. staged nur Scope-Dateien,
+6. erzeugt genau einen lokalen Commit,
+7. liefert Commit-SHA, Diff-Statistik und Testausgaben zurück,
+8. pusht, mergt und erstellt keinen PR.
 
-### 5. Verifizieren
+### 4. Lead-Verifikation
+
+Der Lead prüft frisch:
+
+```bash
+git show --stat --oneline <COMMIT_SHA>
+git diff --check <BASE_SHA>...<COMMIT_SHA>
+git diff --name-only <BASE_SHA>...<COMMIT_SHA>
+```
 
 Mindestens das passende Gate ausführen:
 
@@ -83,22 +122,44 @@ bash scripts/pre-push-gate.sh
 
 Zusätzlich laufen die gezielten Tests aus dem Issue. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop.
 
+### 5. Opus-Review
+
+Der Lead startet `agora-opus-reviewer` mit:
+
+- vollständigem Issue und Akzeptanzkriterien,
+- Release-Ziel,
+- Basis-SHA und Commit-SHA,
+- vollständigem Diff,
+- frischen Test- und Gate-Ausgaben,
+- betroffenen ADRs, Contracts, Security-Grenzen und Evidence-Hartankern.
+
+Der Reviewer antwortet mit `APPROVE` oder `REQUEST_CHANGES`.
+
+Bei `REQUEST_CHANGES` ist höchstens ein enger Korrekturlauf erlaubt. Danach werden Tests, Gate und Review vollständig wiederholt. Ohne `APPROVE` gibt es keinen Push und keinen PR.
+
 ### 6. Pull Request
+
+Nur nach `APPROVE` pusht der Lead den Issue-Branch und öffnet einen separaten Draft-PR.
 
 Der Pull Request enthält:
 
-- Summary
-- Release-Ziel
-- Scope und Out-of-Scope
-- Tests mit Ergebnis
-- Migration/Rollback, falls relevant
-- `Closes #<Issue>` oder `Refs #<Issue>`
+- Summary,
+- Release-Ziel,
+- Scope und Out-of-Scope,
+- Tests mit Ergebnis,
+- Opus-Review-Ergebnis,
+- Migration/Rollback, falls relevant,
+- `Closes #<Issue>` oder `Refs #<Issue>`.
 
 ## Anti-Patterns
 
-- Aufgaben aus archivierten Plänen auswählen
-- Subagenten ohne vollständiges Briefing dispatchen
-- mehrere unabhängige Issues in einen Slice mischen
-- neue Features außerhalb des aktuellen Release-Gates vorziehen
-- Tests oder Reviews aus Kostengründen auslassen
-- Subagent-Output ungeprüft committen
+- Aufgaben aus archivierten Plänen auswählen,
+- Subagenten ohne vollständiges Briefing dispatchen,
+- mehrere unabhängige Issues in einen Commit oder PR mischen,
+- abhängige Issues parallel bearbeiten,
+- Worker ohne Worktree-Isolation schreiben lassen,
+- Opus als Implementer verwenden,
+- Tests oder Reviews aus Kostengründen auslassen,
+- Worker-Output ungeprüft pushen,
+- mehr als einen automatischen Korrekturlauf starten,
+- direkte Änderungen oder Fast-Forward-Pushes auf `main`.

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -149,8 +149,9 @@ Danach läuft der im Briefing festgelegte Issue-Test erneut, mit `tee` gesichert
 
 ```bash
 <ISSUE_TEST_COMMAND> 2>&1 | tee <ISSUE_TEST_LOG>
-test_rc=${PIPESTATUS[0]}
-test "$test_rc" -eq 0
+pipeline_rcs=("${PIPESTATUS[@]}")
+test "${pipeline_rcs[0]}" -eq 0
+test "${pipeline_rcs[1]}" -eq 0
 ```
 
 Anschließend wird abhängig vom Scope genau ein Gate ausgeführt und ebenso gesichert:
@@ -175,11 +176,12 @@ case "<GATE_SCOPE>" in
     ;;
 esac
 } 2>&1 | tee <GATE_LOG>
-gate_rc=${PIPESTATUS[0]}
-test "$gate_rc" -eq 0
+gate_rcs=("${PIPESTATUS[@]}")
+test "${gate_rcs[0]}" -eq 0
+test "${gate_rcs[1]}" -eq 0
 ```
 
-Issue-Test und Gate müssen Exit 0 liefern. Der Lead übergibt ihre vollständigen, frisch erzeugten Ausgaben an den Reviewer. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop und keine unbedingte Ausführung aller Scope-Gates.
+Issue-Test, Gate und das Schreiben beider Protokolle müssen Exit 0 liefern. Der Lead übergibt ihre vollständigen, frisch erzeugten Ausgaben an den Reviewer. Bei Fehlern stoppen; kein automatischer Endlos-Fix-Loop und keine unbedingte Ausführung aller Scope-Gates.
 
 Bei zwei parallelen Issues werden Test und Gate in den jeweiligen Worktrees ausgeführt. Ein Fehler stoppt nur das betroffene Issue, sofern die nachgewiesene Unabhängigkeit des anderen Issues weiterhin gilt.
 


### PR DESCRIPTION
## Summary

- konfiguriert Backend-, Test-, Frontend- und Dokumentations-Worker mit Modellrouting, Effort, Turn-Limits, Background-Ausführung und Worktree-Isolation
- korrigiert den Backend-Worker von Python 3.11 auf Python 3.14
- ergänzt den read-only `agora-opus-reviewer` als verpflichtendes Abschluss-Gate
- erweitert `/agora-next-task` um Worker-Commit, frische Lead-Verifikation und Opus-Review vor dem Push
- ergänzt `/agora-batch-issues` für maximal zwei nachweislich unabhängige Issues mit getrennten Worktrees, Commits, Reviews und Draft-PRs
- synchronisiert `CLAUDE.md` und das Subagent-Routing-Runbook

## Review-Fixes

Die CodeRabbit-Hinweise wurden gegen den aktuellen Branch geprüft und die weiterhin gültigen Punkte umgesetzt:

- Doku-Worker-Vertrag für Markdown und ausdrücklich benannte JSON-Dokumentationsregister vereinheitlicht
- bedingten Sync für `docs/STATUS.md`, `ROADMAP.md`, `CHANGELOG.md` und Folge-Issues ergänzt
- Auditor-Statuswerte auf `PASS`, `FAIL`, `NICHT BELEGT` und `NICHT BETROFFEN` vereinheitlicht
- fehlende Belege eindeutig auf Gesamturteil `FAIL` abgebildet
- verpflichtende Pre-Commit-Reihenfolge festgelegt: Contract-Tests → Schema-Check → Ruff → mypy
- repositoryweites `ruff --fix .` ausgeschlossen; Autofixes nur auf explizite Issue-Dateien begrenzt
- Lead-Verifikation führt Issue-Tests und genau ein passendes Scope-Gate frisch aus
- Batch-Fehler stoppen nur das betroffene, weiterhin unabhängige Issue
- Dokumentationssynchronisation erfolgt im selben Issue-Slice vor Push und Draft-PR

## Motivation

Die Implementierungsarbeit soll aus dem Lead-Kontext ausgelagert werden, ohne Qualität und Release-Gates an günstige Worker zu delegieren. Sonnet übernimmt Implementierung und Tests, Haiku reine Dokumentation, Opus prüft nur den fertigen Issue-Diff und die Testevidenz.

## Scope

- `.claude/agents/agora-refactor-worker.md`
- `.claude/agents/agora-test-worker.md`
- `.claude/agents/agora-frontend-worker.md`
- `.claude/agents/agora-doc-worker.md`
- `.claude/agents/agora-evidence-auditor.md`
- `.claude/agents/agora-opus-reviewer.md`
- `.claude/commands/agora-next-task.md`
- `.claude/commands/agora-batch-issues.md`
- `CLAUDE.md`
- `docs/runbooks/subagent-routing.md`

## Out-of-Scope

- keine Änderungen an Produktivcode, CI oder Runtime
- keine Agent Teams
- keine automatische Merge-Freigabe
- keine Änderung bestehender GitHub Issues

## Verifikation

Lokaler Lauf, bereitgestellt vom Maintainer:

- `cd backend && uv run pytest tests/contracts/ -x -q` — **PASS**, 377 Tests in 3,02 s
- `cd backend && uv run python -m app.contracts.dump_schemas --check` — **PASS**
- `cd backend && uv run ruff check app/ tests/` — **PASS**
- `cd backend && uv run mypy app` — **PASS**

Pytest meldete 17.340 Deprecation-Warnungen, überwiegend aus `neo4j` und `pytest-asyncio` unter Python 3.14. Die Warnungen stammen aus Abhängigkeiten; der Contract-Testlauf selbst war vollständig grün.

Zusätzliche Strukturprüfung:

- Branch-Vergleich gegen `main`: `behind_by=0`
- geänderte Dateien: exakt 10 erwartete Orchestrierungs- und Dokumentationsdateien
- neue und geänderte Frontmatter-Felder entsprechen den unterstützten Claude-Code-Feldern
- `agora-opus-reviewer` besitzt keine Schreib- oder Agent-Werkzeuge
- beide Orchestrator-Commands verwenden `docs/STATUS.md` und keinen fest codierten lokalen Projektpfad

## Hinweise

Der PR enthält ausschließlich Agenten-, Command- und Dokumentationskonfiguration. Beim Merge sollte `Squash and merge` verwendet werden, damit die über die Contents-API erzeugten Einzelcommits als ein sauberer Commit in `main` landen.