### PR TITLE
fix(scripts,tests): lazy BERT-profile + isolate native crash under Py3.14/aarch64

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -113,7 +113,6 @@ markers = [
     "eval: baseline/eval suite (fixture-driven)",
     "llm: Echter LLM-Aufruf (Ollama-Instanz erforderlich). Ausführen mit: pytest -m llm",
     "perf: Performance-Budget-Tests (Stufe 1 deterministisch via Mock; Stufe 2 mit -m 'perf and llm' gegen echtes Ollama).",
-    "crash_py314_aarch64: Test triggert nicht-deterministischen nativen Segfault unter CPython 3.14 auf linux-aarch64 (torch-Init via oasis.social_platform.recsys bzw. pydantic/mcp-GC via camel.toolkits). Isoliert per sysconfig-Check, damit die Tests auf x86/CI aktiv bleiben. Siehe HANDOVER-2026-07-25-crash-diag-followup.md.",
 ]
 
 [tool.coverage.run]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -113,6 +113,7 @@ markers = [
     "eval: baseline/eval suite (fixture-driven)",
     "llm: Echter LLM-Aufruf (Ollama-Instanz erforderlich). Ausführen mit: pytest -m llm",
     "perf: Performance-Budget-Tests (Stufe 1 deterministisch via Mock; Stufe 2 mit -m 'perf and llm' gegen echtes Ollama).",
+    "crash_py314_aarch64: Test triggert nicht-deterministischen nativen Segfault unter CPython 3.14 auf linux-aarch64 (torch-Init via oasis.social_platform.recsys bzw. pydantic/mcp-GC via camel.toolkits). Isoliert per sysconfig-Check, damit die Tests auf x86/CI aktiv bleiben. Siehe HANDOVER-2026-07-25-crash-diag-followup.md.",
 ]
 
 [tool.coverage.run]

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -149,9 +149,9 @@ def _install_runtime_profile() -> None:
     global _memory_stop
     _bert_profile = install_bert_memory_profile()
     _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    logging.getLogger("agora.run_parallel_simulation").info("bert-memory profile = %s", _bert_profile)
     _camel_context_floor = apply_camel_context_floor()
-    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+    logging.getLogger("agora.run_parallel_simulation").info("context-patch token_limit floor = %s", _camel_context_floor)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_parallel_parser().parse_args()

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -126,11 +126,32 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__, verbose=True)
 install_max_tokens_warning_filter()
-_bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-print(f"[bert-memory] profile = {_bert_profile}", flush=True)
-_camel_context_floor = apply_camel_context_floor()
-print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+
+
+def _noop_memory_stop() -> None:
+    """No-Op-Placeholder, bis ``_install_runtime_profile()`` das echte Stop setzt."""
+
+
+# Modul-Level-Default; wird in ``_install_runtime_profile()`` überschrieben.
+# Bleibt no-op, solange das Modul nur importiert wird (z.B. durch Tests).
+_memory_stop = _noop_memory_stop
+
+
+def _install_runtime_profile() -> None:
+    """BERT-Memory-Profil + Sampler + Camel-Context-Floor installieren.
+
+    Bewusst lazy statt auf Modul-Ebene: ein Modul-Import in Tests (z.B.
+    ``test_oasis_provider_dispatch``) darf nicht ``transformers``/``torch``
+    laden. Der torch-Import crasht auf Python 3.14/aarch64 in Kombination mit
+    anderen C-Extensions im pytest-Sammelprozess (Segfault in
+    ``libtorch_python.so initModule``). Siehe HANDOVER-2026-07-25 Aufgabe 3.
+    """
+    global _memory_stop
+    _bert_profile = install_bert_memory_profile()
+    _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
+    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    _camel_context_floor = apply_camel_context_floor()
+    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_parallel_parser().parse_args()
@@ -1997,7 +2018,9 @@ async def main():
     # Create shutdown event at the start of main function to ensure the whole program can respond to exit signal
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
+    _install_runtime_profile()
+
     if not os.path.exists(args.config):
         print(f"Error: Configuration file does not exist: {args.config}")
         sys.exit(1)

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -98,9 +98,9 @@ def _install_runtime_profile() -> None:
     global _memory_stop
     _bert_profile = install_bert_memory_profile()
     _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    logging.getLogger("agora.run_reddit_simulation").info("bert-memory profile = %s", _bert_profile)
     _camel_context_floor = apply_camel_context_floor()
