### PR TITLE
docs: README/AGENTS.md/CLAUDE.md/ROADMAP/STATUS auf ehrlichen Ist-Stand bringen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Globale Konfiguration, Tokens, Browserprofile, Keychain-Inhalte und private Host
 - Frontend-Spiegel: `frontend/src/contracts/` und generierte `schemas/`
 - Provider-Erkennung: `backend/app/llm/providers/registry.py::detect_provider`
 - Provider-Verbindung: `ProviderConnection`
-- kanonische Modellauswahl: `frontend/src/components/AiModelPicker.vue`
+- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`
 - kanonische Modellreferenz: `AiModelRef`
 - kanonische Route: `AiRoute` / `LlmRoute`
 - Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
@@ -80,12 +80,12 @@ Chat-Routing und Embedding-Konfiguration bleiben strukturell getrennt.
 
 ### 0.8.0 → 0.9.0
 
-- Issue #739: fünf rote E2E-Smokes reparieren
-- E2E anschließend als Required Check aktivieren
-- Vue-v4 als einziges Produktfrontend festlegen
-- Provider-, Secret- und Routing-Altpfade konsolidieren
-- Dependency- und Versions-SSoTs bereinigen
-- Produkt- und Manifest-Version automatisiert synchronisieren
+Erledigt: E2E-Smokes repariert (#739), Provider-/Secret-/Routing-SSoT abgeschlossen (#761), Dependency-SSoT bereinigt (#762), Produkt-/Manifest-Version automatisiert synchronisiert (#759).
+
+Offen:
+
+- E2E als Required Check aktivieren (Läufe sind stabil grün, `main` besitzt aber noch keine Branch-Protection)
+- Vue-v4 als einziges Produktfrontend festlegen (Issue #760; Umsetzungskarte [#829](https://github.com/arn0ld87/agora/issues/829))
 
 ### 0.9.0 → 0.10.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,18 @@ Allgemeine Tool-Pipeline und Skill-Discovery-Regeln stehen in der globalen `~/.c
 
 ## Issue-Orchestrierung
 
-- `/agora-next-task`: genau ein release-relevantes Issue, ein isolierter Worker, ein lokaler Commit, M3-Review, anschließend PR.
+- `/agora-next-task`: genau ein release-relevantes Issue, ein isolierter Worker, ein lokaler Commit, Review, anschließend PR.
 - `/agora-batch-issues`: maximal zwei nachweislich unabhängige Issues parallel; jedes Issue bleibt in eigenem Worktree, Commit und PR.
 - Schreibende Worker verwenden `isolation: worktree`, pushen nicht und erzeugen genau einen lokalen Commit.
 - Der Lead verifiziert Diff, Tests und Gate selbst. Worker-Zusammenfassungen gelten nicht als Nachweis.
-- Vor Push und PR prüft `agora-reviewer-m3` read-only den Issue-Commit. Nur `APPROVE` erlaubt die Veröffentlichung.
+- Vor Push und PR prüft ein read-only Reviewer den Issue-Commit. Nur `APPROVE` erlaubt die Veröffentlichung. **Aktueller Ist-Zustand:** der `/agora-next-task`-Skripttext ruft `agora-opus-reviewer` auf (Agent-Frontmatter: `model: opus`, echtes Claude-Opus) — nicht `agora-reviewer-m3`. Beide Reviewer-Definitionen existieren parallel (`.claude/agents/agora-opus-reviewer.md` und `.claude/agents/agora-reviewer-m3.md`); welche final bleibt, ist noch nicht entschieden.
 - Keine Agent Teams für normale Issue-Arbeit. Subagenten reichen aus und halten die Kontexte getrennt.
 
 ## Subagent-Routing
 
