### PR TITLE
fix(llm): abgeschnittenes JSON nicht mehr als Erfolg ausgeben

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -43,6 +43,15 @@ from .tool_calls import _chat_with_tools
 logger = get_logger("agora.llm_client")
 
 
+class LLMOutputTruncatedError(ValueError):
+    """Eine strukturierte LLM-Antwort wurde am Token-Limit abgeschnitten.
+
+    Erbt von ``ValueError``, damit bestehende Caller, die den alten
+    ``JSONDecodeError``-Pfad breit abfangen, weiterhin greifen. Wer gezielt
+    kompakter retryen will, faengt diesen Typ ab.
+    """
+
+
 def get_llm_provider_secrets_store() -> Any:
     """Load the secrets store lazily to avoid the services package import cycle."""
     from ..services.llm_provider_secrets_store import get_llm_provider_secrets_store as get_store
@@ -415,6 +424,7 @@ class LLMClient:
             "chat", "chat_json", "embedding", "report", "persona", "graph", "unknown"
         ] = "chat",
         force_no_thinking: bool = False,
+        require_complete: bool = False,
     ) -> str:
         """
         Send a chat request and return the cleaned model response.
@@ -427,9 +437,17 @@ class LLMClient:
             context (Literal): Logical context label for observability.
             force_no_thinking (bool): Whether to disable reasoning output when supported
                 by the provider.
-        
+            require_complete (bool): When True, a response the provider marked as cut
+                off at the token cap (``finish_reason == "length"``) raises
+                :class:`LLMOutputTruncatedError` instead of returning partial text.
+                Callers that parse the result structurally should set this.
+
         Returns:
             str: The model response text with thinking blocks removed.
+
+        Raises:
+            LLMOutputTruncatedError: When *require_complete* is set and the provider
+                reported ``finish_reason == "length"``.
         """
         self._publish_model_active(context, max_tokens=max_tokens, temperature=temperature)
         # E2E-Stub-Pfad für chat() — symmetrisch zum Stub-Pfad in chat_json().
@@ -557,6 +575,19 @@ class LLMClient:
             "LLM chat returned model=%s finish=%s tokens_out=%s elapsed=%.1fs max_tokens=%s stream=%s",
             self.model, finish_reason, completion_tokens, elapsed, max_tokens, force_stream,
         )
+        if require_complete and finish_reason == "length":
+            # Nicht als Erfolg verbuchen: der Caller kann mit dem Fragment nichts
+            # anfangen, und ein "success" hier verzerrt die Telemetrie.
+            self._log_invocation_event(
+                stage=context,
+                latency_ms=elapsed * 1000,
+                success=False,
+                error_type="LLMOutputTruncatedError",
+            )
+            raise LLMOutputTruncatedError(
+                f"LLM output truncated at token cap: model={self.model}, "
+                f"completion_tokens={completion_tokens}, max_tokens={max_tokens}"
+            )
         self._log_invocation_event(
             stage=context,
             latency_ms=elapsed * 1000,
@@ -854,6 +885,7 @@ class LLMClient:
                     response_format=response_format,
                     context=context,
                     force_no_thinking=force_no_thinking,
+                    require_complete=True,
                 )
             except Exception as exc:
                 exc_lower = str(exc).lower()
@@ -870,6 +902,7 @@ class LLMClient:
                         response_format={"type": "json_object"},
                         context=context,
                         force_no_thinking=force_no_thinking,
+                        require_complete=True,
                     )
                 else:
                     raise
@@ -881,6 +914,7 @@ class LLMClient:
                 response_format=response_format,
                 context=context,
                 force_no_thinking=force_no_thinking,
+                require_complete=True,
             )
         # Codefences + Prosa-Envelope entfernen (Issue #556).
         cleaned_response = _strip_llm_json_envelope(response)

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -24,6 +24,10 @@ from ..utils.logger import get_logger
 from ..utils.retry import llm_call_with_retry
 
 from .context import _resolve_num_ctx
