### PR TITLE
ci(status): STATUS.md-Drift im PR-Gate prüfen statt nach dem Merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,14 @@ jobs:
         working-directory: backend
         run: uv run pytest tests/contracts/ -q
 
+      # 2026-07-25 wieder aktiviert (Issue #883). Der 2026-05-17 entfernte Job
+      # lief auf push:main und meldete Drift erst nach dem Merge. Hier laeuft er
+      # auf dem PR und verhindert ihn. Kein eigener Job: uv, Dependencies und
+      # Checkout stehen in diesem Gate bereits, und der Frontend-Zaehler braucht
+      # nur das Repo. Exit 2 = Messfehler, nicht Drift.
+      - name: STATUS.md drift check
+        run: bash scripts/sync-status.sh --check
+
   frontend-pr-gate:
     name: Frontend PR smoke gate (lint + typecheck + test + build)
     runs-on: ubuntu-latest
@@ -334,6 +342,8 @@ jobs:
         working-directory: frontend
         run: bun run build
 
-  # 2026-05-17 entfernt: status-sync (MAI-16). Lief nur auf push:main,
-  # doppelt sich mit dem alten contract-gates::status-sync-drift Job,
-  # der ebenfalls entfernt wurde. STATUS.md bleibt manuell pflegbar.
+  # 2026-05-17 entfernt: status-sync (MAI-16) als eigener Job — lief nur auf
+  # push:main und doppelte sich mit contract-gates::status-sync-drift.
+  # 2026-07-25 (Issue #883): Die Pruefung ist als Step im backend-pr-gate
+  # zurueck, wo sie auf dem PR laeuft statt nach dem Merge. Kein eigener Job,
+  # daher auch keine Doppelung mehr.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3508 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3570 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -40,6 +40,11 @@ FRONTEND_VERSION=$(get_version_from_json "$REPO_ROOT/frontend/package.json")
 ROOT_VERSION=$(get_version_from_json "$REPO_ROOT/package.json")
 
 BACKEND_TESTS="unknown"
+# Unterscheidet "Messung fehlgeschlagen" von "Wert gemessen". Ohne dieses Flag
+# meldet --check bei einem fehlgeschlagenen Collect-Lauf faelschlich Drift,
+# weil "unknown" gegen die dokumentierte Zahl diffed.
+BACKEND_TESTS_MEASURED=false
+COLLECT_FAILURE_REASON=""
 if command -v uv &>/dev/null; then
   # Optional timeout: GNU coreutils auf Linux/CI, gtimeout auf macOS, sonst kein Wrapper.
   if command -v timeout &>/dev/null; then
@@ -54,13 +59,18 @@ if command -v uv &>/dev/null; then
     MATCH=$(grep -oE '[0-9]+ tests collected' "$COLLECT_TMP" | grep -oE '[0-9]+' | head -1 || true)
     if [[ -n "$MATCH" ]]; then
       BACKEND_TESTS="$MATCH"
+      BACKEND_TESTS_MEASURED=true
     else
       echo "WARNING: pytest --collect-only ran but no count found" >&2
+      COLLECT_FAILURE_REASON="pytest --collect-only lieferte keine auswertbare Testanzahl"
     fi
   else
     echo "WARNING: pytest --collect-only timed out or failed — keeping 'unknown'" >&2
+    COLLECT_FAILURE_REASON="pytest --collect-only ist fehlgeschlagen oder ins Timeout gelaufen"
   fi
   rm -f "$COLLECT_TMP"
+else
+  COLLECT_FAILURE_REASON="uv ist nicht installiert — Backend-Testanzahl nicht messbar"
 fi
 
 FRONTEND_TEST_FILES=$(find "$REPO_ROOT/frontend/src" \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \) 2>/dev/null | wc -l | tr -d ' ')
@@ -131,6 +141,16 @@ replace_block "TESTS"    "$TESTS_BLOCK"    "$TARGET_FILE"
 # --check: compare and report
 # ---------------------------------------------------------------------------
 if [[ "$CHECK_MODE" == true ]]; then
+  # Messfehler ist kein Drift. Ohne diese Unterscheidung wuerde ein
+  # fehlgeschlagener Collect-Lauf als inhaltliche Abweichung gemeldet und das
+  # Gate mit irrefuehrender Begruendung rot faerben.
+  if [[ "$BACKEND_TESTS_MEASURED" != true ]]; then
+    echo "MESSFEHLER: Backend-Testanzahl konnte nicht ermittelt werden." >&2
+    echo "Grund: ${COLLECT_FAILURE_REASON:-unbekannt}" >&2
+    echo "Das ist KEIN STATUS.md-Drift — die Pruefung selbst ist fehlgeschlagen." >&2
+    rm -f "$TARGET_FILE"
+    exit 2
+  fi
   if diff -q "$STATUS_FILE" "$TARGET_FILE" >/dev/null 2>&1; then
     echo "OK: docs/STATUS.md in sync" >&2
     rm -f "$TARGET_FILE"


### PR DESCRIPTION
Closes #883

## Release-Ziel
`0.9.0` Stability Beta. ROADMAP-Kriterium: "`docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft".

## Root Cause
Der `status-sync`-Job wurde am 17.05.2026 mit PR #516 ("PR-Pipeline entschlacken, 13 → 6 Checks") entfernt. Die Begründung im Code war korrekt: er lief nur auf `push:main` und doppelte sich mit dem ebenfalls entfernten `contract-gates::status-sync-drift`.

