### PR TITLE
fix(llm): OASIS-Subprozess erbt Registry-base_url statt stale Backend-Env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ opencode.jsonc
 
 .claude/*.bak
 .claude/*.bak.*
+compose.local.yml

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -23,6 +23,9 @@ from .provider_connections.service import ProviderConnectionService
 from .runtime_run_config import RuntimeRunConfig
 from .secret_resolver import SecretResolver, get_bound_store_api_key
 from .workspace_routing_store import get_workspace_routing_store
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.llm_routing_seed")
 
 _PROVIDER_ID_MAP = {
     "default": None,
@@ -359,13 +362,33 @@ def build_route_subprocess_env(
     env: dict[str, str] = {"LLM_MODEL_NAME": route.model}
     if run_id:
         env["AGORA_RUN_ID"] = run_id
+    provider = next(
+        (p for p in LlmProviderRegistry().get_providers() if p.id == route.provider_id),
+        None,
+    )
+    # Base-URL-Auflösung symmetrisch zur Key-Auflösung in
+    # ``resolve_route_api_key``: trägt die Route keine base_url — der
+    # Legacy-/Workspace-Default-Pfad ohne ``ai_model_ref`` erzeugt Routen mit
+    # nackter Registry-``provider_id`` —, gilt der Registry-Endpoint DERSELBEN
+    # provider_id. Ohne diese Auflösung bleibt ``LLM_BASE_URL`` hier ungesetzt,
+    # der OASIS-Subprozess erbt das stale ``LLM_BASE_URL`` des Backend-Prozesses
+    # (``SAFE_ENV_KEYS``-Whitelist in ``process_manager``) und schickt Modell und
+    # Provider-Key an einen fremden Endpoint — Root Cause des
+    # ``404 model 'MiniMax-M3' not found`` trotz #852. Kein Provider-Fallback:
+    # Key und URL stammen aus derselben provider_id.
+    base_url = route.base_url_sanitized or (provider.base_url if provider else None)
+    if not base_url and route.provider_id:
+        # Weder Route noch Registry kennen einen Endpoint: der Subprozess wird
+        # das Parent-``LLM_BASE_URL`` erben (Alt-Verhalten, Standalone-/
+        # Dev-Pfad). Sichtbar machen statt still driften.
+        logger.warning(
+            "build_route_subprocess_env: keine base_url für provider_id=%s "
+            "auflösbar — Subprozess erbt LLM_BASE_URL aus dem Backend-Env",
+            route.provider_id,
+        )
     if api_key:
         env["LLM_API_KEY"] = api_key
         env["OPENAI_API_KEY"] = api_key
-        provider = next(
-            (p for p in LlmProviderRegistry().get_providers() if p.id == route.provider_id),
-            None,
-        )
         if provider and provider.api_key_ref:
             env[provider.api_key_ref] = api_key
         # CAMELs GeminiModel (OASIS-Subprozess) liest ``GEMINI_API_KEY``; der
@@ -373,11 +396,11 @@ def build_route_subprocess_env(
         # diesen Alias crasht der Subprozess trotz Store-Key mit
         # ``Missing required API keys: GEMINI_API_KEY``. Der Alias haelt den
         # UI-Secrets-Store als Single Source — kein ``.env`` fuer Gemini-Sims.
-        if detect_provider(route.base_url_sanitized, route.model, mode="oasis") == "google":
+        if detect_provider(base_url, route.model, mode="oasis") == "google":
             env["GEMINI_API_KEY"] = api_key
-    if route.base_url_sanitized:
-        env["LLM_BASE_URL"] = route.base_url_sanitized
-        env["OPENAI_BASE_URL"] = route.base_url_sanitized
-        env["OPENAI_API_BASE"] = route.base_url_sanitized
-        env["OPENAI_API_BASE_URL"] = route.base_url_sanitized
+    if base_url:
+        env["LLM_BASE_URL"] = base_url
+        env["OPENAI_BASE_URL"] = base_url
+        env["OPENAI_API_BASE"] = base_url
+        env["OPENAI_API_BASE_URL"] = base_url
     return env

--- a/backend/tests/scripts/test_oasis_route_env_binding.py
+++ b/backend/tests/scripts/test_oasis_route_env_binding.py
@@ -1,0 +1,189 @@
+"""Regressionstest für den OASIS-404 ``model 'MiniMax-M3' not found`` (Folge
+von #852): Eine aufgelöste Route, die nur eine Registry-``provider_id`` trägt
+(Legacy-/Workspace-Default-Pfad ohne ``ai_model_ref``), darf im
+OASIS-Subprozess NICHT auf ein stale ``LLM_BASE_URL`` aus dem Parent-Env
+zurückfallen. ``build_route_subprocess_env`` muss die Base-URL derselben
+``provider_id`` aus der Provider-Registry auflösen — symmetrisch zur
+Key-Auflösung in ``resolve_route_api_key`` und zum HTTP-Pfad
+(``LLMClient.from_route``).
+
+Seam (vorab freigegeben): der reale OASIS/CAMEL-Provider-Completion-Pfad mit
+einer aufgelösten Route — ``build_route_subprocess_env`` → Env-Merge wie in
+``process_manager.start_simulation`` → ``create_model`` →
+``preflight_model_probe``. CAMEL führt einen echten HTTP-Roundtrip gegen
+lokale Stub-Server aus; ``ModelFactory`` wird nicht gemockt.
+
+Die Eingabe-Route entspricht exakt dem gelockten Snapshot des realen
+Fehlerruns (``run_739d2293df07``): ``provider_id`` gesetzt,
+``base_url_sanitized=None``, ``provider_options={}``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _BACKEND_DIR / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from app.contracts.llm_routing_contract import ResolvedRoute  # noqa: E402
+from app.services.llm_routing_seed import build_route_subprocess_env  # noqa: E402
+from app.services.sim.process_manager import SAFE_ENV_KEYS  # noqa: E402
+
+MODEL_ID = "MiniMax-M3"
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """OpenAI-kompatibler Chat-Completions-Stub.
+
+    ``server.mode == "stale"`` antwortet wie der falsche Endpoint des
+    Prod-Fehlers (Ollama-404 ``model not found``), ``"provider"`` wie der
+    korrekte Provider-Endpoint (200 mit gültiger Completion).
+    """
+
+    def do_POST(self) -> None:  # noqa: N802 — http.server-API
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        self.server.hits += 1  # type: ignore[attr-defined]
+        if self.server.mode == "stale":  # type: ignore[attr-defined]
+            body = json.dumps(
+                {
+                    "error": {
+                        "message": f"model '{MODEL_ID}' not found",
+                        "type": "not_found_error",
+                        "param": None,
+                        "code": None,
+                    }
+                }
+            ).encode()
+            self.send_response(404)
+        else:
+            body = json.dumps(
+                {
+                    "id": "chatcmpl-stub-1",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": MODEL_ID,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "OK"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            ).encode()
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:  # noqa: D102 — still
+        pass
+
+
+@pytest.fixture()
+def stub_servers() -> Iterator[tuple[HTTPServer, HTTPServer]]:
+    """Startet die beiden Stub-Server (stale + provider) auf freien Ports."""
+    servers = []
+    for mode in ("stale", "provider"):
+        server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+        server.mode = mode  # type: ignore[attr-defined]
+        server.hits = 0  # type: ignore[attr-defined]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        servers.append(server)
+    yield servers[0], servers[1]
+    for server in servers:
+        server.shutdown()
+        server.server_close()
+
+
+def test_registry_provider_route_reaches_provider_endpoint_not_stale_env(
+    stub_servers: tuple[HTTPServer, HTTPServer],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Route mit Registry-``provider_id`` ohne ``base_url_sanitized`` muss den
+    Registry-Endpoint der Provider-ID treffen — nicht das geerbte
+    ``LLM_BASE_URL`` des Backend-Prozesses (Root Cause des Prod-404)."""
+    stale, provider = stub_servers
+    stale_url = f"http://127.0.0.1:{stale.server_address[1]}/v1"
+    provider_url = f"http://127.0.0.1:{provider.server_address[1]}/v1"
+
+    # Registry-Descriptor der provider_id — Konfigurationsquelle des Tests,
+    # analog zu den Store-Mocks in test_llm_routing_seed.py.
+    class _Descriptor:
+        id = "stub-prov"
+        type = "openai_compatible"
+        base_url = provider_url
+        api_key_ref = None
+
+    class _Registry:
+        def get_providers(self) -> list[_Descriptor]:
+            return [_Descriptor()]
+
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.LlmProviderRegistry", _Registry
+    )
+
+    # Route exakt wie der gelockte Prod-Snapshot: provider_id, kein base_url.
+    route = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="stub-prov",
+        model=MODEL_ID,
+        base_url_sanitized=None,
+        routing_version=1,
+    )
+    runtime_env = build_route_subprocess_env(
+        route, "unit-test-dummy-value", run_id="run_env_binding_test"
+    )
+
+    # Parent-Env des Backend-Containers: stale LLM_BASE_URL aus .env.
+    parent_env = {"LLM_BASE_URL": stale_url, "LLM_MODEL_NAME": "gpt-oss:20b-cloud"}
+    # Merge exakt wie process_manager.start_simulation: Whitelist-Parent-Env,
+    # dann runtime_env (nur nicht-leere Werte) darüber.
+    merged = {k: v for k, v in parent_env.items() if k in SAFE_ENV_KEYS}
+    merged.update({k: v for k, v in runtime_env.items() if v})
+
+    for key in (
+        "LLM_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+        "OPENAI_API_BASE_URL",
+        "LLM_MODEL_NAME",
+        "LLM_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in merged.items():
+        monkeypatch.setenv(key, value)
+
+    from _sim_common import preflight_model_probe
+    from run_parallel_simulation import create_model
+
+    model = create_model({"llm_model": MODEL_ID}, use_boost=False)
+
+    # Realer CAMEL-HTTP-Roundtrip: Vor dem Fix trifft er den stale-Stub und
+    # der Preflight lehnt mit dem Prod-404 ab; nach dem Fix antwortet der
+    # Provider-Stub mit 200.
+    preflight_model_probe(model, max_retries=0)
+
+    assert provider.hits == 1, (  # type: ignore[attr-defined]
+        "Der Completion-Call muss den Endpoint der Registry-provider_id treffen"
+    )
+    assert stale.hits == 0, (  # type: ignore[attr-defined]
+        "Der Completion-Call darf nicht auf das stale Parent-LLM_BASE_URL "
+        "zurückfallen (Root Cause des OASIS-404)"
+    )

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,8 +27,8 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3499 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 3500 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:


### PR DESCRIPTION
## Root Cause

Der produktive Sim-Start (v4-Frontend) sendet kein `ai_model_ref`, nur das Legacy-Feld `llm_model`. Der Legacy-Seed-Pfad erzeugt Stage-Routen mit nackter Registry-`provider_id` ohne `base_url` (belegt durch die gelockten Route-Snapshots des Fehlerruns: `base_url_sanitized: null`). `resolve_route_api_key` löst den Key über die `LlmProviderRegistry` auf, aber `build_route_subprocess_env` hatte keine äquivalente base_url-Auflösung — `LLM_BASE_URL` blieb ungesetzt, der OASIS-Subprozess erbte via `SAFE_ENV_KEYS`-Whitelist das stale `LLM_BASE_URL` des Backend-Containers (Ollama-Endpoint) und schickte MiniMax-M3 samt MiniMax-Key dorthin → `404 model 'MiniMax-M3' not found`.

#852 fixte nur den `ai_model_ref`-Pfad; das ausgelieferte v4-Frontend benutzt ihn nicht.

## Fix

`build_route_subprocess_env` löst fehlende `base_url` aus dem Registry-Descriptor **derselben** `provider_id` auf — symmetrisch zur Key-Auflösung, SSoT `LlmProviderRegistry`, kein Provider-Fallback. Warn-Log, wenn weder Route noch Registry einen Endpoint kennen.

## Verifikation

- Regressionstest `tests/scripts/test_oasis_route_env_binding.py` (RED→GREEN): echter CAMEL-HTTP-Roundtrip gegen zwei lokale Stubs, Route exakt wie der Prod-Snapshot; vor Fix landet der Call auf dem stale Endpoint (Prod-404 byte-identisch), nach Fix auf dem Provider-Endpoint
- Differentialproben: `/models` PASS, OpenAI-SDK direkt PASS, CAMEL mit korrekter Route PASS, echter Legacy-Seed-Pfad FAIL→PASS
- Live-OASIS-Smoke (`run_parallel_simulation.py`, 1 Runde, 4 Agents, absichtlich stale Parent-Env): Preflight PASS, 3× `CREATE_POST` von MiniMax-M3 generiert, Posts persistiert — kein Fallback, keine Stubs
- Gates: contracts 384, 46 Schemas, ruff, mypy, pre-push-gate backend ALL GREEN

## Verbleibende Risiken

- v4-Frontend sollte `ai_model_ref` künftig autoritativ senden (separater Task)
- Keyless Registry-Routen: Registry-URL gewinnt jetzt über geerbtes Backend-Env (konsistente SSoT-Semantik, vorher anders)
- Deployment: Docker-Stack braucht Rebuild, damit der Fix wirkt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Verbesserte Zuordnung von Sprachmodell-Anfragen zur konfigurierten Provider-Adresse.
  * Verhindert, dass veraltete Umgebungsvariablen versehentlich verwendet werden.
  * API-Schlüssel und Basis-URLs werden zuverlässiger erkannt und angewendet.

* **Tests**
  * Neuer Regressionstest stellt sicher, dass Anfragen den vorgesehenen Provider-Endpunkt erreichen.

* **Dokumentation**
  * Automatisch erfasste Backend- und Frontend-Testzahlen wurden aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->