### PR TITLE
fix(report): UI-selected ProviderConnection als autoritative Report-Route (#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Report-Route-SSoT: UI-Auswahl ist die autoritative Report-Route — 2026-07-21, Branch `fix/report-provider-route-ssot`, Issue #817)
+
+- **Route-Snapshot ↔ Client-Divergenz in `ReportGenerationService.start_generation`** behoben
+  (`backend/app/services/report_generation.py`). Bei gesetztem LLM-Profil beschrieb der
+  gelockte `report_generation`-Route-Snapshot den Workspace-/Global-Default (z. B. Google),
+  während der ausgeführte `LLMClient` über den Parallelpfad `build_client_from_profile` ein
+  anderes Profil (z. B. MiniMax) nutzte. Ursache: `seed_run_stage_routing` wurde ohne
+  `llm_profile_id` aufgerufen, und der Client entstand außerhalb der gelockten Route. Fix: ein
+  einziger autoritativer Pfad — seed (mit Profil/AiModelRef) → resolve → lock → `LLMClient.from_route`
+  ausschließlich aus der gelockten Route. Der Parallelpfad `build_client_from_profile` entfällt in
+  `start_generation`; ein Profil ist nur noch Eingang zur Routenerzeugung.
+- **Explizite `ai_model_ref` am Generate-Endpunkt** (`POST /api/report/generate`): Der Request
+  überträgt jetzt die vollständige kanonische Auswahl (`provider_connection_id`, `model_id`,
+  `source`) als autoritative Report-Route. Neuer Backend-Contract `AiModelRef`
+  (`backend/app/contracts/ai_provider_contract.py`) spiegelt das Frontend-`AiModelRefSchema`.
+  Prioritätsreihenfolge: explizite `ai_model_ref` > Legacy-`llm_profile_id` > Projektprofil >
+  Stage-Override > Workspace-Default. Widersprüchliche explizite Eingaben (`ai_model_ref` plus
+  Legacy-Feld) werden mit HTTP 400 abgelehnt; unbekannte/deaktivierte ProviderConnection ebenso.
+- **Run-Metadaten/Model-Attribution** stammen aus der gelockten Route statt aus den rohen
+  Request-Feldern.
+- **Frontend** (`frontend/src/components/Step4Report.vue`, `frontend/src/api/report.ts`): Ein
+  expliziter Picker-Pick sendet `ai_model_ref` und kein konkurrierendes `llm_profile_id`/`llm_model`;
+  ohne Pick wird kein erfundener Override gesendet. `GenerateReportData` ist um `ai_model_ref`
+  typisiert.
+- **Tests neu**: `backend/tests/services/test_report_provider_route_ssot.py` (RED→GREEN:
+  Snapshot ≡ Client, AiModelRef→Route, unbekannte/deaktivierte Connection, Run-Metadaten,
+  kein Secret-Leak), `backend/tests/api/test_report_provider_route_api.py` (Contract + Konflikt-400)
+  und drei Payload-Tests in `frontend/src/components/__tests__/Step4Report.spec.ts`.
+
 ### Fixed (Report-Rescue: positionsblinder `title`-Drop im Strict-Schema-Sanitizer — 2026-07-20, Branch `fix/report-rescue-real-provider`)
 
 - **`_enforce_openai_strict_schema` strippte `title` positionsblind** in

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -120,15 +120,39 @@ def generate_report():
         return json_error(str(mode_exc), status=400)
 
     force_regenerate = data.get('force_regenerate', False)
-    from ..utils.llm_profile_resolver import expand_profile_in_data
-    expand_profile_in_data(data)
-    llm_model_override = (data.get('llm_model') or '').strip() or None
-    try:
-        llm_runtime = parse_runtime_llm_config(data)
-    except ValueError as exc:
-        return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
 
-    llm_profile_id = (data.get('llm_profile_id') or '').strip() or None
+    # Explizite UI-Auswahl (AiModelRef) ist die autoritative Report-Route und
+    # darf nicht still mit Legacy-Feldern kombiniert werden (Issue #817).
+    ai_model_ref = None
+    raw_ref = data.get('ai_model_ref')
+    if raw_ref is not None:
+        from pydantic import ValidationError
+        from ..contracts.ai_provider_contract import AiModelRef
+        try:
+            ai_model_ref = AiModelRef.model_validate(raw_ref)
+        except ValidationError:
+            return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message="ai_model_ref ist ungültig")
+        conflicting = [key for key in ('llm_profile_id', 'llm_model', 'llm_provider') if data.get(key)]
+        if conflicting:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=f"ai_model_ref darf nicht mit {', '.join(conflicting)} kombiniert werden",
+            )
+
+    if ai_model_ref is None:
+        from ..utils.llm_profile_resolver import expand_profile_in_data
+        expand_profile_in_data(data)
+        llm_model_override = (data.get('llm_model') or '').strip() or None
+        try:
+            llm_runtime = parse_runtime_llm_config(data)
+        except ValueError as exc:
+            return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
+        llm_profile_id = (data.get('llm_profile_id') or '').strip() or None
+    else:
+        llm_model_override = None
+        llm_runtime = parse_runtime_llm_config({})
+        llm_profile_id = None
 
     try:
         result = ReportGenerationService.start_generation(
@@ -137,7 +161,8 @@ def generate_report():
             force_regenerate=force_regenerate,
             llm_model_override=llm_model_override,
             llm_runtime=llm_runtime,
-            llm_profile_id=llm_profile_id
+            llm_profile_id=llm_profile_id,
+            ai_model_ref=ai_model_ref,
         )
         return json_success(result)
     except ValueError as exc:

