### PR TITLE
feat(persona): max_tokens-Budget aus AGORA_PERSONA_DETAIL_LEVEL ableiten

### DIFF
--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -75,16 +75,19 @@ PERSONA_DETAIL_LEVELS = {
         'word_count_de': '300–500 Wörter',
         'word_count_en': '300–500 words',
         'context_limit': 1200,
+        'max_tokens': 8192,
     },
     'standard': {
         'word_count_de': '700–900 Wörter',
         'word_count_en': '700–900 words',
         'context_limit': 2000,
+        'max_tokens': 16384,
     },
     'rich': {
         'word_count_de': '1500–2000 Wörter',
         'word_count_en': '2000 words',
         'context_limit': 3000,
+        'max_tokens': 32768,
     },
 }
 
@@ -628,6 +631,8 @@ class OasisProfileGenerator:
         """
 
         is_individual = self._is_individual_entity(entity_type)
+        detail_level = _resolve_persona_detail_level()
+        max_tokens = detail_level['max_tokens']
 
         if is_individual:
             prompt = self._build_individual_persona_prompt(
@@ -666,7 +671,7 @@ class OasisProfileGenerator:
                 result = llm.chat_json(
                     messages=messages,
                     temperature=0.7 - (attempt * 0.1),
-                    max_tokens=16384,
+                    max_tokens=max_tokens,
                     schema=PersonaProfileSchema,
                     schema_name="persona_profile",
                     context="persona",

--- a/backend/tests/test_oasis_profile_generator.py
+++ b/backend/tests/test_oasis_profile_generator.py
@@ -23,6 +23,8 @@ ontology-generator fix in PR #858.
 
 from __future__ import annotations
 
+import pytest
+
 from app.services import oasis_profile_generator as _mod
 from app.services.oasis_profile_generator import (
     OasisProfileGenerator,
@@ -165,6 +167,67 @@ def test_generate_profile_with_llm_uses_sufficient_max_tokens(monkeypatch):
     assert captured["max_tokens"] >= 16384, (
         "max_tokens must be >= 16384 — M3 produces 2349+ token personas and "
         "8192 truncated mid-JSON"
+    )
+
+
+@pytest.mark.parametrize('level,expected_max_tokens', [
+    ('compact', 8192),
+    ('standard', 16384),
+    ('rich', 32768),
+])
+def test_generate_profile_with_llm_derives_max_tokens_from_detail_level(
+    monkeypatch, level, expected_max_tokens,
+):
+    """Issue #868: max_tokens must be derived from AGORA_PERSONA_DETAIL_LEVEL.
+
+    compact/standard/rich map to 8192/16384/32768 so the output token budget
+    tracks the requested persona detail level instead of a fixed constant.
+    """
+    monkeypatch.setenv('AGORA_PERSONA_DETAIL_LEVEL', level)
+    import app.llm.client as _client_mod
+    monkeypatch.setattr(_client_mod, "LLMClient", _CapturingLLMClient)
+
+    gen = _make_generator()
+    gen._generate_profile_with_llm(
+        entity_name="ADFC Muenchen",
+        entity_type="CyclingAdvocate",
+        entity_summary="Cycling advocacy group.",
+        entity_attributes={},
+        context="Radweg-Konflikt München",
+    )
+
+    captured = _CapturingLLMClient.last_instance.captured_kwargs
+    assert captured is not None, "chat_json was not called"
+    assert captured["max_tokens"] == expected_max_tokens, (
+        f"AGORA_PERSONA_DETAIL_LEVEL={level!r} must yield max_tokens="
+        f"{expected_max_tokens}, got {captured['max_tokens']}"
+    )
+
+
+def test_generate_profile_with_llm_unknown_detail_level_uses_standard_max_tokens(
+    monkeypatch,
+):
+    """Issue #868: unknown AGORA_PERSONA_DETAIL_LEVEL falls back to 'standard'
+    budget (16384), mirroring _resolve_persona_detail_level's existing
+    fallback (with logger.warning)."""
+    monkeypatch.setenv('AGORA_PERSONA_DETAIL_LEVEL', 'bogus')
+    import app.llm.client as _client_mod
+    monkeypatch.setattr(_client_mod, "LLMClient", _CapturingLLMClient)
+
+    gen = _make_generator()
+    gen._generate_profile_with_llm(
+        entity_name="ADFC Muenchen",
+        entity_type="CyclingAdvocate",
+        entity_summary="Cycling advocacy group.",
+        entity_attributes={},
+        context="Radweg-Konflikt München",
+    )
+
+    captured = _CapturingLLMClient.last_instance.captured_kwargs
+    assert captured is not None, "chat_json was not called"
+    assert captured["max_tokens"] == 16384, (
+        "Unknown AGORA_PERSONA_DETAIL_LEVEL must fall back to 'standard' "
+        "max_tokens=16384, matching _resolve_persona_detail_level's default"
     )
 
 


### PR DESCRIPTION
Closes #868

## Release-Ziel
`0.9.0` Stability Beta. Follow-up zu PR #866 (`fix(llm): abgeschnittenes JSON nicht mehr als Erfolg ausgeben`).

## Root Cause / Ausgangszustand
`_generate_profile_with_llm` rief `llm.chat_json(...)` mit hartkodiertem `max_tokens=16384` auf. Das Detail-Level steuerte über `PERSONA_DETAIL_LEVELS` bereits Wortzahl und `context_limit`, blieb beim Token-Budget aber wirkungslos. Damit hing die Truncation-Absicherung aus #866 an einem Konstantwert statt am tatsächlich angeforderten Output.

## Scope
- `PERSONA_DETAIL_LEVELS` je Level um `max_tokens` erweitert: `compact`=8192, `standard`=16384, `rich`=32768
- `_resolve_persona_detail_level()` wird in `_generate_profile_with_llm` aufgerufen, **vor** der Retry-Schleife — kein Re-Resolve je Versuch
- `max_tokens=16384` durch das abgeleitete Budget ersetzt

**Harte Randbedingung, vom Lead vorgegeben:** `standard` bleibt auf exakt 16384. Der #866-Regressionstest `test_generate_profile_with_llm_uses_sufficient_max_tokens` setzt kein `AGORA_PERSONA_DETAIL_LEVEL`, läuft also gegen den Default `standard` und assertet `>= 16384`. Ein niedrigerer Wert hätte ihn still gebrochen.

## Out-of-Scope
- `context_limit`, `word_count_de`, `word_count_en`
- Retry-Logik, `temperature`, `force_no_thinking`, Prompt-Texte
- `chat_json`-Signatur, JSON-Schema, Contracts

## Tests
`mattpocock-skills:tdd`, RED vor GREEN.

RED:
```
AssertionError: AGORA_PERSONA_DETAIL_LEVEL='compact' must yield max_tokens=8192, got 16384
assert 16384 == 8192
```
GREEN: 11 passed, inklusive des unveränderten #866-Tests.

Die neuen Tests mocken `LLMClient` über die bestehende `_CapturingLLMClient`-Infrastruktur und rufen den realen Codepfad; geprüft wird der tatsächlich an `chat_json` übergebene Kwarg, nicht die Konstante gegen sich selbst. Parametrisiert über alle drei Level plus Fallback-Test für unbekanntes Level.

**Nachweis, dass der #866-Test unangetastet ist:** `git diff 2b2138b6...HEAD -- backend/tests/test_oasis_profile_generator.py | grep '^-'` liefert keine einzige Zeile. Der Diff an der Testdatei ist rein additiv.

## Gate
Pflichtprüfungen, alle grün:
- `pytest tests/test_oasis_profile_generator.py -x -q` — 11 passed
- `pytest tests/contracts/ -x -q` — 384 passed
- `dump_schemas --check` — 46 Schemas, kein Drift
- `mypy app` — Success, 230 Dateien
- `ruff check app/services/oasis_profile_generator.py tests/test_oasis_profile_generator.py` — All checks passed

`bash scripts/pre-push-gate.sh backend` ist **noch rot**, aus zwei Gründen, die beide nicht von diesem Slice stammen:
1. ruff-Verstöße in `tests/scripts/test_bert_memory_profile.py` → behoben in PR #879
2. `docs/STATUS.md`-Drift (172 dokumentiert, 173 real) → geheilt durch PR #877

**Merge-Reihenfolge: #877 → #879 → dieser PR.** Danach rebase ich und fahre das vollständige Gate. Ich behaupte kein grünes Gate, das ich nicht gesehen habe.

## Build-Verifikation
Entfällt — Backend-Slice ohne Bundle-Auswirkung.

## Subagents und Modelle
Implementierung: Worker "Terra" auf Sonnet, isolierter Worktree, ein atomarer Commit, kein Push. Stoppte korrekt an der Gate-Stop-Bedingung, statt eine fremde Datei zu fixen.
Vorgabe des Mappings, Randbedingung `standard`=16384, Verifikation: Lead (Opus 5).
Review: read-only Reviewer auf Sonnet.

## Matt-Pocock-Skills
`tdd` (RED→GREEN belegt), `code-review` (zweiachsig Standards/Spec).

## Dokumentationssync
Keiner.

## Review-Ergebnis
CHANGES-REQUESTED, ein Finding — vom Lead geprüft und **begründet abgelehnt**:

> `_resolve_persona_detail_level()` wird jetzt zweimal pro Persona-Generierung aufgerufen (neu in `_generate_profile_with_llm:634`, weiterhin in den Prompt-Buildern bei 869/988). Bei unbekanntem Level erscheint die Warnung dadurch doppelt.

Der Befund ist faktisch korrekt. Nicht in diesem Slice behoben, weil der vorgeschlagene Fix `detail_level` durchreicht und damit die Signatur zweier weiterer Methoden ändert — das Issue nennt Refactoring von `_resolve_persona_detail_level()` über das Nötige hinaus ausdrücklich als Out-of-Scope. Der Effekt tritt ausschließlich bei fehlkonfiguriertem Level auf und ist eine Verdopplung von einer auf zwei Warnungen, kein Multiplikator (der Aufruf liegt außerhalb der Retry-Schleife, vom Reviewer verifiziert). Der Reviewer stuft ihn selbst als "sollte, kein Blocker" ein. Folgt als eigenes Issue.

Alle übrigen Achsen: sauber. Der Reviewer bestätigt Mapping-Plausibilität (compact=8192 lässt gegenüber dem historischen Worst-Case von 2349 Tokens rund 3,5× Marge), korrekte Aufrufplatzierung und echte statt tautologische Regressionstests.

## Risiken
`rich` fordert jetzt 32768 statt 16384 Tokens an. Bei Providern mit niedrigerem Output-Limit kann das abgelehnt werden — betrifft nur Läufe mit explizit gesetztem `AGORA_PERSONA_DETAIL_LEVEL=rich`, `standard` und `compact` bleiben unter dem alten Wert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo55HzjhQwyXQEJAzrF8TJ