### PR TITLE
docs(agents): Agent-Skills-Kontext + lokale Tooling-Hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,10 @@ test-seed-*.md
 
 # graphify Knowledge-Graph-Output (lokaler Build-Artefakt-Cache)
 graphify-out/
+
+# open-mem lokaler Memory-Store (SQLite inkl. WAL/SHM, nur maschinenlokal)
+.open-mem/
+
+# Zeitgestempelte Backup-Kopien, die Tools beim Umschreiben von Configs anlegen
+# (z. B. opencode.jsonc.bak.20260720-080351).
+*.bak.[0-9]*

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ graphify-out/
 # Zeitgestempelte Backup-Kopien, die Tools beim Umschreiben von Configs anlegen
 # (z. B. opencode.jsonc.bak.20260720-080351).
 *.bak.[0-9]*
+
+# Lokale Opencode-Konfiguration (persoenliches Setup, nicht repo-weit gueltig)
+opencode.jsonc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,17 @@ Aktive Konfiguration lebt in Neo4j (`EmbeddingConfiguration`-Knoten, eindeutig p
 - Skip confirmations like "I'll continue...".
 - If a task needs one tool call, don't use three.
 - Do not summarize implementation details beyond Commit, Diff, Tests, Gate, Review and Risiken.
+
+## Agent Skills
+
+Konfiguration für externe Skill-Sammlungen, die dieses Repository als Kontext lesen. Diese Dateien beschreiben nur, wie das Repo funktioniert — sie ersetzen keine Regel aus `AGENTS.md` oder diesem Dokument.
+
+| Thema | Datei | Inhalt |
+|---|---|---|
+| Issue-Tracker | [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md) | Issues und PRDs liegen in GitHub Issues; `gh`-Konventionen für Lesen, Anlegen, Labeln und Schließen |
+| Triage-Labels | [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md) | die fünf kanonischen Labels `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` — unverändert übernommen |
+| Domänen-Doku | [`docs/agents/domain.md`](docs/agents/domain.md) | Single-Context-Layout: ADRs unter `docs/decisions/`, optionales `CONTEXT.md` |
+
+`CONTEXT.md` existiert derzeit nicht und wird erst angelegt, wenn tatsächlich Begriffe oder Entscheidungen festzuhalten sind. Sein Fehlen ist kein Defekt und wird nicht gemeldet.
+
+Verbindliche Quelle für Aufgaben bleibt die Reihenfolge aus [`AGENTS.md`](AGENTS.md): `README.md` → `docs/STATUS.md` → `ROADMAP.md` → GitHub Issues.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "ruff>=0.8.0",
     "mypy>=1.10",
+    "pyright>=1.1.350",
     "types-requests>=2.32.0",
     "jsonschema>=4.0.0",
     "fakeredis[lua]>=2.30.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -71,6 +71,7 @@ dev = [
     { name = "fakeredis", extra = ["lua"] },
     { name = "jsonschema" },
     { name = "mypy" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -124,6 +125,7 @@ dev = [
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.30.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "mypy", specifier = ">=1.10" },
+    { name = "pyright", specifier = ">=1.1.350" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -2443,6 +2445,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3437 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3439 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,34 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/decisions/`** — read ADRs that touch the area you're about to work in.
+
+If `CONTEXT.md` doesn't exist, **proceed silently**. Don't flag its absence or suggest creating it upfront. The `/domain-modeling` skill creates it lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repository:
+
+```
+/
+├── CONTEXT.md
+└── docs/decisions/
+    ├── 0001-example-decision.md
+    └── 0002-example-decision.md
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
- `CLAUDE.md` bekommt einen Abschnitt **Agent Skills**, der auf die Kontextdateien externer Skill-Sammlungen verweist.
- Neu unter `docs/agents/`: `issue-tracker.md` (gh-Konventionen), `triage-labels.md` (Label-Mapping), `domain.md` (Single-Context-Layout).
- `.gitignore` deckt lokalen Tool-State ab.
- `pyright` als Dev-Dependency fuer LSP-Feedback.

## Scope
- `CLAUDE.md`, `docs/agents/*.md` (neu)
- `.gitignore` — `.open-mem/` (lokaler SQLite-Memory-Store, ~2 MB inkl. WAL/SHM), `*.bak.[0-9]*` (zeitgestempelte Tool-Backups), `opencode.jsonc` (persoenliche lokale Konfiguration)
- `backend/pyproject.toml` + `backend/uv.lock` — `pyright>=1.1.350`, nur `dev`-Gruppe
- `docs/STATUS.md` — siehe Fremdbefund

## Out-of-Scope
- **Kein CRG-Block in `AGENTS.md`.** `AGENTS.md:57` fuehrt `code-review-graph` bereits als Schritt 1 der Tool-Pipeline; ein zusaetzlicher MCP-Block waere eine zweite Wahrheit.
- Der auto-generierte `open-mem`-Block in `AGENTS.md` wurde zurueckgesetzt und ist nicht enthalten.

## Verifikation der Doku-Aussagen
- Alle fuenf Triage-Labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) existieren im Repo — via `gh label list` geprueft.
- `docs/decisions/` existiert.
- `CONTEXT.md` existiert **nicht**. Das Wording wurde korrigiert: die Datei wird laut `domain.md` erst bei Bedarf angelegt, ihr Fehlen ist kein Defekt.
- `.gitignore`: `git ls-files | git check-ignore --stdin` ist leer — keine bereits getrackte Datei wird neu ignoriert.

## Mitgefuehrter Fremdbefund
`docs/STATUS.md`: Backend-Tests 3437 -> 3439. Die Drift stammt aus den mit #775 gemergten Testdateien, nicht aus diesem Slice (der Doku-Diff enthielt null Python-Dateien), blockierte aber das `schemas`-Gate. Eine generierte Zeile, per `scripts/sync-status.sh` erzeugt.

## Tests
- `uv run pytest tests/contracts/ -x -q` — PASS (384)
- `uv run python -m app.contracts.dump_schemas --check` — PASS (46 Schemas)
- `uv run ruff check app/ tests/` — PASS
- `uv run mypy app` — PASS (230 Dateien)
- `uv lock --check` — konsistent (235 Pakete)
- `scripts/check_version_drift.py` — PASS (0.8.0)
- `bash scripts/sync-status.sh --check` — PASS

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert (Testzahl, siehe oben)
- `ROADMAP.md`: NICHT BETROFFEN — keine Release-Gate- oder Reihenfolgeaenderung
- `CHANGELOG.md`: NICHT BETROFFEN — kein ausgeliefertes Nutzer- oder Betriebsverhalten; Agenten-Kontextdoku, lokale Ignore-Regeln und eine Dev-Dependency
- Folge-Issue: NICHT BETROFFEN — keine offene Restarbeit aus diesem Slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)