### PR TITLE
fix(report): Cloud-Connection ohne gebundenes Secret hart ablehnen (#817-Folge)

### DIFF
--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -116,7 +116,16 @@ def seed_run_stage_routing(
         connection_base_url = canonical_connection_base_url(connection)
         if connection_base_url:
             ref_options["base_url"] = connection_base_url
-        if connection.auth_mode == "api_key" and connection.secret_ref:
+        if connection.auth_mode == "api_key":
+            # Cloud-Connection muss ihr Secret an die Route binden. Ohne gebundenes
+            # Secret KEIN .env-/Server-Key-Fallback — sonst wiche die Secret-Quelle
+            # von der gewählten Route ab (Issue #817). Lokale No-Auth-Connections
+            # (auth_mode="none") brauchen keinen Key und laufen hier nicht durch.
+            if not connection.secret_ref:
+                raise ValueError(
+                    f"ProviderConnection {connection.id!r}: Cloud-Connection ohne "
+                    "gebundenes Secret — kein .env-Fallback für Report-Routen"
+                )
             ref_options["secret_ref"] = connection.secret_ref
             ref_options["connection_only"] = True
         config.stage_overrides[stage_id] = StageLLMRoute(

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -62,6 +62,29 @@ def _resolve_selected_connection(connection_id: str) -> ProviderConnection:
     return match
 
 
+def _bind_connection_secret(
+    connection: ProviderConnection, options: dict[str, object]
+) -> None:
+    """Bindet das Secret einer api_key-Connection strikt an die Route-Options.
+
+    Cloud-Connections (``auth_mode="api_key"``) ohne gebundenes ``secret_ref``
+    werden hart abgelehnt — kein ``.env``-/Server-Key-Fallback, sonst wiche die
+    Secret-Quelle von der gewählten Route ab (Issue #817). Lokale No-Auth-
+    Connections (``auth_mode="none"``) laufen hier nicht durch und bleiben
+    unberührt. Gemeinsame SSoT für den ``ai_model_ref``- und den
+    ``llm_profile_id``-Routing-Pfad, damit keiner der beiden die Bindung umgeht.
+    """
+    if connection.auth_mode != "api_key":
+        return
+    if not connection.secret_ref:
+        raise ValueError(
+            f"ProviderConnection {connection.id!r}: Cloud-Connection ohne "
+            "gebundenes Secret — kein .env-Fallback für Report-Routen"
+        )
+    options["secret_ref"] = connection.secret_ref
+    options["connection_only"] = True
+
+
 def seed_run_stage_routing(
     run_id: str,
     stage_id: StageId,
@@ -116,18 +139,7 @@ def seed_run_stage_routing(
         connection_base_url = canonical_connection_base_url(connection)
         if connection_base_url:
             ref_options["base_url"] = connection_base_url
-        if connection.auth_mode == "api_key":
-            # Cloud-Connection muss ihr Secret an die Route binden. Ohne gebundenes
-            # Secret KEIN .env-/Server-Key-Fallback — sonst wiche die Secret-Quelle
-            # von der gewählten Route ab (Issue #817). Lokale No-Auth-Connections
-            # (auth_mode="none") brauchen keinen Key und laufen hier nicht durch.
-            if not connection.secret_ref:
-                raise ValueError(
-                    f"ProviderConnection {connection.id!r}: Cloud-Connection ohne "
-                    "gebundenes Secret — kein .env-Fallback für Report-Routen"
-                )
-            ref_options["secret_ref"] = connection.secret_ref
-            ref_options["connection_only"] = True
+        _bind_connection_secret(connection, ref_options)
         config.stage_overrides[stage_id] = StageLLMRoute(
             provider_id=connection.id,
             model=ai_model_ref.model_id,
@@ -169,15 +181,12 @@ def seed_run_stage_routing(
             )
         connection = resolved.connection
         provider_options: dict[str, object] = {"base_url": resolved.base_url}
-        # Nur echte api_key-Connections an ihr gebundenes Secret koppeln. Lokale
-        # No-Auth-Connections (auth_mode="none") würden über connection_only sonst
-        # auf ein nicht existentes Secret zeigen; die strikte Auflösung liefert dann
-        # None und der Run bricht mit "LLM_API_KEY not configured" — das lokale
-        # Ollama-Betriebsmodell bliebe gebrochen. Die Auth-Semantik der
-        # ProviderConnection ist maßgeblich (SSoT), kein pauschales connection_only.
-        if connection.auth_mode == "api_key" and connection.secret_ref:
-            provider_options["secret_ref"] = connection.secret_ref
-            provider_options["connection_only"] = True
+        # Auth-Semantik der ProviderConnection ist maßgeblich (SSoT): api_key-
+        # Connections werden an ihr gebundenes Secret gekoppelt und ohne Secret
+        # hart abgelehnt (Issue #817) — identisch zum ai_model_ref-Pfad, damit der
+        # Profilpfad die Bindung nicht umgeht. Lokale No-Auth-Connections
+        # (auth_mode="none") laufen nicht durch und bleiben auf base_url beschränkt.
+        _bind_connection_secret(connection, provider_options)
         config.stage_overrides[stage_id] = StageLLMRoute(
             provider_id=connection.id,
             model=profile.model_name,

--- a/backend/tests/services/test_report_provider_route_ssot.py
+++ b/backend/tests/services/test_report_provider_route_ssot.py
@@ -280,6 +280,16 @@ def test_cloud_connection_without_bound_secret_is_rejected(report_env):
         _start(report_env, ai_model_ref=ref)
 
 
+def test_profile_path_cloud_connection_without_bound_secret_is_rejected(report_env):
+    """Derselbe Reject wie über ``ai_model_ref`` muss auch über den
+    ``llm_profile_id``-Pfad greifen — sonst umginge das Profil-Routing die
+    Secret-Bindung (#817, CodeRabbit-Finding PR #820)."""
+    no_secret = _minimax_connection().model_copy(update={"secret_ref": None})
+    report_env.connection_store.list_connections.return_value = [no_secret]
+    with pytest.raises(ValueError, match="gebundenes Secret"):
+        _start(report_env, llm_profile_id="prof-minimax")
+
+
 def test_no_secret_value_leaks_into_locked_snapshot(report_env):
     """Der gelockte Snapshot trägt nur die Secret-Referenz, nie den Klartext-Key."""
     ref = AiModelRef(

--- a/backend/tests/services/test_report_provider_route_ssot.py
+++ b/backend/tests/services/test_report_provider_route_ssot.py
@@ -268,6 +268,18 @@ def test_run_metadata_reflects_locked_route(report_env):
     assert "api_key" not in route_meta["llm_provider"]
 
 
+def test_cloud_connection_without_bound_secret_is_rejected(report_env):
+    """Slice A: api_key-Connection ohne gebundenes secret_ref → klarer Fehler,
+    kein stiller .env-/Server-Key-Fallback."""
+    no_secret = _minimax_connection().model_copy(update={"secret_ref": None})
+    report_env.connection_store.list_connections.return_value = [no_secret]
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    with pytest.raises(ValueError, match="gebundenes Secret"):
+        _start(report_env, ai_model_ref=ref)
+
+
 def test_no_secret_value_leaks_into_locked_snapshot(report_env):
     """Der gelockte Snapshot trägt nur die Secret-Referenz, nie den Klartext-Key."""
     ref = AiModelRef(

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3465 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3466 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3466 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3467 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/api/report.ts
+++ b/frontend/src/api/report.ts
@@ -3,17 +3,15 @@ import type { ApiEnvelope } from './envelope'
 import type { LlmRuntimePayload } from './llmRuntime'
 import type { Report, EvidenceMap, ReportSection, EvidenceItem } from '../contracts/reportContract'
 import type { ReportMode } from '../contracts/reportV3Contract'
+import type { AiModelRef } from '../contracts/aiModelRef'
 
 // --- Local payload/data types -------------------------------------------
 // These describe the `data` field inside the API envelope, not the envelope itself.
 
 /** Explizite (Connection, Modell)-Auswahl aus dem Report-Picker (Issue #817).
- * Spiegelt `AiModelRef` — die autoritative Report-Route. */
-export interface AiModelRefPayload {
-  provider_connection_id: string
-  model_id: string
-  source: string
-}
+ * Direkt vom kanonischen `AiModelRef` abgeleitet, damit die Enum-Constraint auf
+ * `source` erhalten bleibt und kein Parallel-Contract entsteht. */
+export type AiModelRefPayload = Pick<AiModelRef, 'provider_connection_id' | 'model_id' | 'source'>
 
 export interface GenerateReportData {
   simulation_id: string

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -110,6 +110,15 @@ const STORAGE_REPORT_ROUTE_LEGACY = 'agora.report.route'
 const effectiveModel = useEffectiveModelSelection()
 
 const reportRoute = ref<AiModelRef | null>(null)
+// Expliziter Nutzer-Pick — strikt getrennt vom Anzeige-Default. Der beim Mount
+// aus dem Kanon (routing/defaults.global_default) übernommene Wert befüllt nur
+// reportRoute (Anzeige) und darf keinen Request-Override erzeugen.
+const reportRouteOverride = ref<AiModelRef | null>(null)
+
+function onReportRoutePicked(val: AiModelRef | null) {
+  reportRoute.value = val
+  reportRouteOverride.value = val
+}
 const isRegenerating = ref(false)
 
 const STORAGE_REPORT_PROFILE_ID = 'agora.report.llmProfileId'
@@ -139,20 +148,22 @@ function effectiveReportModel(): string | null {
 /**
  * Baut die Modellauswahl für den Report-Request (Issue #817).
  *
- * Ein expliziter Picker-Pick (`reportRoute`) ist ein Request-Override für genau
- * diese Regenerierung und gewinnt vor dem Legacy-Profil. Beides gleichzeitig zu
- * senden würde das Backend mit HTTP 400 ablehnen — deshalb wird bei gesetztem
- * `reportRoute` weder `llm_profile_id` noch `llm_model` mitgeschickt. Ohne
- * expliziten Pick wird kein erfundener Override gesendet; Stage-/Workspace-
- * Defaults greifen dann serverseitig.
+ * Nur ein expliziter Picker-Pick (`reportRouteOverride`) wird als Request-
+ * Override für genau diese Regenerierung gesendet und gewinnt vor dem Legacy-
+ * Profil. Beides gleichzeitig zu senden würde das Backend mit HTTP 400
+ * ablehnen — deshalb wird bei gesetztem Override weder `llm_profile_id` noch
+ * `llm_model` mitgeschickt. Ein beim Mount aus dem Kanon übernommener
+ * Anzeige-Default (`reportRoute`) erzeugt KEINEN Override: ohne echte
+ * Nutzerwahl bleiben `llm_profile_id` beziehungsweise die serverseitigen
+ * Stage-/Workspace-Defaults unverändert wirksam.
  */
 function buildModelSelection(): Pick<GenerateReportData, 'ai_model_ref' | 'llm_profile_id'> {
-  if (reportRoute.value) {
+  if (reportRouteOverride.value) {
     return {
       ai_model_ref: {
-        provider_connection_id: reportRoute.value.provider_connection_id,
-        model_id: reportRoute.value.model_id,
-        source: reportRoute.value.source ?? 'explicit',
+        provider_connection_id: reportRouteOverride.value.provider_connection_id,
+        model_id: reportRouteOverride.value.model_id,
+        source: reportRouteOverride.value.source ?? 'explicit',
       },
     }
   }
@@ -459,9 +470,10 @@ onUnmounted(stopPolling)
         </div>
         <ReportModelControls
           v-if="resolvedSimulationId || simulationId"
-          v-model="reportRoute"
+          :model-value="reportRoute"
           :is-regenerating="isRegenerating"
           :class="{ 'is-overridden-by-profile': llmProfileId }"
+          @update:model-value="onReportRoutePicked"
           @regenerate="regenerateWithModel"
         />
         <ReportModeControls

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -958,21 +958,26 @@ describe('Step4Report — Report-Route-SSoT-Payload (#817)', () => {
     })
   })
 
-  async function callRegenerate(): Promise<Record<string, unknown>> {
+  async function callRegenerate(pick?: AiModelRef): Promise<Record<string, unknown>> {
     const wrapper = mountComponent({ simulationId: 'sim_test01' })
     await flushPromises()
     await wrapper.vm.$nextTick()
+    if (pick) {
+      // Expliziter Nutzer-Pick über den Picker — kein Mount-Default.
+      const controls = wrapper.findComponent({ name: 'ReportModelControls' })
+      await controls.vm.$emit('update:modelValue', pick)
+      await wrapper.vm.$nextTick()
+    }
     await (wrapper.vm as unknown as { regenerateWithModel: () => Promise<void> }).regenerateWithModel()
     await wrapper.vm.$nextTick()
     return vi.mocked(generateReport).mock.calls.at(-1)![0] as Record<string, unknown>
   }
 
   it('sendet ai_model_ref und kein konkurrierendes llm_profile_id bei explizitem Pick', async () => {
-    mockEffectiveRef.value = PICK
     // Veraltetes Legacy-Profil im localStorage darf den Pick NICHT begleiten.
     localStorageMock.setItem('agora.report.llmProfileId', 'prof-stale')
 
-    const payload = await callRegenerate()
+    const payload = await callRegenerate(PICK)
 
     expect(payload.ai_model_ref).toEqual({
       provider_connection_id: 'conn_minimax',
@@ -981,6 +986,27 @@ describe('Step4Report — Report-Route-SSoT-Payload (#817)', () => {
     })
     expect(payload.llm_profile_id).toBeUndefined()
     expect(payload.llm_model).toBeUndefined()
+  })
+
+  it('erzeugt aus dem beim Mount übernommenen Kanon-Default KEINEN Override', async () => {
+    // Kanon trägt einen Wert, aber der Nutzer hat den Picker nie angefasst.
+    mockEffectiveRef.value = PICK
+
+    const payload = await callRegenerate()
+
+    expect(payload.ai_model_ref).toBeUndefined()
+    expect(payload.llm_profile_id).toBeUndefined()
+    expect(payload.llm_model).toBeUndefined()
+  })
+
+  it('behält llm_profile_id bei, wenn nur der Kanon-Default angezeigt wird (kein Pick)', async () => {
+    mockEffectiveRef.value = PICK
+    localStorageMock.setItem('agora.report.llmProfileId', 'prof-stale')
+
+    const payload = await callRegenerate()
+
+    expect(payload.ai_model_ref).toBeUndefined()
+    expect(payload.llm_profile_id).toBe('prof-stale')
   })
 
   it('sendet ohne expliziten Pick keinen erfundenen Override', async () => {


### PR DESCRIPTION
## Kontext

Folgehärtung zu #817 (UI-selected `ProviderConnection` als autoritative Report-Route). Diese drei Änderungen lagen ungesichert im Working Tree und haben es nicht in den gemergten PR #818 geschafft — hier sauber auf `origin/main` neu aufgesetzt.

## Änderungen

1. **`llm_routing_seed.py`** — Eine `api_key`-Connection ohne gebundenes `secret_ref` wirft jetzt `ValueError`, statt still auf den `.env`-/Server-Key-Fallback zu gehen. Das schließt die Secret-Quelle-Divergenz gegenüber der gewählten Route (Kern von #817). Lokale No-Auth-Connections (`auth_mode="none"`) bleiben unberührt.
2. **`report.ts`** — `AiModelRefPayload` wird per `Pick<AiModelRef, …>` vom kanonischen Contract abgeleitet statt als Parallel-Interface geführt. `source` erbt damit die `AiModelSource`-Enum-Constraint (SSoT-Härtung gegen Contract-Drift).
3. **`Step4Report.vue`** — `reportRouteOverride` strikt vom Anzeige-Default (`reportRoute`) getrennt (`onReportRoutePicked`, explizites `:model-value`/`@update:model-value` statt `v-model`). Ein beim Mount aus dem Kanon übernommener Anzeige-Default erzeugt keinen Request-Override mehr.

## Tests

- Backend: `test_cloud_connection_without_bound_secret_is_rejected` (Reject ohne Secret).
- Frontend: Kanon-Default sendet kein `ai_model_ref`; `llm_profile_id` bleibt bei reinem Anzeige-Default erhalten.

## Verifikation

- Pre-Push-Gate (Cross-Layer) grün: Backend (contracts, 46 Schemas, ruff, mypy), Frontend (170 Files / 1501 Tests, check/build), STATUS-Sync.
- Review (`agora-opus-reviewer`): **APPROVE**, kein Blocker.

## Bekannte, bewusst nicht adressierte Nachrangigkeit

Der neue Secret-Guard fasst nur `auth_mode == "api_key"`. Der Contract erlaubt zusätzlich `oauth`/`session` — diese fallen aktuell **nicht** unter den Guard. Real ungefährlich, da keine der drei Connection-Factories diese Modi erzeugt (dormant). Bei künftiger Aktivierung von `oauth`/`session` ist der Guard zu erweitern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gci42rTkKXk9sh1ecWPTF8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Bei expliziter Auswahl der KI-Verbindung wird die Auswahl zuverlässig für die Report-Generierung übernommen; Legacy-Profile überschreiben keine getroffene Modellauswahl.
  * Standardwerte bleiben weiterhin erhalten, solange keine manuelle Auswahl getroffen wurde.
* **Fehlerbehebungen**
  * Cloud-Verbindungen ohne hinterlegtes gebundenes Secret/keinen API-Schlüssel werden jetzt eindeutig abgelehnt, statt auf einen unsicheren Fallback zurückzugreifen.
* **Dokumentation**
  * Die dokumentierte Anzahl der Backend-Tests wurde aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->