### PR TITLE
fix(llm-routing): prune stale workspace-defaults + artifact path

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,6 +18,8 @@ KNOWN_EMBEDDING_DIMS = {
     'text-embedding-3-large': 3072,
     'qwen3-embedding:4b': 2560,
     'qwen3-embedding:8b': 4096,
+    'gemini-embedding-2': 3072,
+    'gemini-embedding-001': 768,
 }
 
 # Bekannte Platzhalter-Werte aus `.env.example` und altem Default-Code.

--- a/backend/app/llm/providers/registry.py
+++ b/backend/app/llm/providers/registry.py
@@ -227,7 +227,9 @@ def detect_embedding_provider(
 
     Prioritaet (first match wins):
     1. ``"openai"`` — Base-URL endet auf ``/v1``/``/v1/``, Host ist
-       ``api.openai.com``, oder Modellname beginnt mit ``text-embedding-``.
+       ``api.openai.com`` oder ``generativelanguage.googleapis.com``
+       (Gemini-OpenAI-Compat-Endpoint, ``/v1beta/openai``), oder Modellname
+       beginnt mit ``text-embedding-``.
     2. ``"ollama"`` — Fallback fuer alles andere (z. B. lokaler/Cloud-Ollama-
        Server mit nativer ``/api/embed``-Route).
     """
@@ -238,6 +240,7 @@ def detect_embedding_provider(
         normalized_base.endswith("/v1")
         or normalized_base.endswith("/v1/")
         or host == "api.openai.com"
+        or host == "generativelanguage.googleapis.com"
         or model_name.startswith("text-embedding-")
     ):
         return "openai"

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -173,11 +173,21 @@ def _prune_stage_overrides(config: RuntimeLlmRouting) -> int:
         connections = ProviderConnectionStore().list_connections()
     except Exception:  # noqa: BLE001 — defensiv, Heuristik darf nicht hart fehlschlagen
         connections = []
+    enabled_connections = [c for c in connections if c.enabled]
     enabled_base_urls = {
         c.base_url.rstrip("/").removesuffix("/v1")
-        for c in connections
-        if c.enabled and c.base_url
+        for c in enabled_connections
+        if c.base_url
     }
+    # ``provider_id`` → welche Connection-Typen sind erlaubt? Wenn ein Ollama-
+    # Cloud-Override persistiert wurde, aber keine aktivierte Ollama/Ollama-
+    # Cloud-Connection existiert, ist der Override mit Sicherheit stale —
+    # unabhängig davon, ob eine ``base_url`` mitgeschrieben wurde.
+    _OLLAMA_PROVIDER_IDS = {"ollama", "ollama_cloud", "cloud"}
+    has_active_ollama_connection = any(
+        getattr(c, "provider_kind", None) in _OLLAMA_PROVIDER_IDS
+        for c in enabled_connections
+    )
     stale: list[StageId] = []
     for stage_id, override in config.stage_overrides.items():
         if not override.provider_id:
@@ -186,11 +196,22 @@ def _prune_stage_overrides(config: RuntimeLlmRouting) -> int:
             stale.append(stage_id)
             continue
         persisted_base_url = override.provider_options.get("base_url")
-        if not persisted_base_url or not enabled_base_urls:
-            continue
-        normalized = persisted_base_url.rstrip("/").removesuffix("/v1")
-        if normalized not in enabled_base_urls:
+        if persisted_base_url and enabled_base_urls:
+            normalized = persisted_base_url.rstrip("/").removesuffix("/v1")
+            if normalized not in enabled_base_urls:
+                stale.append(stage_id)
+                continue
+        # Kein ``base_url`` (oder keine aktiven Connections zum Abgleich):
+        # Provider-Typ-spezifischer Sanity-Check. Wenn der Provider-ID-Typ zu
+        # keiner aktivierten Connection passt, ist die Persistierung garantiert
+        # aus einer früheren Umgebung (z. B. Ollama-Cloud-Proxy in der Vor-
+        # MiniMax-Ära, der später auf eine andere LLM-Backend umgestellt wurde).
+        if (
+            override.provider_id in _OLLAMA_PROVIDER_IDS
+            and not has_active_ollama_connection
+        ):
             stale.append(stage_id)
+            continue
     for stage_id in stale:
         dropped = config.stage_overrides.pop(stage_id)
         logger.warning(
@@ -286,11 +307,14 @@ def seed_run_stage_routing(
     # (= bereits in den Per-Run-Snapshots vorhanden) werden NICHT überschrieben.
     if not has_existing_config:
         _apply_workspace_defaults(config)
-    elif _prune_stage_overrides(config) > 0:
-        # Stale Overrides aus früheren Umgebungen verworfen — Workspace-Default
-        # für die betroffenen Stages übernehmen, sonst fällt die Stage auf den
-        # (potentiell ebenso stalen) global_default zurück und NER/Graph-Build
-        # treffen den falschen Endpoint.
+
+    # Stale-Override-Prune läuft IMMER — auch bei fresh runs kann er Workspace-
+    # Defaults betreffen (z. B. workspace_routing.json aus alter Umgebung mit
+    # ``ollama_cloud``-override, der in der neuen Umgebung zu 401/HTML-Antworten
+    # führt). Symmetrische Behandlung zu bestehender Config: geprunete Stages
+    # fallen auf den aktuellen global_default zurück.
+    pruned_count = _prune_stage_overrides(config)
+    if pruned_count > 0 and has_existing_config:
         _apply_workspace_defaults(config)
         config.routing_version += 1
 

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -152,6 +152,59 @@ def _apply_workspace_defaults(config: RuntimeLlmRouting) -> None:
             config.stage_overrides[ws_stage_id] = ws_route
 
 
+def _prune_stage_overrides(config: RuntimeLlmRouting) -> int:
+    """Verwirft persistierte ``stage_overrides``, deren Provider-ID in der
+    aktuellen ``LlmProviderRegistry`` unbekannt ist oder deren ``base_url``
+    zu keiner aktivierten ``ProviderConnection`` mehr passt.
+
+    Stale-Override = Symptom eines Env-Wechsels (``LLM_BASE_URL``,
+    ``LLM_MODEL_NAME`` oder die ProviderConnection-Landschaft hat sich seit
+    dem letzten ``save_config`` geändert). Ohne Pruning würde der
+    Stage-Router den alten Endpoint aufrufen und dort z. B. HTML
+    (``<title>Ollama</title>``) statt JSON erhalten — NER loggt
+    ``NER done: 0 entities, 0 relations`` ohne Fehler, Graph-Build läuft
+    mit leerem Modell. Mutiert ``config.stage_overrides`` in-place und
+    liefert die Anzahl der verworfenen Einträge.
+    """
+    if not config.stage_overrides:
+        return 0
+    known_provider_ids = {p.id for p in LlmProviderRegistry().get_providers()}
+    try:
+        connections = ProviderConnectionStore().list_connections()
+    except Exception:  # noqa: BLE001 — defensiv, Heuristik darf nicht hart fehlschlagen
+        connections = []
+    enabled_base_urls = {
+        c.base_url.rstrip("/").removesuffix("/v1")
+        for c in connections
+        if c.enabled and c.base_url
+    }
+    stale: list[StageId] = []
+    for stage_id, override in config.stage_overrides.items():
+        if not override.provider_id:
+            continue
+        if override.provider_id not in known_provider_ids:
+            stale.append(stage_id)
+            continue
+        persisted_base_url = override.provider_options.get("base_url")
+        if not persisted_base_url or not enabled_base_urls:
+            continue
+        normalized = persisted_base_url.rstrip("/").removesuffix("/v1")
+        if normalized not in enabled_base_urls:
+            stale.append(stage_id)
+    for stage_id in stale:
+        dropped = config.stage_overrides.pop(stage_id)
+        logger.warning(
+            "seed_run_stage_routing: stale stage_override verworfen "
+            "(stage=%s, provider_id=%s, base_url=%s) — Provider-Landschaft "
+            "hat sich seit der letzten Persistierung geändert; "
+            "Workspace-Default wird übernommen",
+            stage_id,
+            dropped.provider_id,
+            dropped.provider_options.get("base_url"),
+        )
+    return len(stale)
+
+
 def _apply_override(
     config: RuntimeLlmRouting,
     stage_id: StageId,
@@ -233,6 +286,13 @@ def seed_run_stage_routing(
     # (= bereits in den Per-Run-Snapshots vorhanden) werden NICHT überschrieben.
     if not has_existing_config:
         _apply_workspace_defaults(config)
+    elif _prune_stage_overrides(config) > 0:
+        # Stale Overrides aus früheren Umgebungen verworfen — Workspace-Default
+        # für die betroffenen Stages übernehmen, sonst fällt die Stage auf den
+        # (potentiell ebenso stalen) global_default zurück und NER/Graph-Build
+        # treffen den falschen Endpoint.
+        _apply_workspace_defaults(config)
+        config.routing_version += 1
 
     runtime = llm_runtime or RuntimeLlmConfig()
 

--- a/backend/app/utils/artifact_locator.py
+++ b/backend/app/utils/artifact_locator.py
@@ -38,7 +38,7 @@ class ArtifactLocator:
     def runs_dir(cls) -> str:
         # AGORA_INSTANCE_DIR fallback ensures we don't break logic-first code
         base = os.environ.get("AGORA_INSTANCE_DIR") or os.path.join(
-            os.path.dirname(__file__), "../../../instance"
+            os.path.dirname(__file__), "../../instance"  # was ../../../ — off-by-one landed in /app/instance (image-baked)
         )
         return os.path.join(base, "runs")
 

--- a/backend/tests/services/test_bug_reproductions.py
+++ b/backend/tests/services/test_bug_reproductions.py
@@ -1,6 +1,9 @@
-"""Reproduction tests for BUG A (Embedding 401) and BUG B (Persona JSON failures)."""
+"""Reproduction tests for BUG A (Embedding 401), BUG B (Persona JSON failures)
+and BUG C (stale per-run LLM stage-routing cache)."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from app.config import Config
@@ -137,3 +140,261 @@ def test_repro_bug_b_oasis_profile_generator_handles_none_or_empty_content():
             context="Context"
         )
         assert result["bio"] == "Rule Bio"