--- a/backend/app/contracts/ai_provider_contract.py
+++ b/backend/app/contracts/ai_provider_contract.py
@@ -261,6 +261,34 @@ class AiModel(BaseModel):
     metadata_updated_at: datetime | None = None
 
 
+AiModelRefSource = Literal[
+    "stage-override",
+    "run-override",
+    "project-default",
+    "workspace-default",
+    "explicit",
+    "fallback",
+]
+
+
+class AiModelRef(BaseModel):
+    """Kanonische (Provider-Connection, Modell)-Referenz — Backend-Spiegel des
+    Frontend-``AiModelRefSchema`` (``frontend/src/contracts/aiModelRef.ts``).
+
+    Bewusst klein: identifiziert genau die vom UI gewählte Route. Größere
+    Metadaten (Capabilities, Status) bleiben in der ``ProviderConnection`` bzw.
+    im Model-Katalog. Trägt keine Secrets.
+    """
+
+    model_config = _STRICT
+
+    provider_connection_id: str = Field(min_length=1)
+    model_id: str = Field(min_length=1)
+    source: AiModelRefSource = "explicit"
+    capability_filter: str | None = None
+    fallback_reason: str | None = None
+
+
 class AiRoute(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+from ..contracts.ai_provider_contract import AiModelRef, ProviderConnection
 from ..contracts.llm_routing_contract import ResolvedRoute, RuntimeLlmRouting, StageId, StageLLMRoute
 from ..llm.providers.registry import detect_provider
 from .llm_provider_registry import LlmProviderRegistry
 from .llm_provider_secrets_store import get_llm_provider_secrets_store
 from .llm_profiles_store import get_llm_profiles_store
 from .llm_runtime import RuntimeLlmConfig
-from .profile_connection_resolver import resolve_profile_connection
+from .profile_connection_resolver import canonical_connection_base_url, resolve_profile_connection
 from .provider_connection_store import ProviderConnectionStore
 from .runtime_run_config import RuntimeRunConfig
 from .secret_resolver import SecretResolver, get_bound_store_api_key
@@ -43,6 +44,24 @@ def map_runtime_provider_to_route_provider(provider: str) -> Optional[str]:
     return _PROVIDER_ID_MAP.get((provider or "default").strip().lower())
 
 
+def _resolve_selected_connection(connection_id: str) -> ProviderConnection:
+    """Resolve an explicitly selected ProviderConnection by id.
+
+    Raises ``ValueError`` when the connection is unknown or disabled, so the
+    caller can surface an HTTP 400/422 instead of silently falling back to a
+    different route.
+    """
+    match = next(
+        (c for c in ProviderConnectionStore().list_connections() if c.id == connection_id),
+        None,
+    )
+    if match is None:
+        raise ValueError(f"ProviderConnection {connection_id!r} nicht gefunden")
+    if not match.enabled:
+        raise ValueError(f"ProviderConnection {connection_id!r} ist deaktiviert")
+    return match
+
+
 def seed_run_stage_routing(
     run_id: str,
     stage_id: StageId,
@@ -50,6 +69,7 @@ def seed_run_stage_routing(
     llm_model_override: Optional[str],
     llm_runtime: Optional[RuntimeLlmConfig],
     llm_profile_id: Optional[str] = None,
+    ai_model_ref: Optional[AiModelRef] = None,
 ) -> RuntimeLlmRouting:
     """
     Persist per-run routing for a stage, applying workspace defaults and request-specific overrides.
@@ -87,7 +107,26 @@ def seed_run_stage_routing(
     runtime = llm_runtime or RuntimeLlmConfig()
     route_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
 
-    if llm_model_override or runtime.enabled:
+    if ai_model_ref is not None:
+        # Höchste Priorität: die vom UI explizit gewählte (Connection, Modell)-Route.
+        # Die Connection ist die SSoT für Base-URL und Secret-Bindung — kein
+        # ``.env``-Fallback, keine lokale Detection-Heuristik.
+        connection = _resolve_selected_connection(ai_model_ref.provider_connection_id)
+        ref_options: dict[str, object] = {}
+        connection_base_url = canonical_connection_base_url(connection)
+        if connection_base_url:
+            ref_options["base_url"] = connection_base_url
+        if connection.auth_mode == "api_key" and connection.secret_ref:
+            ref_options["secret_ref"] = connection.secret_ref
+            ref_options["connection_only"] = True
+        config.stage_overrides[stage_id] = StageLLMRoute(
+            provider_id=connection.id,
+            model=ai_model_ref.model_id,
+            provider_options=ref_options,
+        )
+        if has_existing_config:
+            config.routing_version += 1
+    elif llm_model_override or runtime.enabled:
         provider_options = {}
         if runtime.base_url:
             provider_options["base_url"] = runtime.base_url

--- a/backend/app/services/report_generation.py
+++ b/backend/app/services/report_generation.py
@@ -34,13 +34,17 @@ class ReportGenerationService:
         return not force_regenerate and not llm_model_override and not runtime_provider_override
 
     @classmethod
-    def start_generation(cls, simulation_id, report_mode, force_regenerate, llm_model_override, llm_runtime, llm_profile_id=None):
+    def start_generation(cls, simulation_id, report_mode, force_regenerate, llm_model_override, llm_runtime, llm_profile_id=None, ai_model_ref=None):
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
             raise ValueError(ApiErrorCode.NOT_FOUND)
 
-        if cls.can_reuse_existing_report(force_regenerate, llm_model_override, llm_runtime.enabled):
+        if cls.can_reuse_existing_report(
+            force_regenerate,
+            llm_model_override,
+            llm_runtime.enabled or ai_model_ref is not None,
+        ):
             existing_report = ReportManager.get_report_by_simulation(simulation_id)
             if existing_report and existing_report.status == ReportStatus.COMPLETED:
                 return {
@@ -65,6 +69,7 @@ class ReportGenerationService:
         if (
             _resolved_profile is None
             and not llm_profile_id
+            and ai_model_ref is None
             and (not llm_model_override or llm_model_override.lower() == 'default')
             and getattr(project, 'llm_profile_id', None)
         ):
@@ -120,40 +125,58 @@ class ReportGenerationService:
             task_type="report_generate",
             metadata={"simulation_id": simulation_id, "graph_id": graph_id, "report_id": report_id, "run_id": run_record["run_id"]}
         )
+        # Single Source of Truth: das (ggf. aus dem Projekt geerbte) Profil ist nur
+        # ein Eingang zur Routenerzeugung — es darf keinen zweiten Client-Pfad neben
+        # der gelockten Route öffnen. seed → resolve → lock bestimmen die Route; der
+        # Client wird ausschließlich aus dieser Route gebaut (Issue #817).
         seed_run_stage_routing(
             run_record["run_id"],
             "report_generation",
             llm_model_override=llm_model_override,
             llm_runtime=llm_runtime,
+            llm_profile_id=llm_profile_id,
+            ai_model_ref=ai_model_ref,
         )
         route_router = StageModelRouter(run_record["run_id"])
         resolved_route = route_router.resolve("report_generation")
         route_router.lock_stage("report_generation", resolved_route)
 
+        # Model-Attribution und Run-Metadaten stammen aus der gelockten Route (SSoT),
+        # nicht aus den rohen Request-Feldern — sonst zeigte llm_model bei Profil-/
+        # AiModelRef-Auswahl None an, während die Route ein anderes Modell trägt
+        # (Issue #817). Nur Secret-freie Metadaten.
+        run_registry.update_run(
+            run_record["run_id"],
+            metadata={
+                "llm_model": resolved_route.model,
+                "llm_provider": {
+                    "provider_id": resolved_route.provider_id,
+                    "base_url": resolved_route.base_url_sanitized,
+                },
+            },
+        )
+
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
             raise RuntimeError("GraphStorage not initialized — check Neo4j connection")
 
-        if _resolved_profile is not None:
-            from ..utils.llm_client import build_client_from_profile as _build_from_profile
-            shared_llm_client = _build_from_profile(_resolved_profile, run_id=run_record["run_id"])
-            logger.info(
-                "Using LLM profile %r for report (provider=%s, model=%s) [simulation_id=%s, report_id=%s, project_id=%s, run_id=%s]",
-                llm_profile_id,
-                _resolved_profile.provider,
-                _resolved_profile.model_name,
-                simulation_id,
-                report_id,
-                state.project_id,
-                run_record["run_id"]
-            )
-        else:
-            shared_llm_client = LLMClient.from_route(
-                resolved_route,
-                secret_resolver=SecretResolver(),
-                api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
-                run_id=run_record["run_id"],
-            )
+        shared_llm_client = LLMClient.from_route(
+            resolved_route,
+            secret_resolver=SecretResolver(),
+            api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
+            run_id=run_record["run_id"],
+        )
+        logger.info(
+            "Report LLM route locked provider_id=%s model=%s "
+            "[simulation_id=%s, report_id=%s, project_id=%s, run_id=%s, llm_profile_id=%s]",
+            resolved_route.provider_id,
+            resolved_route.model,
+            simulation_id,
+            report_id,
+            state.project_id,
+            run_record["run_id"],
+            llm_profile_id,
+        )
         graph_tools = GraphToolsService(storage=storage, llm_client=shared_llm_client)
 
         def run_generate():

--- a/backend/tests/api/test_report_provider_route_api.py
+++ b/backend/tests/api/test_report_provider_route_api.py
@@ -1,0 +1,76 @@
+"""API-Contract: POST /api/report/generate akzeptiert eine explizite AiModelRef
+und lehnt widersprüchliche explizite Eingaben ab (Issue #817).
+
+Die Konflikt-Prüfungen greifen vor ``start_generation`` — daher ohne
+Storage-/Routing-Stubs testbar. Der Forward-Test patcht ``start_generation``
+und prüft nur, dass die AiModelRef unverändert durchgereicht wird.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.api import report_bp
+
+VALID_SIM_ID = "sim_0123456789ab"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.config["TESTING"] = True
+    app.config["AGORA_REPORT_RATE_LIMIT_MAX"] = 100
+    app.config["AGORA_REPORT_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    app.register_blueprint(report_bp, url_prefix="/api/report")
+    with app.app_context():
+        yield app.test_client()
+
+
+def _ref_body(**extra):
+    body = {
+        "simulation_id": VALID_SIM_ID,
+        "ai_model_ref": {
+            "provider_connection_id": "conn-minimax",
+            "model_id": "MiniMax-M3",
+            "source": "explicit",
+        },
+    }
+    body.update(extra)
+    return body
+
+
+def test_ai_model_ref_conflicts_with_llm_profile_id_returns_400(client):
+    resp = client.post("/api/report/generate", json=_ref_body(llm_profile_id="prof-x"))
+    assert resp.status_code == 400
+    assert b"ai_model_ref" in resp.data
+
+
+def test_ai_model_ref_conflicts_with_llm_model_returns_400(client):
+    resp = client.post("/api/report/generate", json=_ref_body(llm_model="gemini-1.5-pro"))
+    assert resp.status_code == 400
+
+
+def test_invalid_ai_model_ref_returns_400(client):
+    resp = client.post(
+        "/api/report/generate",
+        json={"simulation_id": VALID_SIM_ID, "ai_model_ref": {"model_id": "x"}},
+    )
+    assert resp.status_code == 400
+
+
+def test_valid_ai_model_ref_is_forwarded_to_start_generation(client):
+    fake = MagicMock(return_value={"status": "generating", "report_id": "report_x"})
+    with patch("app.api.report.ReportGenerationService.start_generation", fake):
+        resp = client.post("/api/report/generate", json=_ref_body())
+    assert resp.status_code == 200
+    forwarded = fake.call_args.kwargs["ai_model_ref"]
+    assert forwarded is not None
+    assert forwarded.provider_connection_id == "conn-minimax"
+    assert forwarded.model_id == "MiniMax-M3"
+    # Legacy-Felder werden bei expliziter AiModelRef nicht mitgeschickt.
+    assert fake.call_args.kwargs["llm_profile_id"] is None
+    assert fake.call_args.kwargs["llm_model_override"] is None

--- a/backend/tests/services/test_report_provider_route_ssot.py
+++ b/backend/tests/services/test_report_provider_route_ssot.py
@@ -1,0 +1,280 @@
+"""RED→GREEN: Der gelockte report_generation-Route-Snapshot muss den tatsächlich
+erzeugten ``LLMClient`` beschreiben (Issue #817).
+
+Belegt die Divergenz: bei gesetztem LLM-Profil beschrieb der gelockte
+``report_generation``-Snapshot den Workspace-Default (z. B. Google), während der
+ausgeführte ``LLMClient`` über ``build_client_from_profile`` ein anderes Profil
+(z. B. MiniMax) nutzte.
+
+Verglichen werden ausschließlich Provider-Connection-ID, Modell und Base-URL —
+niemals Secret-Werte (nur Secret-Quelle/-Referenz).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiModelRef, ProviderConnection
+from app.contracts.llm_profile_contract import LlmProfile
+from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+from app.services import report_generation as rg
+from app.services.llm_runtime import RuntimeLlmConfig
+from app.services.runtime_run_config import RuntimeRunConfig
+from app.utils.artifact_locator import ArtifactLocator
+
+RUN_ID = "run_ssot_red"
+_GOOGLE_BASE = "https://generativelanguage.googleapis.com/v1beta/openai/"
+_MINIMAX_BASE = "https://api.minimaxi.chat/v1"
+
+
+def _ensure_dir(path):
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _minimax_profile() -> LlmProfile:
+    now = datetime.now(UTC)
+    return LlmProfile(
+        id="prof-minimax",
+        name="MiniMax M3",
+        provider="minimax",
+        base_url=_MINIMAX_BASE,
+        model_name="MiniMax-M3",
+        api_key=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _minimax_connection() -> ProviderConnection:
+    return ProviderConnection(
+        id="conn-minimax",
+        provider_kind="minimax",
+        display_name="MiniMax",
+        transport="http",
+        auth_mode="api_key",
+        base_url=_MINIMAX_BASE,
+        secret_ref="conn-minimax",
+        enabled=True,
+    )
+
+
+def _google_workspace_default() -> RuntimeLlmRouting:
+    return RuntimeLlmRouting(
+        global_default=StageLLMRoute(
+            provider_id="google",
+            model="gemini-1.5-pro",
+            provider_options={"base_url": _GOOGLE_BASE},
+        ),
+        stage_overrides={},
+    )
+
+
+@pytest.fixture
+def report_env(monkeypatch, tmp_path):
+    """Verdrahtet ``start_generation`` mit In-Memory-Stubs und fängt den
+    ``LLMClient`` ab, den ``GraphToolsService``/``ReportAgent`` bekommen."""
+    run_root = tmp_path / "runs"
+    run_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        ArtifactLocator,
+        "run_dir",
+        classmethod(lambda cls, run_id: str(_ensure_dir(run_root / run_id))),
+    )
+
+    profile_store = MagicMock()
+    profile_store.get.return_value = _minimax_profile()
+
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [_minimax_connection()]
+
+    secrets_store = MagicMock()
+    secrets_store.get_plaintext.return_value = "sk-test-not-a-real-secret"
+
+    workspace_store = MagicMock()
+    workspace_store.load.return_value = _google_workspace_default()
+
+    monkeypatch.setattr(
+        "app.services.llm_profiles_store.get_llm_profiles_store", lambda: profile_store
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_profiles_store",
+        lambda: profile_store,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore", lambda: connection_store
+    )
+    monkeypatch.setattr(
+        "app.services.provider_connection_store.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store", lambda: workspace_store
+    )
+    for target in (
+        "app.services.llm_provider_secrets_store.get_llm_provider_secrets_store",
+        "app.services.llm_routing_seed.get_llm_provider_secrets_store",
+        "app.llm.client.get_llm_provider_secrets_store",
+        "app.services.secret_resolver.get_llm_provider_secrets_store",
+    ):
+        monkeypatch.setattr(target, lambda: secrets_store, raising=False)
+
+    state = SimpleNamespace(
+        project_id="proj-1",
+        graph_id="graph-1",
+        source_simulation_id=None,
+        root_simulation_id=None,
+        branch_name=None,
+        branch_depth=0,
+    )
+    sim_mgr = MagicMock()
+    sim_mgr.get_simulation.return_value = state
+    monkeypatch.setattr(rg, "SimulationManager", lambda: sim_mgr)
+
+    project = SimpleNamespace(
+        graph_id="graph-1", simulation_requirement="Requirement X", llm_profile_id=None
+    )
+    monkeypatch.setattr(rg.ProjectManager, "get_project", staticmethod(lambda pid: project))
+
+    task_mgr = MagicMock()
+    task_mgr.create_task.return_value = "task-1"
+    monkeypatch.setattr(rg, "TaskManager", lambda: task_mgr)
+
+    run_registry = MagicMock()
+    run_registry.create_run.return_value = {"run_id": RUN_ID}
+    monkeypatch.setattr(rg, "run_registry", run_registry)
+
+    captured: dict[str, object] = {}
+
+    class _FakeGraphTools:
+        def __init__(self, *, storage=None, llm_client=None):
+            captured["client"] = llm_client
+
+    monkeypatch.setattr(rg, "GraphToolsService", _FakeGraphTools)
+    monkeypatch.setattr(rg, "current_app", MagicMock())
+    monkeypatch.setattr("app.jobs.enqueue", lambda *a, **k: "job-test")
+
+    return SimpleNamespace(
+        captured=captured,
+        run_id=RUN_ID,
+        profile_store=profile_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        workspace_store=workspace_store,
+        run_registry=run_registry,
+    )
+
+
+def test_locked_route_snapshot_matches_actual_client_for_profile(report_env):
+    """Der gelockte Snapshot und der ausgeführte Client beschreiben dieselbe Route."""
+    result = rg.ReportGenerationService.start_generation(
+        simulation_id="sim_abc",
+        report_mode="balanced",
+        force_regenerate=True,
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        llm_profile_id="prof-minimax",
+    )
+    assert result["status"] == "generating"
+
+    client = report_env.captured.get("client")
+    assert client is not None, "GraphToolsService erhielt keinen LLMClient"
+
+    locked = RuntimeRunConfig(report_env.run_id).load_ai_route_snapshot("report_generation")
+    assert locked is not None, "Kein gelockter report_generation-Snapshot"
+
+    assert client.model == locked.model_id
+    assert client.route_provider_id == locked.provider_connection_id
+    assert (client.base_url or "").rstrip("/") == (
+        locked.provider_options.get("base_url") or ""
+    ).rstrip("/")
+
+
+def _start(report_env, **overrides):
+    kwargs = dict(
+        simulation_id="sim_abc",
+        report_mode="balanced",
+        force_regenerate=True,
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        llm_profile_id=None,
+        ai_model_ref=None,
+    )
+    kwargs.update(overrides)
+    return rg.ReportGenerationService.start_generation(**kwargs)
+
+
+def test_explicit_ai_model_ref_becomes_locked_route_and_client(report_env):
+    """Slice A: die UI-gewählte AiModelRef wird 1:1 die gelockte Route und der Client."""
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    result = _start(report_env, ai_model_ref=ref)
+    assert result["status"] == "generating"
+
+    client = report_env.captured["client"]
+    locked = RuntimeRunConfig(report_env.run_id).load_ai_route_snapshot("report_generation")
+
+    assert locked.provider_connection_id == "conn-minimax"
+    assert locked.model_id == "MiniMax-M3"
+    assert client.route_provider_id == locked.provider_connection_id
+    assert client.model == locked.model_id
+    # Secret nur über die Route-Referenz — der Wert wird nie verglichen.
+    assert locked.provider_options.get("secret_ref") == "conn-minimax"
+    assert locked.provider_options.get("connection_only") is True
+
+
+def test_unknown_provider_connection_is_rejected(report_env):
+    """Slice A: unbekannte Connection → harter Fehler, kein stiller Fallback."""
+    report_env.connection_store.list_connections.return_value = []
+    ref = AiModelRef(
+        provider_connection_id="conn-ghost", model_id="ghost-1", source="explicit"
+    )
+    with pytest.raises(ValueError, match="nicht gefunden"):
+        _start(report_env, ai_model_ref=ref)
+
+
+def test_disabled_provider_connection_is_rejected(report_env):
+    """Slice A: deaktivierte Connection → harter Fehler."""
+    disabled = _minimax_connection().model_copy(update={"enabled": False})
+    report_env.connection_store.list_connections.return_value = [disabled]
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    with pytest.raises(ValueError, match="deaktiviert"):
+        _start(report_env, ai_model_ref=ref)
+
+
+def test_run_metadata_reflects_locked_route(report_env):
+    """Run-Metadaten (Model-Attribution) stammen aus der gelockten Route, nicht
+    aus den rohen Request-Feldern."""
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    _start(report_env, ai_model_ref=ref)
+
+    metadata_updates = [
+        call.kwargs.get("metadata", {})
+        for call in report_env.run_registry.update_run.call_args_list
+    ]
+    route_meta = next(m for m in metadata_updates if m.get("llm_model"))
+    assert route_meta["llm_model"] == "MiniMax-M3"
+    assert route_meta["llm_provider"]["provider_id"] == "conn-minimax"
+    # Kein Secret in den Run-Metadaten.
+    assert "api_key" not in route_meta["llm_provider"]
+
+
+def test_no_secret_value_leaks_into_locked_snapshot(report_env):
+    """Der gelockte Snapshot trägt nur die Secret-Referenz, nie den Klartext-Key."""
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    _start(report_env, ai_model_ref=ref)
+    locked = RuntimeRunConfig(report_env.run_id).load_ai_route_snapshot("report_generation")
+    serialized = locked.model_dump_json().lower()
+    assert "sk-test-not-a-real-secret" not in serialized
+    assert "api_key" not in serialized

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3455 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3465 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/api/report.ts
+++ b/frontend/src/api/report.ts
@@ -7,11 +7,24 @@ import type { ReportMode } from '../contracts/reportV3Contract'
 // --- Local payload/data types -------------------------------------------
 // These describe the `data` field inside the API envelope, not the envelope itself.
 
+/** Explizite (Connection, Modell)-Auswahl aus dem Report-Picker (Issue #817).
+ * Spiegelt `AiModelRef` — die autoritative Report-Route. */
+export interface AiModelRefPayload {
+  provider_connection_id: string
+  model_id: string
+  source: string
+}
+
 export interface GenerateReportData {
   simulation_id: string
   force_regenerate?: boolean
+  /** Legacy-Kompatibilität; bei gesetztem `ai_model_ref` nicht mitsenden. */
   llm_model?: string
   llm_provider?: LlmRuntimePayload
+  /** Legacy-Kompatibilität; bei gesetztem `ai_model_ref` nicht mitsenden. */
+  llm_profile_id?: string
+  /** Autoritative UI-Auswahl. Darf nicht mit den Legacy-Feldern kombiniert werden. */
+  ai_model_ref?: AiModelRefPayload
   /** Report-Modus — wird als ?mode=<value> Query-Parameter übergeben (Backend: request.args.get("mode")). */
   mode?: ReportMode
   [key: string]: unknown

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -7,6 +7,7 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { renderMarkdown } from '../utils/markdown'
 import { generateReport, getAgentLog, getConsoleLog, getReport, getReportStatus, getReportEvidence } from '../api/report'
+import type { GenerateReportData } from '../api/report'
 import { createSimulationBranch } from '../api/simulation'
 import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
@@ -135,15 +136,44 @@ function effectiveReportModel(): string | null {
   return m && m.trim() ? m.trim() : null
 }
 
+/**
+ * Baut die Modellauswahl für den Report-Request (Issue #817).
+ *
+ * Ein expliziter Picker-Pick (`reportRoute`) ist ein Request-Override für genau
+ * diese Regenerierung und gewinnt vor dem Legacy-Profil. Beides gleichzeitig zu
+ * senden würde das Backend mit HTTP 400 ablehnen — deshalb wird bei gesetztem
+ * `reportRoute` weder `llm_profile_id` noch `llm_model` mitgeschickt. Ohne
+ * expliziten Pick wird kein erfundener Override gesendet; Stage-/Workspace-
+ * Defaults greifen dann serverseitig.
+ */
+function buildModelSelection(): Pick<GenerateReportData, 'ai_model_ref' | 'llm_profile_id'> {
+  if (reportRoute.value) {
+    return {
+      ai_model_ref: {
+        provider_connection_id: reportRoute.value.provider_connection_id,
+        model_id: reportRoute.value.model_id,
+        source: reportRoute.value.source ?? 'explicit',
+      },
+    }
+  }
+  if (llmProfileId.value) {
+    return { llm_profile_id: llmProfileId.value }
+  }
+  return {}
+}
+
 async function regenerateWithModel() {
   const simId = resolvedSimulationId.value || props.simulationId
   if (!simId) { addLog('simulationId fehlt — Regenerieren nicht möglich.'); return }
   isRegenerating.value = true
   try {
-    const payload: Record<string, unknown> = { simulation_id: simId, force_regenerate: true, mode: reportMode.value }
-    if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
+    const payload: GenerateReportData = {
+      simulation_id: simId,
+      force_regenerate: true,
+      mode: reportMode.value,
+      ...buildModelSelection(),
+    }
     const m = effectiveReportModel()
-    if (m) payload.llm_model = m
     addLog(`Report neu generieren${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
     const res = (await generateReport(payload)) as ApiResult
     if (res?.success && res.data?.report_id) {
@@ -164,10 +194,12 @@ async function startReportConfirmed() {
   reportPending.value = false
   isRegenerating.value = true
   try {
-    const payload: Record<string, unknown> = { simulation_id: simId, mode: reportMode.value }
-    if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
+    const payload: GenerateReportData = {
+      simulation_id: simId,
+      mode: reportMode.value,
+      ...buildModelSelection(),
+    }
     const m = effectiveReportModel()
-    if (m) payload.llm_model = m
     addLog(`Report starten${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
     const res = (await generateReport(payload)) as ApiResult
     if (res?.success && res.data?.report_id) {

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -932,3 +932,73 @@ describe('Step4Report — Kanon-First Initialisierung (Phase 1)', () => {
     expect(localStorageMock.getItem('agora.report.route')).toBeNull()
   })
 })
+
+// Issue #817: der Report-Start überträgt die vollständige kanonische Auswahl
+// (ai_model_ref) und kombiniert sie nicht mit dem Legacy-Profil.
+describe('Step4Report — Report-Route-SSoT-Payload (#817)', () => {
+  const PICK: AiModelRef = {
+    provider_connection_id: 'conn_minimax',
+    model_id: 'MiniMax-M3',
+    source: 'explicit',
+  } as AiModelRef
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    resetMockSelection()
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { status: 'idle' },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: VALID_REPORT })
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: VALID_EVIDENCE })
+    ;(generateReport as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { report_id: 'report_new01' },
+    })
+  })
+
+  async function callRegenerate(): Promise<Record<string, unknown>> {
+    const wrapper = mountComponent({ simulationId: 'sim_test01' })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    await (wrapper.vm as unknown as { regenerateWithModel: () => Promise<void> }).regenerateWithModel()
+    await wrapper.vm.$nextTick()
+    return vi.mocked(generateReport).mock.calls.at(-1)![0] as Record<string, unknown>
+  }
+
+  it('sendet ai_model_ref und kein konkurrierendes llm_profile_id bei explizitem Pick', async () => {
+    mockEffectiveRef.value = PICK
+    // Veraltetes Legacy-Profil im localStorage darf den Pick NICHT begleiten.
+    localStorageMock.setItem('agora.report.llmProfileId', 'prof-stale')
+
+    const payload = await callRegenerate()
+
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn_minimax',
+      model_id: 'MiniMax-M3',
+      source: 'explicit',
+    })
+    expect(payload.llm_profile_id).toBeUndefined()
+    expect(payload.llm_model).toBeUndefined()
+  })
+
+  it('sendet ohne expliziten Pick keinen erfundenen Override', async () => {
+    // effectiveRef bleibt null, kein Profil im Storage.
+    const payload = await callRegenerate()
+
+    expect(payload.ai_model_ref).toBeUndefined()
+    expect(payload.llm_profile_id).toBeUndefined()
+    expect(payload.llm_model).toBeUndefined()
+    expect(payload.simulation_id).toBe('sim_test01')
+  })
+
+  it('fällt ohne Pick auf das Legacy-llm_profile_id zurück', async () => {
+    localStorageMock.setItem('agora.report.llmProfileId', 'prof-legacy')
+
+    const payload = await callRegenerate()
+
+    expect(payload.llm_profile_id).toBe('prof-legacy')
+    expect(payload.ai_model_ref).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #817.

## Root Cause

In `ReportGenerationService.start_generation` divergierte der gelockte
`report_generation`-Route-Snapshot vom tatsächlich erzeugten `LLMClient`:

- `seed_run_stage_routing(...)` wurde **ohne** `llm_profile_id` aufgerufen → der
  gelockte Snapshot beschrieb den Workspace-/Global-Default (z. B. Google).
- Bei gesetztem Profil wurde der Client über den Parallelpfad
  `build_client_from_profile(...)` gebaut → Provider/Modell = Profil (z. B. MiniMax).
- Ergebnis: Snapshot ≠ Client; `ReportAgent` bekam zudem `model_name=resolved_route.model`
  (Snapshot) neben dem Profil-Client; Run-Metadaten stammten aus rohen Request-Feldern.

## Fix — ein einziger autoritativer Pfad

`start_generation`: Request/Legacy/AiModelRef → `seed_run_stage_routing` (mit
`llm_profile_id`/`ai_model_ref`) → `StageModelRouter.resolve` → `lock_stage` → Secret
und `LLMClient.from_route` **ausschließlich** aus der gelockten Route. Der Parallelpfad
`build_client_from_profile` entfällt in `start_generation`; ein Profil ist nur noch
Eingang zur Routenerzeugung. Run-Metadaten/Attribution kommen aus der gelockten Route.

## Kanonischer Request-Vertrag

Neuer Backend-Contract `AiModelRef` (Spiegel des Frontend-`AiModelRefSchema`). Der
Generate-Request überträgt `ai_model_ref {provider_connection_id, model_id, source}` als
autoritative Route.

**Prioritätsreihenfolge:** explizite `ai_model_ref` > Legacy-`llm_profile_id` >
Projektprofil > Stage-Override `report_generation` > Workspace-Default.

**Konflikte → HTTP 400:** `ai_model_ref` + Legacy-Feld (`llm_profile_id`/`llm_model`/
`llm_provider`); unbekannte oder deaktivierte ProviderConnection.

## Frontend

`Step4Report.vue`: expliziter Picker-Pick sendet `ai_model_ref` und kein konkurrierendes
`llm_profile_id`/`llm_model`; ohne Pick kein erfundener Override. `GenerateReportData` ist
um `ai_model_ref` typisiert.

## Tests

- `backend/tests/services/test_report_provider_route_ssot.py` — RED→GREEN: Snapshot ≡
  Client (Provider-Connection-ID/Modell/Base-URL), AiModelRef→Route, unbekannte/deaktivierte
  Connection, Run-Metadaten aus Route, kein Secret-Leak. Es werden nur Secret-Referenzen
  verglichen, niemals Klartext-Keys.
- `backend/tests/api/test_report_provider_route_api.py` — Contract + Konflikt-400.
- `frontend/src/components/__tests__/Step4Report.spec.ts` — drei Payload-Tests.

## Gates

- `uv run pytest tests/services/test_report_provider_route_ssot.py tests/api/test_report_provider_route_api.py tests/services/test_llm_routing_seed.py tests/api/test_report_modes.py tests/contracts/` → 415 passed
- `uv run python -m app.contracts.dump_schemas --check` → 46/46 OK
- `uv run ruff check app/ tests/` → clean · `uv run mypy app` → Success
- `bun run check` → exit 0 (lint + typecheck + tests + build)
- `bash scripts/pre-push-gate.sh` → ALL GREEN

## Noch offen (Folge-Issues)

- Strikte Connection/Model-Katalog-Validierung (`provider_connection_id` + Fremdprovider-Modell
  → 400) benötigt den Model-Discovery-Katalog pro Connection — siehe Folge-Issue.
- **Realer Provider-Lauf** über den UI-Pfad ist in dieser Session noch nicht ausgeführt
  (keine laufende Backend-/Neo4j-/Provider-Umgebung im Agenten-Kontext). Der Slice ist damit
  automatisiert verifiziert, aber **nicht** real-run-verifiziert.

## Nicht Teil dieses Slices

Redis/RQ-Migration, Daemon-Thread-Ablösung, Restart-/Resume-Vertrag, ReACT-Thinking-Leak,
Alias `format=markdown`, Frontend-Konsolidierung außerhalb des Reportstarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Berichte können über eine explizite Modell- und Provider-Auswahl generiert werden.
  * Die Auswahl wird automatisch konsistent für Generierung, Berichtsmetadaten und Modellzuordnung verwendet.
  * Bestehende Legacy-Auswahl bleibt als Fallback kompatibel.

* **Fehlerbehebungen**
  * Widersprüchliche oder ungültige Modellangaben werden mit HTTP 400 abgelehnt.
  * Unbekannte oder deaktivierte Provider-Verbindungen werden klar zurückgewiesen.
  * Geheimnisse werden nicht in gespeicherten Routendaten offengelegt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->