### PR TITLE
chore(runner): decouple Ollama preflight probe from sim startup

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -442,6 +442,17 @@ _PERMANENT_STATUS = {401, 403, 404}
 _TRANSIENT_STATUS = {408, 429, 500, 502, 503, 599}
 
 
+def _should_skip_preflight() -> bool:
+    """True, wenn der Preflight-Probe per ``AGORA_SKIP_PREFLIGHT=1`` deaktiviert ist.
+
+    Opt-out-Schalter (Default: ``0``/unset → Probe läuft). Entkoppelt den
+    Sim-Start von der Ollama-/Provider-Verfügbarkeit — nützlich für Tests,
+    Mock-Backends und Offline-Entwicklung. Produktive Container bleiben
+    unberührt (kein Default-Verhaltenswechsel). Siehe Issue #871.
+    """
+    return os.environ.get("AGORA_SKIP_PREFLIGHT", "0") == "1"
+
+
 def preflight_model_probe(
     model: Any,
     *,
@@ -456,6 +467,10 @@ def preflight_model_probe(
     sowie nicht behebbare oder nach den Wiederholungen weiterhin bestehende Fehler
     werden als `ValueError` gemeldet. Ausnahmen anderer Plattformen werden unverändert
     weitergegeben.
+
+    Skip: Per ``AGORA_SKIP_PREFLIGHT=1`` (Opt-out, Default off) wird der Probe
+    vollständig übersprungen — die Simulation kann dann ohne erreichbares Ollama
+    starten (Tests, Mock-Backends, Offline-Entwicklung). Eine Warnung wird geloggt.
     
     Parameters:
     	model (Any): Das zu prüfende Modell.
@@ -465,6 +480,12 @@ def preflight_model_probe(
     Raises:
     	ValueError: Wenn ein permanenter oder nicht behebbarer Provider-Fehler auftritt.
     """
+    if _should_skip_preflight():
+        logging.getLogger("agora._sim_common").warning(
+            "preflight probe skipped via AGORA_SKIP_PREFLIGHT"
+        )
+        return
+
     import openai
 
     probe_messages = [{"role": "user", "content": "ping"}]

--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -482,7 +482,8 @@ def preflight_model_probe(
     """
     if _should_skip_preflight():
         logging.getLogger("agora._sim_common").warning(
-            "preflight probe skipped via AGORA_SKIP_PREFLIGHT"
+            "preflight probe skipped via AGORA_SKIP_PREFLIGHT",
+            extra={"event": "preflight_skipped", "env": "AGORA_SKIP_PREFLIGHT"},
         )
         return
 

--- a/backend/tests/scripts/test_oasis_preflight.py
+++ b/backend/tests/scripts/test_oasis_preflight.py
@@ -6,7 +6,11 @@ Verifiziert die beiden Akzeptanzkriterien aus dem OASIS-404-Fix:
   den Fan-out mit N identischen Fehlern laufen zu lassen;
 - der Probe ruft ``model.run`` genau einmal (kein eigener Fan-out, kein
   Mehrfach-Call bei dauerhaftem Fehler).
+
+Zusätzlich (Issue #871): der Probe ist per ``AGORA_SKIP_PREFLIGHT=1`` per Opt-out
+deaktivierbar, damit die Simulation ohne erreichbares Ollama starten kann.
 """
+
 from __future__ import annotations
 
 import sys
@@ -21,6 +25,7 @@ _SCRIPTS_DIR = _BACKEND_DIR / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
+import _sim_common  # noqa: E402
 from _sim_common import preflight_model_probe  # noqa: E402
 
 
@@ -121,3 +126,52 @@ class TestPreflightRunsOnce:
             preflight_model_probe(model, max_retries=2, backoff_base=0.0)
 
         assert model.run.call_count == 3  # 1 initial + 2 retries
+
+
+class TestPreflightSkipSwitch:
+    """Issue #871: ``AGORA_SKIP_PREFLIGHT=1`` entkoppelt den Sim-Start von der
+    Ollama-/Provider-Verfügbarkeit (Opt-out, Default off → Probe läuft)."""
+
+    def test_default_probes_model_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default (ENV nicht gesetzt) → Probe wird ausgeführt, ``model.run`` genau einmal."""
+        monkeypatch.delenv("AGORA_SKIP_PREFLIGHT", raising=False)
+        model = MagicMock()
+        model.run.return_value = MagicMock(name="ok")
+
+        preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 1, (
+            "Ohne AGORA_SKIP_PREFLIGHT muss der Probe ausgeführt werden."
+        )
+
+    def test_skip_env_skips_probe_and_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``AGORA_SKIP_PREFLIGHT=1`` → Probe wird übersprungen, ``model.run``
+        nie aufgerufen, Warnung geloggt."""
+        monkeypatch.setenv("AGORA_SKIP_PREFLIGHT", "1")
+        model = MagicMock()
+
+        with caplog.at_level("WARNING", logger="agora._sim_common"):
+            preflight_model_probe(model, max_retries=3)
+
+        assert model.run.call_count == 0, (
+            "Bei gesetztem AGORA_SKIP_PREFLIGHT darf model.run nicht aufgerufen werden."
+        )
+        assert any(
+            "preflight probe skipped via AGORA_SKIP_PREFLIGHT" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        ), "Skip muss eine WARNUNG mit dem dokumentierten Wortlaut loggen."
+
+    def test_skip_helper_reads_env_lazily(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``_should_skip_preflight`` liest ENV live — Änderung zur Laufzeit
+        wird respektiert (kein Modul-Level-Cache des Werts)."""
+        monkeypatch.delenv("AGORA_SKIP_PREFLIGHT", raising=False)
+        assert _sim_common._should_skip_preflight() is False
+        monkeypatch.setenv("AGORA_SKIP_PREFLIGHT", "1")
+        assert _sim_common._should_skip_preflight() is True
+        monkeypatch.setenv("AGORA_SKIP_PREFLIGHT", "0")
+        assert _sim_common._should_skip_preflight() is False


### PR DESCRIPTION
Fixes #871

## Summary
preflight_model_probe was always called at sim startup, coupling it to Ollama availability. Now skippable via AGORA_SKIP_PREFLIGHT=1 (opt-out, default unchanged — productive containers still probe). Warning logged on skip.

## Acceptance criteria
- [x] ENV-configurable (AGORA_SKIP_PREFLIGHT=1 opt-out), default: probe
- [x] All runner call sites respect the switch (via preflight_model_probe itself)
- [x] Warning logged on skip
- [x] Regression tests: default probes, env skips
- [x] Existing preflight tests stay green
- [x] ruff + mypy + pytest-contracts green

## Test plan
- [x] ruff check (scripts + tests)
- [x] mypy scripts/_sim_common.py (0 new errors vs main baseline)
- [x] pytest tests/scripts/test_oasis_preflight.py (9 passed: 6 existing + 3 new)
- [ ] pytest tests/contracts/ — requires full app stack (flask/jsonschema/...), verified in CI

## Notes
- Runner tests may be skipped under Py3.14/aarch64 via skipif_py314_aarch64 (PR #867) — verified on x86/CI.
- Minimal invasive: skip logic lives in preflight_model_probe itself, no call-site changes needed (all 4 callers use fire-and-forget).
- preflight_model_probe returns None on skip — compatible with all callers (none use the return value).

Refs #871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Der Preflight-Modelltest kann optional übersprungen werden, wenn `AGORA_SKIP_PREFLIGHT=1` gesetzt ist.
  * Beim Überspringen wird eine Warnung geloggt und der Verbindungs-„Ping“ inkl. Wiederholungen nicht ausgeführt.
  * Laufzeitänderungen an der Umgebungsvariablen werden berücksichtigt.

* **Tests**
  * Das Verhalten für aktivierte und deaktivierte Option wurde erweitert und verifiziert.
  * Es wird geprüft, dass im Skip-Fall kein Aufruf des Modell-Checks erfolgt und eine Warnung mit dem erwarteten Inhalt erzeugt wird.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->