Übrig blieb allerdings **gar keine** automatische Prüfung. `docs/STATUS.md` driftete daraufhin unbemerkt: Backend-Testanzahl stand auf 3508, real waren es 3570 — 62 Tests Differenz, aufgelaufen über viele PRs. Aufgefallen ist es erst, als ein Backend-Slice am lokalen Gate hängenblieb.

## Warum nicht der alte Job zurück
Auf `push:main` läuft die Prüfung **nach** dem Merge. Sie hätte den Drift protokolliert, nicht verhindert — genau das ist passiert. Die Prüfung gehört auf den PR.

## Scope

**1. Drift-Check als Step im bestehenden `backend-pr-gate`**
Kein eigener Job. Das Gate setzt uv, Dependencies und Checkout bereits auf, und der Frontend-Zähler braucht nur das Repo — der Step kostet damit kein zweites Setup. Nebeneffekt: die von #516 kritisierte Job-Doppelung entsteht gar nicht erst wieder.

**2. `sync-status.sh` gehärtet — Messfehler ist kein Drift**
Bisher setzte das Skript bei fehlgeschlagenem oder ins 180s-Timeout gelaufenem `pytest --collect-only` still `BACKEND_TESTS="unknown"` und fuhr fort. `--check` diffte dann "unknown" gegen die dokumentierte Zahl und meldete "DRIFT: docs/STATUS.md weicht von autogenerated Inhalt ab" — obwohl kein Drift vorlag, sondern die Messung fehlgeschlagen war.

Als blockierendes Pflicht-Gate wäre das flaky mit irreführender Fehlermeldung gewesen. Das ist exakt die Art Flakiness, gegen die #516 antrat; ohne diese Härtung hätte der Wiedereinbau den alten Fehler reproduziert.

`--check` unterscheidet jetzt:
- exit 0 — in sync
- exit 1 — echter Drift, mit Diff
- exit 2 — Messfehler, mit Grund und dem expliziten Hinweis, dass es kein Drift ist

**3. STATUS.md einmalig synchronisiert** (3508 → 3570)
Ohne das wäre das neue Gate ab dem ersten PR rot.

## Out-of-Scope
- Auto-Commit von STATUS.md durch CI
- Format oder Marker-Blöcke von STATUS.md
- die separate CI/lokal-Lint-Divergenz (#881)
- die manuell gepflegten STATUS-Abschnitte (Layer-Status, Coverage, Milestone) — das Skript fasst nur die Marker-Blöcke an

## Tests
Alle drei Pfade gezielt provoziert und verifiziert:

| Fall | Erwartet | Ergebnis |
|---|---|---|
| STATUS.md in sync | exit 0 | `OK: docs/STATUS.md in sync` |
| `uv` nicht auffindbar (Messfehler) | exit 2, kein "DRIFT" | `MESSFEHLER: … Das ist KEIN STATUS.md-Drift` |
| Zahl manuell auf 9999 verfälscht | exit 1 | `DRIFT: …` |

YAML-Syntax per `yaml.safe_load` validiert, Step-Reihenfolge im `backend-pr-gate` geprüft.

## Gate
`bash scripts/pre-push-gate.sh backend` → `ALL GREEN`, exit 0. Der `sync-status --check`-Schritt meldet `OK: docs/STATUS.md in sync`.

Das ist der erste vollständig grüne Backend-Gate-Lauf dieser Serie — vorher blockierten nacheinander der ruff-Verstoß (PR #879) und dieser Drift.

## Build-Verifikation
Entfällt — CI- und Skript-Änderung ohne Bundle-Auswirkung.

## Subagents und Modelle
Vollständig vom Lead (Opus 5). Kleiner, präziser CI-Eingriff mit Design-Entscheidung (Step statt Job, Messfehler-Trennung) — ein Worker-Briefing wäre teurer als die Umsetzung gewesen.

## Matt-Pocock-Skills
Keiner. Die Verifikation läuft über die drei provozierten Exit-Pfade, nicht über eine Testsuite; `sync-status.sh` hat keine.

## Dokumentationssync
`docs/STATUS.md` auf den realen Stand gebracht. Der `ci.yml`-Kommentar zur Entfernung von 2026-05-17 wurde nicht gelöscht, sondern um Rückkehr und Begründung ergänzt — die Historie bleibt nachvollziehbar.

## Review-Ergebnis
Lead-Review. Der kritische Punkt war nicht der Wiedereinbau selbst, sondern dass ein naiver Wiedereinbau ein flakiges Pflicht-Gate erzeugt hätte. Deshalb die Härtung im selben Slice.

## Risiken
`pytest --collect-only` kostet im Gate rund 50 Sekunden. Vertretbar, weil kein zusätzliches Setup anfällt.

Bleibt die Gesamt-Testanzahl in CI aus Umgebungsgründen hinter dem lokalen Wert zurück (etwa durch Import-Fehler bei optionalen Dependencies), meldet das Gate Drift statt Messfehler — der Collect-Lauf war ja erfolgreich, nur mit anderem Ergebnis. Sollte das auftreten, ist der nächste Schritt, die Backend-Zahl aus dem Auto-Block zu nehmen und nur die deterministischen Werte zu prüfen. Der erste PR gegen dieses Gate zeigt es.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo55HzjhQwyXQEJAzrF8TJ