### PR TITLE
chore(ci): LlmProfilePicker.vue nach Löschung in REMOVED_PATHS aufnehmen

### DIFF
--- a/.github/scripts/check_legacy_model_picker.py
+++ b/.github/scripts/check_legacy_model_picker.py
@@ -14,8 +14,10 @@ folgende Importe einführen:
 * ``@/store/llmRoutingDefaults``
 * ``@/composables/useRuntimeLlmOptions``
 
-Seit Slice 7.7 blockiert der Check außerdem die Rückkehr des entfernten
-v3-Pickers und der unverdrahteten Mock-Routing-Komponenten als Dateien.
+Seit Slice 7.7 blockiert der Check außerdem die Rückkehr entfernter Dateien
+(``REMOVED_PATHS``): der v3-Picker und die unverdrahteten
+Mock-Routing-Komponenten aus 7.7 sowie ``LlmProfilePicker.vue`` aus Issue
+#834. Hier reicht die bloße Existenz der Datei — ein Import ist nicht nötig.
 
 Read-Adapter-Freigabe via ``@deprecated``
 =========================================
@@ -24,9 +26,11 @@ Nach 5.5 gibt es keinen Opt-in-Marker mehr. Stattdessen erkennt der Check das
 ``@deprecated``-JSDoc-Tag am **Ziel** des Imports: Trägt die importierte Datei
 selbst ein ``@deprecated``-Tag, gilt sie als sanktionierter Read-Adapter im
 Deprecation-/Read-only-Fenster und der Import ist erlaubt. So dürfen die
