### PR TITLE
docs: Draft-PR-Terminologie auf PR korrigieren

### DIFF
--- a/.claude/commands/agora-batch-issues.md
+++ b/.claude/commands/agora-batch-issues.md
@@ -9,7 +9,7 @@ Du bist der Lead und Orchestrator. Du implementierst nicht selbst. Die aktive Ta
 
 ## Ziel
 
-Bearbeite maximal zwei voneinander unabhängige Issues parallel. Jedes Issue erhält genau einen Implementer, einen isolierten Worktree, genau einen lokalen Commit, ein eigenes Opus-Review und einen eigenen Draft-PR.
+Bearbeite maximal zwei voneinander unabhängige Issues parallel. Jedes Issue erhält genau einen Implementer, einen isolierten Worktree, genau einen lokalen Commit, ein eigenes Opus-Review und einen eigenen PR.
 
 ## Globale Regeln
 
@@ -19,7 +19,7 @@ Bearbeite maximal zwei voneinander unabhängige Issues parallel. Jedes Issue erh
 - Maximal zwei Implementer gleichzeitig.
 - Subagenten können keine weiteren Agenten starten. Die gesamte Orchestrierung bleibt beim Lead.
 - Worker pushen, mergen und erstellen keine PRs.
-- Nur der Lead darf nach `APPROVE` pushen und einen Draft-PR öffnen.
+- Nur der Lead darf nach `APPROVE` pushen und einen PR öffnen.
 - Kein `--no-verify`, Force-Push oder automatischer Endlos-Fix-Loop.
 - Keine neue Planungsdatei anlegen.
 
@@ -297,9 +297,9 @@ Prüfe für jedes erfolgreiche Issue vor Push und PR, ob im selben Slice sachlic
 
 Dokumentiere für jedes Artefakt `aktualisiert` oder `NICHT BETROFFEN` mit Begründung. Ist ein erforderliches Datei-Artefakt im Commit nicht enthalten, darf nicht gepusht werden. Gib das betroffene Issue einmalig an denselben Worker zurück, lasse den bestehenden lokalen Commit amendieren und wiederhole für den neuen Commit-SHA Schritt 7 und Schritt 8 vollständig. Dadurch bleibt es bei genau einem Issue-Commit.
 
-Erzeuge notwendige Folge-Issues vor dem Draft-PR und verlinke sie im PR-Body. Der Dokumentationssync eines Issues darf keine Dateien oder Planungen des anderen Issues übernehmen.
+Erzeuge notwendige Folge-Issues vor dem PR und verlinke sie im PR-Body. Der Dokumentationssync eines Issues darf keine Dateien oder Planungen des anderen Issues übernehmen.
 
-## Schritt 10: Push und Draft-PR
+## Schritt 10: Push und PR
 
 Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 
@@ -307,7 +307,7 @@ Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 git push -u origin <branch>
 ```
 
-Öffne für jedes Issue einen separaten Draft-PR gegen `main`.
+Öffne für jedes Issue einen separaten PR gegen `main`.
 
 PR-Body:
 
@@ -349,7 +349,7 @@ Keine beiden Issues in einen gemeinsamen PR quetschen. Git kann viel, aber es mu
 ```markdown
 ## Batch-Ergebnis
 
-| Issue | Worker | Commit | Issue-Test | Gate | Opus | Doku-Sync | Draft-PR |
+| Issue | Worker | Commit | Issue-Test | Gate | Opus | Doku-Sync | PR |
 |---|---|---|---|---|---|---|---|
 | #123 | agora-refactor-worker | `<sha>` | PASS | PASS | APPROVE | vollständig | <URL> |
 

--- a/.claude/commands/agora-next-task.md
+++ b/.claude/commands/agora-next-task.md
@@ -1,5 +1,5 @@
 ---
