### PR TITLE
refactor: Graph- und Run-Modellwahl auf AiModelRef migrieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   liegengebliebene `agora.lastModel`-/`agora.lastCustomModel`-Werte werden nicht gelesen,
   geschrieben oder gelöscht. `Step3Simulation` nutzt für Simulation und Report ebenfalls
   keine Legacy-Storage-Route mehr.
+- **Persistierte Ref und Resume-Build (Review-Nachtrag PR #900):** Der Ontology-Run legt die
+  kanonische `AiModelRef` am Projekt ab (`Project.ai_model_ref`, ohne Secrets). Ein
+  Graph-Build ohne eigene Route im Request übernimmt sie, statt — wie zuvor — ganz ohne
+  Modell- und Connection-Bindung zu starten, wenn Tab oder Session verloren gehen. Eine
+  explizite Legacy-Angabe im Request gewinnt weiterhin; eine defekte persistierte Ref fällt
+  protokolliert auf das Legacy-Routing zurück.
+- **Fehlerklassifikation über Typ statt Fehlertext (Review-Nachtrag PR #900):** Nur der
+  exportierte `AiModelRefRoutingInputError` wird auf die 400-Routing-Antwort abgebildet;
+  semantische `ValueError` wie `ONTOLOGY_MISSING` oder `NOT_FOUND` behalten ihren Code. In
+  `generate_ontology` deckt die Routing-Terminalisierung nur noch die Routing-Phase ab —
+  Fehler der Generierungs- und Persistenzphase tragen eine eigene, nicht-routingbezogene
+  Meldung. Die Terminalisierung persistiert den Projektstatus vor dem Registry-Update, damit
+  ein fehlschlagendes Registry-I/O den `FAILED`-Zustand nicht nur im Speicher lässt.
 - **Adapter-Grenze:** `toStoredModelString` und `toStoredModelStringPure` sind entfernt.
   `useEnvForm` mit `Step2EnvSetup` bleibt bis zur Migration in
   [Issue #890](https://github.com/arn0ld87/agora/issues/890) bewusst der letzte produktive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   `AiModelRef` als autoritative Route. Mischfälle mit Legacy-Overrides werden abgelehnt;
   eine explizit gesendete Ref löst ein Re-Prepare aus.
 
+### Changed (Graph-Pipeline und Startpfade ohne `agora.lastModel`-Bridge — 2026-07-26, Issue #897)
+
+- **Graph-Ontologie und Graph-Build:** `generate_ontology` und `build_graph` akzeptieren
+  `ai_model_ref` als kanonische, connection-gebundene Route. Die API validiert die Pydantic-
+  Struktur und die referenzierte `ProviderConnection`, bevor Projekt-, Task- oder Run-
+  Seiteneffekte entstehen. Mischfälle mit `llm_model`, `llm_profile_id`, `llm_provider` oder
+  `llm_runtime` werden mit HTTP 400 abgelehnt; bei einer gültigen Ref bleiben alle Legacy-
+  Overrides aus der Route. Sämtliche synchronen Fehler einer `ai_model_ref`-Route nach der
+  Run-Erzeugung bis zum abgeschlossenen Ontologieaufbau beziehungsweise erfolgreichen Enqueue
+  terminalisieren Projekt und Run sowie einen bereits angelegten Graph-Task. Routing- und
+  Eingabefehler bleiben HTTP 400, Betriebsfehler liefern HTTP 500 und Timeouts HTTP 504;
+  Response, persistierte Fehlertexte und Logs bleiben dabei frei von Provider-Details und
+  Secrets.
+- **Home, Hero, Graph-Pipeline und Step 3:** Ein expliziter Pick wird als vollständige
+  `AiModelRef` im tab-skopierten Run-Override gehalten. Die Graph-Pipeline verwendet zuerst
+  diesen Override, danach den Kanon aus `routing/defaults.global_default`, und reicht dieselbe
+  Ref an Ontologie und Build weiter. Ohne beide Quellen entscheidet das Backend-Routing;
+  liegengebliebene `agora.lastModel`-/`agora.lastCustomModel`-Werte werden nicht gelesen,
+  geschrieben oder gelöscht. `Step3Simulation` nutzt für Simulation und Report ebenfalls
+  keine Legacy-Storage-Route mehr.
+- **Adapter-Grenze:** `toStoredModelString` und `toStoredModelStringPure` sind entfernt.
+  `useEnvForm` mit `Step2EnvSetup` bleibt bis zur Migration in
+  [Issue #890](https://github.com/arn0ld87/agora/issues/890) bewusst der letzte produktive
+  Consumer der Legacy-Modell-Keys; Issue #897 entfernt diese Keys daher noch nicht global.
+
 ### Fixed (133 reihenfolgenabhängige Test-Failures in `tests/api` — 2026-07-26)
 
 - **`backend/tests/conftest.py`** — neues autouse-Fixture `_clean_auth_token_env`.

--- a/backend/app/api/graph_build.py
+++ b/backend/app/api/graph_build.py
@@ -4,12 +4,22 @@ Graph API: Ontology and graph building endpoints.
 
 import os
 import json
+from collections.abc import Mapping
+
 from flask import current_app, request
+from pydantic import ValidationError
+
 from . import graph_bp
 from ..config import Config
-from ..models.project import ProjectManager
+from ..contracts.ai_provider_contract import AiModelRef
+from ..models.project import ProjectManager, ProjectStatus
+from ..services.llm_routing_seed import prevalidate_ai_model_ref_with_discovery
 from ..services.llm_runtime import parse_runtime_llm_config
-from ..services.graph_build import GraphBuildService
+from ..services.graph_build import (
+    AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+    AiModelRefPostValidationError,
+    GraphBuildService,
+)
 from ..utils.file_parser import FileParser
 from ..services.text_processor import TextProcessor
 from ..utils.logger import get_logger
@@ -26,6 +36,34 @@ from ..utils.scopes import require_scope
 from ..container import get_container
 
 logger = get_logger('agora.api.graph_build')
+
+
+_LEGACY_ROUTE_FIELDS = ("llm_model", "llm_profile_id", "llm_provider", "llm_runtime")
+
+
+def _validate_ai_model_ref_payload(
+    raw_ref: object, payload: Mapping[str, object]
+) -> AiModelRef:
+    if isinstance(raw_ref, str):
+        try:
+            raw_ref = json.loads(raw_ref)
+        except json.JSONDecodeError as exc:
+            raise ValueError("ai_model_ref ist ungültig") from exc
+
+    try:
+        ai_model_ref = AiModelRef.model_validate(raw_ref)
+    except ValidationError as exc:
+        raise ValueError("ai_model_ref ist ungültig") from exc
+
+    conflicting = [key for key in _LEGACY_ROUTE_FIELDS if key in payload]
+    if conflicting:
+        raise ValueError(
+            f"ai_model_ref darf nicht mit {', '.join(conflicting)} kombiniert werden"
+        )
+
+    prevalidate_ai_model_ref_with_discovery(ai_model_ref)
+    return ai_model_ref
+
 
 def allowed_file(file_storage) -> bool:
     """Check if file extension and content are allowed"""
@@ -92,21 +130,38 @@ def generate_ontology():
     if not simulation_requirement:
         return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message="Please provide simulation requirement description")
 
-    llm_model_override = (request.form.get('llm_model') or '').strip() or None
-    llm_provider_raw = request.form.get('llm_provider')
-    llm_provider_payload = None
-    if llm_provider_raw:
+    ai_model_ref = None
+    if "ai_model_ref" in request.form:
         try:
-            llm_provider_payload = json.loads(llm_provider_raw)
-        except json.JSONDecodeError:
-            return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message="llm_provider must be a valid JSON object")
+            ai_model_ref = _validate_ai_model_ref_payload(
+                request.form.get("ai_model_ref"), request.form
+            )
+        except ValueError as exc:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            )
 
-    try:
-        llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
-    except ValueError as exc:
-        return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
+        llm_model_override = None
+        llm_runtime = None
+        llm_profile_id = None
+    else:
+        llm_model_override = (request.form.get('llm_model') or '').strip() or None
+        llm_provider_raw = request.form.get('llm_provider')
+        llm_provider_payload = None
+        if llm_provider_raw:
+            try:
+                llm_provider_payload = json.loads(llm_provider_raw)
+            except json.JSONDecodeError:
+                return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message="llm_provider must be a valid JSON object")
 
-    llm_profile_id = (request.form.get('llm_profile_id') or '').strip() or None
+        try:
+            llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
+        except ValueError as exc:
+            return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
+
+        llm_profile_id = (request.form.get('llm_profile_id') or '').strip() or None
 
     uploaded_files = request.files.getlist('files')
     if not uploaded_files or all(not f.filename for f in uploaded_files):
@@ -161,6 +216,9 @@ def generate_ontology():
     ProjectManager.save_project(project)
 
     try:
+        ai_model_ref_kwargs = (
+            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
+        )
         project = GraphBuildService.generate_ontology(
             project_id=project.project_id,
             simulation_requirement=simulation_requirement,
@@ -168,9 +226,23 @@ def generate_ontology():
             llm_model_override=llm_model_override,
             llm_runtime=llm_runtime,
             llm_profile_id=llm_profile_id,
-            additional_context=additional_context
+            additional_context=additional_context,
+            **ai_model_ref_kwargs,
         )
     except ValueError as exc:
+        if ai_model_ref is not None:
+            if (
+                project.status != ProjectStatus.FAILED
+                or project.error != AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+            ):
+                project.status = ProjectStatus.FAILED
+                project.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+                ProjectManager.save_project(project)
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+            )
         ProjectManager.delete_project(project.project_id)
         return json_error_from_exception(exc)
 
@@ -195,21 +267,37 @@ def build_graph():
     if not validate_project_id(project_id):
         return json_error(ApiErrorCode.INVALID_ID, status=400)
 
+    ai_model_ref = None
+    if "ai_model_ref" in data:
+        try:
+            ai_model_ref = _validate_ai_model_ref_payload(data.get("ai_model_ref"), data)
+        except ValueError as exc:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            )
+
     project = ProjectManager.get_project(project_id)
     if not project:
         return json_error(ApiErrorCode.NOT_FOUND, status=404, message=f"Project does not exist: {project_id}")
 
-    from ..utils.llm_profile_resolver import expand_profile_in_data
-    expand_profile_in_data(data)
+    if ai_model_ref is not None:
+        llm_model_override = None
+        llm_runtime = None
+        llm_profile_id = None
+    else:
+        from ..utils.llm_profile_resolver import expand_profile_in_data
+        expand_profile_in_data(data)
 
-    llm_model_override = (data.get('llm_model') or '').strip() or project.llm_model or None
-    llm_provider_payload = data.get('llm_provider')
-    try:
-        llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
-    except ValueError as exc:
-        return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
+        llm_model_override = (data.get('llm_model') or '').strip() or project.llm_model or None
+        llm_provider_payload = data.get('llm_provider')
+        try:
+            llm_runtime = parse_runtime_llm_config({"llm_provider": llm_provider_payload})
+        except ValueError as exc:
+            return json_error(ApiErrorCode.VALIDATION_FAILED, status=400, message=str(exc))
 
-    llm_profile_id = (data.get('llm_profile_id') or '').strip() or None
+        llm_profile_id = (data.get('llm_profile_id') or '').strip() or None
     force = data.get('force', False)
     graph_name = data.get('graph_name', project.name or 'Agora Graph')
     chunk_size = data.get('chunk_size')
@@ -220,6 +308,9 @@ def build_graph():
         return json_error(ApiErrorCode.NEO4J_UNAVAILABLE, status=503, message="GraphStorage not initialized")
 
     try:
+        ai_model_ref_kwargs = (
+            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
+        )
         task_id, run_id = GraphBuildService.build_graph(
             project_id=project_id,
             graph_name=graph_name,
@@ -229,7 +320,8 @@ def build_graph():
             force=force,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            container=container
+            container=container,
+            **ai_model_ref_kwargs,
         )
         return json_success({
             "project_id": project_id,
@@ -238,7 +330,19 @@ def build_graph():
             "message": "Graph build task started. Query progress via /task/{task_id}"
         })
     except ValueError as exc:
+        if ai_model_ref is not None:
+            return json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+            )
         return json_error_from_exception(exc)
+    except AiModelRefPostValidationError:
+        return json_error(
+            "internal server error",
+            status=500,
+            code=ApiErrorCode.INTERNAL_ERROR,
+        )
     except RuntimeError as exc:
         # GRAPH_BUILD_IN_PROGRESS must surface the already-running task_id so
         # the client can poll status instead of starting a parallel run.

--- a/backend/app/api/graph_build.py
+++ b/backend/app/api/graph_build.py
@@ -18,6 +18,7 @@ from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.graph_build import (
     AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
     AiModelRefPostValidationError,
+    AiModelRefRoutingInputError,
     GraphBuildService,
 )
 from ..utils.file_parser import FileParser
@@ -216,9 +217,6 @@ def generate_ontology():
     ProjectManager.save_project(project)
 
     try:
-        ai_model_ref_kwargs = (
-            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
-        )
         project = GraphBuildService.generate_ontology(
             project_id=project.project_id,
             simulation_requirement=simulation_requirement,
@@ -227,22 +225,35 @@ def generate_ontology():
             llm_runtime=llm_runtime,
             llm_profile_id=llm_profile_id,
             additional_context=additional_context,
-            **ai_model_ref_kwargs,
+            ai_model_ref=ai_model_ref,
+        )
+    except AiModelRefRoutingInputError:
+        # Nur echte ai_model_ref-Routingfehler werden hier klassifiziert. Der
+        # Service hat bereits terminalisiert; die Prüfung läuft gegen den
+        # *persistierten* Stand, damit sie tatsächlich idempotent ist und nicht
+        # gegen die stale API-Instanz vergleicht.
+        persisted = ProjectManager.get_project(project.project_id) or project
+        if (
+            persisted.status != ProjectStatus.FAILED
+            or persisted.error != AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+        ):
+            persisted.status = ProjectStatus.FAILED
+            persisted.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+            ProjectManager.save_project(persisted)
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+        )
+    except AiModelRefPostValidationError:
+        # Betriebsfehler jenseits des Routings: Projekt/Run sind im Service
+        # terminalisiert, nach außen darf kein Roh-Fehlertext gelangen.
+        return json_error(
+            "internal server error",
+            status=500,
+            code=ApiErrorCode.INTERNAL_ERROR,
         )
     except ValueError as exc:
-        if ai_model_ref is not None:
-            if (
-                project.status != ProjectStatus.FAILED
-                or project.error != AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
-            ):
-                project.status = ProjectStatus.FAILED
-                project.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
-                ProjectManager.save_project(project)
-            return json_error(
-                ApiErrorCode.VALIDATION_FAILED,
-                status=400,
-                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
-            )
         ProjectManager.delete_project(project.project_id)
         return json_error_from_exception(exc)
 
@@ -308,9 +319,6 @@ def build_graph():
         return json_error(ApiErrorCode.NEO4J_UNAVAILABLE, status=503, message="GraphStorage not initialized")
 
     try:
-        ai_model_ref_kwargs = (
-            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
-        )
         task_id, run_id = GraphBuildService.build_graph(
             project_id=project_id,
             graph_name=graph_name,
@@ -321,7 +329,7 @@ def build_graph():
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
             container=container,
-            **ai_model_ref_kwargs,
+            ai_model_ref=ai_model_ref,
         )
         return json_success({
             "project_id": project_id,
@@ -329,13 +337,15 @@ def build_graph():
             "run_id": run_id,
             "message": "Graph build task started. Query progress via /task/{task_id}"
         })
+    except AiModelRefRoutingInputError:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=400,
+            message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+        )
     except ValueError as exc:
-        if ai_model_ref is not None:
-            return json_error(
-                ApiErrorCode.VALIDATION_FAILED,
-                status=400,
-                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
-            )
+        # Semantische Fehler (ONTOLOGY_MISSING, NOT_FOUND, fehlender Text)
+        # behalten ihren Code — sie sind keine Routingprobleme.
         return json_error_from_exception(exc)
     except AiModelRefPostValidationError:
         return json_error(

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -64,6 +64,13 @@ class Project:
     # Spätere Stages (build_graph, simulation_prepare, report) ziehen dieses
     # Profil als Default heran, wenn der Request kein eigenes Profil mitgibt.
     llm_profile_id: Optional[str] = None
+    # Kanonische (Provider-Connection, Modell)-Referenz des Ontology-Generate-
+    # Runs (``AiModelRef.model_dump()``). Auf dem ``ai_model_ref``-Pfad bleiben
+    # ``llm_model``/``llm_provider``/``llm_profile_id`` bewusst leer — ohne
+    # dieses Feld verlöre ein wiederaufgenommener Graph-Build (neuer Tab,
+    # verlorene Session) jede Modell-/Connection-Bindung. Trägt keine Secrets:
+    # AiModelRef referenziert die Connection nur per ID.
+    ai_model_ref: Optional[Dict[str, Any]] = None
 
     # Error information
     error: Optional[str] = None
@@ -88,6 +95,7 @@ class Project:
             "llm_model": self.llm_model,
             "llm_provider": self.llm_provider,
             "llm_profile_id": self.llm_profile_id,
+            "ai_model_ref": self.ai_model_ref,
             "error": self.error
         }
     
@@ -116,6 +124,7 @@ class Project:
             llm_model=data.get('llm_model'),
             llm_provider=data.get('llm_provider'),
             llm_profile_id=data.get('llm_profile_id'),
+            ai_model_ref=data.get('ai_model_ref'),
             error=data.get('error')
         )
 

--- a/backend/app/services/graph_build.py
+++ b/backend/app/services/graph_build.py
@@ -3,8 +3,11 @@ Service for building graphs and generating ontologies.
 """
 
 import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 
 from ..config import Config
+from ..contracts.ai_provider_contract import AiModelRef
 from ..services.ontology_generator import OntologyGenerator
 from ..services.llm_routing_seed import resolve_route_api_key, seed_run_stage_routing
 from ..services.stage_model_router import StageModelRouter
@@ -14,13 +17,76 @@ from ..utils.artifact_locator import ArtifactLocator
 from ..utils.llm_client import LLMClient
 from ..utils.logger import get_logger
 from ..models.task import TaskManager, TaskStatus
-from ..models.project import ProjectManager, ProjectStatus
+from ..models.project import Project, ProjectManager, ProjectStatus
 from ..services.run_registry import RunRegistry
 from ..services.secret_resolver import SecretResolver
 from ..utils.api_errors import ApiErrorCode
 
 logger = get_logger('agora.graph_build_service')
 run_registry = RunRegistry()
+AI_MODEL_REF_ROUTING_FAILURE_MESSAGE = "ai_model_ref routing could not be finalized"
+
+
+class AiModelRefPostValidationError(RuntimeError):
+    """Safe boundary error for synchronous AiModelRef operational failures."""
+
+
+class _AiModelRefRoutingInputError(ValueError):
+    """Identify ValueErrors raised directly by AiModelRef route seeding."""
+
+
+@contextmanager
+def _classify_ai_model_ref_seed_error(
+    ai_model_ref: AiModelRef | None,
+) -> Iterator[None]:
+    try:
+        yield
+    except ValueError:
+        if ai_model_ref is not None:
+            raise _AiModelRefRoutingInputError from None
+        raise
+
+
+@contextmanager
+def _terminalize_ai_model_ref_sync_failure(
+    *,
+    ai_model_ref: AiModelRef | None,
+    project: Project,
+    run_id: str,
+    phase: str,
+    task_manager: TaskManager | None = None,
+    task_id_getter: Callable[[], str | None] | None = None,
+) -> Iterator[None]:
+    try:
+        yield
+    except Exception as exc:
+        if ai_model_ref is not None:
+            task_id = task_id_getter() if task_id_getter is not None else None
+            logger.warning(
+                "AiModelRef synchronous graph operation failed "
+                "[project_id=%s, run_id=%s, task_id=%s, phase=%s, error_type=%s]",
+                project.project_id,
+                run_id,
+                task_id,
+                phase,
+                type(exc).__name__,
+            )
+            if task_id is not None and task_manager is not None:
+                task_manager.fail_task(task_id, AI_MODEL_REF_ROUTING_FAILURE_MESSAGE)
+            project.status = ProjectStatus.FAILED
+            project.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+            run_registry.update_run(
+                run_id,
+                status="failed",
+                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+                error=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+            )
+            ProjectManager.save_project(project)
+            if isinstance(exc, TimeoutError):
+                raise TimeoutError from None
+            if not isinstance(exc, _AiModelRefRoutingInputError):
+                raise AiModelRefPostValidationError from None
+        raise
 
 
 class GraphBuildService:
@@ -33,7 +99,8 @@ class GraphBuildService:
         llm_model_override=None,
         llm_runtime=None,
         llm_profile_id=None,
-        additional_context=None
+        additional_context=None,
+        ai_model_ref: AiModelRef | None = None,
     ):
         """
         Generate an ontology for a project from its documents and simulation requirements.
