### PR TITLE
fix(llm): positionsblinden `title`-Drop im Strict-Schema-Sanitizer beheben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Report-Rescue: positionsblinder `title`-Drop im Strict-Schema-Sanitizer — 2026-07-20, Branch `fix/report-rescue-real-provider`)
+
+- **`_enforce_openai_strict_schema` strippte `title` positionsblind** in
+  `backend/app/llm/json_mode.py`. Der rekursive `_walk` filterte den
+  JSON-Schema-Metadaten-Key `title` über jeden Dict-Knoten — auch dort,
+  wo `title` der **Name einer Property** ist (`properties: {"title": {...}}`,
+  genutzt von `PlanSection` und `PlanResponse`). Die an
+  OpenAI/Google geschickten Schemas verloren die Pflicht-Property
+  `title`, die LLM-Antworten scheiterten danach an der Pydantic-
+  Validierung mit „12 validation errors for PlanResponse — alle
+  `…title: Field required`", und der gesamte Report-Lauf fiel auf
+  `failed`. Fix: Sonderbehandlung des `properties`-Keys in `_walk` —
+  die Keys darunter sind Property-Namen, keine Schema-Metadaten; nur
+  die Feld-Schemata (values) werden rekursiv gewalkt, dort greift das
+  Metadaten-Stripping normal.
+- **Regressionstest neu** in
+  `backend/tests/llm/test_json_mode_strict_schema.py`: drei Tests
+  pinnen die positionsbewusste Unterscheidung — `title` als
+  Property-Name überlebt in `properties + required`, `title` als
+  Metadatum auf Objekt-Ebene wird weiter gestrippt,
+  `PlanResponse`-Schema behält `title` top-level und je Section.
+  RED → GREEN mit der Code-Änderung verifiziert.
+- **End-to-End-Beweis** auf der `minimax`/`MiniMax-M3`-Route mit
+  `llm_model="MiniMax-M3"` (umgeht die alte
+  `llm_profile_id`-Präzedenz auf das zu schwache `google`-
+  `gemini-2.5-flash-lite`-Profil): Run B
+  (`report_47705048af01`, task `526d06c6…`) lief auf
+  `status: completed`, `progress: 100`, alle 11 Pflichtabschnitte im
+  Outline (`missing_sections: []`, Reihenfolge Executive Summary →
+  Datenlücken eingehalten), Markdown-Export HTTP 200 mit
+  131 067 Bytes (`format=md`), keine Fallback-Marker
+  (`Scenario Evaluation Report` etc.). Out of scope dieses Slices:
+  ReACT-Thinking-Leak, hängende Reports ohne Progress, fehlendes
+  `provider_connection_id`-Param am Generate-Endpunkt und der
+  `/api/report/export?format=markdown` 400 — diese werden in
+  Folgeslices adressiert.
+
 ### Fixed (pinia 4 + @pinia/testing 2 Migration — 2026-07-20, Branch `fix/811-pinia4-vitest-teardown-race`)
 
 - **`pinia` `^3.0.4` → `^4.0.2`, `@pinia/testing` `^1.0.3` → `^2.0.1`** in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,16 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Metadatum auf Objekt-Ebene wird weiter gestrippt,
   `PlanResponse`-Schema behält `title` top-level und je Section.
   RED → GREEN mit der Code-Änderung verifiziert.
-- **End-to-End-Beweis** auf der `minimax`/`MiniMax-M3`-Route mit
-  `llm_model="MiniMax-M3"` (umgeht die alte
-  `llm_profile_id`-Präzedenz auf das zu schwache `google`-
-  `gemini-2.5-flash-lite`-Profil): Run B
-  (`report_47705048af01`, task `526d06c6…`) lief auf
+- **End-to-End-Beweis (zwei aufeinanderfolgende Läufe)** auf der
+  `minimax`/`MiniMax-M3`-Route mit `llm_model="MiniMax-M3"`
+  (umgeht die alte `llm_profile_id`-Präzedenz auf das zu schwache
+  `google`/`gemini-2.5-flash-lite`-Profil): Run B
+  (`report_47705048af01`, task `526d06c6…`) und Run C
+  (`report_715e4a552ce0`, task `5d39cfc1…`) liefen beide auf
   `status: completed`, `progress: 100`, alle 11 Pflichtabschnitte im
   Outline (`missing_sections: []`, Reihenfolge Executive Summary →
   Datenlücken eingehalten), Markdown-Export HTTP 200 mit
