### PR TITLE
fix(e2e): Neo4j-Memory-Defaults im E2E-Stack CI-tauglich begrenzen

### DIFF
--- a/deploy/compose/docker-compose.e2e.override.yml
+++ b/deploy/compose/docker-compose.e2e.override.yml
@@ -19,6 +19,20 @@
 # an, weil sonst der Docker-Daemon das Verzeichnis als root anlegt und
 # der Container-User nicht reinschreiben kann (CI-Failure 25595884785).
 services:
+  # Prod-Defaults (docker-compose.yml: heap_max=2g, pagecache=4g, macher
+  # zusammen ~6g Reservierung) lassen Neo4js Boot-Guard auf CI-Runnern
+  # sporadisch mit "Invalid memory configuration - exceeds physical memory"
+  # (Exit 3) abbrechen — der Check vergleicht die konfigurierte Summe gegen
+  # das zum JVM-Start tatsächlich freie RAM, das auf geteilten Runnern
+  # schwankt (reproduziert lokal via `docker run --memory=<7-9g>`: gleiche
+  # Werte kippen inkonsistent zwischen running/exit=3). E2E-Fixtures sind
+  # klein, 512m/512m reichen mit deutlichem Sicherheitsabstand.
+  neo4j:
+    environment:
+      - NEO4J_server_memory_heap_initial__size=256m
+      - NEO4J_server_memory_heap_max__size=512m
+      - NEO4J_server_memory_pagecache_size=512m
+
   agora:
     read_only: false
     environment:

--- a/deploy/compose/docker-compose.e2e.override.yml
+++ b/deploy/compose/docker-compose.e2e.override.yml
@@ -24,9 +24,10 @@ services:
   # sporadisch mit "Invalid memory configuration - exceeds physical memory"
   # (Exit 3) abbrechen — der Check vergleicht die konfigurierte Summe gegen
   # das zum JVM-Start tatsächlich freie RAM, das auf geteilten Runnern
-  # schwankt (reproduziert lokal via `docker run --memory=<7-9g>`: gleiche
-  # Werte kippen inkonsistent zwischen running/exit=3). E2E-Fixtures sind
-  # klein, 512m/512m reichen mit deutlichem Sicherheitsabstand.
+  # schwankt (reproduziert lokal via `docker run --memory=7g` bzw.
+  # `--memory=9g` mit den Prod-Werten: dieselben Werte kippen inkonsistent
+  # zwischen running/exit=3 je nach Limit). E2E-Fixtures sind klein,
+  # 512m/512m reichen mit deutlichem Sicherheitsabstand.
   neo4j:
     environment:
       - NEO4J_server_memory_heap_initial__size=256m


### PR DESCRIPTION
## Zusammenfassung

- Fixt den sporadischen Neo4j-Startup-Flake im E2E-Smoke-Stack (Restwelle zu #739)
- Root Cause: `deploy/compose/docker-compose.e2e.override.yml` übernahm ungefiltert die Prod-Memory-Defaults aus `docker-compose.yml` (`heap_max=2g` + `pagecache=4g` ≈ 6g Reservierung). Neo4js interne Boot-Guard vergleicht diese konfigurierte Summe gegen das zum JVM-Start tatsächlich freie RAM des Runners — schwankt auf GitHub-Actions-Runnern, während der Rest des Compose-Stacks (Backend-Build, Redis, nginx, mock-models) parallel hochfährt, und lässt den Container sporadisch mit `Invalid memory configuration - exceeds physical memory` (Exit 3) abbrechen.
- Fix: E2E-Override setzt `heap_initial=256m` / `heap_max=512m` / `pagecache=512m` — für die winzigen E2E-Fixture-Graphen (Playwright-Smokes, gestubbte LLM-Calls) ausreichend, Prod-Defaults bleiben unangetastet.

## Verifikation (lokal)

Reproduktions-Loop: `docker run` mit den Prod-Werten und `--memory=6.5g/7g/8g/9g` → inkonsistentes `running`/`exit=3` bei identischen Limits (Race gegen freien Host-RAM, kein festes Schwellenverhalten).

Nach Fix: derselbe Loop bei denselben Limits (inkl. 3x Wiederholung bei `--memory=6500m`) durchgehend grün.

`bash scripts/pre-push-gate.sh` (voller Scope) lief grün vor dem Commit.

## Review

`agora-opus-reviewer` hat den Commit read-only geprüft: **APPROVE**, keine Blocker.

## Test plan

- [x] Lokaler Memory-Repro-Loop vor/nach Fix (siehe oben)
- [x] Pre-Push-Gate (voller Scope) grün
- [ ] CI (`e2e-smokes.yml`) grün nach Merge — bisheriger Flake war zu selten für eine harte CI-Bestätigung vor dem Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gci42rTkKXk9sh1ecWPTF8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Verbesserte Stabilität von End-to-End-Tests mit Neo4j auf CI-Runnern.
  * Verhindert Startfehler durch ungeeignete Speicherlimits bei schwankender verfügbarer Systemressource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->