### PR TITLE
fix(tests): Einrückung in test_ontology_generator.py reparieren

### DIFF
--- a/backend/tests/test_ontology_generator.py
+++ b/backend/tests/test_ontology_generator.py
@@ -108,19 +108,19 @@ class _CapturingLLMClient:
                   schema=None, schema_name="structured_response",
                   context="chat_json", force_no_thinking=False, **kwargs):
         """
-                  Erfasst die übergebenen Chat-Parameter und liefert eine feste Ontologie-Struktur zurück.
-                  
-                  Parameters:
-                      messages: Chat-Nachrichten.
-                      schema: Optionales Schema für die strukturierte Antwort.
-                      schema_name: Name des Antwortschemas.
-                      context: Kontext der Anfrage.
-                      force_no_thinking: Steuert, ob interne Denkprozesse deaktiviert werden.
-                  
-                  Returns:
-                      Eine Ontologie-Struktur mit den Entitätstypen „Person“ und „Organization“.
-                  """
-                  self.captured_kwargs = {
+        Erfasst die übergebenen Chat-Parameter und liefert eine feste Ontologie-Struktur zurück.
+
+        Parameters:
+            messages: Chat-Nachrichten.
+            schema: Optionales Schema für die strukturierte Antwort.
+            schema_name: Name des Antwortschemas.
+            context: Kontext der Anfrage.
+            force_no_thinking: Steuert, ob interne Denkprozesse deaktiviert werden.
+
+        Returns:
+            Eine Ontologie-Struktur mit den Entitätstypen „Person“ und „Organization“.
+        """
+        self.captured_kwargs = {
             "temperature": temperature,
             "max_tokens": max_tokens,
             "schema": schema,


### PR DESCRIPTION
## Problem

`backend/tests/test_ontology_generator.py` parst seit `98d8d596` (PR #858) nicht mehr:

```
E   File "backend/tests/test_ontology_generator.py", line 123
E       self.captured_kwargs = {
E   IndentationError: unexpected indent
```

pytest bricht schon beim Einsammeln ab. **Alle 6 Tests der Datei laufen seitdem nicht mehr** — ohne dass es auffiel, weil ein Collection-Error in einem grünen Gesamtlauf leicht untergeht.

## Warum das mehr als Kosmetik ist

Betroffen sind genau die Regressionstests, die den Ontology-Fix aus #858 absichern sollen, darunter `test_generate_passes_ontology_definition_schema` und `test_generate_passes_force_no_thinking_true`. Der CHANGELOG-Eintrag zu #858 in `main` nennt für diese Datei „6 passed" — im gemergten Stand trifft das nicht zu.

## Ursache

Ein automatischer Docstring-Commit hat den Docstring von `FakeLLMClient.chat_json` und die direkt folgende Zuweisung `self.captured_kwargs = {` von 8 auf 18 Spaces eingerückt.

## Änderung

Reine Einrückungskorrektur des betroffenen Blocks. Keine Änderung an Testlogik, Assertions oder Produktivcode.

## Verifikation

`pytest tests/test_ontology_generator.py` → **6 passed**. Die Tests bestehen, der Ontology-Fix aus #858 ist damit auch tatsächlich abgesichert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Docstring-Formatierung in den Ontologie-Generator-Tests überarbeitet.
  * Keine Änderungen am Verhalten oder an den Testergebnissen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->