### PR TITLE
feat(backend): /prepare auf kanonische AiModelRef migrieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (`/prepare` akzeptiert kanonische `AiModelRef` — Issue #896)
+
+- `/prepare` akzeptiert jetzt eine kanonische, an eine `ProviderConnection` gebundene
+  `AiModelRef` als autoritative Route. Mischfälle mit Legacy-Overrides werden abgelehnt;
+  eine explizit gesendete Ref löst ein Re-Prepare aus.
+
 ### Fixed (133 reihenfolgenabhängige Test-Failures in `tests/api` — 2026-07-26)
 
 - **`backend/tests/conftest.py`** — neues autouse-Fixture `_clean_auth_token_env`.

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -246,6 +246,35 @@ def prepare_simulation():
             message="Invalid simulation_id format",
         )
 
+    ai_model_ref = None
+    raw_ai_model_ref = data.get("ai_model_ref")
+    if raw_ai_model_ref is not None:
+        from ..contracts.ai_provider_contract import AiModelRef
+
+        try:
+            ai_model_ref = AiModelRef.model_validate(raw_ai_model_ref)
+        except ValidationError:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message="ai_model_ref ist ungültig",
+            )
+
+        conflicting = [
+            key
+            for key in ("llm_model", "llm_profile_id", "llm_provider", "llm_runtime")
+            if data.get(key)
+        ]
+        if conflicting:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=(
+                    f"ai_model_ref darf nicht mit {', '.join(conflicting)} "
+                    "kombiniert werden"
+                ),
+            )
+
     manager = SimulationManager()
     state = manager.get_simulation(simulation_id)
     if not state:
@@ -304,20 +333,28 @@ def prepare_simulation():
     # Request-Profil schlägt Projekt-Profil (Single-Run-Override), beide schlagen
     # das Server-Default-Modell. Eine explizite Modellwahl schlägt alles.
     routed_profile_id = None if explicit_model_override else (_data_profile or _project_profile)
-    # UI-Profile-Token expandieren: schickt der Client selbst ein
-    # `llm_model="profile:<id>"` (Legacy-Pfad aus `HeroNewRun.vue`), muss es hier
-    # aufgelöst werden — `seed_run_stage_routing` kennt nur das separate Feld.
-    from ..utils.llm_profile_resolver import expand_profile_in_data
-    expand_profile_in_data(data)
-    llm_model_override = (data.get('llm_model') or '').strip() or None
-    try:
-        llm_runtime = parse_runtime_llm_config(data)
-    except ValueError as exc:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=400,
-            message=str(exc),
-        )
+    if ai_model_ref is not None:
+        # Eine explizite Ref ist die alleinige Routing-Quelle: kein Legacy-
+        # Profil, kein Runtime-Override und kein Projektprofil-Fallback.
+        routed_profile_id = None
+        llm_model_override = None
+        llm_runtime = parse_runtime_llm_config({})
+    else:
+        # UI-Profile-Token expandieren: schickt der Client selbst ein
+        # `llm_model="profile:<id>"` (Legacy-Pfad aus `HeroNewRun.vue`), muss es hier
+        # aufgelöst werden — `seed_run_stage_routing` kennt nur das separate Feld.
+        from ..utils.llm_profile_resolver import expand_profile_in_data
+
+        expand_profile_in_data(data)
+        llm_model_override = (data.get('llm_model') or '').strip() or None
+        try:
+            llm_runtime = parse_runtime_llm_config(data)
+        except ValueError as exc:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            )
     logger.info(
         f"Start processing /prepare Request: simulation_id={simulation_id}, force_regenerate={force_regenerate}",
         extra={'simulation_id': simulation_id},
@@ -339,6 +376,7 @@ def prepare_simulation():
         explicit_model_override
         or explicit_profile_override
         or (llm_runtime.enabled and explicit_runtime_request)
+        or ai_model_ref is not None
     )
     if not force_regenerate and not client_requested_override:
         logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
@@ -410,6 +448,17 @@ def prepare_simulation():
         logger.warning(f"Synchronously get entity countFailed（Will retry in background task）: {exc}")
 
     task_manager = TaskManager()
+    if ai_model_ref is not None:
+        from ..services.llm_routing_seed import prevalidate_ai_model_ref
+
+        try:
+            prevalidate_ai_model_ref(ai_model_ref)
+        except ValueError as exc:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            )
     run_record = run_registry.create_run(
         run_type="simulation_prepare",
         entity_id=simulation_id,
@@ -442,13 +491,62 @@ def prepare_simulation():
             "run_id": run_record["run_id"],
         },
     )
