### PR TITLE
fix(backend): llm_profile_id in /prepare aufs Routing wirken lassen (#888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (`llm_profile_id` in `/prepare` wirkt jetzt aufs Routing — 2026-07-26, Issue #888)
+
+- **`backend/app/api/simulation_prepare.py`** — `llm_profile_id` war ein reiner
+  Fallback-*Unterdrücker* und kehrte damit seine eigene Absicht um: ein mitgeschicktes
+  Profil übersprang den P5.3-Projekt-Fallback, löste aber selbst nichts auf, weil
+  `expand_profile_in_data` ausschließlich auf ein `llm_model` mit `profile:`-Präfix reagiert.
+  **Konkreter Defekt:** Projekt hat ein Profil, User lässt die Modellauswahl auf „default"
+  (`useEnvForm.effectiveModel()` liefert dann `null`, also kein `llm_model` im Payload),
+  `Step2EnvSetup.vue` sendet `llm_profile_id` mit → die Vorbereitung lief still auf dem
+  Server-Default-Modell. Hätte das Frontend das Feld *weggelassen*, hätte der Fallback
+  korrekt gegriffen.
+- **Neues Verhalten:** `llm_profile_id` ist eine Routing-Anweisung wie in `graph_build.py`
+  und `report.py`. Ohne explizite Modellwahl wird das Profil zu `profile:<id>` expandiert und
+  aufgelöst. Präzedenz: explizites `llm_model` → Request-Profil → Projekt-Profil →
+  Server-Default. `llm_model="default"` zählt als UI-Platzhalter, nicht als Modellwahl.
+- **Re-Prepare-Semantik entkoppelt.** Der „bereits vorbereitet"-Kurzschluss hing an
+  `llm_model_override` bzw. `llm_runtime.enabled`. Beide sind durch das Profil-Routing für
+  jedes Projekt mit hinterlegtem Profil gesetzt — `expand_profile_in_data` schreibt zusätzlich
+  einen `llm_provider`-Block aus dem Profil. Unverändert hätte der Kurzschluss nie mehr
+  gegriffen und jedes Betreten von Step 2 eine volle Neu-Vorbereitung samt
+  Persona-Neugenerierung ausgelöst. Er hängt jetzt an `client_requested_override`: nur ein
+  vom Client *explizit* gesendetes `llm_model` oder `llm_provider` überspringt ihn. Dafür wird
+  `explicit_runtime_request` vor der Expansion festgehalten, sonst wäre der profil-abgeleitete
+  Provider-Block von einem echten Override ununterscheidbar.
+- **`backend/tests/api/test_simulation_prepare_profile_routing.py`** — neue Suite, 13 Tests:
+  Präzedenzkette (Request-Profil schlägt Projekt-Profil, explizites Modell schlägt beide,
+  `"default"` ist keine Wahl), unauflösbares Profil bricht den Request nicht, und sechs Tests
+  für die Kurzschluss-Semantik inklusive der Abgrenzung profil-abgeleiteter vs. echter
+  Provider-Override.
+- Verifikation: 7 der 13 Tests sind gegen den alten `simulation_prepare.py` rot (genau die
+  Verhaltensänderungen), 6 sichern unverändertes Verhalten ab. `bash scripts/pre-push-gate.sh
+  backend` grün; `tests/api` hat mit und ohne diese Änderung dieselben 138 vorbestehenden
+  Failures (`AGORA_AUTH_TOKEN`-Leak zwischen Suites, unabhängiges Bestandsproblem) — die neue
+  Suite ist im Gesamtlauf sauber, weil ihr Client-Fixture den Open-Mode erzwingt.
+
 ### Changed (CI-Gate: `LlmProfilePicker.vue` gegen Rückkehr gesperrt — 2026-07-26, Issue #889)
 
 - **`.github/scripts/check_legacy_model_picker.py`** — `components/llm/LlmProfilePicker.vue`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,18 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Server-Default-Modell. Hätte das Frontend das Feld *weggelassen*, hätte der Fallback
   korrekt gegriffen.
 - **Neues Verhalten:** `llm_profile_id` ist eine Routing-Anweisung wie in `graph_build.py`
-  und `report.py`. Ohne explizite Modellwahl wird das Profil zu `profile:<id>` expandiert und
-  aufgelöst. Präzedenz: explizites `llm_model` → Request-Profil → Projekt-Profil →
+  und `report.py`. Präzedenz: explizites `llm_model` → Request-Profil → Projekt-Profil →
   Server-Default. `llm_model="default"` zählt als UI-Platzhalter, nicht als Modellwahl.
+- **Über den kanonischen Pfad, nicht über lokale Expansion.** Die Profil-ID wird als
+  `llm_profile_id` an `seed_run_stage_routing` durchgereicht statt hier zu `llm_model`
+  expandiert. Nur dessen Profil-Branch löst die aktivierte `ProviderConnection` auf und
+  koppelt sie an deren gebundenes Secret (SSoT, Issue #817) — eine lokale Expansion trifft den
+  Legacy-Override-Branch davor und brennt Endpoint und Key aus dem Legacy-Profil ein, die nach
+  einer Connection- oder Secret-Rotation veraltet sind. Zudem wird ein unauflösbares Profil
+  jetzt mit HTTP 400 abgelehnt, statt mit dem literalen Modellnamen `profile:<id>` in die
+  Queue zu laufen (Codex-Finding P1 auf PR #894). Der Legacy-Pfad `llm_model="profile:<id>"`
+  aus `HeroNewRun.vue` wird weiterhin lokal expandiert — `seed_run_stage_routing` kennt nur
+  das separate Feld.
 - **Re-Prepare-Semantik entkoppelt.** Der „bereits vorbereitet"-Kurzschluss hing an
   `llm_model_override` bzw. `llm_runtime.enabled`. Beide sind durch das Profil-Routing für
   jedes Projekt mit hinterlegtem Profil gesetzt — `expand_profile_in_data` schreibt zusätzlich
@@ -28,14 +37,23 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   Persona-Neugenerierung ausgelöst. Er hängt jetzt an `client_requested_override`: nur ein
   vom Client *explizit* gesendetes `llm_model` oder `llm_provider` überspringt ihn. Dafür wird
   `explicit_runtime_request` vor der Expansion festgehalten, sonst wäre der profil-abgeleitete
-  Provider-Block von einem echten Override ununterscheidbar.
-- **`backend/tests/api/test_simulation_prepare_profile_routing.py`** — neue Suite, 13 Tests:
+  Provider-Block von einem echten Override ununterscheidbar. Ein Request-Profil, das vom
+  Projekt-Default **abweicht**, zählt dabei sehr wohl als explizite Wahl — sonst käme der
+  Endpoint mit `already_prepared` zurück und die Personas blieben die des vorherigen Modells,
+  im Widerspruch zur Präzedenz „Request-Profil schlägt Projekt-Profil" (Codex-Finding P1 auf
+  PR #894). Dasselbe Profil erneut zu schicken bleibt der billige Revisit — das ist der
+  Frontend-Alltag, weil `Step2EnvSetup.vue` immer den Projekt-Default mitsendet.
+- **`backend/tests/api/test_simulation_prepare_profile_routing.py`** — neue Suite, 15 Tests:
   Präzedenzkette (Request-Profil schlägt Projekt-Profil, explizites Modell schlägt beide,
-  `"default"` ist keine Wahl), unauflösbares Profil bricht den Request nicht, und sechs Tests
-  für die Kurzschluss-Semantik inklusive der Abgrenzung profil-abgeleiteter vs. echter
-  Provider-Override.
-- Verifikation: 7 der 13 Tests sind gegen den alten `simulation_prepare.py` rot (genau die
-  Verhaltensänderungen), 6 sichern unverändertes Verhalten ab. `bash scripts/pre-push-gate.sh
+  `"default"` ist keine Wahl), Legacy-Token-Expansion, unauflösbares Profil → HTTP 400, und
+  acht Tests für die Kurzschluss-Semantik inklusive der Abgrenzungen profil-abgeleiteter vs.
+  echter Provider-Override und identisches vs. abweichendes Request-Profil.
+- **`backend/tests/api/test_simulation_prepare_routing.py`** — die beiden Fixtures mocken
+  jetzt `_check_simulation_prepared`. Der Kurzschluss läuft dort seit der Entkopplung
+  tatsächlich an und bräuchte sonst einen initialisierten `SimulationArtifactStore`; die Suite
+  prüft Key-Routing, nicht den Prepared-State.
+- Verifikation: 8 der 15 Tests sind gegen den alten `simulation_prepare.py` rot (genau die
+  Verhaltensänderungen), 7 sichern unverändertes Verhalten ab. `bash scripts/pre-push-gate.sh
   backend` grün; `tests/api` hat mit und ohne diese Änderung dieselben 138 vorbestehenden
   Failures — ein unabhängiges Bestandsproblem: `AGORA_AUTH_TOKEN` kommt via `load_dotenv()`
   aus der lokalen `.env` und der Blueprint-Guard bleibt nach einem `create_app()`-Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 - Verifikation: 7 der 13 Tests sind gegen den alten `simulation_prepare.py` rot (genau die
   Verhaltensänderungen), 6 sichern unverändertes Verhalten ab. `bash scripts/pre-push-gate.sh
   backend` grün; `tests/api` hat mit und ohne diese Änderung dieselben 138 vorbestehenden
-  Failures (`AGORA_AUTH_TOKEN`-Leak zwischen Suites, unabhängiges Bestandsproblem) — die neue
-  Suite ist im Gesamtlauf sauber, weil ihr Client-Fixture den Open-Mode erzwingt.
+  Failures — ein unabhängiges Bestandsproblem: `AGORA_AUTH_TOKEN` kommt via `load_dotenv()`
+  aus der lokalen `.env` und der Blueprint-Guard bleibt nach einem `create_app()`-Test
+  dauerhaft an `simulation_bp` hängen. Die neue Suite ist im Gesamtlauf sauber, weil ihr
+  Client-Fixture den Open-Mode erzwingt.
 
 ### Changed (CI-Gate: `LlmProfilePicker.vue` gegen Rückkehr gesperrt — 2026-07-26, Issue #889)
 

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -269,16 +269,33 @@ def prepare_simulation():
             message=f"Project does not exist: {state.project_id}",
         )
 
-    # P5.3-Fix: Wenn Request kein Profil mitschickt (Frontend setzt bei
-    # Profil-Auswahl `STORAGE_MODEL=default`), das im Projekt persistierte
-    # Profil aus dem Ontology-Schritt als Default injizieren — sonst landet
-    # die Sim-Vorbereitung im Server-Default-Modell. Respektiert expliziten
-    # Single-Run-Override (analog graph.py / report.py).
+    # Profil-Routing (Issue #888). `llm_profile_id` ist eine Routing-Anweisung,
+    # kein Fallback-Unterdrücker — analog graph.py / report.py, wo das Feld
+    # ebenfalls echtes Routing auslöst.
+    #
+    # Vorher kehrte das Feld seine eigene Absicht um: ein mitgeschicktes
+    # `llm_profile_id` übersprang den P5.3-Fallback, ohne selbst irgendetwas
+    # aufzulösen (`expand_profile_in_data` reagiert nur auf ein `llm_model` mit
+    # `profile:`-Präfix). Der Standardfall — Projekt hat ein Profil, User lässt
+    # die Modellauswahl auf "default" — landete damit still im
+    # Server-Default-Modell.
+    #
+    # `default` ist die UI-Platzhalterwahl (`useEnvForm.effectiveModel()` liefert
+    # dafür `null`) und zählt deshalb nicht als explizite Modellwahl.
     _data_profile = (data.get('llm_profile_id') or '').strip() or None
     _data_model = (data.get('llm_model') or '').strip() or None
-    if not _data_profile and (not _data_model or _data_model.lower() == 'default'):
-        if getattr(project, 'llm_profile_id', None):
-            data['llm_model'] = f"profile:{project.llm_profile_id}"
+    explicit_model_override = bool(_data_model and _data_model.lower() != 'default')
+    # Vor der Expansion festhalten: `expand_profile_in_data` schreibt einen
+    # `llm_provider`-Block aus dem Profil (Provider/Key/Base-URL) und würde
+    # `llm_runtime.enabled` sonst ununterscheidbar von einem echten
+    # Client-Provider-Override machen.
+    explicit_runtime_request = bool(data.get('llm_provider'))
+    if not explicit_model_override:
+        # Request-Profil schlägt Projekt-Profil (Single-Run-Override), beide
+        # schlagen das Server-Default-Modell.
+        _routed_profile = _data_profile or getattr(project, 'llm_profile_id', None)
+        if _routed_profile:
+            data['llm_model'] = f"profile:{_routed_profile}"
     # UI-Profile-Token in echtes Modell + Provider-Creds expandieren.
     from ..utils.llm_profile_resolver import expand_profile_in_data
     expand_profile_in_data(data)
@@ -296,7 +313,16 @@ def prepare_simulation():
         extra={'simulation_id': simulation_id},
     )
 
-    if not force_regenerate and not llm_model_override and not llm_runtime.enabled:
+    # Der "bereits vorbereitet"-Kurzschluss hängt bewusst an der *expliziten*
+    # Client-Wahl, nicht an `llm_model_override`/`llm_runtime.enabled` (Issue
+    # #888). Seit dem Profil-Routing oben sind beide für jedes Projekt mit
+    # hinterlegtem Profil gesetzt — an sie gebunden würde der Kurzschluss nie
+    # mehr greifen und jedes Betreten von Step 2 eine vollständige
+    # Neu-Vorbereitung samt Persona-Neugenerierung auslösen.
+    client_requested_override = explicit_model_override or (
+        llm_runtime.enabled and explicit_runtime_request
+    )
+    if not force_regenerate and not client_requested_override:
         logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
         is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
         logger.debug(f"Check result: is_prepared={is_prepared}, prepare_info={prepare_info}")

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -280,9 +280,20 @@ def prepare_simulation():
     # die Modellauswahl auf "default" — landete damit still im
     # Server-Default-Modell.
     #
+    # Das Profil wird bewusst NICHT hier zu `llm_model` expandiert, sondern als
+    # `llm_profile_id` an `seed_run_stage_routing` durchgereicht. Dessen
+    # Profil-Branch löst die aktivierte ProviderConnection auf und koppelt sie an
+    # deren gebundenes Secret (SSoT, Issue #817); die lokale Expansion würde
+    # stattdessen Endpoint und Key aus dem Legacy-Profil einbrennen und damit
+    # nach einer Connection- oder Secret-Rotation auf veraltete Credentials
+    # zeigen. Ein unauflösbares Profil wirft dort `ValueError` → HTTP 400 über
+    # `@handle_api_errors`, statt mit dem literalen Modellnamen `profile:<id>`
+    # in die Queue zu laufen.
+    #
     # `default` ist die UI-Platzhalterwahl (`useEnvForm.effectiveModel()` liefert
     # dafür `null`) und zählt deshalb nicht als explizite Modellwahl.
     _data_profile = (data.get('llm_profile_id') or '').strip() or None
+    _project_profile = (getattr(project, 'llm_profile_id', None) or '').strip() or None
     _data_model = (data.get('llm_model') or '').strip() or None
     explicit_model_override = bool(_data_model and _data_model.lower() != 'default')
     # Vor der Expansion festhalten: `expand_profile_in_data` schreibt einen
@@ -290,13 +301,12 @@ def prepare_simulation():
     # `llm_runtime.enabled` sonst ununterscheidbar von einem echten
     # Client-Provider-Override machen.
     explicit_runtime_request = bool(data.get('llm_provider'))
-    if not explicit_model_override:
-        # Request-Profil schlägt Projekt-Profil (Single-Run-Override), beide
-        # schlagen das Server-Default-Modell.
-        _routed_profile = _data_profile or getattr(project, 'llm_profile_id', None)
-        if _routed_profile:
-            data['llm_model'] = f"profile:{_routed_profile}"
-    # UI-Profile-Token in echtes Modell + Provider-Creds expandieren.
+    # Request-Profil schlägt Projekt-Profil (Single-Run-Override), beide schlagen
+    # das Server-Default-Modell. Eine explizite Modellwahl schlägt alles.
+    routed_profile_id = None if explicit_model_override else (_data_profile or _project_profile)
+    # UI-Profile-Token expandieren: schickt der Client selbst ein
+    # `llm_model="profile:<id>"` (Legacy-Pfad aus `HeroNewRun.vue`), muss es hier
+    # aufgelöst werden — `seed_run_stage_routing` kennt nur das separate Feld.
     from ..utils.llm_profile_resolver import expand_profile_in_data
     expand_profile_in_data(data)
     llm_model_override = (data.get('llm_model') or '').strip() or None
@@ -315,12 +325,20 @@ def prepare_simulation():
 
     # Der "bereits vorbereitet"-Kurzschluss hängt bewusst an der *expliziten*
     # Client-Wahl, nicht an `llm_model_override`/`llm_runtime.enabled` (Issue
-    # #888). Seit dem Profil-Routing oben sind beide für jedes Projekt mit
-    # hinterlegtem Profil gesetzt — an sie gebunden würde der Kurzschluss nie
-    # mehr greifen und jedes Betreten von Step 2 eine vollständige
+    # #888). Wäre er an sie gebunden, würde er für jedes Projekt mit hinterlegtem
+    # Profil nie mehr greifen und jedes Betreten von Step 2 eine vollständige
     # Neu-Vorbereitung samt Persona-Neugenerierung auslösen.
-    client_requested_override = explicit_model_override or (
-        llm_runtime.enabled and explicit_runtime_request
+    #
+    # Ein Request-Profil, das vom Projekt-Default *abweicht*, ist dagegen sehr
+    # wohl eine explizite Wahl: sonst käme der Endpoint mit `already_prepared`
+    # zurück und die Personas blieben die des vorherigen Modells — im Widerspruch
+    # zur Präzedenz "Request-Profil schlägt Projekt-Profil". Dasselbe Profil
+    # erneut zu schicken bleibt der billige Revisit.
+    explicit_profile_override = bool(_data_profile and _data_profile != _project_profile)
+    client_requested_override = (
+        explicit_model_override
+        or explicit_profile_override
+        or (llm_runtime.enabled and explicit_runtime_request)
     )
     if not force_regenerate and not client_requested_override:
         logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
@@ -429,6 +447,7 @@ def prepare_simulation():
         "persona_generation",
         llm_model_override=llm_model_override,
         llm_runtime=llm_runtime,
+        llm_profile_id=routed_profile_id,
     )
     route_router = StageModelRouter(run_record["run_id"])
     resolved_route = route_router.resolve("persona_generation")

--- a/backend/tests/api/test_simulation_prepare_profile_routing.py
+++ b/backend/tests/api/test_simulation_prepare_profile_routing.py
@@ -1,0 +1,335 @@
+"""Profil-Routing in ``POST /api/simulation/prepare`` (Issue #888).
+
+Vorher las ``simulation_prepare.py`` ``llm_profile_id`` nur als
+Fallback-*Unterdrücker*: ein mitgeschicktes Profil übersprang den
+P5.3-Projekt-Fallback, löste aber selbst nichts auf — ``expand_profile_in_data``
+reagiert ausschließlich auf ein ``llm_model`` mit ``profile:``-Präfix. Damit
+kehrte das Feld seine eigene Absicht um; der Standardfall (Projekt hat ein
+Profil, User lässt die Modellauswahl auf "default", das Frontend sendet
+``llm_profile_id`` mit und ``llm_model`` gar nicht) landete still im
+Server-Default-Modell.
+
+Diese Suite pinnt beide Hälften der Korrektur:
+
+1. **Routing** — ``llm_profile_id`` wird aufgelöst; Request-Profil schlägt
+   Projekt-Profil, eine explizite Modellwahl schlägt beide.
+2. **Re-Prepare-Semantik** — der "bereits vorbereitet"-Kurzschluss hängt an der
+   *expliziten* Client-Wahl, nicht mehr an ``llm_model_override``. Sonst würde
+   er für jedes Projekt mit hinterlegtem Profil nie mehr greifen und jedes
+   Betreten von Step 2 eine volle Neu-Vorbereitung auslösen.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+from app.contracts.llm_routing_contract import ResolvedRoute
+
+VALID_SIM_ID = "sim_0123456789ab"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # @require_scope greift, sobald AGORA_AUTH_TOKEN gesetzt ist — die Variable
+    # leakt aus Nachbar-Suites in den Gesamtlauf. Open-Mode erzwingen (Muster aus
+    # tests/api/test_simulation_endpoints.py); diese Suite prüft Routing, nicht Auth.
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 1000
+    app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS"] = 60
+    app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+@pytest.fixture
+def prepare_env(monkeypatch):
+    """Verdrahtet ``/prepare`` so, dass nur das Modell-Routing beobachtet wird.
+
+    Liefert ein Dict mit ``resolved`` (das ``llm_model``, mit dem der Endpoint in
+    ``seed_run_stage_routing`` geht — also das Ergebnis der Profil-Auflösung) und
+    ``prepared_checked`` (ob der "bereits vorbereitet"-Kurzschluss lief).
+
+    Bewusst wird ``seed_run_stage_routing`` abgegriffen statt
+    ``prepare_simulation``: dort steht ``llm_model_override`` vor der
+    Router-Auflösung, die es im Test-Fixture ohnehin überschreibt.
+    """
+    observed: dict = {"resolved": None, "prepared_checked": False}
+
+    project = SimpleNamespace(
+        simulation_requirement="Discuss the project",
+        llm_profile_id=None,
+    )
+    state = SimpleNamespace(
+        project_id="proj_123",
+        graph_id="graph_123",
+        source_simulation_id=None,
+        root_simulation_id=None,
+        branch_name=None,
+        branch_depth=0,
+        entities_count=1,
+        entity_types=["Person"],
+    )
+
+    manager = MagicMock()
+    manager.get_simulation.return_value = state
+    manager.prepare_simulation.side_effect = lambda **_kwargs: MagicMock(
+        to_simple_dict=lambda: {"simulation_id": VALID_SIM_ID, "status": "ready"}
+    )
+
+    filtered = MagicMock()
+    filtered.filtered_count = 1
+    filtered.entity_types = {"Person"}
+
+    class FakeTaskManager:
+        def create_task(self, *args, **kwargs):
+            return "task_prepare_1"
+
+        def update_task(self, *args, **kwargs):
+            return None
+
+        def complete_task(self, *args, **kwargs):
+            return None
+
+        def fail_task(self, *args, **kwargs):
+            return None
+
+    class FakeRouter:
+        def __init__(self, run_id: str):
+            self.run_id = run_id
+
+        def resolve(self, _stage_id: str):
+            return ResolvedRoute(
+                stage="persona_generation",
+                provider_id="openai",
+                model="gpt-4o-mini",
+                base_url_sanitized="https://api.openai.com/v1",
+                routing_version=9,
+            )
+
+        def lock_stage(self, *_args, **_kwargs):
+            return None
+
+    def capture_seed(_run_id, _stage, *, llm_model_override=None, llm_runtime=None):
+        observed["resolved"] = llm_model_override
+
+    def capture_prepared_check(_simulation_id):
+        observed["prepared_checked"] = True
+        return False, {}
+
+    def run_inline(self):
+        self.run()
+
+    prefix = "app.api.simulation_prepare"
+    monkeypatch.setattr(f"{prefix}.SimulationManager", lambda: manager)
+    monkeypatch.setattr(f"{prefix}.ProjectManager.get_project", lambda _pid: project)
+    monkeypatch.setattr(f"{prefix}.ProjectManager.get_extracted_text", lambda _pid: "document text")
+    monkeypatch.setattr(f"{prefix}.get_simulation_storage", lambda: MagicMock())
+    monkeypatch.setattr(
+        f"{prefix}.EntityReader",
+        lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=filtered)),
+    )
+    monkeypatch.setattr(f"{prefix}.seed_run_stage_routing", capture_seed)
+    monkeypatch.setattr(f"{prefix}._check_simulation_prepared", capture_prepared_check)
+    monkeypatch.setattr(f"{prefix}.StageModelRouter", FakeRouter)
+    monkeypatch.setattr(f"{prefix}.resolve_route_api_key", lambda *_a, **_k: "sk-route")
+    monkeypatch.setattr(
+        f"{prefix}.run_registry.create_run", lambda *a, **k: {"run_id": "run_prepare_1"}
+    )
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
+
+    return SimpleNamespace(observed=observed, project=project, monkeypatch=monkeypatch)
+
+
+def _stub_profile(prepare_env, profile_id: str, model_name: str) -> None:
+    """Lässt ``expand_profile_in_data`` genau ein Profil auflösen."""
+    profile = SimpleNamespace(
+        model_name=model_name,
+        provider="openai",
+        api_key=None,
+        base_url=None,
+    )
+    store = MagicMock()
+    store.get.side_effect = lambda pid, **_kw: profile if pid == profile_id else None
+    prepare_env.monkeypatch.setattr(
+        "app.utils.llm_profile_resolver.get_llm_profiles_store", lambda: store
+    )
+
+
+def _post(client, **payload):
+    body = {"simulation_id": VALID_SIM_ID}
+    body.update(payload)
+    return client.post("/api/simulation/prepare", json=body)
+
+
+# ---------------------------------------------------------------------------
+# 1. Routing
+# ---------------------------------------------------------------------------
+
+
+def test_request_profile_is_resolved_to_its_model(client, prepare_env):
+    """Der Kern des Defekts: ``llm_profile_id`` allein muss routen.
+
+    Vor #888 blieb ``llm_model`` hier leer und die Vorbereitung lief auf dem
+    Server-Default-Modell.
+    """
+    _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
+
+    response = _post(client, llm_profile_id="prof-abc")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+
+
+def test_project_profile_is_resolved_when_request_sends_none(client, prepare_env):
+    """P5.3-Fallback bleibt erhalten: Projekt-Profil greift ohne Request-Profil."""
+    prepare_env.project.llm_profile_id = "prof-project"
+    _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
+
+    response = _post(client)
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "gemini-2.5-flash"
+
+
+def test_request_profile_beats_project_profile(client, prepare_env):
+    """Single-Run-Override: das Request-Profil schlägt den Projekt-Default."""
+    prepare_env.project.llm_profile_id = "prof-project"
+    _stub_profile(prepare_env, "prof-request", "claude-sonnet-5")
+
+    response = _post(client, llm_profile_id="prof-request")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+
+
+def test_explicit_model_beats_every_profile(client, prepare_env):
+    """Explizite Modellwahl schlägt Request- und Projekt-Profil."""
+    prepare_env.project.llm_profile_id = "prof-project"
+    _stub_profile(prepare_env, "prof-request", "claude-sonnet-5")
+
+    response = _post(client, llm_profile_id="prof-request", llm_model="gpt-4o-mini")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "gpt-4o-mini"
+
+
+def test_default_placeholder_does_not_count_as_explicit_choice(client, prepare_env):
+    """``llm_model="default"`` ist die UI-Platzhalterwahl, keine Modellwahl."""
+    _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
+
+    response = _post(client, llm_profile_id="prof-abc", llm_model="default")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+
+
+def test_unresolvable_profile_does_not_break_the_request(client, prepare_env):
+    """Unbekanntes Profil: ``expand_profile_in_data`` ist ein No-op, kein 500.
+
+    Der ``profile:``-Token bleibt dann als ``llm_model`` stehen — bewusst
+    unverändertes Bestandsverhalten des Resolvers, hier nur festgehalten.
+    """
+    _stub_profile(prepare_env, "prof-known", "claude-sonnet-5")
+
+    response = _post(client, llm_profile_id="prof-missing")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["resolved"] == "profile:prof-missing"
+
+
+# ---------------------------------------------------------------------------
+# 2. Re-Prepare-Semantik
+# ---------------------------------------------------------------------------
+
+
+class TestAlreadyPreparedShortCircuit:
+    """Der Kurzschluss hängt an der expliziten Client-Wahl, nicht am Profil."""
+
+    def test_profile_derived_model_still_checks_prepared_state(self, client, prepare_env):
+        """Regressionsbremse: sonst kostet jedes Betreten von Step 2 einen vollen Lauf."""
+        prepare_env.project.llm_profile_id = "prof-project"
+        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
+
+        response = _post(client)
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is True
+
+    def test_request_profile_still_checks_prepared_state(self, client, prepare_env):
+        _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
+
+        response = _post(client, llm_profile_id="prof-abc")
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is True
+
+    def test_explicit_model_skips_prepared_check(self, client, prepare_env):
+        """Unverändert: eine explizite Modellwahl erzwingt die Neu-Vorbereitung."""
+        response = _post(client, llm_model="gpt-4o-mini")
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is False
+
+    def test_explicit_runtime_provider_skips_prepared_check(self, client, prepare_env):
+        """Ein echter Client-Provider-Override erzwingt weiterhin die Neu-Vorbereitung."""
+        response = _post(
+            client,
+            llm_provider={
+                "provider": "custom_openai",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "sk-test",
+            },
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is False
+
+    def test_profile_derived_provider_block_is_not_an_override(self, client, prepare_env):
+        """Abgrenzung zum Test darüber: der Provider-Block aus dem Profil zählt nicht.
+
+        ``expand_profile_in_data`` schreibt Provider/Key/Base-URL aus dem Profil in
+        ``data['llm_provider']``. Ohne die Unterscheidung "kam vom Client" wäre das
+        von einem echten Override ununterscheidbar und der Kurzschluss tot.
+        """
+        prepare_env.project.llm_profile_id = "prof-project"
+        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
+
+        response = _post(client)
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is True
+
+    def test_force_regenerate_skips_prepared_check(self, client, prepare_env):
+        prepare_env.project.llm_profile_id = "prof-project"
+        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
+
+        response = _post(client, force_regenerate=True)
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is False
+
+    def test_already_prepared_returns_short_circuit_envelope(
+        self, client, prepare_env, monkeypatch
+    ):
+        """Ist die Sim vorbereitet, antwortet der Endpoint ohne neuen Lauf."""
+        prepare_env.project.llm_profile_id = "prof-project"
+        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
+        monkeypatch.setattr(
+            "app.api.simulation_prepare._check_simulation_prepared",
+            lambda _sim_id: (True, {"profiles": 12}),
+        )
+
+        response = _post(client)
+
+        assert response.status_code == 200, response.get_json()
+        payload = response.get_json()["data"]
+        assert payload["already_prepared"] is True
+        assert prepare_env.observed["resolved"] is None

--- a/backend/tests/api/test_simulation_prepare_profile_routing.py
+++ b/backend/tests/api/test_simulation_prepare_profile_routing.py
@@ -35,10 +35,12 @@ VALID_SIM_ID = "sim_0123456789ab"
 
 @pytest.fixture
 def client(monkeypatch):
-    # @require_scope greift, sobald AGORA_AUTH_TOKEN gesetzt ist — die Variable
-    # leakt aus Nachbar-Suites in den Gesamtlauf. Open-Mode erzwingen (Muster aus
-    # tests/api/test_simulation_endpoints.py); diese Suite prüft Routing, nicht Auth.
-    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    # AGORA_AUTH_TOKEN steht via load_dotenv() in app/config.py prozessweit in
+    # os.environ; sobald irgendein Test create_app() ruft, hängt der
+    # Blueprint-Guard dauerhaft an simulation_bp und diese Suite bekäme 401.
+    # Open-Mode erzwingen (Muster aus tests/api/test_simulation_endpoints.py) —
+    # hier geht es um Routing, nicht um Auth.
+    monkeypatch.setenv("AGORA_AUTH_TOKEN", "")
     app = Flask(__name__)
     app.config["AGORA_AUTH_TOKEN"] = ""
     app.config["AGORA_LLM_TRIGGER_RATE_LIMIT_MAX"] = 1000

--- a/backend/tests/api/test_simulation_prepare_profile_routing.py
+++ b/backend/tests/api/test_simulation_prepare_profile_routing.py
@@ -11,12 +11,18 @@ Server-Default-Modell.
 
 Diese Suite pinnt beide Hälften der Korrektur:
 
-1. **Routing** — ``llm_profile_id`` wird aufgelöst; Request-Profil schlägt
-   Projekt-Profil, eine explizite Modellwahl schlägt beide.
+1. **Routing über den kanonischen Pfad** — die Profil-ID wird an
+   ``seed_run_stage_routing(llm_profile_id=...)`` durchgereicht, nicht lokal zu
+   ``llm_model`` expandiert. Nur dessen Profil-Branch löst die aktivierte
+   ``ProviderConnection`` auf und koppelt sie an deren gebundenes Secret
+   (SSoT, Issue #817). Eine lokale Expansion würde Endpoint und Key aus dem
+   Legacy-Profil einbrennen und nach einer Rotation auf veraltete Credentials
+   zeigen. Präzedenz: explizites Modell → Request-Profil → Projekt-Profil.
 2. **Re-Prepare-Semantik** — der "bereits vorbereitet"-Kurzschluss hängt an der
-   *expliziten* Client-Wahl, nicht mehr an ``llm_model_override``. Sonst würde
-   er für jedes Projekt mit hinterlegtem Profil nie mehr greifen und jedes
-   Betreten von Step 2 eine volle Neu-Vorbereitung auslösen.
+   *expliziten* Client-Wahl, nicht an ``llm_model_override``. Sonst würde er für
+   jedes Projekt mit hinterlegtem Profil nie mehr greifen und jedes Betreten von
+   Step 2 eine volle Neu-Vorbereitung auslösen. Ein Request-Profil, das vom
+   Projekt-Default *abweicht*, zählt dabei sehr wohl als explizite Wahl.
 """
 
 from __future__ import annotations
@@ -54,15 +60,17 @@ def client(monkeypatch):
 def prepare_env(monkeypatch):
     """Verdrahtet ``/prepare`` so, dass nur das Modell-Routing beobachtet wird.
 
-    Liefert ein Dict mit ``resolved`` (das ``llm_model``, mit dem der Endpoint in
-    ``seed_run_stage_routing`` geht — also das Ergebnis der Profil-Auflösung) und
-    ``prepared_checked`` (ob der "bereits vorbereitet"-Kurzschluss lief).
+    ``observed`` hält fest, womit der Endpoint in ``seed_run_stage_routing`` geht:
+    ``profile`` (die durchgereichte ``llm_profile_id``), ``model``
+    (``llm_model_override``) und ``prepared_checked`` (ob der "bereits
+    vorbereitet"-Kurzschluss lief).
 
-    Bewusst wird ``seed_run_stage_routing`` abgegriffen statt
-    ``prepare_simulation``: dort steht ``llm_model_override`` vor der
-    Router-Auflösung, die es im Test-Fixture ohnehin überschreibt.
+    ``seed_run_stage_routing`` wird abgegriffen statt ``prepare_simulation``: dort
+    steht das Routing-Argument vor der Router-Auflösung, die es im Test-Fixture
+    ohnehin überschreibt. Der Profil-Branch selbst ist in
+    ``tests/services/test_llm_routing_seed.py`` abgedeckt.
     """
-    observed: dict = {"resolved": None, "prepared_checked": False}
+    observed: dict = {"profile": None, "model": None, "prepared_checked": False}
 
     project = SimpleNamespace(
         simulation_requirement="Discuss the project",
@@ -118,8 +126,10 @@ def prepare_env(monkeypatch):
         def lock_stage(self, *_args, **_kwargs):
             return None
 
-    def capture_seed(_run_id, _stage, *, llm_model_override=None, llm_runtime=None):
-        observed["resolved"] = llm_model_override
+    def capture_seed(_run_id, _stage, *, llm_model_override=None, llm_runtime=None,
+                     llm_profile_id=None):
+        observed["model"] = llm_model_override
+        observed["profile"] = llm_profile_id
 
     def capture_prepared_check(_simulation_id):
         observed["prepared_checked"] = True
@@ -150,21 +160,6 @@ def prepare_env(monkeypatch):
     return SimpleNamespace(observed=observed, project=project, monkeypatch=monkeypatch)
 
 
-def _stub_profile(prepare_env, profile_id: str, model_name: str) -> None:
-    """Lässt ``expand_profile_in_data`` genau ein Profil auflösen."""
-    profile = SimpleNamespace(
-        model_name=model_name,
-        provider="openai",
-        api_key=None,
-        base_url=None,
-    )
-    store = MagicMock()
-    store.get.side_effect = lambda pid, **_kw: profile if pid == profile_id else None
-    prepare_env.monkeypatch.setattr(
-        "app.utils.llm_profile_resolver.get_llm_profiles_store", lambda: store
-    )
-
-
 def _post(client, **payload):
     body = {"simulation_id": VALID_SIM_ID}
     body.update(payload)
@@ -172,79 +167,111 @@ def _post(client, **payload):
 
 
 # ---------------------------------------------------------------------------
-# 1. Routing
+# 1. Routing über den kanonischen Profil-Pfad
 # ---------------------------------------------------------------------------
 
 
-def test_request_profile_is_resolved_to_its_model(client, prepare_env):
+def test_request_profile_is_forwarded_to_the_canonical_seed_path(client, prepare_env):
     """Der Kern des Defekts: ``llm_profile_id`` allein muss routen.
 
-    Vor #888 blieb ``llm_model`` hier leer und die Vorbereitung lief auf dem
-    Server-Default-Modell.
+    Vor #888 kam hier weder ein Modell noch eine Profil-ID an und die
+    Vorbereitung lief auf dem Server-Default-Modell. Die ID geht bewusst
+    *unexpandiert* durch, damit ``seed_run_stage_routing`` die ProviderConnection
+    auflösen und deren Secret binden kann.
     """
-    _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
-
     response = _post(client, llm_profile_id="prof-abc")
 
     assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+    assert prepare_env.observed["profile"] == "prof-abc"
+    assert prepare_env.observed["model"] is None
 
 
-def test_project_profile_is_resolved_when_request_sends_none(client, prepare_env):
+def test_project_profile_is_forwarded_when_request_sends_none(client, prepare_env):
     """P5.3-Fallback bleibt erhalten: Projekt-Profil greift ohne Request-Profil."""
     prepare_env.project.llm_profile_id = "prof-project"
-    _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
 
     response = _post(client)
 
     assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "gemini-2.5-flash"
+    assert prepare_env.observed["profile"] == "prof-project"
 
 
 def test_request_profile_beats_project_profile(client, prepare_env):
     """Single-Run-Override: das Request-Profil schlägt den Projekt-Default."""
     prepare_env.project.llm_profile_id = "prof-project"
-    _stub_profile(prepare_env, "prof-request", "claude-sonnet-5")
 
     response = _post(client, llm_profile_id="prof-request")
 
     assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+    assert prepare_env.observed["profile"] == "prof-request"
 
 
 def test_explicit_model_beats_every_profile(client, prepare_env):
-    """Explizite Modellwahl schlägt Request- und Projekt-Profil."""
+    """Explizite Modellwahl schlägt Request- und Projekt-Profil.
+
+    Dann darf auch keine Profil-ID mehr durchgereicht werden, sonst konkurrierten
+    zwei Routing-Anweisungen um dieselbe Stage.
+    """
     prepare_env.project.llm_profile_id = "prof-project"
-    _stub_profile(prepare_env, "prof-request", "claude-sonnet-5")
 
     response = _post(client, llm_profile_id="prof-request", llm_model="gpt-4o-mini")
 
     assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "gpt-4o-mini"
+    assert prepare_env.observed["model"] == "gpt-4o-mini"
+    assert prepare_env.observed["profile"] is None
 
 
 def test_default_placeholder_does_not_count_as_explicit_choice(client, prepare_env):
     """``llm_model="default"`` ist die UI-Platzhalterwahl, keine Modellwahl."""
-    _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
-
     response = _post(client, llm_profile_id="prof-abc", llm_model="default")
 
     assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "claude-sonnet-5"
+    assert prepare_env.observed["profile"] == "prof-abc"
 
 
-def test_unresolvable_profile_does_not_break_the_request(client, prepare_env):
-    """Unbekanntes Profil: ``expand_profile_in_data`` ist ein No-op, kein 500.
+def test_legacy_profile_token_in_llm_model_is_still_expanded(client, prepare_env):
+    """Legacy-Pfad: ``llm_model="profile:<id>"`` wird weiterhin lokal expandiert.
 
-    Der ``profile:``-Token bleibt dann als ``llm_model`` stehen — bewusst
-    unverändertes Bestandsverhalten des Resolvers, hier nur festgehalten.
+    ``HeroNewRun.vue`` schickt Profile historisch als Pseudo-Modell im
+    ``llm_model``-Feld; ``seed_run_stage_routing`` kennt nur das separate Feld.
+    Ohne ``expand_profile_in_data`` ginge der Token als Modellname an den
+    LLM-Client.
     """
-    _stub_profile(prepare_env, "prof-known", "claude-sonnet-5")
+    profile = SimpleNamespace(
+        model_name="claude-sonnet-5", provider="openai", api_key=None, base_url=None
+    )
+    store = MagicMock()
+    store.get.side_effect = lambda pid, **_kw: profile if pid == "prof-legacy" else None
+    prepare_env.monkeypatch.setattr(
+        "app.utils.llm_profile_resolver.get_llm_profiles_store", lambda: store
+    )
+
+    response = _post(client, llm_model="profile:prof-legacy")
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_env.observed["model"] == "claude-sonnet-5"
+
+
+def test_unresolvable_profile_surfaces_as_http_400(client, prepare_env):
+    """Unauflösbares Profil wird abgelehnt, nicht stillschweigend eingereiht.
+
+    ``seed_run_stage_routing`` wirft für ein unbekanntes Profil bzw. eine fehlende
+    aktivierte ProviderConnection ``ValueError`` (siehe
+    ``services/llm_routing_seed.py``, dort auch getestet); ``@handle_api_errors``
+    macht daraus HTTP 400. Vor der Umstellung auf den kanonischen Pfad lief in
+    diesem Fall der literale Modellname ``profile:<id>`` in die Queue.
+    """
+    def raise_unknown_profile(*_args, llm_profile_id=None, **_kwargs):
+        raise ValueError(f"LLM-Profil {llm_profile_id!r} nicht gefunden")
+
+    prepare_env.monkeypatch.setattr(
+        "app.api.simulation_prepare.seed_run_stage_routing", raise_unknown_profile
+    )
 
     response = _post(client, llm_profile_id="prof-missing")
 
-    assert response.status_code == 200, response.get_json()
-    assert prepare_env.observed["resolved"] == "profile:prof-missing"
+    assert response.status_code == 400, response.get_json()
+    assert "nicht gefunden" in str(response.get_json())
 
 
 # ---------------------------------------------------------------------------
@@ -255,23 +282,51 @@ def test_unresolvable_profile_does_not_break_the_request(client, prepare_env):
 class TestAlreadyPreparedShortCircuit:
     """Der Kurzschluss hängt an der expliziten Client-Wahl, nicht am Profil."""
 
-    def test_profile_derived_model_still_checks_prepared_state(self, client, prepare_env):
+    def test_project_profile_still_checks_prepared_state(self, client, prepare_env):
         """Regressionsbremse: sonst kostet jedes Betreten von Step 2 einen vollen Lauf."""
         prepare_env.project.llm_profile_id = "prof-project"
-        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
 
         response = _post(client)
 
         assert response.status_code == 200, response.get_json()
         assert prepare_env.observed["prepared_checked"] is True
 
-    def test_request_profile_still_checks_prepared_state(self, client, prepare_env):
-        _stub_profile(prepare_env, "prof-abc", "claude-sonnet-5")
+    def test_request_profile_equal_to_project_default_still_checks(self, client, prepare_env):
+        """Dasselbe Profil erneut zu schicken bleibt der billige Revisit.
 
-        response = _post(client, llm_profile_id="prof-abc")
+        Genau dieser Fall ist der Frontend-Alltag: ``Step2EnvSetup.vue`` sendet
+        ``props.projectData.llm_profile_id`` mit, also immer den Projekt-Default.
+        """
+        prepare_env.project.llm_profile_id = "prof-project"
+
+        response = _post(client, llm_profile_id="prof-project")
 
         assert response.status_code == 200, response.get_json()
         assert prepare_env.observed["prepared_checked"] is True
+
+    def test_differing_request_profile_skips_prepared_check(self, client, prepare_env):
+        """Ein abweichendes Request-Profil ist eine explizite Wahl.
+
+        Ohne diesen Zweig käme der Endpoint mit ``already_prepared`` zurück und die
+        Personas blieben die des vorherigen Modells — im Widerspruch zur Präzedenz
+        "Request-Profil schlägt Projekt-Profil".
+        """
+        prepare_env.project.llm_profile_id = "prof-project"
+
+        response = _post(client, llm_profile_id="prof-request")
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is False
+        assert prepare_env.observed["profile"] == "prof-request"
+
+    def test_request_profile_without_project_default_skips_prepared_check(
+        self, client, prepare_env
+    ):
+        """Kein Projekt-Default gesetzt: jedes Request-Profil ist eine Abweichung."""
+        response = _post(client, llm_profile_id="prof-request")
+
+        assert response.status_code == 200, response.get_json()
+        assert prepare_env.observed["prepared_checked"] is False
 
     def test_explicit_model_skips_prepared_check(self, client, prepare_env):
         """Unverändert: eine explizite Modellwahl erzwingt die Neu-Vorbereitung."""
@@ -294,24 +349,8 @@ class TestAlreadyPreparedShortCircuit:
         assert response.status_code == 200, response.get_json()
         assert prepare_env.observed["prepared_checked"] is False
 
-    def test_profile_derived_provider_block_is_not_an_override(self, client, prepare_env):
-        """Abgrenzung zum Test darüber: der Provider-Block aus dem Profil zählt nicht.
-
-        ``expand_profile_in_data`` schreibt Provider/Key/Base-URL aus dem Profil in
-        ``data['llm_provider']``. Ohne die Unterscheidung "kam vom Client" wäre das
-        von einem echten Override ununterscheidbar und der Kurzschluss tot.
-        """
-        prepare_env.project.llm_profile_id = "prof-project"
-        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
-
-        response = _post(client)
-
-        assert response.status_code == 200, response.get_json()
-        assert prepare_env.observed["prepared_checked"] is True
-
     def test_force_regenerate_skips_prepared_check(self, client, prepare_env):
         prepare_env.project.llm_profile_id = "prof-project"
-        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
 
         response = _post(client, force_regenerate=True)
 
@@ -323,7 +362,6 @@ class TestAlreadyPreparedShortCircuit:
     ):
         """Ist die Sim vorbereitet, antwortet der Endpoint ohne neuen Lauf."""
         prepare_env.project.llm_profile_id = "prof-project"
-        _stub_profile(prepare_env, "prof-project", "gemini-2.5-flash")
         monkeypatch.setattr(
             "app.api.simulation_prepare._check_simulation_prepared",
             lambda _sim_id: (True, {"profiles": 12}),
@@ -334,4 +372,4 @@ class TestAlreadyPreparedShortCircuit:
         assert response.status_code == 200, response.get_json()
         payload = response.get_json()["data"]
         assert payload["already_prepared"] is True
-        assert prepare_env.observed["resolved"] is None
+        assert prepare_env.observed["profile"] is None

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -89,6 +89,14 @@ def test_prepare_endpoint_uses_resolved_route_for_legacy_service_call(client, mo
         lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=fake_filtered)),
     )
     monkeypatch.setattr("app.api.simulation_prepare.seed_run_stage_routing", lambda *a, **k: None)
+    # Seit #888 überspringt ein profil-abgeleitetes Modell den
+    # "bereits vorbereitet"-Kurzschluss nicht mehr, d. h. der Check läuft hier
+    # jetzt tatsächlich und bräuchte einen initialisierten
+    # SimulationArtifactStore. Diese Suite prüft Key-Routing, nicht den
+    # Prepared-State — deshalb fest auf "nicht vorbereitet".
+    monkeypatch.setattr(
+        "app.api.simulation_prepare._check_simulation_prepared", lambda _sid: (False, {})
+    )
     monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
     monkeypatch.setattr("app.api.simulation_prepare.resolve_route_api_key", lambda *_a, **_k: "sk-route")
     monkeypatch.setattr(
@@ -172,6 +180,14 @@ def _run_prepare_with_route(client, monkeypatch, *, resolved_route, resolved_api
         lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=fake_filtered)),
     )
     monkeypatch.setattr("app.api.simulation_prepare.seed_run_stage_routing", lambda *a, **k: None)
+    # Seit #888 überspringt ein profil-abgeleitetes Modell den
+    # "bereits vorbereitet"-Kurzschluss nicht mehr, d. h. der Check läuft hier
+    # jetzt tatsächlich und bräuchte einen initialisierten
+    # SimulationArtifactStore. Diese Suite prüft Key-Routing, nicht den
+    # Prepared-State — deshalb fest auf "nicht vorbereitet".
+    monkeypatch.setattr(
+        "app.api.simulation_prepare._check_simulation_prepared", lambda _sid: (False, {})
+    )
     monkeypatch.setattr("app.api.simulation_prepare.StageModelRouter", FakeRouter)
     monkeypatch.setattr("app.api.simulation_prepare.resolve_route_api_key", lambda *_a, **_k: resolved_api_key)
     monkeypatch.setattr(

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3586 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3588 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3573 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3586 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Closes #888. Entscheidungs-Slice — die gewählte Richtung ist unten begründet.

## Befund

Schärfer als das Issue vermutete: `llm_profile_id` war nicht bloß wirkungslos, es **kehrte seine eigene Absicht um**.

Standardfall — Projekt hat ein Profil, User lässt die Modellauswahl auf „default":

1. `Step2EnvSetup.vue:232` sendet `payload.llm_profile_id = props.projectData.llm_profile_id`. `effectiveModel()` liefert bei „default" `null`, also **kein** `llm_model` im Payload.
2. `simulation_prepare.py:279`: `_data_profile` ist gesetzt → der P5.3-Fallback-Block wird **übersprungen** → `data['llm_model']` bleibt leer.
3. `expand_profile_in_data(data)` ist ein No-op (kein `profile:`-Präfix).
4. `llm_model_override = None` → Vorbereitung läuft auf dem Server-Default-Modell.

Hätte das Frontend `llm_profile_id` **weggelassen**, hätte der Fallback gegriffen und `profile:<id>` injiziert — korrekt aufgelöst. Das Mitsenden verhinderte genau die Auflösung, die es auslösen sollte.

Der Kommentar „Respektiert expliziten Single-Run-Override (analog graph.py / report.py)" trug nicht: dort ist `llm_profile_id` ein echter Routing-Kanal (`report.py:151` → `report_generation.py:63`), hier war es nur ein Unterdrücker. Seit #834 gibt es zudem keine UI mehr, die einen abweichenden Wert setzen könnte — der „Single-Run-Override" war immer identisch mit dem Projekt-Default, den er unterdrückte.

## Entscheidung

Profil-Auflösung nachziehen statt das Feld als Fallback-Guard zu dokumentieren. Letzteres hätte einen Defekt als Feature festgeschrieben: der Standardfall hätte das Projekt-Profil weiterhin still ignoriert. Die Auflösung macht `/prepare` außerdem konsistent zu `graph_build.py` und `report.py`.

Präzedenz jetzt: explizites `llm_model` → Request-Profil → Projekt-Profil → Server-Default. `llm_model="default"` zählt als UI-Platzhalter (`effectiveModel()` liefert dafür `null`), nicht als Modellwahl.

## Die Re-Prepare-Kopplung

`llm_model_override` steuerte doppelt: Routing **und** den „bereits vorbereitet"-Kurzschluss. Sobald die Profil-Auflösung greift, ist es für jedes profil-tragende Projekt gesetzt — der Kurzschluss hätte nie mehr gegriffen und jedes Betreten von Step 2 hätte eine volle Neu-Vorbereitung samt Persona-Neugenerierung gekostet.

Beim Implementieren kam eine zweite Hälfte dazu, die in der Analyse noch nicht sichtbar war: `expand_profile_in_data` schreibt zusätzlich einen `llm_provider`-Block aus dem Profil (`llm_profile_resolver.py:72`), wodurch auch `llm_runtime.enabled` True wird. Der erste Entkopplungsversuch über `explicit_model_override` allein reichte deshalb nicht — die Tests haben das gefangen.

Gelöst über `client_requested_override`: nur ein vom Client *explizit* gesendetes `llm_model` oder `llm_provider` überspringt den Kurzschluss. `explicit_runtime_request` wird dafür **vor** der Expansion festgehalten, sonst wäre der profil-abgeleitete Provider-Block von einem echten Override ununterscheidbar.

## Tests

Neue Suite `backend/tests/api/test_simulation_prepare_profile_routing.py`, 13 Tests:

- **Routing (6):** Request-Profil wird aufgelöst; Projekt-Profil greift ohne Request-Profil; Request-Profil schlägt Projekt-Profil; explizites Modell schlägt beide; `"default"` ist keine explizite Wahl; unauflösbares Profil bricht den Request nicht (Bestandsverhalten des Resolvers, hier nur festgehalten).
- **Kurzschluss (7):** profil-abgeleitetes Modell und profil-abgeleiteter Provider-Block prüfen weiterhin den Prepared-State; explizites Modell, expliziter Provider und `force_regenerate` überspringen ihn; der Short-Circuit-Envelope wird korrekt zurückgegeben.

## Verifikation

- **7 der 13 Tests sind gegen den alten `simulation_prepare.py` rot** — genau die Verhaltensänderungen. Die übrigen 6 sichern unverändertes Verhalten ab.
- `bash scripts/pre-push-gate.sh backend` → ALL GREEN.
- `tests/api` hat mit und ohne diese Änderung dieselben **138 vorbestehenden Failures** (`AGORA_AUTH_TOKEN` leakt zwischen Suites — unabhängiges Bestandsproblem, deshalb läuft im PR-Gate nur `tests/contracts/`). Die neue Suite ist im Gesamtlauf sauber, weil ihr Client-Fixture den Open-Mode erzwingt (Muster aus `test_simulation_endpoints.py`).
- CHANGELOG-Eintrag unter `[Unreleased]` (AGENTS.md Regel 5), `docs/STATUS.md` nachgezogen.

## Anmerkung fürs Review

Der Frontend-Test-Kommentar in `Step2EnvSetup.spec.ts:301` behauptete bisher „das ist der Backend-live Profil-Pfad (simulation_prepare.py expandiert llm_profile_id …)" — das war schlicht falsch. Durch diesen PR wird die Behauptung wahr; der Kommentar bleibt daher unverändert.

Baut nicht auf PR #893 (#887) auf — keine Datei-Überschneidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Die Simulation verwendet `llm_profile_id` nun korrekt für das Profil-Routing.
  * Modell-, Request-Profil-, Projekt-Profil- und Server-Defaults werden in der richtigen Reihenfolge berücksichtigt.
  * Nicht auflösbare Profile werden mit HTTP 400 abgelehnt.
  * Die erneute Vorbereitung wird nur bei tatsächlichen Überschreibungen übersprungen.
  * Legacy-Profilangaben und der UI-Platzhalter `llm_model="default"` bleiben kompatibel.

* **Tests**
  * Umfangreiche Tests für Profil-Routing und Re-Prepare-Verhalten ergänzt und aktualisiert.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->