### PR TITLE
fix(llm): Restart eines Prepare-Runs nutzt Store-Key statt .env-Fallback (#798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Restart eines Prepare-Runs nutzt Store-Key statt .env-Fallback — 2026-07-22, Issue #798)
+
+- **`_restart_simulation_prepare` (`backend/app/api/runs.py`)** übergab `manager.prepare_simulation(...)`
+  bisher ohne `llm_runtime` — der Restart eines Runs, der ursprünglich gegen einen Fremd-Provider
+  lief, fiel dadurch still auf `Config.LLM_API_KEY`/`Config.LLM_BASE_URL` aus der lokalen `.env`
+  zurück statt den in der Settings-DB hinterlegten Store-Key des aktiven Providers zu nutzen
+  (Opus-Review-Folgebefund zu Issue #778, dessen Fix nur den Erst-Prepare-Pfad abdeckte).
+- Fix nutzt denselben Resolver-Pfad wie `simulation_prepare.py::prepare_simulation`:
+  `StageModelRouter.resolve` → `resolve_route_api_key` → `build_runtime_llm_config`. Lokale
+  No-Auth-Endpoints bleiben ohne Key funktionsfähig; Fremd-Provider ohne Store-Key lehnen den
+  Restart jetzt hart ab statt still auf den falschen Key auszuweichen.
+
 ### Fixed (Frontend-Testlauf: verbleibende Vitest-Teardown-Race nach #811 — 2026-07-21, Issue #797)
 
 - **`EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`** trat

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -26,10 +26,16 @@ from ..models.task import TaskManager, TaskStatus
 from ..container import get_container
 from ..services.graph_builder import GraphBuilderService  # noqa: F401
 from ..services.graph_tools import GraphToolsService
+from ..services.llm_routing_seed import (
+    build_runtime_llm_config,
+    resolve_route_api_key,
+    seed_run_stage_routing,
+)
 from ..services.report_agent import ReportAgent, ReportManager, ReportStatus
 from ..services.run_registry import RunRegistry
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import RunnerStatus, SimulationRunner
+from ..services.stage_model_router import StageModelRouter
 from ..services.sim.cancel_flag import request_cancel as _request_cancel
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.llm_client import LLMClient
@@ -527,6 +533,40 @@ def _restart_simulation_prepare(run: dict):
         branch_label=state.branch_name,
         metadata={"graph_id": state.graph_id, "branch_name": state.branch_name},
     )
+    run_id = new_run["run_id"]
+
+    # Restart hat keinen Request-Payload — llm_runtime=None, damit das
+    # Resolving ausschließlich über die persistierte Route bzw. den in der
+    # Settings-DB hinterlegten Store-Key läuft und nicht still auf
+    # Config.LLM_API_KEY/LLM_BASE_URL aus der lokalen .env zurückfällt (#798,
+    # Opus-Review-Folgebefund zu #778). Exakt derselbe Resolver-Pfad wie
+    # simulation_prepare.py::prepare_simulation (Zeilen 401-431).
+    from ..api.simulation_prepare import LOCAL_NO_AUTH_API_KEY, _is_local_endpoint
+
+    seed_run_stage_routing(
+        run_id,
+        "persona_generation",
+        llm_model_override=config.get("llm_model"),
+        llm_runtime=None,
+    )
+    route_router = StageModelRouter(run_id)
+    resolved_route = route_router.resolve("persona_generation")
+    route_router.lock_stage("persona_generation", resolved_route)
+    resolved_api_key = resolve_route_api_key(resolved_route, None)
+
+    if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
+        raise ValueError(
+            f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
+            f"für Provider '{resolved_route.provider_id}'. "
+            "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+            "oder im Sitzungsfeld eingeben."
+        )
+
+    if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):
+        resolved_api_key = LOCAL_NO_AUTH_API_KEY
+
+    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
+
     task_manager = TaskManager()
     task_id = task_manager.create_task(
         "simulation_prepare",
@@ -569,6 +609,7 @@ def _restart_simulation_prepare(run: dict):
                 parallel_profile_count=None,
                 storage=storage,
                 llm_model=config.get("llm_model"),
+                llm_runtime=effective_llm_runtime,
                 language=config.get("language"),
                 max_agents=config.get("max_agents"),
                 quota_plan=quota_plan,

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -252,3 +252,230 @@ def test_resume_report_generate_returns_422_when_llm_client_unavailable(env):
     payload = resp.get_json()
     assert payload["success"] is False
     assert payload.get("error")
+
+
+# ---------------------------------------------------------------------------
+# Test 8-10: Restart eines simulation_prepare-Runs nutzt den Store-Key statt
+# dem .env-Fallback (#798 — Opus-Review-Folgebefund zu #778).
+#
+# _restart_simulation_prepare übergab manager.prepare_simulation(...) bisher
+# ohne llm_runtime; _resolve_llm_connection(None) fiel dadurch beim Restart
+# eines Fremd-Provider-Runs still auf Config.LLM_API_KEY/LLM_BASE_URL zurück.
+# ---------------------------------------------------------------------------
+
+import threading as _threading  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from app.contracts.llm_routing_contract import ResolvedRoute  # noqa: E402
+from app.services.llm_runtime import RuntimeLlmConfig  # noqa: E402
+
+
+def _run_restart_prepare_sync(run, **prepare_mock_kwargs):
+    """Helper: ruft _restart_simulation_prepare(run) mit synchronem Thread auf.
+
+    Gibt (MockMgr, call_kwargs) zurück, wobei call_kwargs die kwargs des
+    manager.prepare_simulation(...)-Aufrufs sind.
+    """
+    from app.api.runs import _restart_simulation_prepare
+
+    def capture_start(self):
+        self.run()  # inline statt background
+
+    with patch.object(_threading.Thread, "start", capture_start):
+        _restart_simulation_prepare(run)
+
+
+def test_resume_simulation_prepare_uses_store_key_for_foreign_provider(env):
+    """Restart gegen einen Fremd-Provider mit hinterlegtem Store-Key muss
+    ``manager.prepare_simulation`` mit einem ``llm_runtime`` aufrufen, der den
+    Store-Key trägt — nicht ``llm_runtime=None`` (führt zum .env-Fallback).
+    """
+    run = _create_run(
+        env["registry"],
+        run_type="simulation_prepare",
+        entity_id="sim_test",
+        simulation_id="sim_test",
+        status="failed",
+    )
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_test"
+    fake_state.graph_id = "graph_test"
+    fake_state.branch_name = "main"
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Test requirement"
+
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=1,
+    )
+
+    with (
+        patch("app.api.runs.SimulationManager") as MockMgr,
+        patch("app.api.runs.ProjectManager") as MockProjMgr,
+        patch("app.api.runs.TaskManager") as MockTaskMgr,
+        patch("app.api.runs.run_registry") as mock_registry,
+        patch("app.api.runs.seed_run_stage_routing"),
+        patch("app.api.runs.StageModelRouter") as MockRouter,
+        patch(
+            "app.api.runs.resolve_route_api_key",
+            return_value="store-resolved-key-value",
+        ),
+    ):
+        MockMgr.return_value.get_simulation.return_value = fake_state
+        MockMgr.return_value.get_simulation_config.return_value = {"llm_model": "gpt-4o"}
+        MockProjMgr.get_project.return_value = fake_project
+        MockTaskMgr.return_value.create_task.return_value = "task_001"
+        mock_registry.create_run.return_value = {"run_id": "run_new_001"}
+        mock_registry.update_run.return_value = None
+
+        router_instance = MockRouter.return_value
+        router_instance.resolve.return_value = resolved_route
+        router_instance.lock_stage.return_value = resolved_route
+
+        env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
+
+        with env["app"].app_context():
+            _run_restart_prepare_sync(run)
+
+        assert MockMgr.return_value.prepare_simulation.called
+        call_kwargs = MockMgr.return_value.prepare_simulation.call_args.kwargs
+
+    assert "llm_runtime" in call_kwargs
+    llm_runtime = call_kwargs["llm_runtime"]
+    assert llm_runtime is not None, (
+        "Restart darf llm_runtime nicht None lassen — das fällt in "
+        "_resolve_llm_connection(None) still auf Config.LLM_API_KEY zurück (#798)"
+    )
+    assert llm_runtime.api_key == "store-resolved-key-value", (
+        f"Erwartet Store-Key aus der Settings-DB, erhalten: {llm_runtime.api_key!r}"
+    )
+    assert llm_runtime.provider == "openai"
+    assert llm_runtime != RuntimeLlmConfig(), (
+        "llm_runtime darf nicht der leere Default sein — das wäre äquivalent "
+        "zum alten .env-Fallback-Verhalten"
+    )
+
+
+def test_resume_simulation_prepare_falls_back_to_local_no_auth_key(env):
+    """Restart gegen einen lokalen No-Auth-Endpoint ohne Store-Key darf keinen
+    ValueError werfen und muss den lokalen Platzhalter-Key setzen.
+    """
+    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+
+    run = _create_run(
+        env["registry"],
+        run_type="simulation_prepare",
+        entity_id="sim_test",
+        simulation_id="sim_test",
+        status="failed",
+    )
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_test"
+    fake_state.graph_id = "graph_test"
+    fake_state.branch_name = "main"
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Test requirement"
+
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai_compatible",
+        model="qwen3:14b",
+        base_url_sanitized="http://localhost:11434/v1",
+        routing_version=1,
+    )
+
+    with (
+        patch("app.api.runs.SimulationManager") as MockMgr,
+        patch("app.api.runs.ProjectManager") as MockProjMgr,
+        patch("app.api.runs.TaskManager") as MockTaskMgr,
+        patch("app.api.runs.run_registry") as mock_registry,
+        patch("app.api.runs.seed_run_stage_routing"),
+        patch("app.api.runs.StageModelRouter") as MockRouter,
+        patch("app.api.runs.resolve_route_api_key", return_value=None),
+    ):
+        MockMgr.return_value.get_simulation.return_value = fake_state
+        MockMgr.return_value.get_simulation_config.return_value = {"llm_model": "qwen3:14b"}
+        MockProjMgr.get_project.return_value = fake_project
+        MockTaskMgr.return_value.create_task.return_value = "task_001"
+        mock_registry.create_run.return_value = {"run_id": "run_new_002"}
+        mock_registry.update_run.return_value = None
+
+        router_instance = MockRouter.return_value
+        router_instance.resolve.return_value = resolved_route
+        router_instance.lock_stage.return_value = resolved_route
+
+        env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
+
+        with env["app"].app_context():
+            _run_restart_prepare_sync(run)
+
+        assert MockMgr.return_value.prepare_simulation.called
+        call_kwargs = MockMgr.return_value.prepare_simulation.call_args.kwargs
+
+    llm_runtime = call_kwargs["llm_runtime"]
+    assert llm_runtime is not None
+    assert llm_runtime.api_key == LOCAL_NO_AUTH_API_KEY
+
+
+def test_resume_simulation_prepare_raises_without_key_for_non_local_endpoint(env):
+    """Fremd-Provider ohne Store-Key und ohne lokalen Endpoint muss hart
+    ablehnen — kein stiller .env-Fallback (#798, analog #778).
+    """
+    run = _create_run(
+        env["registry"],
+        run_type="simulation_prepare",
+        entity_id="sim_test",
+        simulation_id="sim_test",
+        status="failed",
+    )
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_test"
+    fake_state.graph_id = "graph_test"
+    fake_state.branch_name = "main"
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Test requirement"
+
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=1,
+    )
+
+    with (
+        patch("app.api.runs.SimulationManager") as MockMgr,
+        patch("app.api.runs.ProjectManager") as MockProjMgr,
+        patch("app.api.runs.TaskManager") as MockTaskMgr,
+        patch("app.api.runs.run_registry") as mock_registry,
+        patch("app.api.runs.seed_run_stage_routing"),
+        patch("app.api.runs.StageModelRouter") as MockRouter,
+        patch("app.api.runs.resolve_route_api_key", return_value=None),
+    ):
+        MockMgr.return_value.get_simulation.return_value = fake_state
+        MockMgr.return_value.get_simulation_config.return_value = {"llm_model": "gpt-4o"}
+        MockProjMgr.get_project.return_value = fake_project
+        MockTaskMgr.return_value.create_task.return_value = "task_001"
+        mock_registry.create_run.return_value = {"run_id": "run_new_003"}
+        mock_registry.update_run.return_value = None
+
+        router_instance = MockRouter.return_value
+        router_instance.resolve.return_value = resolved_route
+        router_instance.lock_stage.return_value = resolved_route
+
+        env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
+
+        with env["app"].app_context():
+            with pytest.raises(ValueError, match="provider_override"):
+                _run_restart_prepare_sync(run)
+
+        assert not MockMgr.return_value.prepare_simulation.called

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3476 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3479 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- Restart eines `simulation_prepare`-Runs übergab `manager.prepare_simulation(...)` bisher ohne `llm_runtime` — beim Restart eines Fremd-Provider-Runs fiel die Sim-Prep still auf `Config.LLM_API_KEY`/`.env` zurück statt den in der Settings-DB hinterlegten Store-Key zu nutzen.
- `_restart_simulation_prepare` löst Route und Store-Key jetzt über denselben Resolver-Pfad wie `simulation_prepare` (`StageModelRouter.resolve` → `resolve_route_api_key` → `build_runtime_llm_config`).

