### PR TITLE
chore(review): CodeRabbit-Konfiguration mit Projekt-Hartankern ergänzen

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,159 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit-Konfiguration für Agora.
+#
+# Zweck dieser Datei ist nicht, mehr Review zu bekommen, sondern gezielteres.
+# CodeRabbit kennt weder ADR-0002 noch die SSoT-Regeln aus AGENTS.md und schlägt
+# ohne diese Hinweise regelmäßig Änderungen vor, die genau die Anker aufweichen,
+# die das Projekt bewusst hart hält.
+#
+# Referenz: https://docs.coderabbit.ai/reference/configuration
+# Wirksame Konfiguration prüfen: `@coderabbitai configuration` im PR posten.
+
+language: "de-DE"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  assess_linked_issues: true
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    # Draft-PRs entstehen hier vor dem Opus-Review-Gate. Ein Bot-Review zu
+    # diesem Zeitpunkt kommentiert einen Stand, der sich noch ändert.
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "[skip review]"
+
+  # Generierte und gesperrte Artefakte erzeugen nur Rauschen. schemas/ ist
+  # bewusst NICHT ausgeschlossen: Schema-Drift ist hier ein inhaltliches Signal.
+  path_filters:
+    - "!backend/uv.lock"
+    - "!frontend/bun.lock"
+    - "!**/*.lock"
+    - "!docs/archive/**"
+    - "!**/__snapshots__/**"
+
+  path_instructions:
+    - path: "backend/app/contracts/**"
+      instructions: |
+        Layer-0-Verträge (ADR: Verträge zuerst, Consumer danach).
+        Pydantic v2 ist verbindlich. Dataclasses und handgeschriebene
+        Inline-Schemas für API-Verträge sind im Projekt verboten.
+        Schlage keine Lockerung oder Entfernung von Validatoren vor.
+        Die Enums EvidenceSourceKind sowie die Validatoren
+        cross_stakeholder_for_high und reject_inferred_in_high_confidence sind
+        Hartanker aus ADR-0002 und dürfen nicht abgeschwächt werden.
+
+    - path: "backend/app/services/report_prompts/**"
+      instructions: |
+        Enthält die Evidence-Gating-Hartanker aus ADR-0002, insbesondere den
+        Block <evidence_gating priority="hard">.
+        Schlage keine Abschwächung, Umformulierung, Kürzung oder Entfernung
+        dieses Blocks vor, auch nicht als Lesbarkeits- oder Stilverbesserung.
+        Wording-Semantik in Prompts ist hier funktionales Verhalten, kein Stil.
+
+    - path: "backend/tests/eval/snapshots/**"
+      instructions: |
+        Eingefrorene Evaluations-Snapshots, unter anderem der Hedge-Wortschatz
+        aus ADR-0002. Änderungen an diesen Dateien sind Verhaltensänderungen und
+        brauchen eine eigene Begründung. Schlage keine Aktualisierung vor, nur
+        weil ein Test dagegen fehlschlägt.
+
+    - path: "backend/app/llm/providers/registry.py"
+      instructions: |
+        Single Source of Truth für Provider-Detection (detect_provider).
+        Schlage keine lokalen Detection-Heuristiken in Aufrufern vor und keine
+        Duplikate dieser Logik an anderer Stelle.
+
+    - path: "backend/app/services/embedding_service.py"
+      instructions: |
+        Zusammen mit embedding_migration.py der einzige Lese- und Schreibpfad
+        für die Embedding-Konfiguration (ADR-0007, aktive Konfiguration lebt in
+        Neo4j). Chat-Routing und Embedding-Konfiguration bleiben strukturell
+        getrennt; schlage keine Zusammenführung vor.
+
+    - path: "backend/tests/**"
+      instructions: |
+        Tests sind die Spezifikation. Schlage niemals abgeschwächte Assertions,
+        globale Skips, pauschale Retries oder gelockerte Toleranzen vor, um rote
+        Tests grün zu machen. Verhaltensänderungen folgen RED -> GREEN -> Refactor.
+
+    - path: "backend/app/**"
+      instructions: |
+        Python 3.14, Pydantic v2. print() in Produktivcode ist verboten,
+        strukturiertes Logging ist Pflicht. Keine API-Keys oder Secrets in Code,
+        Logs, Fixtures oder Beispielen. Keine neuen Query-Token-Parameter
+        (?token=); URL-Auth ausschließlich über signierte Tickets.
+
+    - path: "frontend/src/**/*.vue"
+      instructions: |
+        Vue 3 mit TypeScript und Pinia. Hartkodierte UI-Texte sind verboten,
+        vue-i18n ist Pflicht. Accessibility prüfen (Fokus, Rollen, Labels).
+        AiModelPicker.vue ist die kanonische Modellauswahl; schlage keine neuen
+        parallelen Picker vor.
+
+    - path: "frontend/src/contracts/**"
+      instructions: |
+        Zod-Spiegel der Pydantic-Verträge aus backend/app/contracts.
+        Abweichungen vom Backend-Vertrag sind Fehler, keine Vereinfachungen.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Kein Aufweichen von Gates. Required Checks, Schema-Drift-Prüfung und
+        Secret-Scanning dürfen nicht übersprungen oder auf continue-on-error
+        gesetzt werden.
+
+    - path: "docs/decisions/**"
+      instructions: |
+        Architecture Decision Records. Inhaltliche Änderungen an einer
+        akzeptierten ADR erfolgen über eine neue superseding ADR, nicht durch
+        Bearbeitung der bestehenden.
+
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+    # Autofix-Commits würden das verbindliche Opus-Review-Gate vor Push und PR
+    # umgehen. Fixes gehören in den Issue-Commit, nicht in einen Bot-Nachzügler.
+    autofix:
+      enabled: false
+
+  tools:
+    # Läuft bereits im Pre-Commit- und Pre-Push-Gate; doppelte Meldungen
+    # kosten nur Lesezeit.
+    ruff:
+      enabled: false
+    gitleaks:
+      enabled: true
+    semgrep:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: "auto"
+  issues:
+    scope: "auto"
+
+code_generation:
+  docstrings:
+    language: "de-DE"