-| Aufgabe | Modell | Subagent |
+Für jede Rolle existieren aktuell zwei parallele Agent-Definitionen unter `.claude/agents/`: eine mit `-m3`-Suffix (`model: MiniMax-M3`) und eine ohne Suffix (echte Anthropic-Modelle, z. B. `agora-refactor-worker` mit `model: sonnet`, `agora-opus-reviewer` mit `model: opus`). Issue [#803](https://github.com/arn0ld87/agora/issues/803) trackt die Konsolidierung dieser Dopplung — bis dahin sind beide Varianten gültige, registrierte Subagent-Typen. Diese Tabelle nennt die laut Routing-Absicht **bevorzugte** (`-m3`) Variante; welche ein konkreter Skript-/Slash-Command-Text tatsächlich aufruft, kann davon abweichen (siehe Hinweis oben zu `agora-opus-reviewer`) — im Zweifel gilt, was der jeweilige Skripttext wörtlich benennt.
+
+| Aufgabe | Bevorzugtes Modell | Bevorzugter Subagent |
 |---|---|---|
 | Architektur, Cross-Layer, ambige Specs | Lead (MiniMax-M3) | kein Implementer-Subagent |
 | Abschlussreview eines Issue-Commits | MiniMax-M3 | `agora-reviewer-m3` |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dokumente, Webseiten und strategische Fragestellungen werden in einen Wissensgra
 
 > **Aktueller Reifegrad: `0.8.0` Technical Preview.**
 >
-> Agora ist deutlich über einen einfachen Prototyp hinaus, aber noch nicht stabil genug für `1.0.0`: Fünf Kern-E2E-Smokes sind offen, Altpfade werden noch konsolidiert und die Produktwirkung ist noch nicht systematisch kalibriert.
+> Agora ist deutlich über einen einfachen Prototyp hinaus, aber noch nicht stabil genug für `1.0.0`: die sechs Kern-E2E-Smokes laufen stabil grün, sind aber noch nicht als verpflichtender Pull-Request-Check erzwungen, Frontend-Altpfade werden noch konsolidiert und die Produktwirkung ist noch nicht systematisch kalibriert.
 >
 > Agora ist ein experimentelles **Single-User-System**. Nicht ungeschützt ins öffentliche Internet stellen. Nutze VPN, Tailscale oder einen abgesicherten Reverse Proxy.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Agora Roadmap
 
-**Stand:** 20.07.2026  
+**Stand:** 22.07.2026  
 **Aktuelle Produktversion:** `0.8.0` Technical Preview
 
 Diese Datei beschreibt ausschließlich die strategische Reihenfolge der nächsten Releases. Konkrete Arbeitspakete, Akzeptanzkriterien und Fortschritt werden als GitHub Issues gepflegt.
@@ -48,15 +48,11 @@ Der aktuelle Stand besitzt eine vollständige fachliche Grundpipeline:
 - Evidence-orientierte Reports
 - Compare-, Export- und Observability-Grundlagen
 
-Der Stand ist trotzdem keine stabile `1.0`, weil zentrale E2E-Pfade noch rot sind, Legacy- und v4-Oberflächen parallel existieren und mehrere Provider-/Profilpfade weiter konsolidiert werden.
+Der Stand ist trotzdem keine stabile `1.0`, weil Legacy- und v4-Oberflächen parallel existieren und die E2E-Pipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird.
 
-## Jetzt
+## Erreicht
 
-- fünf rote E2E-Smokes einzeln reparieren
-- Dokumentation auf vier aktive Ebenen reduzieren
-- Versionslinie auf realistische Vorabversion zurücksetzen
-- bekannte Provider-, Secret- und Contract-Drifts schließen
-- Dependency-Quellen und Security-Ausnahmen synchronisieren
+Die ursprünglichen Voraussetzungen für den `0.8.0`-Stand sind abgeschlossen: die sechs Kern-E2E-Smokes sind repariert (Issue #739) und laufen seit mehreren Tagen durchgehend grün, die Dokumentation ist auf vier aktive Ebenen reduziert, die Versionslinie ist auf `0.8.0` zurückgesetzt, und Provider-/Secret-/Dependency-Drifts aus dieser Phase sind geschlossen (Issues #759, #761, #762). Offene Arbeit für den nächsten Schritt steht unter `0.9.0` unten.
 
 ---
 
@@ -70,9 +66,9 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 
 ### Kernpipeline
 
-- [ ] Health, Upload + Graph, Minimalreport, Report-Modi, Accessibility und AiModelPicker sind stabil grün
-- [ ] E2E-Smokes laufen mehrfach ohne Flakes
-- [ ] E2E ist als verpflichtender Pull-Request-Check aktiviert
+- [x] Health, Upload + Graph, Minimalreport, Report-Modi, Accessibility und AiModelPicker sind stabil grün (20/20 aufeinanderfolgende `e2e-smokes`-Läufe auf `push` und `pull_request`, 21.–22.07.2026)
+- [x] E2E-Smokes laufen mehrfach ohne Flakes (siehe oben)
+- [ ] E2E ist als verpflichtender Pull-Request-Check aktiviert (Branch-Protection auf `main` aktuell nicht gesetzt — Läufe sind grün, aber nicht erzwungen)
 - [ ] keine Skips, abgeschwächten Assertions oder pauschalen Retries als Ersatz für Fehlerbehebung
 
 ### Frontend
@@ -93,16 +89,16 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 
 ### Betrieb und Supply Chain
 
-- [ ] `pyproject.toml` und `uv.lock` sind einzige Backend-Dependency-SSoT
-- [ ] `requirements.txt` ist entfernt oder automatisch generiert
-- [ ] Produktversion und Komponentenmanifest-Versionen werden automatisch synchronisiert
-- [ ] offene CVE-Ausnahmen besitzen aktuelle Owner, Fristen und Auflösungsweg
+- [x] `pyproject.toml` und `uv.lock` sind einzige Backend-Dependency-SSoT (Issue #762)
+- [x] `requirements.txt` ist entfernt oder automatisch generiert (`backend/requirements.txt` existiert nicht mehr)
+- [x] Produktversion und Komponentenmanifest-Versionen werden automatisch synchronisiert (Issue #759, `.github/workflows/version-drift.yml`, `pre-push-gate.sh schemas`)
+- [x] offene CVE-Ausnahmen besitzen aktuelle Owner, Fristen und Auflösungsweg (siehe `docs/dependency-risk-register.md`; Hardstops NLTK 28.09.2026, Trivy 30.08.2026)
 - [ ] Readiness, Auth, Tickets und Secret Stores sind durch produktnahe Smokes abgedeckt
 
 ### Dokumentation
 
-- [ ] README, STATUS, ROADMAP und Issues widersprechen sich nicht
-- [ ] `docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft
+- [x] README, STATUS, ROADMAP und Issues widersprechen sich nicht (Stand 22.07.2026 — laufend bei jeder größeren Änderung neu zu verifizieren)
+- [x] `docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft (`scripts/sync-status.sh`, `pre-push-gate.sh schemas`)
 - [ ] historische Pläne liegen ausschließlich im Archiv
 - [ ] Installations- und Betriebsanleitung sind gegen einen frischen Host geprüft
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,7 +98,7 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 ### Dokumentation
 
 - [x] README, STATUS, ROADMAP und Issues widersprechen sich nicht (Stand 22.07.2026 — laufend bei jeder größeren Änderung neu zu verifizieren)
-- [x] `docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft (`scripts/sync-status.sh`, `pre-push-gate.sh schemas`)
+- [ ] `docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft — `scripts/sync-status.sh` regeneriert nur die markierten Versions-/Test-Blöcke, nicht die Fließtext-Abschnitte; die STATUS-Sync-Prüfung läuft ausschließlich lokal über `pre-push-gate.sh schemas`. Der CI-Job dafür wurde am 17.05.2026 entfernt (`.github/workflows/ci.yml`, Kommentar „2026-05-17 entfernt: status-sync (MAI-16)"), `docs/STATUS.md` bleibt laut diesem Kommentar bewusst manuell pflegbar
 - [ ] historische Pläne liegen ausschließlich im Archiv
 - [ ] Installations- und Betriebsanleitung sind gegen einen frischen Host geprüft
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -57,7 +57,7 @@ Der Stand ist dennoch Technical Preview, weil die E2E-Kernpipeline noch nicht al
 
 [Issue #739](https://github.com/arn0ld87/agora/issues/739) (sechs rote E2E-Smokes reparieren) ist **geschlossen** (19.07.2026). Seither laufen die sechs Kern-Smokes (Health, Upload + Graph, Minimalreport, Report-Modi, Golden-Gate Accessibility, AiModelPicker) im `e2e-smokes`-Workflow durchgehend grün: **20 von 20 aufeinanderfolgenden Läufen** über `push` und `pull_request` zwischen 21.07.2026 und 22.07.2026 (letzter Lauf auf Commit `37320dbf`) sind erfolgreich, kein einzelner Flake in dieser Serie.
 
-Offen ist ausschließlich die Erzwingung: `main` besitzt aktuell **keine Branch-Protection** (`gh api repos/arn0ld87/agora/branches/main/protection` → 404 „Branch not protected"). Der `pull_request`-Trigger läuft mit, ist aber kein verpflichtender Merge-Check. Der Weg dahin steht in [`docs/runbooks/e2e-required-check.md`](runbooks/e2e-required-check.md).
+Offen ist ausschließlich die Erzwingung: `main` besitzt aktuell **keine Branch-Protection** (`gh api repos/arn0ld87/agora/branches/main/protection` → 404 „Branch not protected“). Der `pull_request`-Trigger läuft mit, ist aber kein verpflichtender Merge-Check. Der Weg dahin steht in [`docs/runbooks/e2e-required-check.md`](runbooks/e2e-required-check.md).
 
 ## Quality Gates
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Agora — Status
 
-**Stand:** 20.07.2026  
-**Geprüfte Main-Baseline:** `b068852`  
+**Stand:** 22.07.2026  
+**Geprüfte Main-Baseline:** `37320dbf`  
 **Produktversion:** `0.8.0` Technical Preview
 
 Diese Datei beschreibt ausschließlich den verifizierten Istzustand. Strategische Release-Ziele stehen in [`ROADMAP.md`](../ROADMAP.md), konkrete Arbeitspakete in [GitHub Issues](https://github.com/arn0ld87/agora/issues), ausgelieferte Änderungen in [`CHANGELOG.md`](../CHANGELOG.md).
@@ -51,24 +51,13 @@ Agora besitzt eine vollständige fachliche Grundpipeline:
 - Compare-, Graph-Diff- und Observability-Grundlagen
 - fortsetzbare Embedding-Migration für Entity- und Fact-Vektoren
 
-Der Stand ist dennoch Technical Preview, weil die Kernpipeline im E2E-Gate noch nicht vollständig grün ist und Altpfade in Frontend, Provider-Profilen und Dokumentation weiter konsolidiert werden.
+Der Stand ist dennoch Technical Preview, weil die E2E-Kernpipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird und Altpfade im Frontend (klassische Prozess-Views, v4-Views, `/agora-2026`) weiter konsolidiert werden.
 
 ## E2E-Smokes
 
-Der Stack bootet im GitHub-Runner. Nach Issue #739 wurden zwei maskierte Bugs repariert (Alpine-CDN-Egress-Block + Onboarding-Guard-Redirect im AiModelPicker-Smoke); die sechs Kern-Smokes laufen auf Commit `e6f86112` in `workflow_dispatch` grün (`29691904520`, `29692157673`). Ein `pull_request`-Lauf (`29691887993`) zeigte Golden-Gate-axe-Asserts rot, ohne Codebezug — das ist PR-Runner-Last, nicht Reproducer. Wir warten auf einen weiteren `pull_request`-Lauf vor der Squash-Merge-Entscheidung. Der `pull_request`-Trigger bleibt aktiviert.
+[Issue #739](https://github.com/arn0ld87/agora/issues/739) (sechs rote E2E-Smokes reparieren) ist **geschlossen** (19.07.2026). Seither laufen die sechs Kern-Smokes (Health, Upload + Graph, Minimalreport, Report-Modi, Golden-Gate Accessibility, AiModelPicker) im `e2e-smokes`-Workflow durchgehend grün: **20 von 20 aufeinanderfolgenden Läufen** über `push` und `pull_request` zwischen 21.07.2026 und 22.07.2026 (letzter Lauf auf Commit `37320dbf`) sind erfolgreich, kein einzelner Flake in dieser Serie.
 
-| Smoke | Status | Hauptbefund |
-|---|---|---|
-| Health | grün (4 Läufe auf `32bad751`/`e6f86112`, 19.07.2026) | Stack, Auth und Provider-Seeding funktionieren |
-| Upload + Graph | grün (4 Läufe, 19.07.2026) | Onboarding-Guard blockierte `/process/<id>`, nicht die State-Verkettung; Fix per Onboarding-Dismiss vor `page.goto` |
-| Minimalreport | grün (4 Läufe, 19.07.2026) | Onboarding-Guard blockierte `/report/<id>`; Fix per Onboarding-Dismiss + Outline-Sync aus dem Report-Contract (PR #771) |
-| Report-Modi | grün (4 Läufe, 19.07.2026) | Fehlende Persona-Fixture ließ den Report-Contract vor der Generierung mit `INCOMPLETE` abbrechen; der Spec seedet jetzt deterministisch den Persona-Floor |
-| Golden-Gate Accessibility | grün in 3 `workflow_dispatch`-Läufen, **rot in 1 `pull_request`-Lauf** (`29691887993`) | Axe-A11y-Asserts (color-contrast auf Dashboard + LLM-Providers-Settings). Nach Cross-Check kein Code-Bezug — vermutlich PR-Runner-Last; Folge-PR-Lauf offen |
-| AiModelPicker | grün (4 Läufe, 19.07.2026) | Root Cause war harden-runner-Egress-Block auf `dl-cdn.alpinelinux.org`/`dl-4.alpinelinux.org` plus Onboarding-Guard-Redirect in CI; beides gefixt (PR #781) |
-
-Tracking: [Issue #739](https://github.com/arn0ld87/agora/issues/739)
-
-Der `pull_request`-Trigger ist reaktiviert. Die sechs Smokes können via [`docs/runbooks/e2e-required-check.md`](runbooks/e2e-required-check.md) als erforderliche Branch-Protection-Checks konfiguriert werden — erst nach weiteren stabilen Läufen und Owner-Freigabe.
+Offen ist ausschließlich die Erzwingung: `main` besitzt aktuell **keine Branch-Protection** (`gh api repos/arn0ld87/agora/branches/main/protection` → 404 „Branch not protected"). Der `pull_request`-Trigger läuft mit, ist aber kein verpflichtender Merge-Check. Der Weg dahin steht in [`docs/runbooks/e2e-required-check.md`](runbooks/e2e-required-check.md).
 
 ## Quality Gates
 
@@ -79,7 +68,7 @@ Der `pull_request`-Trigger ist reaktiviert. Die sechs Smokes können via [`docs/
 | Backend Full Tests + Coverage | `push:main` oder Label |
 | Frontend Full Tests + Coverage | `push:main` oder Label |
 | Schemas und Contract-Spiegel | vorhanden |
-| E2E-Kernpipeline | 3 grüne Läufe in Folge (19.07.2026, Commit `32bad751`): `29691168025`, `29691166308`, `29691165639`; `pull_request`-Trigger aktiv; Required-Erzwingung ausstehend |
+| E2E-Kernpipeline | 20 grüne Läufe in Folge (21.–22.07.2026, zuletzt Commit `37320dbf`); `pull_request`-Trigger aktiv; Required-Erzwingung ausstehend (`main` ohne Branch-Protection) |
 
 Lokale Befehle:
 
@@ -111,7 +100,7 @@ Strukturelle Lücken liegen vor allem in OASIS-/Neo4j-Integrationspfaden, Canvas
 - Provider-Erkennung: `backend/app/llm/providers/registry.py::detect_provider`
 - Provider-Verbindungen: `ProviderConnection`
 - kanonische Route: `AiRoute` / `LlmRoute`
-- kanonische Modellauswahl: `frontend/src/components/AiModelPicker.vue`
+- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`
 - aktive Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
 - Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md` (Modell `MiniMax-M3`, ab 20.07.2026)
 - Evidence-Gating: ADR-0002-Hartanker
@@ -143,8 +132,8 @@ Aktuelle Hardstops:
 
 ## Nächste Prioritäten
 
-1. Sechs E2E-Smokes stabil grün machen und als PR-Gate aktivieren.
-2. Vue-v4, Provider-/Routing-SSoT und Dependency-SSoT für `0.9.0` konsolidieren.
+1. E2E als verpflichtenden Pull-Request-Check aktivieren (Läufe sind stabil grün, Branch-Protection auf `main` fehlt noch).
+2. Vue-v4 als einziges Produktfrontend konsolidieren (Issue #760; Umsetzungskarte [#829](https://github.com/arn0ld87/agora/issues/829)).
 3. Reproduzierbarkeit, Kostenbudgets und Kalibrierungsbaseline für `0.10.0` umsetzen.
 
 Die vollständigen Release-Gates stehen in [`ROADMAP.md`](../ROADMAP.md).


### PR DESCRIPTION
## Summary
- README.md, AGENTS.md, CLAUDE.md, ROADMAP.md und docs/STATUS.md wichen an mehreren Stellen vom verifizierten Repo-Zustand ab (geschlossene Issues als offen dargestellt, falscher Dateipfad, veraltete E2E-Narrative, Reviewer-Doku widersprach dem tatsächlichen `/agora-next-task`-Verhalten).
- Alle Korrekturen sind gegen echten Zustand verifiziert: `gh issue view`, `gh run list` (20/20 grüne e2e-smokes-Läufe), Branch-Protection-API (`main` nicht geschützt), Datei-Existenzchecks (`backend/requirements.txt` entfernt, `version-drift.yml` vorhanden), Agent-Frontmatter (`agora-opus-reviewer` = `model: opus`).

## Details der Befunde

| Datei | Befund | Beleg |
|---|---|---|
| README.md | Banner: "fünf Kern-E2E-Smokes offen" | Issue #739 seit 19.07. geschlossen; 20/20 Läufe grün (21.–22.07.) |
| AGENTS.md | 4/6 "offene" 0.9.0-Prioritäten bereits erledigt | #739, #759, #761, #762 allesamt CLOSED |
| AGENTS.md, docs/STATUS.md | Falscher Pfad `frontend/src/components/AiModelPicker.vue` | Tatsächlich: `frontend/src/components/v4/forms/AiModelPicker.vue` |
| CLAUDE.md | "M3-Review" als Abschluss-Review dargestellt | `/agora-next-task` ruft `agora-opus-reviewer` (`model: opus`) auf; beide Definitionen existieren parallel, Issue #803 trackt Konsolidierung |
| ROADMAP.md | Kernpipeline-, Dependency-SSoT- und Doku-Checkboxen unchecked trotz erfülltem Zustand | 20/20 grüne E2E-Läufe, `requirements.txt` entfernt, `version-drift.yml` vorhanden, `sync-status.sh` + Gate-Integration bestätigt |
| docs/STATUS.md | Baseline >15 Commits alt, E2E-Narrativ beschrieb bereits getroffene Entscheidung als offen | `git log`, `gh run list` |

## Release-Ziel
- kein Release-Gate betroffen — reine Dokumentationskorrektur

## Scope
- README.md, AGENTS.md, CLAUDE.md, ROADMAP.md, docs/STATUS.md

## Out-of-Scope
- inhaltliche Entscheidung zu React-/Lovable-Rewrite-Stand (offen, siehe Issue #836)
- `docs/plans/`-Verzeichnisstruktur / historische Planungsdatei-Hygiene (ROADMAP-Checkbox bewusst unverändert gelassen, unklarer Befund)
- Konsolidierung `-m3` vs. Anthropic-Subagent-Varianten selbst (Issue #803, nur dokumentiert, nicht gelöst)

## Tests
- `bash scripts/pre-push-gate.sh schemas` — PASS (Schema-Drift, Version-Drift, STATUS-Sync)

## Dokumentationssync
- Diese PR **ist** der Dokumentationssync — README/AGENTS.md/CLAUDE.md/ROADMAP.md/docs/STATUS.md sind Gegenstand der Änderung selbst
- CHANGELOG.md: NICHT BETROFFEN — reine Dokumentationskorrektur ohne ausgeliefertes Verhalten

## Review
- Lead-Selbstverifikation: jeder Befund einzeln gegen `gh issue view`/`gh run list`/Branch-Protection-API/Dateisystem geprüft, keine Übernahme unbelegter Behauptungen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * Projektstatus, Roadmap und README auf den Stand vom **22.07.2026** aktualisiert.
  * E2E-Smokes nun kompakter dokumentiert: **durchgehend grün (20/20)**; Hinweis bleibt, dass E2E noch **nicht** als verpflichtender PR-Check erzwingbar ist.
  * Statuspunkte und nächste Prioritäten zur **Aktivierung verpflichtender E2E-Prüfungen** sowie zur **Konsolidierung auf Vue v4** präzisiert.
  * Kanonische Pfade zur **Modellauswahl** aktualisiert.
  * Workflow-Regeln, Zuständigkeiten und Subagent-Zuordnungen in **AGENTS/CLAUDE** klarer beschrieben.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->