### PR TITLE
fix(llm): Verwaiste pending-Run-/Task-Records bei fehlendem Store-Key markieren (#841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Verwaiste pending-Run-/Task-Records bei fehlendem Store-Key — 2026-07-22, Issue #841)
+
+- **`prepare_simulation` (`backend/app/api/simulation_prepare.py`)** und
+  **`_restart_simulation_prepare` (`backend/app/api/runs.py`)** legten `Run`- (und teils
+  `Task`-)Datensätze bereits an, bevor der Store-Key-Guard einen Lauf mangels API-Key ablehnte —
+  der Datensatz blieb danach dauerhaft `pending` in der Registry, ohne Fehlermeldung. Fix markiert
+  den Run (und, wo bereits vorhanden, den Task) auf dem Guard-Pfad jetzt explizit als `failed` mit
+  der Guard-Fehlermeldung, bevor die 422-Antwort bzw. der `ValueError` zurückgegeben wird
+  (gefunden vom Opus-Reviewer als Nebenbefund bei Issue #798, kein Regress, eigenständiges
+  Datenhygiene-/UX-Problem).
+
 ### Fixed (Restart eines Prepare-Runs nutzt Store-Key statt .env-Fallback — 2026-07-22, Issue #798)
 
 - **`_restart_simulation_prepare` (`backend/app/api/runs.py`)** übergab `manager.prepare_simulation(...)`

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -555,12 +555,20 @@ def _restart_simulation_prepare(run: dict):
     resolved_api_key = resolve_route_api_key(resolved_route, None)
 
     if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
-        raise ValueError(
+        guard_message = (
             f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
             f"für Provider '{resolved_route.provider_id}'. "
             "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
             "oder im Sitzungsfeld eingeben."
         )
+        # Issue #841: new_run existiert an dieser Stelle bereits (Zeile 523) —
+        # ein Task wird erst danach erzeugt (Zeile 570), daher hier kein
+        # task_manager.fail_task. Ohne dieses Markieren bleibt der Run-Datensatz
+        # dauerhaft als "pending" in der Registry verwaist.
+        run_registry.update_run(
+            new_run["run_id"], status="failed", message=guard_message, error=guard_message
+        )
+        raise ValueError(guard_message)
 
     if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):
         resolved_api_key = LOCAL_NO_AUTH_API_KEY

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -419,10 +419,14 @@ def prepare_simulation():
         # Issue #841: run_record und task_id existieren an dieser Stelle
         # bereits (Zeilen 369/393) — ohne dieses Markieren bleibt der
         # Datensatz dauerhaft als "pending" in der Registry verwaist.
+        # Reihenfolge ist bewusst: fail_task() setzt intern per sync_task()
+        # eine generische Task-Message ("Task failed") auf den Run zurück —
+        # der detaillierte update_run()-Aufruf muss deshalb zuletzt laufen,
+        # sonst überschreibt sync_task() die provider_override-Meldung.
+        task_manager.fail_task(task_id, guard_message)
         run_registry.update_run(
             run_record["run_id"], status="failed", message=guard_message, error=guard_message
         )
-        task_manager.fail_task(task_id, guard_message)
         return json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=422,

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -410,15 +410,23 @@ def prepare_simulation():
     resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
 
     if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
+        guard_message = (
+            f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
+            f"für Provider '{resolved_route.provider_id}'. "
+            "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+            "oder im Sitzungsfeld eingeben."
+        )
+        # Issue #841: run_record und task_id existieren an dieser Stelle
+        # bereits (Zeilen 369/393) — ohne dieses Markieren bleibt der
+        # Datensatz dauerhaft als "pending" in der Registry verwaist.
+        run_registry.update_run(
+            run_record["run_id"], status="failed", message=guard_message, error=guard_message
+        )
+        task_manager.fail_task(task_id, guard_message)
         return json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=422,
-            message=(
-                f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
-                f"für Provider '{resolved_route.provider_id}'. "
-                "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
-                "oder im Sitzungsfeld eingeben."
-            ),
+            message=guard_message,
         )
 
     if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):

--- a/backend/tests/api/test_provider_override_key_fallback.py
+++ b/backend/tests/api/test_provider_override_key_fallback.py
@@ -46,8 +46,20 @@ def llm_client(monkeypatch):
     return app.test_client()
 
 
-def _base_prepare_mocks(monkeypatch, *, resolved_api_key: str | None):
-    """Setzt alle Mocks für /api/simulation/prepare außer resolve_route_api_key."""
+def _base_prepare_mocks(
+    monkeypatch,
+    *,
+    resolved_api_key: str | None,
+    task_fail_calls: list | None = None,
+    run_update_calls: list | None = None,
+):
+    """Setzt alle Mocks für /api/simulation/prepare außer resolve_route_api_key.
+
+    ``task_fail_calls``/``run_update_calls`` sind optionale Listen, in die
+    Aufrufe von ``TaskManager.fail_task`` bzw. ``run_registry.update_run``
+    aufgezeichnet werden (Issue #841 — Guard-Pfad muss verwaiste
+    pending-Records als ``failed`` markieren).
+    """
     fake_state = MagicMock()
     fake_state.project_id = "proj_001"
     fake_state.graph_id = "graph_001"
@@ -76,6 +88,8 @@ def _base_prepare_mocks(monkeypatch, *, resolved_api_key: str | None):
         def complete_task(self, *a, **k):
             return None
         def fail_task(self, *a, **k):
+            if task_fail_calls is not None:
+                task_fail_calls.append((a, k))
             return None
 
     monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
@@ -91,6 +105,11 @@ def _base_prepare_mocks(monkeypatch, *, resolved_api_key: str | None):
         "app.api.simulation_prepare.run_registry.create_run",
         lambda *a, **k: {"run_id": "run_test_1"},
     )