-    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+    logging.getLogger("agora.run_reddit_simulation").info("context-patch token_limit floor = %s", _camel_context_floor)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Reddit Simulation').parse_args()

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -75,11 +75,32 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
-_bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-print(f"[bert-memory] profile = {_bert_profile}", flush=True)
-_camel_context_floor = apply_camel_context_floor()
-print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+
+
+def _noop_memory_stop() -> None:
+    """No-Op-Placeholder, bis ``_install_runtime_profile()`` das echte Stop setzt."""
+
+
+# Modul-Level-Default; wird in ``_install_runtime_profile()`` überschrieben.
+# Bleibt no-op, solange das Modul nur importiert wird (z.B. durch Tests).
+_memory_stop = _noop_memory_stop
+
+
+def _install_runtime_profile() -> None:
+    """BERT-Memory-Profil + Sampler + Camel-Context-Floor installieren.
+
+    Bewusst lazy statt auf Modul-Ebene: ein Modul-Import in Tests darf nicht
+    ``transformers``/``torch`` laden. Der torch-Import crasht auf
+    Python 3.14/aarch64 in Kombination mit anderen C-Extensions im
+    pytest-Sammelprozess (Segfault in ``libtorch_python.so initModule``).
+    Siehe HANDOVER-2026-07-25 Aufgabe 3.
+    """
+    global _memory_stop
+    _bert_profile = install_bert_memory_profile()
+    _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
+    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    _camel_context_floor = apply_camel_context_floor()
+    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Reddit Simulation').parse_args()
@@ -890,7 +911,9 @@ async def main():
     # Create shutdown event at the start of main function
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
+    _install_runtime_profile()
+
     if not os.path.exists(args.config):
         print(f"Error: Configuration file does not exist: {args.config}")
         sys.exit(1)

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -75,11 +75,32 @@ init_runner_tracing("agora-oasis-runner")
 init_runner_logging("agora-oasis-runner")
 load_project_env(__file__)
 install_max_tokens_warning_filter()
-_bert_profile = install_bert_memory_profile()
-_memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-print(f"[bert-memory] profile = {_bert_profile}", flush=True)
-_camel_context_floor = apply_camel_context_floor()
-print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+
+
+def _noop_memory_stop() -> None:
+    """No-Op-Placeholder, bis ``_install_runtime_profile()`` das echte Stop setzt."""
+
+
+# Modul-Level-Default; wird in ``_install_runtime_profile()`` überschrieben.
+# Bleibt no-op, solange das Modul nur importiert wird (z.B. durch Tests).
+_memory_stop = _noop_memory_stop
+
+
+def _install_runtime_profile() -> None:
+    """BERT-Memory-Profil + Sampler + Camel-Context-Floor installieren.
+
+    Bewusst lazy statt auf Modul-Ebene: ein Modul-Import in Tests darf nicht
+    ``transformers``/``torch`` laden. Der torch-Import crasht auf
+    Python 3.14/aarch64 in Kombination mit anderen C-Extensions im
+    pytest-Sammelprozess (Segfault in ``libtorch_python.so initModule``).
+    Siehe HANDOVER-2026-07-25 Aufgabe 3.
+    """
+    global _memory_stop
+    _bert_profile = install_bert_memory_profile()
+    _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
+    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    _camel_context_floor = apply_camel_context_floor()
+    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Twitter Simulation').parse_args()
@@ -899,7 +920,9 @@ async def main():
     # Create shutdown event at the start of main function
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
+    _install_runtime_profile()
+
     if not os.path.exists(args.config):
         print(f"Error: Configuration file does not exist: {args.config}")
         sys.exit(1)

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -98,9 +98,9 @@ def _install_runtime_profile() -> None:
     global _memory_stop
     _bert_profile = install_bert_memory_profile()
     _memory_stop = install_memory_sampler(make_default_memory_sink(_runtime_paths.project_root))
-    print(f"[bert-memory] profile = {_bert_profile}", flush=True)
+    logging.getLogger("agora.run_twitter_simulation").info("bert-memory profile = %s", _bert_profile)
     _camel_context_floor = apply_camel_context_floor()
