### PR TITLE
fix(graph): Ontology-Upload bei I/O-Fehlern atomar bereinigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Ontology-Upload bereinigt bei File-I/O-Fehlern atomar — 2026-07-26, Issue #899)
+
+- Schlägt beim Ontology-Upload (`/ontology/generate`) ein Datei-I/O-Schritt zwischen
+  Projektanlage und Übergabe an den Graph-Build-Service fehl (Datei speichern, Text
+  extrahieren, extrahierten Text ablegen, Projekt persistieren), räumt der Endpunkt das
+  halb angelegte Projekt jetzt zuverlässig auf, statt ein verwaistes Projekt mit
+  Teilartefakten zurückzulassen. Die Antwort bleibt eine generische Fehlermeldung ohne
+  Dateipfade oder Provider-Details; scheitert das Aufräumen selbst, wird das protokolliert,
+  ohne die ursprüngliche Fehlerantwort zu überdecken oder fälschlich Erfolg zu melden.
+
 ### Changed (`/prepare` akzeptiert kanonische `AiModelRef` — Issue #896)
 
 - `/prepare` akzeptiert jetzt eine kanonische, an eine `ProviderConnection` gebundene

--- a/backend/app/api/graph_build.py
+++ b/backend/app/api/graph_build.py
@@ -85,6 +85,23 @@ def allowed_file(file_storage) -> bool:
 
     return True
 
+
+def _discard_project_after_upload_failure(project_id: str) -> None:
+    """Verwirft ein halb angelegtes Upload-Projekt.
+
+    Ein Fehler beim Aufräumen darf die ursprüngliche Ursache nicht verdecken:
+    er wird geloggt und geschluckt, damit der Originalfehler die Antwort
+    bestimmt.
+    """
+    try:
+        ProjectManager.delete_project(project_id)
+    except Exception:
+        logger.exception(
+            "Cleanup des Upload-Projekts nach Fehler unvollständig [project_id=%s]",
+            project_id,
+        )
+
+
 def _upload_rate_limit_key() -> str:
     return build_rate_limit_key("graph-ontology-upload")
 
@@ -174,47 +191,51 @@ def generate_ontology():
     document_texts = []
     all_text = ""
 
-    for file in uploaded_files:
-        if file and file.filename:
-            if not allowed_file(file):
-                continue
+    try:
+        for file in uploaded_files:
+            if file and file.filename:
+                if not allowed_file(file):
+                    continue
 
-            # Size check
-            file.seek(0, os.SEEK_END)
-            size = file.tell()
-            file.seek(0)
-            max_upload_bytes = Config.AGORA_MAX_UPLOAD_SIZE_MB * 1024 * 1024
-            if size > max_upload_bytes:
-                ProjectManager.delete_project(project.project_id)
-                return json_error(
-                    ApiErrorCode.UPLOAD_TOO_LARGE,
-                    status=413,
-                    message=f"File {file.filename} exceeds {Config.AGORA_MAX_UPLOAD_SIZE_MB}MB limit",
-                )
+                # Size check
+                file.seek(0, os.SEEK_END)
+                size = file.tell()
+                file.seek(0)
+                max_upload_bytes = Config.AGORA_MAX_UPLOAD_SIZE_MB * 1024 * 1024
+                if size > max_upload_bytes:
+                    _discard_project_after_upload_failure(project.project_id)
+                    return json_error(
+                        ApiErrorCode.UPLOAD_TOO_LARGE,
+                        status=413,
+                        message=f"File {file.filename} exceeds {Config.AGORA_MAX_UPLOAD_SIZE_MB}MB limit",
+                    )
 
-            logger.info("Uploading file: %s (size: %d bytes) [project_id=%s]", file.filename, size, project.project_id)
+                logger.info("Uploading file: %s (size: %d bytes) [project_id=%s]", file.filename, size, project.project_id)
 
-            file_info = ProjectManager.save_file_to_project(project.project_id, file, file.filename)
-            project.files.append({"filename": file_info["original_filename"], "size": file_info["size"]})
+                file_info = ProjectManager.save_file_to_project(project.project_id, file, file.filename)
+                project.files.append({"filename": file_info["original_filename"], "size": file_info["size"]})
 
