### PR TITLE
fix(llm): Persistenzfehler von update_run im Provider-Key-Guard behandeln (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Persistenzfehler von update_run im Provider-Key-Guard maskiert bisher als reguläre Ablehnung — 2026-07-22, Issue #844)
+
+- **`prepare_simulation` (`backend/app/api/simulation_prepare.py`)** und
+  **`_restart_simulation_prepare` (`backend/app/api/runs.py`)** markierten Run/Task beim
+  Provider-Key-Guard (Issue #841) zwar als `failed`, ignorierten dabei aber Rückgabewert und
+  Exceptions von `run_registry.update_run(...)`. Lieferte `update_run` `None` (Run-Manifest
+  zwischenzeitlich verschwunden) oder warf es eine I/O-Exception, gab der Endpunkt trotzdem die
+  reguläre 422-Antwort bzw. den `ValueError` zurück — als sei die Ablehnung sauber persistiert
+  worden, obwohl der Run unbemerkt `pending` blieb (CodeRabbit-Major-Befund auf PR #843).
+- Fix prüft den Rückgabewert von `update_run` explizit und fängt Exceptions ab: bei bestätigter
+  Persistenz bleibt das Verhalten aus #841 unverändert (422 bzw. `ValueError` mit der detaillierten
+  Provider-Key-Meldung); bei Persistenzfehler wird stattdessen das bestehende Projektmuster
+  `ApiErrorCode.INTERNAL_ERROR` verwendet (Prepare-Pfad: `json_error(..., status=500)`;
+  Restart-Pfad: `RuntimeError(ApiErrorCode.INTERNAL_ERROR)`, von `handle_api_errors` auf 500
+  gemappt). Run-/Task-Bezug wird serverseitig geloggt, ohne Details an den Client zu leaken.
+  `TaskManager.fail_task` bleibt bewusst best-effort (keine prüfbare Fehlersemantik ohne
+  Änderung an `task.py`, außerhalb des Slice-Scopes) — dokumentiertes Restrisiko für den
+  seltenen Fall, dass die Task-Markierung fehlschlägt, während die Run-Aktualisierung gelingt.
+
 ### Fixed (Verwaiste pending-Run-/Task-Records bei fehlendem Store-Key — 2026-07-22, Issue #841)
 
 - **`prepare_simulation` (`backend/app/api/simulation_prepare.py`)** und

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -37,6 +37,7 @@ from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import RunnerStatus, SimulationRunner
 from ..services.stage_model_router import StageModelRouter
 from ..services.sim.cancel_flag import request_cancel as _request_cancel
+from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.llm_client import LLMClient
 from ..utils.artifact_locator import ArtifactLocator
@@ -565,9 +566,30 @@ def _restart_simulation_prepare(run: dict):
         # ein Task wird erst danach erzeugt (Zeile 570), daher hier kein
         # task_manager.fail_task. Ohne dieses Markieren bleibt der Run-Datensatz
         # dauerhaft als "pending" in der Registry verwaist.
-        run_registry.update_run(
-            new_run["run_id"], status="failed", message=guard_message, error=guard_message
-        )
+        #
+        # Issue #844: update_run() liefert None, wenn das Run-Manifest
+        # zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception
+        # werfen. Beide Fälle dürfen NICHT als erfolgreich persistierte
+        # Ablehnung durchgehen — sonst wirft der Code weiterhin den regulären
+        # ValueError("provider_override...") und täuscht damit eine sauber
+        # gespeicherte Statusänderung vor, die tatsächlich nicht stattfand.
+        persistence_error: Optional[Exception] = None
+        try:
+            updated_run = run_registry.update_run(
+                new_run["run_id"], status="failed", message=guard_message, error=guard_message
+            )
+        except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
+            updated_run = None
+            persistence_error = exc
+
+        if updated_run is None:
+            logger.error(
+                "Persistenzfehler beim Markieren von run_id=%s als failed im "
+                "Restart-Provider-Key-Guard: %s",
+                new_run["run_id"],
+                persistence_error or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+            )
+            raise RuntimeError(ApiErrorCode.INTERNAL_ERROR) from persistence_error
         raise ValueError(guard_message)
 
     if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -424,9 +424,35 @@ def prepare_simulation():
         # der detaillierte update_run()-Aufruf muss deshalb zuletzt laufen,
         # sonst überschreibt sync_task() die provider_override-Meldung.
         task_manager.fail_task(task_id, guard_message)
-        run_registry.update_run(
-            run_record["run_id"], status="failed", message=guard_message, error=guard_message
-        )
+        # Issue #844: update_run() liefert None, wenn das Run-Manifest
+        # zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception
+        # werfen (write_json_atomic ist ungeschützt). Beide Fälle dürfen
+        # NICHT wie eine erfolgreich persistierte Ablehnung behandelt werden
+        # — sonst bleibt der Run unbemerkt "pending" (siehe #841), obwohl der
+        # Client bereits eine scheinbar abschließende 422-Antwort erhalten
+        # hat. fail_task() selbst hat keine prüfbare Fehlersemantik (siehe
+        # TaskManager.update_task) und bleibt daher best-effort.
+        persistence_error: Optional[Exception] = None
+        try:
+            updated_run = run_registry.update_run(
+                run_record["run_id"], status="failed", message=guard_message, error=guard_message
+            )
+        except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
+            updated_run = None
+            persistence_error = exc
+
+        if updated_run is None:
+            logger.error(
+                "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
+                "failed im Provider-Key-Guard: %s",
+                run_record["run_id"], task_id,
+                persistence_error or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+            )
+            return json_error(
+                ApiErrorCode.INTERNAL_ERROR,
+                status=500,
+                message="Interner Fehler beim Markieren des Runs als fehlgeschlagen. Bitte erneut versuchen.",
+            )
         return json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=422,

--- a/backend/tests/api/test_provider_override_key_fallback.py
+++ b/backend/tests/api/test_provider_override_key_fallback.py
@@ -4,6 +4,7 @@ Smoke-Fix Welle 2, Slice 04 — P1 #3 + #17.
 """
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -46,12 +47,17 @@ def llm_client(monkeypatch):
     return app.test_client()
 
 
+_UNSET = object()
+
+
 def _base_prepare_mocks(
     monkeypatch,
     *,
     resolved_api_key: str | None,
     task_fail_calls: list | None = None,
     run_update_calls: list | None = None,
+    run_update_return: Any = _UNSET,
+    run_update_side_effect: BaseException | None = None,
 ):
     """Setzt alle Mocks für /api/simulation/prepare außer resolve_route_api_key.
 
@@ -59,6 +65,12 @@ def _base_prepare_mocks(
     Aufrufe von ``TaskManager.fail_task`` bzw. ``run_registry.update_run``
     aufgezeichnet werden (Issue #841 — Guard-Pfad muss verwaiste
     pending-Records als ``failed`` markieren).
+
+    ``run_update_return``/``run_update_side_effect`` steuern, was der
+    gemockte ``run_registry.update_run`` zurückgibt bzw. wirft (Issue #844 —
+    Persistenzfehler des Guard-Pfads). Per Default wird ein truthy Dict
+    zurückgegeben (erfolgreiche Persistenz), damit bestehende Tests nicht
+    fälschlich den None-Persistenzfehler-Pfad treffen.
     """
     fake_state = MagicMock()
     fake_state.project_id = "proj_001"
@@ -106,9 +118,17 @@ def _base_prepare_mocks(
         lambda *a, **k: {"run_id": "run_test_1"},
     )
     if run_update_calls is not None:
+        def _fake_update_run(*a, **k):
+            run_update_calls.append((a, k))
+            if run_update_side_effect is not None:
+                raise run_update_side_effect
+            if run_update_return is not _UNSET:
+                return run_update_return
+            return {"run_id": a[0], "status": k.get("status"), "message": k.get("message"), "error": k.get("error")}
+
         monkeypatch.setattr(
             "app.api.simulation_prepare.run_registry.update_run",
-            lambda *a, **k: run_update_calls.append((a, k)),
+            _fake_update_run,
         )
     monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
     monkeypatch.setattr(
@@ -294,6 +314,139 @@ def test_override_422_when_no_payload_no_db_and_cloud_provider(prepare_client, m
     fail_args, _fail_kwargs = task_fail_calls[0]
     assert fail_args[0] == "task_1"
     assert "provider_override" in fail_args[1].lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 3b/3c: Issue #844 — Persistenzfehler von update_run im Guard-Pfad
+#
+# PR #843 (Issue #841) markiert Run/Task beim Provider-Key-Guard als
+# "failed", ignoriert dabei aber Rückgabewert/Exceptions von
+# run_registry.update_run(...). Liefert update_run None (Manifest existiert
+# nicht mehr) oder wirft es einen I/O-Fehler, darf der Endpunkt NICHT mehr
+# die reguläre 422-Ablehnung liefern — das würde eine erfolgreiche
+# Persistenz vortäuschen, die tatsächlich nicht stattgefunden hat.
+# ---------------------------------------------------------------------------
+
+
+def test_override_500_when_run_update_returns_none_after_provider_key_guard(prepare_client, monkeypatch):
+    """update_run() liefert None (Run-Manifest zwischenzeitlich verschwunden) →
+    500 mit internal_error statt der irreführenden 422-Provider-Key-Antwort.
+    """
+
+    class FakeRouter:
+        def __init__(self, _run_id: str):
+            pass
+        def resolve(self, _stage: str):
+            return ResolvedRoute(
+                stage="persona_generation",
+                provider_id="openai",
+                model="gpt-4o-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=1,
+            )
+        def lock_stage(self, *_a, **_k):
+            return None
+
+    task_fail_calls: list = []
+    run_update_calls: list = []
+    _base_prepare_mocks(
+        monkeypatch,
+        resolved_api_key=None,
+        task_fail_calls=task_fail_calls,
+        run_update_calls=run_update_calls,
+        run_update_return=None,
+    )
+    fake_manager = MagicMock()
+    fake_manager.get_simulation.return_value = MagicMock(
+        project_id="proj_001", graph_id="g1",
+        source_simulation_id=None, root_simulation_id=None,
+        branch_name=None, branch_depth=0,
+        entities_count=1, entity_types=["Person"],
+    )
+    monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
+    monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
+
+    resp = prepare_client.post(
+        "/api/simulation/prepare",
+        json={
+            "simulation_id": VALID_SIM_ID,
+            "llm_provider": {"provider": "openai"},
+        },
+    )
+
+    body = resp.get_json()
+    assert resp.status_code == 500, body
+    assert body.get("code") == "internal_error", body
+    # Die detaillierte Provider-Key-Meldung darf nicht als vermeintlich
+    # erfolgreiche 422-Ablehnung nach außen dringen.
+    assert "provider_override" not in str(body).lower()
+
+    # update_run wurde versucht (Rückgabe None), fail_task lief davor wie gehabt.
+    assert len(run_update_calls) == 1
+    assert len(task_fail_calls) == 1
+
+
+def test_override_500_when_run_update_raises_after_provider_key_guard(prepare_client, monkeypatch):
+    """update_run() wirft einen I/O-/Persistenzfehler → 500 mit internal_error,
+    keine Maskierung als normaler Guard-Fall, keine Exception-Details im Body.
+    """
+
+    class FakeRouter:
+        def __init__(self, _run_id: str):
+            pass
+        def resolve(self, _stage: str):
+            return ResolvedRoute(
+                stage="persona_generation",
+                provider_id="openai",
+                model="gpt-4o-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=1,
+            )
+        def lock_stage(self, *_a, **_k):
+            return None
+
+    task_fail_calls: list = []
+    run_update_calls: list = []
+    _base_prepare_mocks(
+        monkeypatch,
+        resolved_api_key=None,
+        task_fail_calls=task_fail_calls,
+        run_update_calls=run_update_calls,
+        run_update_side_effect=OSError("disk full: /uploads/run_registry/run_test_1.json"),
+    )
+    fake_manager = MagicMock()
+    fake_manager.get_simulation.return_value = MagicMock(
+        project_id="proj_001", graph_id="g1",
+        source_simulation_id=None, root_simulation_id=None,
+        branch_name=None, branch_depth=0,
+        entities_count=1, entity_types=["Person"],
+    )
+    monkeypatch.setattr("app.api.simulation_prepare.SimulationManager", lambda: fake_manager)
+    monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
+
+    resp = prepare_client.post(
+        "/api/simulation/prepare",
+        json={
+            "simulation_id": VALID_SIM_ID,
+            "llm_provider": {"provider": "openai"},
+        },
+    )
+
+    body = resp.get_json()
+    assert resp.status_code == 500, body
+    assert body.get("code") == "internal_error", body
+    assert "provider_override" not in str(body).lower()
+    assert "disk full" not in str(body).lower()
+    assert "run_test_1.json" not in str(body)
+    # Kuratierte, run-bezogene Meldung statt der generischen
+    # handle_api_errors-Fallback-Meldung ("internal server error") — stellt
+    # sicher, dass der Guard den Persistenzfehler bewusst behandelt statt
+    # sich zufällig auf den generischen Exception-Handler zu verlassen.
+    assert body.get("error") != "internal server error", body
+    assert "fehlgeschlagen" in body.get("error", "").lower(), body
+
+    assert len(run_update_calls) == 1
+    assert len(task_fail_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -466,7 +466,11 @@ def test_resume_simulation_prepare_raises_without_key_for_non_local_endpoint(env
         MockProjMgr.get_project.return_value = fake_project
         MockTaskMgr.return_value.create_task.return_value = "task_001"
         mock_registry.create_run.return_value = {"run_id": "run_new_003"}
-        mock_registry.update_run.return_value = None
+        # Persistenz erfolgreich (truthy Dict) — dies ist der Erfolgsfall aus
+        # #841. Der Persistenzfehler-Fall (None/Exception) wird separat in
+        # test_resume_simulation_prepare_raises_internal_error_when_run_update_returns_none
+        # und ..._raises (Issue #844) abgedeckt.
+        mock_registry.update_run.return_value = {"run_id": "run_new_003", "status": "failed"}
 
         router_instance = MockRouter.return_value
         router_instance.resolve.return_value = resolved_route
@@ -489,3 +493,145 @@ def test_resume_simulation_prepare_raises_without_key_for_non_local_endpoint(env
     assert "provider_override" in update_call.kwargs["message"]
     assert "provider_override" in update_call.kwargs["error"]
     assert not MockTaskMgr.return_value.create_task.called
+
+
+# ---------------------------------------------------------------------------
+# Test 11-12: Issue #844 — Persistenzfehler von update_run im Restart-Guard
+#
+# Der Restart-Pfad hat an dieser Stelle noch keinen Task (der wird erst nach
+# dem Guard erzeugt, Zeile ~579 in runs.py). Liefert update_run() None oder
+# wirft es eine Exception, darf der Guard NICHT den regulären
+# ValueError("provider_override...") werfen — das würde vortäuschen, der Run
+# sei sauber als "failed" persistiert worden. Stattdessen muss ein interner
+# Persistenzfehler propagiert werden, und es darf weiterhin kein Task
+# erzeugt und kein prepare_simulation gestartet werden.
+# ---------------------------------------------------------------------------
+
+
+def test_resume_simulation_prepare_raises_internal_error_when_run_update_returns_none(env):
+    """update_run() liefert None (Run-Manifest zwischenzeitlich verschwunden) im
+    Restart-Guard → interner Persistenzfehler statt irreführendem
+    ValueError("provider_override..."). Kein Task wird erzeugt,
+    prepare_simulation wird nicht gestartet.
+    """
+    from app.utils.api_errors import ApiErrorCode
+
+    run = _create_run(
+        env["registry"],
+        run_type="simulation_prepare",
+        entity_id="sim_test",
+        simulation_id="sim_test",
+        status="failed",
+    )
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_test"
+    fake_state.graph_id = "graph_test"
+    fake_state.branch_name = "main"
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Test requirement"
+
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=1,
+    )
+
+    with (
+        patch("app.api.runs.SimulationManager") as MockMgr,
+        patch("app.api.runs.ProjectManager") as MockProjMgr,
+        patch("app.api.runs.TaskManager") as MockTaskMgr,
+        patch("app.api.runs.run_registry") as mock_registry,
+        patch("app.api.runs.seed_run_stage_routing"),
+        patch("app.api.runs.StageModelRouter") as MockRouter,
+        patch("app.api.runs.resolve_route_api_key", return_value=None),
+    ):
+        MockMgr.return_value.get_simulation.return_value = fake_state
+        MockMgr.return_value.get_simulation_config.return_value = {"llm_model": "gpt-4o"}
+        MockProjMgr.get_project.return_value = fake_project
+        MockTaskMgr.return_value.create_task.return_value = "task_001"
+        mock_registry.create_run.return_value = {"run_id": "run_new_004"}
+        mock_registry.update_run.return_value = None
+
+        router_instance = MockRouter.return_value
+        router_instance.resolve.return_value = resolved_route
+        router_instance.lock_stage.return_value = resolved_route
+
+        env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
+
+        with env["app"].app_context():
+            with pytest.raises(RuntimeError) as exc_info:
+                _run_restart_prepare_sync(run)
+
+        assert exc_info.value.args and exc_info.value.args[0] == ApiErrorCode.INTERNAL_ERROR
+        # Die irreführende 422-Provider-Key-Meldung darf nicht auftauchen.
+        assert "provider_override" not in str(exc_info.value)
+        assert not MockMgr.return_value.prepare_simulation.called
+        assert not MockTaskMgr.return_value.create_task.called
+
+
+def test_resume_simulation_prepare_raises_internal_error_when_run_update_raises(env):
+    """update_run() wirft einen I/O-/Persistenzfehler im Restart-Guard →
+    interner Persistenzfehler statt Maskierung als normaler Guard-Fall.
+    Kein Task wird erzeugt, prepare_simulation wird nicht gestartet.
+    """
+    from app.utils.api_errors import ApiErrorCode
+
+    run = _create_run(
+        env["registry"],
+        run_type="simulation_prepare",
+        entity_id="sim_test",
+        simulation_id="sim_test",
+        status="failed",
+    )
+
+    fake_state = MagicMock()
+    fake_state.project_id = "proj_test"
+    fake_state.graph_id = "graph_test"
+    fake_state.branch_name = "main"
+
+    fake_project = MagicMock()
+    fake_project.simulation_requirement = "Test requirement"
+
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized="https://api.openai.com/v1",
+        routing_version=1,
+    )
+
+    with (
+        patch("app.api.runs.SimulationManager") as MockMgr,
+        patch("app.api.runs.ProjectManager") as MockProjMgr,
+        patch("app.api.runs.TaskManager") as MockTaskMgr,
+        patch("app.api.runs.run_registry") as mock_registry,
+        patch("app.api.runs.seed_run_stage_routing"),
+        patch("app.api.runs.StageModelRouter") as MockRouter,
+        patch("app.api.runs.resolve_route_api_key", return_value=None),
+    ):
+        MockMgr.return_value.get_simulation.return_value = fake_state
+        MockMgr.return_value.get_simulation_config.return_value = {"llm_model": "gpt-4o"}
+        MockProjMgr.get_project.return_value = fake_project
+        MockTaskMgr.return_value.create_task.return_value = "task_001"
+        mock_registry.create_run.return_value = {"run_id": "run_new_005"}
+        mock_registry.update_run.side_effect = OSError("disk full: /uploads/run_registry/run_new_005.json")
+
+        router_instance = MockRouter.return_value
+        router_instance.resolve.return_value = resolved_route
+        router_instance.lock_stage.return_value = resolved_route
+
+        env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
+
+        with env["app"].app_context():
+            with pytest.raises(RuntimeError) as exc_info:
+                _run_restart_prepare_sync(run)
+
+        assert exc_info.value.args and exc_info.value.args[0] == ApiErrorCode.INTERNAL_ERROR
+        assert "provider_override" not in str(exc_info.value)
+        assert "disk full" not in str(exc_info.value)
+        assert not MockMgr.return_value.prepare_simulation.called
+        assert not MockTaskMgr.return_value.create_task.called

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3479 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3483 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary

- Beide Provider-Key-Guard-Pfade (`simulation_prepare.py::prepare_simulation`, `runs.py::_restart_simulation_prepare`) ignorierten bisher Rückgabewert und Exceptions von `run_registry.update_run(...)` und gaben trotzdem die reguläre 422-Antwort bzw. den `ValueError` zurück, als sei die "failed"-Markierung sauber persistiert worden.
- Fix prüft `update_run` jetzt explizit auf `None` und fängt Exceptions ab. Bei bestätigter Persistenz bleibt das #841-Verhalten unverändert; bei Persistenzfehler greift das bestehende Projektmuster `ApiErrorCode.INTERNAL_ERROR` (Prepare: `json_error(..., status=500)`; Restart: `RuntimeError(ApiErrorCode.INTERNAL_ERROR)`, von `handle_api_errors` auf 500 gemappt).

## Bezug

- Closes #844
- Root-Cause: CodeRabbit-Major-Befund auf #843 (Folge-Slice zu #841)

## Root Cause

- `RunRegistry.update_run` (`backend/app/services/run_registry.py:173`) liefert `Optional[Dict]`: `None` wenn das Run-Manifest zwischenzeitlich verschwunden ist; `write_json_atomic` ist ungeschützt, I/O-Fehler propagieren als Exception.
- `TaskManager.fail_task` → `update_task` hat keine prüfbare Fehlersemantik (kein Rückgabewert, interne `sync_task()`-Exceptions werden geloggt und geschluckt) — bleibt bewusst best-effort, da eine Änderung an `task.py` außerhalb des Slice-Scopes läge.

## Persistenzfehler-Semantik

- **Erfolgsfall (Persistenz bestätigt):** Run/Task werden als `failed` markiert, detaillierte Provider-Key-Meldung bleibt erhalten, danach reguläre Ablehnung (422 bzw. `ValueError`) — #841 regressiert nicht.
- **`None`-Rückgabe:** wird explizit erkannt, serverseitig mit Run-/Task-Bezug geloggt (ohne Secrets), führt zu `ApiErrorCode.INTERNAL_ERROR` (500) statt der irreführenden 422/ValueError-Antwort.
- **Exception (z. B. I/O-Fehler):** wird abgefangen, geloggt (kein Leak an Client), führt ebenfalls zu `ApiErrorCode.INTERNAL_ERROR` (500); im Restart-Pfad über `raise ... from persistence_error` mit Ursache verkettet.
- **Partielle Zustände (Prepare-Pfad):** `fail_task()` läuft bewusst vor `update_run()` (Reihenfolge aus #841 unverändert). Da `fail_task` keine prüfbare Fehlersemantik besitzt, bleibt ein Restrisiko offen dokumentiert (siehe CHANGELOG) statt eine neue Transaktionsebene zu erfinden — außerhalb des Slice-Scopes.
- **Restart-Pfad:** kein Task an dieser Stelle: `RuntimeError` wird vor jeglicher Task-Erzeugung/`prepare_simulation`-Start geworfen; Tests verifizieren `not create_task.called` / `not prepare_simulation.called`.

## Tests

- `cd backend && uv run pytest tests/api/test_provider_override_key_fallback.py tests/api/test_runs_resume_stop.py -q` — 22 passed (4 neue Regressionstests: None + Exception je Guard-Pfad; bestehende #841-Mocks auf truthy Rückgabewert umgestellt, damit sie weiterhin den Erfolgsfall statt versehentlich den neuen Fehlerpfad testen)
- `uv run pytest tests/contracts/ -x -q` — 384 passed
- `uv run python -m app.contracts.dump_schemas --check` — alle 46 Schemas matchen
- `uv run ruff check app/ tests/` — All checks passed
- `uv run mypy app` — Success, no issues

## Backend-Gate

- `bash scripts/pre-push-gate.sh backend` — ALL GREEN

## Dokumentationssync

- `docs/STATUS.md`: aktualisiert (Testzahl 3479→3483 via `sync-status.sh`)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate/Reihenfolge-Impact
- `CHANGELOG.md`: aktualisiert (neuer Fixed-Eintrag, Bezug zu #841/#843)
- Folge-Issue: NICHT BETROFFEN — `fail_task`-Best-effort-Restrisiko ist als dokumentierte, akzeptierte Einschränkung im Code-Kommentar/Changelog festgehalten, kein separates Ticket nötig

## Review

- `agora-opus-reviewer` — APPROVE (keine Blocker; Akzeptanzkriterien, Fehlersemantik, Leak-Freiheit, Mock-Anpassung und Restart-Garantien unabhängig verifiziert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Persistenzfehler beim Aktualisieren des Run- oder Task-Status werden jetzt zuverlässig erkannt.
  * In solchen Fällen wird ein konsistenter interner Serverfehler (HTTP 500) statt einer irreführenden Validierungsfehlermeldung zurückgegeben.
  * Erfolgreiche Ablehnungen wegen fehlender Provider-Schlüssel behalten ihr bisheriges Verhalten bei.

* **Tests**
  * Zusätzliche Prüfungen für fehlgeschlagene Statusaktualisierungen und Neustart-Szenarien.

* **Dokumentation**
  * Changelog und Teststatus wurden aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->