### PR TITLE
refactor(persona): remove duplicate _fix_truncated_json in oasis_profile_generator

### DIFF
--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -34,6 +34,7 @@ from .persona_quota_defaults import (
     build_industry_quota_prompt_block_en,
     default_dach_industry_quota,
 )
+from ..llm.json_mode import _try_repair_truncated_json
 
 logger = get_logger('agora.oasis_profile')
 
@@ -761,35 +762,20 @@ class OasisProfileGenerator:
             missing_fields.append(f"voice_register: invalid value '{vr}'")
 
         return missing_fields
-    
-    def _fix_truncated_json(self, content: str) -> str:
-        """Fix truncated JSON (output truncated by max_tokens limit)"""
 
-        # If JSON is truncated, try to close it
-        content = content.strip()
-
-        # Count unclosed parentheses
-        open_braces = content.count('{') - content.count('}')
-        open_brackets = content.count('[') - content.count(']')
-
-        # Check for unclosed strings
-        # Simple check: if last character is not comma or closing bracket, string might be truncated
-        if content and content[-1] not in '",}]':
-            # Try to close the string
-            content += '"'
-
-        # Close parentheses
-        content += ']' * open_brackets
-        content += '}' * open_braces
-
-        return content
-    
     def _try_fix_json(self, content: str, entity_name: str, entity_type: str, entity_summary: str = "") -> Dict[str, Any]:
         """Try to fix corrupted JSON"""
         import re
 
-        # 1. First try to fix truncated case
-        content = self._fix_truncated_json(content)
+        # 1. First try to fix truncated case via the centralized repair helper
+        # (Issue #869). Returns the repaired payload or None when no
+        # structural recovery is possible — in which case we keep the
+        # original content and let the regex/json.loads fallbacks below
+        # attempt their own recovery (newline sanitization, partial-field
+        # extraction, etc.).
+        repaired = _try_repair_truncated_json(content)
+        if repaired is not None:
+            content = repaired
 
         # 2. Try to extract JSON portion
         json_match = re.search(r'\{[\s\S]*\}', content)

--- a/backend/tests/test_oasis_profile_generator.py
+++ b/backend/tests/test_oasis_profile_generator.py
@@ -198,9 +198,23 @@ def test_fix_truncated_json_method_removed():
     )
 
 
-def test_try_fix_json_truncated_input_recovers_via_centralized_helper():
+def test_try_fix_json_truncated_input_recovers_via_centralized_helper(monkeypatch):
     """Issue #869: _try_fix_json delegates truncation repair to the centralized helper."""
     from app.llm.json_mode import _try_repair_truncated_json
+
+    # Spy that delegates to the real helper — proves _try_fix_json actually
+    # routes through the centralized function (and not via a reintroduced
+    # local repair path). Issue #869.
+    calls = []
+
+    def spy(payload):
+        calls.append(payload)
+        return _try_repair_truncated_json(payload)
+
+    monkeypatch.setattr(
+        "app.services.oasis_profile_generator._try_repair_truncated_json",
+        spy,
+    )
 
     gen = _make_generator()
     # Truncated mid-string: opening brace, key, value cut before the closing quote.
@@ -224,6 +238,10 @@ def test_try_fix_json_truncated_input_recovers_via_centralized_helper():
         f"truncated input must be marked _fixed=True, got: {result!r}"
     )
     assert "bio" in result
+    assert calls == [truncated], (
+        f"_try_fix_json must delegate to the centralized helper with the original "
+        f"truncated payload, got spy calls: {calls!r}"
+    )
 
 
 def test_try_fix_json_valid_input_parses_without_repair():

--- a/backend/tests/test_oasis_profile_generator.py
+++ b/backend/tests/test_oasis_profile_generator.py
@@ -187,3 +187,64 @@ def test_persona_profile_schema_rejects_age_out_of_range():
             raise AssertionError(f"age={bad_age} should be rejected")
         except ValidationError:
             pass