-description: Master-Orchestrator — wählt das nächste release-relevante GitHub Issue, dispatcht einen isolierten Worker, verifiziert den Commit und lässt Opus vor dem Draft-PR reviewen.
+description: Master-Orchestrator — wählt das nächste release-relevante GitHub Issue, dispatcht einen isolierten Worker, verifiziert den Commit und lässt Opus vor dem PR reviewen.
 allowed-tools: Read, Bash, Grep, Glob, TodoWrite, Agent, AskUserQuestion
 ---
 
@@ -14,7 +14,7 @@ Du bist der Orchestrator, nicht der Implementer. Die aktive Aufgabenquelle sind 
 - Nie direkt auf `main` arbeiten.
 - Der Implementer arbeitet mit `isolation: worktree` und erzeugt genau einen lokalen Commit.
 - Der Implementer pusht, mergt und erstellt keinen PR.
-- Nur der Lead darf nach einem `APPROVE` des `agora-opus-reviewer` pushen und einen Draft-PR öffnen.
+- Nur der Lead darf nach einem `APPROVE` des `agora-opus-reviewer` pushen und einen PR öffnen.
 - Kein `--no-verify`, Force-Push oder automatischer Endlos-Fix-Loop.
 - Keine neue Planungsdatei anlegen.
 
@@ -245,7 +245,7 @@ Bleibt das Urteil negativ, stoppe mit einem konkreten Bericht.
 
 ## Schritt 9: Dokumentationssynchronisation abschließen
 
-Der Dokumentationssync findet zwingend **vor** Push und Draft-PR statt. Verbindliche Reihenfolge des gesamten Ablaufs:
+Der Dokumentationssync findet zwingend **vor** Push und PR statt. Verbindliche Reihenfolge des gesamten Ablaufs:
 
 1. Worker-Commit prüfen (Schritt 7),
 2. frische Issue-Tests ausführen (Schritt 7),
@@ -254,7 +254,7 @@ Der Dokumentationssync findet zwingend **vor** Push und Draft-PR statt. Verbindl
 5. Dokumentationssync prüfen (dieser Schritt),
 6. bei fehlender Dokumentation: Korrekturlauf mit Amend und vollständiger Wiederholung von Schritt 7 und 8,
 7. erst danach pushen (Schritt 10),
-8. Draft-PR erstellen (Schritt 10).
+8. PR erstellen (Schritt 10).
 
 Prüfe, ob im selben Slice sachlich korrekt abgebildet sind:
 
@@ -275,9 +275,9 @@ Ist ein erforderliches Dokumentationsartefakt sachlich betroffen, aber nicht im 
 
 Erst nach erneutem `APPROVE` darf das Issue weiter zu Schritt 10.
 
-Erzeuge notwendige Folge-Issues vor dem Draft-PR und verlinke sie im PR-Body.
+Erzeuge notwendige Folge-Issues vor dem PR und verlinke sie im PR-Body.
 
-## Schritt 10: Push und Draft-PR
+## Schritt 10: Push und PR
 
 Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 
@@ -285,7 +285,7 @@ Nur bei `APPROVE` und abgeschlossenem Dokumentationssync:
 git push -u origin <branch>
 ```
 
-Öffne einen Draft-PR gegen `main` mit:
+Öffne einen PR gegen `main` mit:
 
 ```markdown
 ## Summary
@@ -330,7 +330,7 @@ git push -u origin <branch>
 - Pflichtprüfungen: PASS
 - Gate: PASS
 - Opus: APPROVE
