### PR TITLE
fix(api): generate-profiles löst Store-Key auf, 422 statt 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (generate-profiles löst keinen Store-Key auf und liefert 500 statt 422 — 2026-07-22, Issue #799)
+
+- **`generate_profiles` (`backend/app/api/simulation_history.py`)** — der Preview-Endpoint
+  `POST /api/simulation/generate-profiles` (erzeugt bewusst keinen Simulation-Run) las API-Keys
+  bisher ausschließlich aus dem Request-Payload. Anders als `simulation_prepare` wurde der in den
+  Settings hinterlegte Store-Key nie konsultiert; fehlte der Key bei einem Fremd-Provider, warf der
+  Generator `ValueError("LLM_API_KEY not configured")`, was auf HTTP 500 statt eines sauberen 422
+  mit Handlungsanweisung durchschlug.
+- Fix führt Store-Key-Auflösung über denselben Resolver (`resolve_route_api_key`) ein, ohne dabei
+  einen persistierten Run zu erzeugen: zwei reine Helper (`_apply_workspace_defaults`,
+  `_apply_override`) wurden aus `seed_run_stage_routing` extrahiert (`backend/app/services/llm_routing_seed.py`,
+  verhaltensidentisch für bestehende Aufrufer) und in einer neuen zustandslosen Funktion
+  `build_preview_stage_route` wiederverwendet — sie schreibt nie auf Platte und versiegelt keine
+  Stage, um keine neue Klasse von Orphan-Artefakten einzuführen (vgl. Issue #841). Fehlt der Key bei
+  einem nicht-lokalen Endpoint, liefert der Endpoint jetzt HTTP 422 mit derselben Handlungsanweisung
+  wie `simulation_prepare`; lokale Endpoints ohne Key erhalten weiterhin den No-Auth-Platzhalter (#778).
+
 ### Fixed (Persistenzfehler von update_run im Provider-Key-Guard maskiert bisher als reguläre Ablehnung — 2026-07-22, Issue #844)
 
 - **`prepare_simulation` (`backend/app/api/simulation_prepare.py`)** und

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -12,10 +12,11 @@ from flask import current_app, request
 from . import simulation_bp
 from ..api.simulation_prepare import LOCAL_NO_AUTH_API_KEY, _is_local_endpoint
 from ..models.project import ProjectManager
+from ..services.ai_route_resolver import AiRouteResolutionError
 from ..services.entity_reader import EntityReader
+from ..services.llm_routing_seed import build_preview_stage_route, resolve_route_api_key
 from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.oasis_profile_generator import OasisProfileGenerator
-from ..services.prepare_service import _resolve_llm_connection
 from ..services.simulation_manager import SimulationManager
 from ..services.simulation_runner import SimulationRunner
 from ..utils.api_errors import ApiErrorCode
@@ -193,9 +194,35 @@ def generate_profiles():
     # storage + graph_id durchreichen, damit OasisProfileGenerator die
     # Knowledge-Graph-Hybrid-Suche nutzen kann (Gemini-Code-Assist Finding,
     # PR #231).
-    # Track 3c: api_key + base_url aus dem aktiven LLM-Profil mitgeben,
-    # gleiche Helper-Funktion wie prepare_service._phase_generate_profiles.
-    api_key, base_url = _resolve_llm_connection(llm_runtime)
+    # Issue #799: api_key + base_url über denselben Store-Key-fähigen Resolver
+    # wie simulation_prepare auflösen (statt nur Payload-Overrides zu lesen),
+    # damit ein Fremd-Provider ohne Payload-Key sauber 422 statt 500 liefert.
+    try:
+        resolved_route = build_preview_stage_route(
+            "persona_generation",
+            llm_model_override=llm_model_override,
+            llm_runtime=llm_runtime,
+        )
+    except AiRouteResolutionError as exc:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=422,
+            message=str(exc),
+        )
+
+    api_key = resolve_route_api_key(resolved_route, llm_runtime)
+    base_url = resolved_route.base_url_sanitized
+    if api_key is None and not _is_local_endpoint(base_url):
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=422,
+            message=(
+                "kein api_key im Payload und kein Key in der Settings-DB "
+                f"für Provider '{resolved_route.provider_id}'. "
+                "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+                "oder im Sitzungsfeld eingeben."
+            ),
+        )
     if api_key is None and _is_local_endpoint(base_url):
         # Lokaler Endpoint ohne Key ist zulaessig (#778) — Platzhalter statt
         # `None`, damit der Generator-Vertrag "Key + Base-URL aus derselben

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -118,6 +118,67 @@ def _bind_connection_secret(
     options["connection_only"] = True
 
 
+def _apply_workspace_defaults(config: RuntimeLlmRouting) -> None:
+    """Übernimmt Workspace-Routing-Defaults in config (mutiert config in-place)."""
+    try:
+        workspace_defaults = get_workspace_routing_store().load()
+    except Exception:  # noqa: BLE001 — Defaults sind "best effort", kein Stopper
+        workspace_defaults = None
+    if workspace_defaults is not None:
+        if workspace_defaults.global_default.model:
+            config.global_default = workspace_defaults.global_default
+        for ws_stage_id, ws_route in workspace_defaults.stage_overrides.items():
+            config.stage_overrides[ws_stage_id] = ws_route
+
+
+def _apply_override(
+    config: RuntimeLlmRouting,
+    stage_id: StageId,
+    *,
+    llm_model_override: Optional[str],
+    llm_runtime: Optional[RuntimeLlmConfig],
+) -> None:
+    """Überlagert config.stage_overrides[stage_id] mit einem expliziten Override,
+    falls llm_model_override gesetzt ist oder llm_runtime.enabled ist."""
+    runtime = llm_runtime or RuntimeLlmConfig()
+    route_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
+    if llm_model_override or runtime.enabled:
+        provider_options: dict[str, object] = {}
+        if runtime.base_url:
+            provider_options["base_url"] = runtime.base_url
+        # Wenn der Request "default" als Provider schickt, mappt das Provider-ID-Dict
+        # auf None. ResolvedRoute.provider_id ist Pflichtfeld; deshalb auf den
+        # global_default des Runs zurückfallen statt None zu persistieren.
+        effective_provider_id = route_provider_id or config.global_default.provider_id
+        effective_model = llm_model_override or config.global_default.model
+        config.stage_overrides[stage_id] = StageLLMRoute(
+            provider_id=effective_provider_id,
+            model=effective_model,
+            provider_options=provider_options,
+        )
+
+
+def build_preview_stage_route(
+    stage_id: StageId,
+    *,
+    llm_model_override: Optional[str],
+    llm_runtime: Optional[RuntimeLlmConfig],
+) -> ResolvedRoute:
+    """Zustandslose Variante für Preview-Endpoints ohne persistierten Run
+    (z. B. /simulation/generate-profiles). Nutzt denselben Workspace-Default-
+    und Override-Resolver wie seed_run_stage_routing, schreibt aber nie auf
+    Platte und versiegelt keine Stage — sicher für jeden Request."""
+    from uuid import uuid4
+
+    from .stage_model_router import StageModelRouter
+
+    config = RuntimeLlmRouting(global_default=StageLLMRoute())
+    _apply_workspace_defaults(config)
+    _apply_override(config, stage_id, llm_model_override=llm_model_override, llm_runtime=llm_runtime)
+    router = StageModelRouter(f"preview-{uuid4().hex}")
+    return router.resolve(stage_id, runtime_cfg=config)
+
+
 def seed_run_stage_routing(
     run_id: str,
     stage_id: StageId,
@@ -150,18 +211,9 @@ def seed_run_stage_routing(
     # Bei frischen Runs: Workspace-Defaults als Seed übernehmen. Versiegelte Stages
     # (= bereits in den Per-Run-Snapshots vorhanden) werden NICHT überschrieben.
     if not has_existing_config:
-        try:
-            workspace_defaults = get_workspace_routing_store().load()
-        except Exception:  # noqa: BLE001 — Defaults sind „best effort", kein Run-Stopper
-            workspace_defaults = None
-        if workspace_defaults is not None:
-            if workspace_defaults.global_default.model:
-                config.global_default = workspace_defaults.global_default
-            for ws_stage_id, ws_route in workspace_defaults.stage_overrides.items():
-                config.stage_overrides[ws_stage_id] = ws_route
+        _apply_workspace_defaults(config)
 
     runtime = llm_runtime or RuntimeLlmConfig()
-    route_provider_id = map_runtime_provider_to_route_provider(runtime.provider)
 
     if ai_model_ref is not None:
         # Höchste Priorität: die vom UI explizit gewählte (Connection, Modell)-Route.
@@ -182,18 +234,11 @@ def seed_run_stage_routing(
         if has_existing_config:
             config.routing_version += 1
     elif llm_model_override or runtime.enabled:
-        provider_options = {}
-        if runtime.base_url:
-            provider_options["base_url"] = runtime.base_url
-        # Wenn der Request "default" als Provider schickt, mappt das Provider-ID-Dict
-        # auf None. ResolvedRoute.provider_id ist Pflichtfeld; deshalb auf den
-        # global_default des Runs zurückfallen statt None zu persistieren.
-        effective_provider_id = route_provider_id or config.global_default.provider_id
-        effective_model = llm_model_override or config.global_default.model
-        config.stage_overrides[stage_id] = StageLLMRoute(
-            provider_id=effective_provider_id,
-            model=effective_model,
-            provider_options=provider_options,
+        _apply_override(
+            config,
+            stage_id,
+            llm_model_override=llm_model_override,
+            llm_runtime=llm_runtime,
         )
         if has_existing_config:
             config.routing_version += 1

--- a/backend/tests/api/test_simulation_history_provider_passing.py
+++ b/backend/tests/api/test_simulation_history_provider_passing.py
@@ -1,12 +1,20 @@
-"""Test für Track 3c: ``/api/simulation/generate-profiles`` reicht
-api_key + base_url des aktiven LLM-Profils an :class:`OasisProfileGenerator`
-durch.
+"""Test für Track 3c / Issue #799: ``/api/simulation/generate-profiles``
+reicht api_key + base_url an :class:`OasisProfileGenerator` durch.
 
 Vor Track 3c hat der Endpoint nur ``model_name`` durchgereicht — der
 Generator hat dann beim internen :class:`LLMClient`-Init auf
 ``Config.LLM_API_KEY`` zurückgefallen, was bei einem User-konfigurierten
-OpenAI-Profil zu 401-Loops geführt hat. Mit der Härtung greift jetzt der
-gleiche Resolver wie in ``prepare_service._phase_generate_profiles``.
+OpenAI-Profil zu 401-Loops geführt hat.
+
+Vor Issue #799 löste der Endpoint API-Keys ausschließlich aus dem
+Request-Payload auf (``_resolve_llm_connection``) und ignorierte einen in
+den Settings hinterlegten Store-Key komplett. Fehlte der Key bei einem
+Fremd-Provider-Endpoint, warf der Generator einen ``ValueError``, den
+``@handle_api_errors`` auf HTTP 500 mappte — statt eines sauberen 422 wie
+bei ``simulation_prepare``. Seit dem Fix nutzt der Endpoint denselben
+Store-Key-fähigen Resolver (``build_preview_stage_route`` +
+``resolve_route_api_key`` aus ``llm_routing_seed``) und antwortet bei
+fehlendem Routing-Kandidaten bzw. fehlendem Store-Key mit HTTP 422.
 """
 from __future__ import annotations
 
@@ -16,6 +24,7 @@ import pytest
 from flask import Flask
 
 from app.api import simulation_bp
+from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
 
 
 @pytest.fixture
@@ -89,29 +98,134 @@ def test_generate_profiles_passes_provider_credentials(client, patched_generator
     assert captured_generator_kwargs["graph_id"] == "graph_abc"
 
 
-def test_generate_profiles_without_provider_falls_back_to_none(client, patched_generator, captured_generator_kwargs):
-    """Ohne ``llm_provider`` bleibt das Verhalten kompatibel: api_key/base_url
-    None, Generator wird auf interne Defaults zurückfallen (Track 1 hardening
-    verhindert toxic Fallbacks dort)."""
+def test_generate_profiles_without_provider_falls_back_to_none(
+    client, patched_generator, captured_generator_kwargs, monkeypatch
+):
+    """Issue #799: ohne ``llm_provider``, ohne Workspace-Default und ohne
+    Server-Default (``Config.LLM_MODEL_NAME`` leer) existiert überhaupt kein
+    Routing-Kandidat auf keiner Ebene (Stage/Run/Workspace/Provider-Fallback).
+    Das ist bewusst ein Verhaltenswechsel gegenüber dem alten stillschweigenden
+    ``api_key=None``/``base_url=None``-Fallback (der Bug, den dieses Issue
+    behebt): der Endpoint muss jetzt sauber mit HTTP 422
+    (``NoAiRouteCandidateError``) antworten statt den Generator mit leeren
+    Credentials laufen zu lassen, was nachgelagert bei Fremd-Providern in
+    einen 500er lief."""
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: MagicMock(load=lambda: None),
+    )
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "")
+    monkeypatch.setattr("app.config.Config.LLM_BASE_URL", "")
+
     payload = {
         "graph_id": "graph_abc",
-        "llm_model": "gpt-4o-mini",
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    assert resp.status_code == 422, resp.get_json()
+
+
+def test_generate_profiles_uses_server_default_for_local_endpoint(
+    client, patched_generator, captured_generator_kwargs, monkeypatch
+):
+    """Issue #799: ohne Payload-Override, aber mit Server-Default
+    (``Config.LLM_MODEL_NAME``/``LLM_BASE_URL``) greift derselbe
+    Provider-Fallback wie in ``simulation_prepare``. Zeigt der Fallback auf
+    einen lokalen Endpoint, bleibt der No-Auth-Platzhalter zulässig (#778)."""
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: MagicMock(load=lambda: None),
+    )
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "qwen2.5:14b")
+    monkeypatch.setattr("app.config.Config.LLM_BASE_URL", "http://localhost:11434")
+    # Hermetisch machen: ein evtl. real persistierter Store-Key auf dem
+    # Entwicklerrechner darf dieses Ergebnis nicht beeinflussen (#799).
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver.get_api_key",
+        lambda self, provider_id, provider_type: None,
+    )
+
+    payload = {
+        "graph_id": "graph_abc",
         "use_llm": True,
     }
     resp = client.post("/api/simulation/generate-profiles", json=payload)
     assert resp.status_code == 200, resp.get_json()
-    assert captured_generator_kwargs["api_key"] is None
-    assert captured_generator_kwargs["base_url"] is None
+    assert captured_generator_kwargs["api_key"] == LOCAL_NO_AUTH_API_KEY
+
+
+def test_generate_profiles_returns_422_when_no_store_key_for_remote_provider(
+    client, patched_generator, captured_generator_kwargs, monkeypatch
+):
+    """Issue #799: Server-Default zeigt auf einen Fremd-Provider (kein
+    lokaler Endpoint) und die Settings-DB hat keinen Store-Key hinterlegt —
+    der Endpoint muss das jetzt sauber mit HTTP 422 quittieren, statt den
+    generatorseitigen ``ValueError`` auf HTTP 500 durchschlagen zu lassen."""
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: MagicMock(load=lambda: None),
+    )
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o-mini")
+    monkeypatch.setattr("app.config.Config.LLM_BASE_URL", "https://api.openai.com/v1")
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver.get_api_key",
+        lambda self, provider_id, provider_type: None,
+    )
+
+    payload = {
+        "graph_id": "graph_abc",
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    body = resp.get_json()
+    assert resp.status_code == 422, body
+    assert "openai" in body["error"].lower()
+
+
+def test_generate_profiles_uses_store_key_for_remote_provider(
+    client, patched_generator, captured_generator_kwargs, monkeypatch
+):
+    """Issue #799 — der eigentliche Fix: liefert die Settings-DB einen
+    Store-Key für den Server-Default-Provider, reicht der Endpoint ihn durch,
+    statt (wie vor dem Fix) ausschließlich Payload-Keys zu akzeptieren."""
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: MagicMock(load=lambda: None),
+    )
+    monkeypatch.setattr("app.config.Config.LLM_MODEL_NAME", "gpt-4o-mini")
+    monkeypatch.setattr("app.config.Config.LLM_BASE_URL", "https://api.openai.com/v1")
+    stored_key = "sk-stored-testkey1234567890"  # gitleaks:allow
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver.get_api_key",
+        lambda self, provider_id, provider_type: stored_key,
+    )
+
+    payload = {
+        "graph_id": "graph_abc",
+        "use_llm": True,
+    }
+    resp = client.post("/api/simulation/generate-profiles", json=payload)
+    assert resp.status_code == 200, resp.get_json()
+    assert captured_generator_kwargs["api_key"] == stored_key
 
 
 def test_generate_profiles_local_endpoint_without_key_uses_no_auth_placeholder(
-    client, patched_generator, captured_generator_kwargs
+    client, patched_generator, captured_generator_kwargs, monkeypatch
 ):
     """Issue #778 Blocker 1 (Preview-Pfad) — lokaler Endpoint ohne Key darf
     weder 500 noch ``ValueError`` produzieren; der Generator bekommt den
     dokumentierten No-Auth-Platzhalter statt eines rohen ``None``.
+
+    Issue #799: seit der Store-Key-Auflösung muss dieser Test hermetisch
+    sein — ein evtl. real persistierter Store-Key auf dem Entwicklerrechner
+    darf das Ergebnis nicht beeinflussen.
     """
     from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.SecretResolver.get_api_key",
+        lambda self, provider_id, provider_type: None,
+    )
 
     payload = {
         "graph_id": "graph_abc",

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3483 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3486 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- `POST /api/simulation/generate-profiles` (Preview-Endpoint ohne Simulation-Run) löst API-Keys jetzt über denselben Resolver-Pfad wie `simulation_prepare` auf (`resolve_route_api_key`), inkl. Store-Key aus den Settings
- Fehlender Key bei nicht-lokalem Endpoint liefert jetzt HTTP 422 mit derselben Handlungsanweisung wie der Prepare-Guard, statt eines generischen 500

## Release-Ziel
- Kein explizites Milestone; P1-Bug-Fix vor 0.9.0 Stability Beta

## Issue
- Closes #799

## Scope
- `backend/app/services/llm_routing_seed.py` — `_apply_workspace_defaults`/`_apply_override` aus `seed_run_stage_routing` extrahiert (verhaltensidentisch), neue zustandslose `build_preview_stage_route()` (kein Run, keine Persistenz, kein `lock_stage()`)
- `backend/app/api/simulation_history.py::generate_profiles` — nutzt `build_preview_stage_route` + `resolve_route_api_key` statt reinem Payload-Read
- `backend/tests/api/test_simulation_history_provider_passing.py` — 3 neue Tests (Store-Key genutzt, 422 bei fehlendem Key, lokaler Fallback) + hermetische Isolation zweier bestehender Tests von real persistierten Secrets

## Out-of-Scope
- `ai_model_ref`/`llm_profile_id`-Unterstützung in `generate_profiles` (Payload-Contract hat diese Felder nicht)
- Änderungen an `simulation_prepare.py` selbst
- Contract-Änderungen (`ResolvedRoute`, `RuntimeLlmRouting` unverändert)

## Tests
- `pytest tests/api/test_simulation_history_provider_passing.py tests/services/test_llm_routing_seed.py -q` — 23 passed (inkl. unverändert grünem `test_llm_routing_seed.py`)
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert — Backend-Test-Count-Sync (3483 → 3486, mechanisch via `sync-status.sh`)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate ändert sich
- `CHANGELOG.md`: aktualisiert — Fixed-Eintrag unter `[Unreleased]`
- Folge-Issue: NICHT BETROFFEN — Scope vollständig abgedeckt

## Review
- `agora-opus-reviewer` — APPROVE (Refactor verhaltensidentisch verifiziert, keine Schreiboperation in `build_preview_stage_route`, `_resolve_llm_connection` korrekt in `prepare_service.py` erhalten, 422-Message deckungsgleich mit Prepare-Guard, Tests hermetisch, keine echten Secrets im Diff)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Der Preview-Endpunkt zur Profilgenerierung verarbeitet fehlende oder ungültige API-Schlüssel jetzt konsistent mit HTTP 422 statt eines internen Fehlers.
  * Fehlermeldungen enthalten Hinweise zur Behebung, etwa zum Hinterlegen eines Provider-Schlüssels.
  * Gespeicherte Schlüssel werden zuverlässig verwendet; lokale Endpunkte ohne Authentifizierung bleiben unverändert.

* **Dokumentation**
  * Der Unreleased-Changelog wurde um die Anpassungen ergänzt.
  * Die dokumentierte Anzahl der Backend-Tests wurde aktualisiert.

* **Tests**
  * Zusätzliche Tests decken Server-Defaults, fehlende Schlüssel, gespeicherte Schlüssel und lokale Endpunkte ab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->