### PR TITLE
chore(deps): bump @types/node from 25.8.0 to 26.1.1 in /frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (Frontend-Dependency-Batch — 2026-07-20, Branch `chore/frontend-deps-batch`)
+
+- **`@types/node` `^25.8.0` → `^26.1.1`** in `frontend/package.json` (Types-only,
+  kein Laufzeit-Verhalten-Change). Konsolidiert vier kollidierende
+  Dependabot-PRs auf derselben `package.json`-Zeile: #789 (pinia 4) und #791
+  (@pinia/testing 2) wegen eines Vitest-`EnvironmentTeardownError`-Race in
+  `AppShell.spec.ts` vertagt auf [#811](https://github.com/arn0ld87/agora/issues/811),
+  #792 (typescript 7) wegen einer vue-tsc/@typescript-eslint-Toolchain-Blockade
+  vertagt auf [#812](https://github.com/arn0ld87/agora/issues/812), #790
+  (identischer @types/node-Bump) direkt durch diesen Slice ersetzt. Alle vier
+  PRs geschlossen.
+
 ### Added (Subagent-Modellmigration — 2026-07-20)
 
 - **Subagenten auf `MiniMax-M3` migriert**: Sechs operative

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,7 +30,7 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.49.0",
         "@types/d3": "^7.4.3",
-        "@types/node": "^25.8.0",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/parser": "^8.59.2",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/coverage-v8": "^4.1.5",
@@ -320,7 +320,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -374,11 +374,11 @@
 
     "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.34", "", { "dependencies": { "@vue/compiler-dom": "3.5.34", "@vue/shared": "3.5.34" } }, "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ=="],
 
-    "@vue/devtools-api": ["@vue/devtools-api@7.7.9", "", { "dependencies": { "@vue/devtools-kit": "^7.7.9" } }, "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g=="],
+    "@vue/devtools-api": ["@vue/devtools-api@7.7.10", "", { "dependencies": { "@vue/devtools-kit": "^7.7.10" } }, "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA=="],
 
-    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
+    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.10", "", { "dependencies": { "@vue/devtools-shared": "^7.7.10", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw=="],
 
-    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.9", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA=="],
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.10", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ=="],
 
     "@vue/language-core": ["@vue/language-core@3.2.9", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.2.0", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw=="],
 
@@ -914,7 +914,7 @@
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.49.0",
     "@types/d3": "^7.4.3",
-    "@types/node": "^25.8.0",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/parser": "^8.59.2",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.5",


### PR DESCRIPTION
## Was

- `@types/node` `^25.8.0` → `^26.1.1` (Dependabot Bump aus PR #790 übernommen)
- `frontend/bun.lock` regeneriert via `bun install`

## Superseded Dependabot PRs

- [#789](https://github.com/arn0ld87/agora/pull/789) — pinia 3.0.4 → 4.0.2 — **excluded**, siehe #811
- [#790](https://github.com/arn0ld87/agora/pull/790) — @types/node 25.8.0 → 26.1.1 — **superseded by this PR**
- [#791](https://github.com/arn0ld87/agora/pull/791) — @pinia/testing 1.0.3 → 2.0.1 — **excluded**, siehe #811
- [#792](https://github.com/arn0ld87/agora/pull/792) — typescript 6.0.3 → 7.0.2 — **excluded**, siehe #812

## Warum nur @types/node

Vier Dependabot-PRs (#789–#792) zielen alle auf dieselbe Zeile in `frontend/package.json` und kollidieren beim FF-Merge über `main`. Batch-Merge-Strategie gewählt (Alex-Freigabe 2026-07-20), dann eingeschränkt auf einen Bump:

- **@types/node**: types-only, kein Runtime-Risiko, kein Vue/Vite/ESLint-Impact. Sauber im Gate.
- **pinia 4 + @pinia/testing 2** ([#789](https://github.com/arn0ld87/agora/pull/789), [#791](https://github.com/arn0ld87/agora/pull/791)): lösen Vitest `EnvironmentTeardownError` in `AppShell.spec.ts` aus. Tests grün, aber Worker-Exit 1. → siehe #811 für Fix-Tracking.
- **typescript 7** ([#792](https://github.com/arn0ld87/agora/pull/792)): `vue-tsc@3.2.9` ruft `typescript/lib/tsc` auf, das TS 7 aus `exports` entfernt hat. `@typescript-eslint/typescript-estree@8.59.3` wirft TypeError auf TS-7-API-Änderung. → siehe #812 für Fix-Tracking.

## Verifikation

- `bun run lint` ✓
- `bun run typecheck` ✓
- `bun run test` ✓ (170/1496 grün)
- `bun run build` ✓
- Schema-Mirror ✓
- `scripts/pre-push-gate.sh frontend` ALL GREEN

Reviewer: `agora-reviewer-m3` (MiniMax-M3) — APPROVED.

## Out of Scope

- pinia-4-API-Migration der Stores (separater Issue #811)
- TypeScript-7-Migration (separater Issue #812)
- Pre-Push-Gate-Härtung gegen Vitest-Worker-Race (separat zu tracken, niedrige Priorität)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Wartung**
  * Aktualisierte Node.js-Typdefinitionen im Frontend von `@types/node` (keine Laufzeitänderung), um die Kompatibilität mit der TypeScript/Tooling-Umgebung zu verbessern.
* **Chores**
  * Eintrag im Changelog zur aktualisierten Frontend-Abhängigkeit im Bereich „Unreleased“ ergänzt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->