### PR TITLE
fix(process-manager): whitelist REDIS_URL + HF_TOKEN for subprocess

### DIFF
--- a/backend/app/services/sim/process_manager.py
+++ b/backend/app/services/sim/process_manager.py
@@ -72,6 +72,17 @@ def _resolve_child_path(base_dir: str, child_name: str, *, kind: str) -> Path:
 # Secrets (SECRET_KEY, AGORA_AUTH_TOKEN, NEO4J_PASSWORD, LLM_API_KEY,
 # AGORA_FERNET_KEY) werden bewusst NICHT weitergegeben. LLM-Credentials
 # kommen ausschließlich über den ``runtime_env``-Parameter.
+#
+# Optionale Connection-Keys:
+# - ``REDIS_URL``: enthaelt potenziell ein Passwort (Format
+#   ``redis://:pw@host:port/db``). Wir lassen es bewusst zu, weil die
+#   Redis-IPC-Bridge (``scripts/subprocess_redis_bridge.py``) sonst im
+#   Subprozess inaktiv bleibt. Wer das nicht will, leert REDIS_URL vor
+#   dem ``start_simulation``-Call.
+# - ``HF_TOKEN``: Hugging-Face-Authentifizierung fuer private/Gated
+#   Models (z.B. ``Twitter/twhin-bert-base`` ist zwar public, aber
+#   Custom-Mirrors koennen Auth verlangen). Public Models funktionieren
+#   ohne Token.
 SAFE_ENV_KEYS: frozenset[str] = frozenset(
     {
         "PATH",
@@ -83,6 +94,8 @@ SAFE_ENV_KEYS: frozenset[str] = frozenset(
         "LLM_MODEL_NAME",
         "LLM_MAX_OUTPUT_TOKENS",
         "OLLAMA_THINKING",
+        "REDIS_URL",
+        "HF_TOKEN",
     }
 )
 

--- a/backend/tests/services/test_process_manager_env_whitelist.py
+++ b/backend/tests/services/test_process_manager_env_whitelist.py
@@ -110,3 +110,37 @@ class TestSubprocessEnvExcludesSecrets:
         forbidden = {"SECRET_KEY", "AGORA_AUTH_TOKEN", "NEO4J_PASSWORD", "AGORA_FERNET_KEY"}
         overlap = SAFE_ENV_KEYS & forbidden
         assert not overlap, f"SAFE_ENV_KEYS enthält verbotene Keys: {overlap}"
+
+
+class TestSubprocessEnvIncludesOptionalConnectionKeys:
+    """RED-Tests: Optionale Connection-Keys (REDIS_URL, HF_TOKEN) müssen
+    vererbbar sein, damit die Redis-IPC-Bridge und Hugging-Face-Downloads
+    im OASIS-Subprozess funktionieren.
+
+    Hintergrund: Ohne REDIS_URL war die Redis-Bridge im Subprozess
+    inaktiv; ohne HF_TOKEN schlugen private HF-Modelle fehl.
+    """
+
+    def test_safe_env_keys_includes_redis_url(self) -> None:
+        """REDIS_URL muss in SAFE_ENV_KEYS sein, sonst bleibt die Redis-Bridge im Subprozess stumm."""
+        assert "REDIS_URL" in SAFE_ENV_KEYS, (
+            "REDIS_URL fehlt in SAFE_ENV_KEYS — Redis-Bridge im OASIS-Subprozess funktioniert nicht"
+        )
+
+    def test_safe_env_keys_includes_hf_token(self) -> None:
+        """HF_TOKEN muss in SAFE_ENV_KEYS sein, sonst scheitern private HF-Modell-Loads."""
+        assert "HF_TOKEN" in SAFE_ENV_KEYS, (
+            "HF_TOKEN fehlt in SAFE_ENV_KEYS — private Hugging-Face-Modelle laden nicht"
+        )
+
+    def test_subprocess_env_includes_redis_url(self, tmp_path, monkeypatch) -> None:
+        """REDIS_URL aus os.environ landet via Whitelist im Subprozess-Env."""
+        monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
+        captured = _run_start_simulation(tmp_path, monkeypatch)
+        assert captured.get("REDIS_URL") == "redis://redis:6379/0"
+
+    def test_subprocess_env_includes_hf_token(self, tmp_path, monkeypatch) -> None:
+        """HF_TOKEN aus os.environ landet via Whitelist im Subprozess-Env."""
+        monkeypatch.setenv("HF_TOKEN", "hf_testtoken123")
+        captured = _run_start_simulation(tmp_path, monkeypatch)
+        assert captured.get("HF_TOKEN") == "hf_testtoken123"


### PR DESCRIPTION
## Problem
Die Subprozess-Whitelist `SAFE_ENV_KEYS` in `backend/app/services/sim/process_manager.py:75-87` liess bisher nur technische LLM-Connection-Keys durch. Zwei produktive Use-Cases hingen in der Luft:

1. **REDIS_URL**: `scripts/subprocess_redis_bridge.py` aktiviert sich nur, wenn `REDIS_URL` gesetzt ist. Ohne Whitelist-Eintrag blieb die Real-Time-IPC zwischen FastAPI-Parent und OASIS-Subprozess stumm, obwohl `REDIS_URL` im Backend-Env gesetzt war.
2. **HF_TOKEN**: Hugging-Face-Authentifizierung fuer private/Gated Modelle. Public Models wie `Twitter/twhin-bert-base` funktionieren zwar ohne Token, aber Custom-Mirrors brechen ohne `HF_TOKEN`.

## Fix
Erweitert `SAFE_ENV_KEYS` um zwei Connection-Keys:
- `REDIS_URL` — kann ein Passwort enthalten (Format `redis://:pw@host:port/db`). Wir lassen es bewusst zu, weil die Redis-Bridge sonst im Subprozess inaktiv bleibt. Wer das nicht will, leert `REDIS_URL` vor `start_simulation`.
- `HF_TOKEN` — Hugging-Face-Auth fuer private/Gated Models.

`SECRET_KEY`, `AGORA_AUTH_TOKEN`, `NEO4J_PASSWORD`, `LLM_API_KEY`, `AGORA_FERNET_KEY` bleiben explizit draussen — durch `test_safe_env_keys_constant_excludes_secrets` regressionsfest gesichert.

## Tests
- 4 RED-Tests in neuer Klasse `TestSubprocessEnvIncludesOptionalConnectionKeys`:
  - `test_safe_env_keys_includes_redis_url`
  - `test_safe_env_keys_includes_hf_token`
  - `test_subprocess_env_includes_redis_url`
  - `test_subprocess_env_includes_hf_token`
- 11/11 Tests gruen in `test_process_manager_env_whitelist.py`, `test_oasis_route_env_binding.py`, `test_process_manager_runtime_env.py`.

## Compatibility / Backout
- Keine Aenderung an Vererbungs-Logik (nur zwei weitere Keys in der Whitelist).
- Wenn REDIS_URL im Backend-Env nicht gesetzt ist → keine Aenderung.
- Wenn gesetzt → wird an Subprozess vererbt (gewollt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Optionale Verbindungs- und Authentifizierungsdaten werden bei Bedarf an Simulationsprozesse weitergegeben.
  * Dadurch können Redis-basierte Funktionen sowie bestimmte Modelle und Modellspiegel zuverlässiger genutzt werden.

* **Tests**
  * Die Weitergabe der optionalen Konfigurationswerte wird automatisiert überprüft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->