-bestehenden v3-Consumer (Step-Views, WorkspaceHeader, …) die deprecateten
-Picker/Composables weiter lesen, ohne pro-Datei-Marker zu tragen — während
-jeder *neu* eingeführte, nicht-deprecatete v3-Pfad hart blockiert wird.
+bestehenden v3-Consumer (``WorkspaceHeader`` → ``ActiveModelBadge``,
+``Step2EnvSetup``/``Step3Simulation`` → ``useRuntimeLlmOptions``) die
+deprecateten Picker/Composables weiter lesen, ohne pro-Datei-Marker zu
+tragen — während jeder *neu* eingeführte, nicht-deprecatete v3-Pfad hart
+blockiert wird.
 
 Die alten Stores (``llmProviders``/``llmProfiles``/``llmRoutingDefaults``)
 existieren nach 5.5 nicht mehr als Datei (konsolidiert in
@@ -109,6 +113,10 @@ REMOVED_PATHS: tuple[tuple[Path, str], ...] = (
     (
         Path("components/ui/ModelPicker.vue"),
         "v3 ModelPicker.vue wurde in Slice 7.7 entfernt",
+    ),
+    (
+        Path("components/llm/LlmProfilePicker.vue"),
+        "v3 LlmProfilePicker.vue wurde in Issue #834 entfernt",
     ),
     (
         Path("views/Settings/llmRouting/ActiveSnapshotsCard.vue"),
@@ -342,7 +350,7 @@ def main(argv: list[str] | None = None) -> int:
     if not results:
         print(
             f"check_legacy_model_picker: clean ({target}) — "
-            f"no v3 picker imports or removed Slice 7.7 paths found.",
+            f"no v3 picker imports or returned removed paths found.",
             file=sys.stderr,
         )
         return 0

--- a/.github/scripts/test_check_legacy_model_picker.py
+++ b/.github/scripts/test_check_legacy_model_picker.py
@@ -128,12 +128,14 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_deprecated_target_allows_import(self) -> None:
         # Ziel-Datei trägt @deprecated → sanktionierter Read-Adapter.
+        # ActiveModelBadge.vue (nicht in REMOVED_PATHS) statt LlmProfilePicker.vue,
+        # da letzterer Pfad in REMOVED_PATHS steht und schon bei Existenz blockt.
         _write(
-            self.root / "components/llm/LlmProfilePicker.vue",
+            self.root / "components/ActiveModelBadge.vue",
             (
                 "<script setup lang=\"ts\">\n"
                 "/**\n"
-                " * @deprecated Slice 5.5 — v3-Picker, Read-Adapter bis 5.6.\n"
+                " * @deprecated Slice 5.5 — v3-Badge, Read-Adapter bis 5.6.\n"
                 " */\n"
                 "</script>\n"
             ),
@@ -148,7 +150,7 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
             self.root / "consumer.vue",
             (
                 "<script setup lang=\"ts\">\n"
-                "import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'\n"
+                "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n"
                 "import { useRuntimeLlmOptions } from '@/composables/useRuntimeLlmOptions'\n"
                 "</script>\n"
             ),
@@ -166,15 +168,17 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_non_deprecated_target_still_flags(self) -> None:
         # Ziel existiert, trägt aber KEIN @deprecated → Verstoß.
+        # ActiveModelBadge.vue statt LlmProfilePicker.vue, damit der Treffer
+        # aus der Import-Regel stammt und nicht aus REMOVED_PATHS.
         _write(
-            self.root / "components/llm/LlmProfilePicker.vue",
+            self.root / "components/ActiveModelBadge.vue",
             "<script setup lang=\"ts\">\n// kein Tag\n</script>\n",
         )
         _write(
             self.root / "consumer.vue",
             (
                 "<script setup lang=\"ts\">\n"
-                "import LlmProfilePicker from '@/components/llm/LlmProfilePicker.vue'\n"
+                "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n"
                 "</script>\n"
             ),
         )
@@ -189,7 +193,7 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
             1,
             "nicht-deprecatetes Ziel darf nicht durchgehen",
         )
-        self.assertIn("LlmProfilePicker.vue", proc.stdout)
+        self.assertIn("ActiveModelBadge.vue", proc.stdout)
         self.assertIn("llmProviders", proc.stdout)
 
     # ------------------------------------------------------------------
@@ -263,7 +267,32 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
             self.assertIn(Path(relative_path).name, proc.stdout)
 
     # ------------------------------------------------------------------
-    # 9. GH-Actions-Format: ::error file=…,line=…,col=…
+    # 9. Entfernter LlmProfilePicker (Issue #834) darf nicht zurückkehren
+    # ------------------------------------------------------------------
+    def test_removed_llm_profile_picker_path_is_caught(self) -> None:
+        # Reine Datei-Existenz reicht — kein Import nötig. Ein @deprecated-Tag
+        # rettet die Datei nicht, weil REMOVED_PATHS vor der Import-Prüfung greift.
+        _write(
+            self.root / "components/llm/LlmProfilePicker.vue",
+            (
+                "<script setup lang=\"ts\">\n"
+                "/** @deprecated in Issue #834 entfernt. */\n"
+                "</script>\n"
+            ),
+        )
+
+        proc = _run(self.root)
+
+        self.assertEqual(
+            proc.returncode,
+            1,
+            f"zurückgekehrter LlmProfilePicker muss exit 1 ergeben\nstdout={proc.stdout}",
+        )
+        self.assertIn("LlmProfilePicker.vue", proc.stdout)
+        self.assertIn("#834", proc.stdout)
+
+    # ------------------------------------------------------------------
+    # 10. GH-Actions-Format: ::error file=…,line=…,col=…
     # ------------------------------------------------------------------
     def test_github_format_emits_annotation(self) -> None:
         _write(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (CI-Gate: `LlmProfilePicker.vue` gegen Rückkehr gesperrt — 2026-07-26, Issue #889)
+
+- **`.github/scripts/check_legacy_model_picker.py`** — `components/llm/LlmProfilePicker.vue`
+  ist jetzt in `REMOVED_PATHS` eingetragen. Die Datei wurde in Issue #834 physisch gelöscht,
+  der Guard blockte bis dahin aber nur *Importe* des v3-Pickers über `FORBIDDEN_SUBSTRINGS` —
+  eine wieder eingecheckte Datei wäre also unbemerkt durchgelaufen. **Neues CI-Verhalten:**
+  Der Check schlägt jetzt allein bei Datei-Existenz fehl (Exit 1, kein Import nötig); ein
+  `@deprecated`-JSDoc-Tag hebt die Sperre nicht auf, weil `REMOVED_PATHS` vor der
+  Read-Adapter-Freigabe greift. Für `components/ui/ModelPicker.vue` galt das seit Slice 7.7
+  bereits.
+- Modul-Docstring korrigiert: Er beschrieb die `@deprecated`-Read-Adapter-Freigabe noch über
+  „Step-Views", die es nicht mehr gibt (Steps liegen unter `frontend/src/views/v4/steps/`).
+  Jetzt benannt sind die tatsächlichen v3-Consumer — `WorkspaceHeader` → `ActiveModelBadge`,
+  `Step2EnvSetup`/`Step3Simulation` → `useRuntimeLlmOptions`. Die Clean-Meldung sprach von
+  „removed Slice 7.7 paths" und ist durch den #834-Eintrag quellenneutral formuliert.
+- **`.github/scripts/test_check_legacy_model_picker.py`** — neuer Test
+  `test_removed_llm_profile_picker_path_is_caught` (10 statt 9 Tests). Die Fixtures der
+  `@deprecated`-Tests laufen jetzt über `ActiveModelBadge.vue` statt `LlmProfilePicker.vue`,
+  da letzterer Pfad durch `REMOVED_PATHS` schon bei Existenz blockt und die Read-Adapter-
+  Semantik sonst nicht mehr isoliert prüfbar wäre.
+- **`docs/runbooks/pre-push-gate.md`** — Abschnitt „Legacy-Picker-Check" um den Absatz
+  „Entfernte Dateien (`REMOVED_PATHS`)" ergänzt, Consumer-Aussage auf den Ist-Stand gebracht,
+  Testzahl `8` → `10` korrigiert.
+- Verifikation: `python3 .github/scripts/test_check_legacy_model_picker.py` → 10 Tests grün;
+  `python3 .github/scripts/check_legacy_model_picker.py --no-github frontend/src` → Exit 0.
+
 ### Changed (Legacy-Modell-Picker konsolidiert: `LlmProfilePicker` → `AiModelPicker` — 2026-07-25, Issue #834)
 
 - **`frontend/src/components/Step4Report.vue`** — der v3-Profil-Picker-Block (`LlmProfilePicker`

--- a/docs/runbooks/pre-push-gate.md
+++ b/docs/runbooks/pre-push-gate.md
@@ -92,9 +92,17 @@ Opt-in-Marker `legacy-model-picker-allow` ist entfallen. Ein verbotener
 Import ist jetzt genau dann erlaubt, wenn das **importierte Ziel** selbst
 ein `@deprecated`-JSDoc-Tag trägt — also ein sanktionierter Read-Adapter
 im Deprecation-/Read-only-Fenster ist. So dürfen die verbleibenden
-v3-Consumer (Step-Views, `WorkspaceHeader`) die deprecateten
-Picker/Composables weiter lesen, ohne pro-Datei-Marker. Jeder *neu*
-eingeführte, nicht-deprecatete v3-Pfad wird hart blockiert.
+v3-Consumer (`layouts/WorkspaceHeader.vue` → `ActiveModelBadge.vue`,
+`Step2EnvSetup.vue`/`Step3Simulation.vue` → `useRuntimeLlmOptions.ts`) die
+deprecateten Composables/Komponenten weiter lesen, ohne pro-Datei-Marker.
+Jeder *neu* eingeführte, nicht-deprecatete v3-Pfad wird hart blockiert.
+
+**Entfernte Dateien (`REMOVED_PATHS`):** Zusätzlich zur Import-Prüfung
+blockiert der Check die *Rückkehr* gelöschter v3-Dateien — hier reicht die
+bloße Existenz, ein Import ist nicht nötig, und ein `@deprecated`-Tag
+rettet sie nicht. Erfasst sind `components/ui/ModelPicker.vue` und die
+Mock-Routing-UI unter `views/Settings/llmRouting/` (beide Slice 7.7) sowie
+`components/llm/LlmProfilePicker.vue` (in Issue #834 entfernt).
 
 Die Alt-Stores (`llmProviders`/`llmProfiles`/`llmRoutingDefaults`)
 existieren nach 5.5 nicht mehr (konsolidiert in `@/store/aiModels`); ihr
@@ -108,4 +116,4 @@ Unit-Tests für den Check selbst:
 python3 .github/scripts/test_check_legacy_model_picker.py
 ```
 
-(8 Stdlib-`unittest`-Tests, kein `pip install nötig`.)
+(10 Stdlib-`unittest`-Tests, kein `pip install nötig`.)


### PR DESCRIPTION
Closes #889

## Problem

`.github/scripts/check_legacy_model_picker.py` blockte bislang nur **Importe** des v3-Pickers über `FORBIDDEN_SUBSTRINGS`. `frontend/src/components/llm/LlmProfilePicker.vue` wurde in Issue #834 physisch gelöscht (Commit `01c2b6c1`, gemerged via #891), fehlte aber in `REMOVED_PATHS` — die Datei hätte also unbemerkt zurückkehren können, ohne dass ein Gate anschlägt. Für den älteren `ModelPicker.vue` existiert diese Absicherung bereits.

## Änderungen

**`check_legacy_model_picker.py`**
- `Path("components/llm/LlmProfilePicker.vue")` in `REMOVED_PATHS`, Begründung „in Issue #834 entfernt"
- Modul-Docstring beschrieb die Read-Adapter-Freigabe noch über „Step-Views", die es nicht mehr gibt (Steps liegen jetzt unter `views/v4/steps/`). Ersetzt durch die tatsächlichen v3-Consumer: `WorkspaceHeader` → `ActiveModelBadge`, `Step2EnvSetup`/`Step3Simulation` → `useRuntimeLlmOptions`
- `REMOVED_PATHS`-Absatz im Docstring deckt jetzt beide Entfernungs-Quellen ab (Slice 7.7 + #834) und stellt klar, dass die bloße Datei-Existenz blockt
- Clean-Meldung sagte „no v3 picker imports or removed **Slice 7.7** paths found" — durch den #834-Eintrag faktisch falsch, jetzt quellenneutral formuliert

**`test_check_legacy_model_picker.py`**
- Neuer Test `test_removed_llm_profile_picker_path_is_caught` — deckt den REMOVED_PATHS-Eintrag ab und verifiziert, dass ein `@deprecated`-Tag den Pfad *nicht* rettet
- Fixtures in `test_deprecated_target_allows_import` (#3) und `test_non_deprecated_target_still_flags` (#4) von `LlmProfilePicker.vue` auf `ActiveModelBadge.vue` umgestellt. Nötig, weil beide Tests den Pfad als Fixture anlegten und `scan()` ihn jetzt schon bei Existenz flaggt — #3 (erwartet exit 0) wäre sonst gebrochen. `ActiveModelBadge.vue` ist ebenfalls `@deprecated` und ebenfalls verbotener Specifier, aber nicht in `REMOVED_PATHS`, die Read-Adapter-Semantik bleibt also unverändert getestet

**`docs/runbooks/pre-push-gate.md`** (Abschnitt „Legacy-Picker-Check")
- Consumer-Aussage auf den Ist-Stand gebracht (identisch zum Docstring)
- Neuer Absatz „Entfernte Dateien (`REMOVED_PATHS`)" — erklärt Existenz-statt-Import-Prüfung und listet alle erfassten Pfade
- Testzahl `8` → `10` korrigiert (stand bereits vor diesem Slice falsch)

## Verifikation

```
$ python3 .github/scripts/test_check_legacy_model_picker.py
Ran 10 tests in 0.431s
OK

$ python3 .github/scripts/check_legacy_model_picker.py --no-github frontend/src
check_legacy_model_picker: clean (frontend/src) — no v3 picker imports or returned removed paths found.
exit=0
```

Kein Frontend-Gate angefasst (Scope-Vorgabe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Der Legacy-v3-LLM-Profil-Picker-Check blockiert die Rückkehr gelöschter V3-Komponenten bereits anhand der reinen Dateiexistenz – ohne Import erforderlich.
  * Bestehende deprecate-zugelassene Lesezugriffe werden nun genauer von neuen, nicht freigegebenen Verwendungen abgegrenzt.

* **Dokumentation**
  * Das Pre-Push-Runbook wurde präzisiert: Fokus auf Regeln für entfernte Dateien sowie aktualisierte Hinweise zur Testabdeckung.

* **Tests**
  * Zusätzlicher Test für den entfernten LLM-Profil-Picker, inklusive Verifikation von Exit-Code und Ausgabe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->