### PR TITLE
fix(scripts): monkey-patch twhin-bert load in fp16 + add RSS sampler

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -448,24 +448,22 @@ def preflight_model_probe(
     max_retries: int = 3,
     backoff_base: float = 0.2,
 ) -> None:
-    """Einmaliger kleiner Chat-Completion-Probe vor dem Agenten-Fan-out.
-
-    Sendet einen winzigen ``"ping"``-User-Call an das aufgebaute Modell und
-    fängt permanente Auth-/Routing-Fehler (401/403/404) früh mit einer klaren
-    ``ValueError``-Root-Cause ab — ein einzelner Fehler statt N identischer
-    während der Simulation (Root Cause des ``404 model MiniMax-M3 not found``).
-    Transiente Fehler (429/500/502/503) werden mit exponentiellem Backoff
-    retried; erst nach Erschöpfung der Retries schlägt der Probe fehl.
-
-    Der Probe läuft genau einmal pro Aufruf (bzw. einmal pro Retry-Versuch) —
-    er führt keine eigene Fan-out-Logik. Aufrufer (``run_*_simulation``) rufen
-    ihn direkt nach ``create_model`` auf, bevor Agenten erzeugt werden.
-
-    Nur der OpenAI-kompatible Pfad (MiniMax, OpenAI, Qwen Cloud, …) wirft
-    ``openai.APIStatusError`` mit brauchbarem ``status_code``; andere
-    Plattformen (Gemini/Ollama) lassen ihre nativen Exceptions ungefiltert
-    durch — die noch vor dem Fan-out auftreten und damit denselben
-    Ein-Fehler-vor-Fan-out-Effekt erfüllen.
+    """
+    Führt vor der Simulation eine kleine Chat-Completion-Probe für das Modell aus.
+    
+    Sendet eine einzelne „ping“-Nachricht und wiederholt bestimmte vorübergehende
+    Provider-Fehler mit exponentiellem Backoff. Authentifizierungs- und Routingfehler
+    sowie nicht behebbare oder nach den Wiederholungen weiterhin bestehende Fehler
+    werden als `ValueError` gemeldet. Ausnahmen anderer Plattformen werden unverändert
+    weitergegeben.
+    
+    Parameters:
+    	model (Any): Das zu prüfende Modell.
+    	max_retries (int): Maximale Anzahl zusätzlicher Versuche bei vorübergehenden Fehlern.
+    	backoff_base (float): Anfangsverzögerung in Sekunden für den exponentiellen Backoff.
+    
+    Raises:
+    	ValueError: Wenn ein permanenter oder nicht behebbarer Provider-Fehler auftritt.
     """
     import openai
 
@@ -523,22 +521,20 @@ _BERT_PROFILE_DEFAULT = "low"
 
 
 def install_bert_memory_profile(profile: str | None = None) -> str:
-    """Patches ``transformers.AutoModel.from_pretrained`` für TWHIN-BERT-Lazy-Loads.
-
-    ENV-getrieben: ``AGORA_BERT_MEMORY_PROFILE=off|low|lowest``.
-
-    - ``off`` (Default wenn Variable fehlt) — No-Op.
-    - ``low`` (Default) — injiziert ``low_cpu_mem_usage=True`` und
-      ``torch_dtype=torch.float16`` für ``Twitter/twhin-bert-base``. Laedt
-      das Modell in fp16 statt fp32 und vermeidet den transienten
-      Materialisierungs-Peak.
-    - Andere Modellnamen bleiben unveraendert.
-
-    Idempotent: ein zweiter Aufruf ersetzt fruehere Patches ohne Doppel-
-    Wrapping (Detection via ``_agora_bert_memory_profile_applied``).
-
+    """
+    Aktiviert ein speicherschonendes Ladeprofil für TWHIN-BERT.
+    
+    Das Profil wird über den Parameter oder `AGORA_BERT_MEMORY_PROFILE` bestimmt
+    und standardmäßig auf `"low"` gesetzt. Für TWHIN-BERT werden geeignete
+    Speicheroptionen gesetzt; andere Modelle bleiben unverändert. Bei deaktiviertem
+    Profil oder fehlender Transformers-Bibliothek erfolgt keine Anpassung.
+    
+    Args:
+        profile: Zu verwendendes Speicherprofil, beispielsweise `"off"` oder
+            `"low"`.
+    
     Returns:
-        Der effektive Profilname (für Diagnose-Logs).
+        Der effektive Profilname.
     """
     effective = (profile or os.environ.get("AGORA_BERT_MEMORY_PROFILE") or _BERT_PROFILE_DEFAULT).lower()
     if effective == "off":
@@ -571,6 +567,12 @@ def install_bert_memory_profile(profile: str | None = None) -> str:
     def _patched_from_pretrained(*args: Any, **kwargs: Any):
         # Modellname ist typischerweise das erste positional arg oder
         # ``pretrained_model_name_or_path`` als kwarg.
+        """
+        Lädt TWHIN-BERT-Modelle mit speichersparenden Standardeinstellungen.
+        
+        Returns:
+        	Das von der ursprünglichen Ladefunktion erzeugte Modell.
+        """
         model_name = args[0] if args else kwargs.get("pretrained_model_name_or_path")
         if isinstance(model_name, str) and model_name in _TWHIN_BERT_MODEL_NAMES:
             # User-Override hat Vorrang.
@@ -607,26 +609,20 @@ def install_memory_sampler(
     interval_s: float = 0.5,
     rss_reader: Callable[[], float | None] | None = None,
 ) -> Callable[[], None]:
-    """Startet einen RSS-Sampler-Thread, schreibt NDJSON-Snapshots nach ``sink``.
-
-    ENV-getrieben: ``AGORA_DEBUG_MEMORY=1`` (oder ``true``) — alle anderen
-    Werte oder fehlende Variable deaktivieren den Sampler (No-Op).
-
-    Jeder Snapshot ist eine Zeile JSON mit ``label``, ``rss_mb`` und
-    ``time_s`` (Sekunden seit Thread-Start). Hauptzweck: beim naechsten
-    OOM-Run eine echte Boot-Kurve zu sehen, statt auf Vermutungen
-    angewiesen zu sein.
-
+    """
+    Startet bei aktivierter Debug-Konfiguration einen Hintergrund-Thread zur RSS-Speicherüberwachung.
+    
+    Der Sampler schreibt regelmäßig NDJSON-Snapshots mit den Feldern `label`, `rss_mb` und
+    `time_s` in die Zieldatei. Bei deaktivierter Überwachung wird eine No-op-Funktion
+    zurückgegeben.
+    
     Args:
-        sink: NDJSON-Zieldatei (typischerweise ``sim_dir/mem_profile.ndjson``).
-        interval_s: Polling-Intervall in Sekunden (Default 0.5 s).
-        rss_reader: Optionale Override für den RSS-Reader. Default laedt
-            ``_read_rss_mb_linux`` beim Sample (late binding via Modul-
-            Lookup); ein test-spezifischer Callable erlaubt deterministische
-            Werte unabhängig von der echten /proc-Implementierung.
-
+        sink: Zieldatei für die NDJSON-Snapshots.
+        interval_s: Zeitabstand zwischen den Messungen in Sekunden.
+        rss_reader: Optionaler RSS-Reader für die Messwerte.
+    
     Returns:
-        ``stop()``-Callable zum sauberen Beenden; idempotent.
+        Eine idempotente Funktion zum Beenden des Samplers.
     """
     enabled = os.environ.get("AGORA_DEBUG_MEMORY", "").lower() in {"1", "true", "yes"}
     if not enabled:
@@ -640,6 +636,12 @@ def install_memory_sampler(
         default_reader = module.__dict__.get("_read_rss_mb_linux")
 
         def rss_reader() -> float | None:  # type: ignore[no-redef]
+            """
+            Liest den aktuellen Speicherverbrauch über den zur Laufzeit aufgelösten RSS-Reader.
+            
+            Returns:
+                float | None: RSS-Speicherverbrauch in MB oder `None`, wenn kein Messwert verfügbar ist.
+            """
             reader = module.__dict__.get("_read_rss_mb_linux", default_reader)
             if reader is None:
                 return None
@@ -649,6 +651,12 @@ def install_memory_sampler(
         # macOS / kein /proc → Sampler einschalten, aber jede Samplezeile
         # bekommt ``rss_mb=None`` und einen WARNING-Hinweis.
         def rss_reader() -> float | None:  # type: ignore[no-redef]
+            """
+            Liefert keinen RSS-Messwert.
+            
+            Returns:
+            	float | None: Immer `None`.
+            """
             return None
 
     stop_event = threading.Event()
@@ -657,6 +665,12 @@ def install_memory_sampler(
     sink_handle = sink.open("a", encoding="utf-8")
 
     def _sampler_loop() -> None:
+        """
+        Schreibt während der Laufzeit regelmäßig RSS-Speicherschnappschüsse als NDJSON.
+        
+        Schreibfehler auf dem Zieldatenträger werden ignoriert, damit der Sampler den
+        ausführenden Prozess nicht beendet.
+        """
         while not stop_event.is_set():
             snap = {
                 "label": "tick",
@@ -680,6 +694,10 @@ def install_memory_sampler(
     thread.start()
 
     def _stop() -> None:
+        """Beendet die laufende Speicheraufzeichnung und schließt die Zieldatei.
+        
+        Die Funktion kann wiederholt aufgerufen werden.
+        """
         stop_event.set()
         thread.join(timeout=interval_s * 2)
         try:
@@ -691,5 +709,5 @@ def install_memory_sampler(
 
 
 def _noop_stop() -> None:
-    """No-Op-Stop fuer den inaktiven Pfad — immer idempotent."""
+    """Führt beim Beenden des Speichersamplers keine Aktion aus."""
     return None

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import re
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 if TYPE_CHECKING:
     from camel.types import ModelPlatformType  # type: ignore[import]
@@ -492,3 +494,202 @@ def preflight_model_probe(
         # Nicht-openai-Plattformen (Gemini/Ollama) werfen ihre nativen
         # Exceptions — ungefiltert weiterreichen, damit der Run sauber
         # scheitert, statt hier eine lückenhafte Heuristik zu pflegen.
+
+
+# ---------------------------------------------------------------------------
+# Slice fix/oom-bert-lowmem-fp16: BERT-Memory-Profile + RSS-Sampler
+# ---------------------------------------------------------------------------
+# Hintergrund: Auf 2.8-GiB-Container-Hosts kippt der OASIS-Subprozess mit
+# ``Process exit code: -9`` (Linux-OOM-Killer, ``cgroup memory.events: oom_kill=1``),
+# sobald ``Twitter/twhin-bert-base`` (1.06 GB safetensors, fp32) im ersten
+# ``update_rec_table()``-Tick lazy geladen wird — plus den 250-350 MB
+# ``torch``/``transformers``/``sentence_transformers``-Import-Overhead aus
+# ``oasis.social_platform.recsys`` und ``process_recsys_posts``.
+#
+# Diese Helper werden in ``run_parallel_simulation.py`` UND
+# ``run_reddit_simulation.py`` VOR dem ersten ``oasis``-Import aufgerufen.
+# Da Python Modul-Level-Caching nutzt, sieht der spaetere
+# ``from transformers import AutoModel``-Aufruf in
+# ``oasis.social_platform.process_recsys_posts`` die gepatchte Methode
+# auf demselben Klassen-Objekt.
+
+_TWHIN_BERT_MODEL_NAMES: frozenset[str] = frozenset(
+    {
+        "Twitter/twhin-bert-base",
+    }
+)
+
+_BERT_PROFILE_DEFAULT = "low"
+
+
+def install_bert_memory_profile(profile: str | None = None) -> str:
+    """Patches ``transformers.AutoModel.from_pretrained`` für TWHIN-BERT-Lazy-Loads.
+
+    ENV-getrieben: ``AGORA_BERT_MEMORY_PROFILE=off|low|lowest``.
+
+    - ``off`` (Default wenn Variable fehlt) — No-Op.
+    - ``low`` (Default) — injiziert ``low_cpu_mem_usage=True`` und
+      ``torch_dtype=torch.float16`` für ``Twitter/twhin-bert-base``. Laedt
+      das Modell in fp16 statt fp32 und vermeidet den transienten
+      Materialisierungs-Peak.
+    - Andere Modellnamen bleiben unveraendert.
+
+    Idempotent: ein zweiter Aufruf ersetzt fruehere Patches ohne Doppel-
+    Wrapping (Detection via ``_agora_bert_memory_profile_applied``).
+
+    Returns:
+        Der effektive Profilname (für Diagnose-Logs).
+    """
+    effective = (profile or os.environ.get("AGORA_BERT_MEMORY_PROFILE") or _BERT_PROFILE_DEFAULT).lower()
+    if effective == "off":
+        return "off"
+
+    try:
+        import transformers  # type: ignore[import-not-found]
+    except ImportError:
+        # Wenn transformers gar nicht da ist, ist der Patch sinnlos — kein
+        # BERT wird geladen. Kein Hard-Fail, der Subprozess kann ohne
+        # Recsys trotzdem weiterlaufen.
+        return effective
+
+    auto_model = getattr(transformers, "AutoModel", None)
+    if auto_model is None:
+        return effective
+
+    original = auto_model.from_pretrained
+    if getattr(original, "_agora_bert_memory_profile_applied", False):
+        return effective
+
+    # Lazy-Resolve torch dtype; fallback wenn torch fehlt.
+    torch_float16: Any = None
+    try:
+        import torch  # type: ignore[import-not-found]
+        torch_float16 = torch.float16
+    except ImportError:
+        pass
+
+    def _patched_from_pretrained(*args: Any, **kwargs: Any):
+        # Modellname ist typischerweise das erste positional arg oder
+        # ``pretrained_model_name_or_path`` als kwarg.
+        model_name = args[0] if args else kwargs.get("pretrained_model_name_or_path")
+        if isinstance(model_name, str) and model_name in _TWHIN_BERT_MODEL_NAMES:
+            # User-Override hat Vorrang.
+            if "low_cpu_mem_usage" not in kwargs:
+                kwargs["low_cpu_mem_usage"] = True
+            if torch_float16 is not None and "torch_dtype" not in kwargs:
+                kwargs["torch_dtype"] = torch_float16
+        return original(*args, **kwargs)
+
+    _patched_from_pretrained._agora_bert_memory_profile_applied = True  # type: ignore[attr-defined]
+    auto_model.from_pretrained = _patched_from_pretrained
+    return effective
+
+
+def _read_rss_mb_linux() -> float | None:
+    """Liest ``VmRSS`` aus ``/proc/self/status`` (Linux-Container).
+
+    Liefert ``None``, wenn die Datei nicht vorhanden ist (z.B. macOS-Dev).
+    """
+    status_path = Path(f"/proc/{os.getpid()}/status")
+    try:
+        with status_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) / 1024.0
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def install_memory_sampler(
+    sink: Path,
+    *,
+    interval_s: float = 0.5,
+    rss_reader: Callable[[], float | None] | None = None,
+) -> Callable[[], None]:
+    """Startet einen RSS-Sampler-Thread, schreibt NDJSON-Snapshots nach ``sink``.
+
+    ENV-getrieben: ``AGORA_DEBUG_MEMORY=1`` (oder ``true``) — alle anderen
+    Werte oder fehlende Variable deaktivieren den Sampler (No-Op).
+
+    Jeder Snapshot ist eine Zeile JSON mit ``label``, ``rss_mb`` und
+    ``time_s`` (Sekunden seit Thread-Start). Hauptzweck: beim naechsten
+    OOM-Run eine echte Boot-Kurve zu sehen, statt auf Vermutungen
+    angewiesen zu sein.
+
+    Args:
+        sink: NDJSON-Zieldatei (typischerweise ``sim_dir/mem_profile.ndjson``).
+        interval_s: Polling-Intervall in Sekunden (Default 0.5 s).
+        rss_reader: Optionale Override für den RSS-Reader. Default laedt
+            ``_read_rss_mb_linux`` beim Sample (late binding via Modul-
+            Lookup); ein test-spezifischer Callable erlaubt deterministische
+            Werte unabhängig von der echten /proc-Implementierung.
+
+    Returns:
+        ``stop()``-Callable zum sauberen Beenden; idempotent.
+    """
+    enabled = os.environ.get("AGORA_DEBUG_MEMORY", "").lower() in {"1", "true", "yes"}
+    if not enabled:
+        return _noop_stop
+
+    if rss_reader is None:
+        # Late-binding Lookup: ``_read_rss_mb_linux`` muss zur *Laufzeit* im
+        # Modul-Namespace nachgeschlagen werden, sonst greifen Monkey-Patches
+        # im Test (oder alternative Reader-Funktionen) nicht.
+        module = sys.modules[__name__]
+        default_reader = module.__dict__.get("_read_rss_mb_linux")
+
+        def rss_reader() -> float | None:  # type: ignore[no-redef]
+            reader = module.__dict__.get("_read_rss_mb_linux", default_reader)
+            if reader is None:
+                return None
+            return reader()
+
+    if rss_reader() is None and not Path(f"/proc/{os.getpid()}/status").exists():
+        # macOS / kein /proc → Sampler einschalten, aber jede Samplezeile
+        # bekommt ``rss_mb=None`` und einen WARNING-Hinweis.
+        def rss_reader() -> float | None:  # type: ignore[no-redef]
+            return None
+
+    stop_event = threading.Event()
+    start = time.monotonic()
+    sink.parent.mkdir(parents=True, exist_ok=True)
+    sink_handle = sink.open("a", encoding="utf-8")
+
+    def _sampler_loop() -> None:
+        while not stop_event.is_set():
+            snap = {
+                "label": "tick",
+                "rss_mb": rss_reader(),
+                "time_s": time.monotonic() - start,
+            }
+            try:
+                sink_handle.write(json.dumps(snap) + "\n")
+                sink_handle.flush()
+            except OSError:
+                # Disk voll, etc. — silently drop, Sampler darf den
+                # Subprozess nicht zum Absturz bringen.
+                pass
+            stop_event.wait(interval_s)
+
+    thread = threading.Thread(
+        target=_sampler_loop,
+        name="agora-memory-sampler",
+        daemon=True,
+    )
+    thread.start()
+
+    def _stop() -> None:
+        stop_event.set()
+        thread.join(timeout=interval_s * 2)
+        try:
+            sink_handle.close()
+        except OSError:
+            pass
+
+    return _stop
+
+
+def _noop_stop() -> None:
+    """No-Op-Stop fuer den inaktiven Pfad — immer idempotent."""
+    return None

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -711,9 +711,15 @@ def install_memory_sampler(
             try:
                 sink_handle.write(json.dumps(snap) + "\n")
                 sink_handle.flush()
-            except OSError:
+            except (OSError, ValueError):
                 # Disk voll, etc. — silently drop, Sampler darf den
-                # Subprozess nicht zum Absturz bringen.
+                # Subprozess nicht zum Absturz bringen. ``ValueError``
+                # faengt ``"I/O operation on closed file"`` ab, falls
+                # ``_stop()`` das Handle schliesst, waehrend der Thread
+                # noch mitten in einer Write-Call-Sequenz haengt
+                # (Race-Window zwischen ``thread.join(timeout=...)``
+                # und close()). Defensive Härtung fuer
+                # CodeRabbit-Finding #859.
                 pass
             stop_event.wait(interval_s)
 

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -603,6 +603,25 @@ def _read_rss_mb_linux() -> float | None:
     return None
 
 
+def make_default_memory_sink(project_root: Path) -> Path:
+    """Baut den Default-NDJSON-Sink-Pfad fuer den Memory-Sampler.
+
+    Die PID wird in den Dateinamen eingebettet, damit parallele Sim-Runs
+    (z.B. ``run_parallel_simulation.py`` startet Twitter+Reddit in einem
+    Prozess, mehrere ``run_reddit_simulation.py``-Prozesse koennen
+    gleichzeitig auf demselben Host laufen) sich nicht gegenseitig die
+    NDJSON-Datei zerschreiben.
+
+    Vor dem Fix fuehrten alle 3 Run-Scripts auf
+    ``<project_root>/.runtime/mem_profile.ndjson`` ohne PID — POSIX
+    "append"-Mode ist zwischen Prozessen NICHT byteweise atomar
+    (Schreibbuffer > ``PIPE_BUF`` wird verschachtelt), was bei
+    parallelen Runs zerhacktes NDJSON erzeugte (CodeRabbit-Finding
+    #859, 3x).
+    """
+    return project_root / ".runtime" / f"mem_profile.{os.getpid()}.ndjson"
+
+
 def install_memory_sampler(
     sink: Path,
     *,
@@ -647,9 +666,21 @@ def install_memory_sampler(
                 return None
             return reader()
 
-    if rss_reader() is None and not Path(f"/proc/{os.getpid()}/status").exists():
+        user_supplied_reader = False
+    else:
+        user_supplied_reader = True
+
+    if (
+        not user_supplied_reader
+        and rss_reader() is None
+        and not Path(f"/proc/{os.getpid()}/status").exists()
+    ):
         # macOS / kein /proc → Sampler einschalten, aber jede Samplezeile
-        # bekommt ``rss_mb=None`` und einen WARNING-Hinweis.
+        # bekommt ``rss_mb=None`` und einen WARNING-Hinweis. Wird NUR
+        # aktiv, wenn der Caller keinen eigenen Reader geliefert hat —
+        # sonst wuerde der macOS-Fallback den expliziten Reader (z.B.
+        # einen Test-Reader, der bewusst ``None`` zurueckgibt) ueber-
+        # schreiben. Fix fuer CodeRabbit-Finding #859.
         def rss_reader() -> float | None:  # type: ignore[no-redef]
             """
             Liefert keinen RSS-Messwert.

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -96,6 +96,7 @@ try:
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
     )
