### PR TITLE
fix(simulation): bind OASIS runtime to selected provider connection

### DIFF
--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -116,8 +116,13 @@ def start_simulation():
                 status=400,
                 message="ai_model_ref ist ungültig",
             )
+        # Nur die Legacy-Felder prüfen, die dieser Handler auch ausliest und
+        # weiterreicht (llm_model → llm_model_override, llm_provider →
+        # llm_runtime). llm_profile_id wird im Sim-Start nicht unterstützt und
+        # daher nicht als Konfliktgrund geführt — ein Profilpfad ist hier nicht
+        # implementiert (CodeRabbit PR #852).
         conflicting = [
-            key for key in ('llm_model', 'llm_provider', 'llm_profile_id')
+            key for key in ('llm_model', 'llm_provider')
             if data.get(key)
         ]
         if conflicting:

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -93,6 +93,45 @@ def start_simulation():
             status=400,
             message=str(exc),
         )
+    # Explizite UI-Auswahl (AiModelRef) ist die autoritative Sim-Route und darf
+    # nicht still mit Legacy-Feldern kombiniert werden (Issue #817, analog
+    # /api/report/generate). Wenn gesetzt, wird die ProviderConnection zur
+    # Single Source of Truth für Modell, Base-URL und gebundenen Key — kein
+    # .env-Fallback. Root Cause des OASIS-404 ``model MiniMax-M3 not found``:
+    # der Legacy-Pfad reichte nur den nackten Modellnamen weiter und produzierte
+    # eine Route ohne Base-URL + Default-Provider-Key → CAMEL traf den
+    # OpenAI-Default-Endpoint. Der ai_model_ref-Pfad bindet Connection-URL und
+    # -Secret atomar (connection_only=True).
+    ai_model_ref = None
+    raw_ref = data.get('ai_model_ref')
+    if raw_ref is not None:
+        from pydantic import ValidationError as _ValidationError
+
+        from ..contracts.ai_provider_contract import AiModelRef as _AiModelRef
+        try:
+            ai_model_ref = _AiModelRef.model_validate(raw_ref)
+        except _ValidationError:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message="ai_model_ref ist ungültig",
+            )
+        conflicting = [
+            key for key in ('llm_model', 'llm_provider', 'llm_profile_id')
+            if data.get(key)
+        ]
+        if conflicting:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=(
+                    f"ai_model_ref darf nicht mit {', '.join(conflicting)} "
+                    "kombiniert werden"
+                ),
+            )
+        # Legacy-Override stummschalten: die Connection ist maßgeblich.
+        llm_model_override = None
+        llm_runtime = parse_runtime_llm_config({})
     enable_graph_memory_update = data.get('enable_graph_memory_update', False)
     force = data.get('force', False)
 
@@ -234,6 +273,23 @@ def start_simulation():
                     ),
                 )
 
+    # ai_model_ref-Pre-Check VOR der Run-Record-Creation: die Connection muss
+    # existieren, aktiviert sein und (für api_key-Connections) ein gebundenes
+    # Secret tragen — sonst kein .env-Fallback, sondern 422 (analog dem
+    # Legacy-Pre-Check, kein orphaned Run). Die volle Model-Discovery
+    # (Connection/Model-Mismatch, Issue #819) läuft später in
+    # ``seed_run_stage_routing``; deren ValueError wird am Endpunkt zu 4xx.
+    if ai_model_ref is not None:
+        from ..services.llm_routing_seed import prevalidate_ai_model_ref
+        try:
+            prevalidate_ai_model_ref(ai_model_ref)
+        except ValueError as exc:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=422,
+                message=str(exc),
+            )
+
     run_record = run_registry.create_run(
         run_type="simulation_run",
         entity_id=simulation_id,
@@ -260,6 +316,7 @@ def start_simulation():
         "simulation_rounds",
         llm_model_override=llm_model_override,
         llm_runtime=llm_runtime,
+        ai_model_ref=ai_model_ref,
     )
     route_router = StageModelRouter(run_record["run_id"])
     resolved_route = route_router.resolve("simulation_rounds")
@@ -289,7 +346,7 @@ def start_simulation():
             ),
         )
 
-    if simulation_days is not None or llm_model_override or llm_runtime.enabled:
+    if simulation_days is not None or llm_model_override or llm_runtime.enabled or ai_model_ref is not None:
         store = get_artifact_store()
         config = store.read_json(simulation_id, "simulation_config", default=None)
         if not config:
@@ -302,9 +359,9 @@ def start_simulation():
             time_config = dict(config.get("time_config") or {})
             time_config["total_simulation_hours"] = simulation_days * 24
             config["time_config"] = time_config
-        if llm_model_override:
+        if llm_model_override or ai_model_ref is not None:
             config["llm_model"] = resolved_route.model
