### PR TITLE
test(backend): allowed_override_keys gegen Regression festschreiben (#887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Added (Branch-Override-Whitelist gegen Regression festgeschrieben — 2026-07-26, Issue #887)
+
+- **`backend/tests/contracts/test_branch_override_contract.py`** — neue Contract-Suite
+  (27 Tests) für `services/branching_service.py::allowed_override_keys`. Die Whitelist ist
+  die einzige Stelle, die entscheidet, welche Branch-Overrides das Backend akzeptiert, und
+  war bis hierher komplett ungetestet — die vorhandenen Branch-Tests
+  (`tests/api/test_simulation_endpoints.py`, `tests/test_simulation_api_routes.py`) decken
+  nur den fehlenden `branch_name` ab. Genau diese Lücke hat den in #886 beschriebenen
+  Defekt unbemerkt bestehen lassen.
+- **Wirkung statt Nicht-Ablehnung:** je ein Test pro erlaubtem Key (`llm_model`, `language`,
+  `max_agents`, `time_config`, `enable_twitter`, `enable_reddit`, `persona_additions`,
+  `persona_removals`), der belegt, dass der Override im Branch-Artefakt landet — in der
+  `simulation_config`, im `SimulationState` oder in den Reddit-Profilen. Zusätzlich gepinnt:
+  `time_config` wird gemerged statt ersetzt, `None`/`""` sind Nicht-Overrides, und die
+  Quell-Simulation bleibt unverändert.
+- **Ablehnungspfad:** unbekannter Key → `ValueError("Unsupported branch overrides: …")`, die
+  Fehlermeldung listet alle unbekannten Keys sortiert, der Guard greift vor jedem
+  Seiteneffekt (kein Branch entsteht), und über `utils/api_responses.handle_api_errors`
+  wird daraus HTTP 400 am Endpoint `POST /api/simulation/<id>/branch`.
+- **Whitelist als Ganzes:** `test_whitelist_matches_pinned_expectation` liest das Set-Literal
+  per AST aus `branching_service.py` und vergleicht es gegen die im Test gepinnte Menge.
+  Nötig, weil die Whitelist eine lokale Variable in `create_branch` und damit nicht
+  importierbar ist — und weil ein *stilles Hinzufügen* eines Keys verhaltensbasiert nicht
+  erkennbar wäre (der Key-Raum ist unendlich). Damit wird sowohl Hinzufügen als auch
+  Entfernen rot.
+- Verortung in `tests/contracts/`, weil dieses Verzeichnis im verpflichtenden PR-Smoke-Gate
+  und im Pre-Push-Gate läuft (`uv run pytest tests/contracts/ -x -q`). Die Whitelist ist ein
+  API-Vertrag gegenüber dem Frontend (`components/step4/ReportBranchControls.vue`); ein Drift
+  soll im Gate auffallen, nicht erst im Full-Run.
+- **Kein Produktivcode-Fix:** die Suite schreibt ausschließlich den Ist-Zustand fest. Ob
+  `ai_model_ref` in die Whitelist gehört, entscheidet #886 — der Key steht hier bewusst in
+  der Negativliste des Ablehnungspfads.
+- Verifikation: `uv run pytest tests/contracts/test_branch_override_contract.py -q` → 27 grün.
+  Zusätzlich drei Mutationstests gegen den Produktivcode, alle gefangen: `language` aus der
+  Wirkungs-Schleife entfernt → `test_language` rot; `ai_model_ref` still zur Whitelist
+  hinzugefügt → 3 Tests rot; `time_config` still entfernt → 3 Tests rot.
+
 ### Changed (CI-Gate: `LlmProfilePicker.vue` gegen Rückkehr gesperrt — 2026-07-26, Issue #889)
 
 - **`.github/scripts/check_legacy_model_picker.py`** — `components/llm/LlmProfilePicker.vue`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 ### Added (Branch-Override-Whitelist gegen Regression festgeschrieben — 2026-07-26, Issue #887)
 
 - **`backend/tests/contracts/test_branch_override_contract.py`** — neue Contract-Suite
-  (27 Tests) für `services/branching_service.py::allowed_override_keys`. Die Whitelist ist
+  (28 Tests) für `services/branching_service.py::allowed_override_keys`. Die Whitelist ist
   die einzige Stelle, die entscheidet, welche Branch-Overrides das Backend akzeptiert, und
   war bis hierher komplett ungetestet — die vorhandenen Branch-Tests
   (`tests/api/test_simulation_endpoints.py`, `tests/test_simulation_api_routes.py`) decken
@@ -19,7 +19,11 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   `persona_removals`), der belegt, dass der Override im Branch-Artefakt landet — in der
   `simulation_config`, im `SimulationState` oder in den Reddit-Profilen. Zusätzlich gepinnt:
   `time_config` wird gemerged statt ersetzt, `None`/`""` sind Nicht-Overrides, und die
