### PR TITLE
docs(0.9): React-/Lovable-Rewrite vor 1.0 als nicht freigegeben festschreiben

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 - [ ] Vue-v4 ist die einzige produktive Oberfläche
 - [ ] klassische Prozess-Views besitzen Lösch- oder Redirect-Entscheidungen
 - [ ] `/agora-2026` ist kein produktiv gerouteter Parallelentwurf
-- [ ] kein paralleler React-/Lovable-Rewrite
+- [x] kein paralleler React-/Lovable-Rewrite — der Lovable-Prototyp liegt außerhalb dieses Repos, ist unveröffentlicht und nicht produktiv verdrahtet, siehe [`docs/epics/frontend-next/2026-STATUS.md`](docs/epics/frontend-next/2026-STATUS.md)
 - [ ] Responsive- und Accessibility-Gates sind grün
 
 ### Provider und Routing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 - [ ] Vue-v4 ist die einzige produktive Oberfläche
 - [ ] klassische Prozess-Views besitzen Lösch- oder Redirect-Entscheidungen
 - [ ] `/agora-2026` ist kein produktiv gerouteter Parallelentwurf
-- [x] kein paralleler React-/Lovable-Rewrite — der Lovable-Prototyp liegt außerhalb dieses Repos, ist unveröffentlicht und nicht produktiv verdrahtet, siehe [`docs/epics/frontend-next/2026-STATUS.md`](docs/epics/frontend-next/2026-STATUS.md)
+- [x] kein produktiv verdrahteter React-/Lovable-Rewrite — ein Lovable-Prototyp existiert, liegt aber außerhalb dieses Repos, ist unveröffentlicht und in keinem Auslieferungspfad referenziert, siehe [`docs/epics/frontend-next/2026-STATUS.md`](docs/epics/frontend-next/2026-STATUS.md)
 - [ ] Responsive- und Accessibility-Gates sind grün
 
 ### Provider und Routing

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -120,7 +120,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 
 ## Frontend-Next-Stand (React/Lovable)
 