-            text = FileParser.extract_text(file_info["path"])
-            text = TextProcessor.preprocess_text(text)
-            document_texts.append(text)
-            all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
+                text = FileParser.extract_text(file_info["path"])
+                text = TextProcessor.preprocess_text(text)
+                document_texts.append(text)
+                all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
 
-    if not document_texts:
-        ProjectManager.delete_project(project.project_id)
-        return json_error(ApiErrorCode.UNSUPPORTED_FORMAT, status=400, message="No documents successfully processed")
+        if not document_texts:
+            _discard_project_after_upload_failure(project.project_id)
+            return json_error(ApiErrorCode.UNSUPPORTED_FORMAT, status=400, message="No documents successfully processed")
 
-    project.total_text_length = len(all_text)
-    ProjectManager.save_extracted_text(project.project_id, all_text)
+        project.total_text_length = len(all_text)
+        ProjectManager.save_extracted_text(project.project_id, all_text)
 
-    # Persistieren, BEVOR der Service das Projekt frisch von Platte lädt —
-    # create_project() hat bereits VOR dem Setzen von simulation_requirement,
-    # files und total_text_length gespeichert. Ohne dieses save_project gehen
-    # die Felder verloren und Report-Generate/Simulation-Prepare lehnen das
-    # Projekt mit "Missing simulation requirement description" (400) ab.
-    ProjectManager.save_project(project)
+        # Persistieren, BEVOR der Service das Projekt frisch von Platte lädt —
+        # create_project() hat bereits VOR dem Setzen von simulation_requirement,
+        # files und total_text_length gespeichert. Ohne dieses save_project gehen
+        # die Felder verloren und Report-Generate/Simulation-Prepare lehnen das
+        # Projekt mit "Missing simulation requirement description" (400) ab.
+        ProjectManager.save_project(project)
+    except Exception:
+        _discard_project_after_upload_failure(project.project_id)
+        raise
 
     try:
         project = GraphBuildService.generate_ontology(
@@ -254,7 +275,7 @@ def generate_ontology():
             code=ApiErrorCode.INTERNAL_ERROR,
         )
     except ValueError as exc:
-        ProjectManager.delete_project(project.project_id)
+        _discard_project_after_upload_failure(project.project_id)
         return json_error_from_exception(exc)
 
     return json_success({

--- a/backend/tests/api/test_graph_ontology_upload_atomicity.py
+++ b/backend/tests/api/test_graph_ontology_upload_atomicity.py
@@ -1,0 +1,313 @@
+"""Atomizität des Ontology-Uploads bei File-I/O-Fehlern (Issue #899).
+
+Deckt den Abschnitt zwischen ``ProjectManager.create_project`` und dem Aufruf
+von ``GraphBuildService.generate_ontology`` in ``generate_ontology`` ab: ein
+I/O-Fehler in diesem Fenster darf kein halb angelegtes Projekt (Verzeichnis,
+files/, project.json mit Status CREATED) hinterlassen. Verifiziert wird über
+zwei Seams: (a) der HTTP-Seam via Flask-Testclient, (b) der beobachtete
+Cleanup über den gemockten ``ProjectManager``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import graph_bp
+from app.container import AgoraContainer
+from app.models.project import ProjectStatus
+from app.storage.graph_storage import GraphStorage
+
+
+PROJECT_ID = "proj_upload_atomic01"
+SECRET_SENTINEL = "sk-upload-atomicity-secret-must-not-leak"
+
+
+def _capture_agora_logs(monkeypatch, caplog) -> None:
+    """Macht die ``agora.*``-Logger für caplog sichtbar.
+
+    ``get_logger`` setzt ``propagate = False``, deshalb erreicht kein Record den
+    Root-Handler, an dem caplog hängt — ohne diesen Schalter wäre jede
+    ``SECRET_SENTINEL not in caplog.text``-Zusicherung gegen ein leeres caplog
+    trivial wahr. DEBUG-Level, damit auch INFO/DEBUG-Records erfasst werden.
+    """
+    caplog.set_level(logging.DEBUG)
+    for name, candidate in list(logging.root.manager.loggerDict.items()):
+        if isinstance(candidate, logging.Logger) and (
+            name == "agora" or name.startswith("agora.")
+        ):
+            monkeypatch.setattr(candidate, "propagate", True)
+            monkeypatch.setattr(candidate, "level", logging.DEBUG)
+
+
+@pytest.fixture
+def upload_env(monkeypatch, caplog):
+    _capture_agora_logs(monkeypatch, caplog)
+    storage = MagicMock(spec=GraphStorage)
+    app = Flask(__name__)
+    app.config.update(
+        AGORA_AUTH_TOKEN="",
+        AGORA_UPLOAD_RATE_LIMIT_MAX=1000,
+        AGORA_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=60,
+    )
+    app.extensions = {
+        "container": AgoraContainer(neo4j_storage=storage),
+        "neo4j_storage": storage,
+    }
+    app.register_blueprint(graph_bp, url_prefix="/api/graph")
+
+    project = SimpleNamespace(
+        project_id=PROJECT_ID,
+        name="Upload Atomicity Project",
+        files=[],
+        total_text_length=0,
+        ontology=None,
+        analysis_summary=None,
+        simulation_requirement=None,
+        status=ProjectStatus.CREATED,
+        error=None,
+        graph_id=None,
+        graph_build_task_id=None,
+        chunk_size=500,
+        chunk_overlap=50,
+        llm_model=None,
+        llm_provider=None,
+        llm_profile_id=None,
+    )
+    project_manager = MagicMock()
+    project_manager.create_project.return_value = project
+    project_manager.get_project.return_value = project
+    project_manager.save_file_to_project.return_value = {
+        "original_filename": "document.txt",
+        "path": "/tmp/document.txt",
+        "size": 8,
+    }
+    project_manager.delete_project.return_value = True
+
+    generate_ontology_service = MagicMock()
+
+    monkeypatch.setattr("app.api.graph_build.ProjectManager", project_manager)
+    monkeypatch.setattr(
+        "app.api.graph_build.prevalidate_ai_model_ref_with_discovery", lambda _ref: None
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.FileParser.extract_text", lambda _path: "document"
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.TextProcessor.preprocess_text", lambda text: text
+    )
+    monkeypatch.setattr(
+        "app.api.graph_build.GraphBuildService.generate_ontology",
+        generate_ontology_service,
+    )
+
+    return SimpleNamespace(
+        client=app.test_client(),
+        monkeypatch=monkeypatch,
+        project=project,
+        project_manager=project_manager,
+        generate_ontology_service=generate_ontology_service,
+    )
+
+
+def _ref_payload() -> dict[str, str]:
+    return {
+        "provider_connection_id": "conn-upload-atomicity",
+        "model_id": "upload-atomicity-model",
+        "source": "explicit",
+    }
+
+
+def _post(client, *, canonical: bool):
+    data = {
+        "simulation_requirement": "Analyse the document.",
+        "files": (io.BytesIO(b"document"), "document.txt"),
+    }
+    if canonical:
+        data["ai_model_ref"] = json.dumps(_ref_payload())
+    return client.post(
+        "/api/graph/ontology/generate",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+
+def _assert_atomic_failure(
+    response,
+    caplog,
+    capsys,
+    project_manager,
+    *,
+    logged_sentinel: str,
+    expected_project_id: str = PROJECT_ID,
+):
+    """Response bleibt eine generische 500, Cleanup wurde mit der project_id
+    versucht, und weder Sentinel noch Dateipfade tauchen in der Response auf.
+
+    Der Originalfehler muss dabei serverseitig erkennbar bleiben: er wird
+    protokolliert, damit die generische Antwort nicht auch die Diagnose kostet.
+    """
+    captured = capsys.readouterr()
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body == {
+        "success": False,
+        "error": "internal server error",
+        "code": "internal_error",
+    }
+    project_manager.delete_project.assert_called_with(expected_project_id)
+    response_text = response.get_data(as_text=True)
+    assert SECRET_SENTINEL not in response_text
+    assert "/tmp/" not in response_text
+    assert SECRET_SENTINEL not in captured.out
+    assert SECRET_SENTINEL not in captured.err
+    assert logged_sentinel in caplog.text
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_save_file_to_project_failure_cleans_up_project(
+    upload_env, caplog, capsys, canonical
+):
+    upload_env.project_manager.save_file_to_project.side_effect = OSError(
+        f"disk write failed: {SECRET_SENTINEL}"
+    )
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    _assert_atomic_failure(
+        response,
+        caplog,
+        capsys,
+        upload_env.project_manager,
+        logged_sentinel="disk write failed",
+    )
+    upload_env.generate_ontology_service.assert_not_called()
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_extract_text_failure_cleans_up_project(
+    upload_env, caplog, capsys, canonical
+):
+    def _boom(_path):
+        raise OSError(f"read failed: {SECRET_SENTINEL}")
+
+    upload_env.monkeypatch.setattr("app.api.graph_build.FileParser.extract_text", _boom)
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    _assert_atomic_failure(
+        response,
+        caplog,
+        capsys,
+        upload_env.project_manager,
+        logged_sentinel="read failed",
+    )
+    upload_env.generate_ontology_service.assert_not_called()
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_save_extracted_text_failure_cleans_up_project(
+    upload_env, caplog, capsys, canonical
+):
+    upload_env.project_manager.save_extracted_text.side_effect = OSError(
+        f"write extracted text failed: {SECRET_SENTINEL}"
+    )
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    _assert_atomic_failure(
+        response,
+        caplog,
+        capsys,
+        upload_env.project_manager,
+        logged_sentinel="write extracted text failed",
+    )
+    upload_env.generate_ontology_service.assert_not_called()
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_save_project_failure_does_not_falsely_succeed(
+    upload_env, caplog, capsys, canonical
+):
+    # Nur der save_project-Aufruf nach der Extraktion soll scheitern —
+    # create_project() persistiert bereits intern und ruft save_project()
+    # nicht separat auf, dieser Mock trifft daher genau die spätere Persistenz.
+    upload_env.project_manager.save_project.side_effect = OSError(
+        f"persist project failed: {SECRET_SENTINEL}"
+    )
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    _assert_atomic_failure(
+        response,
+        caplog,
+        capsys,
+        upload_env.project_manager,
+        logged_sentinel="persist project failed",
+    )
+    upload_env.generate_ontology_service.assert_not_called()
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_cleanup_failure_itself_does_not_produce_success(
+    upload_env, caplog, capsys, canonical
+):
+    original_failure_sentinel = f"{SECRET_SENTINEL}-original"
+    cleanup_failure_sentinel = f"{SECRET_SENTINEL}-cleanup"
+
+    upload_env.project_manager.save_file_to_project.side_effect = OSError(
+        f"disk write failed: {original_failure_sentinel}"
+    )
+    upload_env.project_manager.delete_project.side_effect = OSError(
+        f"cleanup failed: {cleanup_failure_sentinel}"
+    )
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body == {
+        "success": False,
+        "error": "internal server error",
+        "code": "internal_error",
+    }
+    upload_env.project_manager.delete_project.assert_called_with(PROJECT_ID)
+    response_text = response.get_data(as_text=True)
+    assert original_failure_sentinel not in response_text
+    assert cleanup_failure_sentinel not in response_text
+
+    # Der Cleanup-Fehler wird als Fehler samt Traceback geloggt ...
+    cleanup_records = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR and PROJECT_ID in record.getMessage()
+    ]
+    assert cleanup_records, "Cleanup-Fehler wurde nicht als Fehler geloggt"
+    assert cleanup_records[0].exc_info is not None
+    assert cleanup_failure_sentinel in caplog.text
+    # ... und verdeckt die Ursprungsursache nicht: sie bleibt serverseitig
+    # diagnostizierbar, obwohl die Antwort generisch bleibt.
+    assert original_failure_sentinel in caplog.text
+    upload_env.generate_ontology_service.assert_not_called()
+
+
+@pytest.mark.parametrize("canonical", [False, True], ids=["legacy", "canonical"])
+def test_no_case_leaks_paths_or_provider_details(upload_env, caplog, capsys, canonical):
+    """Sanitization-Sammeltest: keine Dateipfade/Provider-Details/Sentinel in
+    der Response, unabhängig davon, in welcher Stufe der I/O-Fehler auftritt."""
+    upload_env.project_manager.save_file_to_project.side_effect = OSError(
+        f"/var/secret/path failed: {SECRET_SENTINEL} provider=conn-upload-atomicity"
+    )
+
+    response = _post(upload_env.client, canonical=canonical)
+
+    response_text = response.get_data(as_text=True)
+    assert "/var/secret/path" not in response_text
+    assert SECRET_SENTINEL not in response_text
+    assert "conn-upload-atomicity" not in response_text

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3678 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3690 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 173 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
@@ -127,6 +127,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 - Secrets werden nicht in Report-/Simulation-Artefakte serialisiert
 - Readiness prüft Neo4j, Redis, Upload-Verzeichnis und Embedding-Konfiguration
 - Dependency-Ausnahmen werden im [`dependency-risk-register.md`](dependency-risk-register.md) geführt
+- Ontology-Upload (`/ontology/generate`) räumt bei Datei-I/O-Fehlern zwischen Projektanlage und Service-Übergabe das halb angelegte Projekt zuverlässig auf (Issue #899); ein scheiterndes Aufräumen wird protokolliert, ohne die Fehlerantwort zu verfälschen
 
 Aktuelle Hardstops:
 


### PR DESCRIPTION
Closes #899

## Root Cause

`generate_ontology` legt das Projekt in `backend/app/api/graph_build.py` an, bevor Dateiablage, Extraktion und Persistenz abgeschlossen sind — `ProjectManager.create_project()` schreibt Verzeichnis, `files/` und `project.json` mit Status `CREATED` sofort auf Platte.

Der Abschnitt danach war ungeschützt: `save_file_to_project`, `FileParser.extract_text`, `TextProcessor.preprocess_text`, `save_extracted_text` und das abschließende `save_project`. Ein `OSError`/`PermissionError` lief dort am Cleanup vorbei direkt in den `@handle_api_errors`-Decorator, wurde zu einer generischen HTTP 500 — und hinterließ ein verwaistes `CREATED`-Projekt samt Teilartefakten.

Zusätzlich waren die drei bereits existierenden Kompensationsstellen (`delete_project` bei Upload-zu-groß, bei „kein Dokument verarbeitet", im `except ValueError`) selbst ungeschützt: `ProjectManager.delete_project` (`backend/app/models/project.py:252-269`) fängt `shutil.rmtree`-Fehler nicht ab. Ein Cleanup-Fehler konnte damit eine korrekte 413/400 in eine irreführende 500 verwandeln.

## Gewählte Semantik: Rollback vor der Service-Grenze, FAILED ab der Service-Grenze

Das Repo nutzt für Domänenfehler überwiegend FAILED-Persistierung (`runs.py:490-500`, `services/graph_build.py:85`). Für den Abschnitt **vor** dem Service-Aufruf ist Rollback trotzdem richtig, und es ist auch die bereits etablierte lokale Konvention dieser Funktion:

- Zu diesem Zeitpunkt existiert weder ein `run_id` noch eine Ontologie noch ein Task — ein `FAILED`-Projekt wäre für Nutzer wie Diagnose wertlos und würde nur Müll akkumulieren.
- Alle erzeugten Artefakte liegen ausschließlich unter `projects/<project_id>/` und sind sicher identifizierbar.

Ab dem Service-Aufruf bleibt es unverändert bei FAILED-Persistierung — dort terminalisiert der Service selbst. Keine neue Transaktionsarchitektur, kein neuer Storage-Layer, keine Änderung an `models/project.py` oder am AiModelRef-Routing.

## Verhalten je Failure-Punkt

| Fehlerstelle | Verhalten |
|---|---|
| `save_file_to_project` | Projekt wird verworfen, generische 500 |
| `FileParser.extract_text` | Projekt wird verworfen, generische 500 |
| `TextProcessor.preprocess_text` | Projekt wird verworfen, generische 500 |
| `save_extracted_text` | Projekt wird verworfen, generische 500 |
| `save_project` (nach Extraktion) | Projekt wird verworfen, keine fälschlich erfolgreiche Initialisierung |
| Upload zu groß | unverändert 413 — Cleanup jetzt gegen eigene Fehler gehärtet |
| kein Dokument verarbeitet | unverändert 400 — dito |
| `ValueError` aus dem Service | unverändert, Cleanup gehärtet |

## Verhalten bei Cleanup-Fehler

`_discard_project_after_upload_failure` kapselt `delete_project`: schlägt das Aufräumen selbst fehl, wird der Cleanup-Fehler mit `logger.exception` samt Traceback protokolliert und geschluckt. Der Originalfehler bestimmt weiterhin die Antwort (nacktes `raise`), wird nie überdeckt und nie zu einem Erfolg. Beides ist getestet: der Test prüft, dass ein ERROR-Record mit `exc_info` existiert, dass der Cleanup-Fehler im Log steht **und** dass die Ursprungsursache dort ebenfalls erkennbar bleibt — während beide Sentinels aus der HTTP-Response herausbleiben.

## Legacy-/AiModelRef-Parität

Der gesamte File-I/O-Abschnitt liegt vor der Routing-Weiche und referenziert `ai_model_ref` an keiner Stelle — die Parität ist strukturell gegeben, nicht nur testseitig. Jeder der sechs Testfälle läuft parametrisiert für beide Requesttypen (`ids=["legacy", "canonical"]`).

## RED / GREEN

RED gegen den unveränderten Produktivcode, selbst ausgeführt: **10 failed, 2 passed**. Die zwei grünen sind der reine Sanitization-Sammeltest — der war bereits vorher grün, weil `handle_api_errors` schon sanitisiert; er ist Regressionsschutz, kein Bug-Nachweis. Nach dem Fix: **12 passed**.

## Tests

Neu: `backend/tests/api/test_graph_ontology_upload_atomicity.py` — 6 Fälle × 2 Parametrisierungen = 12 Tests. Seams: HTTP-Endpunkt via Flask-Testclient plus beobachteter Cleanup über den gemockten `ProjectManager`; keine Tests gegen private Helfer.

Zur Abgrenzung: Der in den Akzeptanzkriterien genannte **FAILED-Fallback ist bereits abgedeckt** — durch `test_graph_post_seed_failures.py` (Zeilen 207/242/276/309) und `test_graph_provider_route_prevalidation.py` aus #897. Diese Abdeckung wurde geprüft und bewusst nicht dupliziert.

## Gate

Alle Stufen selbst ausgeführt, echte Exit-Codes:

| Stufe | Ergebnis |
|---|---|
| `pytest tests/api/test_graph_ontology_upload_atomicity.py` | 12 passed — exit 0 |
| `pytest tests/ -k "ontology or graph_build"` | 125 passed, 2 skipped (Redis) — exit 0 |
| `pytest tests/contracts/ -x` | 422 passed — exit 0 |
| `dump_schemas --check` | alle 46 Schemas matchen — exit 0 |
| `ruff check app/ tests/` | All checks passed — exit 0 |
| `mypy app` | no issues in 230 files — exit 0 |
| `scripts/pre-push-gate.sh backend` | ALL GREEN — exit 0 |

Das Gate war zwischenzeitlich rot (`docs/STATUS.md`-Drift: 3678 statt 3690 collected tests) und wurde per `scripts/sync-status.sh` behoben.

## Dokumentationssync

`CHANGELOG.md` (neuer `### Fixed`-Abschnitt unter `[Unreleased]`) und `docs/STATUS.md` (Bullet unter „Security und Betrieb" plus autogenerierte Testzahl). `ROADMAP.md` bewusst unverändert — es wird kein Release-Gate erfüllt. #760/#829 bleiben offen.

## Subagents und tatsächlich verwendete Modelle

Der Auftrag war in Codex-Rollen (Sol/Terra/Luna) formuliert; ausgeführt wurde er in Claude Code. Reale Modelle:

| Rolle | Realer Agent | Reales Modell |
|---|---|---|
| Lead | Claude Code | **Opus 5** |
| Explorer A (Upload-Kontrollfluss) | `Explore` | **Sonnet 5** |
| Explorer B (Cleanup-Semantik) | `Explore` | **Sonnet 5** |
| Explorer C (Tests/Fehleroberfläche) | `Explore` | **Sonnet 5** |
| Implementierung | `general-purpose` | **Sonnet 5** |
| Evidence-Auditor | `Explore` | **Sonnet 5** |
| Standards-Reviewer | `Explore` | **Sonnet 5** |

Kein MiniMax-M3, kein GPT-5.x beteiligt. Alle schreibenden Arbeiten liefen in einem isolierten Worktree (`/private/tmp/agora-899`), genau ein atomarer Commit.

## Matt-Pocock-Skills

`tdd` wurde geladen und angewandt (Seams vorab festgelegt, RED vor GREEN, vertikale Slices). `diagnosing-bugs` und `codebase-design` wurden inhaltlich durchlaufen — reproduce → hypothesise → fix → regression test, und die Prüfung, ob ein neuer Helfer gerechtfertigt ist (Ergebnis: ein modul-privater Helfer, keine neue Modulgrenze). Der `code-review`-Skill wurde **nicht formal invoked**; seine beiden Achsen (Standards, Spec/Evidence) wurden stattdessen von zwei dedizierten unabhängigen Reviewern abgedeckt, deren Befunde eingearbeitet sind.

## Eingearbeitete Review-Befunde

- Nicht-diskriminierende Assertion `assert caplog.records` durch eine echte ersetzt (ERROR-Record mit `exc_info`, Cleanup-Sentinel und Originalfehler im Log).
- Ungenutzter `caplog`-Parameter im Assert-Helfer nutzbar gemacht: belegt jetzt, dass der Originalfehler serverseitig diagnostizierbar bleibt. Bewusst **nicht** nach dem Schwesterpattern `assert SECRET_SENTINEL not in caplog.text` — dort ist der Sentinel ein Provider-Secret, hier Teil einer OSError-Message, die protokolliert werden *muss*.
- Fehlende Leerzeile vor dem neuen Helfer (PEP8-Konvention der Datei).
- `unvollstaendig` → `unvollständig` in der Logmeldung (Repo-Konvention sind korrekte Umlaute).
- Hartkodierte Produktions-Zeilennummer aus einem Testkommentar entfernt.

## Verbleibende Risiken und bewusste Scope-Grenzen

1. **Nicht behoben, außerhalb #899:** Bei generischen Nicht-`ValueError`-Fehlern *während* des Service-Aufrufs (Timeout, LLM-Client-Fehler) terminalisiert nur der AiModelRef-Pfad zu `FAILED`; der Legacy-Pfad bleibt in `CREATED`. Das liegt hinter der Service-Grenze in `services/graph_build.py::_terminalize_ai_model_ref_sync_failure` und wäre eine Änderung am #897-Terrain. Verdient ein eigenes Issue.
2. **Nicht behoben, vorbestehend:** `json_error_from_exception` reicht bei einer Legacy-`ValueError` ohne `ApiErrorCode` den rohen `str(exc)` an den Client durch. Unabhängig von #899, aber im selben Zweig sichtbar.
3. **Testreichweite:** `ProjectManager` ist im neuen Test gemockt. Verifiziert wird der Kontrollfluss des API-Layers, nicht die reale Verzeichnislöschung auf Platte.
4. **Baseline-Hinweis, nicht von diesem PR verursacht:** Im Haupt-Checkout scheitern fünf Graph-Ontology-Tests mit `OSError: [Errno 30] Read-only file system: '/app'`. Ursache ist die Prod-`.env` im Repo-Root (`AGORA_INSTANCE_DIR=/app/backend/instance`), die `config.py` mit `override=False` lädt und die `tests/conftest.py` — anders als `AGORA_DATA_DIR` — nicht isoliert. Im Worktree fehlt diese Datei, dort sind alle Tests grün. Reines Testumgebungsproblem ohne Bezug zu Cleanup; verdient ein eigenes Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Fehlerbehebungen**
  - Ontologie-Uploads hinterlassen bei Datei-I/O-Fehlern keine unvollständigen Projekte mehr.
  - Fehlerantworten bleiben allgemein und geben keine sensiblen Datei- oder Provider-Details preis.
  - Fehler beim Aufräumen werden protokolliert, ohne die ursprüngliche Fehlerbehandlung zu verfälschen.

- **Tests**
  - Zusätzliche Tests decken verschiedene Upload- und Bereinigungsszenarien ab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->