### PR TITLE
docs(0.9): Vue-v4-Konsolidierung abschließen und #760 verifizieren

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Agora Roadmap
 
-**Stand:** 22.07.2026  
+**Stand:** 27.07.2026  
 **Aktuelle Produktversion:** `0.8.0` Technical Preview
 
 Diese Datei beschreibt ausschließlich die strategische Reihenfolge der nächsten Releases. Konkrete Arbeitspakete, Akzeptanzkriterien und Fortschritt werden als GitHub Issues gepflegt.
@@ -48,7 +48,7 @@ Der aktuelle Stand besitzt eine vollständige fachliche Grundpipeline:
 - Evidence-orientierte Reports
 - Compare-, Export- und Observability-Grundlagen
 
-Der Stand ist trotzdem keine stabile `1.0`, weil Legacy- und v4-Oberflächen parallel existieren und die E2E-Pipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird.
+Der Stand ist trotzdem keine stabile `1.0`, weil die Vue-v4-Konsolidierung noch nicht abgeschlossen ist (verbleibend: `/home`-Redirect [#915](https://github.com/arn0ld87/agora/issues/915), Migration der v3-Inhaltskomponenten [#922](https://github.com/arn0ld87/agora/issues/922)) und die E2E-Pipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird.
 
 ## Erreicht
 
@@ -75,7 +75,7 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 
 - [ ] Vue-v4 ist die einzige produktive Oberfläche
 - [ ] klassische Prozess-Views besitzen Lösch- oder Redirect-Entscheidungen
-- [ ] `/agora-2026` ist kein produktiv gerouteter Parallelentwurf
+- [x] `/agora-2026` ist kein produktiv gerouteter Parallelentwurf — als Designreferenz unter `docs/design-reference/agora-2026/` archiviert ([PR #878](https://github.com/arn0ld87/agora/pull/878)), Regressionstest pinnt `/agora-2026` → NotFound
 - [x] kein produktiv verdrahteter React-/Lovable-Rewrite — ein Lovable-Prototyp existiert, liegt aber außerhalb dieses Repos, ist unveröffentlicht und in keinem Auslieferungspfad referenziert, siehe [`docs/epics/frontend-next/2026-STATUS.md`](docs/epics/frontend-next/2026-STATUS.md)
 - [ ] Responsive- und Accessibility-Gates sind grün
 
@@ -97,7 +97,7 @@ Agora soll als zusammenhängendes Produkt zuverlässig installierbar, bedienbar 
 
 ### Dokumentation
 
-- [x] README, STATUS, ROADMAP und Issues widersprechen sich nicht (Stand 22.07.2026 — laufend bei jeder größeren Änderung neu zu verifizieren)
+- [x] README, STATUS, ROADMAP und Issues widersprechen sich nicht (Stand 27.07.2026 — laufend bei jeder größeren Änderung neu zu verifizieren)
 - [ ] `docs/STATUS.md` wird automatisch erzeugt oder CI-geprüft — `scripts/sync-status.sh` regeneriert nur die markierten Versions-/Test-Blöcke, nicht die Fließtext-Abschnitte; die STATUS-Sync-Prüfung läuft ausschließlich lokal über `pre-push-gate.sh schemas`. Der CI-Job dafür wurde am 17.05.2026 entfernt (`.github/workflows/ci.yml`, Kommentar „2026-05-17 entfernt: status-sync (MAI-16)"), `docs/STATUS.md` bleibt laut diesem Kommentar bewusst manuell pflegbar
 - [ ] historische Pläne liegen ausschließlich im Archiv
 - [ ] Installations- und Betriebsanleitung sind gegen einen frischen Host geprüft

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Agora — Status
 
-**Stand:** 22.07.2026  
-**Geprüfte Main-Baseline:** `37320dbf`  
+**Stand:** 27.07.2026  
+**Geprüfte Main-Baseline:** `d5bdbada`  
 **Produktversion:** `0.8.0` Technical Preview
 
 Diese Datei beschreibt ausschließlich den verifizierten Istzustand. Strategische Release-Ziele stehen in [`ROADMAP.md`](../ROADMAP.md), konkrete Arbeitspakete in [GitHub Issues](https://github.com/arn0ld87/agora/issues), ausgelieferte Änderungen in [`CHANGELOG.md`](../CHANGELOG.md).
@@ -51,7 +51,7 @@ Agora besitzt eine vollständige fachliche Grundpipeline:
 - Compare-, Graph-Diff- und Observability-Grundlagen
 - fortsetzbare Embedding-Migration für Entity- und Fact-Vektoren
 
-Der Stand ist dennoch Technical Preview, weil die E2E-Kernpipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird und Altpfade im Frontend (klassische Prozess-Views, v4-Views, `/agora-2026`) weiter konsolidiert werden.
+Der Stand ist dennoch Technical Preview, weil die E2E-Kernpipeline noch nicht als verpflichtender Pull-Request-Check erzwungen wird und die verbleibenden Frontend-Altpfade weiter konsolidiert werden: `/home`-Redirect auf `/dashboard` ([#915](https://github.com/arn0ld87/agora/issues/915)) und Migration der v3-Inhaltskomponenten in v4-Wrapper ([#922](https://github.com/arn0ld87/agora/issues/922)).
 
 ## E2E-Smokes
 
@@ -110,7 +110,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 
 ## Bekannte Konsolidierungsschuld
 
-- die fünf klassischen Prozess-Wrapper-Views sind entfernt; ihre benannten Deep-Links bleiben als v4-Redirects kompatibel. Die übrigen v4-Views und `/agora-2026` existieren weiterhin parallel
+- die fünf klassischen Prozess-Wrapper-Views sind entfernt; ihre benannten Deep-Links bleiben als v4-Redirects kompatibel. `/agora-2026` ist als Designreferenz unter `docs/design-reference/agora-2026/` archiviert und nicht produktiv geroutet; v4-Ballast-Views sind entfernt ([PR #877](https://github.com/arn0ld87/agora/pull/877)). Verbleibend: `/home`-Redirect auf `/dashboard` ([#915](https://github.com/arn0ld87/agora/issues/915)) und Migration der v3-Inhaltskomponenten `Step2EnvSetup.vue`/`Step3Simulation.vue`/`Step4Report.vue` in v4-Wrapper ([#922](https://github.com/arn0ld87/agora/issues/922))
 - ein React-/Lovable-Neubau ist als Prototyp umgesetzt, aber nicht als Zielentscheidung freigegeben (Details im nächsten Abschnitt)
 - Legacy-LLM-Profile und Provider-Connections besitzen noch Übergangspfade
 - der credential-basierte Runtime-Provider-Override (`useRuntimeLlmOptions`, `@deprecated` Slice 5.5) ist mit der connection-gebundenen `AiModelRef` unvereinbar und in Step 2 daher gegenseitig ausgeschlossen. Solange er existiert, hält `useEnvForm` weiterhin `modelOption`/`customModel` — allerdings ohne Persistenz. Die Ablösung wird in [Issue #903](https://github.com/arn0ld87/agora/issues/903) geführt
@@ -120,7 +120,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 
 ## Frontend-Next-Stand (React/Lovable)
 
-- **Produktiv:** Vue ist die einzige ausgelieferte Frontend-Technologie. Nicht jede produktive Oberfläche ist bereits v4: `/home` lädt weiterhin die klassische Editorial-View `frontend/src/views/Home.vue`, obwohl ADR-0010 dort einen Redirect auf `/dashboard` vorsieht ([Issue #915](https://github.com/arn0ld87/agora/issues/915)). Die Konsolidierung auf genau eine v4-Route je fachlicher Hauptfunktion läuft weiterhin unter [Issue #760](https://github.com/arn0ld87/agora/issues/760) und ist nicht abgeschlossen.
+- **Produktiv:** Vue ist die einzige ausgelieferte Frontend-Technologie. Nicht jede produktive Oberfläche ist bereits v4: `/home` lädt weiterhin die klassische Editorial-View `frontend/src/views/Home.vue`, obwohl ADR-0010 dort einen Redirect auf `/dashboard` vorsieht ([Issue #915](https://github.com/arn0ld87/agora/issues/915)). Die Konsolidierung auf genau eine v4-Route je fachlicher Hauptfunktion läuft weiterhin unter [Issue #760](https://github.com/arn0ld87/agora/issues/760) und ist nicht abgeschlossen. Zudem werden die v3-Inhaltskomponenten `Step2EnvSetup.vue`/`Step3Simulation.vue`/`Step4Report.vue` noch produktiv über v4-Wrapper geroutet ([Issue #922](https://github.com/arn0ld87/agora/issues/922)).
 - **Prototyp:** Ein Lovable-Projekt („Agora Runs Dashboard", angelegt 2026-07-16) existiert und wurde substanziell umgesetzt (23 Edits, TanStack-Router-SPA, 12 Routen, shadcn/ui). Es ist derzeit **nicht veröffentlicht** (`is_published: false`, keine URL) und **nicht** produktiv verdrahtet — weder Docker-Compose, GitHub-Workflows noch das Root-`package.json` referenzieren es. Der React-Code liegt vollständig außerhalb dieses Repositories. Die tatsächliche Funktionsvollständigkeit des Prototyps ist nicht codegeprüft belegt, sondern nur durch Commit-Aussagen behauptet.
 - **Release-Status:** Kein Teil des freigegebenen Produktpfads vor `1.0.0`.
 - **Zukunft:** Über eine spätere Migration ist keine Entscheidung getroffen.


### PR DESCRIPTION
## Kontext

Abschluss-Slice der Vue-v4-Konsolidierung (Issue #839). #760 wurde vollständig gegen den echten Code auf `origin/main` (`d5bdbada`) verifiziert. **Ergebnis: FAIL** — #760 und #839 bleiben OPEN.

## Verifikations-Matrix (#760-Akzeptanzkriterien)

| Kriterium | Ergebnis | Befund |
|---|---|---|
| C1 — Klassische Prozess-Views besitzen Lösch-/Redirect-Entscheidungen | **FAIL** | `/home` lädt produktiv weiterhin `Home.vue`; ADR-0010 fordert Redirect auf `/dashboard`, aber nicht umgesetzt. Blockiert durch #915. |
| C2 — `/agora-2026` kein produktiv gerouteter Parallelentwurf | **PASS** | Als Designreferenz unter `docs/design-reference/agora-2026/` archiviert (PR #878); Regressionstest pinnt `/agora-2026` → NotFound. |
| C3 — Responsive- und Accessibility-Gates grün | **PARTIAL** | Gates laufen stabil grün, aber C1/C4 blockieren die Gesamtaussage „einzige produktive Oberfläche“. |
| C4 — Vue-v4 ist die einzige produktive Oberfläche | **PARTIAL** | v3-Inhaltskomponenten `Step2EnvSetup.vue`/`Step3Simulation.vue`/`Step4Report.vue` werden produktiv über v4-Wrapper geroutet. Neue Lücke → #922. |
| C5 — Kein produktiv verdrahteter React-/Lovable-Rewrite | **PASS** | Lovable-Prototyp liegt außerhalb des Repos, unveröffentlicht, in keinem Auslieferungspfad referenziert. |
| C6 — Legacy-Profile greifen nicht bevorzugt auf eigene Secrets/Routing zu | **PASS** | Provider-/Routing-SSoT abgeschlossen (#761). |

## Änderungen in diesem PR

Doc-only. Kein Code, keine Contracts, keine Tests.

- **`docs/STATUS.md`** — Stand 27.07.2026, Baseline `d5bdbada`; verbleibende Konsolidierungsschuld (#915, #922) ehrlich benannt; `#922`-Referenz aufgenommen.
- **`ROADMAP.md`** — Stand 27.07.2026; „Legacy- und v4-Oberflächen parallel existieren" → „Vue-v4-Konsolidierung noch nicht abgeschlossen (verbleibend: #915, #922)"; `/agora-2026`-Checkbox `[x]` (C2 PASS, PR #878).

Keine 0.9.0-Freigabekriterien angehakt, die nicht verifiziert erfüllt sind (#76, #77, #80 bleiben bewusst unchecked).

## Folge-Issue

#922 (`refactor(0.9): v3-Inhaltskomponenten (Step2/3/4) aus v4-Wrappern migrieren — Restschuld aus #760`) angelegt.

## Bekannte Drift (nicht in diesem PR-Scope)

ADR-0010 (`docs/decisions/0010-vue-v4-route-consolidation.md`) steht auf **Proposed**, obwohl #830 (ursprünglicher ADR-Issue) CLOSED ist. Status-Korrektur ist eigener Folge-Slice, nicht Teil von #839.

## Gates

- `bun run test`: exit 0 (1587/1587 Tests, 173 Files)
- `bun run check`: exit 0 (Build ok, nur node_modules PURE-Annotation-Warnungen)
- `bash scripts/pre-push-gate.sh frontend`: **ALL GREEN — safe to push 🚀**

## Schlussfolgerung

#760 und #839 werden **nicht** durch diesen PR geschlossen. Beide bleiben OPEN bis #915 (/home-Redirect) und #922 (v3-Inhaltskomponenten-Migration) geschlossen sind. Dieser PR dokumentiert nur den verifizierten Iststand und macht die verbleibende Schuld sichtbar.

Refs #839
Refs #760
Refs #829
Refs #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Roadmap und Statusdokumentation auf den Stand vom 27.07.2026 aktualisiert.
  * Produktreife und verbleibende Frontend-Konsolidierungsarbeiten präzisiert.
  * `/agora-2026` als archivierte Designreferenz dokumentiert und aus dem produktiven Routing entfernt.
  * Verbleibende Übergänge, darunter `/home` zu `/dashboard`, nachvollziehbarer beschrieben.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->