@@ -57,6 +124,10 @@ class GraphBuildService:
         if not project:
             raise ValueError(ApiErrorCode.NOT_FOUND)
 
+        effective_model_override = None if ai_model_ref is not None else llm_model_override
+        effective_llm_runtime = None if ai_model_ref is not None else llm_runtime
+        effective_profile_id = None if ai_model_ref is not None else llm_profile_id
+
         run_record = run_registry.create_run(
             run_type="ontology_generate",
             entity_id=project.project_id,
@@ -66,60 +137,71 @@ class GraphBuildService:
             linked_ids={"project_id": project.project_id},
         )
         run_id = run_record["run_id"]
-        for stage_id in ("document_ingest", "ontology_generation"):
-            seed_run_stage_routing(
-                run_id,
-                stage_id,
-                llm_model_override=llm_model_override,
-                llm_runtime=llm_runtime,
-                llm_profile_id=llm_profile_id,
-            )
-        route_router = StageModelRouter(run_id)
-        ingest_route = route_router.resolve("document_ingest")
-        route_router.lock_stage("document_ingest", ingest_route)
-        ontology_route = route_router.resolve("ontology_generation")
-        route_router.lock_stage("ontology_generation", ontology_route)
-
-        # The locked ontology route is authoritative; profile IDs are metadata only.
-        llm_client = LLMClient.from_route(
-            ontology_route,
-            secret_resolver=SecretResolver(),
-            api_key_override=resolve_route_api_key(ontology_route, llm_runtime),
+        ai_model_ref_kwargs = (
+            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
+        )
+        with _terminalize_ai_model_ref_sync_failure(
+            ai_model_ref=ai_model_ref,
+            project=project,
             run_id=run_id,
-        )
-        logger.info(
-            "Calling LLM to generate ontology definition (model=%s, provider=%s) [project_id=%s, run_id=%s]",
-            llm_client.model,
-            ontology_route.provider_id,
-            project_id,
-            run_id
-        )
+            phase="ontology_generation",
+        ):
+            for stage_id in ("document_ingest", "ontology_generation"):
+                with _classify_ai_model_ref_seed_error(ai_model_ref):
+                    seed_run_stage_routing(
+                        run_id,
+                        stage_id,
+                        llm_model_override=effective_model_override,
+                        llm_runtime=effective_llm_runtime,
+                        llm_profile_id=effective_profile_id,
+                        **ai_model_ref_kwargs,
+                    )
+            route_router = StageModelRouter(run_id)
+            ingest_route = route_router.resolve("document_ingest")
+            route_router.lock_stage("document_ingest", ingest_route)
+            ontology_route = route_router.resolve("ontology_generation")
+            route_router.lock_stage("ontology_generation", ontology_route)
 
-        generator = OntologyGenerator(llm_client=llm_client)
-        ontology = generator.generate(
-            document_texts=document_texts,
-            simulation_requirement=simulation_requirement,
-            additional_context=additional_context
-        )
+            # The locked ontology route is authoritative; profile IDs are metadata only.
+            llm_client = LLMClient.from_route(
+                ontology_route,
+                secret_resolver=SecretResolver(),
+                api_key_override=resolve_route_api_key(ontology_route, effective_llm_runtime),
+                run_id=run_id,
+            )
+            logger.info(
+                "Calling LLM to generate ontology definition (model=%s, provider=%s) [project_id=%s, run_id=%s]",
+                llm_client.model,
+                ontology_route.provider_id,
+                project_id,
+                run_id
+            )
 
-        project.ontology = {
-            "entity_types": ontology.get("entity_types", []),
-            "edge_types": ontology.get("edge_types", [])
-        }
-        project.analysis_summary = ontology.get("analysis_summary", "")
-        project.status = ProjectStatus.ONTOLOGY_GENERATED
-        project.llm_model = llm_model_override
-        project.llm_provider = llm_runtime.redacted_metadata() if llm_runtime else None
-        project.llm_profile_id = llm_profile_id
-        ProjectManager.save_project(project)
+            generator = OntologyGenerator(llm_client=llm_client)
+            ontology = generator.generate(
+                document_texts=document_texts,
+                simulation_requirement=simulation_requirement,
+                additional_context=additional_context
+            )
 
-        run_registry.update_run(
-            run_id,
-            status="completed",
-            progress=100,
-            message="Ontology generation completed",
-            linked_ids={"project_id": project.project_id},
-        )
+            project.ontology = {
+                "entity_types": ontology.get("entity_types", []),
+                "edge_types": ontology.get("edge_types", [])
+            }
+            project.analysis_summary = ontology.get("analysis_summary", "")
+            project.status = ProjectStatus.ONTOLOGY_GENERATED
+            project.llm_model = effective_model_override
+            project.llm_provider = effective_llm_runtime.redacted_metadata() if effective_llm_runtime else None
+            project.llm_profile_id = effective_profile_id
+            ProjectManager.save_project(project)
+
+            run_registry.update_run(
+                run_id,
+                status="completed",
+                progress=100,
+                message="Ontology generation completed",
+                linked_ids={"project_id": project.project_id},
+            )
         return project
 
     @classmethod
@@ -133,7 +215,8 @@ class GraphBuildService:
         force=False,
         chunk_size=None,
         chunk_overlap=None,
-        container=None
+        container=None,
+        ai_model_ref: AiModelRef | None = None,
     ):
         """
         Queue a graph build for a project using its extracted text and ontology.
@@ -174,8 +257,12 @@ class GraphBuildService:
             project.graph_build_task_id = None
             project.error = None
 
-        effective_profile_id = llm_profile_id or project.llm_profile_id
-        if llm_profile_id is not None:
+        effective_model_override = None if ai_model_ref is not None else llm_model_override
+        effective_llm_runtime = None if ai_model_ref is not None else llm_runtime
+        effective_profile_id = (
+            None if ai_model_ref is not None else llm_profile_id or project.llm_profile_id
+        )
+        if ai_model_ref is None and llm_profile_id is not None:
             project.llm_profile_id = llm_profile_id
 
         # Inputs
@@ -206,113 +293,126 @@ class GraphBuildService:
             resume_capability={"available": True, "action": "restart", "label": "Restart graph build"},
             metadata={"graph_name": graph_name},
         )
-        task_id = task_manager.create_task(
-            f"Build graph: {graph_name}",
-            metadata={"project_id": project_id, "run_id": run_record["run_id"]}
+        task_id: str | None = None
+        ai_model_ref_kwargs = (
+            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
         )
-
-        project.status = ProjectStatus.GRAPH_BUILDING
-        project.graph_build_task_id = task_id
-        ProjectManager.save_project(project)
-
-        seed_run_stage_routing(
-            run_record["run_id"],
-            "graph_build",
-            llm_model_override=llm_model_override,
-            llm_runtime=llm_runtime,
-            llm_profile_id=effective_profile_id,
-        )
-        route_router = StageModelRouter(run_record["run_id"])
-        resolved_route = route_router.resolve("graph_build")
-        route_router.lock_stage("graph_build", resolved_route)
-
-        # The locked route is authoritative; legacy profile IDs must not replace it.
-        ner_llm_client = LLMClient.from_route(
-            resolved_route,
-            secret_resolver=SecretResolver(),
-            api_key_override=resolve_route_api_key(resolved_route, llm_runtime),
+        with _terminalize_ai_model_ref_sync_failure(
+            ai_model_ref=ai_model_ref,
+            project=project,
             run_id=run_record["run_id"],
-        )
-        logger.info(
-            "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s [project_id=%s, run_id=%s]",
-            ner_llm_client.model,
-            resolved_route.provider_id,
-            project_id,
-            run_record["run_id"]
-        )
-        ner_override = NERExtractor(llm_client=ner_llm_client)
+            phase="graph_build_enqueue",
+            task_manager=task_manager,
+            task_id_getter=lambda: task_id,
+        ):
+            task_id = task_manager.create_task(
+                f"Build graph: {graph_name}",
+                metadata={"project_id": project_id, "run_id": run_record["run_id"]}
+            )
+            project.status = ProjectStatus.GRAPH_BUILDING
+            project.graph_build_task_id = task_id
+            ProjectManager.save_project(project)
 
-        def build_task():
-            """
-            Builds the project's graph and records its completion or failure state.
-            
-            On failure, marks the project, task, and run as failed and attempts to clean up any
-            partially created graph.
-            """
-            build_logger = get_logger('agora.build')
-            graph_id = None
-            try:
-                task_manager.update_task(task_id, status=TaskStatus.PROCESSING, message="Initializing graph build service...")
-                builder = container.graph_builder()
-
-                task_manager.update_task(task_id, message="Chunking text...", progress=5)
-                chunks = TextProcessor.split_text(text, chunk_size=chunk_size, overlap=chunk_overlap)
-
-                task_manager.update_task(task_id, message="Creating graph...", progress=10)
-                graph_id = builder.create_graph(name=graph_name)
-
-                run_registry.update_run(
+            with _classify_ai_model_ref_seed_error(ai_model_ref):
+                seed_run_stage_routing(
                     run_record["run_id"],
-                    entity_id=project_id,
-                    linked_ids={"graph_id": graph_id, "project_id": project_id, "task_id": task_id},
-                    message=f"Graph created: {graph_id}",
+                    "graph_build",
+                    llm_model_override=effective_model_override,
+                    llm_runtime=effective_llm_runtime,
+                    llm_profile_id=effective_profile_id,
+                    **ai_model_ref_kwargs,
                 )
+            route_router = StageModelRouter(run_record["run_id"])
+            resolved_route = route_router.resolve("graph_build")
+            route_router.lock_stage("graph_build", resolved_route)
 
-                task_manager.update_task(task_id, message="Setting ontology definition...", progress=15)
-                builder.set_ontology(graph_id, ontology)
+            # The locked route is authoritative; legacy profile IDs must not replace it.
+            ner_llm_client = LLMClient.from_route(
+                resolved_route,
+                secret_resolver=SecretResolver(),
+                api_key_override=resolve_route_api_key(resolved_route, effective_llm_runtime),
+                run_id=run_record["run_id"],
+            )
+            logger.info(
+                "Build-Pfad nutzt Route-Snapshot: model=%s provider=%s [project_id=%s, run_id=%s]",
+                ner_llm_client.model,
+                resolved_route.provider_id,
+                project_id,
+                run_record["run_id"]
+            )
+            ner_override = NERExtractor(llm_client=ner_llm_client)
 
-                def add_progress_callback(msg, progress_ratio, completed, total):
-                    progress = 15 + int(progress_ratio * 40)
-                    task_manager.update_task(
-                        task_id, message=msg, progress=progress,
-                        progress_detail={"batch_count": completed, "total_batches": total, "batch_at": time.time()}
+            def build_task():
+                """
+                Builds the project's graph and records its completion or failure state.
+
+                On failure, marks the project, task, and run as failed and attempts to clean up any
+                partially created graph.
+                """
+                build_logger = get_logger('agora.build')
+                graph_id = None
+                try:
+                    task_manager.update_task(task_id, status=TaskStatus.PROCESSING, message="Initializing graph build service...")
+                    builder = container.graph_builder()
+
+                    task_manager.update_task(task_id, message="Chunking text...", progress=5)
+                    chunks = TextProcessor.split_text(text, chunk_size=chunk_size, overlap=chunk_overlap)
+
+                    task_manager.update_task(task_id, message="Creating graph...", progress=10)
+                    graph_id = builder.create_graph(name=graph_name)
+
+                    run_registry.update_run(
+                        run_record["run_id"],
+                        entity_id=project_id,
+                        linked_ids={"graph_id": graph_id, "project_id": project_id, "task_id": task_id},
+                        message=f"Graph created: {graph_id}",
                     )
 
-                builder.add_text_batches(graph_id, chunks, batch_size=3, progress_callback=add_progress_callback, ner_extractor=ner_override)
+                    task_manager.update_task(task_id, message="Setting ontology definition...", progress=15)
+                    builder.set_ontology(graph_id, ontology)
 
-                task_manager.update_task(task_id, message="Retrieving graph data...", progress=95)
-                graph_data = builder.get_graph_data(graph_id)
+                    def add_progress_callback(msg, progress_ratio, completed, total):
+                        progress = 15 + int(progress_ratio * 40)
+                        task_manager.update_task(
+                            task_id, message=msg, progress=progress,
+                            progress_detail={"batch_count": completed, "total_batches": total, "batch_at": time.time()}
+                        )
 
-                builder.mark_graph_completed(graph_id)
-                project.graph_id = graph_id
-                project.status = ProjectStatus.GRAPH_COMPLETED
-                ProjectManager.save_project(project)
+                    builder.add_text_batches(graph_id, chunks, batch_size=3, progress_callback=add_progress_callback, ner_extractor=ner_override)
 
-                task_manager.update_task(
-                    task_id, status=TaskStatus.COMPLETED, message="Graph build completed", progress=100,
-                    result={"project_id": project_id, "graph_id": graph_id, "node_count": graph_data.get("node_count", 0), "edge_count": graph_data.get("edge_count", 0)}
-                )
-                run_registry.update_run(run_record["run_id"], status="completed", progress=100, message="Graph build completed")
+                    task_manager.update_task(task_id, message="Retrieving graph data...", progress=95)
+                    graph_data = builder.get_graph_data(graph_id)
 
-            except Exception as exc:
-                build_logger.exception("Graph build failed [project_id=%s, run_id=%s]", project_id, run_record["run_id"])
-                if graph_id is not None:
-                    try:
-                        builder.delete_graph(graph_id)
-                    except Exception:  # noqa: BLE001 — best-effort cleanup; primary exception already propagated
+                    builder.mark_graph_completed(graph_id)
+                    project.graph_id = graph_id
+                    project.status = ProjectStatus.GRAPH_COMPLETED
+                    ProjectManager.save_project(project)
+
+                    task_manager.update_task(
+                        task_id, status=TaskStatus.COMPLETED, message="Graph build completed", progress=100,
+                        result={"project_id": project_id, "graph_id": graph_id, "node_count": graph_data.get("node_count", 0), "edge_count": graph_data.get("edge_count", 0)}
+                    )
+                    run_registry.update_run(run_record["run_id"], status="completed", progress=100, message="Graph build completed")
+
+                except Exception as exc:
+                    build_logger.exception("Graph build failed [project_id=%s, run_id=%s]", project_id, run_record["run_id"])
+                    if graph_id is not None:
                         try:
-                            builder.mark_graph_failed(graph_id, reason=str(exc))
-                        except Exception as err:  # noqa: BLE001 — best-effort cleanup; primary exception already propagated
-                            logger.debug("graph_build: mark_graph_failed also failed, ignoring: %s", err)
+                            builder.delete_graph(graph_id)
+                        except Exception:  # noqa: BLE001 — best-effort cleanup; primary exception already propagated
+                            try:
+                                builder.mark_graph_failed(graph_id, reason=str(exc))
+                            except Exception as err:  # noqa: BLE001 — best-effort cleanup; primary exception already propagated
+                                logger.debug("graph_build: mark_graph_failed also failed, ignoring: %s", err)
 
-                project.status = ProjectStatus.FAILED
-                project.error = str(exc)
-                ProjectManager.save_project(project)
+                    project.status = ProjectStatus.FAILED
+                    project.error = str(exc)
+                    ProjectManager.save_project(project)
 
-                import traceback
-                task_manager.update_task(task_id, status=TaskStatus.FAILED, message=f"Build failed: {str(exc)}", error=traceback.format_exc())
-                run_registry.update_run(run_record["run_id"], status="failed", message=str(exc), error=str(exc))
+                    import traceback
+                    task_manager.update_task(task_id, status=TaskStatus.FAILED, message=f"Build failed: {str(exc)}", error=traceback.format_exc())
+                    run_registry.update_run(run_record["run_id"], status="failed", message=str(exc), error=str(exc))
 
-        from ..jobs import enqueue
-        enqueue("graph_build", build_task)
+            from ..jobs import enqueue
+            enqueue("graph_build", build_task)
         return task_id, run_record["run_id"]

--- a/backend/app/services/graph_build.py
+++ b/backend/app/services/graph_build.py
@@ -25,14 +25,22 @@ from ..utils.api_errors import ApiErrorCode
 logger = get_logger('agora.graph_build_service')
 run_registry = RunRegistry()
 AI_MODEL_REF_ROUTING_FAILURE_MESSAGE = "ai_model_ref routing could not be finalized"
+AI_MODEL_REF_GENERATION_FAILURE_MESSAGE = "ontology generation could not be completed"
 
 
 class AiModelRefPostValidationError(RuntimeError):
     """Safe boundary error for synchronous AiModelRef operational failures."""
 
 
-class _AiModelRefRoutingInputError(ValueError):
-    """Identify ValueErrors raised directly by AiModelRef route seeding."""
+class AiModelRefRoutingInputError(ValueError):
+    """Identify ValueErrors raised directly by AiModelRef route seeding.
+
+    Public boundary type: the API layer maps *only* this subtype to the
+    ai_model_ref routing validation response (400). Every other ``ValueError``
+    keeps its semantic error code, so unrelated failures such as
+    ``ONTOLOGY_MISSING`` or ``NOT_FOUND`` are no longer mislabeled as routing
+    problems.
+    """
 
 
 @contextmanager
@@ -43,7 +51,7 @@ def _classify_ai_model_ref_seed_error(
         yield
     except ValueError:
         if ai_model_ref is not None:
-            raise _AiModelRefRoutingInputError from None
+            raise AiModelRefRoutingInputError from None
         raise
 
 
@@ -54,6 +62,7 @@ def _terminalize_ai_model_ref_sync_failure(
     project: Project,
     run_id: str,
     phase: str,
+    failure_message: str = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
     task_manager: TaskManager | None = None,
     task_id_getter: Callable[[], str | None] | None = None,
 ) -> Iterator[None]:
@@ -72,19 +81,28 @@ def _terminalize_ai_model_ref_sync_failure(
                 type(exc).__name__,
             )
             if task_id is not None and task_manager is not None:
-                task_manager.fail_task(task_id, AI_MODEL_REF_ROUTING_FAILURE_MESSAGE)
+                task_manager.fail_task(task_id, failure_message)
             project.status = ProjectStatus.FAILED
-            project.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
-            run_registry.update_run(
-                run_id,
-                status="failed",
-                message=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
-                error=AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
-            )
+            project.error = failure_message
+            # Projektstatus zuerst persistieren: schlägt das Registry-I/O fehl,
+            # darf der FAILED-Zustand nicht nur im Speicher stehen, während auf
+            # Platte weiterhin GRAPH_BUILDING/CREATED klebt.
             ProjectManager.save_project(project)
+            try:
+                run_registry.update_run(
+                    run_id,
+                    status="failed",
+                    message=failure_message,
+                    error=failure_message,
+                )
+            except Exception:  # noqa: BLE001 — Terminalisierung darf nicht am Registry-I/O scheitern
+                logger.exception(
+                    "run_registry.update_run failed during terminalization [run_id=%s]",
+                    run_id,
+                )
             if isinstance(exc, TimeoutError):
                 raise TimeoutError from None
-            if not isinstance(exc, _AiModelRefRoutingInputError):
+            if not isinstance(exc, AiModelRefRoutingInputError):
                 raise AiModelRefPostValidationError from None
         raise
 
@@ -113,12 +131,24 @@ class GraphBuildService:
             llm_runtime: Optional runtime configuration for the language model.
             llm_profile_id: Optional language model profile identifier recorded on the project.
             additional_context: Optional context supplied to the ontology generator.
-        
+            ai_model_ref: Canonical (provider connection, model) reference chosen in
+                the UI. When set it is authoritative and suppresses every legacy
+                override (``llm_model_override``, ``llm_runtime``, ``llm_profile_id``
+                are forced to ``None``); it is persisted on the project so a resumed
+                graph build keeps the binding.
+
         Returns:
             The project updated with the generated ontology and analysis summary.
-        
+
         Raises:
             ValueError: If the project does not exist.
+            AiModelRefRoutingInputError: If route seeding rejects the ``ai_model_ref``
+                (unknown/disabled connection, model not in the catalog).
+            AiModelRefPostValidationError: If a non-routing failure occurs after the
+                route was sealed; project and run are terminalized first and the raw
+                error is not propagated.
+            TimeoutError: If a synchronous step times out; states are terminalized
+                before the timeout is re-raised.
         """
         project = ProjectManager.get_project(project_id)
         if not project:
@@ -137,14 +167,14 @@ class GraphBuildService:
             linked_ids={"project_id": project.project_id},
         )
         run_id = run_record["run_id"]
-        ai_model_ref_kwargs = (
-            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
-        )
+        # Routing-Phase: nur hier ist ein Fehler tatsächlich ein
+        # ai_model_ref-Routingproblem und darf als solches terminalisiert und
+        # nach außen als 400 klassifiziert werden.
         with _terminalize_ai_model_ref_sync_failure(
             ai_model_ref=ai_model_ref,
             project=project,
             run_id=run_id,
-            phase="ontology_generation",
+            phase="ontology_routing",
         ):
             for stage_id in ("document_ingest", "ontology_generation"):
                 with _classify_ai_model_ref_seed_error(ai_model_ref):
