### PR TITLE
chore(ci)(deps): Dependabot camel-ai Backend ignorieren (camel-oasis-Pin-Blockade)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,15 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # camel-ai wird durch camel-oasis==0.2.5 exakt auf 0.2.78 festgepinnt
+    # (alle camel-oasis-Releases pinnen 0.2.78; kein Release erlaubt >=0.2.90).
+    # Solange diese Upstream-Blockade besteht, sind camel-ai-Dependabot-Bumps
+    # nicht mergbar (Backend-Gate bricht mit `No solution found`). Tracking:
+    # Issue #806 (camel-oasis-Upstream-Release mit camel-ai>=0.2.90) und
+    # #762 (Master-Thema Backend-Dependency-SSoT). Re-Aktivieren, sobald
+    # camel-oasis>=0.2.6 verfügbar ist, das camel-ai>=0.2.90 akzeptiert.
+    ignore:
+      - dependency-name: "camel-ai"
     groups:
       python-minor-patch:
         update-types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   `disallowedTools`) auf demselben Niveau wie die M3-Varianten;
   siehe [#803](https://github.com/arn0ld87/agora/issues/803).
 
+### Changed (CI/Dependabot — 2026-07-20, Branch `chore/dependabot-ignore-camel-ai`)
+
+- **Dependabot: `camel-ai` im pip-Backend-Block temporär ignoriert**.
+  `camel-oasis==0.2.5` pinnt exakt `camel-ai==0.2.78` (alle
+  `camel-oasis`-Releases auf PyPI pinnen 0.2.78 fest; kein Release
+  akzeptiert `>=0.2.90`). Der offene Dependabot-Bump PR #793 wurde
+  deshalb geschlossen. Der `ignore`-Eintrag verhindert weitere
+  No-Op-Retry-PRs, bis `camel-oasis` ein Release mit
+  `camel-ai>=0.2.90` veröffentlicht (Tracking: [#806](https://github.com/arn0ld87/agora/issues/806))
+  oder Issue #762 (`build(0.9): Backend-Dependency-SSoT und
+  Security-Drift bereinigen`) das Pin-Set löst. Kein
+  Laufzeit-Verhalten-Change.
+
 ### Fixed (Issue #778 — 2026-07-20)
 
 - **Key-Routing-Divergenz in Sim-Prep-Generatoren behoben**:


### PR DESCRIPTION
## Kontext
`camel-oasis==0.2.5` pinnt exakt `camel-ai==0.2.78`. Alle `camel-oasis`-Releases auf PyPI (0.2.0 bis 0.2.5) pinnen 0.2.78 fest; kein Release akzeptiert `camel-ai>=0.2.90`. Solange diese Upstream-Blockade besteht, sind alle `camel-ai`-Dependabot-Bumps nicht mergbar — der Backend-Gate (`uv lock`) bricht mit `No solution found when resolving dependencies for split`.

## Inhalt
- `.github/dependabot.yml`: `ignore`-Eintrag für `camel-ai` im pip-Backend-Block hinzugefügt. Dependabot erzeugt damit keine weiteren No-Op-Retry-PRs, bis Upstream nachzieht.
- `CHANGELOG.md`: Eintrag unter Unreleased → "Changed (CI/Dependabot — 2026-07-20)".

## Re-Aktivierungs-Trigger
Sobald `camel-oasis>=0.2.6` verfügbar ist, das `camel-ai>=0.2.90` akzeptiert:
1. Tracking-Issue [#806](https://github.com/arn0ld87/agora/issues/806) lösen.
2. Den `ignore`-Eintrag aus `.github/dependabot.yml` entfernen.
3. Dependabot-Pipeline reaktivieren → nächster Lauf mergt den Bump automatisch.

Alternativ kann das camel-oasis-Pin-Set auch im Rahmen von [#762](https://github.com/arn0ld87/agora/issues/762) "build(0.9): Backend-Dependency-SSoT und Security-Drift bereinigen" aufgelöst werden (z.B. durch Replacement gegen `langgraph`).

## Verknüpfungen
- Geschlossener Bump: [#793](https://github.com/arn0ld87/agora/pull/793)
- Upstream-Tracking: [#806](https://github.com/arn0ld87/agora/issues/806)
- Master-Thema: [#762](https://github.com/arn0ld87/agora/issues/762)
- Baseline-Doku: [`docs/security-hardening.md` §"Temporäre Baseline" Zeilen 399–410](docs/security-hardening.md)

## Verifikation
- YAML-Syntax geprüft: `ignore: [{dependency-name: "camel-ai"}]` valides Dependabot v2-Schema.
- `git diff` minimal: 2 Dateien, +22/–0.
- agora-reviewer-m3: APPROVE.
- Kein Laufzeit- oder Verhaltens-Change.

Diff-Stat:
- `.github/dependabot.yml`: 9 eingefügt (ignore-Block + Begründungs-Kommentar)
- `CHANGELOG.md`: 13 eingefügt (Changed-Subsektion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Changelog um einen Hinweis zur vorübergehenden Aussetzung automatischer Updates für `camel-ai` ergänzt.
  * Erläutert, dass derzeit keine Änderungen am Laufzeitverhalten erfolgen.

* **Wartung**
  * Automatische Update-Anfragen für `camel-ai` werden vorübergehend unterdrückt, bis eine kompatible Version verfügbar ist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->