### PR TITLE
fix(tests): ruff-Verstöße in test_bert_memory_profile.py beheben

### DIFF
--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -41,7 +41,6 @@ import os
 import sys
 import time
 from pathlib import Path
-from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -53,7 +52,6 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 from _sim_common import install_bert_memory_profile  # noqa: E402
 from _sim_common import install_memory_sampler  # noqa: E402
-from _sim_common import _read_rss_mb_linux  # noqa: E402
 
 
 @pytest.fixture
@@ -99,10 +97,10 @@ class _DummyKwargs(dict):
         Liefert den Wert des angegebenen Attributnamens aus dem Wörterbuch.
         
         Parameter:
-        	name (str): Der abzurufende Attributname.
-        
+            name (str): Der abzurufende Attributname.
+
         Returns:
-        	Der zugehörige Wert oder `None`, wenn der Name nicht vorhanden ist.
+            Der zugehörige Wert oder `None`, wenn der Name nicht vorhanden ist.
         """
         return self.get(name)
 
@@ -207,7 +205,7 @@ def test_low_profile_preserves_user_overrides(
         Erfasst die Schlüsselwortargumente eines Aufrufs und liefert einen Mock zurück.
         
         Returns:
-        	mock.Mock: Ein neuer Mock als Rückgabewert des Aufrufs.
+            mock.Mock: Ein neuer Mock als Rückgabewert des Aufrufs.
         """
         captured.append(_kwargs)
         return mock.Mock()
@@ -243,7 +241,7 @@ def test_memory_sampler_writes_ndjson_when_enabled(
         """Liest den nächsten RSS-Speicherwert aus der Testsequenz.
         
         Returns:
-        	float: Der nächste konfigurierte RSS-Wert in Megabyte.
+            float: Der nächste konfigurierte RSS-Wert in Megabyte.
         """
         return next(rss_values)
 


### PR DESCRIPTION
## Release-Ziel
`0.9.0` Stability Beta — Repo-Hygiene. Kein Issue-Slice, sondern die Behebung eines Defekts auf `main`, der jeden Backend-Slice lokal blockiert hat.

## Root Cause
`backend/tests/scripts/test_bert_memory_profile.py` kam mit PR #859 (`bf80dd09`) ins Repo und verletzt seitdem ruff:

- 2× `F401` — `types.SimpleNamespace` und `_sim_common._read_rss_mb_linux` importiert, nirgends verwendet (je genau ein Vorkommen in der Datei: die Import-Zeile selbst)
- 4× `E101` — vier Docstring-Zeilen mit Tab- statt Space-Einrückung

Damit war `uv run ruff check app/ tests/` auf reinem `main` rot, und `scripts/pre-push-gate.sh backend` brach am allerersten Schritt ab — für jeden, der einen Backend-Slice bearbeitet.

**Warum das durchkam:** Das verpflichtende CI-PR-Gate lintet nur `app/` (`.github/workflows/ci.yml:281`), während das lokale Gate `app/ tests/` prüft. Das lokale Gate ist strenger als CI. Diese Divergenz ist die eigentliche Ursache und wird als eigenes Issue nachgezogen — ohne sie passiert dasselbe wieder.

## Scope
Nur die sechs gemeldeten Verstöße in der einen Datei. Reine Lint-Korrektur, keine Verhaltensänderung.

## Out-of-Scope
- die CI/lokal-Divergenz selbst (eigenes Issue)
- andere Lint-Baselines, `per-file-ignores` in `pyproject.toml`
- inhaltliche Änderungen an den Tests

## Tests
`uv run pytest tests/scripts/test_bert_memory_profile.py` — 11 passed, unverändert gegenüber vorher. Die entfernten Importe wurden vorab auf Verwendung geprüft, nicht blind per `ruff --fix` entfernt.

## Gate
`uv run ruff check app/ tests/` → `All checks passed!` (auf `main` vorher: 6 Fehler).

`bash scripts/pre-push-gate.sh backend` läuft nach diesem Fix bis zum letzten Schritt durch und bricht dort an einem **zweiten, unabhängigen** main-Defekt ab: `docs/STATUS.md` dokumentiert 172 Frontend-Test-Files, real sind es 173 (`sync-status.sh --check` ist auf reinem main exit 1).

Dieser Drift wird durch PR #877 (Issue #833) geheilt, der eine Testdatei löscht und die reale Zahl auf 172 bringt. **Merge-Reihenfolge daher: #877 zuerst, dann dieser PR.** Ein eigener STATUS-Commit hier wäre kontraproduktiv — er würde nach dem #877-Merge sofort wieder driften.

## Subagents und Modelle
Vollständig vom Lead (Opus 5) ausgeführt — bei sechs Lint-Verstößen ist ein Worker-Dispatch teurer als der Fix. Der Befund selbst stammt vom #868-Worker, der korrekt an seiner Stop-Bedingung anhielt statt eine fremde Datei anzufassen.

## Matt-Pocock-Skills
Keiner. Reine Lint-Korrektur ohne Designentscheidung.

## Dokumentationssync
Keiner.

## Risiken
Keine. Die beiden entfernten Importe sind nachweislich unbenutzt, die Tab-Ersetzungen betreffen ausschließlich Docstring-Text. Alle 11 Tests der Datei bleiben grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo55HzjhQwyXQEJAzrF8TJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Testbeschreibungen und Importangaben im BERT-Memory-Profiling wurden bereinigt.
  * Die Testlogik und erwarteten Ergebnisse bleiben unverändert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->