-    print(f"[context-patch] token_limit floor = {_camel_context_floor}", flush=True)
+    logging.getLogger("agora.run_twitter_simulation").info("context-patch token_limit floor = %s", _camel_context_floor)
 
 if __name__ == '__main__' and any(arg in sys.argv for arg in ('-h', '--help')):
     build_single_platform_parser('OASIS Twitter Simulation').parse_args()

--- a/backend/tests/scripts/_crash_skip.py
+++ b/backend/tests/scripts/_crash_skip.py
@@ -1,0 +1,39 @@
+"""Skip-Helper fuer native-Crash-Isolierung unter CPython 3.14 / linux-aarch64.
+
+Siehe ``HANDOVER-2026-07-25-crash-diag-followup.md`` (Aufgabe 3).
+
+CPython 3.14 auf linux-aarch64 crasht beim Modul-Import von
+``run_parallel_simulation`` (Modul-Level ``from oasis import ...`` zieht
+transitiv ``oasis.social_platform.recsys`` -> ``torch`` -> Segfault in
+``libtorch_python.so initModule``) bzw. im GC-Pfad
+(``camel.toolkits`` -> ``mcp`` -> ``pydantic_settings`` -> Segfault in
+``annotationlib.__forward_code__``). Beide Signaturen treten
+nicht-deterministisch an derselben Import-Zeile auf, reproduzierbar in der
+vollen ``tests/scripts``-Suite (2/2), nicht isoliert (3/3 gruen). Auf
+x86/CI bleiben die Tests aktiv.
+"""
+from __future__ import annotations
+
+import platform
+import sys
+import sysconfig
+
+import pytest
+
+_PY314_AARCH64 = (
+    sysconfig.get_platform().startswith("linux-aarch64")
+    and sys.version_info >= (3, 14)
+    and platform.machine() == "aarch64"
+)
+
+#: Skip-Marker fuer Tests, die ``run_parallel_simulation`` /
+#: ``run_reddit_simulation`` / ``run_twitter_simulation`` importieren und
+#: damit den oben beschriebenen nativen Crash-Pfad triggern.
+skipif_py314_aarch64 = pytest.mark.skipif(
+    _PY314_AARCH64,
+    reason=(
+        "Native Segfault unter CPython 3.14 / linux-aarch64 beim Import von "
+        "run_parallel_simulation (oasis -> torch / camel.toolkits -> mcp). "
+        "Isoliert, nicht per App-Code weg (siehe Handover 2026-07-25)."
+    ),
+)

--- a/backend/tests/scripts/_crash_skip.py
+++ b/backend/tests/scripts/_crash_skip.py
@@ -22,7 +22,8 @@ import pytest
 
 _PY314_AARCH64 = (
     sysconfig.get_platform().startswith("linux-aarch64")
-    and sys.version_info >= (3, 14)
+    and platform.python_implementation() == "CPython"
+    and sys.version_info[:2] == (3, 14)
     and platform.machine() == "aarch64"
 )
 

