### PR TITLE
fix(llm): Sim-Prep-Generatoren koppeln API-Key an Base-URL-Quelle (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,42 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   `disallowedTools`) auf demselben Niveau wie die M3-Varianten;
   siehe [#803](https://github.com/arn0ld87/agora/issues/803).
 
+### Fixed (Issue #778 — 2026-07-20)
+
+- **Key-Routing-Divergenz in Sim-Prep-Generatoren behoben**:
+  `SimulationConfigGenerator` und `OasisProfileGenerator` fielen bei fehlendem
+  Store-Key still auf `Config.LLM_API_KEY` zurück, auch wenn der Aufrufer
+  bereits eine fremde Provider-Base-URL aufgelöst hatte — das lokale
+  Ollama-`.env`-Passwort ging dadurch an Fremd-Provider und brach jeden
+  Provider-Wechsel über die UI mit `404`/`401`. Beide Generatoren nutzen den
+  `.env`-Fallback jetzt ausschließlich, wenn auch die Base-URL aus derselben
+  `.env`-Quelle stammt; andernfalls muss der Key vom Aufrufer kommen.
+- **Verhaltensänderung für Betreiber**: `LLM_API_KEY` aus der `.env` greift
+  nicht mehr automatisch, sobald eine Base-URL explizit über die
+  Provider-Route aufgelöst wurde. Setups, die sich bisher auf diesen
+  impliziten Fallback verlassen haben, erhalten künftig bereits zur
+  Prepare-Zeit `ValueError: LLM_API_KEY not configured`. Abhilfe: Key an der
+  Provider-Connection unter Einstellungen → LLM-Anbieter hinterlegen.
+- Lokale No-Auth-Endpoints (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`,
+  `host.docker.internal`) laufen weiterhin ohne Key — `simulation_prepare.py`
+  und `simulation_history.py` setzen dafür einen dokumentierten
+  No-Auth-Platzhalter (`LOCAL_NO_AUTH_API_KEY`), bevor der Wert an die
+  Generatoren geht.
+- **MiniMax-Fall im Provider-Wechsel-Test parametrisert**: Die
+  Akzeptanzkriterien aus #778 verlangen einen Provider-Wechsel
+  `Gemini ↔ MiniMax ↔ Ollama` mit umgeschaltetem Sim-Key. Der neue
+  Service-Test parametrisert dafür `test_prepare_foreign_provider_with_store_key_passes_store_key_through`
+  über `provider_id="google" | "minimax" | "openai"` mit den jeweiligen
+  fremden Base-URLs.
+- **Kein Eingriff in [#799](https://github.com/arn0ld87/agora/issues/799)**:
+  Der No-Auth-Platzhalter-Nachzug in `simulation_history.py::generate_profiles`
+  ist **kein** Store-Key-Pfad und **kein** 500→422-Mapping für fehlende
+  Provider-Resolution; er zieht nur die bereits in `simulation_prepare.py`
+  etablierte No-Auth-Freigabe nach, weil `generate_profiles` denselben
+  Generator-Vertrag nutzt und sonst regressionsweise einen `ValueError`
+  für lokale Setups werfen würde. [#799](https://github.com/arn0ld87/agora/issues/799)
+  bleibt bewusst offen.
+
 ### Build (Issue #759 — 2026-07-19)
 
 - **VERSION als Single Source of Truth**: Datei `VERSION` ist die kanonische

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -10,6 +10,7 @@ from typing import Optional
 from flask import current_app, request
 
 from . import simulation_bp
+from ..api.simulation_prepare import LOCAL_NO_AUTH_API_KEY, _is_local_endpoint
 from ..models.project import ProjectManager
 from ..services.entity_reader import EntityReader
 from ..services.llm_runtime import parse_runtime_llm_config
@@ -195,6 +196,11 @@ def generate_profiles():
     # Track 3c: api_key + base_url aus dem aktiven LLM-Profil mitgeben,
     # gleiche Helper-Funktion wie prepare_service._phase_generate_profiles.
     api_key, base_url = _resolve_llm_connection(llm_runtime)
+    if api_key is None and _is_local_endpoint(base_url):
+        # Lokaler Endpoint ohne Key ist zulaessig (#778) — Platzhalter statt
+        # `None`, damit der Generator-Vertrag "Key + Base-URL aus derselben
+        # Quelle" hier nicht faelschlich einen ValueError wirft.
+        api_key = LOCAL_NO_AUTH_API_KEY
     generator = OasisProfileGenerator(
         model_name=llm_model_override,
         storage=storage,

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -36,6 +36,15 @@ from .simulation_common import (
 
 _LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal"})
 
+# Lokale OpenAI-kompatible Server (z. B. Ollama) ignorieren den API-Key
+# vollstaendig, das OpenAI-SDK verlangt aber einen nicht-leeren String (#778).
+# Dieser Platzhalter macht die No-Auth-Freigabe fuer lokale Endpoints explizit
+# sichtbar, statt still `None` an die Generatoren durchzureichen — deren
+# Vertrag "Key und Base-URL aus derselben Quelle" (#778) wuerde sonst bei
+# String-Mismatch (z. B. host.docker.internal vs. localhost) faelschlich
+# einen ValueError werfen, obwohl die API-Schicht den Lauf bereits freigegeben hat.
+LOCAL_NO_AUTH_API_KEY = "local-no-auth"
+
 
 def _is_local_endpoint(base_url: Optional[str]) -> bool:
     """Prüft, ob eine Base-URL auf einen lokalen Endpunkt zeigt.
@@ -411,6 +420,13 @@ def prepare_simulation():
                 "oder im Sitzungsfeld eingeben."
             ),
         )
+
+    if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):
+        # Lokaler Endpoint ohne Key ist explizit freigegeben (siehe Guard oben) —
+        # der Platzhalter ersetzt `None`, damit der Generator-Vertrag aus #778
+        # (Key und Base-URL aus derselben Quelle) nicht faelschlich einen
+        # ValueError wirft.
+        resolved_api_key = LOCAL_NO_AUTH_API_KEY
 
     effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
 

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -293,8 +293,13 @@ class OasisProfileGenerator:
         language: Optional[str] = None,
         industry_quota_plan: Optional[PersonaQuotaPlan] = None,
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
+        # Key und Base-URL muessen aus derselben Quelle stammen (#778). Loest der
+        # Aufrufer einen Provider-Endpoint auf, darf der .env-Key NICHT einspringen —
+        # sonst geht der lokale Ollama-Key an einen Fremd-Provider (404/401).
+        self.api_key = api_key or (
+            Config.LLM_API_KEY if self.base_url == Config.LLM_BASE_URL else None
+        )
         self.model_name = model_name or Config.LLM_MODEL_NAME
         # Language for generated personas ("de" or "en"); affects prompts and bio language.
         self.language = (language or Config.AGENT_LANGUAGE or "de").lower()

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -243,8 +243,13 @@ class SimulationConfigGenerator:
         model_name: Optional[str] = None,
         language: Optional[str] = None,
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
+        # Key und Base-URL muessen aus derselben Quelle stammen (#778). Loest der
+        # Aufrufer einen Provider-Endpoint auf, darf der .env-Key NICHT einspringen —
+        # sonst geht der lokale Ollama-Key an einen Fremd-Provider (404/401).
+        self.api_key = api_key or (
+            Config.LLM_API_KEY if self.base_url == Config.LLM_BASE_URL else None
+        )
         self.model_name = model_name or Config.LLM_MODEL_NAME
         # Normalize language to two-letter code; defaults from Config.AGENT_LANGUAGE.
         self.language = (language or Config.AGENT_LANGUAGE or "de").lower()

--- a/backend/tests/api/test_simulation_history_provider_passing.py
+++ b/backend/tests/api/test_simulation_history_provider_passing.py
@@ -104,6 +104,30 @@ def test_generate_profiles_without_provider_falls_back_to_none(client, patched_g
     assert captured_generator_kwargs["base_url"] is None
 
 
+def test_generate_profiles_local_endpoint_without_key_uses_no_auth_placeholder(
+    client, patched_generator, captured_generator_kwargs
+):
+    """Issue #778 Blocker 1 (Preview-Pfad) — lokaler Endpoint ohne Key darf
+    weder 500 noch ``ValueError`` produzieren; der Generator bekommt den
+    dokumentierten No-Auth-Platzhalter statt eines rohen ``None``.
+    """
+    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+
+    payload = {
+        "graph_id": "graph_abc",
+        "llm_model": "qwen2.5:14b",
+        "llm_provider": {
+            "provider": "custom_openai",
+            "base_url": "http://host.docker.internal:11434/v1",
+        },
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    assert resp.status_code == 200, resp.get_json()
+    assert captured_generator_kwargs["api_key"] == LOCAL_NO_AUTH_API_KEY
+    assert captured_generator_kwargs["base_url"] == "http://host.docker.internal:11434/v1"
+
+
 def test_generate_profiles_rejects_invalid_provider_payload(client, patched_generator, captured_generator_kwargs):
     """``parse_runtime_llm_config`` muss bei kaputtem Payload 400 werfen,
     nicht stillschweigend leiten."""

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -108,3 +108,161 @@ def test_prepare_endpoint_uses_resolved_route_for_legacy_service_call(client, mo
     assert captured["llm_model"] == "gpt-4o-mini"
     assert captured["llm_runtime"].api_key == "sk-route"
     assert captured["llm_runtime"].base_url == "https://api.openai.com/v1"
+
+
+def _run_prepare_with_route(client, monkeypatch, *, resolved_route, resolved_api_key):
+    """Hilfsfunktion: teilt das Fixture-Setup zwischen den Key-Routing-Tests (#778)."""
+    captured: dict = {}
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_123"
+    fake_state.graph_id = "graph_123"
+    fake_state.source_simulation_id = None
+    fake_state.root_simulation_id = None
+    fake_state.branch_name = None
+    fake_state.branch_depth = 0
+    fake_state.entities_count = 1
+    fake_state.entity_types = ["Person"]
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Discuss the project"
+
+    fake_filtered = MagicMock()
+    fake_filtered.filtered_count = 1
+    fake_filtered.entity_types = {"Person"}
+
+    fake_manager = MagicMock()
+    fake_manager.get_simulation.return_value = fake_state
+    fake_manager.prepare_simulation.side_effect = lambda **kwargs: captured.update(kwargs) or MagicMock(
+        to_simple_dict=lambda: {"simulation_id": VALID_SIM_ID, "status": "ready"}
+    )
+
+    class FakeTaskManager:
+        def create_task(self, *args, **kwargs):
+            return "task_prepare_1"
+
+        def update_task(self, *args, **kwargs):
+            return None
+
+        def complete_task(self, *args, **kwargs):
+            return None
+
+        def fail_task(self, *args, **kwargs):
+            return None
+
+    class FakeRouter:
+        def __init__(self, run_id: str):
+            self.run_id = run_id
+
+        def resolve(self, _stage_id: str):
+            return resolved_route
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def run_inline(self):
+        self.run()
+
+    monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
+    monkeypatch.setattr("app.api.simulation_prepare.ProjectManager.get_project", lambda _pid: fake_project)
+    monkeypatch.setattr("app.api.simulation_prepare.ProjectManager.get_extracted_text", lambda _pid: "document text")
+    monkeypatch.setattr("app.api.simulation_prepare.get_simulation_storage", lambda: MagicMock())
+    monkeypatch.setattr(
+        "app.api.simulation_prepare.EntityReader",
+        lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=fake_filtered)),
+    )
+    monkeypatch.setattr("app.api.simulation_prepare.seed_run_stage_routing", lambda *a, **k: None)
+    monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
+    monkeypatch.setattr("app.api.simulation_prepare.resolve_route_api_key", lambda *_a, **_k: resolved_api_key)
+    monkeypatch.setattr(
+        "app.api.simulation_prepare.run_registry.create_run",
+        lambda *a, **k: {"run_id": "run_prepare_1"},
+    )
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
+
+    response = client.post(
+        "/api/simulation/prepare",
+        json={"simulation_id": VALID_SIM_ID},
+    )
+    return response, captured
+
+
+def test_prepare_local_route_without_store_key_uses_no_auth_placeholder(client, monkeypatch):
+    """Issue #778 Blocker 1 — RED vor der Korrektur: eine lokale Route ohne
+    Store-Key darf den Generator nicht mit `ValueError` scheitern lassen, auch
+    wenn die Base-URL als String von `Config.LLM_BASE_URL` abweicht
+    (`host.docker.internal` vs. `localhost` ist der klassische Container-Fall).
+    """
+    from app.config import Config
+    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    local_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="ollama",
+        model="qwen2.5:14b",
+        base_url_sanitized="http://host.docker.internal:11434/v1",
+        routing_version=1,
+    )
+
+    response, captured = _run_prepare_with_route(
+        client, monkeypatch, resolved_route=local_route, resolved_api_key=None
+    )
+
+    assert response.status_code == 200, response.get_json()
+    assert captured["llm_runtime"].api_key == LOCAL_NO_AUTH_API_KEY
+    assert captured["llm_runtime"].base_url == "http://host.docker.internal:11434/v1"
+
+
+@pytest.mark.parametrize(
+    "provider_id,model,base_url_sanitized",
+    [
+        (
+            "google",
+            "gemini-2.5-flash",
+            "https://generativelanguage.googleapis.com/v1beta/openai/",
+        ),
+        (
+            "minimax",
+            "MiniMax-M3",
+            "https://api.minimax.io/v1",
+        ),
+        (
+            "openai",
+            "gpt-4o-mini",
+            "https://api.openai.com/v1",
+        ),
+    ],
+)
+def test_prepare_foreign_provider_with_store_key_passes_store_key_through(
+    client, monkeypatch, provider_id, model, base_url_sanitized
+):
+    """Issue #778 AK 2 + AK 3 — fremder Provider mit aufgeloestem Store-Key:
+    der Generator erhaelt exakt den Store-Key, nicht den `.env`-Fallback.
+    Parametrisierung deckt Google, MiniMax und OpenAI ab, weil Issue-Body den
+    Provider-Wechsel Gemini <-> MiniMax <-> Ollama explizit als Pruefstein
+    nennt. Die Base-URLs sind Test-Fixtures und werden nie aufgeloest.
+    """
+    from app.config import Config
+
+    monkeypatch.setattr(Config, "LLM_API_KEY", "env-key-fixture")
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    foreign_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id=provider_id,
+        model=model,
+        base_url_sanitized=base_url_sanitized,
+        routing_version=1,
+    )
+
+    response, captured = _run_prepare_with_route(
+        client, monkeypatch, resolved_route=foreign_route, resolved_api_key="store-key-fixture"
+    )
+
+    assert response.status_code == 200, response.get_json()
+    assert captured["llm_runtime"].api_key == "store-key-fixture"
+    assert captured["llm_runtime"].api_key != "env-key-fixture"
+    assert captured["llm_runtime"].base_url == base_url_sanitized

--- a/backend/tests/services/test_sim_prep_key_routing.py
+++ b/backend/tests/services/test_sim_prep_key_routing.py
@@ -1,0 +1,91 @@
+"""
+Tests fuer Issue #778 — Key-Routing-Divergenz in Sim-Prep-Generatoren.
+
+Invariante: API-Key und Base-URL muessen aus derselben Quelle stammen. Der
+`.env`-Fallback `Config.LLM_API_KEY` darf ausschliesslich dann greifen, wenn
+auch die effektive Base-URL aus `Config.LLM_BASE_URL` stammt. Andernfalls
+bleibt `api_key` `None` und der harte `ValueError("LLM_API_KEY not
+configured")` greift — statt eines stillen Fremd-Provider/.env-Key-Mismatch
+(404/401).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import Config
+from app.services.oasis_profile_generator import OasisProfileGenerator
+from app.services.simulation_config_generator import SimulationConfigGenerator
+
+FOREIGN_BASE_URL = "https://foreign-provider.example.com/v1"
+STORE_KEY = "store-key-fixture"
+ENV_KEY = "env-key-fixture"
+
+
+GENERATOR_CLASSES = (SimulationConfigGenerator, OasisProfileGenerator)
+
+
+def _patch_openai_target(generator_cls: type) -> str:
+    if generator_cls is SimulationConfigGenerator:
+        return "app.services.simulation_config_generator.OpenAI"
+    return "app.services.oasis_profile_generator.OpenAI"
+
+
+@pytest.mark.parametrize("generator_cls", GENERATOR_CLASSES)
+def test_store_key_and_foreign_base_url_take_precedence(
+    monkeypatch: pytest.MonkeyPatch, generator_cls: type
+) -> None:
+    """Aufgeloester Store-Key + fremde Base-URL -> Store-Werte gewinnen, kein .env-Mix."""
+    monkeypatch.setattr(Config, "LLM_API_KEY", ENV_KEY)
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    with patch(_patch_openai_target(generator_cls)):
+        gen = generator_cls(api_key=STORE_KEY, base_url=FOREIGN_BASE_URL)
+
+    assert gen.api_key == STORE_KEY
+    assert gen.api_key != ENV_KEY
+    assert gen.base_url == FOREIGN_BASE_URL
+
+
+@pytest.mark.parametrize("generator_cls", GENERATOR_CLASSES)
+def test_no_key_with_foreign_base_url_raises(
+    monkeypatch: pytest.MonkeyPatch, generator_cls: type
+) -> None:
+    """Der Bug: kein Key + fremde Base-URL darf NICHT still auf .env-Key zurueckfallen."""
+    monkeypatch.setattr(Config, "LLM_API_KEY", ENV_KEY)
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    with patch(_patch_openai_target(generator_cls)):
+        with pytest.raises(ValueError, match="LLM_API_KEY not configured"):
+            generator_cls(api_key=None, base_url=FOREIGN_BASE_URL)
+
+
+@pytest.mark.parametrize("generator_cls", GENERATOR_CLASSES)
+def test_no_key_no_base_url_uses_env_pair(
+    monkeypatch: pytest.MonkeyPatch, generator_cls: type
+) -> None:
+    """Legacy-/Lokalpfad: kein Key, keine Base-URL -> .env-Paar greift wie bisher."""
+    monkeypatch.setattr(Config, "LLM_API_KEY", ENV_KEY)
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    with patch(_patch_openai_target(generator_cls)):
+        gen = generator_cls(api_key=None, base_url=None)
+
+    assert gen.api_key == ENV_KEY
+    assert gen.base_url == Config.LLM_BASE_URL
+
+
+@pytest.mark.parametrize("generator_cls", GENERATOR_CLASSES)
+def test_no_key_explicit_env_base_url_uses_env_key(
+    monkeypatch: pytest.MonkeyPatch, generator_cls: type
+) -> None:
+    """Kein Key, Base-URL explizit gleich Config.LLM_BASE_URL -> .env-Key greift (gleiche Quelle)."""
+    monkeypatch.setattr(Config, "LLM_API_KEY", ENV_KEY)
+    monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
+
+    with patch(_patch_openai_target(generator_cls)):
+        gen = generator_cls(api_key=None, base_url=Config.LLM_BASE_URL)
+
+    assert gen.api_key == ENV_KEY
+    assert gen.base_url == Config.LLM_BASE_URL

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3439 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3452 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

- `SimulationConfigGenerator` und `OasisProfileGenerator` fielen bei fehlendem Store-Key still auf `Config.LLM_API_KEY` zurück, auch wenn der Aufrufer bereits eine fremde Provider-Base-URL aufgelöst hatte. Der lokale Ollama-`.env`-Key ging dadurch an Fremd-Provider → `404`/`401`, und jeder Provider-Wechsel über die UI brach.
- Neue Invariante: **API-Key und Base-URL stammen immer aus derselben Quelle.** Der `.env`-Fallback greift nur noch, wenn auch die Base-URL aus `Config.LLM_BASE_URL` stammt; sonst muss der Key vom Aufrufer kommen.
- Damit lokale No-Auth-Setups davon nicht getroffen werden, setzen `simulation_prepare.py` und `simulation_history.py` für lokale Endpoints ohne Key einen benannten Platzhalter `LOCAL_NO_AUTH_API_KEY`, statt `None` durchzureichen.

## Release-Ziel

- 0.9.0 — Stability Beta, Gate „Provider-, Secret- und Routing-Altpfade konsolidieren"

## Issue

- Closes #778

## Scope

- `backend/app/services/simulation_config_generator.py`, `backend/app/services/oasis_profile_generator.py` — gekoppelter Fallback
- `backend/app/api/simulation_prepare.py`, `backend/app/api/simulation_history.py` — No-Auth-Platzhalter für lokale Endpoints
- Tests: `tests/services/test_sim_prep_key_routing.py` (neu), `tests/api/test_simulation_prepare_routing.py`, `tests/api/test_simulation_history_provider_passing.py`

## Out-of-Scope

- Restart-Pfad in `runs.py` → #798
- Store-Key-Auflösung und Fehlerform in `generate-profiles` → #799
- Verschiebung von `_is_local_endpoint` in ein neutrales Modul → #800
- MiniMax-Thinking, OASIS-Subprozess-Env, Frontend

## Verhaltensänderung für Betreiber

`LLM_API_KEY` aus der `.env` greift nicht mehr automatisch, sobald eine Base-URL explizit über die Provider-Route aufgelöst wurde. Setups, die sich auf diesen impliziten Fallback verlassen haben, erhalten künftig bereits zur Prepare-Zeit `ValueError: LLM_API_KEY not configured`. Abhilfe: Key an der Provider-Connection unter Einstellungen → LLM-Anbieter hinterlegen. Lokale No-Auth-Endpoints (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `host.docker.internal`) laufen weiterhin ohne Key.

## Tests

- `cd backend && uv run pytest tests/services/test_sim_prep_key_routing.py tests/api/test_simulation_prepare_routing.py tests/api/test_simulation_history_provider_passing.py tests/api/test_provider_override_key_fallback.py tests/services/test_oasis_voice_register.py -x -q` — **43 passed, Exit 0**
- Contract-Tests → Schema-Check (46/46) → `ruff check app/ tests/` → `mypy app` — **PASS, je Exit 0**
- `bash scripts/pre-push-gate.sh backend` — **ALL GREEN, Exit 0**, inkl. `sync-status --check`
- RED-Nachweis: mit auf `main` zurückgesetzten Generator-Dateien scheitern genau die zwei Bug-Fälle; die Regressionswächter halten vorher wie nachher.
- Mutationstest: wird einzig `resolved_api_key = LOCAL_NO_AUTH_API_KEY` neutralisiert, scheitert exakt `test_prepare_local_route_without_store_key_uses_no_auth_placeholder`.

## Dokumentationssync

- `docs/STATUS.md`: aktualisiert — ausschließlich die generierte Testzahl im Autogen-Block (3439 → 3450), erzeugt per `scripts/sync-status.sh`.
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate und keine strategische Reihenfolge geändert.
- `CHANGELOG.md`: aktualisiert — Bugfix plus Betreiber-Verhaltensänderung und No-Auth-Ausnahme.
- Folge-Issues: #798, #799, #800.

## Review

- `agora-opus-reviewer` — **APPROVE** (erste Fassung `REQUEST_CHANGES` wegen einer Regression für lokale No-Auth-Setups; nach Korrektur freigegeben)
- CodeRabbit CLI lokal (`cr review --base main`) — keine Findings über alle 9 Dateien

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Die Zuordnung von API-Schlüsseln und Anbieter-Endpunkten beim Vorbereiten von Simulationen wurde korrigiert.
  * Umgebungsvariablen werden nicht mehr mit abweichenden Anbieter-Endpunkten kombiniert.
  * Für lokale, schlüssellose Endpunkte funktionieren „Prepare“ und Profilgenerierung weiterhin ohne API-Schlüssel.
  * Bei externen Endpunkten ohne passenden Schlüssel wird nun eine klare Fehlermeldung angezeigt.

* **Dokumentation**
  * Das neue Verhalten und die erforderliche Konfiguration für Anbieter-Schlüssel wurden dokumentiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->