### PR TITLE
fix(frontend): Hero-Modellwahl als autoritatives ai_model_ref zum Sim-Start durchreichen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (v4-Dashboard: Hero-Modellwahl wird als autoritatives ai_model_ref zum Sim-Start durchgereicht — 2026-07-23)
+
+- Die Modellwahl im Dashboard (`HeroNewRun`, AiModelPicker) wurde bislang nur als `model_id`-String
+  nach `STORAGE_MODEL` gespiegelt; beim späteren Simulationsstart gewann der Kanon
+  (`routing/defaults.global_default`) — ein abweichender Dashboard-Pick wurde stillschweigend
+  ignoriert bzw. verlor ohne Kanon-Default seine Connection-Bindung (Legacy-`llm_model`-Pfad).
+- Neu: `frontend/src/store/runModelOverride.ts` — transiente, Zod-validierte sessionStorage-Senke
+  (`agora.run.aiModelRefOverride`). `HeroNewRun` schreibt beim Start den vollen `AiModelRef`
+  (Profile-Start bzw. kein Pick cleart die Senke); `Step3Simulation.doStart` liest sie vorrangig
+  vor dem Kanon und sendet sie als `ai_model_ref` mit `source: "run-override"` (Backend-Literal
+  in `AiModelRefSource` vorhanden). Der persistente Kanon bleibt unberührt — die
+  Phase-1-Konsolidierung („eine persistente Modell-Senke") bleibt intakt.
+- Tests: `store/__tests__/runModelOverride.spec.ts` (Roundtrip, Source-Normalisierung, defensives
+  Entsorgen korrupter Einträge), `Step3Simulation.spec.ts` (Override gewinnt vor Kanon; Override
+  ohne Kanon → kein Legacy-Fallback), `HeroNewRun.spec.ts` (Set bei Pick, Clear bei Profile und
+  ohne Pick).
+
 ### Fixed (Vue-v4: Legacy-Prozessrouten konsolidiert — 2026-07-22, Issue #831)
 
 - Die fünf klassischen Prozessrouten bleiben als benannte, kompatible Redirects erhalten und führen nun auf die kanonischen v4-Step-Routen. Die verwaisten Wrapper-Views `MainView`, `SimulationView`, `SimulationRunView`, `ReportView` und `InteractionView` sowie die einzige zugehörige Spec wurden entfernt.

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -24,7 +24,7 @@ import {
   runtimeProviderMissingKeyEverywhere,
 } from '../composables/useRuntimeLlmOptions'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
-import { getRunModelOverride } from '@/store/runModelOverride'
+import { getRunModelOverride, clearRunModelOverride } from '@/store/runModelOverride'
 import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
@@ -249,6 +249,7 @@ async function doStart() {
     // ``llm_provider`` kombiniert werden (Backend: 400), deshalb nur im
     // Else-Zweig.
     let selection = getRunModelOverride()
+    const usedRunOverride = selection !== null
     if (!selection) {
       try { await effectiveModel.ensureLoaded() } catch { /* best effort; Legacy-Pfad greift unten */ }
       selection = effectiveModel.effectiveRef.value
@@ -273,6 +274,10 @@ async function doStart() {
     addLog(t('step3.controls.starting'))
     const res = await startSimulation(params)
     if (res?.success) {
+      // Consume-on-success: Der Dashboard-Override gilt genau für diesen
+      // Start. Verhindert, dass ein späterer Start einer ANDEREN Simulation
+      // im selben Tab den alten Override stillschweigend erbt.
+      if (usedRunOverride) clearRunModelOverride()
       phase.value = 1
       addLog(t('step3.status.running', { current: 0, total: props.maxRounds || '?' }))
       startPolling()

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -24,6 +24,7 @@ import {
   runtimeProviderMissingKeyEverywhere,
 } from '../composables/useRuntimeLlmOptions'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
+import { getRunModelOverride } from '@/store/runModelOverride'
 import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
@@ -239,15 +240,19 @@ async function doStart() {
     }
     if (props.maxRounds) params.max_rounds = props.maxRounds
     if (props.simulationDays) params.simulation_days = props.simulationDays
-    // Autoritative (Connection, Modell)-Auswahl aus dem Kanon vorziehen; ist
-    // eine konkrete ProviderConnection+Modell gewählt, wird sie als
-    // ``ai_model_ref`` gesendet. Das bindet Base-URL + Secret derselben
-    // Connection an die OASIS-Route — und schließt das .env-Fallback aus.
+    // Autoritative (Connection, Modell)-Auswahl: Der transiente Dashboard-
+    // Run-Override (HeroNewRun-Pick, store/runModelOverride) gewinnt vor dem
+    // Kanon (routing/defaults.global_default). Die Auswahl wird als
+    // ``ai_model_ref`` gesendet — das bindet Base-URL + Secret derselben
+    // Connection an die OASIS-Route und schließt das .env-Fallback aus.
     // ``ai_model_ref`` darf nicht mit den Legacy-Feldern ``llm_model``/
     // ``llm_provider`` kombiniert werden (Backend: 400), deshalb nur im
     // Else-Zweig.
-    try { await effectiveModel.ensureLoaded() } catch { /* best effort; Legacy-Pfad greift unten */ }
-    const selection = effectiveModel.effectiveRef.value
+    let selection = getRunModelOverride()
+    if (!selection) {
+      try { await effectiveModel.ensureLoaded() } catch { /* best effort; Legacy-Pfad greift unten */ }
+      selection = effectiveModel.effectiveRef.value
+    }
     if (selection && selection.provider_connection_id && selection.model_id) {
       params.ai_model_ref = {
         provider_connection_id: selection.provider_connection_id,

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -76,6 +76,14 @@ vi.mock('@/composables/useEffectiveModelSelection', () => ({
   }),
 }))
 
+// Transienter Dashboard-Run-Override (HeroNewRun → store/runModelOverride):
+// Default null (bestehende Tests unverändert); die Override-Tests setzen
+// _runOverrideValue vor dem Mount.
+let _runOverrideValue: { provider_connection_id: string; model_id: string; source: string } | null = null
+vi.mock('@/store/runModelOverride', () => ({
+  getRunModelOverride: () => _runOverrideValue,
+}))
+
 // Captured SSE state-callback — re-assigned per test in describe('phase-promotion').
 // The factory uses a shared slot so tests can fire the callback after mount.
 let _capturedStateCallback: ((msg: unknown) => void) | null = null
@@ -192,6 +200,7 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
     localStorage.clear()
     _capturedStateCallback = null
     _effectiveRefValue = null
+    _runOverrideValue = null
     // Reset useEventStream mock zurück auf Standardimplementation.
     ;(useEventStream as ReturnType<typeof vi.fn>).mockImplementation(
       (_idFn: unknown, handlers: { state?: (msg: unknown) => void }) => {
@@ -394,6 +403,7 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
     localStorage.clear()
     _capturedStateCallback = null
     _effectiveRefValue = null
+    _runOverrideValue = null
     ;(useEventStream as ReturnType<typeof vi.fn>).mockImplementation(
       (_idFn: unknown, handlers: { state?: (msg: unknown) => void }) => {
         if (handlers?.state) _capturedStateCallback = handlers.state
@@ -434,6 +444,72 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
       source: 'explicit',
     })
     // Keine Legacy-Felder gemeinsam mit ai_model_ref (Backend: 400 sonst).
+    expect(payload.llm_model).toBeUndefined()
+    expect(payload.llm_provider).toBeUndefined()
+  })
+
+  it('Dashboard-Run-Override gewinnt vor dem Kanon und wird als ai_model_ref gesendet', async () => {
+    vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
+    vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_test_smoke' } } as never)
+
+    // Kanon zeigt ein ANDERES Modell — der transiente Dashboard-Pick muss gewinnen.
+    _effectiveRefValue = {
+      provider_connection_id: 'conn-kanon',
+      model_id: 'kanon-model',
+      source: 'explicit',
+    }
+    _runOverrideValue = {
+      provider_connection_id: 'conn-hero',
+      model_id: 'hero-model',
+      source: 'run-override',
+    }
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const startBtn = wrapper.findAll('button').find(b => b.text().includes('step3.controls.start'))
+    expect(startBtn).toBeTruthy()
+    await startBtn!.trigger('click')
+    await flushPromises()
+
+    const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn-hero',
+      model_id: 'hero-model',
+      source: 'run-override',
+    })
+    expect(payload.llm_model).toBeUndefined()
+    expect(payload.llm_provider).toBeUndefined()
+  })
+
+  it('Dashboard-Run-Override greift auch ohne Kanon-Auswahl (kein Legacy-Fallback)', async () => {
+    vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
+    vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_test_smoke' } } as never)
+
+    _effectiveRefValue = null
+    _runOverrideValue = {
+      provider_connection_id: 'conn-hero',
+      model_id: 'hero-model',
+      source: 'run-override',
+    }
+    // Legacy-Storage vorhanden — darf trotzdem NICHT greifen.
+    localStorage.setItem('agora.lastModel', 'custom')
+    localStorage.setItem('agora.lastCustomModel', 'deepseek-v3.2:cloud')
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const startBtn = wrapper.findAll('button').find(b => b.text().includes('step3.controls.start'))
+    expect(startBtn).toBeTruthy()
+    await startBtn!.trigger('click')
+    await flushPromises()
+
+    const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn-hero',
+      model_id: 'hero-model',
+      source: 'run-override',
+    })
     expect(payload.llm_model).toBeUndefined()
     expect(payload.llm_provider).toBeUndefined()
   })

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -80,8 +80,10 @@ vi.mock('@/composables/useEffectiveModelSelection', () => ({
 // Default null (bestehende Tests unverändert); die Override-Tests setzen
 // _runOverrideValue vor dem Mount.
 let _runOverrideValue: { provider_connection_id: string; model_id: string; source: string } | null = null
+const _clearRunOverrideSpy = vi.fn()
 vi.mock('@/store/runModelOverride', () => ({
   getRunModelOverride: () => _runOverrideValue,
+  clearRunModelOverride: () => _clearRunOverrideSpy(),
 }))
 
 // Captured SSE state-callback — re-assigned per test in describe('phase-promotion').
@@ -446,6 +448,8 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
     // Keine Legacy-Felder gemeinsam mit ai_model_ref (Backend: 400 sonst).
     expect(payload.llm_model).toBeUndefined()
     expect(payload.llm_provider).toBeUndefined()
+    // Kein Override benutzt → kein Consume-Clear.
+    expect(_clearRunOverrideSpy).not.toHaveBeenCalled()
   })
 
   it('Dashboard-Run-Override gewinnt vor dem Kanon und wird als ai_model_ref gesendet', async () => {
@@ -480,6 +484,8 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
     })
     expect(payload.llm_model).toBeUndefined()
     expect(payload.llm_provider).toBeUndefined()
+    // Consume-on-success: Override gilt genau für diesen Start.
+    expect(_clearRunOverrideSpy).toHaveBeenCalledTimes(1)
   })
 
   it('Dashboard-Run-Override greift auch ohne Kanon-Auswahl (kein Legacy-Fallback)', async () => {
@@ -512,6 +518,8 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
     })
     expect(payload.llm_model).toBeUndefined()
     expect(payload.llm_provider).toBeUndefined()
