### PR TITLE
refactor(frontend): Step 2 auf kanonische AiModelRef-Selektion migrieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,29 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   [Issue #890](https://github.com/arn0ld87/agora/issues/890) bewusst der letzte produktive
   Consumer der Legacy-Modell-Keys; Issue #897 entfernt diese Keys daher noch nicht global.
 
+### Changed (Step 2 wählt Modelle über die kanonische `AiModelRef` — 2026-07-26, Issue #890)
+
+- **Modellauswahl in Step 2:** Der Environment-Setup nutzt jetzt den kanonischen
+  `AiModelPicker`. Eine Auswahl ist eine vollständige, an eine `ProviderConnection`
+  gebundene `AiModelRef` statt eines Modellstrings; Connection und Modell-ID gehen damit
+  nicht mehr verloren. Ohne ausdrückliche Auswahl sendet Step 2 kein Modellfeld, sodass
+  die Präzedenz des Backends greift: Projektprofil vor Workspace-Default.
+- **Eindeutiger `/prepare`-Payload:** Bei ausdrücklicher Auswahl enthält der Request genau
+  ein `ai_model_ref` und keines der Felder `llm_model`, `llm_profile_id` oder
+  `llm_provider`. Damit kann die Mischfall-Ablehnung aus Issue #896 nicht mehr ausgelöst
+  werden. Eine ausdrückliche Auswahl übersteuert das Projektprofil bewusst.
+- **Runtime-Provider bleibt erhalten, schließt sich aber aus:** Der Override für Google-,
+  OpenAI- und kompatible Runtime-Zugangsdaten ist credential- statt connection-basiert und
+  ist deshalb mit einer kanonischen Ref unvereinbar. Solange er aktiv ist, ist der
+  `AiModelPicker` deaktiviert und der bisherige Legacy-Pfad gilt weiter; umgekehrt
+  deaktiviert eine kanonische Auswahl den Runtime-Block.
+- **Storage-Cut:** `useEnvForm` persistiert keine Modellauswahl mehr. `STORAGE_MODEL`,
+  `STORAGE_CUSTOM_MODEL` und `storedEffectiveModel()` sind entfernt; `STORAGE_LANG` für die
+  Agentensprache bleibt unverändert. Bereits vorhandene `agora.lastModel`- und
+  `agora.lastCustomModel`-Werte in Browsern werden weder gelesen noch aktiv gelöscht — sie
+  bleiben wirkungslose Altlast. Nach einem Reload startet die Modellauswahl bewusst leer,
+  statt eine nicht mehr verbindliche Altauswahl vorzutäuschen.
+
 ### Fixed (133 reihenfolgenabhängige Test-Failures in `tests/api` — 2026-07-26)
 
 - **`backend/tests/conftest.py`** — neues autouse-Fixture `_clean_auth_token_env`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,7 +28,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3678 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 172 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 173 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:
@@ -100,7 +100,7 @@ Strukturelle Lücken liegen vor allem in OASIS-/Neo4j-Integrationspfaden, Canvas
 - Provider-Erkennung: `backend/app/llm/providers/registry.py::detect_provider`
 - Provider-Verbindungen: `ProviderConnection`
 - kanonische Route: `AiRoute` / `LlmRoute`
-- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`
+- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`; seit Issue #890 auch im Step-2-Environment-Setup. Eine Auswahl ist eine `AiModelRef` und wird als `ai_model_ref` an `/prepare` gesendet; ohne Auswahl entscheidet die Backend-Präzedenz (Projektprofil vor Workspace-Default). Modellauswahl wird im Frontend nicht mehr persistiert
 - aktive Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
 - strukturierte LLM-JSON-Outputs: `LLMClient.chat_json` mit Pydantic-Schema (strict-json_schema-Pfad); rohe OpenAI-Clients für strukturierte Outputs vermeiden
 - Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md` (Modell `MiniMax-M3`, ab 20.07.2026)
@@ -113,6 +113,8 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 - die fünf klassischen Prozess-Wrapper-Views sind entfernt; ihre benannten Deep-Links bleiben als v4-Redirects kompatibel. Die übrigen v4-Views und `/agora-2026` existieren weiterhin parallel
 - ein React-/Lovable-Neubau ist beschrieben, aber nicht als Zielentscheidung freigegeben
 - Legacy-LLM-Profile und Provider-Connections besitzen noch Übergangspfade
+- der credential-basierte Runtime-Provider-Override (`useRuntimeLlmOptions`, `@deprecated` Slice 5.5) ist mit der connection-gebundenen `AiModelRef` unvereinbar und in Step 2 daher gegenseitig ausgeschlossen. Solange er existiert, hält `useEnvForm` weiterhin `modelOption`/`customModel` — allerdings ohne Persistenz. Die Ablösung ist offen
+- die Browser-Keys `agora.lastModel` und `agora.lastCustomModel` haben seit Issue #890 keinen produktiven Reader oder Writer mehr; vorhandene Werte werden bewusst nicht gelöscht und bleiben wirkungslose Altlast
 - einzelne Provider-Erkennungen beruhen weiterhin auf URL-/Modell-Heuristiken
 - Frontend- und Backend-Provider-Vokabular sind nicht an jeder SSE-Grenze synchron
 

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -1,7 +1,11 @@
 # Slice 5.2 — EnvSetupModelPanel/Step2EnvSetup auf Kanon-AiModelRef (Folge-PR)
 
-**Status:** nicht begonnen · **Vorgänger:** Phase 1 (PR feat/frontend-next-phase12) ·
+**Status:** umgesetzt in Issue #890 (2026-07-26) · **Vorgänger:** Phase 1 (PR feat/frontend-next-phase12) ·
 **Datum:** 2026-07-17 · **Quelle:** Scout-Workflow `frontend-next-scout` (CRG + Spec-Gap-Analyse) + Alex-Entscheidung 2026-07-17.
+
+> **Nachtrag 2026-07-26:** Die Umsetzung weicht in zwei Punkten bewusst von §3(b) und §4
+> ab. Verbindlich ist ab jetzt **§6 (Umsetzungsstand)** am Ende dieses Dokuments; §3 und §4
+> bleiben als Planungsstand von 2026-07-17 erhalten.
 
 > Dieser Slice ist aus Phase 1 ausgegliedert (Alex-Entscheidung: Atomic Slicing, separates
 > PR). Phase 1 (Kanon-First-Root-Cause-Fix der Modellwahl) ist ohne EnvSetupModelPanel
@@ -140,3 +144,67 @@
 - Kein `--no-verify`, keine Edits auf `main`.
 - Pre-Push-Gate: `bash scripts/pre-push-gate.sh frontend`.
 - `useEnvForm.spec.ts`-Assertions nicht abschwächen (AGENTS.md Regel 6).
+
+---
+
+## 6. Umsetzungsstand (Issue #890, 2026-07-26)
+
+Verbindlicher Ist-Stand. Wo dieser Abschnitt §3 oder §4 widerspricht, gilt dieser Abschnitt.
+
+### Abweichung 1 — Selektionssenke ist lokal, nicht `effectiveRef`
+
+§3(b) sah `:model-value="effectiveRef" @update:model-value="setGlobalSelection"` vor. Das ist
+nicht umgesetzt worden. Begründung, am Code belegt:
+
+- `useEffectiveModelSelection.effectiveRef` ist `computed(() => adapter.toAiModelRef(defaultsStore.globalDefault))`
+  und damit vom globalen Workspace-Default abgeleitet. Es ist nie `null`, sobald ein globaler
+  Default existiert. „Nutzer hat nichts gewählt" wäre dadurch nicht ausdrückbar, Step 2 würde
+  immer ein `ai_model_ref` senden, und die Projektprofil-Präzedenz des Backends
+  (`llm_routing_seed.py`) käme nie zum Zug. Das Akzeptanzkriterium „Projektprofil, explizite
+  Auswahl und Default besitzen getestete Präzedenz" wäre unerfüllbar.
+- `setGlobalSelection()` schreibt serverseitig über `replaceGlobalDefault`. Eine Modellwahl im
+  Run-Setup hätte damit den globalen Workspace-Default umgeschrieben — eine
+  Einstellungsmutation als Nebenwirkung einer Run-Konfiguration.
+
+Umgesetzt ist stattdessen `const selectedModelRef = ref(null)` in `Step2EnvSetup.vue` als
+einzige Kanon-Senke: initial `null`, ohne Persistenz, ohne Schreibzugriff auf den globalen
+Default. `useEffectiveModelSelection` wird von Step 2 nicht verwendet.
+
+### Abweichung 2 — `modelOption`/`customModel` bleiben in `useEnvForm`
+
+§2 („was entfällt") sah die vollständige Entfernung vor. Entfernt wurde nur die Persistenz:
+`STORAGE_MODEL`, `STORAGE_CUSTOM_MODEL`, `storedEffectiveModel()` sowie sämtliche Restore- und
+Writer-Logik. `modelOption`, `customModel`, `modelOptions` und `effectiveModel()` bleiben, weil
+sie den Runtime-Provider-Pfad bedienen.
+
+Damit ist das Akzeptanzkriterium „`useEnvForm` enthält keine Modellwahl- oder
+Modellpersistenzlogik mehr" bewusst nur zur Hälfte erfüllt: Persistenz ja, Modellwahl nein.
+Die Restschuld hängt an der Ablösung von `useRuntimeLlmOptions` (bereits `@deprecated`,
+Slice 5.5) und ist als Folge-Issue zu führen.
+
+### Auflösung Risiko B (OASIS-Runtime-Provider)
+
+Geprüft und entschieden: Der Runtime-Provider-Override wird **nicht** auf `AiModelRef`
+abgebildet. Er ist credential-basiert (`runtimePayload()` liefert `{provider, api_key?, base_url?}`
+ohne Modellfeld), der Kanon ist connection-basiert. Beide sind per Backend-Contract unvereinbar:
+`simulation_prepare.py` lehnt `ai_model_ref` zusammen mit einem truthy `llm_provider` mit HTTP 400 ab.
+
+Umgesetzt ist deshalb gegenseitiger Ausschluss in beide Richtungen:
+`modelPickerDisabled` in `Step2EnvSetup.vue` deaktiviert den Picker bei aktivem Runtime-Provider
+und setzt `selectedModelRef` zurück; `runtimeProviderBlockDisabled` in `EnvSetupModelPanel.vue`
+blendet den Runtime-Block aus, sobald eine kanonische Auswahl aktiv ist. Der 400-Guard kann
+dadurch nicht ausgelöst werden.
+
+### Auflösung Risiko C (LlmProfilePicker)
+
+Gegenstandslos: Der `LlmProfilePicker` war bereits in Issue #834 aus `EnvSetupModelPanel.vue`
+entfernt worden. `llmProfileId` bleibt als reiner Lesewert aus `props.projectData` erhalten und
+wird nur im Nicht-Kanon-Zweig als `llm_profile_id` gesendet — es ist keine Selektionsquelle mehr.
+
+### Risiko B — Nachbarbefund #901
+
+Der Verlust von `AiModelRef.source` an der Routing-Grenze (`ai_route_from_stage_route()` setzt
+hart `source="legacy"`) wurde geprüft und ist für #890 **nicht** funktional relevant:
+`resolve_ai_route()` überschreibt `source` ohnehin positional, und der einzige Leser ist das
+Audit-Event in `ai_route_audit.py`. `provider_connection_id` und `model_id` laufen verlustfrei
+bis in die Runtime. Nachverfolgt in Issue #901.

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -48,6 +48,11 @@ const selectedProfile = ref(null)
 const llmProfileId = computed(() => props.projectData?.llm_profile_id ?? null)
 const showSessionKeyOverride = ref(false)
 
+// Issue #890: kanonische AiModelRef-Selektion. Einzige Modell-Kanon-Senke —
+// initial null, keine Persistenz. Gegenseitiger Ausschluss mit dem Runtime-
+// Provider-Pfad (siehe watch(runtimeProvider) unten).
+const selectedModelRef = ref(null)
+
 const {
   runtimeProvider,
   runtimeApiKey,
@@ -93,6 +98,17 @@ watchEffect(() => {
   }
   showSessionKeyOverride.value = false
 })
+
+// Issue #890: gegenseitiger Ausschluss Runtime-Provider vs. AiModelPicker.
+// Sobald der Runtime-Provider aktiv ist, wird die kanonische Modellauswahl
+// zurückgesetzt — der Legacy-Pfad (llm_provider + llm_model) bleibt aktiv.
+watch(runtimeProvider, (provider) => {
+  if (provider !== 'default') {
+    selectedModelRef.value = null
+  }
+})
+
+const modelPickerDisabled = computed(() => runtimeProvider.value !== 'default')
 
 // ----- Model + language picker (useEnvForm) -----
 const {
@@ -229,11 +245,15 @@ async function triggerPrepare() {
     use_llm_for_profiles: true,
     language: language.value,
   }
-  if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
-  const m = effectiveModel()
-  if (m) payload.llm_model = m
-  const provider = runtimePayload()
-  if (provider) payload.llm_provider = provider
+  if (selectedModelRef.value !== null) {
+    payload.ai_model_ref = { ...selectedModelRef.value, source: 'explicit' }
+  } else {
+    if (llmProfileId.value) payload.llm_profile_id = llmProfileId.value
+    const m = effectiveModel()
+    if (m) payload.llm_model = m
+    const provider = runtimePayload()
+    if (provider) payload.llm_provider = provider
+  }
   if (useAgentCap.value && maxAgents.value > 0) {
     payload.max_agents = Math.max(10, maxAgents.value)
   }
@@ -292,6 +312,8 @@ onMounted(() => {
           v-model:runtime-api-key="runtimeApiKey"
           v-model:runtime-base-url="runtimeBaseUrl"
           v-model:show-session-key-override="showSessionKeyOverride"
+          v-model:model-ref="selectedModelRef"
+          :model-picker-disabled="modelPickerDisabled"
           :model-options="modelOptions"
           :loading-models="loadingModels"
           :runtime-provider-enabled="runtimeProviderEnabled"

--- a/frontend/src/components/__tests__/Step2EnvSetup.personaPoolMin.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.personaPoolMin.spec.ts
@@ -80,6 +80,16 @@ const i18n = createI18n({
   messages: { de, en },
 })
 
+// Issue #890: passiver Stub — vermeidet Pinia-Abhaengigkeit von
+// useAvailableModels() beim Mount von Step2EnvSetup (diese Suite prueft die
+// AiModelPicker-Integration nicht).
+const aiModelPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'disabled', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template: '<div data-testid="ai-model-picker-passive-stub" />',
+}
+
 const globalConfig = {
   plugins: [i18n],
   stubs: {
@@ -88,6 +98,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><slot /></div>' },
     Select: { template: '<select><slot /></select>' },
+    AiModelPicker: aiModelPickerStub,
   },
 }
 

--- a/frontend/src/components/__tests__/Step2EnvSetup.providerOverride.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.providerOverride.spec.ts
@@ -137,6 +137,16 @@ const i18n = createI18n({
   },
 })
 
+// Issue #890: passiver Stub — vermeidet Pinia-Abhaengigkeit von
+// useAvailableModels() beim Mount von Step2EnvSetup (diese Suite prueft die
+// AiModelPicker-Integration nicht).
+const aiModelPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'disabled', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template: '<div data-testid="ai-model-picker-passive-stub" />',
+}
+
 const globalConfig = {
   plugins: [i18n],
   stubs: {
@@ -145,6 +155,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><label>{{ label }}</label><input :type="type || \'text\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" :placeholder="placeholder" /></div>', props: ['label', 'modelValue', 'type', 'placeholder'], emits: ['update:modelValue'] },
     Select: { template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option></select>', props: ['label', 'modelValue', 'options'], emits: ['update:modelValue'] },
+    AiModelPicker: aiModelPickerStub,
   },
 }
 

--- a/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
@@ -94,6 +94,16 @@ const i18n = createI18n({
   messages: { de: {}, en: {} },
 })
 
+// Minimaler AiModelPicker-Stub, gemeinsam genutzt in Test-Suites, die den
+// Picker nicht selbst pruefen (vermeidet Pinia-Abhaengigkeit von
+// useAvailableModels() beim Mount von Step2EnvSetup — Issue #890).
+const passiveAiModelPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'disabled', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template: '<div data-testid="ai-model-picker-passive-stub" />',
+}
+
 const globalConfig = {
   plugins: [i18n],
   stubs: {
@@ -102,6 +112,7 @@ const globalConfig = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><slot /></div>' },
     Select: { template: '<select><slot /></select>' },
+    AiModelPicker: passiveAiModelPickerStub,
   },
 }
 
@@ -320,8 +331,176 @@ const globalConfigHints = {
     Kicker: { template: '<span><slot /></span>' },
     Field: { template: '<div><slot /></div>' },
     Select: { template: '<select><slot /></select>' },
+    AiModelPicker: passiveAiModelPickerStub,
   },
 }
+
+// ---------------------------------------------------------------------------
+// Issue #890 — kanonische AiModelRef-Selektion (Step 2)
+// ---------------------------------------------------------------------------
+
+const aiPickerStubModelRef = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'disabled', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template:
+    '<div data-testid="ai-model-picker-stub" :data-disabled="disabled">'
+    + '<button data-testid="pick-explicit" @click="$emit(\'update:modelValue\', '
+    + "{ provider_connection_id: 'conn-x', model_id: 'model-x', source: 'explicit' })\">pick</button>"
+    + '<button data-testid="deselect-explicit" @click="$emit(\'update:modelValue\', null)">deselect</button>'
+    + '</div>',
+}
+
+const selectStubModelRef = {
+  name: 'SelectStub',
+  props: ['modelValue', 'label', 'options'],
+  emits: ['update:modelValue'],
+  template: '<select :data-label="label"></select>',
+}
+
+const globalConfigModelRef = {
+  plugins: [i18nHints],
+  stubs: {
+    Btn: { template: '<button><slot /></button>' },
+    Badge: { template: '<span><slot /></span>' },
+    Kicker: { template: '<span><slot /></span>' },
+    Field: { template: '<div><slot /></div>' },
+    Select: selectStubModelRef,
+    AiModelPicker: aiPickerStubModelRef,
+  },
+}
+
+describe('Step2EnvSetup — kanonische AiModelRef-Selektion (Issue #890)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    ;(getAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { ollama: [], presets: [], current_default: '' },
+    })
+    ;(prepareSimulation as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: {} })
+  })
+
+  async function triggerPrepare(wrapper: ReturnType<typeof mount>) {
+    await (wrapper.vm as unknown as { triggerPrepare: () => Promise<void> }).triggerPrepare()
+    await flushPromises()
+  }
+
+  function lastPayload(): Record<string, unknown> {
+    return (prepareSimulation as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0] as Record<string, unknown>
+  }
+
+  it('kein Projektprofil + keine Auswahl -> Payload enthaelt weder ai_model_ref noch llm_model', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-01', projectData: undefined, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload).not.toHaveProperty('ai_model_ref')
+    expect(payload).not.toHaveProperty('llm_model')
+    wrapper.unmount()
+  })
+
+  it('Projektprofil gesetzt + keine explizite Auswahl -> KEIN ai_model_ref, llm_profile_id wie bisher', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-02', projectData: { llm_profile_id: 'prof-xyz' }, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload).not.toHaveProperty('ai_model_ref')
+    expect(payload.llm_profile_id).toBe('prof-xyz')
+    wrapper.unmount()
+  })
+
+  it('explizite Auswahl -> genau ein ai_model_ref, kein llm_model/llm_profile_id/llm_provider', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-03', projectData: undefined, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="pick-explicit"]').trigger('click')
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn-x',
+      model_id: 'model-x',
+      source: 'explicit',
+    })
+    expect(payload).not.toHaveProperty('llm_model')
+    expect(payload).not.toHaveProperty('llm_profile_id')
+    expect(payload).not.toHaveProperty('llm_provider')
+    wrapper.unmount()
+  })
+
+  it('explizite Auswahl schlaegt Projektprofil: nur ai_model_ref, kein llm_profile_id', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-04', projectData: { llm_profile_id: 'prof-xyz' }, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="pick-explicit"]').trigger('click')
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload.ai_model_ref).toBeTruthy()
+    expect(payload).not.toHaveProperty('llm_profile_id')
+    wrapper.unmount()
+  })
+
+  it('Deselektion: nach expliziter Auswahl wieder null -> Payload wieder ohne ai_model_ref, mit llm_profile_id wie im Ausgangszustand', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-05', projectData: { llm_profile_id: 'prof-xyz' }, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="pick-explicit"]').trigger('click')
+    await wrapper.find('[data-testid="deselect-explicit"]').trigger('click')
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload).not.toHaveProperty('ai_model_ref')
+    expect(payload.llm_profile_id).toBe('prof-xyz')
+    wrapper.unmount()
+  })
+
+  it('Runtime-Provider aktiv -> kein ai_model_ref, stattdessen llm_provider + llm_model wie bisher', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-06', projectData: undefined, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+
+    // Runtime-Provider-Panel aufklappen, dann ueber die Select-Stub-Komponente
+    // (die v-model:runtime-provider bedient) ein Nicht-Default emittieren.
+    const toggle = wrapper.find('.runtime-toggle')
+    expect(toggle.exists()).toBe(true)
+    await toggle.trigger('click')
+    await flushPromises()
+
+    const runtimeSelectComponent = wrapper
+      .findAllComponents(selectStubModelRef)
+      .find((c) => c.props('label') === de.step2.runtimeProvider.label)
+    expect(runtimeSelectComponent).toBeTruthy()
+    await runtimeSelectComponent!.vm.$emit('update:modelValue', 'openai')
+    await flushPromises()
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    expect(payload).not.toHaveProperty('ai_model_ref')
+    expect(payload.llm_provider).toBeTruthy()
+    wrapper.unmount()
+  })
+})
 
 describe('Step2EnvSetup — EnvSetupModelPanel ohne v3-Profil-Legacy-Picker (Issue #834)', () => {
   beforeEach(() => {

--- a/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
@@ -477,6 +477,44 @@ describe('Step2EnvSetup — kanonische AiModelRef-Selektion (Issue #890)', () =>
     wrapper.unmount()
   })
 
+  it('explizite Auswahl gefolgt von Runtime-Provider-Aktivierung -> selectedModelRef wird zurueckgesetzt, Payload sendet nie beide Felder', async () => {
+    const wrapper = mount(Step2EnvSetup, {
+      props: { simulationId: 'sim-890-07', projectData: undefined, graphData: undefined, systemLogs: [] },
+      global: globalConfigModelRef,
+    })
+    await flushPromises()
+
+    // Schritt 1: Nutzer waehlt ZUERST explizit ein Modell.
+    await wrapper.find('[data-testid="pick-explicit"]').trigger('click')
+    await flushPromises()
+    expect((wrapper.vm as unknown as { selectedModelRef: unknown }).selectedModelRef).toEqual({
+      provider_connection_id: 'conn-x',
+      model_id: 'model-x',
+      source: 'explicit',
+    })
+
+    // Schritt 2: DANACH wird der Runtime-Provider auf einen Nicht-Default-Wert
+    // gesetzt. EnvSetupModelPanel blendet den Runtime-Block aus, sobald
+    // selectedModelRef gesetzt ist (runtimeProviderBlockDisabled) — die Select-
+    // Komponente ist dann UI-seitig nicht mehr erreichbar. Der watch(runtimeProvider)
+    // in Step2EnvSetup.vue reagiert aber auf die reaktive Ref selbst, nicht auf
+    // einen UI-Klick — wir setzen sie daher direkt (Dev-Mode-Expose von
+    // script-setup-Bindings ueber wrapper.vm, siehe Home.spec.ts-Pattern), um
+    // exakt den Codepfad zu treffen, den die Lead-Review verifiziert haben will.
+    ;(wrapper.vm as unknown as { runtimeProvider: string }).runtimeProvider = 'openai'
+    await flushPromises()
+
+    await triggerPrepare(wrapper)
+
+    const payload = lastPayload()
+    // Der watch(runtimeProvider)-Reset in Step2EnvSetup.vue muss selectedModelRef
+    // zurueckgesetzt haben — ai_model_ref darf NICHT im Payload sein.
+    expect(payload).not.toHaveProperty('ai_model_ref')
+    // Stattdessen greift der Legacy-Runtime-Provider-Pfad.
+    expect(payload.llm_provider).toBeTruthy()
+    wrapper.unmount()
+  })
+
   it('Runtime-Provider aktiv -> kein ai_model_ref, stattdessen llm_provider + llm_model wie bisher', async () => {
     const wrapper = mount(Step2EnvSetup, {
       props: { simulationId: 'sim-890-06', projectData: undefined, graphData: undefined, systemLogs: [] },

--- a/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
+++ b/frontend/src/components/__tests__/Step2EnvSetup.spec.ts
@@ -451,7 +451,11 @@ describe('Step2EnvSetup — kanonische AiModelRef-Selektion (Issue #890)', () =>
     await triggerPrepare(wrapper)
 
     const payload = lastPayload()
-    expect(payload.ai_model_ref).toBeTruthy()
+    expect(payload.ai_model_ref).toEqual({
+      provider_connection_id: 'conn-x',
+      model_id: 'model-x',
+      source: 'explicit',
+    })
     expect(payload).not.toHaveProperty('llm_profile_id')
     wrapper.unmount()
   })

--- a/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.feedColumns.spec.ts
@@ -83,12 +83,6 @@ vi.mock('../../observability/tracing', () => ({
   traceIdToSigNozUrl: () => null,
 }))
 
-vi.mock('../../composables/useEnvForm', () => ({
-  storedEffectiveModel: () => 'mock',
-  STORAGE_CUSTOM_MODEL: 'k1',
-  STORAGE_MODEL: 'k2',
-}))
-
 vi.mock('../../composables/useRuntimeLlmOptions', () => ({
   runtimeLlmPayloadFromStorage: () => ({}),
   runtimeProviderMissingKeyEverywhere: () => false,

--- a/frontend/src/components/step2/EnvSetupModelPanel.vue
+++ b/frontend/src/components/step2/EnvSetupModelPanel.vue
@@ -2,19 +2,22 @@
 /**
  * EnvSetupModelPanel — Modell-/Sprach-/Runtime-Provider-Auswahl (Step 2).
  *
- * Issue #834: v3-Profil-Legacy-Picker entfernt. Kein AiModelPicker
- * hier als Ersatz — der Profil-Pfad ist backend-seitig live
- * (backend/app/api/simulation_prepare.py expandiert llm_profile_id zu
- * llm_model="profile:<id>"). Eine vollständige Kanon-Migration dieser Stelle
- * (useEffectiveModelSelection, Storage-Cut agora.lastModel, Prepare-Payload-
- * Vertrag) ist ein eigener Slice (siehe
- * docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md) und hier
- * out of scope.
+ * Issue #834: v3-Profil-Legacy-Picker entfernt.
+ * Issue #890: kanonischer AiModelPicker (`modelRef` / `update:modelRef`)
+ * als Modell-Kanon-Senke eingebunden. Die bestehenden Props/Emits
+ * `modelOption`/`customModel`/`modelOptions` und
+ * `update:modelOption`/`update:customModel` bleiben bestehen — sie
+ * bedienen weiterhin den Legacy-Runtime-Provider-Pfad (siehe
+ * `Step2EnvSetup.vue`, `useRuntimeLlmOptions`). Beide Pfade sind
+ * gegenseitig exklusiv; die Steuerung (welcher Pfad aktiv ist, disabled-
+ * Zustand) liegt beim Parent, nicht hier.
  */
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Field from '../ui/Field.vue'
 import Select from '../ui/Select.vue'
+import AiModelPicker from '../v4/forms/AiModelPicker.vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
 
 const { t } = useI18n()
 
@@ -39,17 +42,26 @@ const props = defineProps({
   providerDbKeyChecking: { type: Boolean, default: false },
   showSessionKeyOverride: { type: Boolean, default: false },
   isPreparing: { type: Boolean, default: false },
+  modelRef: { type: Object as () => AiModelRef | null, default: null },
+  modelPickerDisabled: { type: Boolean, default: false },
 })
 
-const emit = defineEmits([
-  'update:modelOption',
-  'update:customModel',
-  'update:language',
-  'update:runtimeProvider',
-  'update:runtimeApiKey',
-  'update:runtimeBaseUrl',
-  'update:showSessionKeyOverride',
-])
+// Issue #890: sobald eine kanonische Modellauswahl aktiv ist, ist der
+// Runtime-Provider-Block deaktiviert (gegenseitiger Ausschluss, siehe
+// Step2EnvSetup.vue). Der Backend-400-Guard (ai_model_ref + llm_provider)
+// kann so nie ausgeloest werden.
+const runtimeProviderBlockDisabled = computed(() => props.modelRef !== null)
+
+const emit = defineEmits<{
+  'update:modelOption': [value: string]
+  'update:customModel': [value: string]
+  'update:language': [value: string]
+  'update:runtimeProvider': [value: string]
+  'update:runtimeApiKey': [value: string]
+  'update:runtimeBaseUrl': [value: string]
+  'update:showSessionKeyOverride': [value: boolean]
+  'update:modelRef': [value: AiModelRef | null]
+}>()
 
 const showRuntimeOptions = ref(false)
 </script>
@@ -61,7 +73,18 @@ const showRuntimeOptions = ref(false)
     </p>
 
     <div class="setup-grid">
-      <!-- Model -->
+      <!-- Kanonische Modell-Auswahl (AiModelRef) -->
+      <div class="setup-cell setup-cell--wide">
+        <label class="field-label">{{ t('step2.model.label') }}</label>
+        <AiModelPicker
+          :model-value="modelRef"
+          mode="chat"
+          :disabled="modelPickerDisabled"
+          @update:model-value="emit('update:modelRef', $event)"
+        />
+      </div>
+
+      <!-- Model (Legacy-Runtime-Provider-Pfad) -->
       <div class="setup-cell">
         <Select
           :model-value="modelOption"
@@ -89,6 +112,7 @@ const showRuntimeOptions = ref(false)
           type="button"
           class="runtime-toggle"
           :aria-expanded="showRuntimeOptions"
+          :disabled="runtimeProviderBlockDisabled"
           @click="showRuntimeOptions = !showRuntimeOptions"
         >
           <span>{{ t('step2.runtimeProvider.toggle') }}</span>
@@ -96,7 +120,7 @@ const showRuntimeOptions = ref(false)
             {{ runtimeProviderEnabled ? t('step2.runtimeProvider.active') : t('step2.runtimeProvider.default') }}
           </span>
         </button>
-        <div v-if="showRuntimeOptions" class="runtime-panel">
+        <div v-if="showRuntimeOptions && !runtimeProviderBlockDisabled" class="runtime-panel">
           <Select
             :model-value="runtimeProvider"
             :label="t('step2.runtimeProvider.label')"
@@ -170,6 +194,13 @@ const showRuntimeOptions = ref(false)
 }
 .setup-cell { display: flex; flex-direction: column; gap: var(--s-2); }
 .setup-cell--wide { grid-column: 1 / -1; }
+.field-label {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
 
 .runtime-toggle {
   display: flex;

--- a/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
+++ b/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * EnvSetupModelPanel — AiModelPicker-Integration (Issue #890, Slice 2).
+ *
+ * Prueft den kanonischen Modell-Selektions-Pfad (`modelRef` / `update:modelRef`)
+ * getrennt vom Legacy-Runtime-Provider-Pfad (`modelOption` / `update:modelOption`).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import EnvSetupModelPanel from '../EnvSetupModelPanel.vue'
+import type { AiModelRef } from '@/contracts/aiModelRef'
+
+const aiPickerStub = {
+  name: 'AiModelPicker',
+  props: ['modelValue', 'disabled', 'placeholder', 'mode', 'allowWorkspaceDefault', 'capabilityFilter'],
+  emits: ['update:modelValue'],
+  template:
+    '<div data-testid="ai-model-picker-stub" :data-disabled="disabled">'
+    + '<button data-testid="pick-a" @click="$emit(\'update:modelValue\', '
+    + "{ provider_connection_id: 'conn-a', model_id: 'model-a', source: 'explicit' })\">pick-a</button>"
+    + '<button data-testid="pick-b" @click="$emit(\'update:modelValue\', '
+    + "{ provider_connection_id: 'conn-b', model_id: 'model-b', source: 'explicit' })\">pick-b</button>"
+    + '<button data-testid="deselect" @click="$emit(\'update:modelValue\', null)">deselect</button>'
+    + '</div>',
+}
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  fallbackLocale: 'de',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { de: {} },
+})
+
+function mountPanel(props: Partial<Record<string, unknown>> = {}) {
+  return mount(EnvSetupModelPanel, {
+    props: {
+      modelOption: 'default',
+      modelOptions: [],
+      customModel: '',
+      language: 'de',
+      runtimeProviderOptions: [],
+      modelRef: null,
+      ...props,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        AiModelPicker: aiPickerStub,
+        Field: { template: '<div><slot /></div>' },
+        Select: { template: '<select><slot /></select>' },
+      },
+    },
+  })
+}
+
+describe('EnvSetupModelPanel — AiModelPicker-Integration (#890)', () => {
+  it('rendert AiModelPicker', () => {
+    const w = mountPanel()
+    expect(w.findComponent(aiPickerStub).exists()).toBe(true)
+  })
+
+  it('modelRef-Prop initial null -> Picker bekommt null', () => {
+    const w = mountPanel({ modelRef: null })
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.props('modelValue')).toBeNull()
+  })
+
+  it('Picker-Auswahl -> Panel emittiert update:modelRef mit vollstaendigem AiModelRef', async () => {
+    const w = mountPanel()
+    await w.find('[data-testid="pick-a"]').trigger('click')
+    const emitted = w.emitted('update:modelRef')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toEqual({
+      provider_connection_id: 'conn-a',
+      model_id: 'model-a',
+      source: 'explicit',
+    } satisfies AiModelRef)
+  })
+
+  it('Modellwechsel -> neues vollstaendiges Ref wird emittiert', async () => {
+    const w = mountPanel()
+    await w.find('[data-testid="pick-a"]').trigger('click')
+    await w.find('[data-testid="pick-b"]').trigger('click')
+    const emitted = w.emitted('update:modelRef')
+    expect(emitted).toHaveLength(2)
+    expect(emitted![1][0]).toEqual({
+      provider_connection_id: 'conn-b',
+      model_id: 'model-b',
+      source: 'explicit',
+    })
+  })
+
+  it('Deselektion (Picker emittiert null) -> Panel emittiert update:modelRef mit null', async () => {
+    const w = mountPanel({ modelRef: { provider_connection_id: 'conn-a', model_id: 'model-a', source: 'explicit' } })
+    await w.find('[data-testid="deselect"]').trigger('click')
+    const emitted = w.emitted('update:modelRef')
+    expect(emitted).toBeTruthy()
+    expect(emitted![emitted!.length - 1][0]).toBeNull()
+  })
+
+  it('modelPickerDisabled=true -> Picker ist disabled', () => {
+    const w = mountPanel({ modelPickerDisabled: true })
+    const picker = w.findComponent(aiPickerStub)
+    expect(picker.props('disabled')).toBe(true)
+  })
+
+  it('keine Legacy-Modell-Events auf dem Kanon-Pfad: Picker-Auswahl loest KEIN update:modelOption/update:customModel aus', async () => {
+    const w = mountPanel()
+    await w.find('[data-testid="pick-a"]').trigger('click')
+    expect(w.emitted('update:modelOption')).toBeUndefined()
+    expect(w.emitted('update:customModel')).toBeUndefined()
+  })
+})

--- a/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
+++ b/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
@@ -4,7 +4,7 @@
  * Prueft den kanonischen Modell-Selektions-Pfad (`modelRef` / `update:modelRef`)
  * getrennt vom Legacy-Runtime-Provider-Pfad (`modelOption` / `update:modelOption`).
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import EnvSetupModelPanel from '../EnvSetupModelPanel.vue'

--- a/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
+++ b/frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts
@@ -112,4 +112,32 @@ describe('EnvSetupModelPanel — AiModelPicker-Integration (#890)', () => {
     expect(w.emitted('update:modelOption')).toBeUndefined()
     expect(w.emitted('update:customModel')).toBeUndefined()
   })
+
+  // Lücke 2 (Lead-Review, Spec-Findings): runtimeProviderBlockDisabled war
+  // ungetestet. Der Runtime-Provider-Block muss erreichbar sein, solange
+  // keine kanonische Auswahl aktiv ist (modelRef === null), und ausgeblendet
+  // werden, sobald sie aktiv ist (modelRef !== null) — Backend-400-Guard.
+  describe('runtimeProviderBlockDisabled — gegenseitiger Ausschluss (Issue #890)', () => {
+    it('modelRef=null -> Runtime-Provider-Toggle ist NICHT disabled und oeffnet den Runtime-Block', async () => {
+      const w = mountPanel({ modelRef: null })
+      const toggle = w.find('.runtime-toggle')
+      expect(toggle.attributes('disabled')).toBeUndefined()
+
+      await toggle.trigger('click')
+
+      expect(w.find('.runtime-panel').exists()).toBe(true)
+    })
+
+    it('modelRef gesetzt -> Runtime-Provider-Toggle ist disabled und der Runtime-Block bleibt ausgeblendet', async () => {
+      const w = mountPanel({
+        modelRef: { provider_connection_id: 'conn-a', model_id: 'model-a', source: 'explicit' },
+      })
+      const toggle = w.find('.runtime-toggle')
+      expect(toggle.attributes('disabled')).toBeDefined()
+
+      await toggle.trigger('click')
+
+      expect(w.find('.runtime-panel').exists()).toBe(false)
+    })
+  })
 })

--- a/frontend/src/composables/__tests__/useEnvForm.spec.ts
+++ b/frontend/src/composables/__tests__/useEnvForm.spec.ts
@@ -276,7 +276,7 @@ describe('useEnvForm', () => {
       expect(f.language.value).toBe('de')
     })
 
-    it('restauriert persistierten modelOption wenn er noch in der neuen Liste ist', async () => {
+    it('#890: modelOption wird NICHT mehr aus localStorage restauriert, auch wenn der Wert in der neuen Liste existiert', async () => {
       localStorageStub.setItem(STORAGE_MODEL, 'gemma3')
       mockedGetAvailableModels.mockResolvedValue({
         success: true,
@@ -292,12 +292,11 @@ describe('useEnvForm', () => {
       } as never)
 
       const f = useEnvForm({ t })
-      // Composable initially reads stored 'gemma3'
-      expect(f.modelOption.value).toBe('gemma3')
+      expect(f.modelOption.value).toBe('default')
 
       await f.loadModels()
-      // Still 'gemma3' because it exists in presets
-      expect(f.modelOption.value).toBe('gemma3')
+      // Storage-Cut: bleibt 'default', keine Restore-Logik mehr.
+      expect(f.modelOption.value).toBe('default')
     })
   })
 
@@ -363,58 +362,47 @@ describe('useEnvForm', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Case 6 — localStorage-Persistence Modellauswahl
+  // Case 6 — Storage-Cut Modellauswahl (Issue #890)
+  //
+  // useEnvForm persistiert Modellauswahl NICHT mehr — agora.lastModel /
+  // agora.lastCustomModel sind Legacy-Keys, die weder gelesen noch aktiv
+  // geloescht werden. Die kanonische Senke ist jetzt Step2EnvSetup.selectedModelRef
+  // (AiModelRef via AiModelPicker), nicht mehr modelOption/customModel.
   // -------------------------------------------------------------------------
 
-  describe('Case 6 — localStorage-Persistence: Modellauswahl', () => {
-    it('modelOption wird beim Mount aus localStorage geladen', () => {
-      localStorageStub.setItem(STORAGE_MODEL, 'custom')
-      const f = useEnvForm({ t })
-      expect(f.modelOption.value).toBe('custom')
-    })
+  describe('Case 6 — Storage-Cut: Modellauswahl wird NICHT mehr persistiert (#890)', () => {
+    it('vorhandene Legacy-Werte in localStorage werden NICHT restauriert — modelOption bleibt "default", customModel bleibt leer', () => {
+      localStorageStub.setItem(STORAGE_MODEL, 'irgendein-modell')
+      localStorageStub.setItem(STORAGE_CUSTOM_MODEL, 'irgendein-custom-modell')
 
-    it('fällt auf "default" zurück wenn kein localStorage-Eintrag', () => {
-      // localStorageStub is empty
       const f = useEnvForm({ t })
+
       expect(f.modelOption.value).toBe('default')
+      expect(f.customModel.value).toBe('')
     })
 
-    it('Änderung von modelOption schreibt in localStorage zurück', async () => {
+    it('Aenderung von modelOption schreibt NICHT mehr nach localStorage (und loescht Altwerte nicht aktiv)', async () => {
+      localStorageStub.setItem(STORAGE_MODEL, 'irgendein-modell')
+
       const f = useEnvForm({ t })
       f.modelOption.value = 'llama3'
 
       await nextTick()
       await nextTick()
 
-      expect(localStorageStub.getItem(STORAGE_MODEL)).toBe('llama3')
+      // Weder ueberschrieben noch geloescht — der Wert bleibt exakt der Alt-Wert.
+      expect(localStorageStub.getItem(STORAGE_MODEL)).toBe('irgendein-modell')
     })
 
-    it('Modellauswahl überlebt Mount-Cycle (neues Composable liest persistierten Wert)', async () => {
-      const f1 = useEnvForm({ t })
-      f1.modelOption.value = 'gemma3'
+    it('Aenderung von customModel schreibt NICHT mehr nach localStorage', async () => {
+      const f = useEnvForm({ t })
+      f.modelOption.value = 'custom'
+      f.customModel.value = 'my-custom-model'
 
       await nextTick()
       await nextTick()
 
-      // Simulate new mount by creating a new composable instance
-      const f2 = useEnvForm({ t })
-      expect(f2.modelOption.value).toBe('gemma3')
-    })
-
-    it('customModel wird persistiert und beim nächsten Mount wieder geladen', async () => {
-      const f1 = useEnvForm({ t })
-      f1.modelOption.value = 'custom'
-      f1.customModel.value = 'deepseek-v3.2:cloud'
-
-      await nextTick()
-      await nextTick()
-
-      expect(localStorageStub.getItem(STORAGE_CUSTOM_MODEL)).toBe('deepseek-v3.2:cloud')
-
-      const f2 = useEnvForm({ t })
-      expect(f2.modelOption.value).toBe('custom')
-      expect(f2.customModel.value).toBe('deepseek-v3.2:cloud')
-      expect(f2.effectiveModel()).toBe('deepseek-v3.2:cloud')
+      expect(localStorageStub.getItem(STORAGE_CUSTOM_MODEL)).toBeNull()
     })
   })
 })

--- a/frontend/src/composables/__tests__/useEnvForm.spec.ts
+++ b/frontend/src/composables/__tests__/useEnvForm.spec.ts
@@ -12,7 +12,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
-import { useEnvForm, STORAGE_CUSTOM_MODEL, STORAGE_MODEL, STORAGE_LANG } from '../useEnvForm'
+import { useEnvForm, STORAGE_LANG } from '../useEnvForm'
+
+// Issue #890: STORAGE_MODEL/STORAGE_CUSTOM_MODEL sind aus useEnvForm.ts
+// entfernt worden — die Keys existieren nicht mehr im Produktionscode.
+// Diese Tests beweisen genau das (Produktion ignoriert diese Keys), duerfen
+// also nicht von einem Export dieser Keys abhaengen. Lokale Testkonstanten:
+const STORAGE_MODEL = 'agora.lastModel'
+const STORAGE_CUSTOM_MODEL = 'agora.lastCustomModel'
 import type { RuntimeProvider } from '../useRuntimeLlmOptions'
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -37,13 +37,12 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-// Issue #890: STORAGE_MODEL/STORAGE_CUSTOM_MODEL sind reine Legacy-Keys.
-// useEnvForm liest und schreibt sie nicht mehr — die kanonische Modell-Senke
-// ist jetzt Step2EnvSetup.selectedModelRef (AiModelRef via AiModelPicker).
-// Die Konstanten bleiben exportiert (Altwerte in Nutzer-Browsern werden NICHT
-// aktiv geloescht), damit bestehende Referenzen/Tests kompilieren.
-export const STORAGE_MODEL = 'agora.lastModel'
-export const STORAGE_CUSTOM_MODEL = 'agora.lastCustomModel'
+// Issue #890: 'agora.lastModel'/'agora.lastCustomModel' (vormals
+// STORAGE_MODEL/STORAGE_CUSTOM_MODEL) existieren nicht mehr im Code.
+// useEnvForm liest und schreibt sie nicht — die kanonische Modell-Senke ist
+// jetzt Step2EnvSetup.selectedModelRef (AiModelRef via AiModelPicker).
+// Altwerte, die in Nutzer-Browsern noch unter diesen Keys liegen, werden
+// weder gelesen noch aktiv geloescht.
 export const STORAGE_LANG = 'agora.agentLanguage'
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -37,25 +37,14 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
+// Issue #890: STORAGE_MODEL/STORAGE_CUSTOM_MODEL sind reine Legacy-Keys.
+// useEnvForm liest und schreibt sie nicht mehr — die kanonische Modell-Senke
+// ist jetzt Step2EnvSetup.selectedModelRef (AiModelRef via AiModelPicker).
+// Die Konstanten bleiben exportiert (Altwerte in Nutzer-Browsern werden NICHT
+// aktiv geloescht), damit bestehende Referenzen/Tests kompilieren.
 export const STORAGE_MODEL = 'agora.lastModel'
 export const STORAGE_CUSTOM_MODEL = 'agora.lastCustomModel'
 export const STORAGE_LANG = 'agora.agentLanguage'
-
-export function storedEffectiveModel(
-  modelKey = STORAGE_MODEL,
-  customModelKey = STORAGE_CUSTOM_MODEL,
-): string | null {
-  try {
-    const stored = localStorage.getItem(modelKey)
-    if (!stored || stored === 'default') return null
-    if (stored === 'custom') {
-      return (localStorage.getItem(customModelKey) || '').trim() || null
-    }
-    return stored
-  } catch {
-    return null
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -110,22 +99,6 @@ function _loadStoredLang(): string {
   }
 }
 
-function _loadStoredModel(): string {
-  try {
-    return localStorage.getItem(STORAGE_MODEL) || 'default'
-  } catch {
-    return 'default'
-  }
-}
-
-function _loadStoredCustomModel(): string {
-  try {
-    return localStorage.getItem(STORAGE_CUSTOM_MODEL) || ''
-  } catch {
-    return ''
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Composable
 // ---------------------------------------------------------------------------
@@ -142,8 +115,9 @@ export function useEnvForm({ t, onError, runtimeProvider }: UseEnvFormOptions): 
   const agentToolsEnabled = ref<boolean>(false)
   const maxToolCallsPerAction = ref<number>(2)
   const loadingModels = ref<boolean>(true)
-  const modelOption = ref<string>(_loadStoredModel())
-  const customModel = ref<string>(_loadStoredCustomModel())
+  // Issue #890: keine Persistenz mehr fuer Modellauswahl — initial 'default'/''.
+  const modelOption = ref<string>('default')
+  const customModel = ref<string>('')
   const language = ref<string>(_loadStoredLang())
 
   // --- Computed ---
@@ -173,22 +147,8 @@ export function useEnvForm({ t, onError, runtimeProvider }: UseEnvFormOptions): 
   })
 
   // --- LocalStorage persistence ---
-
-  watch(modelOption, (val) => {
-    try {
-      localStorage.setItem(STORAGE_MODEL, val)
-    } catch {
-      // ignore — storage may be unavailable in some environments
-    }
-  })
-
-  watch(customModel, (val) => {
-    try {
-      localStorage.setItem(STORAGE_CUSTOM_MODEL, val)
-    } catch {
-      // ignore — storage may be unavailable in some environments
-    }
-  })
+  // Issue #890: modelOption/customModel werden NICHT mehr persistiert
+  // (Storage-Cut). STORAGE_LANG bleibt unveraendert bestehen.
 
   watch(language, (val) => {
     try {
@@ -252,29 +212,8 @@ export function useEnvForm({ t, onError, runtimeProvider }: UseEnvFormOptions): 
             language.value = res.data.default_language
           }
         }
-        // Restore persisted model selection if it still exists in the new list.
-        const stored = (() => {
-          try {
-            return localStorage.getItem(STORAGE_MODEL)
-          } catch {
-            return null
-          }
-        })()
-        const runtimeProviderActive = runtimeProvider?.value && runtimeProvider.value !== 'default'
-        const storedMatchesRuntimeProvider = runtimeProviderActive
-          ? (stored === 'custom' || isRuntimeModelForProvider(runtimeProvider.value, stored || ''))
-          : false
-        if (
-          stored &&
-          (runtimeProviderActive
-            ? storedMatchesRuntimeProvider
-            : (stored === 'default' ||
-              stored === 'custom' ||
-              presetModels.value.some((p) => p.name === stored) ||
-              ollamaModels.value.some((p) => p.name === stored)))
-        ) {
-          modelOption.value = stored
-        }
+        // Issue #890: keine Restore-Logik mehr — modelOption/customModel
+        // werden nicht persistiert und bleiben unveraendert nach loadModels().
       }
     } catch (e) {
       const err = e as { message?: string }

--- a/frontend/src/views/__tests__/Home.spec.ts
+++ b/frontend/src/views/__tests__/Home.spec.ts
@@ -65,7 +65,7 @@ vi.mock('@/api/simulation', () => ({
   }),
 }))
 vi.mock('../store/pendingUpload', () => ({ setPendingUpload: setPendingUploadMock }))
-vi.mock('../composables/useEnvForm', () => ({ STORAGE_LANG: 'agora.lang', STORAGE_MODEL: 'agora.lastModel' }))
+vi.mock('../composables/useEnvForm', () => ({ STORAGE_LANG: 'agora.lang' }))
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: routerPushMock }) }))
 vi.mock('@/store/runModelOverride', () => ({
   setRunModelOverride: runOverrideMocks.set,


### PR DESCRIPTION
Closes #890

Step 2 wählt Modelle jetzt über den kanonischen `AiModelPicker`. Eine Auswahl ist eine vollständige, an eine `ProviderConnection` gebundene `AiModelRef` statt eines Modellstrings — Connection und Modell-ID gehen damit nicht mehr verloren.

## Vorheriger Legacy-State

Step 2 war nach dem Merge von #898 (Issue #896) und #900 (Issue #897) der letzte produktive Consumer der Legacy-Modellwahl. Verifiziert per Consumer-Scan über `frontend/src` ohne Tests: `agora.lastModel`, `agora.lastCustomModel`, `STORAGE_MODEL`, `STORAGE_CUSTOM_MODEL` und `storedEffectiveModel()` wurden ausschließlich in `useEnvForm.ts` gelesen und geschrieben (Zeilen 40, 41, 44–46, 115, 123, 179, 187, 258), konsumiert nur von `Step2EnvSetup.vue`. `Home.vue` und `HeroNewRun.vue` importierten aus `useEnvForm` lediglich `STORAGE_LANG` — das bleibt unangetastet.

## Neue Source of Truth

`const selectedModelRef = ref(null)` in `Step2EnvSetup.vue:54`. Initial `null`, keine Persistenz, kein Schreibzugriff auf den globalen Workspace-Default.

**Abweichung vom Slice-Dokument §3(b), bewusst und dokumentiert.** Das Slice-Dokument sah `:model-value="effectiveRef" @update:model-value="setGlobalSelection"` vor. Das ist nicht umsetzbar, ohne zwei Akzeptanzkriterien zu verletzen:

- `useEffectiveModelSelection.effectiveRef` ist `computed(() => adapter.toAiModelRef(defaultsStore.globalDefault))` und damit vom globalen Workspace-Default abgeleitet. Es ist nie `null`, sobald ein globaler Default existiert. „Keine explizite Auswahl" wäre nicht ausdrückbar, Step 2 würde immer ein `ai_model_ref` senden, und die Projektprofil-Präzedenz des Backends käme nie zum Zug. Das AK „Projektprofil, explizite Auswahl und Default besitzen getestete Präzedenz" wäre unerfüllbar.
- `setGlobalSelection()` schreibt serverseitig über `replaceGlobalDefault`. Eine Modellwahl im Run-Setup hätte den globalen Workspace-Default umgeschrieben — eine Einstellungsmutation als Nebenwirkung einer Run-Konfiguration.

Das Slice-Dokument ist entsprechend um einen verbindlichen §6 „Umsetzungsstand" ergänzt; §3 und §4 bleiben als Planungsstand erhalten.

## Payload-Vertrag

`triggerPrepare()` in `Step2EnvSetup.vue:248-256` sendet exklusiv:

- `selectedModelRef !== null` → genau ein `ai_model_ref` mit `source: 'explicit'`, und **keines** der Felder `llm_model`, `llm_profile_id`, `llm_provider`.
- `selectedModelRef === null` → kein `ai_model_ref`; der bisherige Legacy-Zweig bleibt unverändert.

Damit kann der Mischfall-Guard in `backend/app/api/simulation_prepare.py:263-276` (HTTP 400 bei `ai_model_ref` zusammen mit einem truthy Legacy-Feld) strukturell nicht ausgelöst werden.

## Projektprofil-Präzedenz

Unverändert vom Backend entschieden (`backend/app/services/llm_routing_seed.py:349-406`): `ai_model_ref` → `llm_model`/`llm_runtime` → `llm_profile_id` (Request vor Projekt) → Workspace-Default. Ohne explizite Auswahl sendet Step 2 kein Modellfeld und überlässt die Entscheidung dieser Kette. Eine explizite Auswahl übersteuert das Projektprofil bewusst.

## Runtime-Provider: gegenseitiger Ausschluss

Der OASIS-Runtime-Provider-Override ist credential-basiert (`runtimePayload()` liefert `{provider, api_key?, base_url?}` ohne Modellfeld), der Kanon ist connection-basiert. Beide sind per Backend-Contract unvereinbar. Umgesetzt ist Ausschluss in beide Richtungen:

- `modelPickerDisabled` (`Step2EnvSetup.vue:111`) deaktiviert den Picker bei aktivem Runtime-Provider; `watch(runtimeProvider)` (`:105-109`) setzt `selectedModelRef` zurück.
- `runtimeProviderBlockDisabled` (`EnvSetupModelPanel.vue:53`) blendet den Runtime-Block aus, sobald eine kanonische Auswahl aktiv ist.

## Storage-Cut

`STORAGE_MODEL`, `STORAGE_CUSTOM_MODEL` und `storedEffectiveModel()` sind entfernt, samt Restore- und Writer-Logik. `STORAGE_LANG` bleibt unverändert.

**Alte Browserwerte werden weder gelesen noch aktiv gelöscht.** Es gibt keine Storage-Migration; `agora.lastModel` und `agora.lastCustomModel` bleiben als wirkungslose Altlast liegen. Nach einem Reload startet die Modellauswahl bewusst leer, statt eine nicht mehr verbindliche Altauswahl vorzutäuschen.

## OASIS-/Runtime-Prüfung (Risiko B, im Issue verlangt)

Zwei getrennte Befunde:

**#901 blockiert #890 nicht.** Der Verlust von `AiModelRef.source` an der Routing-Grenze wurde am Code verifiziert: `ai_route_from_stage_route()` setzt zwar hart `source="legacy"` (`backend/app/contracts/ai_provider_contract.py:498-504`), aber `resolve_ai_route()` überschreibt `source` unmittelbar danach positional (`backend/app/services/ai_route_resolver.py:70-83`) und ignoriert den vom Kandidaten mitgebrachten Wert vollständig. Der einzige Leser außerhalb dieser Positionslogik ist das Audit-Event in `backend/app/services/ai_route_audit.py:32`. Es existiert kein `if source ==`-Verzweigungspfad im Backend. `provider_connection_id` und `model_id` laufen verlustfrei bis ins Runtime-Env-Binding. #901 ist reine Audit-Metadatenkorrektur.

**Die UX-Kopplung war der eigentliche Risikoanteil.** `watch(runtimeProvider)` in `useEnvForm.ts` schrieb aktiv `modelOption`, und `runtimePayload()` transportiert kein Modellfeld — der Modellname für einen Runtime-Run reist ausschließlich über `payload.llm_model`. Ein ersatzloses Entfernen von `modelOption` hätte diesen Pfad gebrochen. Deshalb bleibt der Modellwahl-State für den Runtime-Zweig erhalten (siehe „Bekannte Restschuld").

## RED/GREEN

Vertikale Slices, ein Test pro Zyklus:

1. **Panel-Vertrag** — RED: 7/7 fehlgeschlagen (`Cannot call trigger on empty DOMWrapper`, Picker fehlt). GREEN nach Einbau von `AiModelPicker` samt Prop/Emit-Erweiterung.
2. **Step2-Payload** — RED: `expected undefined to deeply equal {...}` für explizite Auswahl und Projektprofil-Override. GREEN nach `selectedModelRef` und Payload-Zweig.
3. **Storage-Cut** — RED: `expected 'gemma3' to be 'default'`. GREEN nach Entfernen der Persistenz- und Restore-Logik.

Die brechenden Bestandstests in `useEnvForm.spec.ts` wurden ans neue Verhalten angepasst, nicht abgeschwächt und nicht geskippt (AGENTS.md Regel 6). Die reinen Persistenz-Tests sind durch inhaltlich stärkere Nicht-Persistenz-Tests ersetzt.

## Tests

Neue Spec `frontend/src/components/step2/__tests__/EnvSetupModelPanel.spec.ts`: rendert Picker, initial `null`, Auswahl emittiert vollständigen Ref, Modellwechsel, Deselektion nach `null`, `modelPickerDisabled`, keine Legacy-Events auf dem Kanon-Pfad, Runtime-Block-Ausschluss.

`Step2EnvSetup.spec.ts`: kein Profil + keine Auswahl; Profil + keine Auswahl; explizite Auswahl mit vollem Ref-Inhalt und ohne Legacy-Felder; explizite Auswahl schlägt Projektprofil; Deselektion; Runtime-Provider aktiv; Reihenfolge „explizite Auswahl, danach Runtime-Provider aktivieren".

`useEnvForm.spec.ts`: Altwerte werden nicht restauriert **und** nicht gelöscht — letzteres bewiesen durch `expect(localStorageStub.getItem(...)).toBe('irgendein-modell')` nach einer Modelländerung.

Zwei Anmerkungen zur Testqualität, die ich nicht verschweige:

- Der Test für den `watch(runtimeProvider)`-Reset greift über `wrapper.vm` auf `selectedModelRef` und `runtimeProvider` zu, statt über die UI. Grund: Sobald eine kanonische Auswahl aktiv ist, blendet `runtimeProviderBlockDisabled` den Runtime-Block aus — die Reihenfolge „erst Modell wählen, dann Runtime-Provider aktivieren" ist über die Oberfläche gar nicht erreichbar. Der `watch`-Reset ist damit eine reine Verteidigungslinie gegen künftige Regressionen, kein heute erreichbarer Nutzerpfad. Der Test verlässt bewusst die Seam-Disziplin, um genau diesen Zweig abzudecken; er wurde durch Auskommentieren der Produktivzeile als wirksam nachgewiesen (RED: `expected … to not have property "ai_model_ref"`).
- Beide neuen Tests wurden nicht klassisch RED-first geschrieben, weil der Produktivcode zu diesem Zeitpunkt schon existierte. Ihre Wirksamkeit ist stattdessen durch temporäres Deaktivieren der jeweiligen Produktivzeile belegt, mit anschließender Wiederherstellung. `git diff --name-only` gegen den Vorgänger-Commit weist aus, dass nur die zwei Spec-Dateien geändert wurden.

## Gates

`bun run test`, `bun run check`, `bash scripts/pre-push-gate.sh frontend` und `bash scripts/pre-push-gate.sh schemas` grün. Das `schemas`-Gate war zwischenzeitlich rot (STATUS.md-Drift durch die neue Spec-Datei) und wurde per `bash scripts/sync-status.sh` behoben.

## Dokumentationssync

- `CHANGELOG.md`: neuer `[Unreleased]`-Abschnitt zu Issue #890.
- `docs/STATUS.md`: kanonischer Pfad ergänzt, zwei Einträge unter „Bekannte Konsolidierungsschuld".
- Slice-Dokument: verbindlicher §6 „Umsetzungsstand" mit beiden Abweichungen und der Auflösung von Risiko B und C.
- `ROADMAP.md`: **nicht** geändert. #890 erfüllt kein Release-Gate-Kriterium; #760 und #829 bleiben offen.

## Bekannte Restschuld

Das AK „`useEnvForm` enthält keine Modellwahl- **oder Modellpersistenzlogik** mehr" ist bewusst nur zur Hälfte erfüllt. Die Persistenz ist vollständig entfernt. `modelOption`, `customModel`, `modelOptions` und `effectiveModel()` bleiben, weil der credential-basierte Runtime-Provider-Pfad einen reinen Modellstring braucht und mit einer connection-gebundenen Ref nicht bedienbar ist. Die Restschuld hängt an der Ablösung von `useRuntimeLlmOptions` (bereits `@deprecated`, Slice 5.5) und wird in **#903** geführt. Das AK ist im Issue bewusst nicht als erledigt abgehakt.

## Risiken

- Nutzer verlieren die automatische Wiederherstellung ihrer letzten Modellwahl nach einem Reload. Das ist beabsichtigt: Der gespeicherte String trug keine `provider_connection_id` und war gegenüber dem Kanon nicht mehr verbindlich.
- Solange der Runtime-Provider aktiv ist, gilt weiterhin der Legacy-Payload-Pfad. Das ist kein Rückschritt, sondern der unveränderte Ist-Zustand dieses Features.
- Kein Backend-Diff, keine Änderung an `AiModelPicker.vue`, keine Schema-Änderung.

## Verwendete Agents und Modelle

Kein Codex, kein GPT-5.6. Lead: Claude Opus 5. Read-only Explorer für Datenfluss, `/prepare`-Contract, OASIS-Risiko und Spec-Review: Claude Sonnet 5. Read-only Legacy-Inventur und Standards-Review: Claude Haiku 4.5. Implementierung: Claude Sonnet 5 im eigenen Worktree. Matt-Pocock-Skills: `codebase-design` vor der Architekturentscheidung, `tdd` für die Slice-Disziplin, `code-review` als Review-Raster. `diagnosing-bugs` war nicht nötig — es gab keine Abweichung vom belegten Contract.

Alle Worker-Ergebnisse wurden vom Lead unabhängig am Diff und durch eigene Gate-Läufe nachgeprüft. Zwei Findings gingen dabei zur Nachbesserung zurück (unvollständige Entfernung der Storage-Konstanten, zu schwacher Präzedenz-Test), zwei weitere kamen aus dem Spec-Review (fehlende Tests für den `watch`-Reset und den Runtime-Block-Ausschluss).