-- Draft-PR: <URL>
+- PR: <URL>
 - Dokumentationssync: <Nachweis>
 - Verbleibende Risiken: keine
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ Allgemeine Tool-Pipeline und Skill-Discovery-Regeln stehen in der globalen `~/.c
 
 ## Issue-Orchestrierung
 
-- `/agora-next-task`: genau ein release-relevantes Issue, ein isolierter Worker, ein lokaler Commit, M3-Review, anschließend Draft-PR.
-- `/agora-batch-issues`: maximal zwei nachweislich unabhängige Issues parallel; jedes Issue bleibt in eigenem Worktree, Commit und Draft-PR.
+- `/agora-next-task`: genau ein release-relevantes Issue, ein isolierter Worker, ein lokaler Commit, M3-Review, anschließend PR.
+- `/agora-batch-issues`: maximal zwei nachweislich unabhängige Issues parallel; jedes Issue bleibt in eigenem Worktree, Commit und PR.
 - Schreibende Worker verwenden `isolation: worktree`, pushen nicht und erzeugen genau einen lokalen Commit.
 - Der Lead verifiziert Diff, Tests und Gate selbst. Worker-Zusammenfassungen gelten nicht als Nachweis.
 - Vor Push und PR prüft `agora-reviewer-m3` read-only den Issue-Commit. Nur `APPROVE` erlaubt die Veröffentlichung.

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -215,7 +215,7 @@ Fehlt ein sachlich erforderliches Datei-Artefakt, wird nicht gepusht. Der besteh
 
 ### 7. Pull Request
 
-Nur nach `APPROVE` und vollständigem Dokumentationssync pusht der Lead den Issue-Branch und öffnet einen separaten Draft-PR.
+Nur nach `APPROVE` und vollständigem Dokumentationssync pusht der Lead den Issue-Branch und öffnet einen separaten PR.
 
 Der Pull Request enthält:
 


### PR DESCRIPTION
## Summary
- \`Draft-PR\` durch \`PR\` ersetzt in \`CLAUDE.md\`, \`.claude/commands/agora-next-task.md\`, \`.claude/commands/agora-batch-issues.md\`, \`docs/runbooks/subagent-routing.md\`

## Release-Ziel
- Kein Produkt-Release-Bezug — reine Prozess-/Doku-Korrektur

## Scope
- Vier Dateien, nur Terminologie-Änderung, kein Verhaltens-Code

## Out-of-Scope
- \`docs/HANDOVER-2026-07-20.md\` (historisches Session-Protokoll, bewusst unverändert)
- \`~/.claude/skills/coderabbit/references/yaml-config.md\` (allgemeine, Repo-unabhängige Tool-Doku)

## Begründung
Opus-Review lief in \`/agora-next-task\` und \`/agora-batch-issues\` immer schon vor Push/PR (Schritt 8 vor Schritt 10). Der Draft-Zustand danach war nie sinnvoll — CodeRabbit reviewt Drafts laut \`.coderabbit.yaml\` (\`drafts: false\`) ohnehin nicht automatisch. Das erzwang in dieser Session zweimal (PR #813, #814) einen unnötigen \`gh pr ready\`-Umweg, bevor CodeRabbit überhaupt anlief.

## Tests
- Keine — reine Markdown-Terminologie, kein Code-, Contract- oder Schema-Touch. Kein Gate-Scope einschlägig.

## Dokumentationssync
- \`docs/STATUS.md\`: NICHT BETROFFEN — kein Produkt-Istzustand
- \`ROADMAP.md\`: NICHT BETROFFEN — kein Release-Gate
- \`CHANGELOG.md\`: NICHT BETROFFEN — kein ausgeliefertes Nutzer-/Betriebsverhalten, reiner interner Agent-Workflow
- Folge-Issue: NICHT BETROFFEN

## Tracking
- Kein zugehöriges Issue — administrative Korrektur, im Chat mit Alex entschieden (2026-07-20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Aktualisierte Anleitungen und Runbooks beschreiben nun die Erstellung eines regulären Pull Requests statt eines Draft-PRs nach erfolgreicher Freigabe.
  * Die Reihenfolge von Dokumentationsabgleich, Folge-Issues sowie Push und PR wurde präzisiert.
  * Abschlussausgaben und Ergebnistabellen zeigen nun die PR-URL beziehungsweise den regulären PR-Status an.
  * Die bestehenden Regeln für die parallele Bearbeitung unabhängiger Aufgaben bleiben unverändert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->