+    if run_update_calls is not None:
+        monkeypatch.setattr(
+            "app.api.simulation_prepare.run_registry.update_run",
+            lambda *a, **k: run_update_calls.append((a, k)),
+        )
     monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
     monkeypatch.setattr(
         "app.api.simulation_prepare.resolve_route_api_key",
@@ -231,7 +250,14 @@ def test_override_422_when_no_payload_no_db_and_cloud_provider(prepare_client, m
         def lock_stage(self, *_a, **_k):
             return None
 
-    _base_prepare_mocks(monkeypatch, resolved_api_key=None)
+    task_fail_calls: list = []
+    run_update_calls: list = []
+    _base_prepare_mocks(
+        monkeypatch,
+        resolved_api_key=None,
+        task_fail_calls=task_fail_calls,
+        run_update_calls=run_update_calls,
+    )
     fake_manager = MagicMock()
     fake_manager.get_simulation.return_value = MagicMock(
         project_id="proj_001", graph_id="g1",
@@ -253,6 +279,21 @@ def test_override_422_when_no_payload_no_db_and_cloud_provider(prepare_client, m
     assert resp.status_code == 422, resp.get_json()
     body = resp.get_json()
     assert "provider_override" in body.get("message", "").lower() or "provider_override" in str(body).lower()
+
+    # Issue #841 — verwaister pending-Run-/Task-Record muss auf dem
+    # Guard-Pfad als "failed" markiert werden (run_record und task_id
+    # existieren an dieser Stelle bereits, siehe simulation_prepare.py).
+    assert len(run_update_calls) == 1
+    update_args, update_kwargs = run_update_calls[0]
+    assert update_args[0] == "run_test_1"
+    assert update_kwargs["status"] == "failed"
+    assert "provider_override" in update_kwargs["message"].lower()
+    assert "provider_override" in update_kwargs["error"].lower()
+
+    assert len(task_fail_calls) == 1
+    fail_args, _fail_kwargs = task_fail_calls[0]
+    assert fail_args[0] == "task_1"
+    assert "provider_override" in fail_args[1].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -488,3 +488,4 @@ def test_resume_simulation_prepare_raises_without_key_for_non_local_endpoint(env
     assert update_call.kwargs["status"] == "failed"
     assert "provider_override" in update_call.kwargs["message"]
     assert "provider_override" in update_call.kwargs["error"]
+    assert not MockTaskMgr.return_value.create_task.called

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -479,3 +479,12 @@ def test_resume_simulation_prepare_raises_without_key_for_non_local_endpoint(env
                 _run_restart_prepare_sync(run)
 
         assert not MockMgr.return_value.prepare_simulation.called
+
+    # Issue #841 — verwaister pending-Run-Datensatz muss auf dem Guard-Pfad
+    # als "failed" markiert werden (new_run existiert bereits, Task noch nicht).
+    assert mock_registry.update_run.call_count == 1
+    update_call = mock_registry.update_run.call_args
+    assert update_call.args[0] == "run_new_003"
+    assert update_call.kwargs["status"] == "failed"
+    assert "provider_override" in update_call.kwargs["message"]
+    assert "provider_override" in update_call.kwargs["error"]


### PR DESCRIPTION
## Summary
- Zwei Guards lehnten einen Prepare-Lauf wegen fehlendem Store-Key ab, nachdem sie den `Run`- (und teils `Task`-)Datensatz bereits erzeugt hatten — ohne ihn als `failed` zu markieren. Der Datensatz blieb dauerhaft `pending` in der Registry, ohne Fehlermeldung.
- `prepare_simulation` (`simulation_prepare.py`) markiert jetzt Run **und** Task als `failed`, `_restart_simulation_prepare` (`runs.py`) markiert nur den Run (Task existiert an dieser Stelle noch nicht).

## Release-Ziel
- 0.9.0 — Stability Beta

## Issue
- Closes #841

## Scope
- `backend/app/api/simulation_prepare.py`
- `backend/app/api/runs.py`
- `backend/tests/api/test_provider_override_key_fallback.py`
- `backend/tests/api/test_runs_resume_stop.py`

## Out-of-Scope
- Die Resolver-Kette selbst (`StageModelRouter`, `resolve_route_api_key`, `build_runtime_llm_config`) — unverändert
- HTTP-Statuscode-Mapping des `generate-profiles`-Endpoints — Gegenstand von #799

## Tests
- `cd backend && uv run pytest tests/api/test_runs_resume_stop.py tests/api/test_provider_override_key_fallback.py -x -q` — 18 passed
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS (`✓ pre-push-gate: ALL GREEN`)

## Dokumentationssync
- `CHANGELOG.md`: aktualisiert (`[Unreleased] → Fixed`, Issue #841)
- `docs/STATUS.md`: NICHT BETROFFEN (Gate bestätigt „in sync", keine Testzähler-Änderung)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate geändert

## Review
- `agora-opus-reviewer` — APPROVE (alle vier Akzeptanzkriterien einzeln bestätigt, inklusive der bewussten Asymmetrie run-only vs. run+task, keine Blocker)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Läufe und zugehörige Aufgaben werden bei fehlenden bzw. nicht auflösbaren Zugangsdaten nun zuverlässig als fehlgeschlagen markiert (inkl. Konsistenz bei Resume/Restart).
  * Verhindert, dass betroffene Einträge dauerhaft im Status „Ausstehend“ verbleiben.
  * Fehlermeldungen werden konsistent für Lauf- und Aufgabenübersichten bereitgestellt.
* **Tests**
  * Erweiterte Prüfungen und Mock-Validierungen für die Guard-Fehlerpfade bei fehlenden Provider-Keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->