### PR TITLE
fix(embedding): append /embeddings to Gemini /v1beta/openai base_url

### DIFF
--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -334,7 +334,16 @@ class EmbeddingService:
 
     def _build_embed_url(self) -> str:
         if self._provider == 'openai':
-            if self.base_url.endswith('/v1') or self.base_url.endswith('/v1/'):
+            # Gemini OpenAI-Compat-Endpoint endet bereits auf ``/v1beta/openai``
+            # (oder ``/v1beta/openai/``) — ein weiteres ``/v1``-Segment ergibt
+            # ``…/v1beta/openai/v1/embeddings`` und antwortet 404. Direkt
+            # ``/embeddings`` anhängen statt nochmal ``/v1`` zu injizieren.
+            if (
+                self.base_url.endswith('/v1')
+                or self.base_url.endswith('/v1/')
+                or self.base_url.endswith('/v1beta/openai')
+                or self.base_url.endswith('/v1beta/openai/')
+            ):
                 return f"{self.base_url.rstrip('/')}/embeddings"
             return f"{self.base_url.rstrip('/')}/v1/embeddings"
         return f"{self.base_url}/api/embed"

--- a/backend/tests/test_embedding_service.py
+++ b/backend/tests/test_embedding_service.py
@@ -59,6 +59,42 @@ def test_embed_keeps_ollama_embedding_detection_separate(monkeypatch):
     assert "Authorization" not in post.call_args.kwargs["headers"]
 
 
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        # Gemini OpenAI-Compat-Endpoint enthaelt bereits ``/v1beta/openai`` —
+        # ein zusaetzliches ``/v1``-Segment wuerde ``/v1beta/openai/v1/embeddings``
+        # ergeben und 404 antworten. Direkt ``/embeddings`` anhängen.
+        ("https://generativelanguage.googleapis.com/v1beta/openai", "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"),
+        ("https://generativelanguage.googleapis.com/v1beta/openai/", "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"),
+    ],
+)
+def test_embed_uses_gemini_openai_compat_url_without_extra_v1_segment(
+    monkeypatch, base_url: str, expected_url: str
+) -> None:
+    """Issue: Gemini OpenAI-Compat-Endpoint darf NICHT zu ``/v1beta/openai/v1/embeddings`` werden.
+
+    Der Endpunkt akzeptiert nur ``/v1beta/openai/embeddings`` direkt — ein
+    weiteres ``/v1``-Segment wuerde 404 auslösen. Regressionstest fuer den
+    Whitelist-Suffix in ``EmbeddingService._build_embed_url``.
+    """
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    response = MagicMock()
+    response.json.return_value = {"data": [{"embedding": [0.5, 0.6]}]}
+
+    with patch("app.storage.embedding_service.requests.post", return_value=response) as post:
+        vector = EmbeddingService(
+            model="text-embedding-3-small",
+            base_url=base_url,
+            api_key="sk-test",
+            max_retries=1,
+        ).embed("document")
+
+    assert vector == [0.5, 0.6]
+    assert post.call_args.args[0] == expected_url
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+
 def test_infer_vector_dim_for_known_models():
     assert infer_vector_dim_for_model('nomic-embed-text') == 768
     assert infer_vector_dim_for_model('nomic-embed-text:latest') == 768


### PR DESCRIPTION
## Problem
Gemini OpenAI-Compat-Endpoint endet auf `/v1beta/openai` (oder `/v1beta/openai/`). `EmbeddingService._build_embed_url` baut aber immer `{base_url}/v1/embeddings` — das ergibt `.../v1beta/openai/v1/embeddings`, was Gemini mit 404 ablehnt.

## Fix
Erweitert die Whitelist der Suffixe in `_build_embed_url` (`app/storage/embedding_service.py:341-348`), die kein zusaetzliches `/v1`-Segment brauchen:
```python
if (
    self.base_url.endswith('/v1')
    or self.base_url.endswith('/v1/')
    or self.base_url.endswith('/v1beta/openai')
    or self.base_url.endswith('/v1beta/openai/')
):
    return f"{self.base_url.rstrip('/')}/embeddings"
return f"{self.base_url.rstrip('/')}/v1/embeddings"
```

## Tests
Parametrisierter Regressionstest in `tests/test_embedding_service.py`:
- `test_embed_uses_gemini_openai_compat_url_without_extra_v1_segment` mit zwei Varianten (mit und ohne trailing slash)

```
tests/test_embedding_service.py ............  22 passed
```

## Compatibility
- Andere OpenAI-Endpoints (`api.openai.com`, `api.deepseek.com`, `api.mistral.ai`) folgen weiterhin dem `{base}/v1/embeddings`-Pfad — keine Regression.
- Ollama-Pfad (`/api/embed`) bleibt unveraendert.

Refs: Stash@{0} von task-c-embedding-url-v1beta-openai-fix (WIP aus frueherer Session).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Embedding-Anfragen an Gemini OpenAI-kompatible Endpunkte verwenden nun die korrekte URL, ohne ein zusätzliches `/v1`-Segment.

* **Tests**
  * Regressionstests für URLs mit und ohne abschließenden Schrägstrich ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->