+    // Consume-on-success: Override gilt genau für diesen Start.
+    expect(_clearRunOverrideSpy).toHaveBeenCalledTimes(1)
   })
 
   it('fällt ohne Kanon-Auswahl auf Legacy llm_model/llm_provider zurück', async () => {

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -101,6 +101,11 @@ const effectiveModel = useEffectiveModelSelection()
 
 const selectedProfileId = ref<string | null>(readLocal(STORAGE_HERO_PROFILE_ID))
 const selectedModel = ref<AiModelRef | null>(null)
+// Run-Override nur bei explizitem Picker-Pick schreiben: selectedModel wird
+// beim Mount aus dem Kanon initialisiert und darf den Kanon nicht als
+// Override festschreiben — spätere Kanon-Änderungen sollen bis zum Sim-Start
+// durchschlagen (Review-Finding PR #853).
+const hasExplicitPick = ref(false)
 const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
 const simulationRequirement = ref('')
 
@@ -205,6 +210,7 @@ function onPickModel(aiRef: AiModelRef | null) {
   // Transienter Run-Override: nur STORAGE_MODEL-Spiegel für den Sim-Start
   // (MainView.handleNewProject). KEINE eigene persistente Modell-Senke mehr —
   // der Default kommt aus dem Kanon.
+  hasExplicitPick.value = true
   selectedModel.value = aiRef
   if (aiRef) {
     // STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default' bei leerer model_id).
@@ -246,8 +252,9 @@ async function startSimulation() {
       writeLocal(STORAGE_MODEL, stored)
       // Voller AiModelRef (inkl. provider_connection_id) als transienter
       // Run-Override: Step3Simulation sendet ihn beim Sim-Start vorrangig
-      // vor dem Kanon als autoritatives ai_model_ref.
-      if (selectedModel.value) {
+      // vor dem Kanon als autoritatives ai_model_ref. Nur bei explizitem
+      // Picker-Pick — der Kanon-Initialwert vom Mount wird nicht eingefroren.
+      if (hasExplicitPick.value && selectedModel.value) {
         setRunModelOverride(selectedModel.value)
       } else {
         clearRunModelOverride()

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -19,6 +19,7 @@ import { setPendingUpload } from '../../../store/pendingUpload'
 import { STORAGE_LANG, STORAGE_MODEL } from '../../../composables/useEnvForm'
 import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
+import { setRunModelOverride, clearRunModelOverride } from '@/store/runModelOverride'
 import type { LlmProfile } from '../../../contracts/llmProfileContract'
 import type { AiModelRef } from '@/contracts/aiModelRef'
 import { getSystemStatus } from '../../../api/status'
@@ -76,8 +77,11 @@ function removeLocal(key: string): void {
  * Default-Modell kommt NICHT mehr aus einem eigenen `agora.hero.aiModelRef`-Key,
  * sondern aus dem Kanon (routing/defaults.global via useEffectiveModelSelection)
  * — damit der Dashboard-Start dieselbe Auswahl wie Settings zeigt. Ein
- * Dashboard-Pick ist ein transienter Run-Override (nur STORAGE_MODEL-Spiegel für
- * MainView). Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route` wird
+ * Dashboard-Pick ist ein transienter Run-Override: STORAGE_MODEL-Spiegel für
+ * MainView plus voller AiModelRef in der sessionStorage-Senke
+ * `agora.run.aiModelRefOverride` (store/runModelOverride), die Step3Simulation
+ * beim Sim-Start vorrangig vor dem Kanon als `ai_model_ref` sendet.
+ * Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route` wird
  * NICHT mehr gelesen und beim Mount defensiv entfernt.
  *
  * MainView.handleNewProject liest weiterhin den klassischen STORAGE_MODEL-Key
@@ -232,11 +236,22 @@ async function startSimulation() {
     // nicht versehentlich einen stale Override mitsendet.
     if (profileId) {
       writeLocal(STORAGE_MODEL, 'default')
+      // Profile gewinnt — Run-Override defensiv räumen, damit Step3 nicht
+      // einen stale Direkt-Pick vorzieht.
+      clearRunModelOverride()
     } else {
       // Slice 5.4: STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default'
       // wenn kein Model gewählt — verhindert stale Route).
       const stored = adapter.toStoredModelString(selectedModel.value)
       writeLocal(STORAGE_MODEL, stored)
+      // Voller AiModelRef (inkl. provider_connection_id) als transienter
+      // Run-Override: Step3Simulation sendet ihn beim Sim-Start vorrangig
+      // vor dem Kanon als autoritatives ai_model_ref.
+      if (selectedModel.value) {
+        setRunModelOverride(selectedModel.value)
+      } else {
+        clearRunModelOverride()
+      }
     }
     setPendingUpload(
       files.value,

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -614,6 +614,34 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     expect(setRunModelOverrideMock).not.toHaveBeenCalled()
   })
 
+  it('startSimulation: Kanon-Initialisierung ohne Picker-Interaktion setzt KEINEN Run-Override', async () => {
+    // selectedModel wird beim Mount aus dem Kanon initialisiert — ohne
+    // expliziten Picker-Pick darf der Kanon NICHT als Override eingefroren
+    // werden (spätere Kanon-Änderungen sollen bis zum Sim-Start durchschlagen).
+    effectiveRefHolder.current = {
+      provider_connection_id: 'conn-kanon',
+      model_id: 'kanon-model',
+      source: 'explicit',
+    }
+    const w = await mountHero()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    await w.find('.hero-cta').trigger('click')
+    await flushPromises()
+
+    expect(setRunModelOverrideMock).not.toHaveBeenCalled()
+    expect(clearRunModelOverrideMock).toHaveBeenCalledTimes(1)
+  })
+
   it('startSimulation: ohne Pick und ohne Profile wird der Run-Override gecleart', async () => {
     const w = await mountHero()
 

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -82,6 +82,8 @@ const {
   routerPushMock,
   ensureLoadedMock,
   setGlobalSelectionMock,
+  setRunModelOverrideMock,
+  clearRunModelOverrideMock,
   effectiveRefHolder,
 } = vi.hoisted(() => ({
   fetchLlmProfilesMock: vi.fn(),
@@ -90,6 +92,8 @@ const {
   routerPushMock: vi.fn(),
   ensureLoadedMock: vi.fn(),
   setGlobalSelectionMock: vi.fn(),
+  setRunModelOverrideMock: vi.fn(),
+  clearRunModelOverrideMock: vi.fn(),
   effectiveRefHolder: { current: null as AiModelRef | null },
 }))
 
@@ -99,6 +103,14 @@ vi.mock('@/api/llmProfiles', () => ({
 
 vi.mock('@/store/pendingUpload', () => ({
   setPendingUpload: setPendingUploadMock,
+}))
+
+// Transiente Run-Override-Senke: HeroNewRun schreibt beim Start den vollen
+// AiModelRef (Pick) bzw. cleart (Profile/kein Pick) — Step3Simulation liest
+// sie vorrangig vor dem Kanon.
+vi.mock('@/store/runModelOverride', () => ({
+  setRunModelOverride: setRunModelOverrideMock,
+  clearRunModelOverride: clearRunModelOverrideMock,
 }))
 
 vi.mock('@/api/status', () => ({
@@ -270,6 +282,8 @@ async function mountHero(seed: Record<string, string> = {}) {
 
   setPendingUploadMock.mockClear()
   routerPushMock.mockClear()
+  setRunModelOverrideMock.mockClear()
+  clearRunModelOverrideMock.mockClear()
   getSystemStatusMock.mockClear()
   getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
   adapterMock.toLlmRoute.mockClear()
@@ -532,6 +546,92 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'gpt-4o-mini')
     expect(setPendingUploadMock).toHaveBeenCalled()
     expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+  })
+
+  it('startSimulation: ohne Profile setzt die Picker-Wahl den Run-Override (voller AiModelRef)', async () => {
+    const w = await mountHero()
+    // Picker emit aiRef → transienter Run-Override inkl. provider_connection_id.
+    const picker = w.findComponent(aiPickerStub)
+    await picker.trigger('click')
+    await flushPromises()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    await w.find('.hero-cta').trigger('click')
+    await flushPromises()
+
+    // Der volle AiModelRef wandert in die Run-Override-Senke — Step3Simulation
+    // sendet ihn beim Sim-Start vorrangig vor dem Kanon als ai_model_ref.
+    expect(setRunModelOverrideMock).toHaveBeenCalledWith({
+      provider_connection_id: 'conn-openai-1',
+      model_id: 'gpt-4o-mini',
+      source: 'explicit',
+    })
+    expect(clearRunModelOverrideMock).not.toHaveBeenCalled()
+  })
+
+  it('startSimulation: bei aktivem Profile wird der Run-Override gecleart (Profile gewinnt)', async () => {
+    fetchLlmProfilesMock.mockResolvedValue([
+      {
+        id: 'abc',
+        name: 'Mein GPT-4o',
+        provider: 'openai',
+        base_url: 'https://api.openai.com/v1',
+        model_name: 'gpt-4o',
+        is_default: true,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    const w = await mountHero()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    const select = w.find<HTMLSelectElement>('select#hero-profile')
+    await select.setValue('abc')
+    await flushPromises()
+
+    await w.find('.hero-cta').trigger('click')
+    await flushPromises()
+
+    expect(clearRunModelOverrideMock).toHaveBeenCalledTimes(1)
+    expect(setRunModelOverrideMock).not.toHaveBeenCalled()
+  })
+
+  it('startSimulation: ohne Pick und ohne Profile wird der Run-Override gecleart', async () => {
+    const w = await mountHero()
+
+    const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    const textarea = w.find<HTMLTextAreaElement>('textarea#hero-requirement')
+    await textarea.setValue('Wie reagiert die DACH-Region?')
+    await flushPromises()
+
+    await w.find('.hero-cta').trigger('click')
+    await flushPromises()
+
+    expect(clearRunModelOverrideMock).toHaveBeenCalledTimes(1)
+    expect(setRunModelOverrideMock).not.toHaveBeenCalled()
   })
 
   it('startSimulation: setPendingUpload wird ueber Pinia exportiert (Smoke)', async () => {

--- a/frontend/src/store/__tests__/runModelOverride.spec.ts
+++ b/frontend/src/store/__tests__/runModelOverride.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * runModelOverride — Spec für die transiente Run-Override-Senke.
+ *
+ * Sichert Roundtrip, Source-Normalisierung auf 'run-override' und das
+ * defensive Entsorgen korrupter/invalider sessionStorage-Einträge ab.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  RUN_MODEL_OVERRIDE_KEY,
+  clearRunModelOverride,
+  getRunModelOverride,
+  setRunModelOverride,
+} from '../runModelOverride'
+
+describe('runModelOverride (transiente Dashboard-Senke)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('Roundtrip: set normalisiert source auf run-override, get liefert den Ref', () => {
+    setRunModelOverride({
+      provider_connection_id: 'conn-1',
+      model_id: 'm-1',
+      source: 'explicit',
+    })
+    expect(getRunModelOverride()).toEqual({
+      provider_connection_id: 'conn-1',
+      model_id: 'm-1',
+      source: 'run-override',
+    })
+  })
+
+  it('clear entfernt die Senke', () => {
+    setRunModelOverride({
+      provider_connection_id: 'conn-1',
+      model_id: 'm-1',
+      source: 'explicit',
+    })
+    clearRunModelOverride()
+    expect(getRunModelOverride()).toBeNull()
+    expect(sessionStorage.getItem(RUN_MODEL_OVERRIDE_KEY)).toBeNull()
+  })
+
+  it('korrupter JSON-Inhalt wird defensiv entsorgt', () => {
+    sessionStorage.setItem(RUN_MODEL_OVERRIDE_KEY, '{not json')
+    expect(getRunModelOverride()).toBeNull()
+    expect(sessionStorage.getItem(RUN_MODEL_OVERRIDE_KEY)).toBeNull()
+  })
+
+  it('invalides Shape (leere model_id) wird defensiv entsorgt', () => {
+    sessionStorage.setItem(
+      RUN_MODEL_OVERRIDE_KEY,
+      JSON.stringify({ provider_connection_id: 'conn-1', model_id: '', source: 'run-override' }),
+    )
+    expect(getRunModelOverride()).toBeNull()
+    expect(sessionStorage.getItem(RUN_MODEL_OVERRIDE_KEY)).toBeNull()
+  })
+
+  it('set mit invalider Referenz schreibt nichts', () => {
+    setRunModelOverride({
+      provider_connection_id: '',
+      model_id: 'm-1',
+      source: 'explicit',
+    })
+    expect(sessionStorage.getItem(RUN_MODEL_OVERRIDE_KEY)).toBeNull()
+  })
+})

--- a/frontend/src/store/runModelOverride.ts
+++ b/frontend/src/store/runModelOverride.ts
@@ -12,7 +12,10 @@
  * Bewusst sessionStorage: tab-scoped, überlebt den mehrstufigen Flow
  * (Dashboard → Graph-Build → Env-Setup → Simulation) inklusive Reload und
  * stirbt mit dem Tab. Lebensdauer: bis zum nächsten Dashboard-Start, der die
- * Senke neu schreibt oder cleart (Profile-Start / kein Pick).
+ * Senke neu schreibt oder cleart (Profile-Start / kein expliziter Pick) —
+ * oder bis zum ersten erfolgreichen Sim-Start (consume-on-success in
+ * Step3Simulation), damit kein späterer Start einer anderen Simulation im
+ * selben Tab den alten Override erbt.
  */
 import { AiModelRefSchema, type AiModelRef } from '@/contracts/aiModelRef'
 

--- a/frontend/src/store/runModelOverride.ts
+++ b/frontend/src/store/runModelOverride.ts
@@ -1,0 +1,80 @@
+/**
+ * runModelOverride — transiente Run-Override-Senke für die Dashboard-Modellwahl.
+ *
+ * HeroNewRun schreibt hier beim Start die explizite Picker-Auswahl als vollen
+ * {@link AiModelRef} (inkl. ``provider_connection_id``); Step3Simulation liest
+ * sie beim Sim-Start vorrangig vor dem Kanon (routing/defaults.global_default)
+ * und sendet sie als autoritatives ``ai_model_ref``. Damit behält ein
+ * Dashboard-Pick seine Connection-Bindung (Base-URL + Secret derselben
+ * ProviderConnection), ohne den persistenten Kanon zu berühren — die
+ * Phase-1-Konsolidierung („eine persistente Modell-Senke") bleibt intakt.
+ *
+ * Bewusst sessionStorage: tab-scoped, überlebt den mehrstufigen Flow
+ * (Dashboard → Graph-Build → Env-Setup → Simulation) inklusive Reload und
+ * stirbt mit dem Tab. Lebensdauer: bis zum nächsten Dashboard-Start, der die
+ * Senke neu schreibt oder cleart (Profile-Start / kein Pick).
+ */
+import { AiModelRefSchema, type AiModelRef } from '@/contracts/aiModelRef'
+
+export const RUN_MODEL_OVERRIDE_KEY = 'agora.run.aiModelRefOverride'
+
+function storageOrNull(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const ss = window.sessionStorage
+    if (!ss || typeof ss.getItem !== 'function') return null
+    return ss
+  } catch {
+    return null
+  }
+}
+
+export function setRunModelOverride(ref: AiModelRef): void {
+  const ss = storageOrNull()
+  if (!ss) return
+  // source wird auf 'run-override' normalisiert — die Senke IST die
+  // Run-Override-Ebene der Auswahl-Hierarchie (Master-Prompt §6.3).
+  const candidate: AiModelRef = {
+    provider_connection_id: ref.provider_connection_id,
+    model_id: ref.model_id,
+    source: 'run-override',
+  }
+  if (!AiModelRefSchema.safeParse(candidate).success) return
+  try {
+    ss.setItem(RUN_MODEL_OVERRIDE_KEY, JSON.stringify(candidate))
+  } catch {
+    /* Quota/Private-Mode: Override entfällt, Kanon greift */
+  }
+}
+
+export function clearRunModelOverride(): void {
+  const ss = storageOrNull()
+  if (!ss) return
+  try {
+    ss.removeItem(RUN_MODEL_OVERRIDE_KEY)
+  } catch {
+    /* swallow */
+  }
+}
+
+export function getRunModelOverride(): AiModelRef | null {
+  const ss = storageOrNull()
+  if (!ss) return null
+  try {
+    const raw = ss.getItem(RUN_MODEL_OVERRIDE_KEY)
+    if (!raw) return null
+    const parsed = AiModelRefSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) {
+      ss.removeItem(RUN_MODEL_OVERRIDE_KEY)
+      return null
+    }
+    return parsed.data
+  } catch {
+    try {
+      ss.removeItem(RUN_MODEL_OVERRIDE_KEY)
+    } catch {
+      /* swallow */
+    }
+    return null
+  }
+}


### PR DESCRIPTION
## Problem

Die Modellwahl im v4-Dashboard (`HeroNewRun`, AiModelPicker) war beim Simulationsstart nicht autoritativ: Sie wurde nur als `model_id`-String nach `STORAGE_MODEL` gespiegelt. Beim späteren `POST /api/simulation/start` (einziger Callsite: `Step3Simulation.doStart`, seit #852 `ai_model_ref`-fähig) gewann der Kanon (`routing/defaults.global_default`) — ein abweichender Dashboard-Pick wurde stillschweigend ignoriert bzw. verlor ohne Kanon-Default seine Connection-Bindung (Legacy-`llm_model`-Pfad ohne Base-URL-/Secret-Bindung).

## Lösung

Transiente Run-Override-Senke (Option 1 aus der Analyse):

- **Neu** [`frontend/src/store/runModelOverride.ts`](../blob/fix/hero-run-model-override/frontend/src/store/runModelOverride.ts): Zod-validierte sessionStorage-Senke `agora.run.aiModelRefOverride` (tab-scoped, überlebt den mehrstufigen Flow inkl. Reload; korrupte Einträge werden defensiv entsorgt; `source` wird auf `run-override` normalisiert — Backend-Literal in `AiModelRefSource` vorhanden).
- **`HeroNewRun.vue`**: schreibt beim Start den vollen `AiModelRef` (inkl. `provider_connection_id`) in die Senke; Profile-Start bzw. kein Pick cleart sie.
- **`Step3Simulation.vue` (`doStart`)**: liest die Senke vorrangig vor dem Kanon und sendet sie als autoritatives `ai_model_ref`; Legacy-Felder bleiben ausgeschlossen (Backend: 400 bei Kombination).
- Der persistente Kanon bleibt unberührt — die Phase-1-Konsolidierung („eine persistente Modell-Senke") und der Slice-7.6c-Storage-Cut bleiben intakt.

## Tests

- `store/__tests__/runModelOverride.spec.ts`: Roundtrip, Source-Normalisierung, defensives Entsorgen korrupter/invalider Einträge, No-Op bei invalider Referenz.
- `Step3Simulation.spec.ts`: Override gewinnt vor Kanon; Override greift auch ohne Kanon (kein Legacy-Fallback); bestehende #819-Tests unverändert grün.
- `HeroNewRun.spec.ts`: Set bei Pick, Clear bei aktivem Profile, Clear ohne Pick.

## Verifikation

- `bun run test`: 174 Dateien, 1537 Tests grün
- `bun run check`: grün
- `bash scripts/pre-push-gate.sh frontend`: ALL GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Die im v4-Dashboard gewählte KI-Modellreferenz wird beim Simulationsstart zuverlässig übernommen.
  * Eine explizite Modellauswahl (Direkt-Picker) hat jetzt Vorrang vor anderen Modellquellen.
  * Veraltete, ungültige oder widersprüchliche Auswahlwerte werden automatisch verworfen.
  * Nach erfolgreichem Start wird eine einmal verwendete Direkt-Auswahl entfernt, sodass spätere Starts in derselben Sitzung nicht beeinflusst werden.
  * Beim Start mit aktivem Profil oder ohne ausdrückliche Modellauswahl werden mögliche Restwerte bereinigt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->