### PR TITLE
docs: Restschuld aus #890 auf Folge-Issue #903 verweisen

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -113,7 +113,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 - die fünf klassischen Prozess-Wrapper-Views sind entfernt; ihre benannten Deep-Links bleiben als v4-Redirects kompatibel. Die übrigen v4-Views und `/agora-2026` existieren weiterhin parallel
 - ein React-/Lovable-Neubau ist beschrieben, aber nicht als Zielentscheidung freigegeben
 - Legacy-LLM-Profile und Provider-Connections besitzen noch Übergangspfade
-- der credential-basierte Runtime-Provider-Override (`useRuntimeLlmOptions`, `@deprecated` Slice 5.5) ist mit der connection-gebundenen `AiModelRef` unvereinbar und in Step 2 daher gegenseitig ausgeschlossen. Solange er existiert, hält `useEnvForm` weiterhin `modelOption`/`customModel` — allerdings ohne Persistenz. Die Ablösung ist offen
+- der credential-basierte Runtime-Provider-Override (`useRuntimeLlmOptions`, `@deprecated` Slice 5.5) ist mit der connection-gebundenen `AiModelRef` unvereinbar und in Step 2 daher gegenseitig ausgeschlossen. Solange er existiert, hält `useEnvForm` weiterhin `modelOption`/`customModel` — allerdings ohne Persistenz. Die Ablösung wird in [Issue #903](https://github.com/arn0ld87/agora/issues/903) geführt
 - die Browser-Keys `agora.lastModel` und `agora.lastCustomModel` haben seit Issue #890 keinen produktiven Reader oder Writer mehr; vorhandene Werte werden bewusst nicht gelöscht und bleiben wirkungslose Altlast
 - einzelne Provider-Erkennungen beruhen weiterhin auf URL-/Modell-Heuristiken
 - Frontend- und Backend-Provider-Vokabular sind nicht an jeder SSE-Grenze synchron

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -180,7 +180,7 @@ sie den Runtime-Provider-Pfad bedienen.
 Damit ist das Akzeptanzkriterium „`useEnvForm` enthält keine Modellwahl- oder
 Modellpersistenzlogik mehr" bewusst nur zur Hälfte erfüllt: Persistenz ja, Modellwahl nein.
 Die Restschuld hängt an der Ablösung von `useRuntimeLlmOptions` (bereits `@deprecated`,
-Slice 5.5) und ist als Folge-Issue zu führen.
+Slice 5.5) und wird in [Issue #903](https://github.com/arn0ld87/agora/issues/903) geführt.
 
 ### Auflösung Risiko B (OASIS-Runtime-Provider)
 


### PR DESCRIPTION
Nachtrag zu PR #902.

Der Doku-Commit mit den Verweisen auf #903 landete zeitgleich mit dem Merge von #902 und ist deshalb nicht in dessen Squash enthalten. In `main` steht daher an zwei Stellen noch "ist als Folge-Issue zu führen" beziehungsweise "Die Ablösung ist offen", obwohl #903 inzwischen existiert.

Dieser PR ersetzt beide Formulierungen durch den konkreten Verweis auf #903:

- `docs/STATUS.md`, Abschnitt "Bekannte Konsolidierungsschuld"
- `docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` §6, Abweichung 2

Reine Dokumentationsänderung, zwei Zeilen, kein Code. `bash scripts/pre-push-gate.sh schemas` grün (inklusive `sync-status --check`).

Refs #890, #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Status der bekannten Konsolidierungsschuld für credential-basierte Runtime-Provider-Overrides präzisiert.
  * Die Einschränkung im Zusammenhang mit der verbindungsgebundenen Modellreferenz in Schritt 2 dokumentiert.
  * Verbleibende Nacharbeiten und der zugehörige Vorgang zur Nachverfolgung konkretisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->