### PR DESCRIPTION
## Warum

Agora lief bisher mit CodeRabbit-Defaults. Der Bot kennt weder ADR-0002 noch die SSoT-Regeln aus `AGENTS.md` und schlägt deshalb regelmäßig Änderungen vor, die genau die Anker aufweichen, die das Projekt bewusst hart hält — Lockerung von Evidence-Gating-Validatoren, lokale Provider-Detection-Heuristiken neben der Registry, abgeschwächte Test-Assertions.

Diese Konfiguration gibt dem Reviewer den fehlenden Projektkontext.

## Was

- `path_instructions` für Evidence-Gating (ADR-0002), Layer-0-Contracts, Provider-Detection-SSoT, Embedding-Pfade (ADR-0007), Tests, Vue/i18n, Workflows und ADRs
- `path_filters` gegen Lockfiles und Archiv. `schemas/` bleibt bewusst **im** Review, weil Schema-Drift ein inhaltliches Signal ist
- `finishing_touches.autofix: false` — Autofix-Commits würden das Opus-Review-Gate vor Push und PR umgehen
- `ruff` und `markdownlint` aus, weil beide bereits im Pre-Push-Gate laufen
- `auto_review.drafts: false` — Draft-PRs entstehen hier vor dem Review-Gate

## Verifikation

- Gegen `https://coderabbit.ai/integrations/schema.v2.json` validiert: **0 Fehler**, alle Tool-Keys existieren
- Backend-Gate grün: 384 Contract-Tests, 46 Schemas in sync, `sync-status --check` OK
- Frontend-Gate grün: 170 Testdateien, 1496 Tests

Der Diff enthält ausschließlich `.coderabbit.yaml`, keine Code-Dateien.

## Dieser PR ist sein eigener Test

CodeRabbit reviewt hier seine eigene Konfiguration. Ob die `path_instructions` greifen, zeigt sich erst an den nächsten PRs, die die geschützten Pfade berühren.

## Bekannte Nebenbefunde (nicht Teil dieses PRs)

- `CLAUDE.md` nennt als ADR-0002-Hartanker `backend/app/services/report_prompts.py`. Die Datei existiert nicht mehr — es ist ein Paket, der `evidence_gating`-Block steckt in `report_prompts/sections.py`. Diese Konfiguration zeigt bereits auf den Paketpfad.
- `frontend/src/views/v4/__tests__/HistoryView.spec.ts` erzeugt sporadisch `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`. Alle Tests bestehen, aber der Lauf endet mit Exit 1. Im Wiederholungslauf grün — Flake, kein Defekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Code-Reviews werden umfassend automatisiert und durch projektspezifische Prüfvorgaben, Sicherheitsprüfungen und Chat-Antworten unterstützt.
  * Zusammenfassungen und generierte Docstrings werden auf Deutsch erstellt.

* **Konfiguration**
  * Bestimmte Dateien und Artefakte werden von Reviews ausgeschlossen.
  * Vorgaben für Backend, Frontend, Tests, Protokollierung, Barrierefreiheit und Geheimnisse wurden ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->