-  Quell-Simulation bleibt unverändert.
+  Quell-Simulation bleibt unverändert. Die Quell-Simulation setzt `enable_twitter=False`
+  und `enable_reddit=True` explizit, damit jeder Plattform-Override den Ausgangswert
+  umdrehen muss — `create_simulation` hat für beide `True` als Default, ein Override auf
+  `True` wäre also auch bei reinem Erben grün (Codex-Finding P2 auf PR #893). Ein
+  Gegentest hält fest, dass ohne Override tatsächlich geerbt wird.
 - **Ablehnungspfad:** unbekannter Key → `ValueError("Unsupported branch overrides: …")`, die
   Fehlermeldung listet alle unbekannten Keys sortiert, der Guard greift vor jedem
   Seiteneffekt (kein Branch entsteht), und über `utils/api_responses.handle_api_errors`
@@ -40,7 +44,8 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - Verifikation: `uv run pytest tests/contracts/test_branch_override_contract.py -q` → 27 grün.
   Zusätzlich drei Mutationstests gegen den Produktivcode, alle gefangen: `language` aus der
   Wirkungs-Schleife entfernt → `test_language` rot; `ai_model_ref` still zur Whitelist
-  hinzugefügt → 3 Tests rot; `time_config` still entfernt → 3 Tests rot.
+  hinzugefügt → 3 Tests rot; `time_config` still entfernt → 3 Tests rot; Plattform-Overrides
+  auf reines Erben umgestellt → 2 Tests rot; `enable_twitter` hartkodiert → 1 Test rot.
 
 ### Changed (CI-Gate: `LlmProfilePicker.vue` gegen Rückkehr gesperrt — 2026-07-26, Issue #889)
 

--- a/backend/tests/contracts/test_branch_override_contract.py
+++ b/backend/tests/contracts/test_branch_override_contract.py
@@ -1,0 +1,350 @@
+"""Contract-Tests für die Branch-Override-Whitelist (Issue #887).
+
+``branching_service.allowed_override_keys`` ist die einzige Stelle im Backend,
+die entscheidet, welche Branch-Overrides akzeptiert werden. Bis #887 gab es
+dafür keinen einzigen Test — die vorhandenen Branch-Tests
+(``tests/api/test_simulation_endpoints.py``, ``tests/test_simulation_api_routes.py``)
+decken nur den fehlenden ``branch_name`` ab.
+
+Diese Suite hält drei Dinge fest:
+
+1. **Wirkung je Key** — jeder erlaubte Override landet nachweisbar im
+   Branch-Artefakt (Config, State oder Profil-Datei). "Wird nicht abgelehnt"
+   reicht nicht: genau diese Lücke hat den in #886 beschriebenen Defekt
+   unbemerkt bestehen lassen.
+2. **Ablehnungspfad** — ein unbekannter Key wirft ``ValueError`` und wird über
+   ``utils/api_responses.handle_api_errors`` zu HTTP 400.
+3. **Whitelist als Ganzes** — das Set-Literal wird per AST gegen
+   ``EXPECTED_OVERRIDE_KEYS`` gepinnt, damit auch ein *stilles Hinzufügen*
+   eines Keys rot wird (verhaltensbasiert nicht erkennbar, der Key-Raum ist
+   unendlich).
+
+Bewusst nur Ist-Zustand: ob ``ai_model_ref`` in die Whitelist gehört, entscheidet
+#886. Dieser Slice ändert keinen Produktivcode.
+
+Verortung in ``tests/contracts/``, weil dieses Verzeichnis im verpflichtenden
+PR-Smoke-Gate und im Pre-Push-Gate läuft (``pytest tests/contracts/ -x -q``).
+Die Whitelist ist ein API-Vertrag gegenüber dem Frontend
+(``components/step4/ReportBranchControls.vue``) — ein Drift soll im Gate
+auffallen, nicht erst im nächtlichen Full-Run.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Any, Dict, Set
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+from app.services import branching_service
+from app.services.artifact_store import InMemoryArtifactStore
+from app.services.run_registry import RunRegistry
+from app.services.simulation_manager import SimulationManager, SimulationStatus
+
+# ---------------------------------------------------------------------------
+# Gepinnter Ist-Zustand (Stand main d43e4d27, Issue #887)
+# ---------------------------------------------------------------------------
+
+EXPECTED_OVERRIDE_KEYS: Set[str] = {
+    "llm_model",
+    "language",
+    "max_agents",
+    "time_config",
+    "enable_twitter",
+    "enable_reddit",
+    "persona_additions",
+    "persona_removals",
+}
+
+BASE_CONFIG: Dict[str, Any] = {
+    "llm_model": "source-model",
+    "language": "de",
+    "max_agents": 10,
+    "time_config": {"rounds": 3, "round_minutes": 60},
+    "enable_twitter": False,
+    "enable_reddit": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch) -> SimulationManager:
+    """Manager mit isoliertem Datenverzeichnis, In-Memory-Store und tmp-RunRegistry.
+
+    ``create_branch`` schreibt am Ende einen Run ins ``RunRegistry``; dessen
+    ``REGISTRY_DIR`` hängt zur Importzeit an ``Config.UPLOAD_FOLDER`` und würde
+    sonst das echte ``backend/uploads/`` verschmutzen (Muster analog
+    ``tests/services/test_run_registry_authority.py``).
+    """
+    monkeypatch.setattr(
+        SimulationManager, "SIMULATION_DATA_DIR", str(tmp_path / "simulations")
+    )
+    registry_dir = str(tmp_path / "run_registry")
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", registry_dir)
+    RunRegistry._instance = None
+    os.makedirs(registry_dir, exist_ok=True)
+    yield SimulationManager(store=InMemoryArtifactStore())
+    RunRegistry._instance = None
+
+
+@pytest.fixture
+def source_id(manager: SimulationManager) -> str:
+    """Eine branch-fähige Quell-Simulation: READY + persistierte ``simulation_config``.
+
+    Der FSM-Pfad CREATED → PREPARING → READY wird explizit gefahren, statt
+    ``state.status`` zu setzen — ``create_branch`` verlangt einen vorbereiteten
+    Status und ``_set_status`` validiert gegen die Transitions-Tabelle.
+    """
+    state = manager.create_simulation(project_id="proj-887", graph_id="graph-887")
+    manager._set_status(state, SimulationStatus.PREPARING)
+    manager._set_status(state, SimulationStatus.READY)
+    manager._store.write_json(state.simulation_id, "simulation_config", dict(BASE_CONFIG))
+    return state.simulation_id
+
+
+def branch_config(manager: SimulationManager, branch_id: str) -> Dict[str, Any]:
+    return manager._store.read_json(branch_id, "simulation_config", default={}) or {}
+
+
+# ---------------------------------------------------------------------------
+# 1. Whitelist als Ganzes
+# ---------------------------------------------------------------------------
+
+
+def _whitelist_from_source() -> Set[str]:
+    """Extrahiere das Set-Literal ``allowed_override_keys`` per AST.
+
+    Die Whitelist ist eine *lokale* Variable in ``create_branch`` und damit
+    nicht importierbar. AST statt Regex, damit Umformatierung (Zeilenumbrüche,
+    Quote-Stil) den Test nicht bricht. Erkannt wird jede Zuweisung an den Namen
+    ``allowed_override_keys`` mit einem Set-Literal aus String-Konstanten —
+    egal ob lokal oder als Modul-Konstante.
+    """
+    source_path = Path(branching_service.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "allowed_override_keys" not in names:
+            continue
+        if not isinstance(node.value, ast.Set):
+            pytest.fail(
+                "allowed_override_keys ist kein Set-Literal mehr "
+                f"({type(node.value).__name__}). Test an die neue Form anpassen — "
+                "aber bewusst, nicht durch Löschen dieser Prüfung."
+            )
+        keys = set()
+        for element in node.value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                pytest.fail(
+                    "allowed_override_keys enthält einen nicht-konstanten Eintrag; "
+                    "die Whitelist muss statisch prüfbar bleiben."
+                )
+            keys.add(element.value)
+        return keys
+
+    pytest.fail(
+        "allowed_override_keys nicht in branching_service.py gefunden. Wurde die "
+        "Whitelist verschoben oder umbenannt? Dann diesen Test mitziehen — die "
+        "Whitelist darf nicht ungepinnt bleiben (Issue #887)."
+    )
+
+
+def test_whitelist_matches_pinned_expectation() -> None:
+    """Hinzufügen ODER Entfernen eines Keys macht diesen Test rot.
+
+    Bewusste Änderungen gehören hier nachgezogen — zusammen mit einem
+    Wirkungs-Test in ``TestOverrideTakesEffect``.
+    """
+    assert _whitelist_from_source() == EXPECTED_OVERRIDE_KEYS
+
+
+@pytest.mark.parametrize("key", sorted(EXPECTED_OVERRIDE_KEYS))
+def test_every_pinned_key_is_accepted(
+    manager: SimulationManager, source_id: str, key: str
+) -> None:
+    """Kein gepinnter Key darf am Validierungs-Guard scheitern."""
+    branching_service.create_branch(
+        manager, source_id, f"branch-{key}", overrides={key: None}
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Wirkung je erlaubtem Key
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideTakesEffect:
+    """Je ein Test pro Whitelist-Key: der Override landet im Branch-Artefakt."""
+
+    def test_llm_model(self, manager: SimulationManager, source_id: str) -> None:
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"llm_model": "branch-model"}
+        )
+        assert branch_config(manager, branch.simulation_id)["llm_model"] == "branch-model"
+
+    def test_language(self, manager: SimulationManager, source_id: str) -> None:
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"language": "en"}
+        )
+        assert branch_config(manager, branch.simulation_id)["language"] == "en"
+
+    def test_max_agents(self, manager: SimulationManager, source_id: str) -> None:
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"max_agents": 42}
+        )
+        assert branch_config(manager, branch.simulation_id)["max_agents"] == 42
+
+    @pytest.mark.parametrize("empty", [None, ""])
+    def test_scalar_override_ignores_empty_values(
+        self, manager: SimulationManager, source_id: str, empty: Any
+    ) -> None:
+        """``None``/``""`` sind Nicht-Overrides — der Source-Wert bleibt stehen.
+
+        Bewusst gepinnt: das Frontend sendet leere Felder mit, ein Branch darf
+        dadurch nicht sein Modell verlieren.
+        """
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"llm_model": empty}
+        )
+        assert branch_config(manager, branch.simulation_id)["llm_model"] == "source-model"
+
+    def test_time_config_merges_into_source(
+        self, manager: SimulationManager, source_id: str
+    ) -> None:
+        """``time_config`` wird gemerged, nicht ersetzt."""
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"time_config": {"rounds": 9}}
+        )
+        time_config = branch_config(manager, branch.simulation_id)["time_config"]
+        assert time_config["rounds"] == 9
+        assert time_config["round_minutes"] == 60
+
+    def test_enable_twitter(self, manager: SimulationManager, source_id: str) -> None:
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"enable_twitter": True}
+        )
+        assert branch.enable_twitter is True
+        assert branch_config(manager, branch.simulation_id)["enable_twitter"] is True
+
+    def test_enable_reddit(self, manager: SimulationManager, source_id: str) -> None:
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"enable_reddit": False}
+        )
+        assert branch.enable_reddit is False
+        assert branch_config(manager, branch.simulation_id)["enable_reddit"] is False
+
+    def test_persona_removals(self, manager: SimulationManager, source_id: str) -> None:
+        manager._store.write_json(
+            source_id, "reddit_profiles", [{"username": "alice"}, {"username": "bob"}]
+        )
+        branch = branching_service.create_branch(
+            manager, source_id, "b", overrides={"persona_removals": ["bob"]}
+        )
+        profiles = manager._store.read_json(branch.simulation_id, "reddit_profiles", default=[])
+        assert [p["username"] for p in profiles] == ["alice"]
+
+    def test_persona_additions(self, manager: SimulationManager, source_id: str) -> None:
+        manager._store.write_json(source_id, "reddit_profiles", [{"username": "alice"}])
+        branch = branching_service.create_branch(
+            manager,
+            source_id,
+            "b",
+            overrides={"persona_additions": [{"platform": "reddit", "username": "carol"}]},
+        )
+        profiles = manager._store.read_json(branch.simulation_id, "reddit_profiles", default=[])
+        assert [p["username"] for p in profiles] == ["alice", "carol"]
+
+    def test_source_stays_untouched(self, manager: SimulationManager, source_id: str) -> None:
+        """Overrides wirken auf den Branch, nie zurück auf die Quelle."""
+        branching_service.create_branch(
+            manager, source_id, "b", overrides={"llm_model": "branch-model", "max_agents": 42}
+        )
+        source_config = branch_config(manager, source_id)
+        assert source_config["llm_model"] == "source-model"
+        assert source_config["max_agents"] == 10
+
+
+# ---------------------------------------------------------------------------
+# 3. Ablehnungspfad
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOverrideIsRejected:
+    @pytest.mark.parametrize(
+        "unknown_key",
+        [
+            # Kandidaten aus #886: heute NICHT in der Whitelist.
+            "ai_model_ref",
+            "llm_profile_id",
+            "model_id",
+            "totally_made_up",
+        ],
+    )
+    def test_raises_value_error(
+        self, manager: SimulationManager, source_id: str, unknown_key: str
+    ) -> None:
+        with pytest.raises(ValueError, match="Unsupported branch overrides"):
+            branching_service.create_branch(
+                manager, source_id, "b", overrides={unknown_key: "x"}
+            )
+
+    def test_error_lists_every_unknown_key_sorted(
+        self, manager: SimulationManager, source_id: str
+    ) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            branching_service.create_branch(
+                manager,
+                source_id,
+                "b",
+                overrides={"zeta": 1, "alpha": 2, "llm_model": "ok"},
+            )
+        assert str(excinfo.value) == "Unsupported branch overrides: alpha, zeta"
+
+    def test_rejects_before_touching_the_source(
+        self, manager: SimulationManager, source_id: str
+    ) -> None:
+        """Der Guard greift vor jeder Seiteneffekt-Operation — kein Branch entsteht."""
+        before = len(manager.list_simulations(project_id="proj-887"))
+        with pytest.raises(ValueError):
+            branching_service.create_branch(
+                manager, source_id, "b", overrides={"nope": 1}
+            )
+        assert len(manager.list_simulations(project_id="proj-887")) == before
+
+
+def test_unknown_override_surfaces_as_http_400(monkeypatch, tmp_path) -> None:
+    """End-to-End über ``handle_api_errors``: ValueError → HTTP 400.
+
+    Der Whitelist-Guard läuft vor dem Existenz-Check der Simulation, deshalb
+    genügt eine gültig formatierte ID ohne echten Datensatz.
+    """
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        SimulationManager, "SIMULATION_DATA_DIR", str(tmp_path / "simulations")
+    )
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+
+    response = app.test_client().post(
+        "/api/simulation/sim_0123456789ab/branch",
+        json={"branch_name": "b", "overrides": {"ai_model_ref": "openai:gpt-4o"}},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert "Unsupported branch overrides" in str(payload)

--- a/backend/tests/contracts/test_branch_override_contract.py
+++ b/backend/tests/contracts/test_branch_override_contract.py
@@ -61,13 +61,18 @@ EXPECTED_OVERRIDE_KEYS: Set[str] = {
     "persona_removals",
 }
 
+# Gegensätzliche Ausgangswerte, damit jeder Plattform-Override den Source-Wert
+# tatsächlich umdrehen muss (siehe Docstring der ``source_id``-Fixture).
+SOURCE_ENABLE_TWITTER = False
+SOURCE_ENABLE_REDDIT = True
+
 BASE_CONFIG: Dict[str, Any] = {
     "llm_model": "source-model",
     "language": "de",
     "max_agents": 10,
     "time_config": {"rounds": 3, "round_minutes": 60},
-    "enable_twitter": False,
-    "enable_reddit": True,
+    "enable_twitter": SOURCE_ENABLE_TWITTER,
+    "enable_reddit": SOURCE_ENABLE_REDDIT,
 }
 
 
@@ -103,8 +108,20 @@ def source_id(manager: SimulationManager) -> str:
     Der FSM-Pfad CREATED → PREPARING → READY wird explizit gefahren, statt
     ``state.status`` zu setzen — ``create_branch`` verlangt einen vorbereiteten
     Status und ``_set_status`` validiert gegen die Transitions-Tabelle.
+
+    ``enable_twitter``/``enable_reddit`` werden explizit gesetzt und decken
+    gegensätzliche Ausgangswerte ab. ``create_simulation`` hat für beide
+    ``True`` als Default; ein Test, der auf ``True`` overridet, würde auch dann
+    bestehen, wenn ``create_branch`` den Override ignoriert und schlicht vom
+    Source erbt. Die Werte spiegeln ``BASE_CONFIG``, damit State und Config
+    nicht auseinanderlaufen.
     """
-    state = manager.create_simulation(project_id="proj-887", graph_id="graph-887")
+    state = manager.create_simulation(
+        project_id="proj-887",
+        graph_id="graph-887",
+        enable_twitter=SOURCE_ENABLE_TWITTER,
+        enable_reddit=SOURCE_ENABLE_REDDIT,
+    )
     manager._set_status(state, SimulationStatus.PREPARING)
     manager._set_status(state, SimulationStatus.READY)
     manager._store.write_json(state.simulation_id, "simulation_config", dict(BASE_CONFIG))
@@ -232,6 +249,7 @@ class TestOverrideTakesEffect:
         assert time_config["round_minutes"] == 60
 
     def test_enable_twitter(self, manager: SimulationManager, source_id: str) -> None:
+        """Override dreht den Source-Wert um (Source: ``False``)."""
         branch = branching_service.create_branch(
             manager, source_id, "b", overrides={"enable_twitter": True}
         )
@@ -239,11 +257,28 @@ class TestOverrideTakesEffect:
         assert branch_config(manager, branch.simulation_id)["enable_twitter"] is True
 
     def test_enable_reddit(self, manager: SimulationManager, source_id: str) -> None:
+        """Override dreht den Source-Wert um (Source: ``True``)."""
         branch = branching_service.create_branch(
             manager, source_id, "b", overrides={"enable_reddit": False}
         )
         assert branch.enable_reddit is False
         assert branch_config(manager, branch.simulation_id)["enable_reddit"] is False
+
+    def test_platform_flags_are_inherited_without_override(
+        self, manager: SimulationManager, source_id: str
+    ) -> None:
+        """Abgrenzung: ohne Override erbt der Branch beide Flags vom Source.
+
+        Zusammen mit den beiden Tests darüber ist damit jede Richtung abgedeckt
+        — Erben und Umdrehen —, sodass weder ein ignorierter Override noch ein
+        fälschlich hartkodierter Wert durchrutscht.
+        """
+        branch = branching_service.create_branch(manager, source_id, "b")
+        config = branch_config(manager, branch.simulation_id)
+        assert branch.enable_twitter is SOURCE_ENABLE_TWITTER
+        assert branch.enable_reddit is SOURCE_ENABLE_REDDIT
+        assert config["enable_twitter"] is SOURCE_ENABLE_TWITTER
+        assert config["enable_reddit"] is SOURCE_ENABLE_REDDIT
 
     def test_persona_removals(self, manager: SimulationManager, source_id: str) -> None:
         manager._store.write_json(

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3600 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3601 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3573 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3600 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Closes #887.

## Problem

`backend/app/services/branching_service.py::allowed_override_keys` ist die einzige Stelle, die entscheidet, welche Branch-Overrides das Backend akzeptiert. Für diese Whitelist existierte kein einziger Test. Die vorhandenen Branch-Tests in `tests/api/test_simulation_endpoints.py` und `tests/test_simulation_api_routes.py` decken nur den fehlenden `branch_name` ab; ein `tests/services/test_branching*` gab es nicht. Genau deshalb konnte der in #886 beschriebene Defekt unbemerkt bestehen.

## Was drin ist

Eine neue Contract-Suite, `backend/tests/contracts/test_branch_override_contract.py`, 27 Tests:

**1. Wirkung je erlaubtem Key** — je ein Test pro Key (`llm_model`, `language`, `max_agents`, `time_config`, `enable_twitter`, `enable_reddit`, `persona_additions`, `persona_removals`), der belegt, dass der Override tatsächlich im Branch-Artefakt landet: in der `simulation_config`, im `SimulationState` oder in den Reddit-Profilen. Nicht nur, dass er nicht abgelehnt wird. Zusätzlich gepinnt, weil es echtes Verhalten ist: `time_config` wird gemerged statt ersetzt, `None`/`""` sind Nicht-Overrides (das Frontend sendet leere Felder mit — ein Branch darf dadurch nicht sein Modell verlieren), und die Quell-Simulation bleibt unverändert.

**2. Ablehnungspfad** — unbekannter Key → `ValueError("Unsupported branch overrides: …")`, die Meldung listet alle unbekannten Keys sortiert, der Guard greift vor jedem Seiteneffekt (es entsteht kein Branch), und über `utils/api_responses.handle_api_errors` wird daraus HTTP 400 am Endpoint `POST /api/simulation/<id>/branch`.

**3. Whitelist als Ganzes** — `test_whitelist_matches_pinned_expectation` liest das Set-Literal per AST aus `branching_service.py` und vergleicht es gegen die im Test gepinnte Menge.

Warum AST und nicht rein verhaltensbasiert: die Whitelist ist eine *lokale* Variable in `create_branch`, also nicht importierbar. Und ein stilles **Hinzufügen** eines Keys ist verhaltensbasiert grundsätzlich nicht erkennbar — der Key-Raum ist unendlich, man kann nur endlich viele Negativfälle testen. Der AST-Test schließt genau diese Lücke; Hinzufügen und Entfernen werden gleichermaßen rot. Der Helper scheitert mit expliziter Meldung, falls die Whitelist umbenannt oder in eine andere Form überführt wird, statt still zu passen.

## Verortung

`backend/tests/contracts/` — dieses Verzeichnis läuft im verpflichtenden PR-Smoke-Gate (`ci.yml`: `uv run pytest tests/contracts/ -q`) und im Pre-Push-Gate. Die Whitelist ist ein API-Vertrag gegenüber dem Frontend (`components/step4/ReportBranchControls.vue` referenziert `allowed_override_keys` sogar namentlich im Kommentar); ein Drift soll im Gate auffallen, nicht erst im Full-Run. `tests/services/` wäre die Alternative gewesen, läuft aber nicht im PR-Gate — für eine Regressionsbremse der falsche Ort.

## Scope-Grenze

Kein Produktivcode-Fix. Die Suite schreibt ausschließlich den Ist-Zustand fest. Ob `ai_model_ref` in die Whitelist kommt, entscheidet #886 — der Key steht hier bewusst in der Negativliste des Ablehnungspfads und wird dort beim Fix nachgezogen.

## Verifikation

- Ist-Stand gegen `main` (d43e4d27) verifiziert, nicht gegen die im Issue zitierte 7cb7a735; #891 und #892 sind eingerechnet.
- `bash scripts/pre-push-gate.sh backend` → ALL GREEN (ruff, mypy, contracts, Schema-Drift, sync-status).
- `uv run pytest tests/contracts/test_branch_override_contract.py -q` → 27 passed.
- Drei Mutationstests gegen den Produktivcode, alle gefangen und danach zurückgerollt:
  - `language` aus der Wirkungs-Schleife entfernt → `test_language` rot
  - `ai_model_ref` still zur Whitelist hinzugefügt → 3 Tests rot
  - `time_config` still aus der Whitelist entfernt → 3 Tests rot
- `docs/STATUS.md` nachgezogen (Testzahl 3573 → 3600), CHANGELOG-Eintrag unter `[Unreleased]` (AGENTS.md Regel 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Neue Contract-Test-Suite stellt die Branch-Override-Whitelist gegen Regressionen sicher.
  * Verifizierte Wirkung aller erlaubten Override-Keys direkt im Branch-Artefakt.
  * Unbekannte Override-Keys werden deterministisch abgelehnt und als HTTP-400 mit passendem Hinweis zurückgegeben.
  * Zusätzlich wird geprüft, dass fehlerhafte Anfragen keine Quelldaten verändern.
* **Dokumentation**
  * Die dokumentierte Anzahl der gesammelten Backend-Tests wurde aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->