-        if llm_runtime.enabled and resolved_route.base_url_sanitized:
+        if (llm_runtime.enabled or ai_model_ref is not None) and resolved_route.base_url_sanitized:
             config["llm_base_url"] = resolved_route.base_url_sanitized
         store.write_json(simulation_id, "simulation_config", config)
 

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -118,6 +118,24 @@ def _bind_connection_secret(
     options["connection_only"] = True
 
 
+def prevalidate_ai_model_ref(ai_model_ref: AiModelRef) -> ProviderConnection:
+    """Günstige Vorab-Prüfung einer ``ai_model_ref``: löst die Connection auf
+    und verifiziert die Secret-Bindung — ohne teure Live-Model-Discovery.
+
+    Wirft ``ValueError``, wenn die Connection fehlt oder deaktiviert ist oder
+    eine ``api_key``-Connection ohne gebundenes ``secret_ref`` daherkommt.
+    Aufrufer (z. B. ``/api/simulation/start``) nutzen das, um vor der
+    Run-Record-Creation mit 4xx abzubrechen — kein orphaned Run. Die volle
+    Model-Discovery (Issue #819, Connection/Model-Mismatch) läuft später in
+    ``seed_run_stage_routing``; deren ``ValueError`` wird am Endpunkt ebenfalls
+    zu 4xx. Gemeinsame SSoT mit dem Profil-Pfad, kein .env-Fallback.
+    """
+    connection = _resolve_selected_connection(ai_model_ref.provider_connection_id)
+    options: dict[str, object] = {}
+    _bind_connection_secret(connection, options)
+    return connection
+
+
 def _apply_workspace_defaults(config: RuntimeLlmRouting) -> None:
     """Übernimmt Workspace-Routing-Defaults in config (mutiert config in-place)."""
     try:

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
@@ -423,3 +424,71 @@ def compute_start_hour_offset(
     if not hour_counts:
         return 9
     return int(hour_counts.most_common(1)[0][0])
+
+
+# ---------------------------------------------------------------------------
+# Preflight-Probe: ein einzelner Chat-Completion-Call vor dem Agenten-Fan-out
+# ---------------------------------------------------------------------------
+
+# Status-Codes, die auf einen permanenten Konfigurationsfehler hinweisen —
+# Auth (401/403) oder Routing/Modell (404). Ein Retry wäre hier verschwendete
+# Zeit; der Run muss mit einer klaren Root-Cause-Meldung abgelehnt werden,
+# bevor N Agenten denselben Fehler produzieren (Akzeptanzkriterium #6).
+_PERMANENT_STATUS = {401, 403, 404}
+# Transiente/Server-Fehler, die ein Backoff-Retry rechtfertigen. 408/599
+# ergänzen die typische openai-Retry-Menge; 429 ist Rate-Limit.
+_TRANSIENT_STATUS = {408, 429, 500, 502, 503, 599}
+
+
+def preflight_model_probe(
+    model: Any,
+    *,
+    max_retries: int = 3,
+    backoff_base: float = 0.2,
+) -> None:
+    """Einmaliger kleiner Chat-Completion-Probe vor dem Agenten-Fan-out.
+
+    Sendet einen winzigen ``"ping"``-User-Call an das aufgebaute Modell und
+    fängt permanente Auth-/Routing-Fehler (401/403/404) früh mit einer klaren
+    ``ValueError``-Root-Cause ab — ein einzelner Fehler statt N identischer
+    während der Simulation (Root Cause des ``404 model MiniMax-M3 not found``).
+    Transiente Fehler (429/500/502/503) werden mit exponentiellem Backoff
+    retried; erst nach Erschöpfung der Retries schlägt der Probe fehl.
+
+    Der Probe läuft genau einmal pro Aufruf (bzw. einmal pro Retry-Versuch) —
+    er führt keine eigene Fan-out-Logik. Aufrufer (``run_*_simulation``) rufen
+    ihn direkt nach ``create_model`` auf, bevor Agenten erzeugt werden.
+
+    Nur der OpenAI-kompatible Pfad (MiniMax, OpenAI, Qwen Cloud, …) wirft
+    ``openai.APIStatusError`` mit brauchbarem ``status_code``; andere
+    Plattformen (Gemini/Ollama) lassen ihre nativen Exceptions ungefiltert
+    durch — die noch vor dem Fan-out auftreten und damit denselben
+    Ein-Fehler-vor-Fan-out-Effekt erfüllen.
+    """
+    import openai
+
+    probe_messages = [{"role": "user", "content": "ping"}]
+    for attempt in range(max_retries + 1):
+        try:
+            model.run(probe_messages)
+            return
+        except openai.APIStatusError as exc:
+            status = getattr(exc, "status_code", None)
+            if status in _PERMANENT_STATUS:
+                raise ValueError(
+                    f"OASIS-Preflight: permanenter Provider-Fehler "
+                    f"(HTTP {status}) für die aufgelöste Route — Simulation "
+                    f"vor dem Fan-out abgelehnt. Ursache: {exc}"
+                ) from exc
+            if status in _TRANSIENT_STATUS and attempt < max_retries:
+                time.sleep(backoff_base * (2 ** attempt))
+                continue
+            # Unbekannter Status oder Retries erschöpft → als permanent gelten.
+            raise ValueError(
+                f"OASIS-Preflight: Provider-Fehler (HTTP {status}) ließ sich "
+                f"nach {attempt + 1} Versuch(en) nicht beheben — Simulation "
+                f"vor dem Fan-out abgelehnt. Ursache: {exc}"
+            ) from exc
+        # Nicht-openai-Plattformen (Gemini/Ollama) werfen ihre nativen
+        # Exceptions — ungefiltert weiterreichen, damit der Run sauber
+        # scheitert, statt hier eine lückenhafte Heuristik zu pflegen.

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -94,6 +94,7 @@ try:
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
     )
 except ImportError:  # direct script execution
@@ -109,6 +110,7 @@ except ImportError:  # direct script execution
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
     )
 
@@ -1338,10 +1340,19 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
         if minimax_extra:
             model_cfg["extra_body"] = minimax_extra
 
+        # Explizite Übergabe von url/api_key an ModelFactory.create statt
+        # blindes Verlassen auf os.environ: CAMELs OpenAIModel.__init__ gibt
+        # expliziten Parametern Vorrang vor OPENAI_API_KEY/OPENAI_API_BASE_URL.
+        # Ein Stale-Parent-Env (z. B. OpenAI-Default aus .env) konnte sonst die
+        # aufgelöste Route überschatten → 404 ``model MiniMax-M3 not found``
+        # (Root Cause). url/api_key leer → None → CAMEL fällt wie bisher auf
+        # Env zurück (Standalone-/Dev-Pfad unbeschädigt).
         return ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
             model_type=llm_model,
             model_config_dict=model_cfg,
+            url=llm_base_url or None,
+            api_key=llm_api_key or None,
         )
 
 
@@ -1437,6 +1448,10 @@ async def run_twitter_simulation(
 
     # Twitter use common LLM configuration
     model = create_model(config, use_boost=False)
+    # Preflight: ein einzelner Probe-Call vor dem Fan-out fängt permanente
+    # Auth-/Routing-Fehler (401/403/404) mit klarer Root-Cause ab — kein
+    # N-facher identischer Fehler während der Simulation.
+    preflight_model_probe(model)
 
     # Native CAMEL function-calling replaces the old ReACT-style tool_loop.
     # Tools are attached to each SocialAgent after generation below; OASIS's
@@ -1716,6 +1731,10 @@ async def run_reddit_simulation(
     
     # Reddit use acceleration LLM configuration(if available，otherwise fallback toCommon configuration）
     model = create_model(config, use_boost=True)
+    # Preflight: ein einzelner Probe-Call vor dem Fan-out fängt permanente
+    # Auth-/Routing-Fehler (401/403/404) mit klarer Root-Cause ab — kein
+    # N-facher identischer Fehler während der Simulation.
+    preflight_model_probe(model)
 
     # Native CAMEL function-calling replaces the old ReACT-style tool_loop.
     tool_loop = None

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -42,6 +42,7 @@ try:
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
     )
@@ -57,6 +58,7 @@ except ImportError:  # direct script execution
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
     )