-- **Produktiv:** Das produktive Frontend ist ausschließlich Vue-v4. Die Konsolidierung auf genau eine Route je fachlicher Hauptfunktion läuft weiterhin unter [Issue #760](https://github.com/arn0ld87/agora/issues/760) und ist nicht abgeschlossen.
+- **Produktiv:** Vue ist die einzige ausgelieferte Frontend-Technologie. Nicht jede produktive Oberfläche ist bereits v4: `/home` lädt weiterhin die klassische Editorial-View `frontend/src/views/Home.vue`, obwohl ADR-0010 dort einen Redirect auf `/dashboard` vorsieht ([Issue #915](https://github.com/arn0ld87/agora/issues/915)). Die Konsolidierung auf genau eine v4-Route je fachlicher Hauptfunktion läuft weiterhin unter [Issue #760](https://github.com/arn0ld87/agora/issues/760) und ist nicht abgeschlossen.
 - **Prototyp:** Ein Lovable-Projekt („Agora Runs Dashboard", angelegt 2026-07-16) existiert und wurde substanziell umgesetzt (23 Edits, TanStack-Router-SPA, 12 Routen, shadcn/ui). Es ist derzeit **nicht veröffentlicht** (`is_published: false`, keine URL) und **nicht** produktiv verdrahtet — weder Docker-Compose, GitHub-Workflows noch das Root-`package.json` referenzieren es. Der React-Code liegt vollständig außerhalb dieses Repositories. Die tatsächliche Funktionsvollständigkeit des Prototyps ist nicht codegeprüft belegt, sondern nur durch Commit-Aussagen behauptet.
 - **Release-Status:** Kein Teil des freigegebenen Produktpfads vor `1.0.0`.
 - **Zukunft:** Über eine spätere Migration ist keine Entscheidung getroffen.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -111,12 +111,20 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 ## Bekannte Konsolidierungsschuld
 
 - die fünf klassischen Prozess-Wrapper-Views sind entfernt; ihre benannten Deep-Links bleiben als v4-Redirects kompatibel. Die übrigen v4-Views und `/agora-2026` existieren weiterhin parallel
-- ein React-/Lovable-Neubau ist beschrieben, aber nicht als Zielentscheidung freigegeben
+- ein React-/Lovable-Neubau ist als Prototyp umgesetzt, aber nicht als Zielentscheidung freigegeben (Details im nächsten Abschnitt)
 - Legacy-LLM-Profile und Provider-Connections besitzen noch Übergangspfade
 - der credential-basierte Runtime-Provider-Override (`useRuntimeLlmOptions`, `@deprecated` Slice 5.5) ist mit der connection-gebundenen `AiModelRef` unvereinbar und in Step 2 daher gegenseitig ausgeschlossen. Solange er existiert, hält `useEnvForm` weiterhin `modelOption`/`customModel` — allerdings ohne Persistenz. Die Ablösung wird in [Issue #903](https://github.com/arn0ld87/agora/issues/903) geführt
 - die Browser-Keys `agora.lastModel` und `agora.lastCustomModel` haben seit Issue #890 keinen produktiven Reader oder Writer mehr; vorhandene Werte werden bewusst nicht gelöscht und bleiben wirkungslose Altlast
 - einzelne Provider-Erkennungen beruhen weiterhin auf URL-/Modell-Heuristiken
 - Frontend- und Backend-Provider-Vokabular sind nicht an jeder SSE-Grenze synchron
+
+## Frontend-Next-Stand (React/Lovable)
+
+- **Produktiv:** Das produktive Frontend ist ausschließlich Vue-v4. Die Konsolidierung auf genau eine Route je fachlicher Hauptfunktion läuft weiterhin unter [Issue #760](https://github.com/arn0ld87/agora/issues/760) und ist nicht abgeschlossen.
+- **Prototyp:** Ein Lovable-Projekt („Agora Runs Dashboard", angelegt 2026-07-16) existiert und wurde substanziell umgesetzt (23 Edits, TanStack-Router-SPA, 12 Routen, shadcn/ui). Es ist derzeit **nicht veröffentlicht** (`is_published: false`, keine URL) und **nicht** produktiv verdrahtet — weder Docker-Compose, GitHub-Workflows noch das Root-`package.json` referenzieren es. Der React-Code liegt vollständig außerhalb dieses Repositories. Die tatsächliche Funktionsvollständigkeit des Prototyps ist nicht codegeprüft belegt, sondern nur durch Commit-Aussagen behauptet.
+- **Release-Status:** Kein Teil des freigegebenen Produktpfads vor `1.0.0`.
+- **Zukunft:** Über eine spätere Migration ist keine Entscheidung getroffen.
+- Beleg: [`docs/epics/frontend-next/2026-STATUS.md`](epics/frontend-next/2026-STATUS.md).
 
 ## Security und Betrieb
 


### PR DESCRIPTION
Closes #837
Refs #836

## Ausgangslage

Baut auf dem präzisierten Faktenstand aus #836 / PR #907 / PR #912 auf. Verifiziert vor Beginn: PR #912 gemergt (`48540305`), #836 geschlossen, #837 offen, kein konkurrierender PR.

## Belegter Ist-Stand

Quelle: [`docs/epics/frontend-next/2026-STATUS.md`](docs/epics/frontend-next/2026-STATUS.md) — unverändert, nur referenziert.

- Ein reales Lovable-Projekt („Agora Runs Dashboard", angelegt 2026-07-16) existiert und wurde substanziell prototypisch umgesetzt (23 Edits, TanStack-Router-SPA, 12 Routen, shadcn/ui).
- Es ist **nicht veröffentlicht** (`is_published: false`, keine URL).
- Es ist **nicht** produktiv verdrahtet — weder docker-compose noch GitHub-Workflows noch das Root-`package.json` referenzieren es.
- Der React-Code liegt vollständig **außerhalb** dieses Repositories.
- Die tatsächliche Funktionsvollständigkeit ist **nicht codegeprüft** belegt, sondern nur durch Commit-Aussagen behauptet.

Bewusst **nicht** behauptet: das Projekt sei gelöscht, verworfen, habe nie existiert, oder dürfe nach `1.0.0` automatisch produktiv werden.

## ROADMAP-Änderung

Im 0.9.0-Block `### Frontend` wurde **ausschließlich** die Checkbox „kein paralleler React-/Lovable-Rewrite" abgehakt und mit einem Belegverweis versehen. Die übrigen Checkboxen des Blocks — insbesondere „Vue-v4 ist die einzige produktive Oberfläche" — bleiben unverändert offen; sie gehören zu #838/#839.

Begründung für das Abhaken: kein React-/Lovable-Rewrite befindet sich im produktiven Pfad von 0.9.0. Der Prototyp liegt außerhalb des Repos, unveröffentlicht und unverdrahtet.

## STATUS-Änderung

Neuer Abschnitt `## Frontend-Next-Stand (React/Lovable)` mit der Trennung **Produktiv** / **Prototyp** / **Release-Status** / **Zukunft**. Die bestehende Zeile in „Bekannte Konsolidierungsschuld" wurde minimal angepasst, damit keine zweite konkurrierende Aussage danebensteht.

Zwei Präzisierungen gegenüber dem ersten Entwurf, vom Lead vorgenommen:

1. Die Formulierung „Vue-v4 ist die einzige produktive Oberfläche" wurde ersetzt — sie hätte der bewusst offen gebliebenen gleichlautenden ROADMAP-Checkbox und der Zeile „die übrigen v4-Views und `/agora-2026` existieren weiterhin parallel" widersprochen. Jetzt: Vue-v4 ist das einzige produktive Frontend, die Routen-Konsolidierung läuft weiter unter #760.
2. Die Beleggrenze zur Funktionsvollständigkeit wurde ergänzt, damit keine Aussage stärker ist als die Quelle sie trägt.

## Kein Produktivcode betroffen

Reines Doku-Ticket. `git diff --name-only` gegen `main` zeigt exakt zwei Dateien: `ROADMAP.md` und `docs/STATUS.md`. Insbesondere unverändert: `docs/epics/frontend-next/*` (Akzeptanzkriterium von #837), Produktivcode, Deploy-Konfiguration, das Lovable-Projekt selbst.

`README.md` wurde geprüft (`grep -i "react|lovable"` → keine Treffer) und deshalb nicht angefasst.

## Verhältnis zu #910

**#910 Punkt 3 bleibt erforderlich.** Er betrifft die irreführende Stand-Zeile `docs/epics/frontend-next/brief.md:3` („noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet"). Dieser PR fasst `brief.md` nicht an, weil #837 Änderungen unter `docs/epics/frontend-next/` ausdrücklich ausschließt. Die Zeile bleibt damit unverändert widerlegt im Repo stehen und ist weiter in #910 zu bereinigen — nicht ersatzlos streichen.

#910 Punkte 1 und 2 sind von diesem PR unberührt.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `bash scripts/sync-status.sh --check` | `OK: docs/STATUS.md in sync`, Exit 0 |
| `git diff --check` | sauber |
| `git diff --name-only` | nur `ROADMAP.md`, `docs/STATUS.md` |
| Konsistenz ROADMAP ↔ STATUS | kein Widerspruch |
| Konsistenz gegen `2026-STATUS.md` | kein Widerspruch |

Kein Frontend-/Backend-Gate ausgeführt — für zwei Markdown-Dateien ist kein solcher Scope einschlägig; `sync-status.sh --check` ist die einzige greifende Prüfung.

## Subagents und Modelle

| Rolle | Agent | Reales Modell |
|---|---|---|
| Evidence-Audit (read-only) | `Explore` | Haiku |
| Doku-Änderung | `agora-doc-worker` | Sonnet |
| Evidence-Review (read-only) | `agora-evidence-auditor` | Haiku |
| Entscheidungen, Präzisierung, Commit, Verifikation | Lead | Opus |

Anmerkung: Der Doku-Worker konnte wegen erzwungener Worktree-Isolation nicht im vorgegebenen Pfad committen. Der Lead hat den Diff daraufhin selbst geprüft, die zwei oben genannten Präzisierungen vorgenommen und den Commit selbst erstellt.

Der unabhängige Evidence-Reviewer hat jede Tatsachenbehauptung gegen `2026-STATUS.md` geprüft und mit **APPROVE** ohne Blocker abgeschlossen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Roadmap- und Statusdokumentation zum Frontend-Next-Stand präzisiert.
  * Festgehalten, dass Vue weiterhin das einzige ausgelieferte Frontend ist.
  * Der vorhandene React-/Lovable-Prototyp wird als unveröffentlicht und nicht produktiv eingebunden dokumentiert.
  * Der Prototyp ist vor Version 1.0.0 nicht Bestandteil des freigegebenen Produktpfads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->