@@ -154,7 +184,7 @@ class GraphBuildService:
                         llm_model_override=effective_model_override,
                         llm_runtime=effective_llm_runtime,
                         llm_profile_id=effective_profile_id,
-                        **ai_model_ref_kwargs,
+                        ai_model_ref=ai_model_ref,
                     )
             route_router = StageModelRouter(run_id)
             ingest_route = route_router.resolve("document_ingest")
@@ -162,6 +192,16 @@ class GraphBuildService:
             ontology_route = route_router.resolve("ontology_generation")
             route_router.lock_stage("ontology_generation", ontology_route)
 
+        # Generierungs-/Persistenzphase: Fehler werden weiterhin terminalisiert
+        # und sanitisiert, tragen aber eine eigene, nicht-routingbezogene
+        # Meldung, damit Routingfehler unterscheidbar bleiben.
+        with _terminalize_ai_model_ref_sync_failure(
+            ai_model_ref=ai_model_ref,
+            project=project,
+            run_id=run_id,
+            phase="ontology_generation",
+            failure_message=AI_MODEL_REF_GENERATION_FAILURE_MESSAGE,
+        ):
             # The locked ontology route is authoritative; profile IDs are metadata only.
             llm_client = LLMClient.from_route(
                 ontology_route,
@@ -193,6 +233,12 @@ class GraphBuildService:
             project.llm_model = effective_model_override
             project.llm_provider = effective_llm_runtime.redacted_metadata() if effective_llm_runtime else None
             project.llm_profile_id = effective_profile_id
+            # Kanonische Referenz persistieren: auf dem ai_model_ref-Pfad sind
+            # alle Legacy-Felder None, ein wiederaufgenommener Build hätte sonst
+            # keinerlei Modell-/Connection-Bindung mehr (#900).
+            project.ai_model_ref = (
+                ai_model_ref.model_dump(mode="json") if ai_model_ref is not None else None
+            )
             ProjectManager.save_project(project)
 
             run_registry.update_run(
@@ -231,14 +277,24 @@ class GraphBuildService:
             chunk_size: Optional text chunk size.
             chunk_overlap: Optional overlap between consecutive text chunks.
             container: Service container used to create the graph builder.
-        
+            ai_model_ref: Canonical (provider connection, model) reference. When set
+                it is authoritative and suppresses every legacy override. When absent
+                and the request carries no legacy route either, a reference persisted
+                on the project by the ontology run is used instead.
+
         Returns:
             A tuple containing the task identifier and run identifier.
-        
+
         Raises:
             ValueError: If the project, extracted text, or ontology is missing, or if
                 the project has not completed ontology generation.
             RuntimeError: If a graph build is already in progress and `force` is false.
+            AiModelRefRoutingInputError: If route seeding rejects the ``ai_model_ref``.
+            AiModelRefPostValidationError: If a non-routing failure occurs after the
+                route was sealed; project, run and task are terminalized first and the
+                raw error is not propagated.
+            TimeoutError: If a synchronous step times out; states are terminalized
+                before the timeout is re-raised.
         """
         project = ProjectManager.get_project(project_id)
         if not project:
@@ -256,6 +312,25 @@ class GraphBuildService:
             project.graph_id = None
             project.graph_build_task_id = None
             project.error = None
+
+        # Resume-Pfad: hat der Request keine eigene Route und trägt das Projekt
+        # eine beim Ontology-Generate persistierte AiModelRef, ist diese die
+        # kanonische Bindung — analog zum llm_profile_id-Default darunter (#900).
+        if (
+            ai_model_ref is None
+            and project.ai_model_ref
+            and not llm_model_override
+            and (llm_runtime is None or not llm_runtime.enabled)
+            and not llm_profile_id
+        ):
+            try:
+                ai_model_ref = AiModelRef.model_validate(project.ai_model_ref)
+            except Exception:  # noqa: BLE001 — defekte Persistenz darf den Legacy-Pfad nicht blockieren
+                logger.warning(
+                    "Persistierte ai_model_ref des Projekts ist ungültig, "
+                    "Legacy-Routing wird verwendet [project_id=%s]",
+                    project_id,
+                )
 
         effective_model_override = None if ai_model_ref is not None else llm_model_override
         effective_llm_runtime = None if ai_model_ref is not None else llm_runtime
@@ -294,9 +369,6 @@ class GraphBuildService:
             metadata={"graph_name": graph_name},
         )
         task_id: str | None = None
-        ai_model_ref_kwargs = (
-            {"ai_model_ref": ai_model_ref} if ai_model_ref is not None else {}
-        )
         with _terminalize_ai_model_ref_sync_failure(
             ai_model_ref=ai_model_ref,
             project=project,
@@ -320,7 +392,7 @@ class GraphBuildService:
                     llm_model_override=effective_model_override,
                     llm_runtime=effective_llm_runtime,
                     llm_profile_id=effective_profile_id,
-                    **ai_model_ref_kwargs,
+                    ai_model_ref=ai_model_ref,
                 )
             route_router = StageModelRouter(run_record["run_id"])
             resolved_route = route_router.resolve("graph_build")

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -84,12 +84,17 @@ def _verify_selected_model(connection: ProviderConnection, model_id: str) -> Non
         store=ProviderConnectionStore(),
         secrets_store=get_llm_provider_secrets_store(),
     )
-    result = service.probe(connection)
+    try:
+        result = service.probe(connection)
+    except Exception as exc:  # noqa: BLE001 — Providerfehler dürfen keine Secrets propagieren
+        raise ValueError(
+            f"Modell-Katalog für ProviderConnection {connection.id!r} derzeit "
+            f"nicht abrufbar ({type(exc).__name__})"
+        ) from None
     if result.status != "available":
         raise ValueError(
             f"Modell-Katalog für ProviderConnection {connection.id!r} derzeit "
-            f"nicht abrufbar ({result.status}): "
-            f"{result.status_message or 'keine Detailmeldung'}"
+            f"nicht abrufbar ({result.status})"
         )
     known_model_ids = {model.model_id for model in result.models}
     if model_id not in known_model_ids:
@@ -122,20 +127,24 @@ def _bind_connection_secret(
 
 
 def prevalidate_ai_model_ref(ai_model_ref: AiModelRef) -> ProviderConnection:
-    """Günstige Vorab-Prüfung einer ``ai_model_ref``: löst die Connection auf
-    und verifiziert die Secret-Bindung — ohne teure Live-Model-Discovery.
+    """Günstige Vorab-Prüfung einer ``ai_model_ref`` ohne Live-Discovery.
 
-    Wirft ``ValueError``, wenn die Connection fehlt oder deaktiviert ist oder
-    eine ``api_key``-Connection ohne gebundenes ``secret_ref`` daherkommt.
-    Aufrufer (z. B. ``/api/simulation/start``) nutzen das, um vor der
-    Run-Record-Creation mit 4xx abzubrechen — kein orphaned Run. Die volle
-    Model-Discovery (Issue #819, Connection/Model-Mismatch) läuft später in
-    ``seed_run_stage_routing``; deren ``ValueError`` wird am Endpunkt ebenfalls
-    zu 4xx. Gemeinsame SSoT mit dem Profil-Pfad, kein .env-Fallback.
+    Löst die Connection auf und verifiziert die Secret-Bindung. Prepare- und
+    Simulation-Start-Endpunkte nutzen diese Variante bewusst vor der
+    Run-Erzeugung, ohne einen zusätzlichen Provider-Probe auszulösen.
     """
     connection = _resolve_selected_connection(ai_model_ref.provider_connection_id)
     options: dict[str, object] = {}
     _bind_connection_secret(connection, options)
+    return connection
+
+
+def prevalidate_ai_model_ref_with_discovery(
+    ai_model_ref: AiModelRef,
+) -> ProviderConnection:
+    """Vollständige AiModelRef-Prüfung inklusive bestehender Model-Discovery."""
+    connection = prevalidate_ai_model_ref(ai_model_ref)
+    _verify_selected_model(connection, ai_model_ref.model_id)
     return connection
 
 

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -87,6 +87,14 @@ def _verify_selected_model(connection: ProviderConnection, model_id: str) -> Non
     try:
         result = service.probe(connection)
     except Exception as exc:  # noqa: BLE001 — Providerfehler dürfen keine Secrets propagieren
+        # Bewusst ohne str(exc): der Provider-Fehlertext kann Credentials
+        # tragen. Typ + connection.id reichen, um einen Discovery-Ausfall im
+        # Betrieb von einem echten Model-Mismatch zu unterscheiden.
+        logger.warning(
+            "Model-Discovery fehlgeschlagen [connection_id=%s, error_type=%s]",
+            connection.id,
+            type(exc).__name__,
+        )
         raise ValueError(
             f"Modell-Katalog für ProviderConnection {connection.id!r} derzeit "
             f"nicht abrufbar ({type(exc).__name__})"
@@ -101,6 +109,16 @@ def _verify_selected_model(connection: ProviderConnection, model_id: str) -> Non
         raise ValueError(
             f"Modell {model_id!r} gehört nicht zur ProviderConnection {connection.id!r}"
         )
+
+
+def _assert_connection_secret_bound(connection: ProviderConnection) -> None:
+    """Prüft die Secret-Bindung, ohne Route-Options zu konfigurieren.
+
+    Validierungspfade (Prevalidate) brauchen nur die Ablehnung ungebundener
+    Cloud-Connections — nicht die Options. Der verworfene Dict-Aufruf sah nach
+    totem Code aus; dieser Wrapper macht die Absicht explizit.
+    """
+    _bind_connection_secret(connection, {})
 
 
 def _bind_connection_secret(
@@ -134,8 +152,7 @@ def prevalidate_ai_model_ref(ai_model_ref: AiModelRef) -> ProviderConnection:
     Run-Erzeugung, ohne einen zusätzlichen Provider-Probe auszulösen.
     """
     connection = _resolve_selected_connection(ai_model_ref.provider_connection_id)
-    options: dict[str, object] = {}
-    _bind_connection_secret(connection, options)
+    _assert_connection_secret_bound(connection)
     return connection
 
 

--- a/backend/tests/api/test_graph_post_seed_failures.py
+++ b/backend/tests/api/test_graph_post_seed_failures.py
@@ -1,0 +1,290 @@
+"""Terminalisierung synchroner Graph-Fehler nach erfolgreichem Routing-Seed."""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.container import AgoraContainer
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.models.project import ProjectStatus
+from app.services.graph_build import AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+from app.storage.graph_storage import GraphStorage
+
+
+PROJECT_ID = "proj_0123456789ab"
+SECRET_SENTINEL = "sk-post-seed-secret-must-not-leak"
+
+
+class _Router:
+    def __init__(self, _run_id):
+        pass
+
+    def resolve(self, stage_id):
+        return ResolvedRoute(
+            stage=stage_id,
+            provider_id="conn-post-seed",
+            model="post-seed-model",
+            routing_version=1,
+        )
+
+    def lock_stage(self, *_args):
+        return None
+
+
+@pytest.fixture
+def post_seed_env(monkeypatch):
+    storage = MagicMock(spec=GraphStorage)
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_AUTH_TOKEN="",
+        AGORA_UPLOAD_RATE_LIMIT_MAX=1000,
+        AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60,
+    )
+    app.extensions = {
+        "container": AgoraContainer(neo4j_storage=storage),
+        "neo4j_storage": storage,
+    }
+    app.register_blueprint(graph_bp, url_prefix="/api/graph")
+
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Post-seed project",
+        files=[],
+        total_text_length=0,
+        ontology={"entity_types": [], "edge_types": []},
+        analysis_summary=None,
+        simulation_requirement=None,
+        status=ProjectStatus.ONTOLOGY_GENERATED,
+        error=None,
+        graph_id=None,
+        graph_build_task_id=None,
+        chunk_size=500,
+        chunk_overlap=50,
+        llm_model=None,
+        llm_provider=None,
+        llm_profile_id=None,
+    )
+    project_manager = MagicMock()
+    project_manager.create_project.return_value = project
+    project_manager.get_project.return_value = project
+    project_manager.get_extracted_text.return_value = "document"
+    project_manager.save_file_to_project.return_value = {
+        "original_filename": "document.txt",
+        "path": "/tmp/document.txt",
+        "size": 8,
+    }
+    project_manager._get_project_dir.return_value = "/tmp/project"
+    run_registry = MagicMock()
+    run_registry.create_run.side_effect = lambda **kwargs: {
+        "run_id": f"run-{kwargs['run_type']}"
+    }
+    seed = MagicMock()
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-post-seed"
+
+    monkeypatch.setattr("app.api.graph_build.ProjectManager", project_manager)
+    monkeypatch.setattr("app.services.graph_build.ProjectManager", project_manager)
+    monkeypatch.setattr("app.services.graph_build.run_registry", run_registry)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", _Router)
+    monkeypatch.setattr(
+        "app.services.graph_build.resolve_route_api_key", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.LLMClient.from_route", lambda *_args, **_kwargs: MagicMock(model="post-seed-model")
+    )
+    monkeypatch.setattr("app.services.graph_build.TaskManager", lambda: task_manager)
+    monkeypatch.setattr(
+        "app.services.graph_build.ArtifactLocator.existing_paths", lambda _paths: {}
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.FileParser.extract_text", lambda _path: "document"
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.TextProcessor.preprocess_text", lambda text: text
+    )
+    return SimpleNamespace(
+        client=app.test_client(),
+        monkeypatch=monkeypatch,
+        project=project,
+        project_manager=project_manager,
+        run_registry=run_registry,
+        seed=seed,
+        task_manager=task_manager,
+    )
+
+
+def _ref_payload() -> dict[str, str]:
+    return {
+        "provider_connection_id": "conn-post-seed",
+        "model_id": "post-seed-model",
+        "source": "explicit",
+    }
+
+
+def _assert_public_error_is_safe(
+    response, caplog, capsys, *, status: int, error: str, code: str
+):
+    captured = capsys.readouterr()
+    assert response.status_code == status
+    assert response.status_code != 400
+    assert response.get_json() == {
+        "success": False,
+        "error": error,
+        "code": code,
+    }
+    assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in caplog.text
+    assert SECRET_SENTINEL not in captured.out
+    assert SECRET_SENTINEL not in captured.err
+
+
+def test_ontology_post_seed_generation_failure_terminalizes_run_and_project(
+    post_seed_env, caplog, capsys
+):
+    failure = ValueError(f"generator failed with {SECRET_SENTINEL}")
+    generator = MagicMock()
+    generator.generate.side_effect = failure
+    post_seed_env.monkeypatch.setattr(
+        "app.services.graph_build.OntologyGenerator", lambda **_kwargs: generator
+    )
+
+    response = post_seed_env.client.post(
+        "/api/graph/ontology/generate",
+        data={
+            "simulation_requirement": "Analyse the document.",
+            "files": (io.BytesIO(b"document"), "document.txt"),
+            "ai_model_ref": json.dumps(_ref_payload()),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert SECRET_SENTINEL in str(generator.generate.side_effect)
+    _assert_public_error_is_safe(
+        response,
+        caplog,
+        capsys,
+        status=500,
+        error="internal server error",
+        code="internal_error",
+    )
+    assert post_seed_env.seed.call_count == 2
+    assert post_seed_env.project.status == ProjectStatus.FAILED
+    assert post_seed_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    post_seed_env.project_manager.delete_project.assert_not_called()
+    failed_run = post_seed_env.run_registry.update_run.call_args
+    assert failed_run.args == ("run-ontology_generate",)
+    assert failed_run.kwargs["status"] == "failed"
+
+
+def test_graph_post_seed_enqueue_failure_terminalizes_run_task_and_project(
+    post_seed_env, caplog, capsys
+):
+    failure = RuntimeError(f"enqueue failed with {SECRET_SENTINEL}")
+
+    def fail_enqueue(*_args, **_kwargs):
+        raise failure
+
+    post_seed_env.monkeypatch.setattr("app.jobs.enqueue", fail_enqueue)
+
+    response = post_seed_env.client.post(
+        "/api/graph/build",
+        json={"project_id": PROJECT_ID, "ai_model_ref": _ref_payload()},
+    )
+
+    assert SECRET_SENTINEL in str(failure)
+    _assert_public_error_is_safe(
+        response,
+        caplog,
+        capsys,
+        status=500,
+        error="internal server error",
+        code="internal_error",
+    )
+    post_seed_env.seed.assert_called_once()
+    assert post_seed_env.project.status == ProjectStatus.FAILED
+    assert post_seed_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    post_seed_env.task_manager.fail_task.assert_called_once_with(
+        "task-post-seed", AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    )
+    failed_run = post_seed_env.run_registry.update_run.call_args
+    assert failed_run.args == ("run-graph_build",)
+    assert failed_run.kwargs["status"] == "failed"
+
+
+def test_graph_create_task_failure_terminalizes_pending_run_without_task(
+    post_seed_env, caplog, capsys
+):
+    failure = RuntimeError(f"task storage failed with {SECRET_SENTINEL}")
+    post_seed_env.task_manager.create_task.side_effect = failure
+
+    response = post_seed_env.client.post(
+        "/api/graph/build",
+        json={"project_id": PROJECT_ID, "ai_model_ref": _ref_payload()},
+    )
+
+    assert SECRET_SENTINEL in str(failure)
+    _assert_public_error_is_safe(
+        response,
+        caplog,
+        capsys,
+        status=500,
+        error="internal server error",
+        code="internal_error",
+    )
+    post_seed_env.run_registry.create_run.assert_called_once()
+    assert post_seed_env.run_registry.create_run.call_args.kwargs["status"] == "pending"
+    post_seed_env.seed.assert_not_called()
+    post_seed_env.task_manager.fail_task.assert_not_called()
+    assert post_seed_env.project.status == ProjectStatus.FAILED
+    assert post_seed_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    assert post_seed_env.project.graph_build_task_id is None
+    failed_run = post_seed_env.run_registry.update_run.call_args
+    assert failed_run.args == ("run-graph_build",)
+    assert failed_run.kwargs["status"] == "failed"
+    assert SECRET_SENTINEL not in str(failed_run)
+
+
+def test_graph_post_seed_timeout_preserves_gateway_timeout_and_terminalizes_states(
+    post_seed_env, caplog, capsys
+):
+    failure = TimeoutError(f"enqueue timed out with {SECRET_SENTINEL}")
+
+    def fail_enqueue(*_args, **_kwargs):
+        raise failure
+
+    post_seed_env.monkeypatch.setattr("app.jobs.enqueue", fail_enqueue)
+
+    response = post_seed_env.client.post(
+        "/api/graph/build",
+        json={"project_id": PROJECT_ID, "ai_model_ref": _ref_payload()},
+    )
+
+    assert SECRET_SENTINEL in str(failure)
+    _assert_public_error_is_safe(
+        response,
+        caplog,
+        capsys,
+        status=504,
+        error="request timed out",
+        code="timeout",
+    )
+    assert post_seed_env.project.status == ProjectStatus.FAILED
+    assert post_seed_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    post_seed_env.task_manager.fail_task.assert_called_once_with(
+        "task-post-seed", AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    )
+    failed_run = post_seed_env.run_registry.update_run.call_args
+    assert failed_run.args == ("run-graph_build",)
+    assert failed_run.kwargs["status"] == "failed"
+    assert SECRET_SENTINEL not in str(failed_run)

--- a/backend/tests/api/test_graph_post_seed_failures.py
+++ b/backend/tests/api/test_graph_post_seed_failures.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -14,7 +15,10 @@ from app.api import graph_bp
 from app.container import AgoraContainer
 from app.contracts.llm_routing_contract import ResolvedRoute
 from app.models.project import ProjectStatus
-from app.services.graph_build import AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+from app.services.graph_build import (
+    AI_MODEL_REF_GENERATION_FAILURE_MESSAGE,
+    AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+)
 from app.storage.graph_storage import GraphStorage
 
 
@@ -38,8 +42,26 @@ class _Router:
         return None
 
 
+def _capture_agora_logs(monkeypatch, caplog) -> None:
+    """Macht die ``agora.*``-Logger für caplog sichtbar.
+
+    ``get_logger`` setzt ``propagate = False``, deshalb erreicht kein Record den
+    Root-Handler, an dem caplog hängt — ohne diesen Schalter wäre jede
+    ``SECRET_SENTINEL not in caplog.text``-Zusicherung gegen ein leeres caplog
+    trivial wahr. DEBUG-Level, damit auch INFO/DEBUG-Records erfasst werden.
+    """
+    caplog.set_level(logging.DEBUG)
+    for name, candidate in list(logging.root.manager.loggerDict.items()):
+        if isinstance(candidate, logging.Logger) and (
+            name == "agora" or name.startswith("agora.")
+        ):
+            monkeypatch.setattr(candidate, "propagate", True)
+            monkeypatch.setattr(candidate, "level", logging.DEBUG)
+
+
 @pytest.fixture
-def post_seed_env(monkeypatch):
+def post_seed_env(monkeypatch, caplog):
+    _capture_agora_logs(monkeypatch, caplog)
     storage = MagicMock(spec=GraphStorage)
     app = Flask(__name__)
     app.config.update(
@@ -144,6 +166,9 @@ def _assert_public_error_is_safe(
         "code": code,
     }
     assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    # Die Terminalisierung loggt garantiert eine Warnung — ohne diese Prüfung
+    # wäre die Sentinel-Zusicherung gegen ein leeres caplog trivial wahr.
+    assert caplog.records
     assert SECRET_SENTINEL not in caplog.text
     assert SECRET_SENTINEL not in captured.out
     assert SECRET_SENTINEL not in captured.err
@@ -180,7 +205,9 @@ def test_ontology_post_seed_generation_failure_terminalizes_run_and_project(
     )
     assert post_seed_env.seed.call_count == 2
     assert post_seed_env.project.status == ProjectStatus.FAILED
-    assert post_seed_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    # Generierungsfehler tragen bewusst *nicht* die Routing-Meldung: das
+    # Routing war erfolgreich, gescheitert ist die Ontology-Generierung.
+    assert post_seed_env.project.error == AI_MODEL_REF_GENERATION_FAILURE_MESSAGE
     post_seed_env.project_manager.delete_project.assert_not_called()
     failed_run = post_seed_env.run_registry.update_run.call_args
     assert failed_run.args == ("run-ontology_generate",)

--- a/backend/tests/api/test_graph_provider_route_api.py
+++ b/backend/tests/api/test_graph_provider_route_api.py
@@ -106,12 +106,10 @@ def graph_route_env(monkeypatch):
     monkeypatch.setattr(
         "app.services.llm_routing_seed.prevalidate_ai_model_ref_with_discovery",
         prevalidate,
-        raising=False,
     )
     monkeypatch.setattr(
         "app.api.graph_build.prevalidate_ai_model_ref_with_discovery",
         prevalidate,
-        raising=False,
     )
     return SimpleNamespace(
         observed=observed,
@@ -263,12 +261,10 @@ def test_unknown_connection_returns_400_without_orphan_side_effects_or_secret_le
     graph_route_env.monkeypatch.setattr(
         "app.services.llm_routing_seed.prevalidate_ai_model_ref_with_discovery",
         reject_unknown_connection,
-        raising=False,
     )
     graph_route_env.monkeypatch.setattr(
         "app.api.graph_build.prevalidate_ai_model_ref_with_discovery",
         reject_unknown_connection,
-        raising=False,
     )
 
     response = (

--- a/backend/tests/api/test_graph_provider_route_api.py
+++ b/backend/tests/api/test_graph_provider_route_api.py
@@ -1,0 +1,286 @@
+"""AiModelRef-Vertrag der beiden Graph-Erzeugungsendpunkte (#897)."""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.container import AgoraContainer
+from app.storage.graph_storage import GraphStorage
+
+
+PROJECT_ID = "proj_0123456789ab"
+CONNECTION_ID = "conn-minimax"
+MODEL_ID = "MiniMax-M3"
+SECRET_SENTINEL = "sk-test-secret-must-not-leak"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("AGORA_AUTH_TOKEN", "")
+    storage = MagicMock(spec=GraphStorage)
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_AUTH_TOKEN="",
+        AGORA_UPLOAD_RATE_LIMIT_MAX=1000,
+        AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60,
+    )
+    app.extensions = {
+        "container": AgoraContainer(neo4j_storage=storage),
+        "neo4j_storage": storage,
+    }
+    app.register_blueprint(graph_bp, url_prefix="/api/graph")
+    return app.test_client()
+
+
+@pytest.fixture
+def graph_route_env(monkeypatch):
+    observed: dict[str, object] = {
+        "events": [],
+        "prevalidated_ref": None,
+        "ontology_kwargs": None,
+        "build_kwargs": None,
+    }
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Route project",
+        files=[],
+        total_text_length=0,
+        ontology={"entity_types": [], "edge_types": []},
+        analysis_summary="ok",
+        simulation_requirement=None,
+        llm_model=None,
+        llm_provider=None,
+        llm_profile_id=None,
+        graph_build_task_id=None,
+        graph_id=None,
+    )
+    project_manager = MagicMock()
+
+    def create_project(*, name):
+        observed["events"].append("create_project")
+        project.name = name
+        return project
+
+    project_manager.create_project.side_effect = create_project
+    project_manager.get_project.return_value = project
+    project_manager.save_file_to_project.return_value = {
+        "original_filename": "document.txt",
+        "path": "/tmp/document.txt",
+        "size": 13,
+    }
+
+    file_parser = MagicMock()
+    file_parser.extract_text.return_value = "document body"
+    text_processor = MagicMock()
+    text_processor.preprocess_text.return_value = "document body"
+
+    def generate_ontology(**kwargs):
+        observed["events"].append("generate_ontology")
+        observed["ontology_kwargs"] = kwargs
+        return project
+
+    def build_graph(**kwargs):
+        observed["events"].append("build_graph")
+        observed["build_kwargs"] = kwargs
+        return "task_graph_1", "run_graph_1"
+
+    def prevalidate(ai_model_ref):
+        observed["events"].append("prevalidate")
+        observed["prevalidated_ref"] = ai_model_ref
+        return MagicMock(name="ValidatedProviderConnection")
+
+    monkeypatch.setattr("app.api.graph_build.ProjectManager", project_manager)
+    monkeypatch.setattr("app.api.graph_build.FileParser", file_parser)
+    monkeypatch.setattr("app.api.graph_build.TextProcessor", text_processor)
+    monkeypatch.setattr(
+        "app.api.graph_build.GraphBuildService.generate_ontology", generate_ontology
+    )
+    monkeypatch.setattr("app.api.graph_build.GraphBuildService.build_graph", build_graph)
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.prevalidate_ai_model_ref_with_discovery",
+        prevalidate,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery",
+        prevalidate,
+        raising=False,
+    )
+    return SimpleNamespace(
+        observed=observed,
+        project=project,
+        project_manager=project_manager,
+        monkeypatch=monkeypatch,
+    )
+
+
+def _ref_payload(connection_id: str = CONNECTION_ID) -> dict[str, str]:
+    return {
+        "provider_connection_id": connection_id,
+        "model_id": MODEL_ID,
+        "source": "explicit",
+    }
+
+
+def _post_ontology(client, *, ai_model_ref=None, **extra):
+    data = {
+        "simulation_requirement": "Discuss climate policy.",
+        "files": (io.BytesIO(b"document body"), "document.txt"),
+        "ai_model_ref": json.dumps(ai_model_ref or _ref_payload()),
+        **extra,
+    }
+    return client.post(
+        "/api/graph/ontology/generate", data=data, content_type="multipart/form-data"
+    )
+
+
+def _post_build(client, *, ai_model_ref=None, **extra):
+    return client.post(
+        "/api/graph/build",
+        json={"project_id": PROJECT_ID, "ai_model_ref": ai_model_ref or _ref_payload(), **extra},
+    )
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+def test_valid_ai_model_ref_is_prevalidated_and_forwarded(
+    client, graph_route_env, endpoint
+):
+    response = (
+        _post_ontology(client) if endpoint == "ontology" else _post_build(client)
+    )
+
+    assert response.status_code == 200, response.get_json()
+    prevalidated = graph_route_env.observed["prevalidated_ref"]
+    assert prevalidated.provider_connection_id == CONNECTION_ID
+    assert prevalidated.model_id == MODEL_ID
+    kwargs = graph_route_env.observed[f"{endpoint}_kwargs"]
+    forwarded = kwargs["ai_model_ref"]
+    assert forwarded.provider_connection_id == CONNECTION_ID
+    assert forwarded.model_id == MODEL_ID
+    assert kwargs["llm_model_override"] is None
+    assert kwargs["llm_profile_id"] is None
+    assert graph_route_env.observed["events"][0] == "prevalidate"
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+@pytest.mark.parametrize(
+    ("legacy_field", "ontology_value", "build_value"),
+    [
+        ("llm_model", "gpt-4o-mini", "gpt-4o-mini"),
+        ("llm_profile_id", "profile-legacy", "profile-legacy"),
+        (
+            "llm_provider",
+            json.dumps({"provider": "openai"}),
+            {"provider": "openai"},
+        ),
+        (
+            "llm_runtime",
+            json.dumps({"provider": "openai"}),
+            {"provider": "openai"},
+        ),
+    ],
+)
+def test_ai_model_ref_conflicts_with_every_legacy_route_field(
+    client,
+    graph_route_env,
+    endpoint,
+    legacy_field,
+    ontology_value,
+    build_value,
+):
+    response = (
+        _post_ontology(client, **{legacy_field: ontology_value})
+        if endpoint == "ontology"
+        else _post_build(client, **{legacy_field: build_value})
+    )
+
+    assert response.status_code == 400
+    assert "ai_model_ref" in response.get_data(as_text=True)
+    assert graph_route_env.observed["ontology_kwargs"] is None
+    assert graph_route_env.observed["build_kwargs"] is None
+    graph_route_env.project_manager.create_project.assert_not_called()
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+@pytest.mark.parametrize(
+    ("legacy_field", "ontology_value", "build_value"),
+    [
+        ("llm_model", "", ""),
+        ("llm_profile_id", "", ""),
+        ("llm_provider", "{}", {}),
+        ("llm_runtime", "{}", {}),
+    ],
+)
+def test_ai_model_ref_conflicts_with_present_but_empty_legacy_field(
+    client, graph_route_env, endpoint, legacy_field, ontology_value, build_value
+):
+    response = (
+        _post_ontology(client, **{legacy_field: ontology_value})
+        if endpoint == "ontology"
+        else _post_build(client, **{legacy_field: build_value})
+    )
+
+    assert response.status_code == 400
+    assert "ai_model_ref" in response.get_data(as_text=True)
+    assert graph_route_env.observed["ontology_kwargs"] is None
+    assert graph_route_env.observed["build_kwargs"] is None
+    graph_route_env.project_manager.create_project.assert_not_called()
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+def test_malformed_ai_model_ref_returns_400_without_side_effect_or_input_echo(
+    client, graph_route_env, endpoint
+):
+    if endpoint == "ontology":
+        response = _post_ontology(client, ai_model_ref={"model_id": SECRET_SENTINEL})
+    else:
+        response = _post_build(client, ai_model_ref={"model_id": SECRET_SENTINEL})
+
+    assert response.status_code == 400
+    assert "ai_model_ref" in response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    assert graph_route_env.observed["ontology_kwargs"] is None
+    assert graph_route_env.observed["build_kwargs"] is None
+    graph_route_env.project_manager.create_project.assert_not_called()
+    assert graph_route_env.project.graph_build_task_id is None
+    assert graph_route_env.project.graph_id is None
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+def test_unknown_connection_returns_400_without_orphan_side_effects_or_secret_leak(
+    client, graph_route_env, endpoint
+):
+    def reject_unknown_connection(_ref):
+        raise ValueError("ProviderConnection 'conn-missing' nicht gefunden")
+
+    graph_route_env.monkeypatch.setattr(
+        "app.services.llm_routing_seed.prevalidate_ai_model_ref_with_discovery",
+        reject_unknown_connection,
+        raising=False,
+    )
+    graph_route_env.monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery",
+        reject_unknown_connection,
+        raising=False,
+    )
+
+    response = (
+        _post_ontology(client, ai_model_ref=_ref_payload("conn-missing"))
+        if endpoint == "ontology"
+        else _post_build(client, ai_model_ref=_ref_payload("conn-missing"))
+    )
+
+    assert response.status_code == 400
+    assert "ProviderConnection" in response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    assert graph_route_env.observed["ontology_kwargs"] is None
+    assert graph_route_env.observed["build_kwargs"] is None
+    assert graph_route_env.project.graph_build_task_id is None
+    assert graph_route_env.project.graph_id is None

--- a/backend/tests/api/test_graph_provider_route_prevalidation.py
+++ b/backend/tests/api/test_graph_provider_route_prevalidation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -13,6 +14,11 @@ from flask import Flask
 from app.api import graph_bp
 from app.container import AgoraContainer
 from app.contracts.ai_provider_contract import AiModel, ProviderConnection
+from app.services.graph_build import (
+    AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+    AiModelRefRoutingInputError,
+)
+from app.models.project import ProjectStatus
 from app.services.llm_routing_seed import prevalidate_ai_model_ref_with_discovery
 from app.services.provider_connections.adapters import ProviderProbeResult
 from app.storage.graph_storage import GraphStorage
@@ -24,8 +30,25 @@ MODEL_ID = "selected-model"
 SECRET_SENTINEL = "sk-discovery-secret-must-not-leak"
 
 
+def _capture_agora_logs(monkeypatch, caplog) -> None:
+    """Macht die ``agora.*``-Logger für caplog sichtbar.
+
+    ``get_logger`` setzt ``propagate = False``; ohne diesen Schalter erreicht
+    kein Record den Root-Handler von caplog und jede
+    ``SECRET_SENTINEL not in caplog.text``-Prüfung wäre trivial wahr.
+    """
+    caplog.set_level(logging.DEBUG)
+    for name, candidate in list(logging.root.manager.loggerDict.items()):
+        if isinstance(candidate, logging.Logger) and (
+            name == "agora" or name.startswith("agora.")
+        ):
+            monkeypatch.setattr(candidate, "propagate", True)
+            monkeypatch.setattr(candidate, "level", logging.DEBUG)
+
+
 @pytest.fixture
-def discovery_env(monkeypatch):
+def discovery_env(monkeypatch, caplog):
+    _capture_agora_logs(monkeypatch, caplog)
     storage = MagicMock(spec=GraphStorage)
     app = Flask(__name__)
     app.config.update(
@@ -181,7 +204,11 @@ def test_full_model_discovery_rejects_before_any_graph_side_effect(
 def test_seed_race_secret_is_not_exposed_in_response_or_logs(
     discovery_env, caplog, endpoint
 ):
-    race_error = ValueError(f"route changed concurrently: {SECRET_SENTINEL}")
+    # Der Boundary-Typ entscheidet über die 400-Klassifizierung; ein generischer
+    # ValueError wäre ein semantischer Fehler und dürfte hier nicht landen.
+    race_error = AiModelRefRoutingInputError(
+        f"route changed concurrently: {SECRET_SENTINEL}"
+    )
     discovery_env.monkeypatch.setattr(
         "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
     )
@@ -200,14 +227,16 @@ def test_seed_race_secret_is_not_exposed_in_response_or_logs(
     assert SECRET_SENTINEL not in caplog.text
 
 
-def test_ontology_seed_race_keeps_terminal_failed_project(discovery_env):
-    race_error = ValueError("route changed concurrently")
+def test_ontology_seed_race_overwrites_divergent_terminal_error(discovery_env):
+    """Terminalisiert der Service mit abweichendem Fehlertext, korrigiert der
+    API-Layer Status und Meldung auf den kanonischen Endzustand."""
+    race_error = AiModelRefRoutingInputError("route changed concurrently")
     discovery_env.monkeypatch.setattr(
         "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
     )
 
     def fail_after_terminalizing_project(**_kwargs):
-        discovery_env.project.status = "failed"
+        discovery_env.project.status = ProjectStatus.FAILED
         discovery_env.project.error = "routing failed"
         raise race_error
 
@@ -216,5 +245,35 @@ def test_ontology_seed_race_keeps_terminal_failed_project(discovery_env):
     response = _post(discovery_env, "ontology")
 
     assert response.status_code == 400
-    assert discovery_env.project.status == "failed"
+    assert discovery_env.project.status == ProjectStatus.FAILED
+    assert discovery_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    # Ein save_project stammt aus dem Upload-Pfad vor dem Service-Aufruf, das
+    # zweite ist die Korrektur des abweichenden Endzustands.
+    assert discovery_env.project_manager.save_project.call_count == 2
+
+
+def test_ontology_seed_race_is_idempotent_when_service_already_terminalized(
+    discovery_env,
+):
+    """Hat der Service bereits exakt den kanonischen Endzustand gesetzt, darf
+    der API-Layer kein zweites Mal speichern (Idempotenz-Bedingung)."""
+    race_error = AiModelRefRoutingInputError("route changed concurrently")
+    discovery_env.monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
+    )
+
+    def fail_after_terminalizing_project(**_kwargs):
+        discovery_env.project.status = ProjectStatus.FAILED
+        discovery_env.project.error = AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+        raise race_error
+
+    discovery_env.ontology_service.side_effect = fail_after_terminalizing_project
+
+    response = _post(discovery_env, "ontology")
+
+    assert response.status_code == 400
+    assert discovery_env.project.status == ProjectStatus.FAILED
+    assert discovery_env.project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
+    # Nur der Upload-Pfad speichert; der API-Layer schreibt nicht erneut.
+    assert discovery_env.project_manager.save_project.call_count == 1
     discovery_env.project_manager.delete_project.assert_not_called()

--- a/backend/tests/api/test_graph_provider_route_prevalidation.py
+++ b/backend/tests/api/test_graph_provider_route_prevalidation.py
@@ -1,0 +1,220 @@
+"""Model-Discovery muss vor Graph-Side-Effects abgeschlossen sein (#897)."""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.container import AgoraContainer
+from app.contracts.ai_provider_contract import AiModel, ProviderConnection
+from app.services.llm_routing_seed import prevalidate_ai_model_ref_with_discovery
+from app.services.provider_connections.adapters import ProviderProbeResult
+from app.storage.graph_storage import GraphStorage
+
+
+PROJECT_ID = "proj_0123456789ab"
+CONNECTION_ID = "conn-discovery"
+MODEL_ID = "selected-model"
+SECRET_SENTINEL = "sk-discovery-secret-must-not-leak"
+
+
+@pytest.fixture
+def discovery_env(monkeypatch):
+    storage = MagicMock(spec=GraphStorage)
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_AUTH_TOKEN="",
+        AGORA_UPLOAD_RATE_LIMIT_MAX=1000,
+        AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60,
+    )
+    app.extensions = {
+        "container": AgoraContainer(neo4j_storage=storage),
+        "neo4j_storage": storage,
+    }
+    app.register_blueprint(graph_bp, url_prefix="/api/graph")
+
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Discovery project",
+        files=[],
+        total_text_length=0,
+        ontology={"entity_types": [], "edge_types": []},
+        analysis_summary=None,
+        simulation_requirement=None,
+        llm_model=None,
+        graph_build_task_id=None,
+        graph_id=None,
+        status=None,
+        error=None,
+    )
+    project_manager = MagicMock()
+    project_manager.create_project.return_value = project
+    project_manager.get_project.return_value = project
+    project_manager.save_file_to_project.return_value = {
+        "original_filename": "document.txt",
+        "path": "/tmp/document.txt",
+        "size": 8,
+    }
+    ontology_service = MagicMock(return_value=project)
+    build_service = MagicMock(return_value=("task-1", "run-1"))
+    monkeypatch.setattr("app.api.graph_build.ProjectManager", project_manager)
+    monkeypatch.setattr(
+        "app.api.graph_build.GraphBuildService.generate_ontology", ontology_service
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.GraphBuildService.build_graph", build_service
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery",
+        prevalidate_ai_model_ref_with_discovery,
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.FileParser.extract_text", lambda _path: "document"
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.TextProcessor.preprocess_text", lambda text: text
+    )
+
+    connection = ProviderConnection(
+        id=CONNECTION_ID,
+        provider_kind="openai_compatible",
+        display_name="Discovery gateway",
+        transport="http",
+        auth_mode="api_key",
+        base_url="https://gateway.example/v1",
+        secret_ref="configured-secret-ref",
+        enabled=True,
+    )
+    connection_store = MagicMock()
+    connection_store.list_connections.return_value = [connection]
+    probe_service = MagicMock()
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionStore",
+        lambda: connection_store,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.get_llm_provider_secrets_store",
+        lambda: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.ProviderConnectionService",
+        lambda **_kwargs: probe_service,
+    )
+    return SimpleNamespace(
+        client=app.test_client(),
+        connection=connection,
+        probe_service=probe_service,
+        project_manager=project_manager,
+        ontology_service=ontology_service,
+        build_service=build_service,
+        monkeypatch=monkeypatch,
+        project=project,
+    )
+
+
+def _post(env, endpoint):
+    ref = {
+        "provider_connection_id": CONNECTION_ID,
+        "model_id": MODEL_ID,
+        "source": "explicit",
+    }
+    if endpoint == "ontology":
+        return env.client.post(
+            "/api/graph/ontology/generate",
+            data={
+                "simulation_requirement": "Analyse the document.",
+                "files": (io.BytesIO(b"document"), "document.txt"),
+                "ai_model_ref": json.dumps(ref),
+            },
+            content_type="multipart/form-data",
+        )
+    return env.client.post(
+        "/api/graph/build", json={"project_id": PROJECT_ID, "ai_model_ref": ref}
+    )
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+@pytest.mark.parametrize("failure", ["model_mismatch", "discovery_failure"])
+def test_full_model_discovery_rejects_before_any_graph_side_effect(
+    discovery_env, caplog, endpoint, failure
+):
+    if failure == "model_mismatch":
+        discovery_env.probe_service.probe.return_value = ProviderProbeResult(
+            status="available",
+            status_message=None,
+            models=(
+                AiModel(
+                    provider_connection_id=CONNECTION_ID,
+                    model_id="other-model",
+                    display_name="other-model",
+                    source="live",
+                    status="available",
+                    local_or_cloud="cloud",
+                ),
+            ),
+        )
+    else:
+        discovery_env.probe_service.probe.return_value = ProviderProbeResult(
+            status="invalid_credentials",
+            status_message=f"credentials rejected: {SECRET_SENTINEL}",
+        )
+
+    response = _post(discovery_env, endpoint)
+
+    assert response.status_code == 400
+    discovery_env.probe_service.probe.assert_called_once_with(discovery_env.connection)
+    assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in caplog.text
+    discovery_env.project_manager.create_project.assert_not_called()
+    discovery_env.project_manager.get_project.assert_not_called()
+    discovery_env.ontology_service.assert_not_called()
+    discovery_env.build_service.assert_not_called()
+
+
+@pytest.mark.parametrize("endpoint", ["ontology", "build"])
+def test_seed_race_secret_is_not_exposed_in_response_or_logs(
+    discovery_env, caplog, endpoint
+):
+    race_error = ValueError(f"route changed concurrently: {SECRET_SENTINEL}")
+    discovery_env.monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
+    )
+    service = (
+        discovery_env.ontology_service
+        if endpoint == "ontology"
+        else discovery_env.build_service
+    )
+    service.side_effect = race_error
+
+    response = _post(discovery_env, endpoint)
+
+    assert SECRET_SENTINEL in str(service.side_effect)
+    assert response.status_code == 400
+    assert SECRET_SENTINEL not in response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in caplog.text
+
+
+def test_ontology_seed_race_keeps_terminal_failed_project(discovery_env):
+    race_error = ValueError("route changed concurrently")
+    discovery_env.monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
+    )
+
+    def fail_after_terminalizing_project(**_kwargs):
+        discovery_env.project.status = "failed"
+        discovery_env.project.error = "routing failed"
+        raise race_error
+
+    discovery_env.ontology_service.side_effect = fail_after_terminalizing_project
+
+    response = _post(discovery_env, "ontology")
+
+    assert response.status_code == 400
+    assert discovery_env.project.status == "failed"
+    discovery_env.project_manager.delete_project.assert_not_called()