@@ -114,6 +115,7 @@ except ImportError:  # direct script execution
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
     )
@@ -125,7 +127,7 @@ init_runner_logging("agora-oasis-runner")
 load_project_env(__file__, verbose=True)
 install_max_tokens_warning_filter()
 _bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
 print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -91,7 +91,9 @@ try:
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -107,7 +109,9 @@ except ImportError:  # direct script execution
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -120,6 +124,9 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__, verbose=True)
 install_max_tokens_warning_filter()
+_bert_profile = install_bert_memory_profile()
+_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
@@ -2181,6 +2188,7 @@ if __name__ == "__main__":
     except SystemExit:
         pass
     finally:
+        _memory_stop()
         # Clean up multiprocessing resource tracker (prevent warning on exit)
         try:
             from multiprocessing import resource_tracker

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -39,7 +39,9 @@ try:
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -55,7 +57,9 @@ except ImportError:  # direct script execution
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -69,6 +73,9 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
+_bert_profile = install_bert_memory_profile()
+_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
@@ -928,4 +935,5 @@ if __name__ == "__main__":
     except SystemExit:
         pass
     finally:
+        _memory_stop()
         print("Simulation process exited")

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -44,6 +44,7 @@ try:
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
@@ -62,6 +63,7 @@ except ImportError:  # direct script execution
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
@@ -74,7 +76,7 @@ init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
 _bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
 print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -44,6 +44,7 @@ try:
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
@@ -62,6 +63,7 @@ except ImportError:  # direct script execution
         install_memory_sampler,
         install_script_paths,
         load_project_env,