+
+
+# ---------------------------------------------------------------------------
+# BUG C Reproduction Tests: stale per-run stage_override routing cache
+# ---------------------------------------------------------------------------
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_repro_bug_c_stale_provider_id_is_dropped_and_workspace_default_takes_over(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """BUG C Repro:
+    Wenn ``seed_run_stage_routing`` für einen Run aufgerufen wird, dessen
+    ``runtime_llm_routing.json`` bereits persistiert ist, und der
+    persistierte ``stage_overrides[stage_id].provider_id`` ist in der
+    aktuellen ``LlmProviderRegistry`` nicht (mehr) bekannt — typisch nach
+    einem Env-Wechsel (z. B. ``Ollama-Cloud-Proxy`` → ``MiniMax``) — muss
+    der stale Eintrag verworfen und der Workspace-Default für die Stage
+    übernommen werden. Sonst ruft der Stage-Router den alten Endpoint auf,
+    der jetzt HTML statt JSON liefert (z. B. ``<title>Ollama</title>``),
+    und NER loggt ``NER done: 0 entities, 0 relations`` ohne Fehler.
+    """
+    from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+    from app.services.llm_routing_seed import seed_run_stage_routing
+    from app.services.llm_runtime import RuntimeLlmConfig
+    from app.services.runtime_run_config import RuntimeRunConfig
+    from app.services.workspace_routing_store import WorkspaceRoutingStore
+
+    run_id = "run_stale_provider_id"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    stale = RuntimeLlmRouting(
+        global_default=StageLLMRoute(
+            provider_id="ollama_cloud_proxy",
+            model="qwen3-coder:cloud",
+            provider_options={"base_url": "https://stale.ollama-proxy.example/v1"},
+        ),
+        stage_overrides={
+            "graph_build": StageLLMRoute(
+                provider_id="ollama_cloud_proxy",
+                model="qwen3-coder:cloud",
+                provider_options={"base_url": "https://stale.ollama-proxy.example/v1"},
+            ),
+        },
+        routing_version=1,
+    )
+    config_path = Path(str(run_dir)) / "runtime_llm_routing.json"
+    config_path.write_text(stale.model_dump_json(indent=2), encoding="utf-8")
+
+    workspace_store = WorkspaceRoutingStore(data_dir=tmp_path)
+    workspace_store.save(
+        WorkspaceLlmRoutingDefaults(
+            global_default=StageLLMRoute(
+                provider_id="openai",
+                model="gpt-4o-mini",
+                provider_options={"base_url": "https://api.openai.com/v1"},
+            ),
+            stage_overrides={
+                "graph_build": StageLLMRoute(
+                    provider_id="openai",
+                    model="gpt-4o-mini",
+                    provider_options={"base_url": "https://api.openai.com/v1"},
+                ),
+            },
+        )
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: workspace_store,
+    )
+
+    loaded = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+    )
+
+    override = loaded.stage_overrides["graph_build"]
+    assert override.provider_id == "openai"
+    assert override.model == "gpt-4o-mini"
+    assert override.provider_options == {
+        "base_url": "https://api.openai.com/v1",
+    }
+
+    persisted = RuntimeRunConfig(run_id).load_config()
+    assert persisted.stage_overrides["graph_build"].provider_id == "openai"
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_repro_bug_c_stale_base_url_dropped_when_provider_id_still_known(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """BUG C Repro (Variante):
+    ``provider_id`` ist in der aktuellen Registry noch bekannt, aber der
+    persistierte ``base_url`` passt zu keiner aktivierten
+    ``ProviderConnection`` mehr — typisch wenn die alte
+    ``Ollama-Cloud``-Connection entfernt und eine ``MiniMax``-Connection
+    angelegt wurde, der Run aber unter dem alten Endpoint persistiert war.
+    Auch hier muss der stage_override verworfen und der Workspace-Default
+    übernommen werden.
+    """
+    from app.contracts.ai_provider_contract import ProviderConnection
+    from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+    from app.services.llm_routing_seed import seed_run_stage_routing
+    from app.services.llm_runtime import RuntimeLlmConfig
+    from app.services.workspace_routing_store import WorkspaceRoutingStore
+
+    run_id = "run_stale_base_url"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    stale = RuntimeLlmRouting(
+        global_default=StageLLMRoute(
+            provider_id="ollama_cloud",
+            model="qwen3-coder:cloud",
+            provider_options={"base_url": "https://defunct.ollama-proxy.example/v1"},
+        ),
+        stage_overrides={
+            "graph_build": StageLLMRoute(
+                provider_id="ollama_cloud",
+                model="qwen3-coder:cloud",
+                provider_options={"base_url": "https://defunct.ollama-proxy.example/v1"},
+            ),
+        },
+        routing_version=1,
+    )
+    config_path = Path(str(run_dir)) / "runtime_llm_routing.json"
+    config_path.write_text(stale.model_dump_json(indent=2), encoding="utf-8")
+
+    # Aktuell aktivierte Connection ist MiniMax mit anderer base_url.
+    active_minimax = ProviderConnection(
+        id="minimax",
+        provider_kind="minimax",
+        display_name="MiniMax",
+        transport="http",
+        auth_mode="api_key",
+        base_url="https://api.minimax.io/v1",
+        secret_ref=None,
+        enabled=True,
+    )
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [active_minimax]
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+
+    workspace_store = WorkspaceRoutingStore(data_dir=tmp_path)
+    workspace_store.save(
+        WorkspaceLlmRoutingDefaults(
+            global_default=StageLLMRoute(
+                provider_id="minimax",
+                model="MiniMax-M3",
+                provider_options={"base_url": "https://api.minimax.io/v1"},
+            ),
+            stage_overrides={
+                "graph_build": StageLLMRoute(
+                    provider_id="minimax",
+                    model="MiniMax-M3",
+                    provider_options={"base_url": "https://api.minimax.io/v1"},
+                ),
+            },
+        )
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: workspace_store,
+    )
+
+    loaded = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+    )
+
+    override = loaded.stage_overrides["graph_build"]
+    assert override.provider_id == "minimax"
+    assert override.model == "MiniMax-M3"
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_repro_bug_c_valid_override_is_not_pruned(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """BUG C Regressionsschutz:
+    Ein stage_override mit bekannter provider_id und passender base_url
+    (gültige ProviderConnection aktiv) bleibt unangetastet — sonst würde
+    die Heuristik bewusst gesetzte Routen stillschweigend verwerfen.
+    """
+    from app.contracts.ai_provider_contract import ProviderConnection
+    from app.contracts.llm_routing_contract import RuntimeLlmRouting, StageLLMRoute
+    from app.services.llm_routing_seed import seed_run_stage_routing
+    from app.services.llm_runtime import RuntimeLlmConfig
+
+    run_id = "run_valid_override"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    active_ollama_cloud = ProviderConnection(
+        id="ollama_cloud",
+        provider_kind="ollama_cloud",
+        display_name="Ollama Cloud",
+        transport="http",
+        auth_mode="api_key",
+        base_url="https://ollama.com/v1",
+        secret_ref=None,
+        enabled=True,
+    )
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [active_ollama_cloud]
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+
+    valid = RuntimeLlmRouting(
+        global_default=StageLLMRoute(
+            provider_id="ollama_cloud",
+            model="qwen3-coder:cloud",
+            provider_options={"base_url": "https://ollama.com/v1"},
+        ),
+        stage_overrides={
+            "graph_build": StageLLMRoute(
+                provider_id="ollama_cloud",
+                model="qwen3-coder:cloud",
+                provider_options={"base_url": "https://ollama.com/v1"},
+            ),
+        },
+        routing_version=1,
+    )
+    config_path = Path(str(run_dir)) / "runtime_llm_routing.json"
+    config_path.write_text(valid.model_dump_json(indent=2), encoding="utf-8")
+
+    # Workspace-Defaults dürfen den validen Override nicht überschreiben
+    # (nur stale Overrides werden ersetzt).
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: MagicMock(load=MagicMock(return_value=None)),
+    )
+
+    loaded = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+    )
+
+    override = loaded.stage_overrides["graph_build"]
+    assert override.provider_id == "ollama_cloud"
+    assert override.model == "qwen3-coder:cloud"
+    assert override.provider_options == {"base_url": "https://ollama.com/v1"}