-  131 067 Bytes (`format=md`), keine Fallback-Marker
+  ≥ 131 067 Bytes (`format=md`), keine Fallback-Marker
   (`Scenario Evaluation Report` etc.). Out of scope dieses Slices:
   ReACT-Thinking-Leak, hängende Reports ohne Progress, fehlendes
   `provider_connection_id`-Param am Generate-Endpunkt und der

--- a/backend/app/llm/json_mode.py
+++ b/backend/app/llm/json_mode.py
@@ -122,6 +122,15 @@ def _enforce_openai_strict_schema(model_or_schema: Any) -> Dict[str, Any]:
             for k, v in node.items():
                 if k in _STRICT_DROP_KEYS:
                     continue
+                if k == "properties" and isinstance(v, dict):
+                    # Keys unter ``properties`` sind Property-NAMEN, keine
+                    # Schema-Metadaten-Keywords. Sie dürfen nie gegen
+                    # _STRICT_DROP_KEYS gefiltert werden — sonst verschwindet
+                    # eine Property, die zufällig ``title`` (oder ``default``,
+                    # ``format`` …) heißt. Die Feld-Schemata (values) werden
+                    # weiter gewalkt, dort greift das Metadaten-Stripping normal.
+                    out[k] = {pk: _walk(pv, seen) for pk, pv in v.items()}
+                    continue
                 out[k] = _walk(v, seen)
             if out.get("type") == "object":
                 out["additionalProperties"] = False

--- a/backend/tests/llm/test_json_mode_strict_schema.py
+++ b/backend/tests/llm/test_json_mode_strict_schema.py
@@ -1,0 +1,69 @@
+"""Regressionstests für _enforce_openai_strict_schema (backend/app/llm/json_mode.py).
+
+Root-Cause-Regression (Report-Rescue 2026-07-20):
+Der Strict-Schema-Sanitizer strippte ``title`` positionsblind — auch dort, wo
+``title`` der NAME einer Property ist (``properties: {"title": {...}}``) und
+nicht ein JSON-Schema-Metadaten-Keyword auf einem Objekt-Knoten. Dadurch verlor
+das an Google/OpenAI gesendete Schema die Pflicht-Property ``title``; die
+LLM-Antwort ohne ``title`` scheiterte danach an der vollständigen
+Pydantic-Validierung (``12 validation errors for PlanResponse`` — alle
+``…title: Field required``), was den kompletten Report-Lauf auf ``failed``
+zog.
+
+Diese Tests pinnen die positionsbewusste Unterscheidung:
+- ``title`` als Property-NAME muss überleben (properties + required).
+- ``title`` als Metadaten-Keyword auf einem Objekt-Knoten wird weiter gestrippt.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.llm.json_mode import _enforce_openai_strict_schema
+from app.services.report_agent.schemas import PlanResponse
+
+
+class _SectionLike(BaseModel):
+    """Minimalmodell mit einer Property, die zufällig ``title`` heißt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, description="Abschnittstitel")
+    description: str = Field(default="—", description="Inhaltsbeschreibung")
+
+
+def test_property_named_title_survives_strict_sanitize() -> None:
+    """Eine Property namens ``title`` darf NICHT gestrippt werden."""
+    out = _enforce_openai_strict_schema(_SectionLike)
+
+    props = out["properties"]
+    assert "title" in props, (
+        "Property-Name 'title' wurde fälschlich gestrippt — "
+        f"vorhandene Properties: {sorted(props)}"
+    )
+    assert "description" in props
+    # OpenAI/Google strict-mode: jede Property muss in required[] stehen.
+    assert set(out["required"]) == {"title", "description"}
+
+
+def test_object_level_title_metadata_is_still_dropped() -> None:
+    """Das Objekt-Metadatum ``title`` (Sibling von type/properties) bleibt weg."""
+    out = _enforce_openai_strict_schema(_SectionLike)
+
+    # Pydantic setzt auf Objekt-Ebene "title": "_SectionLike" — reines Metadatum.
+    assert "title" not in {k for k in out if k != "properties"}
+    # Auch im Feld-Schema selbst ist "title" ein Pydantic-Metadatum → gestrippt.
+    assert "title" not in out["properties"]["title"]
+
+
+def test_plan_response_schema_keeps_title_in_sections() -> None:
+    """Regression: PlanResponse-Schema behält title top-level und je Section."""
+    out = _enforce_openai_strict_schema(PlanResponse)
+
+    assert "title" in out["properties"], "top-level title-Property fehlt"
+    assert "title" in out["required"]
+
+    section_schema = out["properties"]["sections"]["items"]
+    assert "title" in section_schema["properties"], (
+        "Section-Property 'title' wurde gestrippt — Gemini kann sie nicht liefern"
+    )
+    assert "title" in section_schema["required"]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3452 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3455 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Was