-    seed_run_stage_routing(
-        run_record["run_id"],
-        "persona_generation",
-        llm_model_override=llm_model_override,
-        llm_runtime=llm_runtime,
-        llm_profile_id=routed_profile_id,
-    )
+    if ai_model_ref is not None:
+        try:
+            seed_run_stage_routing(
+                run_record["run_id"],
+                "persona_generation",
+                llm_model_override=llm_model_override,
+                llm_runtime=llm_runtime,
+                llm_profile_id=routed_profile_id,
+                ai_model_ref=ai_model_ref,
+            )
+        except ValueError as exc:
+            routing_error = str(exc)
+            task_manager.fail_task(task_id, routing_error)
+
+            persistence_error: Optional[Exception] = None
+            try:
+                updated_run = run_registry.update_run(
+                    run_record["run_id"],
+                    status="failed",
+                    message=routing_error,
+                    error=routing_error,
+                )
+            except Exception as update_exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
+                updated_run = None
+                persistence_error = update_exc
+
+            if updated_run is None:
+                logger.error(
+                    "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
+                    "failed nach AiModelRef-Routingfehler: %s",
+                    run_record["run_id"],
+                    task_id,
+                    persistence_error
+                    or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+                )
+                return json_error(
+                    ApiErrorCode.INTERNAL_ERROR,
+                    status=500,
+                    message=(
+                        "Interner Fehler beim Markieren des Runs als fehlgeschlagen. "
+                        "Bitte erneut versuchen."
+                    ),
+                )
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=routing_error,
+            )
+    else:
+        seed_run_stage_routing(
+            run_record["run_id"],
+            "persona_generation",
+            llm_model_override=llm_model_override,
+            llm_runtime=llm_runtime,
+            llm_profile_id=routed_profile_id,
+        )
     route_router = StageModelRouter(run_record["run_id"])
     resolved_route = route_router.resolve("persona_generation")
     route_router.lock_stage("persona_generation", resolved_route)