+        make_default_memory_sink,
         preflight_model_probe,
         resolve_runtime_paths,
         setup_oasis_logging,
@@ -74,7 +76,7 @@ init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
 _bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
 print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -39,7 +39,9 @@ try:
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -55,7 +57,9 @@ except ImportError:  # direct script execution
         detect_oasis_platform,
         init_runner_tracing,
         init_runner_logging,
+        install_bert_memory_profile,
         install_max_tokens_warning_filter,
+        install_memory_sampler,
         install_script_paths,
         load_project_env,
         preflight_model_probe,
@@ -69,6 +73,9 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
+_bert_profile = install_bert_memory_profile()
+_memory_stop = install_memory_sampler(_runtime_paths.project_root / ".runtime" / "mem_profile.ndjson")
+print(f"[bert-memory] profile = {_bert_profile}", flush=True)
 _camel_context_floor = apply_camel_context_floor()
 print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
@@ -937,4 +944,5 @@ if __name__ == "__main__":
     except SystemExit:
         pass
     finally:
+        _memory_stop()
         print("Simulation process exited")

--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -1,0 +1,266 @@
+"""Regressionstests für die BERT-Memory-Profile in ``_sim_common``.
+
+Hintergrund: Auf 2.8-GiB-Container-Hosts kippt der OASIS-Subprozess mit
+``Process exit code: -9`` (Linux-OOM-Killer, ``cgroup memory.events: oom_kill=1``),
+sobald ``Twitter/twhin-bert-base`` (1.06 GB safetensors, fp32) im ersten
+``update_rec_table()``-Tick lazy geladen wird — plus den 250-350 MB
+``torch``/``transformers``/``sentence_transformers``-Import-Overhead aus
+``oasis.social_platform.recsys`` und ``process_recsys_posts``.
+
+Zwei ENV-getriebene Härten werden hier verriegelt:
+
+1. ``AGORA_BERT_MEMORY_PROFILE=low`` (Default) — Monkey-Patch auf
+   ``transformers.AutoModel.from_pretrained``: für ``Twitter/twhin-bert-base``
+   werden ``low_cpu_mem_usage=True`` und ``torch_dtype=torch.float16``
+   injiziert. Damit sinkt der dauerhafte RSS-Bedarf des Modells von ~1.2 GB
+   auf ~600 MB und der transiente Load-Peak um weitere 300-500 MB. Für
+   andere Modellnamen ist der Patch ein No-Op.
+
+2. ``AGORA_DEBUG_MEMORY=1`` — startet einen Background-Thread, der
+   ``process.memory_info().rss`` alle 0.5 s in eine NDJSON-Datei unter
+   ``sim_dir/mem_profile.ndjson`` schreibt. Damit kann der nächste OOM-Run
+   eine echte Boot-Kurve liefern, statt auf Vermutungen angewiesen zu sein.
+
+Beide ENV-Schalter sind **opt-in per Default** (Profil = off, Debug = off) und
+werden nur dann aktiv, wenn die jeweilige Variable gesetzt ist. Backwards-
+compatibel für alle existierenden Runs.
+
+Seam: die beiden Helper ``install_bert_memory_profile`` und
+``install_memory_sampler`` in ``backend.scripts._sim_common``. Der Patch wird
+in ``run_parallel_simulation.py`` und ``run_reddit_simulation.py`` direkt
+nach ``install_max_tokens_warning_filter`` aktiviert, **bevor** ``oasis``-
+Imports ``transformers.AutoModel`` lazy materialisieren. Da Python
+Modul-Level-Caching nutzt, sieht der spätere ``from transformers import
+AutoModel``-Aufruf in ``oasis.social_platform.process_recsys_posts`` die
+gepatchte Methode auf dem selben Klassen-Objekt.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _BACKEND_DIR / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from _sim_common import install_bert_memory_profile  # noqa: E402
+from _sim_common import install_memory_sampler  # noqa: E402
+from _sim_common import _read_rss_mb_linux  # noqa: E402
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stellt sicher, dass kein vorangegangener Test ENV-Leaks hinterlässt."""
+    for var in ("AGORA_BERT_MEMORY_PROFILE", "AGORA_DEBUG_MEMORY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def fake_torch() -> mock.Mock:
+    """Setzt ``sys.modules["torch"]`` auf ein Modul-Stub mit ``float16``.
+
+    Hintergrund: Auf macOS-ARM mit Python 3.14 crasht ``import torch`` in
+    ``libtorch_python.dylib`` zuverlässig (SIGSEGV), wenn der echte
+    Torch-Stack im Test-venv initialisiert wird. Da unsere Funktion
+    ``torch`` ausschließlich für ``torch.float16`` als ``torch_dtype``-
+    Argument benötigt, ist ein Stub mit einem ``float16``-Sentinel
+    ausreichend. Wird in jedem Test, der ``AGORA_BERT_MEMORY_PROFILE=low``
+    aktiviert, als autouse-Fixture eingehängt.
+    """
+    stub = mock.Mock(name="torch_stub")
+    stub.float16 = "fp16"
+    return stub
+
+
+def _patch_transformers_and_torch(
+    fake_module: mock.Mock, fake_torch_module: mock.Mock | None
+) -> mock._patch_dict:
+    """Overrides für ``sys.modules`` als ``mock.patch.dict``-Manager.
+
+    Im ``transformers``-Mock sitzt ``AutoModel.from_pretrained`` so, dass
+    die Tests den echten Monkey-Patch isoliert prüfen können. ``torch``
+    wird nur überschrieben, wenn der Test es explizit anfordert — sonst
+    könnte ein anderer Test denselben Stub teilen.
+    """
+    overrides: dict[str, object] = {"transformers": fake_module}
+    if fake_torch_module is not None:
+        overrides["torch"] = fake_torch_module
+    return mock.patch.dict(sys.modules, overrides)
+
+
+class _DummyKwargs(dict):
+    """Dict-Subklasse mit Attributzugriff für ``torch.dtype``-Mock-Kompatibilität."""
+
+    def __getattr__(self, name: str):
+        return self.get(name)
+
+
+def test_default_profile_does_not_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ohne ``AGORA_BERT_MEMORY_PROFILE`` bleibt ``from_pretrained`` unangetastet."""
+    monkeypatch.delenv("AGORA_BERT_MEMORY_PROFILE", raising=False)
+
+    sentinel = mock.Mock(name="original_from_pretrained")
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = sentinel
+    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+        install_bert_memory_profile()
+
+    # ``from_pretrained`` darf weder gelesen noch ersetzt worden sein.
+    assert fake_module.AutoModel.from_pretrained is sentinel
+
+
+def test_low_profile_patches_twhin_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``AGORA_BERT_MEMORY_PROFILE=low`` patcht nur ``Twitter/twhin-bert-base``."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "low")
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args, **kwargs):
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+        install_bert_memory_profile()
+
+    patched = fake_module.AutoModel.from_pretrained
+    assert patched is not _fake_from_pretrained
+
+    # twhin-bert-base: low_cpu_mem_usage + float16 müssen gesetzt sein.
+    patched("Twitter/twhin-bert-base")
+    assert len(captured_calls) == 1
+    kwargs = captured_calls[0]["kwargs"]
+    assert kwargs.get("low_cpu_mem_usage") is True
+    assert "torch_dtype" in kwargs  # Wert hängt von torch ab, muss aber gesetzt sein
+
+    # anderes Modell: low_cpu_mem_usage darf NICHT injiziert werden.
+    patched("sentence-transformers/all-MiniLM-L6-v2")
+    assert len(captured_calls) == 2
+    assert "low_cpu_mem_usage" not in captured_calls[1]["kwargs"]
+
+
+def test_off_profile_does_not_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AGORA_BERT_MEMORY_PROFILE=off`` schaltet den Patch explizit aus."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "off")
+
+    sentinel = mock.Mock(name="original_from_pretrained")
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = sentinel
+    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+        install_bert_memory_profile()
+
+    assert fake_module.AutoModel.from_pretrained is sentinel
+
+
+def test_low_profile_preserves_user_overrides(
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
+) -> None:
+    """Wenn der Aufrufer bereits ``torch_dtype`` setzt, wird es nicht überschrieben."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "low")
+
+    captured: list[dict] = []
+
+    def _fake(*_args: object, **_kwargs: object) -> mock.Mock:
+        captured.append(_kwargs)
+        return mock.Mock()
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake
+    with _patch_transformers_and_torch(fake_module, fake_torch):
+        install_bert_memory_profile()
+        patched = fake_module.AutoModel.from_pretrained
+
+    # Aufrufer hat bereits torch_dtype=bfloat16 gesetzt — bleibt.
+    sentinel_dtype = object()
+    patched("Twitter/twhin-bert-base", torch_dtype=sentinel_dtype)
+    assert captured[0]["torch_dtype"] is sentinel_dtype
+    # low_cpu_mem_usage wird trotzdem ergänzt (User hat es nicht gesetzt).
+    assert captured[0]["low_cpu_mem_usage"] is True
+
+
+def test_memory_sampler_writes_ndjson_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AGORA_DEBUG_MEMORY=1`` schreibt mindestens einen RSS-Snapshot in die NDJSON-Datei."""
+    monkeypatch.setenv("AGORA_DEBUG_MEMORY", "1")
+    sink = tmp_path / "mem.ndjson"
+
+    # Deterministischer RSS-Reader: zyklische Sequenz, damit der Thread
+    # auch nach Test-Ende nicht in StopIteration läuft und der Daemon-
+    # Cleanup keine unhandled exception wirft.
+    import itertools
+    rss_values = itertools.cycle([100.0, 100.5, 101.0, 101.5])
+
+    def _fake_reader() -> float:
+        return next(rss_values)
+
+    stop = install_memory_sampler(sink=sink, interval_s=0.05, rss_reader=_fake_reader)
+    try:
+        time.sleep(0.2)  # mindestens 2–3 Samples
+    finally:
+        stop()
+
+    lines = sink.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 2, "Sampler muss mindestens 2 Snapshots schreiben"
+    sample = json.loads(lines[0])
+    assert sample["label"] == "tick"
+    assert isinstance(sample["rss_mb"], float)
+    assert sample["rss_mb"] > 0
+    assert "time_s" in sample
+    # ``time_s`` ist non-negativ (relativ zu Thread-Start); auf macOS kann
+    # ``time.monotonic`` fuer sehr kurze Intervalle gleiche Werte liefern,
+    # deshalb nur "nicht negativ" pruefen statt strikt monotonic.
+    times = [json.loads(line)["time_s"] for line in lines]
+    assert all(t >= 0 for t in times)
+
+
+def test_memory_sampler_is_noop_without_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ohne ``AGORA_DEBUG_MEMORY`` bleibt der Sampler inaktiv und erzeugt keine Datei."""
+    monkeypatch.delenv("AGORA_DEBUG_MEMORY", raising=False)
+    sink = tmp_path / "mem.ndjson"
+
+    stop = install_memory_sampler(sink=sink, interval_s=0.05)
+    try:
+        time.sleep(0.15)
+    finally:
+        stop()
+
+    assert not sink.exists() or sink.read_text(encoding="utf-8") == ""
+
+
+def test_memory_sampler_stop_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mehrfaches ``stop()`` darf nicht crashen (Cleanup-Pfad ist optional)."""
+    monkeypatch.setenv("AGORA_DEBUG_MEMORY", "1")
+    sink = tmp_path / "mem.ndjson"
+
+    stop = install_memory_sampler(sink=sink, interval_s=0.05)
+    stop()
+    stop()  # idempotent
+
+
+def test_low_profile_does_not_break_if_transformers_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wenn ``transformers`` nicht installiert ist, schlägt der Patch still fehl."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "low")
+
+    # Simuliere ``ImportError``: transformers aus sys.modules entfernen
+    # und ``import transformers`` in einen ImportError laufen lassen.
+    with mock.patch.dict(sys.modules, {"transformers": None}):
+        # Sollte keine Exception werfen.
+        install_bert_memory_profile()

--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -122,9 +122,15 @@ def test_default_profile_does_not_patch(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_low_profile_patches_twhin_only(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
 ) -> None:
-    """``AGORA_BERT_MEMORY_PROFILE=low`` patcht nur ``Twitter/twhin-bert-base``."""
+    """``AGORA_BERT_MEMORY_PROFILE=low`` patcht nur ``Twitter/twhin-bert-base``.
+
+    Nutzt ``fake_torch`` (Fixture) statt des echten torch-Moduls — sonst
+    haengt der Test an der Test-Umgebung (passiert nur, weil im Dev-venv
+    ``torch`` installiert ist). Fix fuer CodeRabbit-Finding #859: ohne
+    Isolation schleppte der Test reale torch-Imports in andere Tests.
+    """
     monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "low")
 
     captured_calls: list[dict] = []
@@ -135,7 +141,7 @@ def test_low_profile_patches_twhin_only(
 
     fake_module = mock.Mock()
     fake_module.AutoModel.from_pretrained = _fake_from_pretrained
-    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+    with _patch_transformers_and_torch(fake_module, fake_torch):
         install_bert_memory_profile()
 
     patched = fake_module.AutoModel.from_pretrained
@@ -146,7 +152,7 @@ def test_low_profile_patches_twhin_only(
     assert len(captured_calls) == 1
     kwargs = captured_calls[0]["kwargs"]
     assert kwargs.get("low_cpu_mem_usage") is True
-    assert "torch_dtype" in kwargs  # Wert hängt von torch ab, muss aber gesetzt sein
+    assert "torch_dtype" in kwargs  # fake_torch.float16 = "fp16" sentinel
 
     # anderes Modell: low_cpu_mem_usage darf NICHT injiziert werden.
     patched("sentence-transformers/all-MiniLM-L6-v2")
@@ -279,3 +285,125 @@ def test_low_profile_does_not_break_if_transformers_missing(
     with mock.patch.dict(sys.modules, {"transformers": None}):
         # Sollte keine Exception werfen.
         install_bert_memory_profile()
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit Review #859 — Regressionstests fuer Findings 1, 3-5, 7
+# ---------------------------------------------------------------------------
+
+
+def test_memory_sampler_preserves_user_reader_when_returning_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Finding 1: macOS-Fallback darf einen vom Caller uebergebenen
+    ``rss_reader`` NICHT durch ein No-Op ersetzen, nur weil der Reader
+    (transient) ``None`` liefert.
+
+    Vor dem Fix: ``rss_reader() is None`` + ``/proc/self/status`` fehlt →
+    die Funktion definierte ``rss_reader`` lokal neu als
+    ``return None`` und schluckte damit den Caller-Reader. Tests, die
+    einen Reader liefern, der periodisch ``None`` zurueckgibt, schreiben
+    danach unsichtbare Samples.
+    """
+    monkeypatch.setenv("AGORA_DEBUG_MEMORY", "1")
+    sink = tmp_path / "mem.ndjson"
+
+    call_count = {"n": 0}
+
+    def user_reader() -> float | None:
+        call_count["n"] += 1
+        return None  # simuliert macOS / kein RSS zugaenglich
+
+    # macOS simulieren: ``/proc/self/status`` darf nicht "existieren".
+    real_exists = Path.exists
+
+    def fake_exists(self: Path) -> bool:
+        if str(self).startswith("/proc/") and "status" in str(self):
+            return False
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+    stop = install_memory_sampler(
+        sink=sink, interval_s=0.05, rss_reader=user_reader
+    )
+    try:
+        time.sleep(0.2)  # mindestens 2–3 Sample-Ticks
+    finally:
+        stop()
+
+    # Initialer Probe-Aufruf (1) + Thread-Loop-Calls (>=2) — beweist, dass
+    # der Caller-Reader NICHT durch den macOS-Fallback ersetzt wurde.
+    assert call_count["n"] >= 2, (
+        f"User-rss_reader wurde nur {call_count['n']}x aufgerufen — "
+        "macOS-Fallback hat den Caller-Reader ueberschrieben."
+    )
+
+
+def test_make_default_memory_sink_includes_pid(tmp_path: Path) -> None:
+    """Findings 3-5: Default-Sink-Pfad muss die PID enthalten, damit
+    parallele Sim-Runs nicht denselben NDJSON-Sink ueberschreiben.
+
+    Vor dem Fix: alle 3 ``run_*_simulation.py``-Caller schrieben auf
+    ``<project_root>/.runtime/mem_profile.ndjson`` ohne PID —
+    POSIX-Append-Concurrency fuehrte zu zerschossenem NDJSON.
+    """
+    from _sim_common import make_default_memory_sink
+
+    sink = make_default_memory_sink(tmp_path)
+
+    assert sink.parent == tmp_path / ".runtime", (
+        f"Default-Sink muss unter <project_root>/.runtime liegen, "
+        f"bekam parent: {sink.parent}"
+    )
+    assert sink.name.startswith("mem_profile."), (
+        f"Erwarteter Prefix 'mem_profile.', bekam: {sink.name}"
+    )
+    assert sink.name.endswith(".ndjson"), (
+        f"Erwartetes Suffix '.ndjson', bekam: {sink.name}"
+    )
+    assert f".{os.getpid()}." in sink.name, (
+        f"Sink-Dateiname muss die PID enthalten (für Concurrent-Runs), "
+        f"bekam: {sink.name}"
+    )
+
+
+def test_low_profile_no_torch_does_not_inject_torch_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Finding 7: Auch ohne ``torch`` (oder mit unavailable torch) darf
+    der Patch ``low_cpu_mem_usage=True`` setzen — ``torch_dtype`` wird
+    dann gar nicht injiziert, weil die Quelle fehlt.
+
+    Sperrt das Verhalten fest, sodass der bestehende Test
+    ``test_low_profile_patches_twhin_only`` (der das aktuell nur per
+    Glueck durchlaeuft, weil das Test-venv echtes torch hat) auf eine
+    deterministische fake_torch-Fixture umgestellt werden kann.
+    """
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "low")
+
+    # Torch komplett aus sys.modules entfernen → ImportError.
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args: object, **kwargs: object) -> mock.Mock:
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+        install_bert_memory_profile()
+
+    patched = fake_module.AutoModel.from_pretrained
+    assert patched is not _fake_from_pretrained
+
+    patched("Twitter/twhin-bert-base")
+    assert len(captured_calls) == 1
+    kwargs = captured_calls[0]["kwargs"]
+    assert kwargs.get("low_cpu_mem_usage") is True
+    # Kein torch → kein torch_dtype-Key (sonst wuerde der echte
+    # AutoModel.from_pretrained mit einem ungueltigen dtype fehlschlagen).
+    assert "torch_dtype" not in kwargs

--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -65,15 +65,11 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def fake_torch() -> mock.Mock:
-    """Setzt ``sys.modules["torch"]`` auf ein Modul-Stub mit ``float16``.
-
-    Hintergrund: Auf macOS-ARM mit Python 3.14 crasht ``import torch`` in
-    ``libtorch_python.dylib`` zuverlässig (SIGSEGV), wenn der echte
-    Torch-Stack im Test-venv initialisiert wird. Da unsere Funktion
-    ``torch`` ausschließlich für ``torch.float16`` als ``torch_dtype``-
-    Argument benötigt, ist ein Stub mit einem ``float16``-Sentinel
-    ausreichend. Wird in jedem Test, der ``AGORA_BERT_MEMORY_PROFILE=low``
-    aktiviert, als autouse-Fixture eingehängt.
+    """
+    Erstellt einen Torch-Stub mit einem `float16`-Sentinel für Tests des Low-Memory-Profils.
+    
+    Returns:
+        mock.Mock: Ein Stub mit dem Attribut `float16`.
     """
     stub = mock.Mock(name="torch_stub")
     stub.float16 = "fp16"
@@ -83,12 +79,11 @@ def fake_torch() -> mock.Mock:
 def _patch_transformers_and_torch(
     fake_module: mock.Mock, fake_torch_module: mock.Mock | None
 ) -> mock._patch_dict:
-    """Overrides für ``sys.modules`` als ``mock.patch.dict``-Manager.
-
-    Im ``transformers``-Mock sitzt ``AutoModel.from_pretrained`` so, dass
-    die Tests den echten Monkey-Patch isoliert prüfen können. ``torch``
-    wird nur überschrieben, wenn der Test es explizit anfordert — sonst
-    könnte ein anderer Test denselben Stub teilen.
+    """
+    Erzeugt einen Patch-Manager für die vorübergehende Ersetzung von `transformers` und optional `torch` in `sys.modules`.
+    
+    Returns:
+        mock._patch_dict: Patch-Manager für das `sys.modules`-Overlay.
     """
     overrides: dict[str, object] = {"transformers": fake_module}
     if fake_torch_module is not None:
@@ -100,6 +95,15 @@ class _DummyKwargs(dict):
     """Dict-Subklasse mit Attributzugriff für ``torch.dtype``-Mock-Kompatibilität."""
 
     def __getattr__(self, name: str):
+        """
+        Liefert den Wert des angegebenen Attributnamens aus dem Wörterbuch.
+        
+        Parameter:
+        	name (str): Der abzurufende Attributname.
+        
+        Returns:
+        	Der zugehörige Wert oder `None`, wenn der Name nicht vorhanden ist.
+        """
         return self.get(name)
 
 
@@ -172,6 +176,12 @@ def test_low_profile_preserves_user_overrides(
     captured: list[dict] = []
 
     def _fake(*_args: object, **_kwargs: object) -> mock.Mock:
+        """
+        Erfasst die Schlüsselwortargumente eines Aufrufs und liefert einen Mock zurück.
+        
+        Returns:
+        	mock.Mock: Ein neuer Mock als Rückgabewert des Aufrufs.
+        """
         captured.append(_kwargs)
         return mock.Mock()
 
@@ -203,6 +213,11 @@ def test_memory_sampler_writes_ndjson_when_enabled(
     rss_values = itertools.cycle([100.0, 100.5, 101.0, 101.5])
 
     def _fake_reader() -> float:
+        """Liest den nächsten RSS-Speicherwert aus der Testsequenz.
+        
+        Returns:
+        	float: Der nächste konfigurierte RSS-Wert in Megabyte.
+        """
         return next(rss_values)
 
     stop = install_memory_sampler(sink=sink, interval_s=0.05, rss_reader=_fake_reader)

--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -107,18 +107,37 @@ class _DummyKwargs(dict):
         return self.get(name)
 
 
-def test_default_profile_does_not_patch(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ohne ``AGORA_BERT_MEMORY_PROFILE`` bleibt ``from_pretrained`` unangetastet."""
+def test_default_profile_patches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default-Profil IST ``low`` (per ``_BERT_PROFILE_DEFAULT``) — patching
+    MUSS stattfinden. Verifiziert, dass die Idempotenz-Pruefung im Helper
+    nicht fälschlich frueh zurueckkehrt.
+
+    Wichtig: ``original`` ist eine echte Funktion (kein ``mock.Mock``).
+    ``install_bert_memory_profile`` prueft per
+    ``getattr(original, "_agora_bert_memory_profile_applied", False)``
+    auf Idempotenz; ein ``Mock``-Sentinel wuerde das Attribut truthy
+    auto-magieren und der Patch wuerde stillschweigend ueberspringen
+    (CodeRabbit-Finding #859).
+    """
     monkeypatch.delenv("AGORA_BERT_MEMORY_PROFILE", raising=False)
 
-    sentinel = mock.Mock(name="original_from_pretrained")
+    def sentinel(*_args: object, **_kwargs: object) -> mock.Mock:
+        return mock.Mock(name="model")
+
     fake_module = mock.Mock()
     fake_module.AutoModel.from_pretrained = sentinel
     with mock.patch.dict(sys.modules, {"transformers": fake_module}):
         install_bert_memory_profile()
 
-    # ``from_pretrained`` darf weder gelesen noch ersetzt worden sein.
-    assert fake_module.AutoModel.from_pretrained is sentinel
+    # Default = "low" → Patching MUSS stattgefunden haben.
+    assert fake_module.AutoModel.from_pretrained is not sentinel
+    # Das gesetzte Flag haengt am neuen (gepatchten) Callable, nicht am
+    # Original — verhindert Doppel-Wrapping bei wiederholten Aufrufen.
+    assert getattr(
+        fake_module.AutoModel.from_pretrained,
+        "_agora_bert_memory_profile_applied",
+        False,
+    ) is True
 
 
 def test_low_profile_patches_twhin_only(
@@ -164,7 +183,9 @@ def test_off_profile_does_not_patch(monkeypatch: pytest.MonkeyPatch) -> None:
     """``AGORA_BERT_MEMORY_PROFILE=off`` schaltet den Patch explizit aus."""
     monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "off")
 
-    sentinel = mock.Mock(name="original_from_pretrained")
+    def sentinel(*_args: object, **_kwargs: object) -> mock.Mock:
+        return mock.Mock(name="model")
+
     fake_module = mock.Mock()
     fake_module.AutoModel.from_pretrained = sentinel
     with mock.patch.dict(sys.modules, {"transformers": fake_module}):


### PR DESCRIPTION
## Problem
OASIS-Subprozess kippt im 2.8-GiB-Container mit exit code -9 (Linux-OOM-Killer), sobald `Twitter/twhin-bert-base` (1.06 GB safetensors, fp32) im ersten `update_rec_table()`-Tick lazy geladen wird — plus 250-350 MB torch/transformers/sentence_transformers Import-Overhead aus `oasis.social_platform.recsys` und `process_recsys_posts`.

Container-Logs vom Crash:
```
cgroup memory.events: oom_kill=1
Process exit code: -9
```

## Root Cause
H1 (validiert durch Subagent-Recherche, AGORA/.code-review-graph head_matches_build=true bei 98d8d596):
1. **`Twitter/twhin-bert-base` (1.06 GB safetensors, fp32)** wird im ersten `update_rec_table()`-Tick lazy geladen → +1.2-1.4 GB RSS-Spike
2. Modul-Level-Imports in `oasis/social_platform/recsys.py` und `process_recsys_posts.py` ziehen `torch`/`transformers`/`sentence_transformers`/`sklearn` → +250-350 MB Import-Overhead
3. Zusammen mit FastAPI-Parent (~0.5-1.0 GB) → Container-Limit überschritten

`recsys_type="twhin-bert"` ist in `oasis/environment/env.py:81` hardcoded → kein Override-Punkt ohne Library-Fork.

## Fix-Strategie (Monkey-Patch, da Library-Code)
Da wir OASIS nicht forken wollen, patchen wir `transformers.AutoModel.from_pretrained` von außen, BEVOR `oasis` importiert wird:

- `install_bert_memory_profile()` (neu in `scripts/_sim_common.py`):
  - ENV-getrieben via `AGORA_BERT_MEMORY_PROFILE=off|low` (default `low`)
  - Bei `low`: injiziert `low_cpu_mem_usage=True` + `torch_dtype=torch.float16` für `Twitter/twhin-bert-base`
  - User-Overrides haben Vorrang
  - Idempotent (kein Doppel-Wrapping)
- `install_memory_sampler()` (neu in `scripts/_sim_common.py`):
  - Background-Thread schreibt alle 0.5 s RSS-Snapshots als NDJSON nach `.runtime/mem_profile.ndjson`
  - ENV-getrieben via `AGORA_DEBUG_MEMORY=1`
  - Late-binding RSS-Reader via `rss_reader=`-Parameter (plattformunabhaengig testbar)
  - Idempotenter `stop()`

Eingebunden in `run_parallel_simulation.py`, `run_twitter_simulation.py`, `run_reddit_simulation.py` direkt nach `install_max_tokens_warning_filter`, VOR dem ersten `import oasis`.

## Erwartete Wirkung
- Dauerhafter RSS-Bedarf des TWHIN-BERT-Modells sinkt von ~1.2 GB auf ~600 MB (fp16 statt fp32)
- Transienter Load-Peak um weitere 300-500 MB reduziert (low_cpu_mem_usage=True)
- Bei Container-Limit 2.8 GiB und FastAPI-Parent ~0.5-1.0 GB: Headroom ~500 MB statt OOM-Kill
- Optional: echte Boot-Kurve für die naechste OOM-Diagnose via `AGORA_DEBUG_MEMORY=1`

## Tests
- 8 RED-Tests in `tests/scripts/test_bert_memory_profile.py`:
  - profile=off, profile=low, low preserves user overrides
  - sampler writes ndjson, sampler no-op, sampler idempotent stop
  - transformers-missing fallback
- torch-Segfault auf macOS ARM + Python 3.14 abgefangen durch `fake_torch` Stub-Fixture (`sys.modules['torch']` Mock)
- `rss_reader=`-Parameter macht Sampler-Test plattformunabhaengig (kein /proc/self/status auf macOS)

```
tests/scripts/test_bert_memory_profile.py ........  [100%]  8 passed
```

## Smoke-Validierung
- `python scripts/run_*_simulation.py --help` → sauber, Printout `[bert-memory] profile = low`
- 113 Tests in `tests/scripts/`-Suite gruen (alle _sim_common-touching Tests + run_parallel_timestamp + default_floor + default_tokens)

## Container-Smoke-Run (ausstehend)
Mini-Run mit `AGORA_DEBUG_MEMORY=1` + 2 agents + 2 rounds zur Verifikation, dass die Boot-Kurve einen flachen Verlauf zeigt statt eines BERT-Spikes. Geplant als follow-up nach PR-Merge.

## Compatibility / Backout
- Default-Profil ist `low` (production-friendly). Wer den alten Pfad will: `AGORA_BERT_MEMORY_PROFILE=off`.
- Sampler default off, niemand muss was setzen.
- Keine Schema- oder API-Änderungen.
- Library-Code (OASIS) wird nicht angefasst → upstream-kompatibel.

## Risiken / Trade-offs
- Monkey-Patching auf Library-Code: bei transformers-Major-Updates kann die Signatur sich ändern. Aktuelle Implementierung passt auf transformers 4.x; bei 5.x revalidieren.
- `torch_dtype=torch.float16` kann numerische Drift verursachen — fuer Embedding-Recsys irrelevant (cosine sim ranking).
- Wenn User bereits `torch_dtype` setzt, wird das respektiert (User-Override-Pfad getestet).

Refs: AGORA/.code-review-graph head_matches_build=true bei 98d8d596 (build context valid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Neue Funktionen**
  - Optionales BERT-Speicherprofil reduziert den Speicherbedarf beim Laden des Modells.
  - Speicherverbrauch kann während Simulationen regelmäßig erfasst und als NDJSON-Datei protokolliert werden.
  - Speicherdiagnose lässt sich über Umgebungsvariablen aktivieren oder deaktivieren.

- **Verbesserungen**
  - Speicherprofile und Diagnoseaufzeichnungen werden beim Beenden der Simulation zuverlässig abgeschlossen.
  - Die Simulation bleibt auch bei fehlenden Diagnosevoraussetzungen oder Schreibfehlern stabil.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->