### PR TITLE
fix(e2e): Teardown-Logs über Compose-Servicenamen statt Container-Namen (#739)

### DIFF
--- a/frontend/tests/e2e/global-teardown.ts
+++ b/frontend/tests/e2e/global-teardown.ts
@@ -27,10 +27,13 @@ function dumpContainerLogs(repoRoot: string): void {
     '-f deploy/compose/docker-compose.e2e.override.yml',
   ].join(' ');
 
+  // Compose-SERVICE-Namen (docker-compose.yml), nicht Container-Namen: `docker
+  // compose logs <name>` erwartet den Service-Key. Mit den Container-Namen
+  // (agora-neo4j/agora-redis) lieferte der Aufruf im CI-Fehlerfall leere Logs.
   const services: Array<{ name: string; tail: number }> = [
     { name: 'agora', tail: 500 },
-    { name: 'agora-neo4j', tail: 200 },
-    { name: 'agora-redis', tail: 100 },
+    { name: 'neo4j', tail: 200 },
+    { name: 'redis', tail: 100 },
   ];
 
   console.log('\n========== [e2e-globalTeardown] CONTAINER LOGS ==========');


### PR DESCRIPTION
## Problem

`frontend/tests/e2e/global-teardown.ts` dumpt bei CI-Fehlern Container-Logs, um den sonst unsichtbaren Backend-Traceback sichtbar zu machen. Der Aufruf nutzte aber die **Container-Namen** `agora-neo4j`/`agora-redis` statt der **Compose-Service-Keys**. `docker compose logs <name>` erwartet den Service-Namen — mit den Container-Namen kam nichts zurück, die Logs blieben im Fehlerfall leer.

## Fix

Service-Keys aus `docker-compose.yml` verwendet: `neo4j`, `redis` (`agora` war bereits korrekt). Plus ein Kommentar, der Service- vs. Container-Name festhält.

## Verifikation

Frontend-Pre-Push-Gate grün (170 Files / 1499 Tests, lint/typecheck/build). Die Änderung betrifft nur den E2E-Teardown-Logpfad, keine Produktlogik.

## Kontext

Teil von #739 (E2E-Smokes). Entblockt die Diagnose der separaten Neo4j-Startup-Flake, weil Container-Logs bei CI-Fehlern jetzt wirklich erscheinen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gci42rTkKXk9sh1ecWPTF8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * CI-Fehlerprotokolle zeigen nun zuverlässig die Logs der betroffenen Dienste an.
  * Die Ausgabe bleibt auf CI-Umgebungen beschränkt und führt bei nicht verfügbaren Logs weiterhin nicht zum Abbruch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->