+
+
+def test_fix_truncated_json_method_removed():
+    """Issue #869: _fix_truncated_json duplication must be removed."""
+    gen = _make_generator()
+    assert not hasattr(gen, "_fix_truncated_json"), (
+        "Issue #869: OasisProfileGenerator._fix_truncated_json must be removed; "
+        "truncation repair is delegated to app.llm.json_mode._try_repair_truncated_json."
+    )
+
+
+def test_try_fix_json_truncated_input_recovers_via_centralized_helper():
+    """Issue #869: _try_fix_json delegates truncation repair to the centralized helper."""
+    from app.llm.json_mode import _try_repair_truncated_json
+
+    gen = _make_generator()
+    # Truncated mid-string: opening brace, key, value cut before the closing quote.
+    truncated = '{"bio": "Lena lebt in Münch'
+
+    # Sanity: the centralized helper repairs this case (closes the open string
+    # and the unclosed top-level brace).
+    repaired = _try_repair_truncated_json(truncated)
+    assert repaired is not None, "centralized helper must repair this case"
+    assert repaired.endswith('"}'), (
+        f"centralized helper must close the open string + brace, got: {repaired!r}"
+    )
+
+    # Regression: _try_fix_json still recovers the payload and marks it as fixed.
+    result = gen._try_fix_json(
+        truncated, entity_name="Lena", entity_type="Person",
+        entity_summary="Lena lebt in München",
+    )
+    assert isinstance(result, dict)
+    assert result.get("_fixed") is True, (
+        f"truncated input must be marked _fixed=True, got: {result!r}"
+    )
+    assert "bio" in result
+
+
+def test_try_fix_json_valid_input_parses_without_repair():
+    """Issue #869: valid JSON parses via the unchanged downstream path (regex/json.loads)."""
+    import json as _json
+
+    gen = _make_generator()
+    valid = _json.dumps({
+        "bio": "Mobilitätsberaterin aus München.",
+        "persona": "Ausführliche Personenbeschreibung.",
+        "age": 41,
+        "gender": "female",
+        "mbti": "INTJ",
+        "country": "DE",
+        "voice_register": "neutral-de",
+    })
+
+    result = gen._try_fix_json(
+        valid, entity_name="Lena", entity_type="Person",
+        entity_summary="Lena lebt in München",
+    )
+    assert isinstance(result, dict)
+    assert result.get("bio") == "Mobilitätsberaterin aus München."
+    assert result.get("_fixed") is True


### PR DESCRIPTION
Fixes #869

## Summary
oasis_profile_generator._fix_truncated_json was a pre-#866 copy of the JSON-truncation-repair logic, superseded by app.llm.json_mode._try_repair_truncated_json (added in PR #866). _try_fix_json now delegates to the centralized helper; the duplicate method is removed.

## Acceptance criteria
- [x] Audit: zentrales repair-Modul existiert (app.llm.json_mode._try_repair_truncated_json)
- [x] _try_fix_json ruft die zentrale Variante auf; behält Fallback wenn Helper None liefert
- [x] Regression-Test: _try_fix_json mit trunciertem Persona-JSON produziert dasselbe Ergebnis
- [x] _fix_truncated_json entfernt, keine toten Verweise
- [x] ruff check ✓, mypy ✓ (no new errors in app/services/oasis_profile_generator.py), pytest ✓ (7 passed in test_oasis_profile_generator.py)

## Notes
- Centralized helper (json_mode.py:272) tracks in-string state, handles dangling backslashes, validates via json.loads. Lessons learned from #866 are encoded there (see json_mode.py L305-308).
- Out of scope (noted, not addressed in this PR): simulation_config_generator.py also has a duplicate _fix_truncated_json (~L496, L526, L549). Tracked separately if/when desired.

Refs #869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behobene Fehler**
  * Die Verarbeitung abgeschnittener oder fehlerhafter JSON-Antworten wurde verbessert und kann wiederhergestellte Inhalte zuverlässig übernehmen.
  * Gültige JSON-Daten bleiben unverändert und werden weiterhin zuverlässig verarbeitet.
* **Tests**
  * Zusätzliche Regressionstests decken die Wiederherstellung trunkierter JSON-Inhalte ab.
  * Es wird geprüft, dass bei gültigen Eingaben kein unnötiger Reparaturpfad genutzt wird und die Ausgabe wie erwartet bleibt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->