OpenAI-/Google-strict-**json_schema**-Mode lehnt das JSON-Schema-
Metadaten-Keyword `title` auf Objekt-Knoten ab. Unser Sanitizer
`_enforce_openai_strict_schema` filterte `title` über jeden
rekursiven _walk-Schritt — auch dort, wo `title` der **Name einer
Property** ist (`properties: {"title": {...}}`, genutzt von
`PlanSection` und `PlanResponse`).

Dadurch verlor das an den Provider gesendete Schema die
Pflicht-Property `title`, die LLM-Antwort lieferte kein
`title`-Feld, Pydantic-Validierung schlug mit zwölf
"Field required"-Fehlern fehl, und der Report-Lauf fiel über den
schwachen 3-Section-English-Fallback in `plan_outline()` auf
`status='failed'`.

## Fix

In `_walk` wird `properties` als Sonderfall behandelt — die
Keys darunter sind Property-**Namen** und werden **nicht** gegen
`_STRICT_DROP_KEYS` gefiltert. Nur die Feld-Schemata (values)
werden rekursiv gewalkt; dort greift das Metadaten-Stripping
weiter normal.

```python
if k == "properties" and isinstance(v, dict):
    # Keys unter properties sind Property-NAMEN, keine
    # Schema-Metadaten-Keywords. Sie dürfen nie gegen
    # _STRICT_DROP_KEYS gefiltert werden …
    out[k] = {pk: _walk(pv, seen) for pk, pv in v.items()}
    continue
```

## Regressionstest

`backend/tests/llm/test_json_mode_strict_schema.py` (3 Cases):
1. `test_property_named_title_survives_strict_sanitize` — Property
   namens `title` überlebt in `properties + required`.
2. `test_object_level_title_metadata_is_still_dropped` —
   `title` als Metadatum auf Objekt-Ebene wird weiter gestrippt.
3. `test_plan_response_schema_keeps_title_in_sections` —
   `PlanResponse` real, `title` top-level und je Section.

RED → GREEN mit derselben Code-Änderung verifiziert.

## E2E-Beweis (minimax / MiniMax-M3, simulation_id sim_df233e7366bd)

| Run | Provider | Model | Status | Progress | Missing Sections | Markdown Export |
|---|---|---|---|---|---|---|
| run_15fc172d57e3 (B) | minimax | MiniMax-M3 | **completed** | 100 | 0/11 | HTTP 200, 131 067 Bytes |

Alle 11 Pflichtabschnitte in korrekter Reihenfolge im Outline
(`missing_sections=[]`): Executive Summary, Segment-Tabelle,
Persona-Tabelle, Multiplikator-Auswertung, Top 10 Reibungspunkte,
Top 10 Vertrauenssignale, Top 10 Änderungen, Projektwirkung,
Positionierung, Content-Ideen, Datenlücken. Kein
`Scenario Evaluation Report`/Fallback-Marker.

Out-of-scope dieses Slices (Folgissues): ReACT-Thinking-Leak,
hängende Reports ohne Progress, fehlendes `provider_connection_id`
am Generate-Endpunkt, `/api/report/export?format=markdown` 400.

## Pre-Push-Gate (alle grün)

```
contracts pytest      384 passed
dump_schemas --check  alle 46 Schemas matchen
ruff check app/ tests/  All checks passed
mypy app              Success: no issues found in 230 source files
new strict-schema tests 3 passed  (bestehende 27 unverändert grün)
```

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Schema-Feldnamen wie „title“ bleiben bei der Verarbeitung erhalten.
  * Plan- und Report-Validierungen funktionieren dadurch wieder zuverlässig.
  * Nicht benötigte Schema-Metadaten werden weiterhin korrekt entfernt.

* **Tests**
  * Regressionstests decken betroffene Schemas und aufeinanderfolgende Abläufe ab.
  * Die dokumentierte Anzahl erfolgreicher Backend-Tests wurde aktualisiert.

* **Dokumentation**
  * Der Fix wurde im Abschnitt „Unreleased“ des Changelogs ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->