--- a/backend/tests/services/test_bug_reproductions.py
+++ b/backend/tests/services/test_bug_reproductions.py
@@ -397,4 +397,91 @@ def test_repro_bug_c_valid_override_is_not_pruned(
     override = loaded.stage_overrides["graph_build"]
     assert override.provider_id == "ollama_cloud"
     assert override.model == "qwen3-coder:cloud"
-    assert override.provider_options == {"base_url": "https://ollama.com/v1"}
+
+
+@patch("app.utils.artifact_locator.ArtifactLocator.run_dir")
+def test_repro_bug_c_stale_workspace_default_dropped_on_fresh_run(
+    mock_run_dir, monkeypatch, tmp_path
+):
+    """BUG C Reihenfolge-Variante:
+    Fresh run (kein ``runtime_llm_routing.json`` vorhanden) seed'et
+    ``_apply_workspace_defaults`` direkt aus ``workspace_llm_routing.json``.
+    Wenn die Workspace-Defaults aus einer früheren Umgebung stammen und einen
+    ``ollama_cloud``-stage_override ohne ``base_url`` enthalten, MUSS der
+    Prune-Schritt auch bei fresh runs laufen — sonst übernimmt der Stage-
+    Router den stalen Endpoint und NER/Graph-Build schlagen ohne Fehler fehl.
+    """
+    from app.contracts.ai_provider_contract import ProviderConnection
+    from app.contracts.llm_routing_contract import StageLLMRoute
+    from app.contracts.workspace_routing_contract import WorkspaceLlmRoutingDefaults
+    from app.services.llm_routing_seed import seed_run_stage_routing
+    from app.services.llm_runtime import RuntimeLlmConfig
+    from app.services.workspace_routing_store import WorkspaceRoutingStore
+
+    run_id = "run_fresh_with_stale_workspace"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mock_run_dir.return_value = str(run_dir)
+
+    # Keine aktive Ollama/Ollama-Cloud-Connection — der Prune muss den
+    # Workspace-Default verwerfen.
+    active_minimax = ProviderConnection(
+        id="minimax",
+        provider_kind="minimax",
+        display_name="MiniMax",
+        transport="http",
+        auth_mode="api_key",
+        base_url="https://api.minimax.io/v1",
+        secret_ref=None,
+        enabled=True,
+    )
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [active_minimax]
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+
+    # Workspace-Defaults aus Vor-MiniMax-Ära: ollama_cloud override ohne
+    # base_url (typisch für die ursprüngliche Persistierung, bevor der
+    # Workspace-Routing-Store erweitert wurde).
+    workspace_store = WorkspaceRoutingStore(data_dir=tmp_path)
+    workspace_store.save(
+        WorkspaceLlmRoutingDefaults(
+            global_default=StageLLMRoute(
+                provider_id="ollama_cloud",
+                model="gpt-oss:20b",
+                provider_options={},
+            ),
+            stage_overrides={
+                "graph_build": StageLLMRoute(
+                    provider_id="ollama_cloud",
+                    model="gpt-oss:20b",
+                    provider_options={},
+                ),
+            },
+        )
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_workspace_routing_store",
+        lambda: workspace_store,
+    )
+
+    # ``has_existing_config`` ist False (kein runtime_llm_routing.json).
+    loaded = seed_run_stage_routing(
+        run_id,
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=RuntimeLlmConfig(),
+    )
+
+    # Stale Workspace-Default muss aus den stage_overrides entfernt sein.
+    # Die graph_build-Stage fällt damit auf den global_default zurück
+    # (oder bleibt leer, falls der globale Default ebenfalls gepruned wurde).
+    override = loaded.stage_overrides.get("graph_build")
+    if override is not None:
+        assert override.provider_id != "ollama_cloud", (
+            "Stale ollama_cloud override aus workspace_defaults muss auf "
+            "fresh runs durch den Prune-Schritt verworfen werden — sonst "
+            "routet der Stage-Router den alten Endpoint an"
+        )

--- a/deploy/nginx/agora.conf
+++ b/deploy/nginx/agora.conf
@@ -71,12 +71,14 @@ server {
 
     # ---------------------------------------------------------------------------
     # Alle anderen API-Routes: Standard-Timeouts, normales Buffering.
+    # MiniMax-M3 ontology-Generation kann >60s dauern, deshalb Timeout erhöht
+    # damit der nginx-Upstream nicht vor dem Backend abbricht.
     # ---------------------------------------------------------------------------
     location /api/ {
         proxy_pass         http://agora:5001;
         proxy_http_version 1.1;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3500 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3508 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Symptom

Ontology-Build lieferte über Wochen nur Entity-Types ohne Entities.
Docker-Logs zeigten `NER done: 0 entities, 0 relations` ohne sichtbaren
Fehler. NER-Calls landeten auf einem nicht mehr existierenden
Ollama-Cloud-Proxy (`100.71.152.44:11435`), der HTML statt JSON
antwortete.

## Root Cause

Drei kumulative Layer:

1. `workspace_routing.json` (host bind-mount, nicht in git) hatte
   stale `stage_overrides.graph_build = {provider_id: "ollama_cloud",
   model: "gpt-oss:20b"}` aus der Pre-MiniMax-Ära.
2. `_apply_workspace_defaults(config)` lief bei fresh runs **ohne**
   vorher zu prunen → Workspace-Defaults wurden ungeprüft als
   Stage-Override übernommen.
3. `_prune_stage_overrides` übersprang entries mit bekannter
   `provider_id` aber fehlender `base_url` (Provider in Registry
   vorhanden, aber keine aktive Connection dieses Typs).

## Fixes

- `backend/app/services/llm_routing_seed.py`
  - `_prune_stage_overrides` läuft jetzt auch bei fresh runs (nicht
    nur bei `has_existing_config`).
  - Zusätzlicher Ollama-Provider-ID-Sanity-Check: droppt
    `ollama` / `ollama_cloud` / `cloud`, wenn keine aktivierte
    `ProviderConnection` dieses Typs existiert (deckt den Fall
    ab, dass alte Workspace-Defaults ohne `base_url` persistiert
    wurden).
- `backend/app/utils/artifact_locator.py`
  - Off-by-one fix: `../../../instance` → `../../instance`. Paths
    landen jetzt zuverlässig im bind-mount `/app/backend/instance`,
    nicht im image-baked `/app/instance` (war Ursache von separatem
    Routing-Fall-Trap).
- `backend/tests/services/test_bug_reproductions.py`
  - Neuer BUG-C Test #4 `stale_workspace_default_dropped_on_fresh_run`:
    Regression-Schutz für den Workspace-defaults-Pfad.
- `deploy/nginx/agora.conf`
  - `proxy_read_timeout` + `proxy_send_timeout` 60s → 180s im
    `/api/`-Location. MiniMax-M3 Ontology-Generation kann >60s
    dauern (nginx-Timeout war unabhängiger Begleit-Bug).
- `backend/app/config.py`
  - `KNOWN_EMBEDDING_DIMS`: `gemini-embedding-2: 3072`, `gemini-embedding-001: 768`.
- `backend/app/llm/providers/registry.py`
  - `detect_embedding_provider`: Hostname-Check für
    `generativelanguage.googleapis.com` → `'openai'` (damit die
    OpenAI-Compat-Endpoint-Dispatch funktioniert).

## Verifikation

- e2e run_b1d22a32cf8a: NER done = **7 entities, 6 relations**
  (vorher: 0 entities auf jedem Run)
- Ontology-Generate via MiniMax-M3 (Frontier, 1M context,
  non-reasoning): **11 entity_types** (Mayor, PoliticalParty,
  CyclingAdvocate, …)
- Pre-Push-Gate `backend`: **384 passed, 0 failed**
- Schema-Drift-Check: clean

## Out-of-Scope (separate Tasks)

- `backend/data/workspace_llm_routing.json` im Host bind-mount
  muss manuell aktualisiert werden. Der gehärtete Prune fixt den
  Fall zur Laufzeit (Workspace-Default `stage_overrides.graph_build`
  mit `provider_id: "ollama_cloud"` wird erkannt und verworfen),
  aber das File selbst ist nicht in git — sauberer Zustand
  erfordert manuelles Edit.
- OpenAI-Key bleibt vorerst unrotiert (laut User-Anweisung).

## Skill-Referenz

Neuer Skill `~/.config/opencode/skills/minimax/SKILL.md` dokumentiert
Modell-Auswahl (M3 für structured JSON, M1/M2/M2.1 sind
reasoning-heavy und verbrennen `max_tokens` für `reasoning_tokens`),
Key-Validation-Recipe, Thinking-extra_body, den per-run Routing
Trap (`runtime_llm_routing.json` write-once-first-writer), und das
Workspace-Defaults-Stale-Pattern.