@@ -548,6 +550,8 @@ class RedditSimulationRunner:
                 model_platform=ModelPlatformType.OPENAI,
                 model_type=llm_model,
                 model_config_dict=model_cfg,
+                url=llm_base_url or None,
+                api_key=llm_api_key or None,
             )
     
     def _get_active_agents_for_round(
@@ -643,7 +647,10 @@ class RedditSimulationRunner:
         
         print("\nInitialize LLM model...")
         model = self._create_model()
-        
+        # Preflight: ein einzelner Probe-Call vor dem Fan-out fängt permanente
+        # Auth-/Routing-Fehler (401/403/404) mit klarer Root-Cause ab.
+        preflight_model_probe(model)
+
         print("Load Agent Profile...")
         profile_path = self._get_profile_path()
         if not os.path.exists(profile_path):

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -42,6 +42,7 @@ try:
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
     )
@@ -57,6 +58,7 @@ except ImportError:  # direct script execution
         install_max_tokens_warning_filter,
         install_script_paths,
         load_project_env,
+        preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
     )
@@ -535,6 +537,8 @@ class TwitterSimulationRunner:
                 model_platform=ModelPlatformType.OPENAI,
                 model_type=llm_model,
                 model_config_dict=model_cfg,
+                url=llm_base_url or None,
+                api_key=llm_api_key or None,
             )
     
     def _get_active_agents_for_round(
@@ -649,6 +653,9 @@ class TwitterSimulationRunner:
         # Create model
         print("\nInitialize LLM model...")
         model = self._create_model()
+        # Preflight: ein einzelner Probe-Call vor dem Fan-out fängt permanente
+        # Auth-/Routing-Fehler (401/403/404) mit klarer Root-Cause ab.
+        preflight_model_probe(model)
         
         # Load Agent graph
         print("Load Agent Profile...")

--- a/backend/tests/api/test_simulation_start_provider_route_api.py
+++ b/backend/tests/api/test_simulation_start_provider_route_api.py
@@ -1,0 +1,150 @@
+"""API-Contract: POST /api/simulation/start akzeptiert eine explizite
+``AiModelRef`` (ProviderConnection + Modell) und reicht sie an
+``seed_run_stage_routing`` weiter, sodass der OASIS-Subprozess Modell, Base-URL
+und gebundenen Key derselben Connection erhält (Root Cause des
+``404 model MiniMax-M3 not found``).
+
+Die Konflikt-Prüfungen greifen vor der Run-Record-Creation — daher ohne
+Storage-/Routing-Stubs testbar. Der Forward-Test patcht die schwere
+Sim-Infrastruktur und prüft nur, dass die AiModelRef unverändert durchgereicht
+wird und die Legacy-Felder genullt sind.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+
+VALID_SIM_ID = "sim_0123456789ab"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.config["TESTING"] = True
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    with app.test_request_context(), app.test_client() as test_client:
+        yield test_client
+
+
+def _ref_body(**extra):
+    body = {
+        "simulation_id": VALID_SIM_ID,
+        "platform": "parallel",
+        "ai_model_ref": {
+            "provider_connection_id": "conn-minimax",
+            "model_id": "MiniMax-M3",
+            "source": "explicit",
+        },
+    }
+    body.update(extra)
+    return body
+
+
+def test_ai_model_ref_conflicts_with_llm_model_returns_400(client):
+    resp = client.post("/api/simulation/start", json=_ref_body(llm_model="gemini-1.5-pro"))
+    assert resp.status_code == 400
+    assert b"ai_model_ref" in resp.data
+
+
+def test_ai_model_ref_conflicts_with_llm_provider_returns_400(client):
+    resp = client.post(
+        "/api/simulation/start",
+        json=_ref_body(llm_provider={"provider": "openai", "base_url": "https://api.openai.com/v1"}),
+    )
+    assert resp.status_code == 400
+    assert b"ai_model_ref" in resp.data
+
+
+def test_invalid_ai_model_ref_returns_400(client):
+    resp = client.post(
+        "/api/simulation/start",
+        json={"simulation_id": VALID_SIM_ID, "platform": "parallel", "ai_model_ref": {"model_id": "x"}},
+    )
+    assert resp.status_code == 400
+
+
+def _stub_start_infra(monkeypatch):
+    """Stubbt die schwere Sim-Infrastruktur weg, damit der Endpunkt nach dem
+    ``ai_model_ref``-Parsing zu HTTP 200 läuft. ``seed_run_stage_routing`` wird
+    NICHT gestubbt — das ist gerade der Aufruf, dessen ``ai_model_ref``-KWArg wir
+    verifizieren."""
+    from app.services.simulation_manager import SimulationStatus
+
+    fake_state = MagicMock()
+    fake_state.status = SimulationStatus.READY
+    fake_state.project_id = "proj-x"
+    fake_state.graph_id = None
+    fake_state.branch_name = None
+    fake_state.source_simulation_id = None
+    fake_state.root_simulation_id = None
+    fake_state.branch_depth = 0
+    fake_manager = MagicMock(get_simulation=MagicMock(return_value=fake_state))
+    monkeypatch.setattr("app.api.simulation_run.SimulationManager", lambda: fake_manager)
+
+    run_record = {"run_id": "run_minimax_forward"}
+    fake_run_registry = MagicMock()
+    fake_run_registry.create_run.return_value = run_record
+    monkeypatch.setattr("app.api.simulation_run.run_registry", fake_run_registry)
+
+    # Resolve + Key + Env + Start durch Stubs ersetzen; seed_run_stage_routing
+    # bleibt echt, damit das ai_model_ref-KWarg nachgewiesen wird.
+    from app.contracts.llm_routing_contract import ResolvedRoute
+
+    resolved = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="conn-minimax",
+        model="MiniMax-M3",
+        base_url_sanitized="https://api.minimax.io/v1",
+        routing_version=1,
+        provider_options={"base_url": "https://api.minimax.io/v1", "connection_only": True, "secret_ref": "minimax-conn"},
+    )
+    fake_router = MagicMock()
+    fake_router.resolve.return_value = resolved
+    fake_router.lock_stage.return_value = resolved
+    monkeypatch.setattr("app.api.simulation_run.StageModelRouter", lambda _run_id: fake_router)
+    monkeypatch.setattr("app.api.simulation_run.resolve_route_api_key", lambda _r, _rt: "mm-bound-secret")
+    monkeypatch.setattr(
+        "app.api.simulation_run.build_route_subprocess_env",
+        lambda _r, _k, _rid: {"LLM_MODEL_NAME": "MiniMax-M3", "LLM_BASE_URL": "https://api.minimax.io/v1", "LLM_API_KEY": "mm-bound-secret"},
+    )
+    fake_runner = MagicMock()
+    fake_runner.start_simulation.return_value = MagicMock(
+        to_dict=MagicMock(return_value={"simulation_id": VALID_SIM_ID})
+    )
+    monkeypatch.setattr("app.api.simulation_run.SimulationRunner", fake_runner)
+    monkeypatch.setattr("app.api.simulation_run.get_artifact_store", lambda: MagicMock(name="ArtifactStore"))
+    # ``_simulation_resume_capability`` läuft über simulation_common und dessen
+    # eigene ``get_artifact_store``-Importe — ebenfalls stubben.
+    monkeypatch.setattr("app.api.simulation_common.get_artifact_store", lambda: MagicMock(name="ArtifactStore"), raising=False)
+    # Pre-Check (Connection+Secret-Bindung) wird im Routing-Seed-Unit-Test
+    # separat geprüft; hier stubben wir ihn weg, damit der Forward-Pfad
+    # fokokussiert auf das ai_model_ref-KWarg bleibt. Der Pre-Check importiert
+    # ``prevalidate_ai_model_ref`` lokal aus dem Seed-Modul, deshalb an der
+    # Quelle patchen.
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.prevalidate_ai_model_ref",
+        lambda _ref: MagicMock(name="ProviderConnection"),
+        raising=False,
+    )
+    # persona-review-gate bleibt stumm
+    monkeypatch.setattr("app.api.simulation_run.Config.PERSONA_REVIEW_ENABLED", False, raising=False)
+
+
+def test_valid_ai_model_ref_is_forwarded_to_seed_run_stage_routing(client, monkeypatch):
+    _stub_start_infra(monkeypatch)
+    with patch("app.api.simulation_run.seed_run_stage_routing", wraps=lambda *a, **kw: MagicMock()) as spy:
+        resp = client.post("/api/simulation/start", json=_ref_body())
+    assert resp.status_code == 200, resp.data
+    assert spy.call_args.kwargs.get("ai_model_ref") is not None
+    forwarded = spy.call_args.kwargs["ai_model_ref"]
+    assert forwarded.provider_connection_id == "conn-minimax"
+    assert forwarded.model_id == "MiniMax-M3"
+    # Legacy-Felder werden bei expliziter AiModelRef nicht mitgeschickt.
+    assert spy.call_args.kwargs.get("llm_model_override") is None
+    assert not (spy.call_args.kwargs.get("llm_runtime") or MagicMock()).enabled

--- a/backend/tests/scripts/test_oasis_preflight.py
+++ b/backend/tests/scripts/test_oasis_preflight.py
@@ -1,0 +1,123 @@
+"""Tests für ``preflight_model_probe``: ein einzelner Chat-Completion-Probe
+vor dem OASIS-Agenten-Fan-out.
+
+Verifiziert die beiden Akzeptanzkriterien aus dem OASIS-404-Fix:
+- permanenter Provider-Fehler (404) wird mit ``ValueError`` abgelehnt, statt
+  den Fan-out mit N identischen Fehlern laufen zu lassen;
+- der Probe ruft ``model.run`` genau einmal (kein eigener Fan-out, kein
+  Mehrfach-Call bei dauerhaftem Fehler).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import openai
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _BACKEND_DIR / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from _sim_common import preflight_model_probe  # noqa: E402
+
+
+def _make_openai_error(status_code: int, message: str = "boom") -> openai.APIStatusError:
+    """Baut eine ``openai.APIStatusError`` mit gesetztem ``status_code``.
+
+    Der reale Konstruktor verlangt ein Response-Objekt; für den Probe reicht
+    ein Mock, der ``status_code`` und eine Message exponiert, wie es
+    ``preflight_model_probe`` über ``getattr(exc, "status_code", None)`` liest.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    exc = openai.APIStatusError.__new__(openai.APIStatusError)
+    exc.status_code = status_code  # type: ignore[attr-defined]
+    exc.message = message  # type: ignore[attr-defined]
+    exc.response = response  # type: ignore[attr-defined]
+    exc.body = None  # type: ignore[attr-defined]
+    exc.request = None  # type: ignore[attr-defined]
+    return exc
+
+
+class TestPreflightPermanentErrors:
+    def test_permanent_404_raises_value_error_before_fanout(self) -> None:
+        """Ein permanenter 404 (``model MiniMax-M3 not found``) muss den Probe
+        mit einer klaren Root-Cause-``ValueError`` abbrechen — kein Retry,
+        kein Fan-out."""
+        model = MagicMock()
+        model.run.side_effect = _make_openai_error(404, "model MiniMax-M3 not found")
+
+        with pytest.raises(ValueError, match="404"):
+            preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 1, (
+            "Permanenter 404 darf nicht retried werden — genau ein Probe-Call."
+        )
+
+    def test_permanent_401_raises_value_error(self) -> None:
+        model = MagicMock()
+        model.run.side_effect = _make_openai_error(401, "invalid api key")
+
+        with pytest.raises(ValueError, match="401"):
+            preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 1
+
+    def test_permanent_403_raises_value_error(self) -> None:
+        model = MagicMock()
+        model.run.side_effect = _make_openai_error(403, "forbidden")
+
+        with pytest.raises(ValueError, match="403"):
+            preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 1
+
+
+class TestPreflightRunsOnce:
+    def test_successful_probe_calls_run_exactly_once(self) -> None:
+        """Ein erfolgreicher Probe ruft ``model.run`` genau einmal auf und
+        kehrt ohne Exception zurück — kein Mehrfach-Probe, kein Fan-out."""
+        model = MagicMock()
+        model.run.return_value = MagicMock(name="ChatMessage")
+
+        preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 1
+        # Probe-Nachricht ist ein einzelner User-"ping".
+        sent = model.run.call_args.args[0]
+        assert isinstance(sent, list) and len(sent) == 1
+        assert sent[0]["role"] == "user"
+
+    def test_transient_429_retries_then_succeeds_within_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transiente Fehler (429) werden mit Backoff retried; nach endlich
+        vielen Versuchen läuft der Probe erfolgreich — und insgesamt öfter
+        als einmal, aber nur weil der Retry-Policy es so vorsieht."""
+        monkeypatch.setattr("_sim_common.time.sleep", lambda _s: None)
+        model = MagicMock()
+        model.run.side_effect = [
+            _make_openai_error(429, "rate limit"),
+            MagicMock(name="ok"),
+        ]
+
+        preflight_model_probe(model, max_retries=3, backoff_base=0.0)
+
+        assert model.run.call_count == 2
+
+    def test_transient_500_exhausts_retries_then_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bleibt der transiente Fehler dauerhaft, erschöpft der Probe die
+        Retries und schlägt mit ``ValueError`` fehl — kein endloser Fan-out."""
+        monkeypatch.setattr("_sim_common.time.sleep", lambda _s: None)
+        model = MagicMock()
+        model.run.side_effect = _make_openai_error(500, "server error")
+
+        with pytest.raises(ValueError):
+            preflight_model_probe(model, max_retries=2, backoff_base=0.0)
+
+        assert model.run.call_count == 3  # 1 initial + 2 retries

--- a/backend/tests/scripts/test_oasis_provider_dispatch.py
+++ b/backend/tests/scripts/test_oasis_provider_dispatch.py
@@ -229,6 +229,47 @@ class TestCreateModelMiniMaxBranch:
         model_cfg = calls[0]["kwargs"].get("model_config_dict", {})
         assert model_cfg.get("extra_body") == {"thinking": {"type": "adaptive"}}
 
+    def test_minimax_openai_branch_passes_resolved_url_and_api_key_explicitly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Root Cause 404 ``model MiniMax-M3 not found``: Der OPENAI-Branch von
+        ``create_model`` relied ausschließlich auf ``os.environ["OPENAI_BASE_URL"]``
+        und ``OPENAI_API_KEY``. Ein Stale-Parent-Env (z. B. OpenAI-Default aus
+        ``.env``) konnte die aufgelöste MiniMax-Route überschatten. CAMELs
+        ``OpenAIModel.__init__`` gibt expliziten ``url``/``api_key``-Parametern
+        Vorrang vor dem Env — deshalb muss der Branch sie explizit übergeben.
+
+        Vor dem Fix wurden ``url``/``api_key`` im OPENAI-Branch NICHT an
+        ``ModelFactory.create`` übergeben → dieser Test schlägt fehl (RED)."""
+        monkeypatch.setenv("LLM_MODEL_NAME", "MiniMax-M3")
+        monkeypatch.setenv("LLM_API_KEY", "mm-bound-key")
+        monkeypatch.setenv("LLM_BASE_URL", "https://api.minimax.io/v1")
+        monkeypatch.delenv("OLLAMA_THINKING", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        # Stale-Parent-Env, das die Route überschatten dürfte, wenn sie nicht
+        # explizit übergeben wird:
+        monkeypatch.setenv("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.setenv("OPENAI_API_KEY", "stale-openai-key")
+
+        mock_factory, calls = _make_model_factory_mock()
+
+        import run_parallel_simulation as rps  # type: ignore[import]
+        monkeypatch.setattr(rps, "ModelFactory", mock_factory)
+
+        rps.create_model({}, use_boost=False)
+
+        assert len(calls) == 1
+        kwargs = calls[0]["kwargs"]
+        assert kwargs.get("model_platform") == ModelPlatformType.OPENAI
+        assert kwargs.get("url") == "https://api.minimax.io/v1", (
+            "OPENAI-Branch muss die aufgelöste MiniMax-URL explizit an "
+            "ModelFactory.create übergeben, sonst gewinnt ein Stale-Env."
+        )
+        assert kwargs.get("api_key") == "mm-bound-key", (
+            "OPENAI-Branch muss den gebundenen MiniMax-Key explizit übergeben, "
+            "sonst gewinnt ein Stale-OPENAI_API_KEY aus dem Parent-Env."
+        )
+
 
 class TestCreateModelOllamaBranch:
     """create_model() with an Ollama model must route via OllamaModel with url/api_key

--- a/backend/tests/services/test_llm_routing_seed.py
+++ b/backend/tests/services/test_llm_routing_seed.py
@@ -553,3 +553,170 @@ def test_build_runtime_llm_config_maps_resolved_route_for_legacy_callers():
     assert cfg.provider == "custom_openai"
     assert cfg.api_key == "local-key"
     assert cfg.base_url == "http://localhost:11434/v1"
+
+
+# ---------------------------------------------------------------------------
+# OASIS-Sim-Start: eine ausgewählte MiniMax-ProviderConnection muss Modell,
+# Base-URL und gebundenen Key als zusammengehörige Einheit bis in den
+# Subprozess-Env durchreichen (Root Cause „404 model MiniMax-M3 not found").
+# ---------------------------------------------------------------------------
+
+
+def _minimax_connection() -> ProviderConnection:
+    return ProviderConnection(
+        id="conn-minimax",
+        provider_kind="openai_compatible",
+        display_name="MiniMax",
+        transport="http",
+        auth_mode="api_key",
+        base_url="https://api.minimax.io/v1",
+        secret_ref="minimax-conn",
+        enabled=True,
+    )
+
+
+def _stub_minimax_probe(monkeypatch, connection_store) -> MagicMock:
+    """Stellt den Model-Discovery-Pfad für die MiniMax-Connection auf ein
+    deterministisches ``available``-Ergebnis mit ``MiniMax-M3`` im Katalog."""
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_provider_secrets_store",
+        lambda: MagicMock(),
+        raising=False,
+    )
+    probe_service = MagicMock()
+    probe_service.probe.return_value = ProviderProbeResult(
+        status="available",
+        status_message=None,
+        models=(
+            AiModel(
+                provider_connection_id="conn-minimax",
+                model_id="MiniMax-M3",
+                display_name="MiniMax-M3",
+                source="live",
+                status="available",
+                local_or_cloud="cloud",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionService",
+        lambda **kwargs: probe_service,
+    )
+    return probe_service
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_ai_model_ref_minimax_route_reaches_subprocess_as_unit(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """Regression für den OASIS-404: Eine ausgewählte MiniMax-ProviderConnection
+    mit ``MiniMax-M3`` muss Modell, Base-URL und den gebundenen Key derselben
+    Connection gemeinsam bis in den OASIS-Subprozess-Env gelangen lassen — als
+    eine Route, nicht als isolierte Env-Variablen.
+
+    Vor dem Fix reichte ``start_simulation`` das ``ai_model_ref`` nicht an
+    ``seed_run_stage_routing`` weiter; der Legacy-``llm_model``-Override
+    produzierte eine Route ohne Base-URL und mit dem Default-Provider-Key →
+    CAMEL traf den OpenAI-Default-Endpoint → 404 ``model MiniMax-M3 not found``.
+    """
+    from app.services.stage_model_router import StageModelRouter
+    from app.services.workspace_routing_store import get_workspace_routing_store
+
+    get_workspace_routing_store().reset_for_tests()
+
+    run_id = "run_minimax_unit"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    connection = _minimax_connection()
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [connection]
+    _stub_minimax_probe(monkeypatch, connection_store)
+
+    # Gebundener MiniMax-Key aus dem Secrets-Store (kein .env-Fallback).
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_bound_store_api_key",
+        lambda secret_ref, *, secrets_store=None: (
+            "mm-bound-secret" if secret_ref == "minimax-conn" else None
+        ),
+    )
+
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    seed_run_stage_routing(
+        run_id,
+        "simulation_rounds",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        ai_model_ref=ref,
+    )
+
+    router = StageModelRouter(run_id)
+    resolved_route = router.resolve("simulation_rounds")
+    api_key = resolve_route_api_key(resolved_route, RuntimeLlmConfig())
+    env = build_route_subprocess_env(resolved_route, api_key, run_id)
+
+    # Modell, Base-URL und Key stammen atomar aus derselben MiniMax-Connection.
+    assert env["LLM_MODEL_NAME"] == "MiniMax-M3"
+    assert env["LLM_BASE_URL"] == "https://api.minimax.io/v1"
+    assert env["LLM_API_KEY"] == "mm-bound-secret"
+    assert env["OPENAI_API_KEY"] == "mm-bound-secret"
+    # connection_only ist versiegelt — kein fremder Default-Provider-Key.
+    assert resolved_route.provider_options.get("connection_only") is True
+    assert resolved_route.provider_options.get("secret_ref") == "minimax-conn"
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_ai_model_ref_minimax_route_no_env_or_foreign_key_fallback(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """Bei einer expliziten Cloud-ProviderConnection darf der Key-NICht aus
+    ``Config.LLM_API_KEY`` oder dem Settings-DB-Key eines anderen Providers
+    stammen. ``SecretResolver.get_api_key`` (der .env-/Store-Fallback-Pfad) darf
+    für eine ``connection_only``-Route gar nicht erst angerufen werden."""
+    from app.services.stage_model_router import StageModelRouter
+    from app.services.workspace_routing_store import get_workspace_routing_store
+
+    get_workspace_routing_store().reset_for_tests()
+
+    run_id = "run_minimax_no_fallback"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    connection = _minimax_connection()
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [connection]
+    _stub_minimax_probe(monkeypatch, connection_store)
+
+    get_api_key_mock = MagicMock(return_value="foreign-default-key")
+    monkeypatch.setattr(
+        "app.services.secret_resolver.SecretResolver.get_api_key", get_api_key_mock
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_bound_store_api_key",
+        lambda secret_ref, *, secrets_store=None: "mm-bound-secret",
+    )
+
+    ref = AiModelRef(
+        provider_connection_id="conn-minimax", model_id="MiniMax-M3", source="explicit"
+    )
+    seed_run_stage_routing(
+        run_id,
+        "simulation_rounds",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+        ai_model_ref=ref,
+    )
+
+    resolved_route = StageModelRouter(run_id).resolve("simulation_rounds")
+    api_key = resolve_route_api_key(resolved_route, RuntimeLlmConfig())
+
+    assert api_key == "mm-bound-secret"
+    get_api_key_mock.assert_not_called()

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,8 +27,8 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3486 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 168 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 3499 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:

--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -1,6 +1,7 @@
 import service from './index'
 import type { LlmRuntimePayload } from './llmRuntime'
 import type { PersonaQuotaPlan } from '../contracts/personaQuotaContract'
+import type { AiModelRefPayload } from './report'
 
 // --- Local types --------------------------------------------------------
 
@@ -41,8 +42,14 @@ export interface StartSimulationData {
   max_rounds?: number
   simulation_days?: number
   enable_graph_memory_update?: boolean
+  /** Legacy-Kompatibilität; bei gesetztem `ai_model_ref` nicht mitsenden. */
   llm_model?: string
+  /** Legacy-Kompatibilität; bei gesetztem `ai_model_ref` nicht mitsenden. */
   llm_provider?: LlmRuntimePayload
+  /** Autoritative UI-Auswahl (Connection+Modell). Bindet Base-URL und Secret
+   * derselben ProviderConnection an die OASIS-Route — kein .env-Fallback.
+   * Darf nicht mit `llm_model`/`llm_provider` kombiniert werden. */
+  ai_model_ref?: AiModelRefPayload
   force?: boolean
 }
 

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -23,6 +23,7 @@ import {
   runtimeLlmPayloadFromStorage,
   runtimeProviderMissingKeyEverywhere,
 } from '../composables/useRuntimeLlmOptions'
+import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
@@ -191,6 +192,12 @@ const _simClock = computed(() => useSimClock(props.simulationId || '__unset__'))
 const currentSimTime = computed(() => _simClock.value.currentSimTime.value)
 const simElapsedSec = computed(() => _simClock.value.elapsed.value)
 
+// Kanonische (Connection, Modell)-Auswahl aus routing/defaults.global_default.
+// Wird beim Sim-Start als autoritatives ``ai_model_ref`` gesendet und bindet
+// Base-URL + Secret derselben ProviderConnection an die OASIS-Route — kein
+// .env-Fallback (Root Cause ``404 model MiniMax-M3 not found``).
+const effectiveModel = useEffectiveModelSelection()
+
 const statusStream = useEventStream(() => props.simulationId, {
   state: (msg) => applyRunStateEvent(msg?.payload),
   control: (msg) => applyControlEvent(msg?.payload),
@@ -232,15 +239,32 @@ async function doStart() {
     }
     if (props.maxRounds) params.max_rounds = props.maxRounds
     if (props.simulationDays) params.simulation_days = props.simulationDays
-    const model = storedEffectiveModel()
-    if (model) params.llm_model = model
-    if (await runtimeProviderMissingKeyEverywhere()) {
-      addLog(t('step2.runtimeProvider.missingKey'))
-      emit('update-status', 'error')
-      return
+    // Autoritative (Connection, Modell)-Auswahl aus dem Kanon vorziehen; ist
+    // eine konkrete ProviderConnection+Modell gewählt, wird sie als
+    // ``ai_model_ref`` gesendet. Das bindet Base-URL + Secret derselben
+    // Connection an die OASIS-Route — und schließt das .env-Fallback aus.
+    // ``ai_model_ref`` darf nicht mit den Legacy-Feldern ``llm_model``/
+    // ``llm_provider`` kombiniert werden (Backend: 400), deshalb nur im
+    // Else-Zweig.
+    try { await effectiveModel.ensureLoaded() } catch { /* best effort; Legacy-Pfad greift unten */ }
+    const selection = effectiveModel.effectiveRef.value
+    if (selection && selection.provider_connection_id && selection.model_id) {
+      params.ai_model_ref = {
+        provider_connection_id: selection.provider_connection_id,
+        model_id: selection.model_id,
+        source: selection.source ?? 'explicit',
+      }
+    } else {
+      const model = storedEffectiveModel()
+      if (model) params.llm_model = model
+      if (await runtimeProviderMissingKeyEverywhere()) {
+        addLog(t('step2.runtimeProvider.missingKey'))
+        emit('update-status', 'error')
+        return
+      }
+      const runtimeProvider = runtimeLlmPayloadFromStorage()
+      if (runtimeProvider) params.llm_provider = runtimeProvider
     }
-    const runtimeProvider = runtimeLlmPayloadFromStorage()
-    if (runtimeProvider) params.llm_provider = runtimeProvider
     addLog(t('step3.controls.starting'))
     const res = await startSimulation(params)
     if (res?.success) {

--- a/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
@@ -94,6 +94,20 @@ vi.mock('../../composables/useRuntimeLlmOptions', () => ({
   runtimeProviderMissingKeyEverywhere: () => false,
 }))
 
+// Kanonische Modell-Auswahl stubben: Step3 ruft useEffectiveModelSelection
+// im Setup auf; ohne Mock läge kein Pinia-/Store-Kontext vor. Default: keine
+// Auswahl → Legacy-Pfad bleibt unberührt (Feed-Test ruft doStart nicht auf).
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: { value: null },
+    effectiveRoute: { value: null },
+    loading: { value: false },
+    error: { value: null },
+    ensureLoaded: vi.fn().mockResolvedValue(undefined),
+    setGlobalSelection: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
 // useSimFeed: echtes Modul behalten — wir wollen die Routing- und
 // Dedupe-Logik mittesten.
 import { clearSimFeed } from '../../composables/useSimFeed'

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -62,6 +62,20 @@ vi.mock('../../api/runs', () => ({
   cancelRun: vi.fn().mockResolvedValue({ success: true, data: { run_id: 'sim_test_smoke', status: 'cancel_requested' } }),
 }))
 
+// Kanonische Modell-Auswahl: Default ist kein ai_model_ref (Legacy-Pfad bleibt
+// für bestehende Tests intakt). Der ai_model_ref-Test überschreibt effectiveRef.
+let _effectiveRefValue: { provider_connection_id: string; model_id: string; source: string } | null = null
+vi.mock('@/composables/useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: { get value() { return _effectiveRefValue }, set value(_v: unknown) { /* noop */ } },
+    effectiveRoute: { value: null },
+    loading: { value: false },
+    error: { value: null },
+    ensureLoaded: vi.fn().mockResolvedValue(undefined),
+    setGlobalSelection: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
 // Captured SSE state-callback — re-assigned per test in describe('phase-promotion').
 // The factory uses a shared slot so tests can fire the callback after mount.
 let _capturedStateCallback: ((msg: unknown) => void) | null = null
@@ -177,6 +191,7 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
     vi.clearAllMocks()
     localStorage.clear()
     _capturedStateCallback = null
+    _effectiveRefValue = null
     // Reset useEventStream mock zurück auf Standardimplementation.
     ;(useEventStream as ReturnType<typeof vi.fn>).mockImplementation(
       (_idFn: unknown, handlers: { state?: (msg: unknown) => void }) => {
@@ -362,5 +377,85 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
       simulation_id: 'sim_test_smoke',
       llm_model: 'deepseek-v3.2:cloud',
     })
+  })
+})
+
+/**
+ * ai_model_ref beim Simulationsstart (Root Cause ``404 model MiniMax-M3 not found``).
+ *
+ * Sichert ab, dass Step3 die kanonische (Connection, Modell)-Auswahl aus
+ * routing/defaults.global_default als ``ai_model_ref`` an ``startSimulation``
+ * sendet — und NICHT gleichzeitig die Legacy-Felder ``llm_model``/``llm_provider``
+ * mitschickt (Backend lehnt die Kombination mit 400 ab).
+ */
+describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    _capturedStateCallback = null
+    _effectiveRefValue = null
+    ;(useEventStream as ReturnType<typeof vi.fn>).mockImplementation(
+      (_idFn: unknown, handlers: { state?: (msg: unknown) => void }) => {
+        if (handlers?.state) _capturedStateCallback = handlers.state
+        return {
+          isStreaming: { value: false },
+          error: { value: null },
+          lastEventAt: { value: null },
+          start: vi.fn().mockResolvedValue(undefined),
+          stop: vi.fn(),
+        }
+      }
+    )
+  })
+
+  it('sendet ai_model_ref aus dem Kanon und lässt llm_model/llm_provider weg', async () => {
+    vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
+    vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_test_smoke' } } as never)
+
+    _effectiveRefValue = {
+      provider_connection_id: 'conn-minimax',
+      model_id: 'MiniMax-M3',
+      source: 'explicit',
+    }
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const startBtn = wrapper.findAll('button').find(b => b.text().includes('step3.controls.start'))
+    expect(startBtn).toBeTruthy()
+    await startBtn!.trigger('click')
+    await flushPromises()
+
+    expect(simulationApi.startSimulation).toHaveBeenCalledTimes(1)
+    const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn-minimax',
+      model_id: 'MiniMax-M3',
+      source: 'explicit',
+    })
+    // Keine Legacy-Felder gemeinsam mit ai_model_ref (Backend: 400 sonst).
+    expect(payload.llm_model).toBeUndefined()
+    expect(payload.llm_provider).toBeUndefined()
+  })
+
+  it('fällt ohne Kanon-Auswahl auf Legacy llm_model/llm_provider zurück', async () => {
+    vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
+    vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_test_smoke' } } as never)
+    // Kein ai_model_ref aus dem Kanon → Legacy-Pfad.
+    _effectiveRefValue = null
+    localStorage.setItem('agora.lastModel', 'custom')
+    localStorage.setItem('agora.lastCustomModel', 'deepseek-v3.2:cloud')
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const startBtn = wrapper.findAll('button').find(b => b.text().includes('step3.controls.start'))
+    expect(startBtn).toBeTruthy()
+    await startBtn!.trigger('click')
+    await flushPromises()
+
+    const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
+    expect(payload.ai_model_ref).toBeUndefined()
+    expect(payload.llm_model).toBe('deepseek-v3.2:cloud')
   })
 })


### PR DESCRIPTION
## Root Cause

`openai.NotFoundError: Error code: 404 model 'MiniMax-M3' not found` in der OASIS-Twitter/-Reddit-Simulation. Ontologie-/Persona-/Report-Pfade liefen mit derselben MiniMax-Connection — nur der OASIS-Subprocess scheiterte.

`/api/simulation/start` reichte die `ai_model_ref` der vom UI gewählten ProviderConnection nicht weiter. Der Legacy-Pfad baute eine Route ohne Base-URL + Default-Provider-Key → CAMEL traf den OpenAI-Default-Endpoint → 404.

## Datenfluss (neu)

Frontend (Step3) sendet `ai_model_ref` aus `routing/defaults.global_default`
→ `/api/simulation/start` reicht `ai_model_ref` an `seed_run_stage_routing`
→ `StageLLMRoute` bindet `connection_base_url` + `secret_ref` (`connection_only`, kein .env-Fallback)
→ `build_route_subprocess_env` injiziert `LLM_MODEL_NAME`/`LLM_BASE_URL`/`LLM_API_KEY` derselben Connection
→ `create_model` (OPENAI-Branch) übergibt `url`+`api_key` **explizit** an `ModelFactory.create` (Vorrang vor Stale-Parent-Env)
→ `preflight_model_probe`: ein Chat-Completion-Probe vor dem Fan-out fängt permanente 401/403/404 mit klarer Root-Cause ab (ein Fehler statt N), transiente 429/500/502/503 mit Backoff-Retry.

## Änderungen

- `backend/app/api/simulation_run.py` — `ai_model_ref`-Parsing, Konflikt-Check gegen `llm_model`/`llm_provider` (400), `prevalidate_ai_model_ref`-Pre-Check vor Run-Record-Creation (422), Weiterreichung an `seed_run_stage_routing` + sim-config.
- `backend/app/services/llm_routing_seed.py` — `prevalidate_ai_model_ref`-Helper (Connection+Secret-Bindung ohne Live-Probe).
- `backend/scripts/_sim_common.py` — `preflight_model_probe`.
- `backend/scripts/run_{parallel,twitter,reddit}_simulation.py` — OPENAI-Branch übergibt `url`/`api_key` explizit; Preflight nach `create_model`.
- `frontend/src/api/simulation.ts` — `StartSimulationData.ai_model_ref`.
- `frontend/src/components/Step3Simulation.vue` — sendet `ai_model_ref` aus `useEffectiveModelSelection`, Legacy-Fallback nur ohne Kanon-Auswahl.

## Tests (RED→GREEN)

- `test_simulation_start_provider_route_api` (4): Konflikt-Checks, Invalid-Ref, Forward an seed.
- `test_oasis_preflight` (6): permanent 404/401/403, einmaliger Probe, 429-Retry, 500-Retry-Erschöpfung.
- `test_oasis_provider_dispatch` MiniMax-Branch (1): explizite `url`/`api_key` trotz Stale-Env.
- `test_llm_routing_seed` MiniMax-Route (2): Subprocess-Env als Einheit, kein .env-/Fremd-Key-Fallback.

Ollama-/Gemini-Pfade unberührt (eigene Tests grün).

## Verifikation

- Contracts 384 ok, Schemas 46 ok, `ruff` clean, `mypy app` ok.
- Frontend `bun run check`: 173 files / 1527 tests ok.
- `pre-push-gate.sh backend|frontend|schemas`: ALL GREEN.
- Live-Smoke mit gebundenem MiniMax-Key: `ModelFactory.create(OPENAI, "MiniMax-M3", url=…, api_key=…)` + `preflight_model_probe` → echte Chat-Completion-Antwort, kein 404.

## Risiken

- Preflight greift nur `openai.APIStatusError` (OpenAI-kompatibel). Gemini/Ollama werfen native Exceptions, die ungefiltert propagieren — scheitern noch vor Fan-out, aber ohne Backoff-Retry.
- `goReport`-Shortcut in Step3 sendet weiterhin Legacy-Felder (Report-API hat eigenen `ai_model_ref`-Pfad via Step4Report); nicht Teil des Sim-Root-Cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Simulationen können nun über eine kanonische Verbindung-und-Modell-Auswahl (`ai_model_ref`) gestartet werden.
  * Das Frontend sendet bei gültiger Auswahl `ai_model_ref`, andernfalls wird nahtlos auf die Legacy-Felder zurückgegriffen.
  * Vor dem Start wird das Modell gezielt geprüft, bevor die Simulation in den Ausführungs-Flow übergeht.
* **Fehlerbehebungen**
  * Verhindert ungültige bzw. widersprüchliche Startkombinationen von `ai_model_ref` mit Legacy-Feldern (klare 400/422-Antworten).
  * Frühzeitige Erkennung von Auth-/Routing-Problemen inkl. Retry bei temporären Fehlern.
* **Tests**
  * Erweiterte API-, Routing-, Secret-/Umgebungs-Regressionstests sowie Preflight-Retry-Tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->