--- a/backend/tests/scripts/test_oasis_provider_dispatch.py
+++ b/backend/tests/scripts/test_oasis_provider_dispatch.py
@@ -21,13 +21,16 @@ import pytest
 # ---------------------------------------------------------------------------
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _SCRIPTS_DIR = _BACKEND_DIR / "scripts"
-if str(_SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_SCRIPTS_DIR))
+_TESTS_DIR = Path(__file__).resolve().parent
+for _p in (_SCRIPTS_DIR, _TESTS_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
 
 # Use the real camel.types — camel-ai is always installed in this venv.
 from camel.types import ModelPlatformType  # type: ignore[import]  # noqa: E402
 
 from _sim_common import detect_oasis_platform  # noqa: E402
+from _crash_skip import skipif_py314_aarch64  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +127,7 @@ def _make_model_factory_mock() -> tuple[MagicMock, list[dict[str, Any]]]:
     return mock_factory, calls
 
 
+@skipif_py314_aarch64
 class TestCreateModelGeminiBranch:
     """create_model() with a Gemini model must not touch OPENAI_BASE_URL."""
 
@@ -152,6 +156,7 @@ class TestCreateModelGeminiBranch:
         assert platform_arg == ModelPlatformType.GEMINI
 
 
+@skipif_py314_aarch64
 class TestCreateModelOpenAIBranch:
     """create_model() with an OpenAI model must set OPENAI_BASE_URL (unchanged behaviour)."""
 
@@ -182,6 +187,7 @@ class TestCreateModelOpenAIBranch:
             "OPENAI branch must not emit extra_body (think/num_ctx are Ollama-only)"
 
 
+@skipif_py314_aarch64
 class TestCreateModelMiniMaxBranch:
     """create_model() mit einem MiniMax-Modell (api.minimax.io) routet ueber den
     OpenAI-Compat-Pfad und muss den MiniMax-`thinking`-Block in
@@ -271,6 +277,7 @@ class TestCreateModelMiniMaxBranch:
         )
 
 
+@skipif_py314_aarch64
 class TestCreateModelOllamaBranch:
     """create_model() with an Ollama model must route via OllamaModel with url/api_key
     and emit think/num_ctx in extra_body — even for ``:latest`` suffixes and

--- a/backend/tests/scripts/test_oasis_route_env_binding.py
+++ b/backend/tests/scripts/test_oasis_route_env_binding.py
@@ -30,12 +30,15 @@ import pytest
 
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _SCRIPTS_DIR = _BACKEND_DIR / "scripts"
-if str(_SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_SCRIPTS_DIR))
+_TESTS_DIR = Path(__file__).resolve().parent
+for _p in (_SCRIPTS_DIR, _TESTS_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
 
 from app.contracts.llm_routing_contract import ResolvedRoute  # noqa: E402
 from app.services.llm_routing_seed import build_route_subprocess_env  # noqa: E402
 from app.services.sim.process_manager import SAFE_ENV_KEYS  # noqa: E402
+from _crash_skip import skipif_py314_aarch64  # noqa: E402
 
 MODEL_ID = "MiniMax-M3"
 
@@ -111,6 +114,7 @@ def stub_servers() -> Iterator[tuple[HTTPServer, HTTPServer]]:
         server.server_close()
 
 
+@skipif_py314_aarch64
 def test_registry_provider_route_reaches_provider_endpoint_not_stale_env(
     stub_servers: tuple[HTTPServer, HTTPServer],
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -2,8 +2,14 @@ import importlib.util
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Skip-Helper fuer native-Crash-Isolierung unter CPython 3.14 / linux-aarch64.
+# _load_module("run_parallel_simulation") triggert denselben nicht-deterministischen
+# Segfault-Pfad (oasis -> torch / camel.toolkits -> mcp -> pydantic-GC) wie der
+# direkte Import in tests/scripts. Siehe HANDOVER-2026-07-25-crash-diag-followup.md.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "scripts"))
+from _crash_skip import skipif_py314_aarch64  # noqa: E402
 
 
 RUNNER_SCRIPTS = (
@@ -31,6 +37,7 @@ def _load_module(module_name: str, relative_path: str):
             sys.path.remove(parent_dir)
 
 
+@skipif_py314_aarch64
 def test_resolve_model_runtime_settings_cloud(monkeypatch):
     module = _load_module("run_parallel_simulation_test", "backend/scripts/run_parallel_simulation.py")
 
@@ -49,6 +56,7 @@ def test_resolve_model_runtime_settings_cloud(monkeypatch):
     assert settings["is_cloud_model"] is True
 
 
+@skipif_py314_aarch64
 def test_resolve_model_runtime_settings_local(monkeypatch):
     module = _load_module("run_parallel_simulation_test_local", "backend/scripts/run_parallel_simulation.py")
 


### PR DESCRIPTION
## Was

Isoliert zwei unabhängige native Segfaults unter **CPython 3.14 / linux-aarch64**, die in ~29–38 % der Suite reproduzierbar waren und CI rot gemacht haben. Beide pre-existing, keiner ist ein App-Logik-Bug.

## Crash 1 — torch-Import auf Modul-Ebene (lazy verschoben)

Die drei Sim-Runner riefen `install_bert_memory_profile()` auf Modul-Ebene auf. Unter Py 3.14/aarch64 crasht der Modul-Import mit Segfault in `libtorch_python.so initModule` bei `PyModule_AddFunctions` (transformers → torch).

**Fix:** Aufruf lazy in `_install_runtime_profile()` ausgelagert, läuft nur in `main()`. `_memory_stop` bekommt No-Op-Default `_noop_memory_stop`, wird per `global` überschrieben.

| Datei | Modul-Level (vorher) | `main()` |
|---|---|---|
| `backend/scripts/run_parallel_simulation.py` | ~Z. 129 | ~Z. 2020 |
| `backend/scripts/run_reddit_simulation.py` | ~Z. 78 | ~Z. 915 |
| `backend/scripts/run_twitter_simulation.py` | ~Z. 78 | ~Z. 923 |

### Befund: Crash 1 nicht vollständig gehoben

`run_parallel_simulation.py:207` importiert auf Modul-Ebene `from oasis import ...`, das transitiv `oasis.social_platform.recsys:26` → `import torch` zieht. Dieser implizite torch-Pfad steht noch — der lazy-Fix hat nur `install_bert_memory_profile()` verschoben. In 2/2 Suite-Läufen trat einmal die pydantic/mcp-GC-Signatur, einmal die `libtorch_python.so`-Signatur auf (nicht-deterministisch, dieselbe Import-Zeile). Die Isolierung (s.u.) deckt beide Signaturen ab. Vollständige Wurzelbehebung würde Modul-Level `from oasis import` erfordern — Follow-up.

## Crash 2 — Pydantic-GC / `camel.toolkits` → `mcp`-Import (isoliert)

Bei Modul-Import von `run_parallel_simulation` lädt `camel.agents.chat_agent` transitiv `camel.toolkits` → `mcp` → `pydantic_settings`. Unter Py 3.14/aarch64 crasht der GC in `annotationlib.__forward_code__` / `typing.__or__`. **Nicht per App-Code weg** (Alex, 2026-07-25 via AskUserQuestion). Isoliert per `sysconfig.get_platform()`-Skip.

## Isolierung

- Neuer Helper `backend/tests/scripts/_crash_skip.py` exposes `skipif_py314_aarch64` (sysconfig `linux-aarch64` + CPython ≥ 3.14).
- Neue pytest-Marker `crash_py314_aarch64` in `pyproject.toml`.
- **9 Tests** in `tests/scripts` (4 `TestCreateModel*Branch`-Klassen + `test_registry_provider_route_reaches_provider_endpoint_not_stale_env`) + **2 `_load_module`-Tests** in `tests/test_simulation_runtime.py` werden unter Py3.14/aarch64 geskippt. Auf x86/CI bleiben sie aktiv.

## Verifikation

- `tests/scripts`: **192 passed, 9 skipped, EXIT 0** (vorher SIGSEGV 139).
- `tests/` (volle Suite): **3507 passed, 21 skipped, EXIT 1** wegen 6 pre-existing LLM-Connection-Failures (Ollama nicht erreichbar — identisch auf `main` verifiziert, 0-Zeilen-Diff der 3 betroffenen Dateien).
- `ruff check`: **All checks passed.**
- CRG-Graph aktualisiert (13 Dateien, 261 Knoten).

## Siehe auch

- `HANDOVER-2026-07-25-crash-diag-followup.md` (Aufgabe 3)

## Folgearbeiten (separat)

- Crash-1-Wurzelbehebung: Modul-Level `from oasis import` in `run_parallel_simulation.py:207` lazy machen (größerer CRG-Impact, separates Ticket).
- Aufgaben 1, 2, 4 aus dem Vorgänger-Handover (Persona-Token-Budget, doppelte `_fix_truncated_json`, drei kleinere Tickets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Verbesserungen**
  - Simulationen starten Profiling- und Speicherüberwachung erst beim tatsächlichen Programmstart statt beim Import.
  - Der Startvorgang belastet dadurch Import- und Testumgebungen weniger.
  - Statusmeldungen werden konsistent über die Protokollierung ausgegeben.

- **Tests**
  - Bestimmte Tests werden auf betroffenen Python-3.14-Linux-AArch64-Umgebungen automatisch übersprungen, um native Abstürze zu vermeiden.
  - Die Testinitialisierung findet lokale Hilfsmodule zuverlässiger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->