--- a/backend/tests/services/test_graph_build_ai_model_ref_contract.py
+++ b/backend/tests/services/test_graph_build_ai_model_ref_contract.py
@@ -1,0 +1,165 @@
+"""Service-Vertrag für AiModelRef an allen Graph-Stage-Seeds (#897)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiModelRef
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.models.project import ProjectStatus
+from app.services.graph_build import GraphBuildService
+
+
+PROJECT_ID = "proj_0123456789ab"
+MODEL_ID = "shared-model-id"
+
+
+class _Router:
+    connection_id = ""
+
+    def __init__(self, _run_id):
+        pass
+
+    def resolve(self, stage_id):
+        return ResolvedRoute(
+            stage=stage_id,
+            provider_id=self.connection_id,
+            model=MODEL_ID,
+            routing_version=1,
+        )
+
+    def lock_stage(self, *_args):
+        return None
+
+
+def _ref(connection_id: str) -> AiModelRef:
+    return AiModelRef(
+        provider_connection_id=connection_id,
+        model_id=MODEL_ID,
+        source="explicit",
+    )
+
+
+@pytest.mark.parametrize("connection_id", ["conn-alpha", "conn-beta"])
+def test_ontology_forwards_exact_ref_to_both_stage_seeds(monkeypatch, connection_id):
+    project = MagicMock(project_id=PROJECT_ID)
+    seed = MagicMock()
+    generator = MagicMock()
+    generator.generate.return_value = {
+        "entity_types": [],
+        "edge_types": [],
+        "analysis_summary": "ok",
+    }
+    _Router.connection_id = connection_id
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_project", lambda _id: project
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.save_project", lambda _project: None
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.run_registry.create_run",
+        lambda **_kwargs: {"run_id": "run-ontology-ref"},
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.run_registry.update_run", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", _Router)
+    monkeypatch.setattr(
+        "app.services.graph_build.resolve_route_api_key", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.LLMClient.from_route", lambda *_a, **_k: MagicMock()
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.OntologyGenerator", lambda **_k: generator
+    )
+    selected_ref = _ref(connection_id)
+
+    GraphBuildService.generate_ontology(
+        project_id=PROJECT_ID,
+        simulation_requirement="Analyse the document.",
+        document_texts=["document"],
+        ai_model_ref=selected_ref,
+    )
+
+    expected_kwargs = {
+        "llm_model_override": None,
+        "llm_runtime": None,
+        "llm_profile_id": None,
+        "ai_model_ref": selected_ref,
+    }
+    assert seed.call_args_list == [
+        call("run-ontology-ref", "document_ingest", **expected_kwargs),
+        call("run-ontology-ref", "ontology_generation", **expected_kwargs),
+    ]
+
+
+@pytest.mark.parametrize("connection_id", ["conn-alpha", "conn-beta"])
+def test_graph_build_forwards_exact_ref_to_graph_stage_seed(monkeypatch, connection_id):
+    project = MagicMock()
+    project.project_id = PROJECT_ID
+    project.status = ProjectStatus.ONTOLOGY_GENERATED
+    project.graph_id = None
+    project.graph_build_task_id = None
+    project.error = None
+    project.chunk_size = 500
+    project.chunk_overlap = 50
+    project.ontology = {"entity_types": [], "edge_types": []}
+    project.llm_profile_id = "legacy-profile"
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-ref"
+    seed = MagicMock()
+    _Router.connection_id = connection_id
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_project", lambda _id: project
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_extracted_text", lambda _id: "text"
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.save_project", lambda _project: None
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager._get_project_dir", lambda _id: "/tmp/project"
+    )
+    monkeypatch.setattr("app.services.graph_build.TaskManager", lambda: task_manager)
+    monkeypatch.setattr(
+        "app.services.graph_build.run_registry.create_run",
+        lambda **_kwargs: {"run_id": "run-graph-ref"},
+    )
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", _Router)
+    monkeypatch.setattr(
+        "app.services.graph_build.resolve_route_api_key", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.LLMClient.from_route", lambda *_a, **_k: MagicMock()
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.NERExtractor", lambda **_k: MagicMock()
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ArtifactLocator.existing_paths", lambda _paths: {}
+    )
+    monkeypatch.setattr("app.jobs.enqueue", lambda *_a, **_k: None)
+    selected_ref = _ref(connection_id)
+
+    GraphBuildService.build_graph(
+        project_id=PROJECT_ID,
+        graph_name="Contract graph",
+        container=MagicMock(),
+        ai_model_ref=selected_ref,
+    )
+
+    seed.assert_called_once_with(
+        "run-graph-ref",
+        "graph_build",
+        llm_model_override=None,
+        llm_runtime=None,
+        llm_profile_id=None,
+        ai_model_ref=selected_ref,
+    )

--- a/backend/tests/services/test_graph_build_ai_model_ref_persistence.py
+++ b/backend/tests/services/test_graph_build_ai_model_ref_persistence.py
@@ -1,0 +1,196 @@
+"""AiModelRef überlebt den Ontology-Run und bindet den Resume-Build (#900).
+
+Auf dem ``ai_model_ref``-Pfad bleiben ``llm_model``/``llm_provider``/
+``llm_profile_id`` bewusst leer. Ohne persistierte Referenz verlöre ein
+wiederaufgenommener Graph-Build (neuer Tab, verlorene Session) jede Modell- und
+Connection-Bindung.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiModelRef
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.models.project import ProjectStatus
+from app.services.graph_build import GraphBuildService
+
+
+PROJECT_ID = "proj_0123456789ab"
+CONNECTION_ID = "conn-persisted"
+MODEL_ID = "persisted-model"
+
+
+def _ref() -> AiModelRef:
+    return AiModelRef(
+        provider_connection_id=CONNECTION_ID,
+        model_id=MODEL_ID,
+        source="explicit",
+    )
+
+
+class _Router:
+    def __init__(self, _run_id):
+        pass
+
+    def resolve(self, stage_id):
+        return ResolvedRoute(
+            stage=stage_id,
+            provider_id=CONNECTION_ID,
+            model=MODEL_ID,
+            routing_version=1,
+        )
+
+    def lock_stage(self, *_args):
+        return None
+
+
+@pytest.fixture
+def service_env(monkeypatch):
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Persistence project",
+        status=ProjectStatus.CREATED,
+        graph_id=None,
+        graph_build_task_id=None,
+        error=None,
+        chunk_size=500,
+        chunk_overlap=50,
+        ontology={"entity_types": [], "edge_types": []},
+        analysis_summary=None,
+        llm_model=None,
+        llm_provider=None,
+        llm_profile_id=None,
+        ai_model_ref=None,
+    )
+    save_project = MagicMock()
+    seed = MagicMock()
+    run_registry = MagicMock()
+    run_registry.create_run.side_effect = lambda **kwargs: {
+        "run_id": f"run-{kwargs['run_type']}"
+    }
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-persisted"
+
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_project", lambda _id: project
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_extracted_text", lambda _id: "text"
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager._get_project_dir",
+        lambda _id: "/tmp/project",
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.save_project", save_project
+    )
+    monkeypatch.setattr("app.services.graph_build.run_registry", run_registry)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", seed)
+    monkeypatch.setattr("app.services.graph_build.StageModelRouter", _Router)
+    monkeypatch.setattr(
+        "app.services.graph_build.LLMClient.from_route",
+        lambda *_args, **_kwargs: MagicMock(model=MODEL_ID),
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.resolve_route_api_key", lambda *_args: None
+    )
+    monkeypatch.setattr("app.services.graph_build.TaskManager", lambda: task_manager)
+    monkeypatch.setattr(
+        "app.services.graph_build.ArtifactLocator.existing_paths", lambda _paths: {}
+    )
+    monkeypatch.setattr("app.services.graph_build.NERExtractor", lambda **_kwargs: None)
+    monkeypatch.setattr("app.jobs.enqueue", MagicMock())
+
+    generator = MagicMock()
+    generator.generate.return_value = {
+        "entity_types": ["Person"],
+        "edge_types": ["knows"],
+        "analysis_summary": "summary",
+    }
+    monkeypatch.setattr(
+        "app.services.graph_build.OntologyGenerator", lambda **_kwargs: generator
+    )
+
+    return SimpleNamespace(project=project, seed=seed, save_project=save_project)
+
+
+def test_generate_ontology_persists_canonical_ai_model_ref(service_env):
+    GraphBuildService.generate_ontology(
+        project_id=PROJECT_ID,
+        simulation_requirement="Analyse the document.",
+        document_texts=["document"],
+        ai_model_ref=_ref(),
+    )
+
+    assert service_env.project.status == ProjectStatus.ONTOLOGY_GENERATED
+    assert service_env.project.ai_model_ref == {
+        "provider_connection_id": CONNECTION_ID,
+        "model_id": MODEL_ID,
+        "source": "explicit",
+        "capability_filter": None,
+        "fallback_reason": None,
+    }
+    # Legacy-Felder bleiben leer — genau deshalb braucht es das neue Feld.
+    assert service_env.project.llm_model is None
+    assert service_env.project.llm_provider is None
+    assert service_env.project.llm_profile_id is None
+
+
+def test_generate_ontology_without_ref_leaves_field_empty(service_env):
+    GraphBuildService.generate_ontology(
+        project_id=PROJECT_ID,
+        simulation_requirement="Analyse the document.",
+        document_texts=["document"],
+        llm_model_override="legacy-model",
+    )
+
+    assert service_env.project.ai_model_ref is None
+    assert service_env.project.llm_model == "legacy-model"
+
+
+def test_build_graph_resumes_with_persisted_ai_model_ref(service_env):
+    service_env.project.status = ProjectStatus.ONTOLOGY_GENERATED
+    service_env.project.ai_model_ref = _ref().model_dump(mode="json")
+
+    GraphBuildService.build_graph(
+        project_id=PROJECT_ID,
+        graph_name="Resumed graph",
+        container=MagicMock(),
+    )
+
+    seeded = service_env.seed.call_args.kwargs["ai_model_ref"]
+    assert seeded == _ref()
+    assert service_env.seed.call_args.kwargs["llm_model_override"] is None
+    assert service_env.seed.call_args.kwargs["llm_profile_id"] is None
+
+
+def test_build_graph_request_route_wins_over_persisted_ref(service_env):
+    service_env.project.status = ProjectStatus.ONTOLOGY_GENERATED
+    service_env.project.ai_model_ref = _ref().model_dump(mode="json")
+
+    GraphBuildService.build_graph(
+        project_id=PROJECT_ID,
+        graph_name="Explicit legacy graph",
+        llm_model_override="request-model",
+        container=MagicMock(),
+    )
+
+    assert service_env.seed.call_args.kwargs["ai_model_ref"] is None
+    assert service_env.seed.call_args.kwargs["llm_model_override"] == "request-model"
+
+
+def test_build_graph_ignores_corrupt_persisted_ref(service_env):
+    service_env.project.status = ProjectStatus.ONTOLOGY_GENERATED
+    service_env.project.ai_model_ref = {"provider_connection_id": ""}
+
+    GraphBuildService.build_graph(
+        project_id=PROJECT_ID,
+        graph_name="Corrupt ref graph",
+        container=MagicMock(),
+    )
+
+    assert service_env.seed.call_args.kwargs["ai_model_ref"] is None