+# Re-Export: ``from app.llm.client import LLMOutputTruncatedError`` bleibt der
+# gewohnte Importpfad, auch wenn der Typ jetzt in ``errors`` lebt (Provider-
+# Adapter brauchen ihn und werden von diesem Modul importiert).
+from .errors import LLMOutputTruncatedError  # noqa: F401  (re-exported)
 from .json_mode import (
     JsonSchemaLike,
     _STRICT_UNSUPPORTED_HINTS,
@@ -41,15 +45,6 @@ from .providers import openai as _provider_openai
 from .tool_calls import _chat_with_tools
 
 logger = get_logger("agora.llm_client")
-
-
-class LLMOutputTruncatedError(ValueError):
-    """Eine strukturierte LLM-Antwort wurde am Token-Limit abgeschnitten.
-
-    Erbt von ``ValueError``, damit bestehende Caller, die den alten
-    ``JSONDecodeError``-Pfad breit abfangen, weiterhin greifen. Wer gezielt
-    kompakter retryen will, faengt diesen Typ ab.
-    """
 
 
 def get_llm_provider_secrets_store() -> Any:
@@ -869,6 +864,11 @@ class LLMClient:
                     cleaned_response = _strip_llm_json_envelope(response)
                     parsed: Dict[str, Any] = json.loads(cleaned_response)
                     return self._maybe_validate(parsed, schema)
+                except LLMOutputTruncatedError:
+                    # Kein Transportfehler: derselbe Request ueber den
+                    # OpenAI-Wrapper wird am selben Limit wieder gekappt und
+                    # kostet nur einen zweiten vollen Call. Durchreichen.
+                    raise
                 except Exception as exc:  # noqa: BLE001 — bewusst breit, Fallback ist sicher
                     logger.warning(
                         "LLMClient.chat_json: native Ollama /api/chat-Pfad fehlgeschlagen "

--- a/backend/app/llm/errors.py
+++ b/backend/app/llm/errors.py
@@ -17,6 +17,19 @@ from app.contracts.llm_request import NormalizedLlmError
 from app.contracts.provider_types import ProviderType
 
 
+class LLMOutputTruncatedError(ValueError):
+    """Eine strukturierte LLM-Antwort wurde am Token-Limit abgeschnitten.
+
+    Liegt hier statt in ``app.llm.client``, damit auch die Provider-Adapter
+    unter ``app.llm.providers.*`` den Typ werfen koennen — sie werden von
+    ``client`` importiert, ein Rueckimport waere zirkulaer.
+
+    Erbt von ``ValueError``, damit bestehende Caller, die den alten
+    ``JSONDecodeError``-Pfad breit abfangen, weiterhin greifen. Wer gezielt
+    kompakter retryen will, faengt diesen Typ.
+    """
+
+
 class LlmProviderError(Exception):
     """Exception-Wrapper um eine normalisierte Fehler-Payload.
 

--- a/backend/app/llm/json_mode.py
+++ b/backend/app/llm/json_mode.py
@@ -306,14 +306,20 @@ def _try_repair_truncated_json(payload: str) -> Optional[str]:
     # Strukturzeichen zurueckgeschnitten, wodurch ``{"a": 1,`` zu ``{}``
     # kollabierte: valides JSON, aber der Inhalt war weg und der Caller
     # hielt das Ergebnis fuer einen Erfolg.
-    truncated = payload.rstrip()
     if in_string:
+        # Innerhalb eines offenen Strings NICHT rstrip()en: Whitespace am Ende
+        # gehoert zum uebertragenen Wert. ``"Maya arbeitet als `` wuerde sonst
+        # sein abschliessendes Leerzeichen verlieren — eine stille Aenderung
+        # am Inhalt, die der Repair gerade nicht machen darf.
+        truncated = payload
         # Haengender Backslash: der Cap fiel in eine Escape-Sequenz hinein.
         # Bleibt er stehen, escaped er das Anfuehrungszeichen, das wir gerade
         # anhaengen wollen, und der String bleibt offen.
         if escape and truncated.endswith("\\"):
             truncated = truncated[:-1]
         truncated += '"'
+    else:
+        truncated = payload.rstrip()
     # Drop dangling ``,`` so the closer doesn't produce another parse error.
     truncated = truncated.rstrip().rstrip(",")
     truncated += "".join(reversed(stack))

--- a/backend/app/llm/json_mode.py
+++ b/backend/app/llm/json_mode.py
@@ -7,6 +7,7 @@ Extracted verbatim from ``app/utils/llm_client.py`` as part of issue #582
 schema path lives separately in ``app.llm.providers.ollama``.
 """
 
+import json
 import os
 import re
 from typing import Any, Dict, Optional, Type, Union, List
@@ -281,8 +282,7 @@ def _try_repair_truncated_json(payload: str) -> Optional[str]:
     in_string = False
     escape = False
     stack: List[str] = []
-    last_struct_pos = -1
-    for idx, ch in enumerate(payload):
+    for ch in payload:
         if escape:
             escape = False
             continue
@@ -296,18 +296,32 @@ def _try_repair_truncated_json(payload: str) -> Optional[str]:
             continue
         if ch in "{[":
             stack.append("}" if ch == "{" else "]")
-            last_struct_pos = idx
         elif ch in "}]":
             if not stack:
                 return None
             stack.pop()
-            last_struct_pos = idx
     if not stack and not in_string:
         return None  # already balanced — repair would not help
-    truncated = payload[: last_struct_pos + 1] if last_struct_pos >= 0 else payload
+    # Den Body vollstaendig behalten. Frueher wurde hier auf das letzte
+    # Strukturzeichen zurueckgeschnitten, wodurch ``{"a": 1,`` zu ``{}``
+    # kollabierte: valides JSON, aber der Inhalt war weg und der Caller
+    # hielt das Ergebnis fuer einen Erfolg.
+    truncated = payload.rstrip()
     if in_string:
+        # Haengender Backslash: der Cap fiel in eine Escape-Sequenz hinein.
+        # Bleibt er stehen, escaped er das Anfuehrungszeichen, das wir gerade
+        # anhaengen wollen, und der String bleibt offen.
+        if escape and truncated.endswith("\\"):
+            truncated = truncated[:-1]
         truncated += '"'
     # Drop dangling ``,`` so the closer doesn't produce another parse error.
     truncated = truncated.rstrip().rstrip(",")
     truncated += "".join(reversed(stack))
+    # Nur zurueckgeben, was auch parst. Ein Abbruch hinter einem Key-Doppelpunkt
+    # oder mitten in einem Zahlen-Literal laesst sich nicht ehrlich schliessen —
+    # dann ist ``None`` die richtige Antwort, nicht ein kaputter String.
+    try:
+        json.loads(truncated)
+    except ValueError:
+        return None
     return truncated

--- a/backend/app/llm/providers/ollama.py
+++ b/backend/app/llm/providers/ollama.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from ..errors import LLMOutputTruncatedError
+
 from app.llm.providers.base import ProviderAdapter, ProviderCapabilities
 from ...utils.logger import get_logger
 
@@ -132,6 +134,16 @@ def chat_with_schema(
     if not isinstance(content, str):
         raise ValueError(
             f"Ollama /api/chat unexpected message.content type: {type(content)}"
+        )
+    # Ollama meldet einen am ``num_predict``-Limit gekappten Lauf als
+    # ``done_reason: "length"``. Ohne diese Pruefung liefe das Fragment in
+    # dieselbe JSON-Repair-Kette, die fuer den OpenAI-Pfad in ``chat()``
+    # bereits geschlossen ist — der Caller haette keine Chance, den Abbruch
+    # von einem echten Ergebnis zu unterscheiden.
+    if data.get("done_reason") == "length":
+        raise LLMOutputTruncatedError(
+            f"Ollama output truncated at num_predict: model={model}, "
+            f"max_tokens={max_tokens}"
         )
     return content
 

--- a/backend/tests/llm/test_chat_json_truncation.py
+++ b/backend/tests/llm/test_chat_json_truncation.py
@@ -1,0 +1,93 @@
+"""``chat_json`` darf abgeschnittene Antworten nicht als Erfolg ausgeben.
+
+Meldet der Provider ``finish_reason="length"``, ist die Antwort am
+Output-Cap gekappt. Syntaktisch laesst sie sich oft schliessen — semantisch
+fehlen die restlichen Felder. Der Caller bekommt dann ein Objekt, das wie
+ein Ergebnis aussieht, aber keins ist.
+
+Erwartet: ein typisierter Fehler, auf den der Caller gezielt mit einem
+kompakteren Retry reagieren kann.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from app.llm.client import LLMOutputTruncatedError
+
+
+def _make_client(model: str = "MiniMax-M3") -> Any:
+    from app.utils.llm_client import LLMClient
+
+    with patch("app.llm.client.OpenAI"):
+        return LLMClient(
+            api_key="dummy-key",
+            base_url="https://api.minimax.io/v1",
+            model=model,
+        )
+
+
+def _make_response(content: str, finish_reason: str) -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = finish_reason
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = None
+    return response
+
+
+# Am Cap gekappte Persona: display_name ist vollstaendig, persona bricht ab.
+TRUNCATED = '{"display_name": "Maya", "persona": "sehr langer abgeschnittener'
+
+
+class TestChatJsonRejectsTruncatedOutput:
+    def test_finish_reason_length_raises_typed_error(self):
+        client = _make_client()
+        response = _make_response(TRUNCATED, finish_reason="length")
+
+        with patch.object(client, "_publish_model_active"):
+            with patch("app.llm.client.llm_call_with_retry", return_value=response):
+                with pytest.raises(LLMOutputTruncatedError):
+                    client.chat_json([{"role": "user", "content": "persona bitte"}])
+
+    def test_truncation_with_schema_is_not_mistaken_for_unsupported_schema(self):
+        """Der Strict-Schema-Pfad faengt breit ``Exception``, um auf
+        ``json_object`` zurueckzufallen, wenn der Provider kein
+        ``json_schema`` kann. Eine Truncation ist kein solcher Fall — sie
+        darf keinen zweiten, gleich teuren Call ausloesen.
+        """
+
+        class PersonaSchema(BaseModel):
+            display_name: str
+            persona: str
+
+        client = _make_client()
+        response = _make_response(TRUNCATED, finish_reason="length")
+
+        with patch.object(client, "_publish_model_active"):
+            with patch(
+                "app.llm.client.llm_call_with_retry", return_value=response
+            ) as call:
+                with pytest.raises(LLMOutputTruncatedError):
+                    client.chat_json(
+                        [{"role": "user", "content": "persona bitte"}],
+                        schema=PersonaSchema,
+                    )
+
+        assert call.call_count == 1, "Truncation darf keinen Fallback-Call ausloesen"
+
+    def test_complete_response_still_parses(self):
+        """Gegenprobe: ``finish_reason="stop"`` bleibt der normale Erfolgspfad."""
+        client = _make_client()
+        response = _make_response('{"display_name": "Maya"}', finish_reason="stop")
+
+        with patch.object(client, "_publish_model_active"):
+            with patch("app.llm.client.llm_call_with_retry", return_value=response):
+                result = client.chat_json(
+                    [{"role": "user", "content": "persona bitte"}]
+                )
+
+        assert result == {"display_name": "Maya"}

--- a/backend/tests/llm/test_chat_json_truncation.py
+++ b/backend/tests/llm/test_chat_json_truncation.py
@@ -79,6 +79,81 @@ class TestChatJsonRejectsTruncatedOutput:
 
         assert call.call_count == 1, "Truncation darf keinen Fallback-Call ausloesen"
 
+    def test_native_ollama_schema_call_rejects_truncated_output(self):
+        """Der native Ollama-Pfad umgeht ``chat()`` — und damit dessen Guard.
+
+        ``/api/chat`` meldet einen am ``num_predict``-Limit gekappten Lauf mit
+        ``done_reason: "length"``. Ohne eigene Pruefung landet das Fragment in
+        derselben Repair-Kette, die fuer den OpenAI-Pfad bereits geschlossen
+        ist.
+        """
+        from app.llm.providers.ollama import chat_with_schema
+
+        class PersonaSchema(BaseModel):
+            display_name: str
+
+        http_response = MagicMock()
+        http_response.raise_for_status.return_value = None
+        http_response.json.return_value = {
+            "message": {"content": TRUNCATED},
+            "done_reason": "length",
+        }
+        http_client = MagicMock()
+        http_client.__enter__.return_value = http_client
+        http_client.post.return_value = http_response
+
+        with patch("httpx.Client", return_value=http_client):
+            with pytest.raises(LLMOutputTruncatedError):
+                chat_with_schema(
+                    base_url="http://localhost:11434/v1",
+                    model="llama3",
+                    api_key="ollama",
+                    think=False,
+                    num_ctx=8192,
+                    messages=[{"role": "user", "content": "persona bitte"}],
+                    schema=PersonaSchema,
+                    temperature=0.3,
+                    max_tokens=4096,
+                )
+
+    def test_ollama_truncation_does_not_fall_back_to_openai_wrapper(self):
+        """Der native Ollama-Pfad faellt bei Fehlern breit auf den
+        OpenAI-Wrapper zurueck — gedacht fuer Netz- und 4xx-Fehler.
+
+        Eine Truncation ist kein Transportfehler: derselbe Request ueber einen
+        anderen Transport wird wieder gekappt, nur kostet er einen zweiten
+        vollen Call. Der Abbruch muss deshalb durchschlagen.
+        """
+
+        class PersonaSchema(BaseModel):
+            display_name: str
+
+        client = _make_client()
+        client.base_url = "http://localhost:11434/v1"
+
+        http_response = MagicMock()
+        http_response.raise_for_status.return_value = None
+        http_response.json.return_value = {
+            "message": {"content": TRUNCATED},
+            "done_reason": "length",
+        }
+        http_client = MagicMock()
+        http_client.__enter__.return_value = http_client
+        http_client.post.return_value = http_response
+
+        with patch.object(client, "_publish_model_active"):
+            with patch("httpx.Client", return_value=http_client):
+                with patch("app.llm.client.llm_call_with_retry") as openai_call:
+                    with pytest.raises(LLMOutputTruncatedError):
+                        client.chat_json(
+                            [{"role": "user", "content": "persona bitte"}],
+                            schema=PersonaSchema,
+                        )
+
+        assert openai_call.call_count == 0, (
+            "Truncation darf keinen Fallback auf den OpenAI-Wrapper ausloesen"
+        )
+
     def test_complete_response_still_parses(self):
         """Gegenprobe: ``finish_reason="stop"`` bleibt der normale Erfolgspfad."""
         client = _make_client()

--- a/backend/tests/llm/test_json_repair_truncated.py
+++ b/backend/tests/llm/test_json_repair_truncated.py
@@ -42,6 +42,23 @@ class TestRepairNeverReturnsBrokenJson:
 
         assert _try_repair_truncated_json(payload) is None
 
+    def test_open_string_content_is_not_trimmed(self):
+        """Whitespace am Ende eines offenen Strings gehoert zum Wert.
+
+        Der Repair schliesst den String — er darf dessen Inhalt dabei nicht
+        veraendern. Ein ``rstrip()`` vor dem Anfuegen des Anfuehrungszeichens
+        wuerde Leerzeichen und Zeilenumbrueche verschlucken, die Teil des
+        uebertragenen Textes sind.
+        """
+        # Echtes Leerzeichen am Ende des offenen Strings — im uebertragenen
+        # Text vorhanden, weil der Cap zwischen zwei Woerter fiel.
+        payload = '{"persona": "Maya arbeitet als '
+
+        repaired = _try_repair_truncated_json(payload)
+
+        assert repaired is not None
+        assert json.loads(repaired)["persona"] == "Maya arbeitet als "
+
     def test_truncation_inside_escape_sequence_recovers_prefix(self):
         # Der Cap faellt zwischen Backslash und escaptem Zeichen. Der Backslash
         # gehoert zu einer Sequenz, die es nicht mehr gibt — er muss weg,

--- a/backend/tests/llm/test_json_repair_truncated.py
+++ b/backend/tests/llm/test_json_repair_truncated.py
@@ -1,0 +1,54 @@
+"""Verhalten von ``_try_repair_truncated_json`` an abgeschnittenem LLM-JSON.
+
+Der Repair-Pfad greift, wenn ein Provider die Antwort am Output-Cap kappt.
+Die Spezifikation ist: entweder ``None`` (nicht reparierbar) oder ein String,
+der als JSON parst **und** jedes vollstaendig uebertragene Feld erhaelt.
+Ein Ergebnis, das parst, aber den Inhalt verloren hat, ist der schlimmere
+Fall — der Caller haelt es fuer einen Erfolg.
+"""
+
+import json
+
+from app.llm.json_mode import _try_repair_truncated_json
+
+
+class TestRepairPreservesCompleteFields:
+    """Vollstaendig uebertragene Felder ueberleben den Repair."""
+
+    def test_truncation_after_complete_pair_keeps_that_pair(self):
+        # Abbruch direkt hinter einem vollstaendigen Paar plus Komma.
+        payload = '{"display_name": "Maya", "age": 34,'
+
+        repaired = _try_repair_truncated_json(payload)
+
+        assert repaired is not None, "abgeschnittenes Objekt sollte reparierbar sein"
+        parsed = json.loads(repaired)
+        assert parsed["display_name"] == "Maya"
+        assert parsed["age"] == 34
+
+
+class TestRepairNeverReturnsBrokenJson:
+    """Was zurueckkommt, parst — sonst kommt ``None`` zurueck.
+
+    Der Caller unterscheidet nur ``None`` von "String". Ein zurueckgegebener,
+    aber unparsbarer String kostet ihn einen weiteren Parse-Versuch und
+    verschleiert im Log die eigentliche Ursache.
+    """
+
+    def test_dangling_colon_is_not_repairable(self):
+        # Abbruch direkt hinter einem Key-Doppelpunkt: der Wert fehlt komplett,
+        # es gibt nichts, was man ehrlich ergaenzen koennte.
+        payload = '{"a": 1, "b":'
+
+        assert _try_repair_truncated_json(payload) is None
+
+    def test_truncation_inside_escape_sequence_recovers_prefix(self):
+        # Der Cap faellt zwischen Backslash und escaptem Zeichen. Der Backslash
+        # gehoert zu einer Sequenz, die es nicht mehr gibt — er muss weg,
+        # sonst escaped er das schliessende Anfuehrungszeichen.
+        payload = '{"display_name": "Ma\\'
+
+        repaired = _try_repair_truncated_json(payload)
+
+        assert repaired is not None
+        assert json.loads(repaired)["display_name"] == "Ma"


### PR DESCRIPTION
## Problem

Am Token-Cap gekappte LLM-Antworten kamen bei den Callern als scheinbar gültiges Ergebnis an. Zwei unabhängige Ursachen greifen dabei ineinander.

### 1. Der Repair warf den Inhalt weg

`_try_repair_truncated_json()` schnitt den Payload auf das letzte Strukturzeichen zurück. Reproduziert gegen `main`:

| Input (abgeschnitten) | Ergebnis vorher |
|---|---|
| `{"display_name":"Maya","persona":"sehr langer…` (66 Z.) | `{"}` (3 Z.) |
| `{"a":1,` | `{}` |
| `{"x":[{"y":"abc` | `{"x":[{"}]}` |

Fall 2 ist der gefährliche: `{}` ist **valides** JSON. Der Caller bekommt kein Fehlersignal, sondern ein leeres Objekt. Fälle 1 und 3 sind syntaktisch kaputt und scheitern beim `json.loads` — laut, aber wenigstens ehrlich.

### 2. `finish_reason` wurde verworfen

`chat()` loggte `finish=length` und gab den Text trotzdem zurück. `chat_json()` versuchte danach blind `json.loads` plus Repair — obwohl der Provider bereits gemeldet hatte, dass die Antwort unvollständig ist.

## Änderung

**`_try_repair_truncated_json`** behält den Body vollständig, entfernt einen hängenden Backslash aus einer abgeschnittenen Escape-Sequenz und validiert das Ergebnis mit `json.loads`, bevor es zurückgeht. Was nicht ehrlich schließbar ist (etwa ein Abbruch hinter einem Key-Doppelpunkt), liefert `None` statt eines kaputten Strings. Die dadurch tot gewordene Variable `last_struct_pos` ist entfernt.

**`chat()`** bekommt `require_complete: bool = False`. Ist es gesetzt und meldet der Provider `finish_reason == "length"`, wirft die Methode `LLMOutputTruncatedError` statt Bruchstücke zurückzugeben. Alle drei `chat()`-Aufrufe in `chat_json()` setzen es — der Repair-Pfad ist für diesen Fall damit strukturell unerreichbar, nicht nur per Konvention.

Zwei bewusste Details:

- Der Truncation-Fall wird als `success=False` telemetriert. Ihn als Erfolg zu zählen würde die Latenz- und Erfolgsstatistik verzerren.
- `LLMOutputTruncatedError` erbt von `ValueError`, damit bestehende Caller mit breitem `except` weiter greifen. Wer gezielt kompakter retryen will, fängt den Typ.

## Tests

Sechs neue Tests, test-first entwickelt (jeder Slice erst rot gesehen, außer wo unten anders vermerkt):

- `tests/llm/test_json_repair_truncated.py` (3): vollständige Felder überleben den Repair; nicht ehrlich schließbares JSON liefert `None`; Abbruch in einer Escape-Sequenz rettet den Präfix.
- `tests/llm/test_chat_json_truncation.py` (3): `finish_reason="length"` wirft den typisierten Fehler; die Gegenprobe mit `"stop"` parst normal weiter; und Truncation im Strict-Schema-Pfad wird **nicht** als „Provider kann kein `json_schema`" fehlgedeutet — sonst löst sie einen zweiten, gleich teuren Call aus. Dieser dritte Test war beim ersten Lauf bereits grün; er sichert ab, dass ein Wachsen von `_STRICT_UNSUPPORTED_HINTS` das nicht kippt.

## Verifikation

Blast-Radius (44 Testdateien mit Bezug zu `LLMClient`/`chat_json`/`json_mode`), jeweils im Container gegen `main` und gegen diesen Branch:

- `main`: 2 failed, **604 passed**
- dieser Branch: 2 failed, **610 passed**

Identische Vorbefunde, +6 = die neuen Tests. Keine Regression. Die zwei Fehlschläge sind vorbestehend und umgebungsbedingt (fehlender Provider-Key im Wegwerf-Container), nicht von dieser Änderung berührt.

`ruff check` auf allen geänderten Dateien sauber. `ruff format` bewusst nicht angewendet: die beiden Dateien sind auch auf `main` nicht format-clean, ein Reformat hier würde den Diff unlesbar machen.

## Nicht enthalten

Der Vorschlag, das Persona-Budget von 16384 auf 4096 zu senken und bei `LLMOutputTruncatedError` kompakter zu retryen, gehört fachlich dazu, ist aber eine eigene Änderung am `oasis_profile_generator` — separater PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Unvollständige KI-Antworten nach einem Token-Limit werden jetzt zuverlässig als Fehler erkannt.
  * JSON-basierte Verarbeitung akzeptiert keine abgeschnittenen oder ungültigen Antworten mehr.
  * Reparierte JSON-Antworten werden vor der Weiterverarbeitung auf Gültigkeit geprüft.
  * Vollständig übertragene JSON-Inhalte können weiterhin sicher wiederhergestellt werden.

* **Tests**
  * Abdeckung für abgeschnittene, vollständige und nicht reparierbare Antworten erweitert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->