### PR TITLE
docs(frontend): Frontend-Next- und Lovable-Iststand dokumentieren

### DIFF
--- a/docs/epics/frontend-next/2026-STATUS.md
+++ b/docs/epics/frontend-next/2026-STATUS.md
@@ -14,7 +14,9 @@ Erhebungsmethode: Lovable-MCP-Connector (nur lesend, keine Aktion am Projekt), `
 
 > „Entwurf / Analyse-Ergebnis, noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet."
 
-Diese Zeile ist **überholt**. Sie beschreibt den Stand am 2026-07-16 vor der Projektanlage und wurde danach nie aktualisiert. Tatsächlich existiert ein Lovable-Projekt mit substanzieller Umsetzung. Es ist jedoch **zu keinem Zeitpunkt veröffentlicht** worden und **nicht** mit einem produktiven Agora-Deployment verbunden.
+Diese Zeile ist **überholt**. Sie beschreibt den Stand am 2026-07-16 vor der Projektanlage und wurde danach nie aktualisiert. Tatsächlich existiert ein Lovable-Projekt mit substanzieller Umsetzung. Es ist jedoch **derzeit nicht veröffentlicht** und **nicht** mit einem produktiven Agora-Deployment verbunden.
+
+Zur Genauigkeit dieser Aussage: Der Connector liefert mit `is_published` einen **Momentanwert**, keine Veröffentlichungshistorie. Belegt ist damit der Zustand zum Erhebungszeitpunkt 2026-07-26. Ob ein Projekt zwischenzeitlich veröffentlicht und später wieder zurückgezogen wurde, lässt sich aus den verfügbaren Feldern nicht ausschließen — siehe „Unklar".
 
 ---
 
@@ -27,7 +29,7 @@ Fakten mit Primärquelle, unabhängig von den Handover-Dokumenten bestätigt.
 | Lovable-Workspace „Alexander's Lovable" existiert, Plan `pro`, 5 Projekte | Connector `list_workspaces`, Workspace-ID `ywW2AknvnOdwQW1Yt23P` |
 | Lovable-Projekt „Agora Runs Dashboard" existiert | Connector `list_projects`, Projekt-ID `a061f7f7-294f-4380-935d-a8f0eb4110a3` |
 | Angelegt 2026-07-16T07:55:21Z, letzte Änderung 2026-07-17T19:59:29Z, Status `completed` | Connector `list_projects` |
-| **`is_published: false`** — nie veröffentlicht, kein `url`-Feld | Connector `list_projects` |
+| **`is_published: false`** zum Erhebungszeitpunkt, kein `url`-Feld | Connector `list_projects` |
 | 23 Edits: 9 Lovable-AI-Commits, 14 lokale Developer-Commits | Connector `list_edits` |
 | Codebasis: TanStack-Router-SPA, 12 Routen, 7 API-Module, 7 Contract-Module, shadcn/ui | Connector `list_files` (`src/routes/`, `src/api/`, `src/contracts/`) |
 | Zweites Projekt „Agora Prototype" (`c6e02187-301e-44b5-bddb-d2471befe332`) existiert, hat aber **null Edits** | Connector `list_edits` liefert leeres Array |
@@ -65,7 +67,7 @@ Wichtig für das mentale Modell: Die trotz ihres Namens „frontend-next" heiße
 
 Was der Connector unmittelbar zeigt, ohne Umweg über die Handover-Dokumente:
 
-| Projekt | ID | Edits | Status | Published |
+| Projekt | ID | Edits | Status | Published (Stand 2026-07-26) |
 |---|---|---|---|---|
 | Agora Runs Dashboard | `a061f7f7-294f-4380-935d-a8f0eb4110a3` | 23 | `completed` | **nein** |
 | Agora Prototype | `c6e02187-301e-44b5-bddb-d2471befe332` | 0 | `completed` | **nein** |
@@ -74,7 +76,7 @@ Was der Connector unmittelbar zeigt, ohne Umweg über die Handover-Dokumente:
 
 Die drei weiteren Projekte im Workspace („Delightful Designs", „Grade Overview", „Dify Chat Studio") gehören nicht zu Agora.
 
-Zur Preview-URL: Lovable hält für jedes Projekt eine interne Preview-Adresse bereit. Das ist eine Editor-Vorschau, keine Veröffentlichung — `is_published` bleibt davon unberührt und steht bei beiden Agora-Projekten auf `false`.
+Zur Preview-URL: Lovable hält für jedes Projekt eine interne Preview-Adresse bereit. Das ist eine Editor-Vorschau, keine Veröffentlichung — `is_published` bleibt davon unberührt und stand bei beiden Agora-Projekten am 2026-07-26 auf `false`.
 
 ---
 
@@ -108,6 +110,7 @@ Nicht zuverlässig verifizierbar, ohne den Rahmen von #836 zu verlassen:
 - Der Grad der Divergenz zwischen Lovable-Remote, GitHub-Sync-Repo und lokalem Klon. Belegt ist nur, dass der lokale Klon älter ist und uncommittete Änderungen trägt.
 - Ob der lokale Klon `/Volumes/T7/Projekte/agora-runs-dashboard` noch aktiv bearbeitet wird oder liegen geblieben ist.
 - Warum „Agora Prototype" angelegt und sofort aufgegeben wurde.
+- Ob eines der Projekte **zwischenzeitlich** veröffentlicht und später zurückgezogen wurde. `is_published` ist ein Momentanwert; der Connector liefert keine Veröffentlichungshistorie, und `list_edits` enthält keine Publish-/Unpublish-Ereignisse. Für den Zeitraum vor dem 2026-07-26 ist dazu keine Aussage belegbar.
 
 ---
 
@@ -117,7 +120,7 @@ Nicht zuverlässig verifizierbar, ohne den Rahmen von #836 zu verlassen:
 
 Belege:
 
-- beide Lovable-Projekte tragen `is_published: false` und besitzen keine öffentliche URL,
+- beide Lovable-Projekte tragen zum Erhebungszeitpunkt `is_published: false` und besitzen keine öffentliche URL,
 - das GitHub-Sync-Repo `arn0ld87/agora-runs-dashboard` ist privat,
 - weder `docker-compose*.yml` noch `deploy/` noch `scripts/` noch die GitHub-Workflows referenzieren das Vorhaben; der einzige Treffer auf „react" in `.github/workflows/e2e-smokes.yml` ist der Report-Datenfeldname `generate_section_react` und hat keinen Bezug zum Frontend,
 - das Root-`package.json` definiert weder Workspaces noch einen `frontend-next`-Eintrag,
@@ -127,10 +130,13 @@ Das ausgelieferte Produktfrontend von Agora ist unverändert das Vue-Frontend un
 
 ---
 
-## Empfohlene Folgearbeit
+## Abgrenzung
 
-Nicht Gegenstand dieses Tickets, aber aus dem Befund abgeleitet:
+Dieses Dokument ist ein abgeschlossener Untersuchungsbefund zu #836, keine Planungsdatei und keine konkurrierende Statusquelle. Verbindlich bleiben `README.md`, `docs/STATUS.md`, `ROADMAP.md` und die GitHub Issues in der in [`AGENTS.md`](../../../AGENTS.md) festgelegten Reihenfolge.
 
-1. Die Stand-Zeile in `brief.md` korrigieren oder auf dieses Dokument verweisen — sie ist aktiv irreführend (#837).
-2. `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` aus diesem Verzeichnis in den Vue-Kontext verschieben oder als externe Abhängigkeit kennzeichnen.
-3. Die Benennung der `feat/frontend-next-*`-Branches als Stolperstein festhalten: sie enthalten Vue-Arbeit.
+Die aus dem Befund abgeleitete Folgearbeit wird ausschließlich über Issues geführt, nicht hier:
+
+- die Release-Einordnung des React-/Lovable-Vorhabens → #837
+- die Doku-Stolpersteine dieses Verzeichnisses (Ablage von `SLICE-5.2`, irreführende Branch-Namen, veraltete `brief.md`-Stand-Zeile) → #910
+
+Sobald #837 die Einordnung in `ROADMAP.md` und `docs/STATUS.md` verankert hat, ist dieses Dokument nur noch Beleg-Archiv für die dort getroffene Aussage.

--- a/docs/epics/frontend-next/2026-STATUS.md
+++ b/docs/epics/frontend-next/2026-STATUS.md
@@ -1,0 +1,136 @@
+# Frontend-Next — verifizierter Ist-Stand
+
+**Erstellt:** 2026-07-26
+**Anlass:** [Issue #836](https://github.com/arn0ld87/agora/issues/836) — der Ist-Stand des React-/Lovable-Vorhabens musste belegt werden, bevor er an anderer Stelle eingeordnet wird.
+**Charakter:** reine Tatsachenfeststellung. Dieses Dokument trifft **keine** Architektur- oder Freigabeentscheidung; die verbindliche Einordnung ist Gegenstand von [Issue #837](https://github.com/arn0ld87/agora/issues/837).
+
+Erhebungsmethode: Lovable-MCP-Connector (nur lesend, keine Aktion am Projekt), `gh`, lokale Git-Historie, Dateisystem, Volltext der acht Dokumente in diesem Verzeichnis.
+
+---
+
+## Kernaussage
+
+`brief.md` trägt in Zeile 3 die Stand-Zeile:
+
+> „Entwurf / Analyse-Ergebnis, noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet."
+
+Diese Zeile ist **überholt**. Sie beschreibt den Stand am 2026-07-16 vor der Projektanlage und wurde danach nie aktualisiert. Tatsächlich existiert ein Lovable-Projekt mit substanzieller Umsetzung. Es ist jedoch **zu keinem Zeitpunkt veröffentlicht** worden und **nicht** mit einem produktiven Agora-Deployment verbunden.
+
+---
+
+## Belegt
+
+Fakten mit Primärquelle, unabhängig von den Handover-Dokumenten bestätigt.
+
+| Feststellung | Beleg |
+|---|---|
+| Lovable-Workspace „Alexander's Lovable" existiert, Plan `pro`, 5 Projekte | Connector `list_workspaces`, Workspace-ID `ywW2AknvnOdwQW1Yt23P` |
+| Lovable-Projekt „Agora Runs Dashboard" existiert | Connector `list_projects`, Projekt-ID `a061f7f7-294f-4380-935d-a8f0eb4110a3` |
+| Angelegt 2026-07-16T07:55:21Z, letzte Änderung 2026-07-17T19:59:29Z, Status `completed` | Connector `list_projects` |
+| **`is_published: false`** — nie veröffentlicht, kein `url`-Feld | Connector `list_projects` |
+| 23 Edits: 9 Lovable-AI-Commits, 14 lokale Developer-Commits | Connector `list_edits` |
+| Codebasis: TanStack-Router-SPA, 12 Routen, 7 API-Module, 7 Contract-Module, shadcn/ui | Connector `list_files` (`src/routes/`, `src/api/`, `src/contracts/`) |
+| Zweites Projekt „Agora Prototype" (`c6e02187-301e-44b5-bddb-d2471befe332`) existiert, hat aber **null Edits** | Connector `list_edits` liefert leeres Array |
+| GitHub-Sync-Repo `arn0ld87/agora-runs-dashboard` existiert, **privat** | `gh repo view`, angelegt 2026-07-16T08:32:50Z |
+| Letzter Push dorthin 2026-07-17T19:59:31Z — deckt sich sekundengenau mit dem letzten Lovable-Edit | `gh repo view` vs. Connector `list_edits` |
+| Die Projekt-ID in `HANDOVER.md` stimmt mit der Connector-Antwort überein | `HANDOVER.md` Abschnitt „Lovable-Projekt" |
+
+Die Umsetzungstiefe lässt sich aus den Commit-Messages der Edit-Historie belegen: Onboarding-Wizard, Simulation mit Persona-Review-Grid, SSE-Live-Feed, Report-Seite mit Chat und Export, Settings mit Tabs, History- und Compare-Seiten, Auth-Bootstrap, Verdrahtung gegen die echte Flask-API sowie ein vollständiger Rip-out der MSW-Mocks.
+
+Aus denselben Commit-Messages ergeben sich unmittelbar auch die offenen Enden:
+
+- die Settings-Tabs Routing, Embedding-Migration, API-Keys und Audit-Log zeigen laut Commit `32fdb0dc` einen „nicht angebunden"-Platzhalter,
+- es existiert laut Commit `1955fea0` kein Aufrufer, der eine echte `simulation_id` liefert — der Run-Erstellungspfad fehlt.
+
+---
+
+## Lokal
+
+| Feststellung | Beleg |
+|---|---|
+| `frontend-next/` existiert **nicht** im Agora-Repo-Root | `ls -la frontend-next` → „No such file or directory" |
+| `frontend-next/` war **nie** in Git getrackt | `git log --all -- frontend-next` → leer |
+| Kein Eintrag für `frontend-next` in `.gitignore` | `grep` ohne Treffer |
+| Nur zwei `package.json` im Repo: `./package.json`, `./frontend/package.json` | `find -maxdepth 3 -name package.json` |
+| Die Branches `feat/frontend-next`, `origin/feat/frontend-next-phase12`, `origin/feat/frontend-next-phase2-onboarding-granularity` enthalten **null** `.tsx`-Dateien | `git ls-tree -r --name-only <branch> \| grep -c '\.tsx$'` → 0 |
+| Ein lokaler Klon des React-Projekts liegt **außerhalb** dieses Repos unter `/Volumes/T7/Projekte/agora-runs-dashboard` | `ls`, `git log` |
+| Dieser Klon steht auf `32fdb0d` (2026-07-16) und ist damit **hinter** dem Lovable-Stand; zusätzlich uncommittete Änderungen | `git log -1`, `git status --short` |
+| Klon enthält 65 `.tsx`-Dateien | `find src -name '*.tsx' \| wc -l` |
+
+Wichtig für das mentale Modell: Die trotz ihres Namens „frontend-next" heißenden Branches enthalten **Vue**-Arbeit am bestehenden Frontend, keinen React-Code. Der React-Code hat nie im Agora-Repository gelegen.
+
+---
+
+## Lovable
+
+Was der Connector unmittelbar zeigt, ohne Umweg über die Handover-Dokumente:
+
+| Projekt | ID | Edits | Status | Published |
+|---|---|---|---|---|
+| Agora Runs Dashboard | `a061f7f7-294f-4380-935d-a8f0eb4110a3` | 23 | `completed` | **nein** |
+| Agora Prototype | `c6e02187-301e-44b5-bddb-d2471befe332` | 0 | `completed` | **nein** |
+
+„Agora Prototype" wurde am 2026-07-16T07:15:28Z angelegt und drei Sekunden später zuletzt berührt. Ohne einen einzigen Edit ist es eine leere Projekthülle, kein Umsetzungsstand.
+
+Die drei weiteren Projekte im Workspace („Delightful Designs", „Grade Overview", „Dify Chat Studio") gehören nicht zu Agora.
+
+Zur Preview-URL: Lovable hält für jedes Projekt eine interne Preview-Adresse bereit. Das ist eine Editor-Vorschau, keine Veröffentlichung — `is_published` bleibt davon unberührt und steht bei beiden Agora-Projekten auf `false`.
+
+---
+
+## Planung
+
+Was ausschließlich in Planungs- und Übergabedokumenten steht. Diese Dokumente sind überwiegend **Arbeitsaufträge an nachfolgende Agenten-Sessions**, keine Abnahmeberichte — ihre Fertigstellungsangaben sind Behauptungen, nicht Nachweise.
+
+| Dokument | Typ | Inhalt |
+|---|---|---|
+| `brief.md` | Konzept | vollständiger Architektur-Brief für die React-SPA; Stand-Zeile veraltet (siehe oben) |
+| `HANDOVER.md` | Übergabe-Prompt | nennt Projekt-ID, Editor-, Preview- und GitHub-Sync-URL; bezeichnet Slices 1–3 als „live in der Preview" |
+| `HANDOVER-GLM-MMX.md` | Übergabe-Prompt | Übergabe Phase 1+2 an eine Folge-Session |
+| `PHASE-1-2-OPUS-HANDOVER.md` | Übergabe-Prompt | Kanon-Entscheidung `routing/defaults.global_default` als SSoT |
+| `PHASE-1-DIVERGENZ.md` | Analyse | Inventar der konkurrierenden Persistenz-Senken der Modellwahl |
+| `PHASE-2-ONBOARDING-HANDOVER.md` | Übergabe-Prompt | hält Phase 2 ausdrücklich als **offen** fest, Design-Konflikt ungeklärt |
+| `PHASE-5-VERIFICATION-HANDOVER.md` | Übergabe-Prompt | Verifikationsplan; nennt als Vorbedingung, dass Phase 3+4 ausgeliefert ist |
+
+Der Dateiname `PHASE-5-VERIFICATION-HANDOVER.md` trägt keine Aussage über tatsächlich durchgeführte Verifikation. Das Dokument ist der Auftrag dazu, nicht dessen Ergebnis.
+
+### Fremdkörper im Verzeichnis
+
+`SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` liegt zwar hier, behandelt aber ausschließlich **Vue**-Komponenten (`EnvSetupModelPanel.vue`, `Step2EnvSetup.vue`, `AiModelPicker.vue`) und gehört zu [Issue #890](https://github.com/arn0ld87/agora/issues/890) am bestehenden Produktfrontend. Es ist als einziges Dokument des Verzeichnisses am 2026-07-26 geändert worden, alle übrigen stammen vom 2026-07-18. Es zählt nicht zum React-Vorhaben.
+
+---
+
+## Unklar
+
+Nicht zuverlässig verifizierbar, ohne den Rahmen von #836 zu verlassen:
+
+- Ob die als „live in der Preview" bezeichneten Slices 1–3 funktional vollständig sind. Belegt ist, dass entsprechender Code existiert und Commits mit passenden Nachrichten gelaufen sind — nicht, dass die Oberfläche fehlerfrei bedienbar ist. Ein Preview-Abruf oder Testlauf war nicht Gegenstand dieses Tickets.
+- Der Grad der Divergenz zwischen Lovable-Remote, GitHub-Sync-Repo und lokalem Klon. Belegt ist nur, dass der lokale Klon älter ist und uncommittete Änderungen trägt.
+- Ob der lokale Klon `/Volumes/T7/Projekte/agora-runs-dashboard` noch aktiv bearbeitet wird oder liegen geblieben ist.
+- Warum „Agora Prototype" angelegt und sofort aufgegeben wurde.
+
+---
+
+## Produktiver Status
+
+**Kein React-/Lovable-Frontend ist derzeit produktiv mit Agora verbunden oder veröffentlicht.**
+
+Belege:
+
+- beide Lovable-Projekte tragen `is_published: false` und besitzen keine öffentliche URL,
+- das GitHub-Sync-Repo `arn0ld87/agora-runs-dashboard` ist privat,
+- weder `docker-compose*.yml` noch `deploy/` noch `scripts/` noch die GitHub-Workflows referenzieren das Vorhaben; der einzige Treffer auf „react" in `.github/workflows/e2e-smokes.yml` ist der Report-Datenfeldname `generate_section_react` und hat keinen Bezug zum Frontend,
+- das Root-`package.json` definiert weder Workspaces noch einen `frontend-next`-Eintrag,
+- der React-Code liegt vollständig außerhalb dieses Repositories.
+
+Das ausgelieferte Produktfrontend von Agora ist unverändert das Vue-Frontend unter `frontend/`.
+
+---
+
+## Empfohlene Folgearbeit
+
+Nicht Gegenstand dieses Tickets, aber aus dem Befund abgeleitet:
+
+1. Die Stand-Zeile in `brief.md` korrigieren oder auf dieses Dokument verweisen — sie ist aktiv irreführend (#837).
+2. `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` aus diesem Verzeichnis in den Vue-Kontext verschieben oder als externe Abhängigkeit kennzeichnen.
+3. Die Benennung der `feat/frontend-next-*`-Branches als Stolperstein festhalten: sie enthalten Vue-Arbeit.


### PR DESCRIPTION
Closes #836

## Warum

`docs/epics/frontend-next/brief.md` trägt in Zeile 3 bis heute die Stand-Zeile „Entwurf / Analyse-Ergebnis, noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet." Diese Zeile ist überholt und war als Beleg für eine Release-Einordnung nicht tragfähig. #837 braucht einen belegten Ist-Stand, bevor dort eine verbindliche Aussage getroffen wird.

## Untersuchte Quellen

- Lovable-MCP-Connector (`list_workspaces`, `list_projects`, `list_edits`, `list_files`) — **ausschließlich lesend**, keine Aktion an den Projekten, kein Deploy, keine Bearbeitung
- `gh repo view` für das GitHub-Sync-Repo
- lokale Git-Historie: Branch-Inhalte, Datei-Historie, Commit-Daten
- Dateisystem: Repo-Root, `package.json`-Inventar, lokaler Klon
- Volltext aller acht Dokumente unter `docs/epics/frontend-next/`

## Belegter Stand

Ein Lovable-Projekt existiert und ist substanziell umgesetzt — die `brief.md`-Zeile ist widerlegt.

| Projekt | ID | Edits | Published |
|---|---|---|---|
| Agora Runs Dashboard | `a061f7f7-294f-4380-935d-a8f0eb4110a3` | 23 | **nein** |
| Agora Prototype | `c6e02187-301e-44b5-bddb-d2471befe332` | 0 | **nein** |

„Agora Runs Dashboard" ist eine TanStack-Router-SPA mit 12 Routen, 7 API- und 7 Contract-Modulen, gegen die echte Flask-API verdrahtet (vollständiger MSW-Rip-out). Die in `HANDOVER.md` genannte Projekt-ID stimmt mit der Connector-Antwort überein — unabhängige Korroboration.

„Agora Prototype" wurde angelegt und drei Sekunden später zuletzt berührt; ohne einen einzigen Edit ist es eine leere Hülle.

## Lokale Artefakte

- `frontend-next/` existiert **nicht** im Repo-Root und war **nie** getrackt
- die Branches `feat/frontend-next`, `origin/feat/frontend-next-phase12` und `origin/feat/frontend-next-phase2-onboarding-granularity` enthalten **null** `.tsx`-Dateien — trotz ihres Namens ist das Vue-Arbeit
- der React-Code lag nie in diesem Repository; ein lokaler Klon liegt außerhalb unter `/Volumes/T7/Projekte/agora-runs-dashboard`, steht auf einem älteren Stand und trägt uncommittete Änderungen

## Produktiver Status

**Kein React-/Lovable-Frontend ist produktiv verbunden oder veröffentlicht.** Beide Projekte `is_published: false`, GitHub-Sync-Repo privat, keine Referenz in `docker-compose*.yml`, `deploy/`, `scripts/` oder den Workflows. Der einzige `react`-Treffer in `e2e-smokes.yml` ist der Report-Datenfeldname `generate_section_react`.

## Unbekannte Punkte

Im Dokument als solche ausgewiesen: funktionale Vollständigkeit der als „live in der Preview" bezeichneten Slices, Divergenzgrad zwischen Lovable-Remote / GitHub-Sync / lokalem Klon, aktueller Bearbeitungsstand des lokalen Klons.

## Bewusste Nicht-Aussage

Das Dokument trifft **keine** Freigabe- oder Architekturentscheidung. Der Satz „React/Lovable ist bis 1.0.0 nicht freigegeben" steht bewusst **nicht** darin — die verbindliche Einordnung gehört zu #837. Der Review hat das explizit gegengeprüft.

## Nebenbefund

`SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` liegt in diesem Verzeichnis, behandelt aber ausschließlich Vue-Komponenten und gehört zu #890. Im Dokument als Fremdkörper markiert, nicht verschoben (out of scope).

## Änderungen

Genau eine neue Datei, 136 Zeilen, keine Löschungen. **Kein Produktivcode**, kein `ROADMAP.md`, kein `docs/STATUS.md`.

## Verifikation

`git diff --check` sauber, `git status` sauber. Kein Testlauf — reiner Docs-Slice, Gate-Scope laut Issue: keiner.

## Subagents, Modelle und Skills

| Rolle | Agent | Tatsächlich verwendetes Modell |
|---|---|---|
| Dokumentchronologie (read-only) | `Explore` | Haiku |
| Lokaler Code + Git-Historie (read-only) | `Explore` | Haiku |
| Lovable-Connector-Recherche | Lead selbst (Connector-Zugriff nur dort verfügbar) | Opus |
| Evidence-Review des Dokuments | `agora-evidence-auditor-m3` | Sonnet — APPROVE |

Research-Skill: quellenbasiertes Vorgehen nach `mattpocock-skills:research` — Primärquelle vor Zusammenfassung, kein Rückschluss von Dateinamen wie `PHASE-5-VERIFICATION` auf tatsächliche Umsetzung.

Abweichung vom geplanten Dispatch: Das Dokument wurde vom Lead geschrieben statt von `agora-doc-worker-m3`. Grund: Die Primärevidenz aus dem Lovable-Connector lag ausschließlich im Lead-Kontext, und der Lead muss für jede Tatsachenbehauptung ohnehin selbst einstehen. Der Haiku-Rechercheur zum lokalen Code hatte aus `brief.md` fälschlich „kein Lovable-Projekt" geschlossen; dieser Widerspruch wurde gegen die Primärquelle aufgelöst, nicht gemittelt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * Eine neue, verifizierte Statusübersicht zum React-/Lovable-Vorhaben wurde ergänzt.
  * Der Veröffentlichungs- und Integrationsstatus ist nun eindeutig dargestellt (inkl. Abgrenzung zum produktiv ausgelieferten Frontend).
  * Belegte Fakten, lokale Erkenntnisse, Planungen und offene/unklare Punkte sind klar voneinander getrennt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->