--- a/backend/tests/services/test_graph_build_profile_routing.py
+++ b/backend/tests/services/test_graph_build_profile_routing.py
@@ -81,6 +81,7 @@ def test_generate_ontology_profile_routes_document_ingest_and_ontology_stage(mon
             llm_model_override=None,
             llm_runtime=None,
             llm_profile_id="profile-openai",
+            ai_model_ref=None,
         ),
         call(
             "run_ontology_profile",
@@ -88,6 +89,7 @@ def test_generate_ontology_profile_routes_document_ingest_and_ontology_stage(mon
             llm_model_override=None,
             llm_runtime=None,
             llm_profile_id="profile-openai",
+            ai_model_ref=None,
         ),
     ]
 

--- a/backend/tests/services/test_graph_build_seed_race.py
+++ b/backend/tests/services/test_graph_build_seed_race.py
@@ -1,0 +1,121 @@
+"""Terminalzustände bei einem Seed-Race nach Run-/Task-Erzeugung (#897)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.contracts.ai_provider_contract import AiModelRef
+from app.models.project import ProjectStatus
+from app.services.graph_build import GraphBuildService
+
+
+PROJECT_ID = "proj_0123456789ab"
+SECRET_SENTINEL = "sk-seed-race-secret-must-not-leak"
+
+
+def _ref() -> AiModelRef:
+    return AiModelRef(
+        provider_connection_id="conn-race",
+        model_id="race-model",
+        source="explicit",
+    )
+
+
+def _seed_race(*_args, **_kwargs):
+    raise ValueError(f"route changed concurrently: {SECRET_SENTINEL}")
+
+
+def test_ontology_seed_race_terminalizes_run_and_project(monkeypatch):
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        status=ProjectStatus.CREATED,
+        error=None,
+    )
+    save_project = MagicMock()
+    run_registry = MagicMock()
+    run_registry.create_run.return_value = {"run_id": "run-ontology-race"}
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_project", lambda _id: project
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.save_project", save_project
+    )
+    monkeypatch.setattr("app.services.graph_build.run_registry", run_registry)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", _seed_race)
+
+    with pytest.raises(ValueError) as exc_info:
+        GraphBuildService.generate_ontology(
+            project_id=PROJECT_ID,
+            simulation_requirement="Analyse the document.",
+            document_texts=["document"],
+            ai_model_ref=_ref(),
+        )
+
+    assert SECRET_SENTINEL not in str(exc_info.value)
+    assert project.status == ProjectStatus.FAILED
+    save_project.assert_called_once_with(project)
+    failed_update = run_registry.update_run.call_args
+    assert failed_update.args == ("run-ontology-race",)
+    assert failed_update.kwargs["status"] == "failed"
+
+
+def test_graph_seed_race_terminalizes_run_task_and_project(monkeypatch):
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Race project",
+        status=ProjectStatus.ONTOLOGY_GENERATED,
+        graph_id=None,
+        graph_build_task_id=None,
+        error=None,
+        chunk_size=500,
+        chunk_overlap=50,
+        ontology={"entity_types": [], "edge_types": []},
+        llm_profile_id=None,
+    )
+    save_project = MagicMock()
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-race"
+    run_registry = MagicMock()
+    run_registry.create_run.return_value = {"run_id": "run-graph-race"}
+    enqueue = MagicMock()
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_project", lambda _id: project
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.get_extracted_text", lambda _id: "text"
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager._get_project_dir", lambda _id: "/tmp/project"
+    )
+    monkeypatch.setattr(
+        "app.services.graph_build.ProjectManager.save_project", save_project
+    )
+    monkeypatch.setattr("app.services.graph_build.TaskManager", lambda: task_manager)
+    monkeypatch.setattr("app.services.graph_build.run_registry", run_registry)
+    monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", _seed_race)
+    monkeypatch.setattr(
+        "app.services.graph_build.ArtifactLocator.existing_paths", lambda _paths: {}
+    )
+    monkeypatch.setattr("app.jobs.enqueue", enqueue)
+
+    with pytest.raises(ValueError) as exc_info:
+        GraphBuildService.build_graph(
+            project_id=PROJECT_ID,
+            graph_name="Race graph",
+            container=MagicMock(),
+            ai_model_ref=_ref(),
+        )
+
+    assert SECRET_SENTINEL not in str(exc_info.value)
+    assert project.status == ProjectStatus.FAILED
+    assert project.graph_build_task_id == "task-race"
+    assert save_project.call_count == 2
+    task_manager.fail_task.assert_called_once()
+    assert task_manager.fail_task.call_args.args[0] == "task-race"
+    failed_update = run_registry.update_run.call_args
+    assert failed_update.args == ("run-graph-race",)
+    assert failed_update.kwargs["status"] == "failed"
+    enqueue.assert_not_called()

--- a/backend/tests/services/test_graph_build_seed_race.py
+++ b/backend/tests/services/test_graph_build_seed_race.py
@@ -9,7 +9,11 @@ import pytest
 
 from app.contracts.ai_provider_contract import AiModelRef
 from app.models.project import ProjectStatus
-from app.services.graph_build import GraphBuildService
+from app.services.graph_build import (
+    AI_MODEL_REF_ROUTING_FAILURE_MESSAGE,
+    AiModelRefRoutingInputError,
+    GraphBuildService,
+)
 
 
 PROJECT_ID = "proj_0123456789ab"
@@ -46,7 +50,10 @@ def test_ontology_seed_race_terminalizes_run_and_project(monkeypatch):
     monkeypatch.setattr("app.services.graph_build.run_registry", run_registry)
     monkeypatch.setattr("app.services.graph_build.seed_run_stage_routing", _seed_race)
 
-    with pytest.raises(ValueError) as exc_info:
+    # Der konkrete Typ ist Teil der Zusicherung: ein argumentloser
+    # ``_AiModelRefRoutingInputError`` hat ein leeres ``str()``, die
+    # Sentinel-Prüfung allein wäre auch bei jedem anderen ValueError grün.
+    with pytest.raises(AiModelRefRoutingInputError) as exc_info:
         GraphBuildService.generate_ontology(
             project_id=PROJECT_ID,
             simulation_requirement="Analyse the document.",
@@ -56,6 +63,7 @@ def test_ontology_seed_race_terminalizes_run_and_project(monkeypatch):
 
     assert SECRET_SENTINEL not in str(exc_info.value)
     assert project.status == ProjectStatus.FAILED
+    assert project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
     save_project.assert_called_once_with(project)
     failed_update = run_registry.update_run.call_args
     assert failed_update.args == ("run-ontology-race",)
@@ -101,7 +109,7 @@ def test_graph_seed_race_terminalizes_run_task_and_project(monkeypatch):
     )
     monkeypatch.setattr("app.jobs.enqueue", enqueue)
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(AiModelRefRoutingInputError) as exc_info:
         GraphBuildService.build_graph(
             project_id=PROJECT_ID,
             graph_name="Race graph",
@@ -111,6 +119,7 @@ def test_graph_seed_race_terminalizes_run_task_and_project(monkeypatch):
 
     assert SECRET_SENTINEL not in str(exc_info.value)
     assert project.status == ProjectStatus.FAILED
+    assert project.error == AI_MODEL_REF_ROUTING_FAILURE_MESSAGE
     assert project.graph_build_task_id == "task-race"
     assert save_project.call_count == 2
     task_manager.fail_task.assert_called_once()

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3651 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3678 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3633 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3651 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/frontend/src/api/graph.ts
+++ b/frontend/src/api/graph.ts
@@ -1,11 +1,13 @@
 import service, { requestWithRetry } from './index'
 import type { ApiResponse } from '../types/run'
+import type { AiModelRefPayload } from './report'
 
 // --- Local types --------------------------------------------------------
 
 export interface BuildGraphData {
   project_id: string
   graph_name?: string
+  ai_model_ref?: AiModelRefPayload
   [key: string]: unknown
 }
 
@@ -42,6 +44,7 @@ export interface ProjectResponse {
   status?: string
   graph_id?: string
   graph_build_task_id?: string
+  llm_profile_id?: string | null
   [key: string]: unknown
 }
 

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -18,13 +18,8 @@ import {
 } from '../api/simulation'
 import { cancelRun } from '../api/runs'
 import { generateReport } from '../api/report'
-import { storedEffectiveModel, STORAGE_CUSTOM_MODEL, STORAGE_MODEL } from '../composables/useEnvForm'
-import {
-  runtimeLlmPayloadFromStorage,
-  runtimeProviderMissingKeyEverywhere,
-} from '../composables/useRuntimeLlmOptions'
-import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
-import { getRunModelOverride, clearRunModelOverride } from '@/store/runModelOverride'
+import { useRunModelResolver } from '@/composables/useRunModelResolver'
+import { clearRunModelOverride } from '@/store/runModelOverride'
 import Button from '@/components/v4/forms/Button.vue'
 import Badge from './ui/Badge.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
@@ -188,11 +183,12 @@ const _simClock = computed(() => useSimClock(props.simulationId || '__unset__'))
 const currentSimTime = computed(() => _simClock.value.currentSimTime.value)
 const simElapsedSec = computed(() => _simClock.value.elapsed.value)
 
-// Kanonische (Connection, Modell)-Auswahl aus routing/defaults.global_default.
-// Wird beim Sim-Start als autoritatives ``ai_model_ref`` gesendet und bindet
+// Autoritative (Connection, Modell)-Auswahl: tab-skopierter Run-Override vor
+// routing/defaults.global_default. Wird beim Sim-Start als ``ai_model_ref``
+// gesendet und bindet
 // Base-URL + Secret derselben ProviderConnection an die OASIS-Route — kein
 // .env-Fallback (Root Cause ``404 model MiniMax-M3 not found``).
-const effectiveModel = useEffectiveModelSelection()
+const { resolveRunModel } = useRunModelResolver()
 
 const statusStream = useEventStream(() => props.simulationId, {
   state: (msg) => applyRunStateEvent(msg?.payload),
@@ -240,31 +236,15 @@ async function doStart() {
     // Kanon (routing/defaults.global_default). Die Auswahl wird als
     // ``ai_model_ref`` gesendet — das bindet Base-URL + Secret derselben
     // Connection an die OASIS-Route und schließt das .env-Fallback aus.
-    // ``ai_model_ref`` darf nicht mit den Legacy-Feldern ``llm_model``/
-    // ``llm_provider`` kombiniert werden (Backend: 400), deshalb nur im
-    // Else-Zweig.
-    let selection = getRunModelOverride()
-    const usedRunOverride = selection !== null
-    if (!selection) {
-      try { await effectiveModel.ensureLoaded() } catch { /* best effort; Legacy-Pfad greift unten */ }
-      selection = effectiveModel.effectiveRef.value
-    }
+    // Ohne Override und ohne Kanon entscheidet das Backend-Routing; lokale
+    // Legacy-Modellstrings sind keine Routingquelle mehr.
+    const { ref: selection, usedRunOverride } = await resolveRunModel()
     if (selection && selection.provider_connection_id && selection.model_id) {
       params.ai_model_ref = {
         provider_connection_id: selection.provider_connection_id,
         model_id: selection.model_id,
         source: selection.source ?? 'explicit',
       }
-    } else {
-      const model = storedEffectiveModel()
-      if (model) params.llm_model = model
-      if (await runtimeProviderMissingKeyEverywhere()) {
-        addLog(t('step2.runtimeProvider.missingKey'))
-        emit('update-status', 'error')
-        return
-      }
-      const runtimeProvider = runtimeLlmPayloadFromStorage()
-      if (runtimeProvider) params.llm_provider = runtimeProvider
     }
     addLog(t('step3.controls.starting'))
     const res = await startSimulation(params)
@@ -456,15 +436,6 @@ async function goReport() {
   isGeneratingReport.value = true
   try {
     const payload = { simulation_id: props.simulationId }
-    const model = storedEffectiveModel('agora.reportModel', 'agora.reportCustomModel')
-      || storedEffectiveModel(STORAGE_MODEL, STORAGE_CUSTOM_MODEL)
-    if (model) payload.llm_model = model
-    if (await runtimeProviderMissingKeyEverywhere()) {
-      addLog(t('step2.runtimeProvider.missingKey'))
-      return
-    }
-    const runtimeProvider = runtimeLlmPayloadFromStorage()
-    if (runtimeProvider) payload.llm_provider = runtimeProvider
     const res = await generateReport(payload)
     if (res?.success && res.data?.report_id) {
       router.push({ name: 'Report', params: { reportId: res.data.report_id } })

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -62,8 +62,8 @@ vi.mock('../../api/runs', () => ({
   cancelRun: vi.fn().mockResolvedValue({ success: true, data: { run_id: 'sim_test_smoke', status: 'cancel_requested' } }),
 }))
 
-// Kanonische Modell-Auswahl: Default ist kein ai_model_ref (Legacy-Pfad bleibt
-// für bestehende Tests intakt). Der ai_model_ref-Test überschreibt effectiveRef.
+// Kanonische Modell-Auswahl: Default ist kein ai_model_ref. Die Routing-Tests
+// überschreiben effectiveRef gezielt.
 let _effectiveRefValue: { provider_connection_id: string; model_id: string; source: string } | null = null
 vi.mock('@/composables/useEffectiveModelSelection', () => ({
   useEffectiveModelSelection: () => ({
@@ -363,7 +363,7 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
     vi.restoreAllMocks()
   })
 
-  it('sendet ein persistiertes Custom-Modell beim Reportstart', async () => {
+  it('sendet beim initialen Reportstart ohne expliziten Report-Pick nur simulation_id', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     ;(generateReport as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
@@ -371,6 +371,8 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
     })
     localStorage.setItem('agora.lastModel', 'custom')
     localStorage.setItem('agora.lastCustomModel', 'deepseek-v3.2:cloud')
+    localStorage.setItem('agora.reportModel', 'legacy-report-model')
+    localStorage.setItem('agora.reportCustomModel', 'legacy-report-custom')
 
     const wrapper = mountComponent()
     await flushPromises()
@@ -384,10 +386,7 @@ describe('Step3Simulation — phase promotion (Sub-Slice A, #209)', () => {
     await reportBtn!.trigger('click')
     await flushPromises()
 
-    expect(generateReport).toHaveBeenCalledWith({
-      simulation_id: 'sim_test_smoke',
-      llm_model: 'deepseek-v3.2:cloud',
-    })
+    expect(generateReport).toHaveBeenCalledWith({ simulation_id: 'sim_test_smoke' })
   })
 })
 
@@ -522,10 +521,9 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
     expect(_clearRunOverrideSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('fällt ohne Kanon-Auswahl auf Legacy llm_model/llm_provider zurück', async () => {
+  it('fällt ohne Override und Kanon-Auswahl nicht auf Legacy-Storage zurück', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_test_smoke' } } as never)
-    // Kein ai_model_ref aus dem Kanon → Legacy-Pfad.
     _effectiveRefValue = null
     localStorage.setItem('agora.lastModel', 'custom')
     localStorage.setItem('agora.lastCustomModel', 'deepseek-v3.2:cloud')
@@ -540,6 +538,9 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
 
     const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
     expect(payload.ai_model_ref).toBeUndefined()
-    expect(payload.llm_model).toBe('deepseek-v3.2:cloud')
+    expect(payload.llm_model).toBeUndefined()
+    expect(payload.llm_provider).toBeUndefined()
+    expect(localStorage.getItem('agora.lastModel')).toBe('custom')
+    expect(localStorage.getItem('agora.lastCustomModel')).toBe('deepseek-v3.2:cloud')
   })
 })

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -16,8 +16,7 @@ import AiModelPicker from '../forms/AiModelPicker.vue'
 import IconPlus from '../shell/icons/IconPlus.vue'
 import { fetchLlmProfiles } from '../../../api/llmProfiles'
 import { setPendingUpload } from '../../../store/pendingUpload'
-import { STORAGE_LANG, STORAGE_MODEL } from '../../../composables/useEnvForm'
-import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
+import { STORAGE_LANG } from '../../../composables/useEnvForm'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import { setRunModelOverride, clearRunModelOverride } from '@/store/runModelOverride'
 import type { LlmProfile } from '../../../contracts/llmProfileContract'
@@ -77,23 +76,16 @@ function removeLocal(key: string): void {
  * Default-Modell kommt NICHT mehr aus einem eigenen `agora.hero.aiModelRef`-Key,
  * sondern aus dem Kanon (routing/defaults.global via useEffectiveModelSelection)
  * — damit der Dashboard-Start dieselbe Auswahl wie Settings zeigt. Ein
- * Dashboard-Pick ist ein transienter Run-Override: STORAGE_MODEL-Spiegel für
- * MainView plus voller AiModelRef in der sessionStorage-Senke
+ * Dashboard-Pick ist ein transienter Run-Override als voller AiModelRef in der sessionStorage-Senke
  * `agora.run.aiModelRefOverride` (store/runModelOverride), die Step3Simulation
  * beim Sim-Start vorrangig vor dem Kanon als `ai_model_ref` sendet.
  * Slice 7.6c (Storage-Cut): Der Legacy-Key `agora.hero.route` wird
  * NICHT mehr gelesen und beim Mount defensiv entfernt.
- *
- * MainView.handleNewProject liest weiterhin den klassischen STORAGE_MODEL-Key
- * via `storedEffectiveModel()` — wir spiegeln `aiModelRef.model_id` dorthin,
- * damit der bestehende Sim-Start-Flow (Backend resolved Provider via
- * SecretResolver, vgl. PR #499) ohne Touch in MainView durchgeht.
  */
 const STORAGE_HERO_PROFILE_ID = 'agora.hero.profileId'
 // Slice 7.6c (Storage-Cut): nur noch als Ziel für defensives removeLocal.
 const STORAGE_HERO_ROUTE_LEGACY = 'agora.hero.route'
 
-const adapter = useAiModelRefAdapter()
 // Phase-1 Konsolidierung: Default-Modell kommt aus dem Kanon
 // (routing/defaults.global via useEffectiveModelSelection), nicht mehr aus
 // einem eigenen localStorage-Key.
@@ -207,18 +199,15 @@ function formatBytes(bytes: number): string {
 }
 
 function onPickModel(aiRef: AiModelRef | null) {
-  // Transienter Run-Override: nur STORAGE_MODEL-Spiegel für den Sim-Start
-  // (MainView.handleNewProject). KEINE eigene persistente Modell-Senke mehr —
-  // der Default kommt aus dem Kanon.
+  // Der volle Ref wird erst beim Start gespeichert; eine leere Auswahl räumt
+  // einen möglicherweise älteren tab-skopierten Override sofort auf.
   hasExplicitPick.value = true
   selectedModel.value = aiRef
   if (aiRef) {
-    // STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default' bei leerer model_id).
-    writeLocal(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
     removeLocal(STORAGE_HERO_ROUTE_LEGACY)
   } else {
     removeLocal(STORAGE_HERO_ROUTE_LEGACY)
-    writeLocal(STORAGE_MODEL, 'default')
+    clearRunModelOverride()
   }
 }
 
@@ -237,19 +226,12 @@ async function startSimulation() {
   try {
     writeLocal(STORAGE_LANG, language.value)
     const profileId = selectedProfileId.value || null
-    // Wenn ein Profile aktiv ist, gewinnt es — direct-AiModelRef ignorieren
-    // und den STORAGE_MODEL-Key auf "default" zurücksetzen, damit MainView
-    // nicht versehentlich einen stale Override mitsendet.
+    // Wenn ein Profile aktiv ist, gewinnt es — direct-AiModelRef ignorieren.
     if (profileId) {
-      writeLocal(STORAGE_MODEL, 'default')
       // Profile gewinnt — Run-Override defensiv räumen, damit Step3 nicht
       // einen stale Direkt-Pick vorzieht.
       clearRunModelOverride()
     } else {
-      // Slice 5.4: STORAGE_MODEL-Spiegel via Adapter (defensiv: 'default'
-      // wenn kein Model gewählt — verhindert stale Route).
-      const stored = adapter.toStoredModelString(selectedModel.value)
-      writeLocal(STORAGE_MODEL, stored)
       // Voller AiModelRef (inkl. provider_connection_id) als transienter
       // Run-Override: Step3Simulation sendet ihn beim Sim-Start vorrangig
       // vor dem Kanon als autoritatives ai_model_ref. Nur bei explizitem

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -10,9 +10,8 @@
  * einem eigenen `agora.hero.aiModelRef`-localStorage-Key. Beim Mount wird
  * `effectiveModel.ensureLoaded()` gerufen und `selectedModel` aus
  * `effectiveModel.effectiveRef` initialisiert. Ein Dashboard-Pick ist ein
- * TRANSIENTER Run-Override: nur STORAGE_MODEL-Spiegel fuer MainView + defensive
- * Entfernung des Legacy-Keys `agora.hero.route`. KEINE eigene persistente
- * Modell-Senke mehr.
+ * TRANSIENTER Run-Override: voller AiModelRef beim Start, ohne Schreiben oder
+ * Clearen der Legacy-Modell-Keys. KEINE eigene persistente Modell-Senke mehr.
  *
  * Coverage:
  *  1. mountet ohne Crash
@@ -22,12 +21,11 @@
  *  5. AiModelPicker in Config-Zone sichtbar
  *  6. Kanon-First-Init: selectedModel wird onMounted aus effectiveRef initialisiert
  *  7. Storage-Cut: Legacy-Key `agora.hero.route` wird NICHT mehr gelesen, beim Mount entfernt
- *  8. onPickModel: spiegelt model_id transient nach STORAGE_MODEL (agora.lastModel)
- *  9. onPickModel(null): STORAGE_MODEL auf 'default', Legacy-Route entfernt
+ *  8. onPickModel/onPickModel(null): Legacy-Modell-Keys bleiben unangetastet
  * 10. onPickProfile: persistiert Profile-ID (kein Model-Clear mehr)
  * 11. canSubmit: false ohne Files, false ohne Requirement
- * 12. startSimulation: bei Profile aktiv wird STORAGE_MODEL='default'
- * 13. startSimulation: ohne Profile wird Picker-Wahl als STORAGE_MODEL gespiegelt
+ * 12. startSimulation: Profile cleart den Run-Override
+ * 13. startSimulation: expliziter Pick wird als voller Run-Override gespeichert
  * 14. startSimulation: ruft setPendingUpload + router.push
  * 15. i18n-Key: dashboard.hero.modelPlaceholder
  * 16. Capability-Filter: Picker bekommt mode='chat' (Default)
@@ -180,32 +178,6 @@ vi.mock('@/composables/useEffectiveModelSelection', () => {
 fetchLlmProfilesMock.mockResolvedValue([])
 getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
 
-const adapterMock: {
-  toLlmRoute: ReturnType<typeof vi.fn>
-  toAiModelRef: ReturnType<typeof vi.fn>
-  toStoredModelString: ReturnType<typeof vi.fn>
-} = {
-  toLlmRoute: vi.fn((aiRef: { provider_connection_id: string; model_id: string }) => ({
-    stage: null,
-    provider_id: 'openai',
-    model: aiRef.model_id,
-    temperature: null,
-    max_tokens: null,
-    reasoning_effort: 'none',
-    provider_options: {},
-  })),
-  toAiModelRef: vi.fn((route: { provider_id?: string | null; model?: string | null }) => ({
-    provider_connection_id: route.provider_id ?? 'conn-fallback',
-    model_id: route.model ?? '',
-    source: 'workspace-default' as const,
-  })),
-  toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
-}
-
-vi.mock('@/composables/useAiModelRefAdapter', () => ({
-  useAiModelRefAdapter: () => adapterMock,
-}))
-
 // localStorage Mock pro Test kontrollieren
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -286,8 +258,6 @@ async function mountHero(seed: Record<string, string> = {}) {
   clearRunModelOverrideMock.mockClear()
   getSystemStatusMock.mockClear()
   getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
-  adapterMock.toLlmRoute.mockClear()
-  adapterMock.toStoredModelString.mockClear()
   // Kanon-Stub: ensureLoaded muss resolven, damit die Komponente beim Mount
   // selectedModel aus effectiveRef initialisiert.
   ensureLoadedMock.mockReset()
@@ -316,7 +286,7 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
   beforeEach(() => {
     // clearAllMocks wuerde auch mockResolvedValue/Mock-Implementierungen loeschen.
     // Wir resetten nur die Call-History, nicht die Mocks selbst.
-    for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, setPendingUploadMock, routerPushMock, getSystemStatusMock, adapterMock.toLlmRoute, adapterMock.toStoredModelString, adapterMock.toAiModelRef]) {
+    for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, setPendingUploadMock, routerPushMock, getSystemStatusMock]) {
       m.mockClear()
     }
     installLocalStorageMock()
@@ -399,27 +369,31 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     expect(localStorageMock.getItem).not.toHaveBeenCalledWith('agora.hero.route')
   })
 
-  it('onPickModel: spiegelt model_id transient nach STORAGE_MODEL (agora.lastModel)', async () => {
+  it('onPickModel schreibt oder cleart keine Legacy-Modell-Keys', async () => {
     const w = await mountHero()
     const picker = w.findComponent(aiPickerStub)
     await picker.trigger('click')
     await flushPromises()
-    // Transienter Run-Override: nur STORAGE_MODEL-Spiegel, keine eigene Senke.
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'gpt-4o-mini')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     // Legacy-Route wird bei jedem Pick defensiv entfernt.
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
     // Kein Schreiben in die entfernte Senke agora.hero.aiModelRef.
     expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.hero.aiModelRef', expect.anything())
   })
 
-  it('onPickModel(null): STORAGE_MODEL auf default, Legacy-Route entfernt', async () => {
+  it('onPickModel(null) schreibt oder cleart keine Legacy-Modell-Keys', async () => {
     const w = await mountHero()
     const picker = w.findComponent(aiPickerStub)
     // Manuell null emittieren (AiModelRef | null).
     ;(picker.vm as unknown as { $emit: (e: string, v: unknown) => void }).$emit('update:modelValue', null)
     await flushPromises()
-    // STORAGE_MODEL wird auf 'default' zurueckgesetzt (kein stale Override).
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'default')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     // Legacy-Route wird entfernt.
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.hero.route')
     // Kein Schreiben in / kein Entfernen der entfernten Senke agora.hero.aiModelRef.
@@ -467,7 +441,7 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     // Vollstaendige Profil-Selektion wird in onPickProfile-Test dokumentiert.
   })
 
-  it('startSimulation: bei Profile aktiv wird STORAGE_MODEL auf default gesetzt', async () => {
+  it('startSimulation: bei Profile aktiv berührt keine Legacy-Modell-Keys', async () => {
     fetchLlmProfilesMock.mockResolvedValue([
       {
         id: 'abc',
@@ -506,9 +480,10 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     await cta.trigger('click')
     await flushPromises()
 
-    // Bei aktivem Profile gewinnt das Profile — STORAGE_MODEL wird auf
-    // 'default' zurueckgesetzt, damit MainView keinen stale Override mitsendet.
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'default')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     expect(setPendingUploadMock).toHaveBeenCalledWith(
       [file],
       'Wie reagiert die DACH-Region?',
@@ -519,9 +494,9 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
   })
 
-  it('startSimulation: ohne Profile wird Picker-Wahl als STORAGE_MODEL gespiegelt', async () => {
+  it('startSimulation: ohne Profile lässt Legacy-Modell-Keys unangetastet', async () => {
     const w = await mountHero()
-    // Picker emit aiRef (transienter Run-Override → STORAGE_MODEL-Spiegel)
+    // Picker emit aiRef (transienter Run-Override).
     const picker = w.findComponent(aiPickerStub)
     await picker.trigger('click')
     await flushPromises()
@@ -538,12 +513,15 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     await textarea.setValue('Wie reagiert die DACH-Region?')
     await flushPromises()
 
-    // Starten (ohne Profil → Picker-Wahl gewinnt, STORAGE_MODEL=model_id)
+    // Starten (ohne Profil → Picker-Wahl gewinnt).
     const cta = w.find('.hero-cta')
     await cta.trigger('click')
     await flushPromises()
 
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('agora.lastModel', 'gpt-4o-mini')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     expect(setPendingUploadMock).toHaveBeenCalled()
     expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
   })

--- a/frontend/src/composables/__tests__/useAiModelRefAdapter.spec.ts
+++ b/frontend/src/composables/__tests__/useAiModelRefAdapter.spec.ts
@@ -6,14 +6,13 @@
  *  2. toLlmRoute ohne Lookup (defensiver Fallback + console.warn)
  *  3. toAiModelRef mit Provider-Kind-Lookup (Happy Path)
  *  4. toAiModelRef ohne Lookup (defensiver Fallback)
- *  5. toStoredModelString mit und ohne Ref
- *  6. buildProviderKindLookup gruppiert nach provider_kind
- *  7. firstConnectionId liefert erste Connection-ID pro Kind
- *  8. Zod-Spiegel akzeptiert gueltiges AiModelRef
- *  9. Zod-Spiegel lehnt AiModelRef ohne provider_connection_id ab
- * 10. Zod-Spiegel lehnt unbekannte source ab
- * 11. Zod-Spiegel akzeptiert alle AiModelSource-Werte
- * 12. Round-Trip: toLlmRoute(toAiModelRef(r)) ist verlustfrei
+ *  5. buildProviderKindLookup gruppiert nach provider_kind
+ *  6. firstConnectionId liefert erste Connection-ID pro Kind
+ *  7. Zod-Spiegel akzeptiert gueltiges AiModelRef
+ *  8. Zod-Spiegel lehnt AiModelRef ohne provider_connection_id ab
+ *  9. Zod-Spiegel lehnt unbekannte source ab
+ * 10. Zod-Spiegel akzeptiert alle AiModelSource-Werte
+ * 11. Round-Trip: toLlmRoute(toAiModelRef(r)) ist verlustfrei
  *
  * Slice 7.6c: Der Legacy-Storage-Migrations-Helper (`migrateStoredRoute*`)
  * wurde mit dem Storage-Cut entfernt; die zugehörigen Tests entfallen.
@@ -32,7 +31,6 @@ import {
   toAiModelRefPure,
   buildProviderKindLookup,
   firstConnectionId,
-  toStoredModelStringPure,
   type ConnectionLookup,
 } from '../useAiModelRefAdapter'
 
@@ -184,17 +182,6 @@ describe('useAiModelRefAdapter (Slice 5.4)', () => {
     expect(roundA?.provider_connection_id).toBe('conn-a')
     expect(roundB?.provider_connection_id).toBe('conn-b')
     expect(roundA?.provider_connection_id).not.toBe(roundB?.provider_connection_id)
-  })
-
-  it('toStoredModelString: null → "default", sonst model_id', () => {
-    expect(toStoredModelStringPure(null)).toBe('default')
-    expect(
-      toStoredModelStringPure({
-        provider_connection_id: 'c',
-        model_id: 'qwen3',
-        source: 'explicit',
-      }),
-    ).toBe('qwen3')
   })
 
   it('buildProviderKindLookup: gruppiert Connections nach provider_kind', () => {

--- a/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
@@ -25,10 +25,6 @@ const modelSelection = vi.hoisted(() => ({
   ensureLoaded: vi.fn(),
   getRunModelOverride: vi.fn(),
 }))
-const legacyRouting = vi.hoisted(() => ({
-  storedEffectiveModel: vi.fn(),
-  runtimeLlmPayloadFromStorage: vi.fn(),
-}))
 const legacyStorageValues = new Map<string, string>()
 const localStorageMock = {
   getItem: (key: string) => legacyStorageValues.get(key) ?? null,
@@ -62,10 +58,6 @@ vi.mock('../usePolling', () => ({
 }))
 vi.mock('../useSystemLog', () => ({
   useSystemLog: () => ({ systemLogs: { value: [] }, addLog: vi.fn(), clearLog: vi.fn() }),
-}))
-vi.mock('../useEnvForm', () => ({ storedEffectiveModel: legacyRouting.storedEffectiveModel }))
-vi.mock('../useRuntimeLlmOptions', () => ({
-  runtimeLlmPayloadFromStorage: legacyRouting.runtimeLlmPayloadFromStorage,
 }))
 vi.mock('../useEffectiveModelSelection', () => ({
   useEffectiveModelSelection: () => ({
@@ -106,8 +98,6 @@ describe('useGraphBuildPipeline', () => {
     modelSelection.runOverride = null
     modelSelection.ensureLoaded.mockResolvedValue(undefined)
     modelSelection.getRunModelOverride.mockImplementation(() => modelSelection.runOverride)
-    legacyRouting.storedEffectiveModel.mockReturnValue('legacy-model')
-    legacyRouting.runtimeLlmPayloadFromStorage.mockReturnValue({ provider: 'legacy-provider' })
     pendingUpload.getPendingUpload.mockReturnValue({
       isPending: true,
       files: [new File(['source'], 'source.txt', { type: 'text/plain' })],
@@ -145,8 +135,6 @@ describe('useGraphBuildPipeline', () => {
     })
     expect(graphApi.buildGraph).toHaveBeenCalledTimes(1)
     expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42' })
-    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
-    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
     expect(pipeline.currentProjectId.value).toBe('project_42')
   })
 
@@ -197,8 +185,6 @@ describe('useGraphBuildPipeline', () => {
       ai_model_ref: modelSelection.runOverride,
     })
     expect(modelSelection.ensureLoaded).not.toHaveBeenCalled()
-    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
-    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
     expect(localStorageMock.getItem('agora.lastModel')).toBe('custom')
     expect(localStorageMock.getItem('agora.lastCustomModel')).toBe('legacy-model')
   })
@@ -228,8 +214,6 @@ describe('useGraphBuildPipeline', () => {
       ai_model_ref: modelSelection.effectiveRef,
     })
     expect(modelSelection.ensureLoaded).toHaveBeenCalledTimes(1)
-    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
-    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
   })
 
   it('sendet ohne Override und ohne Kanon keine Routingfelder und ignoriert liegengebliebene Legacy-Werte', async () => {
@@ -252,8 +236,6 @@ describe('useGraphBuildPipeline', () => {
     expect(formData.get('llm_model')).toBeNull()
     expect(formData.get('llm_provider')).toBeNull()
     expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42' })
-    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
-    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
     expect(localStorageMock.getItem('agora.lastModel')).toBe('custom')
     expect(localStorageMock.getItem('agora.lastCustomModel')).toBe('legacy-model')
   })

--- a/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
@@ -11,6 +11,31 @@ const pendingUpload = vi.hoisted(() => ({
   getPendingUpload: vi.fn(),
   clearPendingUpload: vi.fn(),
 }))
+const modelSelection = vi.hoisted(() => ({
+  effectiveRef: null as {
+    provider_connection_id: string
+    model_id: string
+    source: string
+  } | null,
+  runOverride: null as {
+    provider_connection_id: string
+    model_id: string
+    source: string
+  } | null,
+  ensureLoaded: vi.fn(),
+  getRunModelOverride: vi.fn(),
+}))
+const legacyRouting = vi.hoisted(() => ({
+  storedEffectiveModel: vi.fn(),
+  runtimeLlmPayloadFromStorage: vi.fn(),
+}))
+const legacyStorageValues = new Map<string, string>()
+const localStorageMock = {
+  getItem: (key: string) => legacyStorageValues.get(key) ?? null,
+  setItem: (key: string, value: string) => { legacyStorageValues.set(key, value) },
+  removeItem: (key: string) => { legacyStorageValues.delete(key) },
+  clear: () => { legacyStorageValues.clear() },
+}
 const polling = vi.hoisted(() => ({
   calls: 0,
   taskStart: vi.fn(),
@@ -38,9 +63,22 @@ vi.mock('../usePolling', () => ({
 vi.mock('../useSystemLog', () => ({
   useSystemLog: () => ({ systemLogs: { value: [] }, addLog: vi.fn(), clearLog: vi.fn() }),
 }))
-vi.mock('../useEnvForm', () => ({ storedEffectiveModel: vi.fn(() => 'fallback-model') }))
+vi.mock('../useEnvForm', () => ({ storedEffectiveModel: legacyRouting.storedEffectiveModel }))
 vi.mock('../useRuntimeLlmOptions', () => ({
-  runtimeLlmPayloadFromStorage: vi.fn(() => ({ provider: 'fallback-provider' })),
+  runtimeLlmPayloadFromStorage: legacyRouting.runtimeLlmPayloadFromStorage,
+}))
+vi.mock('../useEffectiveModelSelection', () => ({
+  useEffectiveModelSelection: () => ({
+    effectiveRef: { get value() { return modelSelection.effectiveRef } },
+    effectiveRoute: { value: null },
+    loading: { value: false },
+    error: { value: null },
+    ensureLoaded: modelSelection.ensureLoaded,
+    setGlobalSelection: vi.fn(),
+  }),
+}))
+vi.mock('../../store/runModelOverride', () => ({
+  getRunModelOverride: modelSelection.getRunModelOverride,
 }))
 
 import { useGraphBuildPipeline } from '../useGraphBuildPipeline'
@@ -62,6 +100,14 @@ describe('useGraphBuildPipeline', () => {
     vi.clearAllMocks()
     polling.calls = 0
     polling.taskTick = null
+    vi.stubGlobal('localStorage', localStorageMock)
+    localStorageMock.clear()
+    modelSelection.effectiveRef = null
+    modelSelection.runOverride = null
+    modelSelection.ensureLoaded.mockResolvedValue(undefined)
+    modelSelection.getRunModelOverride.mockImplementation(() => modelSelection.runOverride)
+    legacyRouting.storedEffectiveModel.mockReturnValue('legacy-model')
+    legacyRouting.runtimeLlmPayloadFromStorage.mockReturnValue({ provider: 'legacy-provider' })
     pendingUpload.getPendingUpload.mockReturnValue({
       isPending: true,
       files: [new File(['source'], 'source.txt', { type: 'text/plain' })],
@@ -98,7 +144,9 @@ describe('useGraphBuildPipeline', () => {
       params: { projectId: 'project_42' },
     })
     expect(graphApi.buildGraph).toHaveBeenCalledTimes(1)
-    expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42', llm_model: 'fallback-model', llm_provider: { provider: 'fallback-provider' } })
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42' })
+    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
+    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
     expect(pipeline.currentProjectId.value).toBe('project_42')
   })
 
@@ -112,7 +160,7 @@ describe('useGraphBuildPipeline', () => {
     expect(pipeline.error.value).toBe('errors.pendingUploadMissing')
   })
 
-  it('verwendet ohne Profil das Fallback-Modell und den Fallback-Provider im Ontology-FormData', async () => {
+  it('verwendet ohne Profil den Run-Override als vollständige ai_model_ref vor dem Kanon und behält die Connection', async () => {
     pendingUpload.getPendingUpload.mockReturnValue({
       isPending: true,
       files: [new File(['source'], 'source.txt', { type: 'text/plain' })],
@@ -121,14 +169,93 @@ describe('useGraphBuildPipeline', () => {
       numAgents: 30,
       numRounds: 10,
     })
+    // Gleiche model_id auf zwei Connections: Nur der vollständige Ref kann
+    // die explizit gewählte Connection zuverlässig erhalten.
+    modelSelection.effectiveRef = {
+      provider_connection_id: 'conn-workspace',
+      model_id: 'shared-model',
+      source: 'workspace-default',
+    }
+    modelSelection.runOverride = {
+      provider_connection_id: 'conn-run',
+      model_id: 'shared-model',
+      source: 'run-override',
+    }
+    localStorageMock.setItem('agora.lastModel', 'custom')
+    localStorageMock.setItem('agora.lastCustomModel', 'legacy-model')
     const pipeline = useGraphBuildPipeline({ projectId: 'new', router: createRouter(), t })
 
     await pipeline.initialize()
 
     const formData = graphApi.generateOntology.mock.calls[0][0] as FormData
     expect(formData.get('llm_profile_id')).toBeNull()
-    expect(formData.get('llm_model')).toBe('fallback-model')
-    expect(formData.get('llm_provider')).toBe(JSON.stringify({ provider: 'fallback-provider' }))
+    expect(JSON.parse(String(formData.get('ai_model_ref')))).toEqual(modelSelection.runOverride)
+    expect(formData.get('llm_model')).toBeNull()
+    expect(formData.get('llm_provider')).toBeNull()
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({
+      project_id: 'project_42',
+      ai_model_ref: modelSelection.runOverride,
+    })
+    expect(modelSelection.ensureLoaded).not.toHaveBeenCalled()
+    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
+    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
+    expect(localStorageMock.getItem('agora.lastModel')).toBe('custom')
+    expect(localStorageMock.getItem('agora.lastCustomModel')).toBe('legacy-model')
+  })
+
+  it('verwendet ohne Run-Override den vollständigen effektiven Kanon-Ref für Ontologie und Build', async () => {
+    pendingUpload.getPendingUpload.mockReturnValue({
+      isPending: true,
+      files: [new File(['source'], 'source.txt', { type: 'text/plain' })],
+      simulationRequirement: 'Analyse',
+      llmProfileId: null,
+      numAgents: 30,
+      numRounds: 10,
+    })
+    modelSelection.effectiveRef = {
+      provider_connection_id: 'conn-workspace',
+      model_id: 'shared-model',
+      source: 'workspace-default',
+    }
+
+    const pipeline = useGraphBuildPipeline({ projectId: 'new', router: createRouter(), t })
+    await pipeline.initialize()
+
+    const formData = graphApi.generateOntology.mock.calls[0][0] as FormData
+    expect(JSON.parse(String(formData.get('ai_model_ref')))).toEqual(modelSelection.effectiveRef)
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({
+      project_id: 'project_42',
+      ai_model_ref: modelSelection.effectiveRef,
+    })
+    expect(modelSelection.ensureLoaded).toHaveBeenCalledTimes(1)
+    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
+    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
+  })
+
+  it('sendet ohne Override und ohne Kanon keine Routingfelder und ignoriert liegengebliebene Legacy-Werte', async () => {
+    pendingUpload.getPendingUpload.mockReturnValue({
+      isPending: true,
+      files: [new File(['source'], 'source.txt', { type: 'text/plain' })],
+      simulationRequirement: 'Analyse',
+      llmProfileId: null,
+      numAgents: 30,
+      numRounds: 10,
+    })
+    localStorageMock.setItem('agora.lastModel', 'custom')
+    localStorageMock.setItem('agora.lastCustomModel', 'legacy-model')
+
+    const pipeline = useGraphBuildPipeline({ projectId: 'new', router: createRouter(), t })
+    await pipeline.initialize()
+
+    const formData = graphApi.generateOntology.mock.calls[0][0] as FormData
+    expect(formData.get('ai_model_ref')).toBeNull()
+    expect(formData.get('llm_model')).toBeNull()
+    expect(formData.get('llm_provider')).toBeNull()
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42' })
+    expect(legacyRouting.storedEffectiveModel).not.toHaveBeenCalled()
+    expect(legacyRouting.runtimeLlmPayloadFromStorage).not.toHaveBeenCalled()
+    expect(localStorageMock.getItem('agora.lastModel')).toBe('custom')
+    expect(localStorageMock.getItem('agora.lastCustomModel')).toBe('legacy-model')
   })
 
   it('behält Pending Upload bei Ontologiefehler und startet weder Build noch Navigation', async () => {
@@ -184,6 +311,88 @@ describe('useGraphBuildPipeline', () => {
       expect(pipeline.graphData.value).toEqual({ graph_id: 'graph_42', nodes: [], edges: [] })
       expect(pipeline.currentPhase.value).toBe(2)
     }
+  })
+
+  it('restored ontology_generated mit Profil startet den Build ohne ai_model_ref und ohne Resolver', async () => {
+    modelSelection.runOverride = {
+      provider_connection_id: 'conn-run',
+      model_id: 'shared-model',
+      source: 'run-override',
+    }
+    modelSelection.effectiveRef = {
+      provider_connection_id: 'conn-workspace',
+      model_id: 'shared-model',
+      source: 'workspace-default',
+    }
+    graphApi.getProject.mockResolvedValue({
+      success: true,
+      data: {
+        project_id: 'project_profile',
+        status: 'ontology_generated',
+        llm_profile_id: 'profile_42',
+      },
+    })
+    const pipeline = useGraphBuildPipeline({ projectId: 'project_profile', router: createRouter(), t })
+
+    await pipeline.initialize()
+
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_profile' })
+    expect(modelSelection.getRunModelOverride).not.toHaveBeenCalled()
+    expect(modelSelection.ensureLoaded).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      label: 'Run-Override',
+      override: {
+        provider_connection_id: 'conn-run',
+        model_id: 'shared-model',
+        source: 'run-override',
+      },
+      effective: {
+        provider_connection_id: 'conn-workspace',
+        model_id: 'shared-model',
+        source: 'workspace-default',
+      },
+      expectedConnection: 'conn-run',
+      ensureCalls: 0,
+    },
+    {
+      label: 'Kanon',
+      override: null,
+      effective: {
+        provider_connection_id: 'conn-workspace',
+        model_id: 'shared-model',
+        source: 'workspace-default',
+      },
+      expectedConnection: 'conn-workspace',
+      ensureCalls: 1,
+    },
+  ])('restored ontology_generated ohne Profil verwendet $label als vollständigen Ref', async ({
+    override,
+    effective,
+    expectedConnection,
+    ensureCalls,
+  }) => {
+    modelSelection.runOverride = override
+    modelSelection.effectiveRef = effective
+    graphApi.getProject.mockResolvedValue({
+      success: true,
+      data: { project_id: 'project_restore', status: 'ontology_generated', llm_profile_id: null },
+    })
+    const pipeline = useGraphBuildPipeline({ projectId: 'project_restore', router: createRouter(), t })
+
+    await pipeline.initialize()
+
+    expect(graphApi.buildGraph).toHaveBeenCalledWith({
+      project_id: 'project_restore',
+      ai_model_ref: {
+        provider_connection_id: expectedConnection,
+        model_id: 'shared-model',
+        source: override?.source ?? effective.source,
+      },
+    })
+    expect(modelSelection.ensureLoaded).toHaveBeenCalledTimes(ensureCalls)
   })
 
   it('lädt bei einer echten A→B-Routennavigation das neue konkrete Projekt', async () => {

--- a/frontend/src/composables/useAiModelRefAdapter.ts
+++ b/frontend/src/composables/useAiModelRefAdapter.ts
@@ -7,8 +7,7 @@
  * - AiModelRef.provider_connection_id (Connection-ID, z. B. "conn-uuid-xyz")
  * - LlmRoute.provider_id            (Provider-Connection-ID, identisch seit 7.3.3)
  *
- * Tests: Die pure-Helper (`toLlmRoutePure`, `toAiModelRefPure`,
- * `toStoredModelStringPure`) sind ohne Store testbar.
+ * Tests: Die pure-Helper (`toLlmRoutePure`, `toAiModelRefPure`) sind ohne Store testbar.
  *
  * Slice 7.6c: Body-Type heißt `LlmRoute` (siehe `frontend/src/contracts/llmRoute.ts`).
  * Das Backend bleibt Pydantic-SSoT, der Frontend-Type ist nur die
@@ -29,8 +28,6 @@ export interface AiModelRefAdapter {
   /** Konvertiert LlmRoute → AiModelRef (Picker-Anzeige). `null`, wenn
    *  die Route keine gültige Provider-Connection-ID + Modell trägt. */
   toAiModelRef: (route: LlmRoute) => AiModelRef | null
-  /** STORAGE_MODEL-Spiegel: nur model_id (MainView liest das klassisch). */
-  toStoredModelString: (ref: AiModelRef | null) => string
   /** Lookup-Builder für externe Aufrufer (z. B. Tests). */
   buildLookup: () => ConnectionLookup
 }
@@ -82,10 +79,6 @@ export function firstConnectionId(
   return lookup?.get(providerKind)?.[0]?.id
 }
 
-export function toStoredModelStringPure(ref: AiModelRef | null): string {
-  return ref?.model_id ?? 'default'
-}
-
 export function useAiModelRefAdapter(): AiModelRefAdapter {
   const store = useLlmProvidersStore()
   const buildLookup = (): ConnectionLookup => {
@@ -101,9 +94,7 @@ export function useAiModelRefAdapter(): AiModelRefAdapter {
     const kindLookup = buildProviderKindLookup(buildLookup())
     return toAiModelRefPure(route, firstConnectionIdByKind(kindLookup))
   }
-  const toStoredModelString = (ref: AiModelRef | null): string =>
-    toStoredModelStringPure(ref)
-  return { toLlmRoute, toAiModelRef, toStoredModelString, buildLookup }
+  return { toLlmRoute, toAiModelRef, buildLookup }
 }
 
 function firstConnectionIdByKind(

--- a/frontend/src/composables/useGraphBuildPipeline.ts
+++ b/frontend/src/composables/useGraphBuildPipeline.ts
@@ -10,11 +10,11 @@ import {
   type ProjectResponse,
   type TaskStatusResponse,
 } from '../api/graph'
+import type { AiModelRefPayload } from '../api/report'
 import { usePolling } from './usePolling'
 import { useSystemLog } from './useSystemLog'
 import { getPendingUpload, clearPendingUpload } from '../store/pendingUpload'
-import { storedEffectiveModel } from './useEnvForm'
-import { runtimeLlmPayloadFromStorage } from './useRuntimeLlmOptions'
+import { useRunModelResolver } from './useRunModelResolver'
 
 type RouterAdapter = {
   replace: (location: { name: string; params: Record<string, string> }) => Promise<unknown> | void
@@ -43,6 +43,7 @@ export function useGraphBuildPipeline({
   const currentTaskId = ref<string | null>(null)
   let activeGeneration = 0
   const { systemLogs, addLog } = useSystemLog({ cap: 100 })
+  const { resolveRunModel } = useRunModelResolver()
 
   const taskPolling = usePolling(async () => {
     if (currentTaskId.value) await pollTaskStatus(currentTaskId.value)
@@ -116,13 +117,12 @@ export function useGraphBuildPipeline({
       formData.append('num_agents', String(pending.numAgents))
       formData.append('num_rounds', String(pending.numRounds))
 
+      let aiModelRef: AiModelRefPayload | null = null
       if (pending.llmProfileId) {
         formData.append('llm_profile_id', pending.llmProfileId)
       } else {
-        const selectedModel = storedEffectiveModel()
-        if (selectedModel) formData.append('llm_model', selectedModel)
-        const runtimeProvider = runtimeLlmPayloadFromStorage()
-        if (runtimeProvider) formData.append('llm_provider', JSON.stringify(runtimeProvider))
+        aiModelRef = (await resolveRunModel()).ref
+        if (aiModelRef) formData.append('ai_model_ref', JSON.stringify(aiModelRef))
       }
 
       const response = await generateOntology(formData)
@@ -138,7 +138,7 @@ export function useGraphBuildPipeline({
       projectData.value = response.data
       ontologyProgress.value = null
       await router.replace({ name: 'StepGraphBuild', params: { projectId: response.data.project_id } })
-      if (isCurrent(generation)) await startBuildGraph(generation)
+      if (isCurrent(generation)) await startBuildGraph(generation, aiModelRef)
     } catch (caughtError) {
       if (!isCurrent(generation)) return
       error.value = messageFor(caughtError)
@@ -162,7 +162,7 @@ export function useGraphBuildPipeline({
       projectData.value = response.data
       updatePhaseByStatus(response.data.status)
       if (response.data.status === 'ontology_generated' && !response.data.graph_id) {
-        await startBuildGraph(generation)
+        await startBuildGraph(generation, response.data.llm_profile_id ? null : undefined)
       } else if (response.data.status === 'graph_building' && response.data.graph_build_task_id) {
         currentPhase.value = 1
         startPollingTask(response.data.graph_build_task_id)
@@ -180,15 +180,18 @@ export function useGraphBuildPipeline({
     }
   }
 
-  async function startBuildGraph(generation: number): Promise<void> {
+  async function startBuildGraph(
+    generation: number,
+    resolvedAiModelRef?: AiModelRefPayload | null,
+  ): Promise<void> {
     try {
       currentPhase.value = 1
       buildProgress.value = { progress: 0, message: t('step1.build.running') }
       const payload: BuildGraphData = { project_id: currentProjectId.value }
-      const selectedModel = storedEffectiveModel()
-      if (selectedModel) payload.llm_model = selectedModel
-      const runtimeProvider = runtimeLlmPayloadFromStorage()
-      if (runtimeProvider) payload.llm_provider = runtimeProvider
+      const aiModelRef = resolvedAiModelRef === undefined
+        ? (await resolveRunModel()).ref
+        : resolvedAiModelRef
+      if (aiModelRef) payload.ai_model_ref = aiModelRef
 
       const response = await buildGraph(payload)
       if (!isCurrent(generation)) return

--- a/frontend/src/composables/useRunModelResolver.ts
+++ b/frontend/src/composables/useRunModelResolver.ts
@@ -7,6 +7,16 @@ export interface RunModelResolution {
   usedRunOverride: boolean
 }
 
+function toPayload(
+  ref: Pick<AiModelRefPayload, 'provider_connection_id' | 'model_id' | 'source'>,
+): AiModelRefPayload {
+  return {
+    provider_connection_id: ref.provider_connection_id,
+    model_id: ref.model_id,
+    source: ref.source,
+  }
+}
+
 export function useRunModelResolver(): {
   resolveRunModel: () => Promise<RunModelResolution>
 } {
@@ -15,30 +25,22 @@ export function useRunModelResolver(): {
   async function resolveRunModel(): Promise<RunModelResolution> {
     const override = getRunModelOverride()
     if (override) {
-      return {
-        ref: {
-          provider_connection_id: override.provider_connection_id,
-          model_id: override.model_id,
-          source: override.source,
-        },
-        usedRunOverride: true,
-      }
+      return { ref: toPayload(override), usedRunOverride: true }
     }
 
     try {
       await effectiveModel.ensureLoaded()
-    } catch {
-      // Best effort: Ohne ladbaren Kanon entscheidet das Backend-Routing.
+    } catch (err) {
+      // Best effort: Ohne ladbaren Kanon entscheidet das Backend-Routing —
+      // aber nicht stumm, sonst ist genau dieser Fall nicht diagnostizierbar.
+      console.warn(
+        '[useRunModelResolver] Kanon nicht ladbar, Backend-Routing entscheidet',
+        err,
+      )
     }
     const effectiveRef = effectiveModel.effectiveRef.value
     return {
-      ref: effectiveRef
-        ? {
-            provider_connection_id: effectiveRef.provider_connection_id,
-            model_id: effectiveRef.model_id,
-            source: effectiveRef.source,
-          }
-        : null,
+      ref: effectiveRef ? toPayload(effectiveRef) : null,
       usedRunOverride: false,
     }
   }

--- a/frontend/src/composables/useRunModelResolver.ts
+++ b/frontend/src/composables/useRunModelResolver.ts
@@ -1,0 +1,47 @@
+import type { AiModelRefPayload } from '@/api/report'
+import { getRunModelOverride } from '@/store/runModelOverride'
+import { useEffectiveModelSelection } from './useEffectiveModelSelection'
+
+export interface RunModelResolution {
+  ref: AiModelRefPayload | null
+  usedRunOverride: boolean
+}
+
+export function useRunModelResolver(): {
+  resolveRunModel: () => Promise<RunModelResolution>
+} {
+  const effectiveModel = useEffectiveModelSelection()
+
+  async function resolveRunModel(): Promise<RunModelResolution> {
+    const override = getRunModelOverride()
+    if (override) {
+      return {
+        ref: {
+          provider_connection_id: override.provider_connection_id,
+          model_id: override.model_id,
+          source: override.source,
+        },
+        usedRunOverride: true,
+      }
+    }
+
+    try {
+      await effectiveModel.ensureLoaded()
+    } catch {
+      // Best effort: Ohne ladbaren Kanon entscheidet das Backend-Routing.
+    }
+    const effectiveRef = effectiveModel.effectiveRef.value
+    return {
+      ref: effectiveRef
+        ? {
+            provider_connection_id: effectiveRef.provider_connection_id,
+            model_id: effectiveRef.model_id,
+            source: effectiveRef.source,
+          }
+        : null,
+      usedRunOverride: false,
+    }
+  }
+
+  return { resolveRunModel }
+}

--- a/frontend/src/store/__tests__/runModelOverride.spec.ts
+++ b/frontend/src/store/__tests__/runModelOverride.spec.ts
@@ -4,7 +4,7 @@
  * Sichert Roundtrip, Source-Normalisierung auf 'run-override' und das
  * defensive Entsorgen korrupter/invalider sessionStorage-Einträge ab.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   RUN_MODEL_OVERRIDE_KEY,
   clearRunModelOverride,
@@ -26,6 +26,28 @@ describe('runModelOverride (transiente Dashboard-Senke)', () => {
     expect(getRunModelOverride()).toEqual({
       provider_connection_id: 'conn-1',
       model_id: 'm-1',
+      source: 'run-override',
+    })
+  })
+
+  it('überlebt einen Modul-Reload im selben Tab und liefert weiterhin einen Zod-validen Ref', async () => {
+    setRunModelOverride({
+      provider_connection_id: 'conn-reload',
+      model_id: 'shared-model',
+      source: 'explicit',
+    })
+
+    vi.resetModules()
+    const [{ getRunModelOverride: getAfterReload }, { AiModelRefSchema }] = await Promise.all([
+      import('../runModelOverride'),
+      import('@/contracts/aiModelRef'),
+    ])
+    const restored = getAfterReload()
+
+    expect(AiModelRefSchema.safeParse(restored).success).toBe(true)
+    expect(restored).toEqual({
+      provider_connection_id: 'conn-reload',
+      model_id: 'shared-model',
       source: 'run-override',
     })
   })

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -12,10 +12,10 @@ import AgoraGlyph from '../components/ui/AgoraGlyph.vue'
 import AgoraBrand from '../components/brand/AgoraBrand.vue'
 import AiModelPicker from '@/components/v4/forms/AiModelPicker.vue'
 import { getAvailableModels } from '../api/simulation'
-import { STORAGE_LANG, STORAGE_MODEL } from '../composables/useEnvForm'
+import { STORAGE_LANG } from '../composables/useEnvForm'
 import { setPendingUpload } from '../store/pendingUpload'
-import { useAiModelRefAdapter } from '@/composables/useAiModelRefAdapter'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
+import { clearRunModelOverride, setRunModelOverride } from '@/store/runModelOverride'
 
 const { t, tm } = useI18n()
 const router = useRouter()
@@ -42,13 +42,11 @@ const language = ref(localStorage.getItem(STORAGE_LANG) || 'de')
 //   Das Default-Modell kommt aus dem Kanon (routing/defaults.global via
 //   useEffectiveModelSelection), NICHT mehr aus einem eigenen
 //   agora.home.aiModelRef-Key — damit Home dieselbe Auswahl wie Settings zeigt.
-//   Ein Picker-Pick ist ein transienter Override nur für diesen Start; er wird
-//   auf STORAGE_MODEL gespiegelt (Step2/MainView-Pipeline, Backend resolved
-//   Provider+Key serverseitig via SecretResolver). Slice 7.6c (Storage-Cut):
-//   Legacy-Key agora.home.route wird defensiv entfernt.
+//   Ein Picker-Pick ist ein transienter Override nur für diesen Start und wird
+//   als vollständiger AiModelRef in der tab-skopierten Run-Senke gespeichert.
+//   Slice 7.6c (Storage-Cut): Legacy-Key agora.home.route wird defensiv entfernt.
 const STORAGE_HOME_ROUTE_LEGACY = 'agora.home.route'
 
-const adapter = useAiModelRefAdapter()
 const effectiveModel = useEffectiveModelSelection()
 
 const selectedModel = ref(null)
@@ -60,11 +58,10 @@ function onPickModel(aiRef) {
   selectedModel.value = aiRef
   modelOverridden.value = aiRef !== null
   if (aiRef) {
-    localStorage.setItem(STORAGE_MODEL, adapter.toStoredModelString(aiRef))
     localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
   } else {
     localStorage.removeItem(STORAGE_HOME_ROUTE_LEGACY)
-    localStorage.setItem(STORAGE_MODEL, 'default')
+    clearRunModelOverride()
   }
 }
 
@@ -142,10 +139,11 @@ async function startSimulation() {
   loading.value = true
   errorMsg.value = ''
   try {
-    // Spiegele die AiModelPicker-Auswahl auf STORAGE_MODEL, damit der bestehende
-    // MainView/Step2-Pfad (storedEffectiveModel → llm_model) sie aufgreift.
-    // Provider+Key resolved das Backend serverseitig via SecretResolver (PR #499).
-    localStorage.setItem(STORAGE_MODEL, adapter.toStoredModelString(selectedModel.value))
+    if (modelOverridden.value && selectedModel.value) {
+      setRunModelOverride(selectedModel.value)
+    } else {
+      clearRunModelOverride()
+    }
     localStorage.setItem(STORAGE_LANG, language.value)
 
     setPendingUpload(files.value, simulationPrompt.value)

--- a/frontend/src/views/__tests__/Home.spec.ts
+++ b/frontend/src/views/__tests__/Home.spec.ts
@@ -3,11 +3,10 @@
  *
  * Drei Kanon-First-Pruefungen + zwei Init-Tests:
  *  - Picker-Anbindung: AiModelPicker gerendert, ModelPicker (v4 legacy) NICHT
- *  - Picker-Pick ist TRANSIENT (KEIN setGlobalSelection): schreibt nur
- *    STORAGE_MODEL-Spiegel (agora.lastModel) via adapter.toStoredModelString
- *    und entfernt defensiv den Legacy-Key agora.home.route.
- *  - null-Pfad: entfernt agora.home.route + STORAGE_MODEL='default',
- *    modelOverridden wird wieder false.
+ *  - Picker-Pick ist TRANSIENT (KEIN setGlobalSelection): Beim Start wird der
+ *    volle AiModelRef als Run-Override gespeichert; Legacy-Modell-Keys bleiben
+ *    unangetastet.
+ *  - null-Pfad: entfernt agora.home.route, modelOverridden wird wieder false.
  *  - Kanon-First-Init: selectedModel wird aus effectiveRef vorbelegt, wenn
  *    der User nichts waehlt (ensureLoaded in onMounted aufgerufen).
  *  - Nach explizitem Pick (modelOverridden=true) ueberschreibt die
@@ -54,6 +53,10 @@ const stubs = {
 
 const setPendingUploadMock = vi.fn()
 const routerPushMock = vi.fn()
+const runOverrideMocks = vi.hoisted(() => ({
+  set: vi.fn(),
+  clear: vi.fn(),
+}))
 
 vi.mock('@/api/simulation', () => ({
   getAvailableModels: vi.fn().mockResolvedValue({
@@ -64,13 +67,10 @@ vi.mock('@/api/simulation', () => ({
 vi.mock('../store/pendingUpload', () => ({ setPendingUpload: setPendingUploadMock }))
 vi.mock('../composables/useEnvForm', () => ({ STORAGE_LANG: 'agora.lang', STORAGE_MODEL: 'agora.lastModel' }))
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: routerPushMock }) }))
-
-const adapterMock = {
-  toLlmRoute: vi.fn(),
-  toAiModelRef: vi.fn(),
-  toStoredModelString: vi.fn((aiRef: { model_id: string } | null) => aiRef?.model_id ?? 'default'),
-}
-vi.mock('@/composables/useAiModelRefAdapter', () => ({ useAiModelRefAdapter: () => adapterMock }))
+vi.mock('@/store/runModelOverride', () => ({
+  setRunModelOverride: runOverrideMocks.set,
+  clearRunModelOverride: runOverrideMocks.clear,
+}))
 
 // ---- Kanon-Composable-Mock (steuerbar, Kanon-First). ----
 // effectiveRef/effectiveRoute als Plain-Ref-Objekte (.value wird von Home
@@ -163,7 +163,9 @@ function resetEffMock(opts: { deferEnsureLoaded?: boolean } = {}) {
 
 async function mountHome() {
   localStorageMock.clear()
-  for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem, adapterMock.toStoredModelString]) m.mockClear()
+  for (const m of [localStorageMock.getItem, localStorageMock.setItem, localStorageMock.removeItem]) m.mockClear()
+  runOverrideMocks.set.mockClear()
+  runOverrideMocks.clear.mockClear()
   vi.stubGlobal('localStorage', localStorageMock)
   const pinia = createPinia(); setActivePinia(pinia)
   return mount(Home, { global: { plugins: [makeI18n()], stubs } })
@@ -183,7 +185,7 @@ describe('Home (Kanon-First, Phase-1)', () => {
     expect(w.findComponent(legacyModelPickerStub).exists()).toBe(false)
   })
 
-  it('onPickModel: transienter Override — STORAGE_MODEL-Spiegel + agora.home.route-Entfernung, KEIN setGlobalSelection, KEIN aiModelRef-Storage', async () => {
+  it('onPickModel berührt die Legacy-Modell-Keys nicht und speichert den Override noch nicht', async () => {
     const w = await mountHome()
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
@@ -194,9 +196,11 @@ describe('Home (Kanon-First, Phase-1)', () => {
     })
     await flushPromises()
 
-    // (a) STORAGE_MODEL-Spiegel via Adapter geschrieben.
-    const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
-    expect(modelCall?.[1]).toBe('gpt-4o-mini')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
+    expect(runOverrideMocks.set).not.toHaveBeenCalled()
 
     // (b) Legacy-Route-Key defensiv entfernt (mindestens beim Pick).
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.route')
@@ -213,7 +217,7 @@ describe('Home (Kanon-First, Phase-1)', () => {
     expect(effMock.setGlobalSelection).not.toHaveBeenCalled()
   })
 
-  it('onPickModel: bei null — agora.home.route entfernt + STORAGE_MODEL="default", modelOverridden===false', async () => {
+  it('onPickModel(null) schreibt oder cleart keine Legacy-Modell-Keys', async () => {
     const w = await mountHome()
     await flushPromises()
     const picker = w.findComponent(aiPickerStub)
@@ -222,9 +226,10 @@ describe('Home (Kanon-First, Phase-1)', () => {
 
     // Legacy-Route-Key entfernt (onMounted + beim null-Pick).
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('agora.home.route')
-    // STORAGE_MODEL auf 'default' zurueckgesetzt.
-    const modelCall = localStorageMock.setItem.mock.calls.find((c) => c[0] === 'agora.lastModel')
-    expect(modelCall?.[1]).toBe('default')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     // Entfernter aiModelRef-Sink wird NICHT angeruehrt.
     expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.home.aiModelRef')
     expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.home.aiModelRef', expect.anything())
@@ -232,6 +237,30 @@ describe('Home (Kanon-First, Phase-1)', () => {
     // modelOverridden===false: workspaceDefaultHint wird wieder gerendert
     // (v-if="!modelOverridden && !loadingModels", loadingModels=false nach flush).
     expect(w.html()).toContain('WORKSPACE_DEFAULT_HINT')
+  })
+
+  it('speichert einen expliziten Picker-Pick erst beim Start als vollständigen Run-Override', async () => {
+    const w = await mountHome()
+    await flushPromises()
+    const picker = w.findComponent(aiPickerStub)
+    await picker.trigger('click')
+    expect(runOverrideMocks.set).not.toHaveBeenCalled()
+
+    const file = new File(['briefing'], 'briefing.md', { type: 'text/markdown' })
+    const input = w.find<HTMLInputElement>('input[type=file]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await w.find<HTMLTextAreaElement>('textarea.prompt').setValue('Analyse')
+    await w.findAll('button').find(button => button.text() === 'Start')!.trigger('click')
+    await flushPromises()
+
+    expect(runOverrideMocks.set).toHaveBeenCalledWith({
+      provider_connection_id: 'conn-openai-1',
+      model_id: 'gpt-4o-mini',
+      source: 'explicit',
+    })
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastModel', expect.anything())
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('agora.lastCustomModel', expect.anything())
   })
 
   it('Kanon-First-Init: selectedModel wird aus effectiveRef vorbelegt, wenn User nichts waehlt; ensureLoaded in onMounted aufgerufen, setGlobalSelection NICHT', async () => {


### PR DESCRIPTION
## Summary

- beide Graph-Endpunkte akzeptieren und validieren vollständige AiModelRef inklusive Connection-/Modell-Bindung
- Home, Hero, Graph-Pipeline und Step 3 verwenden den kanonischen Run-Override ohne Legacy-Stringspiegel
- Routing-, Betriebs- und Timeoutfehler werden mit 400/500/504 korrekt klassifiziert; Projekt, Run und Task werden terminalisiert und Fehlerdaten sanitisiert
- Profil-Restore und die Grenze zu Step 2/useEnvForm bleiben erhalten

## Verification

- Backend: 83 gezielte Tests grün
- Frontend: 79 gezielte Tests grün
- Ruff, Mypy, vue-tsc und git diff --check grün
- Codegraph aktualisiert
- Standards-, Spec- und Evidence-Review: APPROVE
- Volltests und vollständige Pre-Push-Gates laufen wie vereinbart in GitHub Actions

## Follow-up

- generische Upload-/File-I-O-Transaktionalität: #899
- `AiModelRef.source` geht im Route-Snapshot verloren (Codex-P2 aus diesem Review): #901

Closes #897

Umgesetzt mit GPT-5.6 Sol Lead-Agent und spezialisierten Test-, Refactor-, Frontend-, Docs- und Evidence-Agenten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Graph- und Ontologie-Erstellung unterstützen nun `ai_model_ref` als kanonische Modellreferenz inkl. Provider-Verbindung.
  * Modell-/Run-Overrides werden konsistent für Simulation, Graph-Build und Resume verwendet; die Modellbindung wird im Projektzustand persistiert.
  * Report-Erstellung benötigt keine zusätzlichen Modell-/Provider-Angaben mehr (nur `simulation_id`).

* **Fehlerbehebungen**
  * Widersprüchliche Legacy-Modellangaben werden frühzeitig mit HTTP 400 abgelehnt.
  * Routing-/Post-Validation-Fehler setzen Projekt/Runs zuverlässig auf „fehlgeschlagen“; Secrets werden weder geleakt noch in Logs/Antworten ausgegeben.

* **Tests**
  * Umfangreiche Abdeckung für Validierung, Weitergabe, Persistenz, Resume und Race-Conditions ergänzt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