## Release-Ziel
- 0.9.0 — Stability Beta

## Issue
- Closes #798

## Scope
- `backend/app/api/runs.py::_restart_simulation_prepare`
- `backend/tests/api/test_runs_resume_stop.py`

## Out-of-Scope
- `resume_run`s Dispatch-/Fehler-Weiterleitungslogik (422-vs-500-Mapping) — Gegenstand von #799, betrifft einen anderen Endpoint (`generate-profiles`)
- `simulation_prepare.py` — bereits korrekter Referenzpfad, unverändert

## Tests
- `cd backend && uv run pytest tests/api/test_runs_resume_stop.py -x -q` — 10 passed
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS (`✓ pre-push-gate: ALL GREEN`)

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert (mechanisch via `sync-status.sh`, Backend-Testzähler 3476 → 3479)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate geändert
- `CHANGELOG.md`: aktualisiert (`[Unreleased] → Fixed`, Issue #798)
- Folge-Issue: NICHT BETROFFEN — der vom Reviewer notierte Hinweis (verwaister `pending`-Run-Record bei hartem Ablehnen ohne Key) ist identisches Verhalten zum bereits gemergten Referenzpfad in `simulation_prepare.py` und kein durch diesen Commit eingeführter Regress

## Review
- `agora-opus-reviewer` — APPROVE (alle drei Akzeptanzkriterien einzeln bestätigt, keine Blocker)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Neustarts vorbereiteter Simulationen verwenden nun zuverlässig den hinterlegten API-Schlüssel des aktiven LLM-Providers.
  * Lokale No-Auth-Endpunkte funktionieren weiterhin ohne hinterlegten Schlüssel.
  * Neustarts mit externen Providern ohne API-Schlüssel brechen jetzt eindeutig mit einer Fehlermeldung ab, statt einen falschen Schlüssel zu verwenden.

* **Tests**
  * Zusätzliche Tests decken Provider-Schlüssel, lokale No-Auth-Endpunkte und fehlende Schlüssel ab.
  * Die dokumentierte Anzahl der Backend-Tests wurde aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->