--- a/backend/tests/api/test_simulation_prepare_provider_route_api.py
+++ b/backend/tests/api/test_simulation_prepare_provider_route_api.py
@@ -1,0 +1,299 @@
+"""API-Vertrag für ``POST /api/simulation/prepare`` mit ``AiModelRef`` (#896)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+from app.contracts.llm_routing_contract import ResolvedRoute
+
+
+VALID_SIM_ID = "sim_0123456789ab"
+CONNECTION_ID = "conn-minimax"
+MODEL_ID = "MiniMax-M3"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("AGORA_AUTH_TOKEN", "")
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_AUTH_TOKEN="",
+        AGORA_LLM_TRIGGER_RATE_LIMIT_MAX=1000,
+        AGORA_LLM_TRIGGER_RATE_LIMIT_WINDOW_SECONDS=60,
+    )
+    app.extensions = {"neo4j_storage": MagicMock(name="Neo4jStorage")}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+@pytest.fixture
+def prepare_route_env(monkeypatch):
+    observed: dict[str, object] = {
+        "seed_ref": None,
+        "seed_profile": None,
+        "prevalidated_ref": None,
+        "prepared_checked": False,
+        "resolved": None,
+        "locked": None,
+        "failed_run": None,
+        "failed_task": None,
+    }
+    project = SimpleNamespace(
+        simulation_requirement="Discuss the project",
+        llm_profile_id=None,
+    )
+    state = SimpleNamespace(
+        project_id="proj_123",
+        graph_id="graph_123",
+        source_simulation_id=None,
+        root_simulation_id=None,
+        branch_name=None,
+        branch_depth=0,
+        entities_count=1,
+        entity_types=["Person"],
+    )
+    manager = MagicMock()
+    manager.get_simulation.return_value = state
+    manager.prepare_simulation.side_effect = lambda **_kwargs: MagicMock(
+        to_simple_dict=lambda: {"simulation_id": VALID_SIM_ID, "status": "ready"}
+    )
+    filtered = MagicMock(filtered_count=1, entity_types={"Person"})
+    resolved_route = ResolvedRoute(
+        stage="persona_generation",
+        provider_id=CONNECTION_ID,
+        model=MODEL_ID,
+        base_url_sanitized="https://api.minimax.io/v1",
+        routing_version=1,
+        provider_options={"connection_only": True, "secret_ref": "configured-secret"},
+    )
+
+    class FakeTaskManager:
+        def create_task(self, *_args, **_kwargs):
+            return "task_prepare_1"
+
+        def update_task(self, *_args, **_kwargs):
+            return None
+
+        def complete_task(self, *_args, **_kwargs):
+            return None
+
+        def fail_task(self, task_id, error):
+            observed["failed_task"] = {"task_id": task_id, "error": error}
+            return None
+
+    class FakeRouter:
+        def __init__(self, _run_id: str):
+            pass
+
+        def resolve(self, _stage_id: str):
+            observed["resolved"] = resolved_route
+            return resolved_route
+
+        def lock_stage(self, _stage_id: str, route: ResolvedRoute):
+            observed["locked"] = route
+            return route
+
+    def capture_seed(
+        _run_id,
+        _stage,
+        *,
+        llm_model_override=None,
+        llm_runtime=None,
+        llm_profile_id=None,
+        ai_model_ref=None,
+    ):
+        observed["seed_ref"] = ai_model_ref
+        observed["seed_profile"] = llm_profile_id
+
+    def capture_prepared_check(_simulation_id):
+        observed["prepared_checked"] = True
+        return False, {}
+
+    def capture_prevalidation(ai_model_ref):
+        observed["prevalidated_ref"] = ai_model_ref
+        return MagicMock(name="ValidatedProviderConnection")
+    def capture_failed_run(run_id, **updates):
+        observed["failed_run"] = {"run_id": run_id, **updates}
+        return observed["failed_run"]
+
+    def run_inline(self):
+        self.run()
+
+    prefix = "app.api.simulation_prepare"
+    monkeypatch.setattr(f"{prefix}.SimulationManager", lambda: manager)
+    monkeypatch.setattr(f"{prefix}.ProjectManager.get_project", lambda _pid: project)
+    monkeypatch.setattr(f"{prefix}.ProjectManager.get_extracted_text", lambda _pid: "document text")
+    monkeypatch.setattr(f"{prefix}.get_simulation_storage", lambda: MagicMock())
+    monkeypatch.setattr(
+        f"{prefix}.EntityReader",
+        lambda _storage: MagicMock(filter_defined_entities=MagicMock(return_value=filtered)),
+    )
+    monkeypatch.setattr(f"{prefix}.seed_run_stage_routing", capture_seed)
+    monkeypatch.setattr(f"{prefix}._check_simulation_prepared", capture_prepared_check)
+    monkeypatch.setattr(f"{prefix}.StageModelRouter", FakeRouter)
+    monkeypatch.setattr(f"{prefix}.resolve_route_api_key", lambda *_args: "bound-key")
+    monkeypatch.setattr(
+        f"{prefix}.run_registry.create_run", lambda *_args, **_kwargs: {"run_id": "run_prepare_1"}
+    )
+    monkeypatch.setattr(f"{prefix}.run_registry.update_run", capture_failed_run)
+    monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
+    monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.prevalidate_ai_model_ref",
+        capture_prevalidation,
+        raising=False,
+    )
+
+    return SimpleNamespace(
+        observed=observed,
+        project=project,
+        monkeypatch=monkeypatch,
+    )
+
+
+def _ref_body(**extra):
+    body = {
+        "simulation_id": VALID_SIM_ID,
+        "ai_model_ref": {
+            "provider_connection_id": CONNECTION_ID,
+            "model_id": MODEL_ID,
+            "source": "explicit",
+        },
+    }
+    body.update(extra)
+    return body
+
+
+def _post(client, **payload):
+    return client.post("/api/simulation/prepare", json=_ref_body(**payload))
+
+
+def test_valid_ai_model_ref_is_seeded_resolved_and_locked(client, prepare_route_env):
+    response = _post(client)
+
+    assert response.status_code == 200, response.get_json()
+    forwarded = prepare_route_env.observed["seed_ref"]
+    assert forwarded is not None
+    assert forwarded.provider_connection_id == CONNECTION_ID
+    assert forwarded.model_id == MODEL_ID
+    prevalidated = prepare_route_env.observed["prevalidated_ref"]
+    assert prevalidated is not None
+    assert prevalidated.provider_connection_id == CONNECTION_ID
+    assert prevalidated.model_id == MODEL_ID
+    resolved = prepare_route_env.observed["resolved"]
+    assert resolved.provider_id == CONNECTION_ID
+    assert resolved.model == MODEL_ID
+    assert prepare_route_env.observed["locked"] is resolved
+
+
+@pytest.mark.parametrize(
+    ("legacy_field", "legacy_value"),
+    [
+        ("llm_model", "gpt-4o-mini"),
+        ("llm_profile_id", "profile-legacy"),
+        ("llm_provider", {"provider": "openai", "base_url": "https://api.openai.com/v1"}),
+        ("llm_runtime", {"provider": "openai", "base_url": "https://api.openai.com/v1"}),
+    ],
+)
+def test_ai_model_ref_conflicts_with_legacy_override_returns_400(
+    client, prepare_route_env, legacy_field, legacy_value
+):
+    response = _post(client, **{legacy_field: legacy_value})
+    assert response.status_code == 400
+    assert "ai_model_ref" in str(response.get_json())
+
+
+def test_ai_model_ref_reprepare_bypasses_already_prepared_short_circuit(
+    client, prepare_route_env
+):
+    prepare_route_env.monkeypatch.setattr(
+        "app.api.simulation_prepare._check_simulation_prepared",
+        lambda _simulation_id: (True, {"profiles": 12}),
+    )
+
+    response = _post(client)
+
+    assert response.status_code == 200, response.get_json()
+    payload = response.get_json()["data"]
+    assert payload["already_prepared"] is False
+    assert prepare_route_env.observed["seed_ref"] is not None
+
+
+def test_explicit_ai_model_ref_beats_project_profile(client, prepare_route_env):
+    prepare_route_env.project.llm_profile_id = "profile-project"
+
+    response = _post(client)
+
+    assert response.status_code == 200, response.get_json()
+    assert prepare_route_env.observed["seed_ref"] is not None
+    assert prepare_route_env.observed["seed_profile"] is None
+
+
+def test_invalid_ai_model_ref_returns_400_without_echoing_sensitive_input(client, prepare_route_env):
+    response = client.post(
+        "/api/simulation/prepare",
+        json={"simulation_id": VALID_SIM_ID, "ai_model_ref": {"model_id": "sensitive-value"}},
+    )
+
+    assert response.status_code == 400
+    assert "ai_model_ref" in str(response.get_json())
+    assert "sensitive-value" not in response.get_data(as_text=True)
+
+
+def test_seed_model_mismatch_fails_created_run_and_task_without_secret_leak(
+    client, prepare_route_env
+):
+    def reject_model_mismatch(*_args, **_kwargs):
+        raise ValueError(
+            f"Modell {MODEL_ID!r} gehört nicht zur ProviderConnection {CONNECTION_ID!r}"
+        )
+
+    prepare_route_env.monkeypatch.setattr(
+        "app.api.simulation_prepare.seed_run_stage_routing",
+        reject_model_mismatch,
+    )
+    response = _post(client)
+    assert response.status_code == 400
+    error = str(response.get_json())
+    assert "gehört nicht zur ProviderConnection" in error
+    assert "configured-secret" not in error
+    failed_run = prepare_route_env.observed["failed_run"]
+    assert failed_run is not None
+    assert failed_run["run_id"] == "run_prepare_1"
+    assert failed_run["status"] == "failed"
+    assert "gehört nicht zur ProviderConnection" in failed_run["error"]
+    assert "configured-secret" not in failed_run["error"]
+    failed_task = prepare_route_env.observed["failed_task"]
+    assert failed_task is not None
+    assert failed_task["task_id"] == "task_prepare_1"
+    assert "gehört nicht zur ProviderConnection" in failed_task["error"]
+    assert "configured-secret" not in failed_task["error"]
+
+
+def test_unknown_provider_connection_returns_deterministic_400_without_secret_leak(
+    client, prepare_route_env
+):
+    def reject_unknown_connection(_ref):
+        raise ValueError("ProviderConnection 'conn-missing' nicht gefunden")
+
+    prepare_route_env.monkeypatch.setattr(
+        "app.services.llm_routing_seed.prevalidate_ai_model_ref",
+        reject_unknown_connection,
+        raising=False,
+    )
+
+    response = _post(client, ai_model_ref={
+        "provider_connection_id": "conn-missing",
+        "model_id": MODEL_ID,
+        "source": "explicit",
+    })
+
+    assert response.status_code == 400
+    error = str(response.get_json())
+    assert "ProviderConnection" in error
+    assert "conn-missing" in error
+    assert "configured-secret" not in error

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3623 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3633 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -15,11 +15,12 @@
 - **Q1 — Scope:** Phase 1 + Specs werden **zuvor** als eigener PR gemergt. **§5.2 ist ein
   separates Folge-PR/Issue.** Begründung: Atomic Slicing, sauberer Review, der
   Backend-Payload-Vertrag (`triggerPrepare`) bekommt eigenen Fokus.
-- **Q2 — Backend-Payload:** `triggerPrepare.llm_model` **und** `llm_profile_id` **entfallen**
-  (kein Backend-Touch). Reiner FE-Sync via `useEffectiveModelSelection.setGlobalSelection`
-  (schreibt `routing/defaults.global` + `active-config` im Gleichschritt).
-  Profile → optionale Presets (schlagen dem `AiModelPicker` nur einen Wert vor, kein
-  Override, kein eigenes Payload-Feld).
+- **Q2 — Backend-Payload:** Die frühere Annahme „kein Backend-Touch; `llm_model` und
+  `llm_profile_id` entfallen ohne `ai_model_ref`" ist nicht gültig. Issue #896 ist die
+  Voraussetzung: `/prepare` akzeptiert eine kanonische, connection-gebundene `AiModelRef`
+  als autoritative Route und lehnt Mischfälle mit Legacy-Overrides ab. Nach dem Merge kann
+  Step2 den expliziten Pickerwert als `ai_model_ref` senden; Issue #897 bereitet den
+  Storage-Cut vor.
 
 ---
 
@@ -53,7 +54,7 @@
 
 ---
 
-## 3. Migrationsplan (7 Schritte, kein Backend-Touch, reiner FE-Sync)
+## 3. Migrationsplan (7 Schritte)
 
 ### (a) `Step2EnvSetup.vue` — useEnvForm ersetzen für MODELL-Auswahl
 - `const { effectiveRef, effectiveRoute, ensureLoaded, setGlobalSelection, loading } = useEffectiveModelSelection()`
@@ -79,13 +80,10 @@
   Modell-Auswahl).
 
 ### (d) `triggerPrepare` (`Step2EnvSetup.vue:232-264`) — Payload konsolidieren
-- `payload.llm_model = effectiveModel()` **ENTFÄLLT** (Q2). Backend
-  `stage_model_router.py:116` liest `routing/defaults.global_default` direkt, via
-  `setGlobalSelection`-Gleichschritt synchron gehalten → kein doppelter `llm_model`-Payload.
-- `payload.llm_profile_id` **ENTFÄLLT** als Override (Q2). Profile sind nur Presets; kein
-  eigenes Payload-Feld.
-- `runtimePayload()` (Override-Provider) bleibt orthogonal; Override ist kein Profil,
-  sondern connection-basiert.
+- Voraussetzung ist der Merge von Issue #896. Danach kann Step2 den expliziten Pickerwert
+  als `ai_model_ref` an `/prepare` senden.
+- `llm_model` und `llm_profile_id` nicht ohne die in #896 eingeführte Abgrenzung zu
+  Legacy-Overrides entfernen. Issue #897 bereitet den Storage-Cut vor.
 
 ### (e) State/Store-Übersicht
 - Ersetzt wird: `modelOption`/`customModel`/`effectiveModel`-Block aus `useEnvForm.ts` +
@@ -101,10 +99,7 @@
 - `AiModelPicker` ist der kanonische Picker laut AGENTS.md.
 - Zod-Spiegel `AiModelRefSchema` (`frontend/src/contracts/aiModelRef.ts`) validiert
   `effectiveRef` bereits.
-- Kein Backend-Touch — `setGlobalSelection` schreibt bereits
-  `routing/defaults.global_default` + `active-config` im Gleichschritt, sodass beide
-  Runtime-Leser (`llm/client.py::use_active_config`,
-  `stage_model_router.py::routing/defaults.global_default`) konsistent bleiben.
+- Für den `/prepare`-Payload gilt #896 als Voraussetzung; #897 bereitet den Storage-Cut vor.
 
 ### (g) Reihenfolge
 1. `useEffectiveModelSelection` in `Step2EnvSetup` verdrahten.
@@ -121,11 +116,9 @@
 
 ## 4. Risiken (Pflicht-Verifikation vor Edit)
 
-- **A — Backend-Payload:** Vor Streichen von `triggerPrepare.llm_model`/`llm_profile_id`
-  per CRG/Code-Read verifizieren, dass `stage_model_router.py` und ggf. weitere Consumer
-  (`backend/app/api/simulation.py` o.ä.) `routing/defaults.global_default` wirklich
-  direkt lesen und `llm_model` im Payload nicht als zwingenden Fallback brauchen.
-  Cross-Check mit Backend-Contract (`backend/app/contracts/`).
+- **A — Backend-Payload:** `ai_model_ref` erst nach Merge von #896 als expliziten
+  Pickerwert senden. Das Entfernen von Legacy-Feldern folgt dem von #897 vorbereiteten
+  Storage-Cut.
 - **B — OASIS-Runtime-Provider:** `useEnvForm` hat `runtimeProvider`-Override-Logik
   (`defaultRuntimeModelForProvider`, `isRuntimeModelForProvider`,
   `runtimeModelOptionsForProvider` aus `useRuntimeLlmOptions`). Der `AiModelRef`-Kanon ist
@@ -141,7 +134,7 @@
 
 ## 5. Hard Constraints (gelten weiter)
 
-- Kein Backend-Touch ohne separaten Slice + User-Sign-off (Q2 bestätigt: kein Backend-Touch).
+- Änderungen am `/prepare`-Payload setzen #896 voraus; der Storage-Cut folgt #897.
 - Keine Anthropic-Subagents (Workflow/Agent: `model`/`agentType` weglassen).
 - Frontend-Toolchain: `bun` (nicht pnpm/npm).
 - Kein `--no-verify`, keine Edits auf `main`.


### PR DESCRIPTION
Closes #896

## Änderung

- `POST /prepare` akzeptiert die kanonische `AiModelRef`.
- `ai_model_ref` hat eindeutige Präzedenz und darf nicht mit `llm_model`, `llm_profile_id`, `llm_provider` oder dessen produktivem Alias `llm_runtime` gemischt werden.
- ProviderConnection und Secret-Bindung werden vor Run-Erstellung validiert.
- Die Route wird über die bestehende Routing-SSoT geseedet, aufgelöst und gelockt.
- Semantische Routingfehler nach Run-/Task-Erstellung markieren beide Datensätze als `failed`; Persistenzfehler werden nicht als erfolgreicher 400-Pfad kaschiert.
- Projektprofil und Runtime-Overrides können eine explizite `AiModelRef` nicht überschreiben.

## Verifikation

- RED: ursprünglicher Contract 8/8 rot; Orphan-Regression 1 rot; `llm_runtime`-Alias 1 rot.
- GREEN: 25 gezielte Prepare-/Routing-Tests.
- 422 Pydantic-Contract-Tests.
- 46/46 Schemas ohne Drift.
- Slice-Ruff und Mypy grün.
- Drei finale unabhängige Reviews: Standards, Spec und Evidence jeweils `APPROVE`.
- Die vollständige Testmatrix läuft bewusst in GitHub Actions.

## Dokumentation

- `CHANGELOG.md`, `docs/STATUS.md` und die kanonische Slice-Dokumentation sind synchronisiert.
- Keine Änderung an Release-Reihenfolge oder Gates; daher kein `ROADMAP.md`-Delta.

## Agenten

Lead: GPT-5.6 Sol. Eingesetzt wurden spezialisierte Agora-Test-, Refactor-, Docs- und Evidence-Rollen sowie unabhängige Explorer/Reviewer; die initial als Luna angeforderten Explorer liefen laut Runtime tatsächlich auf GPT-5.6 Terra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Neue Funktionen**
  - `/prepare` akzeptiert jetzt eine kanonische, verbindungsgebundene `AiModelRef` als autoritative Modellroute.
  - Explizite Modellreferenzen können bestehende Vorbereitungen erneut auslösen und überschreiben Projekteinstellungen.

- **Fehlerbehebungen**
  - Unzulässige Kombinationen mit Legacy-Modellfeldern werden mit einer verständlichen Fehlermeldung abgelehnt.
  - Ungültige Modell- oder Provider-Zuordnungen führen zuverlässig zu Fehlerstatus, ohne sensible Daten offenzulegen.

- **Dokumentation**
  - Changelog und Migrationsdokumentation zur Modellroute und den erforderlichen Übergangsregeln wurden aktualisiert.

- **Tests**
  - Die Abdeckung der `/prepare`-Modellrouten wurde erweitert; die dokumentierte Anzahl erfolgreicher Backend-Tests wurde aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->