### PR TITLE
fix(report): Report-Pipeline vertrauenswürdig machen — Entailment, Provenance, Final-Content-Contract

### DIFF
--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -53,13 +53,30 @@ class EvidenceSourceKind(str, Enum):
 
     Wird von den Cross-Stakeholder-/Inferred-Validators auf
     ``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).
-    Drift-Guard: Genau diese 4 Werte sind im Prompt-Block
-    ``backend/app/services/report_prompts.py`` referenziert (Anker 1).
+    Drift-Guard: Diese Werte sind im Prompt-Block
+    ``backend/app/services/report_prompts/sections.py`` referenziert (Anker 1).
+
+    Erweiterung (Report-Trust-Slice): ``agent_action`` und ``web_source``
+    ergänzen die ursprünglichen vier Werte. Das ist additiv und verschärft
+    ADR-0002, statt es zu schwächen — vorher liefen Agentenaktionen und
+    Web-Treffer über den Default ``seed_corpus`` und verschmolzen damit
+    Seed-Dokument, Simulation und Recherche zu einer einzigen Quellengattung.
+    Für die Confidence-Anker gilt weiterhin: nur ``agent_quote`` zählt als
+    Stakeholder-Stimme, nur ``seed_corpus`` als Dokumentfakt.
     """
     seed_corpus = "seed_corpus"
     agent_quote = "agent_quote"
+    agent_action = "agent_action"
     graph_relation = "graph_relation"
+    web_source = "web_source"
     inferred = "inferred"
+
+
+#: Quellengattungen, die aus der Simulation stammen — nie ein Seed-Fakt.
+SIMULATION_SOURCE_KINDS: frozenset[EvidenceSourceKind] = frozenset({
+    EvidenceSourceKind.agent_quote,
+    EvidenceSourceKind.agent_action,
+})
 
 
 # Diese Typen sind im audit_trail erlaubt, nicht im evidence-Array
@@ -109,9 +126,13 @@ class EvidenceItemModel(BaseModel):
         le=1.0,
         description="Sentiment des Quellen-Snippets (-1 negativ, 0 neutral, +1 positiv).",
     )
-    # ADR-0002 Anker 3 (Sub-Slice M11.7b): Default seed_corpus sichert die
-    # Backward-Compat fuer alte Fixtures, die das Feld nicht mitschicken.
-    source_kind: EvidenceSourceKind = EvidenceSourceKind.seed_corpus
+    # ADR-0002 Anker 3 (Sub-Slice M11.7b): Der Default war seed_corpus und hat
+    # damit jedes Item ohne explizite Angabe zum Dokumentfakt erklärt —
+    # inklusive Agentenaktionen und Web-Treffern. Der Default ist jetzt
+    # `inferred`: unbekannte Herkunft ist abgeleitet, nicht belegt. Alte
+    # Fixtures ohne das Feld laden weiterhin, verlieren aber ihren
+    # unverdienten Seed-Status (reject_inferred_in_high_confidence greift).
+    source_kind: EvidenceSourceKind = EvidenceSourceKind.inferred
     # Slice 8 (User-Bericht 2026-05-16): welches LLM-Modell hat dieses
     # Evidence-Item extrahiert. None = nicht erfasst (Backward-Compat für
     # bestehende evidence.json). Format "<provider>/<model_id>", z. B.
@@ -337,6 +358,15 @@ class ReportSectionModel(BaseModel):
         default_factory=list, max_length=50
     )
     data_gaps: list[ReportSectionDataGapModel] = Field(default_factory=list)
+    # P0-6: Von `generate_section_metadata` extrahierte ReportV3-Strukturdaten
+    # (Personas, Segmente, Reibungspunkte …). Sie landeten bisher nur im
+    # Report-Logger, weshalb ReportV3 leer blieb, während der Prosa-Report die
+    # Inhalte zeigte. Hier persistiert, damit `build_report_v3` sie übernimmt.
+    # Bewusst untypisiert: die Einzel-DTOs werden in `metadata_merge` validiert,
+    # ein einzelner ungültiger Eintrag darf die Section-Persistenz nicht kippen.
+    structured_metadata: dict[str, Any] = Field(default_factory=dict)
+    # P0-7: True, wenn der Abschnitt nur Fallback-/Fehlertext enthält.
+    generation_failed: bool = False
 
 
 class ReportOutlineSectionModel(BaseModel):

--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -79,6 +79,19 @@ SIMULATION_SOURCE_KINDS: frozenset[EvidenceSourceKind] = frozenset({
 })
 
 
+class EntailmentVerdict(str, Enum):
+    """Urteil der zweiten Binding-Stufe.
+
+    Spiegelt ``app.services.evidence_entailment.EntailmentVerdict``. Nur
+    ``SUPPORTED`` rechtfertigt ``supports_claim=True``; ``RELATED_ONLY`` und
+    ``INSUFFICIENT`` erhöhen die Confidence nie.
+    """
+    SUPPORTED = "SUPPORTED"
+    CONTRADICTED = "CONTRADICTED"
+    RELATED_ONLY = "RELATED_ONLY"
+    INSUFFICIENT = "INSUFFICIENT"
+
+
 # Diese Typen sind im audit_trail erlaubt, nicht im evidence-Array
 FORBIDDEN_EVIDENCE_TYPES = {"model_generated_inference", "section_synthesis"}
 
@@ -116,7 +129,18 @@ class EvidenceItemModel(BaseModel):
     #   "kg:entity:9b2f-...."
     source_id_anchor: Optional[str] = Field(default=None, min_length=1, max_length=200)
     match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    # Stufe 1 des Bindings: Cosine-Similarity. Beantwortet "gleiches Thema?",
+    # nicht "belegt?". Alias von match_score, bewusst eigenes Feld, damit der
+    # Retrieval-Wert nicht länger als Beleggrad gelesen wird.
+    retrieval_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    # Stufe 2: Urteil aus evidence_entailment. supports_claim ist genau dann
+    # True, wenn entailment == "SUPPORTED".
+    entailment: Optional[EntailmentVerdict] = None
+    entailment_reason: Optional[str] = Field(default=None, max_length=500)
     supports_claim: Optional[bool] = None
+    # True bei entailment == "CONTRADICTED". Wird von
+    # detect_contradiction_penalty als Widerspruchs-Signal ausgewertet.
+    contradicts_claim: Optional[bool] = None
     # MAI-14: Sentiment des Quellen-Snippets (-1 = negativ, 0 = neutral, +1 = positiv).
     # None = nicht bestimmt. Wird von confidence_calculator._has_contradiction
     # genutzt, um widersprüchliche Sentiment-Vektoren zu erkennen.
@@ -392,11 +416,21 @@ class ReportOutlineModel(BaseModel):
 
     @model_validator(mode="after")
     def require_default_sections(self) -> "ReportOutlineModel":
-        from app.services.report_agent.contract_validator import validate_required_sections
+        from app.services.report_agent.contract_validator import (
+            matches_known_preset,
+            validate_required_sections,
+        )
         from app.services.report_prompts import DEFAULT_REPORT_SECTIONS
 
-        required_titles = [title for title, _ in DEFAULT_REPORT_SECTIONS]
         outline_titles = [section.title for section in self.sections]
+        # Intent-Presets (opinion, risk, comparison, explorative) haben bewusst
+        # nicht die elf Full-Report-Pflichtabschnitte. Eine Outline, die genau
+        # einem bekannten Preset entspricht, ist gültig; alles andere muss den
+        # vollständigen Pflichtsatz tragen.
+        if matches_known_preset(outline_titles):
+            return self
+
+        required_titles = [title for title, _ in DEFAULT_REPORT_SECTIONS]
         missing = validate_required_sections(outline_titles, required_titles)
         if missing:
             raise ValueError(

--- a/backend/app/services/confidence_calculator.py
+++ b/backend/app/services/confidence_calculator.py
@@ -144,12 +144,41 @@ def _component_consistency(evidence: List[Dict]) -> float:
     return 0.0
 
 
+def partition_by_entailment(evidence: List[Dict]) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+    """Teilt Evidence in (stützend, widersprechend, nur verwandt).
+
+    Items ohne ``entailment``-Feld stammen aus der Zeit vor der zweiten
+    Binding-Stufe und gelten weiterhin als stützend — sonst würden alte
+    Reports beim Neuberechnen ihre gesamte Confidence verlieren.
+    """
+    supporting: List[Dict] = []
+    contradicting: List[Dict] = []
+    related: List[Dict] = []
+    for item in evidence:
+        verdict = str(item.get("entailment") or "").upper()
+        if verdict == "CONTRADICTED" or item.get("contradicts_claim") is True:
+            contradicting.append(item)
+        elif verdict in {"RELATED_ONLY", "INSUFFICIENT"}:
+            related.append(item)
+        elif verdict == "SUPPORTED" or item.get("supports_claim") is not False:
+            supporting.append(item)
+        else:
+            related.append(item)
+    return supporting, contradicting, related
+
+
 def compute_confidence(
     evidence: List[Dict],
     *,
     contradiction_penalty: float = 0.0,
 ) -> Tuple[float, str]:
     """Liefert (score, label) für eine Evidence-Liste.
+
+    Nur tatsächlich stützende Evidence geht in den Score ein. Thematisch
+    verwandte Treffer (``RELATED_ONLY``/``INSUFFICIENT``) erhöhen die
+    Confidence nicht — vorher floss ihr Retrieval-``match_score`` mit 40 %
+    Gewicht in die Relevanz und machte Ähnlichkeit zu Sicherheit.
+    Widersprechende Evidence senkt den Score zusätzlich.
 
     MAI-14: Wenn sentiment_score-Felder in den Evidence-Items vorhanden sind
     und _has_contradiction() anschlägt, wird automatisch ein Sentiment-
@@ -158,6 +187,15 @@ def compute_confidence(
     """
     if not evidence:
         return 0.15, "speculative"
+
+    supporting, contradicting, _related = partition_by_entailment(evidence)
+    if not supporting:
+        # Kein einziger Beleg — thematische Nähe allein trägt keinen Claim.
+        return 0.15, "speculative"
+    if contradicting:
+        contradiction_penalty += _CONTRADICTION_PENALTY_AMOUNT * min(len(contradicting), 2)
+    evidence = supporting
+
     relevance = _component_relevance(evidence)
     source_quality = _component_source_quality(evidence)
     specificity = _component_specificity(evidence)
@@ -256,6 +294,68 @@ def compute_claim_confidence(
     return score, label, applied_penalties
 
 
+def compute_confidence_breakdown(evidence: List[Dict]) -> Dict[str, float]:
+    """Trennt Quellentreue von Simulationskonsens.
+
+    Ein korrekt wiedergegebener Seed-Fakt ist etwas anderes als eine über
+    mehrere Stakeholder-Gruppen hinweg konsistente Simulationsreaktion. Beides
+    in eine Zahl zu pressen war die Ursache dafür, dass praktisch jeder Claim
+    "medium" wurde.
+
+    ``source_fidelity``
+        Wie zuverlässig gibt der Claim wieder, was in den Quellen steht.
+        Hoch heißt: der Claim ist quellentreu — nicht, dass die Aussage für
+        die reale Bevölkerung gilt.
+    ``simulation_consensus``
+        Wie breit tragen unabhängige simulierte Stakeholder-Gruppen die
+        Aussage. Eine einzelne Persona bleibt hier niedrig.
+    """
+    supporting, contradicting, related = partition_by_entailment(evidence)
+    if not supporting:
+        return {
+            "source_fidelity": 0.0,
+            "simulation_consensus": 0.0,
+            "supporting_count": 0.0,
+            "contradicting_count": float(len(contradicting)),
+            "related_only_count": float(len(related)),
+        }
+
+    seed_items = [e for e in supporting if str(e.get("source_kind")) == "seed_corpus"]
+    quote_items = [e for e in supporting if str(e.get("source_kind")) == "agent_quote"]
+
+    # Quellentreue: getragen von Seed- und Graph-Belegen, gedämpft durch
+    # Widersprüche.
+    fidelity_base = len(seed_items) / max(1, len(supporting))
+    fidelity = min(1.0, 0.5 + 0.5 * fidelity_base)
+    if contradicting:
+        fidelity = max(0.0, fidelity - 0.25 * min(len(contradicting), 2))
+
+    # Simulationskonsens: Anzahl unterschiedlicher Stakeholder-Gruppen unter
+    # den stützenden Agentenzitaten.
+    groups = {
+        str(e.get("persona_stakeholder_group") or "").strip()
+        for e in quote_items
+        if str(e.get("persona_stakeholder_group") or "").strip()
+    }
+    if len(groups) >= 3:
+        consensus = 1.0
+    elif len(groups) == 2:
+        consensus = 0.75
+    elif len(groups) == 1:
+        consensus = 0.4
+    else:
+        consensus = 0.0
+
+    return {
+        "source_fidelity": round(fidelity, 3),
+        "simulation_consensus": round(consensus, 3),
+        "supporting_count": float(len(supporting)),
+        "contradicting_count": float(len(contradicting)),
+        "related_only_count": float(len(related)),
+        "stakeholder_group_count": float(len(groups)),
+    }
+
+
 _ECHO_CAP_THRESHOLD: float = 0.75
 _ECHO_CAP_MAX_SCORE: float = 0.84
 
@@ -289,6 +389,8 @@ def apply_echo_cap(
 __all__ = [
     "apply_echo_cap",
     "compute_confidence",
+    "compute_confidence_breakdown",
     "compute_claim_confidence",
+    "partition_by_entailment",
     "_has_contradiction",
 ]

--- a/backend/app/services/evidence_binder.py
+++ b/backend/app/services/evidence_binder.py
@@ -17,7 +17,10 @@ Fake einsetzen).
 from __future__ import annotations
 
 import math
-from typing import Any, Callable, Dict, List, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - nur für Typprüfung
+    from .evidence_entailment import EntailmentJudge
 
 EmbedFn = Callable[[str], Sequence[float]]
 
@@ -61,11 +64,24 @@ def bind_evidence_to_claim(
     *,
     threshold: float = 0.65,
     top_k: int = 5,
+    judge: "EntailmentJudge | None" = None,
 ) -> List[Dict[str, Any]]:
-    """Bind ranked evidence to a claim by embedding cosine similarity.
+    """Bindet Evidence an einen Claim — in zwei getrennten Stufen.
 
-    Returns deepcopy-freundliche neue Dicts mit zusätzlichem
-    ``match_score`` (round 3 decimals) und ``supports_claim`` bool.
+    Stufe 1 (Retrieval): Cosine-Similarity findet Kandidaten und schreibt
+    ``retrieval_score``. Sie beantwortet nur, ob beide Texte vom selben
+    Thema handeln.
+
+    Stufe 2 (Entailment): :func:`classify_evidence` entscheidet, ob die
+    Evidence den Claim trägt, und schreibt ``entailment``. Nur das Urteil
+    ``SUPPORTED`` setzt ``supports_claim=True``; ``CONTRADICTED`` setzt
+    zusätzlich ``contradicts_claim=True``.
+
+    ``match_score`` bleibt als Alias von ``retrieval_score`` erhalten, damit
+    bestehende Consumer (confidence_calculator, Contracts, Frontend) ohne
+    Migration weiterlaufen — es ist aber ausdrücklich ein Retrieval-Wert und
+    kein Beleggrad.
+
     Items unter dem Threshold fallen raus, der Rest wird nach Score
     absteigend sortiert und auf ``top_k`` gekürzt.
 
@@ -73,6 +89,8 @@ def bind_evidence_to_claim(
     Embedder-Errors werden hochgereicht; der Caller entscheidet ob er
     fallen lässt (ReportAgent fängt das in seinem Try-Block).
     """
+    from .evidence_entailment import EntailmentVerdict, classify_evidence  # noqa: PLC0415
+
     if not (claim_text or "").strip() or not candidates:
         return []
 
@@ -89,12 +107,21 @@ def bind_evidence_to_claim(
         score = _cosine(claim_vec, cand_vec)
         if score < threshold:
             continue
+
         bound = dict(item)
-        bound["match_score"] = round(float(score), 3)
-        bound["supports_claim"] = True
+        rounded = round(float(score), 3)
+        bound["retrieval_score"] = rounded
+        bound["match_score"] = rounded
+
+        result = classify_evidence(claim_text, item, judge=judge)
+        bound["entailment"] = result.verdict.value
+        bound["entailment_reason"] = result.reason
+        bound["supports_claim"] = result.verdict is EntailmentVerdict.SUPPORTED
+        if result.verdict is EntailmentVerdict.CONTRADICTED:
+            bound["contradicts_claim"] = True
         scored.append(bound)
 
-    scored.sort(key=lambda it: it["match_score"], reverse=True)
+    scored.sort(key=lambda it: it["retrieval_score"], reverse=True)
     return scored[:top_k]
 
 

--- a/backend/app/services/evidence_entailment.py
+++ b/backend/app/services/evidence_entailment.py
@@ -1,0 +1,486 @@
+"""Zweite Stufe des Evidence-Bindings: Beweist die Evidence den Claim?
+
+Der `evidence_binder` beantwortet mit Cosine-Similarity nur die Frage
+"handeln beide Texte vom selben Thema?". Das ist eine Retrieval-Frage,
+keine Beweisfrage. Dieses Modul beantwortet die zweite Frage und trennt
+damit ``retrieval_score`` sauber von ``supports_claim``.
+
+Vier Urteile:
+
+``SUPPORTED``
+    Die Evidence trägt den Claim. Nur hier darf ``supports_claim=True``
+    gesetzt werden und nur hier darf die Confidence steigen.
+``CONTRADICTED``
+    Die Evidence widerspricht dem Claim (falsche Zahl, gegenläufige
+    Richtung). Wird als Contradiction-Evidence behandelt.
+``RELATED_ONLY``
+    Gleiches Thema, aber kein Beleg. Erhöht die Confidence nie.
+``INSUFFICIENT``
+    Zu wenig Überschneidung für ein Urteil.
+
+Deterministische Checks haben Vorrang: sobald ein Claim eine Zahl, eine
+Bezugsgruppe oder eine Mengenaussage trägt, entscheidet die Regel — nicht
+das Embedding und nicht der optionale LLM-Judge. Ein LLM-Judge darf ein
+regelbasiertes SUPPORTED nur abschwächen, nie erzeugen.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+
+class EntailmentVerdict(str, Enum):
+    """Urteil der zweiten Binding-Stufe."""
+
+    SUPPORTED = "SUPPORTED"
+    CONTRADICTED = "CONTRADICTED"
+    RELATED_ONLY = "RELATED_ONLY"
+    INSUFFICIENT = "INSUFFICIENT"
+
+
+class FactModality(str, Enum):
+    """Ist die Zahl ein berichteter Ist-Wert oder eine Zielvorgabe?
+
+    "70 % der Lehrkräfte *sollen* geschult sein" ist eine Anforderung, kein
+    gemessener Zustimmungswert. Diese Unterscheidung verhindert genau die
+    Verfälschung aus dem Referenzlauf.
+    """
+
+    FACTUAL = "factual"
+    NORMATIVE = "normative"
+
+
+@dataclass(frozen=True)
+class NumericFact:
+    """Eine Zahl zusammen mit ihrer Bezugsgruppe und ihrer Aussage."""
+
+    value: float
+    unit: str
+    subject: str
+    predicate: str
+    modality: FactModality = FactModality.FACTUAL
+    raw: str = ""
+
+
+@dataclass
+class EntailmentResult:
+    verdict: EntailmentVerdict
+    reason: str
+    matched_fact: Optional[NumericFact] = None
+    claim_fact: Optional[NumericFact] = None
+    checks: List[str] = field(default_factory=list)
+
+    @property
+    def supports(self) -> bool:
+        return self.verdict is EntailmentVerdict.SUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# Numerische Faktenextraktion
+# ---------------------------------------------------------------------------
+
+_PERCENT_RE = re.compile(
+    r"(?P<value>\d{1,3}(?:[.,]\d+)?)\s*(?:%|Prozent)\s*"
+    r"(?:der|des|von\s+den|von|aller)?\s*",
+    re.IGNORECASE,
+)
+
+_ABSOLUTE_RE = re.compile(
+    r"(?P<value>\d{1,3}(?:\.\d{3})+|\d+(?:[.,]\d+)?)\s+"
+    r"(?P<noun>[A-ZÄÖÜ][\wÄÖÜäöüß-]+)",
+)
+
+# Kleingeschriebene Wörter, die eine Nominalphrase nicht beenden.
+_SUBJECT_CONNECTORS = {"und", "bzw", "sowie", "oder", "der", "die", "das", "den"}
+
+_NORMATIVE_MARKERS = (
+    "soll",
+    "sollen",
+    "sollte",
+    "sollten",
+    "muss",
+    "müssen",
+    "geplant",
+    "vorgesehen",
+    "angestrebt",
+    "ziel ist",
+    "verpflichtend",
+    "should",
+    "must",
+    "planned",
+    "required",
+)
+
+_MAJORITY_MARKERS = (
+    "mehrheitlich",
+    "die mehrheit",
+    "mehrheit der",
+    "überwiegend",
+    "die meisten",
+    "großteil",
+    "grossteil",
+    "majority",
+    "most of",
+)
+
+_MINORITY_MARKERS = (
+    "eine minderheit",
+    "wenige",
+    "ein kleiner teil",
+    "minority",
+)
+
+_STOPWORDS = {
+    "der", "die", "das", "den", "dem", "des", "ein", "eine", "einer", "eines",
+    "einem", "einen", "und", "oder", "aber", "bei", "von", "vom", "zu", "zum",
+    "zur", "mit", "für", "auf", "in", "im", "an", "am", "als", "auch", "ist",
+    "sind", "war", "waren", "wird", "werden", "hat", "haben", "sich", "nicht",
+    "mindestens", "etwa", "rund", "ca", "prozent", "the", "of", "and", "a", "to",
+}
+
+
+def _tokens(text: str) -> List[str]:
+    return [t for t in re.split(r"\W+", (text or "").lower()) if t and t not in _STOPWORDS]
+
+
+def _content_tokens(text: str) -> set[str]:
+    return {t for t in _tokens(text) if len(t) > 3}
+
+
+def _parse_number(raw: str) -> Optional[float]:
+    cleaned = raw.strip()
+    if re.fullmatch(r"\d{1,3}(?:\.\d{3})+", cleaned):  # 1.234.567
+        cleaned = cleaned.replace(".", "")
+    else:
+        cleaned = cleaned.replace(",", ".")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _split_subject_predicate(tail: str) -> tuple[str, str]:
+    """Trennt die Bezugsgruppe vom Prädikat.
+
+    Deutsche Nomen sind großgeschrieben: die Nominalphrase läuft bis zum
+    ersten kleingeschriebenen Wort, das kein Bindewort ist.
+    """
+    words = tail.split()
+    subject_parts: List[str] = []
+    idx = 0
+    for idx, word in enumerate(words):
+        bare = word.strip(",.;:()").lower()
+        if word[:1].isupper() or bare in _SUBJECT_CONNECTORS:
+            # Ein Bindewort zählt nur mit, wenn danach wieder ein Nomen folgt.
+            if bare in _SUBJECT_CONNECTORS and not subject_parts:
+                continue
+            subject_parts.append(word)
+            continue
+        break
+    else:
+        idx = len(words)
+
+    # Trailing-Bindewörter gehören nicht zum Subjekt ("Eltern und" → "Eltern").
+    while subject_parts and subject_parts[-1].strip(",.;:()").lower() in _SUBJECT_CONNECTORS:
+        subject_parts.pop()
+        idx -= 1
+
+    subject = " ".join(subject_parts).strip(",.;:() ")
+    predicate = " ".join(words[idx:]).strip(",.;:() ")
+    return subject, predicate
+
+
+def _modality_of(predicate: str) -> FactModality:
+    lowered = f" {predicate.lower()} "
+    if any(f" {marker} " in lowered or lowered.startswith(f" {marker} ") for marker in _NORMATIVE_MARKERS):
+        return FactModality.NORMATIVE
+    return FactModality.FACTUAL
+
+
+def _sentences(text: str) -> List[str]:
+    parts = re.split(r"(?<=[.!?])\s+", (text or "").strip())
+    return [p for p in parts if p.strip()]
+
+
+def extract_numeric_facts(text: str) -> List[NumericFact]:
+    """Extrahiert Zahlen samt Bezugsgruppe, Aussage und Modalität.
+
+    Nur was sich einer Bezugsgruppe zuordnen lässt, wird zum ``NumericFact`` —
+    eine nackte Zahl ohne Subjekt ist für den Faktencheck wertlos.
+    """
+    facts: List[NumericFact] = []
+    for sentence in _sentences(text):
+        for match in _PERCENT_RE.finditer(sentence):
+            value = _parse_number(match.group("value"))
+            if value is None:
+                continue
+            subject, predicate = _split_subject_predicate(sentence[match.end():])
+            if not subject:
+                continue
+            facts.append(
+                NumericFact(
+                    value=value,
+                    unit="percent",
+                    subject=subject,
+                    predicate=predicate,
+                    modality=_modality_of(predicate),
+                    raw=sentence.strip(),
+                )
+            )
+        if not any(f.raw == sentence.strip() for f in facts):
+            for match in _ABSOLUTE_RE.finditer(sentence):
+                value = _parse_number(match.group("value"))
+                if value is None:
+                    continue
+                subject, predicate = _split_subject_predicate(sentence[match.start("noun"):])
+                if not subject:
+                    continue
+                facts.append(
+                    NumericFact(
+                        value=value,
+                        unit="absolute",
+                        subject=subject,
+                        predicate=predicate,
+                        modality=_modality_of(predicate),
+                        raw=sentence.strip(),
+                    )
+                )
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Vergleichs-Primitive
+# ---------------------------------------------------------------------------
+
+
+def _overlap_ratio(left: str, right: str) -> float:
+    """Containment-Overlap: Anteil der kleineren Tokenmenge in der größeren."""
+    a, b = _content_tokens(left), _content_tokens(right)
+    if not a or not b:
+        return 0.0
+    return len(a & b) / min(len(a), len(b))
+
+
+def subjects_match(left: str, right: str) -> bool:
+    """Bezugsgruppen-Vergleich mit leichter Stamm-Normalisierung.
+
+    "Lehrkräfte" und "Lehrkraft" sind dieselbe Gruppe, "Lehrkräfte" und
+    "Eltern" nicht.
+    """
+    def stems(value: str) -> set[str]:
+        return {t[:6] for t in _tokens(value) if len(t) > 3}
+
+    a, b = stems(left), stems(right)
+    if not a or not b:
+        return False
+    return bool(a & b)
+
+
+def _quantifier_direction(text: str) -> Optional[str]:
+    lowered = (text or "").lower()
+    if any(marker in lowered for marker in _MAJORITY_MARKERS):
+        return "majority"
+    if any(marker in lowered for marker in _MINORITY_MARKERS):
+        return "minority"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hauptklassifikation
+# ---------------------------------------------------------------------------
+
+#: Ab diesem Containment-Overlap gilt eine Aussage als dieselbe Aussage.
+PREDICATE_MATCH_THRESHOLD = 0.5
+#: Darunter besteht nicht einmal thematische Nähe.
+TOPIC_MATCH_THRESHOLD = 0.2
+
+EntailmentJudge = Callable[[str, str], str]
+"""Optionaler strukturierter Judge: (claim, evidence_text) -> Verdict-Name."""
+
+
+def _evidence_text(item: Dict[str, Any]) -> str:
+    parts = [str(item.get("snippet") or ""), str(item.get("quote") or ""), str(item.get("value") or "")]
+    raw = item.get("raw")
+    if isinstance(raw, dict):
+        for key in ("content", "text", "snippet", "summary"):
+            val = raw.get(key)
+            if isinstance(val, str) and val:
+                parts.append(val)
+    elif isinstance(raw, str):
+        parts.append(raw)
+    return " ".join(p for p in parts if p).strip()
+
+
+def classify_evidence(
+    claim_text: str,
+    evidence_item: Dict[str, Any],
+    *,
+    judge: Optional[EntailmentJudge] = None,
+) -> EntailmentResult:
+    """Entscheidet, ob ``evidence_item`` den Claim tatsächlich stützt.
+
+    Reihenfolge ist bewusst: numerische und Mengen-Checks laufen zuerst und
+    sind bindend. Der ``judge`` wird nur befragt, wenn die Regeln kein Urteil
+    fällen konnten, und darf ein SUPPORTED nur verhindern, nie erzeugen.
+    """
+    claim = (claim_text or "").strip()
+    evidence_text = _evidence_text(evidence_item)
+    if not claim or not evidence_text:
+        return EntailmentResult(EntailmentVerdict.INSUFFICIENT, "leerer Claim oder Evidence-Text")
+
+    checks: List[str] = []
+    claim_facts = extract_numeric_facts(claim)
+    evidence_facts = extract_numeric_facts(evidence_text)
+    topic_overlap = _overlap_ratio(claim, evidence_text)
+
+    # --- Regel 1: Claim trägt eine Zahl ------------------------------------
+    if claim_facts:
+        checks.append("numeric_claim")
+        for claim_fact in claim_facts:
+            for ev_fact in evidence_facts:
+                same_value = abs(claim_fact.value - ev_fact.value) < 0.001
+                same_subject = subjects_match(claim_fact.subject, ev_fact.subject)
+                predicate_overlap = _overlap_ratio(claim_fact.predicate, ev_fact.predicate)
+
+                if same_value and same_subject:
+                    if ev_fact.modality is FactModality.NORMATIVE and (
+                        claim_fact.modality is FactModality.FACTUAL
+                    ):
+                        return EntailmentResult(
+                            EntailmentVerdict.CONTRADICTED,
+                            "Zielvorgabe wird als Ist-Wert wiedergegeben",
+                            matched_fact=ev_fact,
+                            claim_fact=claim_fact,
+                            checks=checks + ["modality_mismatch"],
+                        )
+                    if predicate_overlap >= PREDICATE_MATCH_THRESHOLD:
+                        return EntailmentResult(
+                            EntailmentVerdict.SUPPORTED,
+                            "Zahl, Bezugsgruppe und Aussage stimmen überein",
+                            matched_fact=ev_fact,
+                            claim_fact=claim_fact,
+                            checks=checks + ["value_subject_predicate_match"],
+                        )
+                    return EntailmentResult(
+                        EntailmentVerdict.CONTRADICTED,
+                        "Zahl und Bezugsgruppe passen, die Aussage dazu nicht",
+                        matched_fact=ev_fact,
+                        claim_fact=claim_fact,
+                        checks=checks + ["predicate_mismatch"],
+                    )
+
+                if same_value and not same_subject:
+                    return EntailmentResult(
+                        EntailmentVerdict.CONTRADICTED,
+                        "Zahl wird einer anderen Bezugsgruppe zugeschrieben",
+                        matched_fact=ev_fact,
+                        claim_fact=claim_fact,
+                        checks=checks + ["subject_mismatch"],
+                    )
+
+                if (
+                    same_subject
+                    and not same_value
+                    and predicate_overlap >= PREDICATE_MATCH_THRESHOLD
+                ):
+                    return EntailmentResult(
+                        EntailmentVerdict.CONTRADICTED,
+                        "gleiche Aussage über dieselbe Gruppe, abweichender Zahlenwert",
+                        matched_fact=ev_fact,
+                        claim_fact=claim_fact,
+                        checks=checks + ["value_mismatch"],
+                    )
+
+        return EntailmentResult(
+            EntailmentVerdict.INSUFFICIENT,
+            "numerischer Claim ohne passenden Zahlenbeleg",
+            claim_fact=claim_facts[0],
+            checks=checks + ["no_matching_number"],
+        )
+
+    # --- Regel 2: Claim behauptet eine Mehrheit/Minderheit ------------------
+    direction = _quantifier_direction(claim)
+    if direction and evidence_facts:
+        checks.append("quantifier_claim")
+        for ev_fact in evidence_facts:
+            if ev_fact.unit != "percent" or not subjects_match(claim, ev_fact.subject):
+                continue
+            is_majority = ev_fact.value > 50.0
+            if direction == "majority" and not is_majority:
+                return EntailmentResult(
+                    EntailmentVerdict.CONTRADICTED,
+                    f"Mehrheitsaussage steht gegen einen Anteil von {ev_fact.value:g} %",
+                    matched_fact=ev_fact,
+                    checks=checks + ["majority_vs_minority"],
+                )
+            if direction == "minority" and is_majority:
+                return EntailmentResult(
+                    EntailmentVerdict.CONTRADICTED,
+                    f"Minderheitsaussage steht gegen einen Anteil von {ev_fact.value:g} %",
+                    matched_fact=ev_fact,
+                    checks=checks + ["minority_vs_majority"],
+                )
+        return EntailmentResult(
+            EntailmentVerdict.RELATED_ONLY,
+            "Mengenaussage ohne quantitativen Beleg",
+            checks=checks + ["quantifier_unbacked"],
+        )
+
+    # --- Regel 3: rein qualitativer Claim ----------------------------------
+    if topic_overlap < TOPIC_MATCH_THRESHOLD:
+        return EntailmentResult(
+            EntailmentVerdict.INSUFFICIENT,
+            "zu geringe inhaltliche Überschneidung",
+            checks=checks + ["low_overlap"],
+        )
+
+    if judge is not None:
+        try:
+            raw_verdict = str(judge(claim, evidence_text)).strip().upper()
+            if raw_verdict in EntailmentVerdict.__members__:
+                verdict = EntailmentVerdict[raw_verdict]
+                return EntailmentResult(
+                    verdict, "strukturierter Judge", checks=checks + ["judge"]
+                )
+        except Exception:  # noqa: BLE001 — Judge ist optional; Regelpfad bleibt gültig
+            checks.append("judge_failed")
+
+    if topic_overlap >= PREDICATE_MATCH_THRESHOLD:
+        return EntailmentResult(
+            EntailmentVerdict.SUPPORTED,
+            "qualitative Aussage deckt sich weitgehend mit der Evidence",
+            checks=checks + ["high_lexical_overlap"],
+        )
+
+    return EntailmentResult(
+        EntailmentVerdict.RELATED_ONLY,
+        "thematisch verwandt, aber kein Beleg",
+        checks=checks + ["topic_only"],
+    )
+
+
+def classify_many(
+    claim_text: str,
+    evidence_items: Sequence[Dict[str, Any]],
+    *,
+    judge: Optional[EntailmentJudge] = None,
+) -> List[EntailmentResult]:
+    return [classify_evidence(claim_text, item, judge=judge) for item in evidence_items]
+
+
+__all__ = [
+    "EntailmentJudge",
+    "EntailmentResult",
+    "EntailmentVerdict",
+    "FactModality",
+    "NumericFact",
+    "PREDICATE_MATCH_THRESHOLD",
+    "TOPIC_MATCH_THRESHOLD",
+    "classify_evidence",
+    "classify_many",
+    "extract_numeric_facts",
+    "subjects_match",
+]

--- a/backend/app/services/evidence_entailment.py
+++ b/backend/app/services/evidence_entailment.py
@@ -83,8 +83,8 @@ class EntailmentResult:
 # ---------------------------------------------------------------------------
 
 _PERCENT_RE = re.compile(
-    r"(?P<value>\d{1,3}(?:[.,]\d+)?)\s*(?:%|Prozent)\s*"
-    r"(?:der|des|von\s+den|von|aller)?\s*",
+    r"(?P<value>\d{1,3}(?:[.,]\d+)?)\s*(?:%|Prozent|percent)\s*"
+    r"(?:der|des|von\s+den|von|aller|of)?\s*",
     re.IGNORECASE,
 )
 
@@ -162,11 +162,28 @@ def _parse_number(raw: str) -> Optional[float]:
         return None
 
 
+#: Englische Verben, die den Übergang von Bezugsgruppe zu Prädikat markieren.
+#: Ohne NLP-Tagger reicht eine kleine Liste häufiger Report-Verben — ein
+#: fehlendes Verb führt höchstens zu einem längeren Subjekt, nie zu einem
+#: Fehlurteil (die Zahl-Bezugsgruppe-Prüfung greift trotzdem).
+_EN_SUBJECT_VERBS = frozenset({
+    "rated", "reported", "stated", "said", "believed", "indicated",
+    "found", "noted", "mentioned", "claimed", "expressed", "gave",
+    "showed", "saw", "experienced", "felt", "think", "thought",
+    "consider", "considered", "view", "viewed", "judge", "judged",
+})
+
+
 def _split_subject_predicate(tail: str) -> tuple[str, str]:
     """Trennt die Bezugsgruppe vom Prädikat.
 
     Deutsche Nomen sind großgeschrieben: die Nominalphrase läuft bis zum
-    ersten kleingeschriebenen Wort, das kein Bindewort ist.
+    ersten kleingeschriebenen Wort, das kein Bindewort ist. Für englische
+    Seeds (keine Großschreibung-Pflicht) fällt diese Heuristik leer aus —
+    dann übernimmt ein Fallback, der die Bezugsgruppe bis zum ersten
+    bekannten Report-Verb nimmt. Without that, ``extract_numeric_facts``
+    liefert für englische Sätze keine Fakten und die Fließtext-Prüfung
+    überspringt sie still (Handover P2.7).
     """
     words = tail.split()
     subject_parts: List[str] = []
@@ -190,6 +207,21 @@ def _split_subject_predicate(tail: str) -> tuple[str, str]:
 
     subject = " ".join(subject_parts).strip(",.;:() ")
     predicate = " ".join(words[idx:]).strip(",.;:() ")
+
+    # Englischer Fallback: keine Großschreibung → deutscher Pfad leer.
+    if not subject and words:
+        subject_parts = []
+        end_idx = len(words)
+        for en_idx, word in enumerate(words):
+            bare = word.strip(",.;:()").lower()
+            if bare in _EN_SUBJECT_VERBS:
+                end_idx = en_idx
+                break
+            subject_parts.append(word)
+        if subject_parts:
+            subject = " ".join(subject_parts).strip(",.;:() ")
+            predicate = " ".join(words[end_idx:]).strip(",.;:() ")
+
     return subject, predicate
 
 

--- a/backend/app/services/evidence_entailment.py
+++ b/backend/app/services/evidence_entailment.py
@@ -525,9 +525,20 @@ def classify_evidence(
         try:
             raw_verdict = str(judge(claim, evidence_text)).strip().upper()
             if raw_verdict in EntailmentVerdict.__members__:
-                verdict = EntailmentVerdict[raw_verdict]
+                judge_verdict = EntailmentVerdict[raw_verdict]
+                # ADR-0002: Der LLM-Judge darf ein regelbasiertes SUPPORTED
+                # nur abschwächen, nie erzeugen. Im qualitativen Pfad (Regel 3)
+                # gibt es kein regelbasiertes SUPPORTED — also wäre ein
+                # Judge-SUPPORTED ein ungedeckter Claim, der durch das Tor
+                # geschlüpft wäre. Downgraden auf RELATED_ONLY.
+                if judge_verdict is EntailmentVerdict.SUPPORTED:
+                    return EntailmentResult(
+                        EntailmentVerdict.RELATED_ONLY,
+                        "Judge-Bestätigung darf SUPPORTED nicht erzeugen (ADR-0002)",
+                        checks=checks + ["judge_downgraded"],
+                    )
                 return EntailmentResult(
-                    verdict, "strukturierter Judge", checks=checks + ["judge"]
+                    judge_verdict, "strukturierter Judge", checks=checks + ["judge"]
                 )
         except Exception:  # noqa: BLE001 — Judge ist optional; Regelpfad bleibt gültig
             checks.append("judge_failed")

--- a/backend/app/services/evidence_entailment.py
+++ b/backend/app/services/evidence_entailment.py
@@ -264,6 +264,31 @@ def _overlap_ratio(left: str, right: str) -> float:
     return len(a & b) / min(len(a), len(b))
 
 
+def coverage_ratio(claim_text: str, evidence_text: str) -> float:
+    """Anteil der Claim-Aussage, der von der Evidence gedeckt ist.
+
+    Bewusst asymmetrisch — und das ist der Punkt. ``_overlap_ratio`` misst
+    Containment und liefert 1.0, sobald die Evidence *Teilmenge* des Claims
+    ist. Genau so rutschte im E2E-Lauf durch:
+
+        Seed:  "61 % der Lehrkräfte berichteten von Zeitersparnis …"
+        Claim: "61 % der Lehrkräfte bewerteten die Lernhilfe positiv
+                und berichteten von Zeitersparnis …"
+
+    Der Seed steckt vollständig im Claim, also Containment 1.0 — obwohl der
+    Claim eine zusätzliche, unbelegte Behauptung trägt. Die Deckungsrichtung
+    muss umgekehrt sein: Was der Claim behauptet, muss in der Evidence stehen.
+    Für obigen Fall ergibt das 0.56 statt 1.0.
+    """
+    claim_tokens = _content_tokens(claim_text)
+    evidence_tokens = _content_tokens(evidence_text)
+    if not claim_tokens:
+        return 0.0
+    if not evidence_tokens:
+        return 0.0
+    return len(claim_tokens & evidence_tokens) / len(claim_tokens)
+
+
 def subjects_match(left: str, right: str) -> bool:
     """Bezugsgruppen-Vergleich mit leichter Stamm-Normalisierung.
 
@@ -296,6 +321,17 @@ def _quantifier_direction(text: str) -> Optional[str]:
 PREDICATE_MATCH_THRESHOLD = 0.5
 #: Darunter besteht nicht einmal thematische Nähe.
 TOPIC_MATCH_THRESHOLD = 0.2
+#: Mindestanteil der Claim-Aussage, der von der Evidence gedeckt sein muss,
+#: damit ein numerischer Fakt als übernommen gilt. Höchstens ein Viertel der
+#: inhaltlichen Aussage darf über die Evidence hinausgehen.
+#:
+#: Am realen Fall kalibriert (E2E gegen sim_7058c126da03):
+#:   0.56 — "61 % … bewerteten die Lernhilfe positiv UND berichteten von
+#:           Zeitersparnis" gegen den Seed, der nur die Zeitersparnis belegt
+#:   1.00 — "72 % der Schülerinnen und Schüler bewerteten die Lernhilfe
+#:           positiv", wörtlich aus dem Seed
+#: Der Schwellwert trennt diese beiden Fälle mit Abstand nach beiden Seiten.
+PREDICATE_COVERAGE_THRESHOLD = 0.75
 
 EntailmentJudge = Callable[[str, str], str]
 """Optionaler strukturierter Judge: (claim, evidence_text) -> Verdict-Name."""
@@ -356,13 +392,29 @@ def classify_evidence(
                             claim_fact=claim_fact,
                             checks=checks + ["modality_mismatch"],
                         )
-                    if predicate_overlap >= PREDICATE_MATCH_THRESHOLD:
+                    # Die Evidence muss die Aussage des Claims decken. Ein
+                    # Claim, der die Zahl korrekt zitiert und ihr zusätzlich
+                    # eine unbelegte Aussage anhängt, ist nicht gestützt.
+                    coverage = coverage_ratio(claim_fact.predicate, ev_fact.predicate)
+                    if (
+                        predicate_overlap >= PREDICATE_MATCH_THRESHOLD
+                        and coverage >= PREDICATE_COVERAGE_THRESHOLD
+                    ):
                         return EntailmentResult(
                             EntailmentVerdict.SUPPORTED,
                             "Zahl, Bezugsgruppe und Aussage stimmen überein",
                             matched_fact=ev_fact,
                             claim_fact=claim_fact,
                             checks=checks + ["value_subject_predicate_match"],
+                        )
+                    if coverage < PREDICATE_COVERAGE_THRESHOLD:
+                        return EntailmentResult(
+                            EntailmentVerdict.CONTRADICTED,
+                            "Zahl und Bezugsgruppe passen, der Claim behauptet "
+                            f"aber mehr als die Quelle deckt (Deckung {coverage:.2f})",
+                            matched_fact=ev_fact,
+                            claim_fact=claim_fact,
+                            checks=checks + ["predicate_overreach"],
                         )
                     return EntailmentResult(
                         EntailmentVerdict.CONTRADICTED,

--- a/backend/app/services/llm_entailment_judge.py
+++ b/backend/app/services/llm_entailment_judge.py
@@ -1,0 +1,122 @@
+"""LLM-Judge für das Evidence-Entailment (ADR-0002).
+
+``classify_evidence(judge=...)`` in ``evidence_entailment.py`` befragt einen
+optionalen LLM-Judge im qualitativen Pfad — also nur dann, wenn die
+deterministischen Checks (Zahl, Bezugsgruppe, Mengenaussage) kein Urteil
+fällen konnten. Dieser Builder verdrahtet ``LLMClient.chat_json`` als
+Judge-Quelle, ohne einen neuen Provider-Pfad zu öffnen.
+
+ADR-0002-Anker (im Regelpfad von ``classify_evidence`` bereits erzwungen):
+Der Judge darf ein SUPPORTED nur **abschwächen**, nie erzeugen. ``chat_json``
+liefert strukturierte Verdicts; ``classify_evidence`` wandelt ein
+Judge-SUPPORTED in RELATED_ONLY um. Dieser Builder erzwingt das nicht erneut —
+die Verteidigungslinie liegt im Klassifikator, nicht im Judge.
+
+Bewusst optional und nicht in der Report-Pipeline voreingestellt: ein
+Judge-Call pro qualitativem Evidence-Item ist teuer. Die Verdrahtung ist ein
+Konfigurationsschritt, nicht Default (Issue #931-Kontext: Kosten-, Token- und
+Zeitbudgets stehen auf der 0.9→0.10-Roadmap).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..llm.client import LLMClient
+from .evidence_entailment import EntailmentJudge, EntailmentVerdict
+
+logger = logging.getLogger(__name__)
+
+
+class EntailmentJudgeVerdict(BaseModel):
+    """Strukturiertes Judge-Output-Schema für ``chat_json``."""
+
+    verdict: EntailmentVerdict = Field(
+        description=(
+            "SUPPORTED, CONTRADICTED, RELATED_ONLY oder INSUFFICIENT. "
+            "SUPPORTED wird vom Klassifikator auf RELATED_ONLY abgeschwächt "
+            "(ADR-0002: Judge darf SUPPORTED nie erzeugen)."
+        )
+    )
+    reason: str = Field(
+        default="",
+        description="Kurze Begründung des Urteils (ein Satz).",
+    )
+
+
+_JUDGE_SYSTEM_PROMPT = (
+    "Du bist ein strenger Entailment-Judge. Du erhältst einen Claim und einen "
+    "Evidence-Text. Entscheide, ob die Evidence den Claim *trägt* — nicht nur, "
+    "ob sie thematisch verwandt sind.\n\n"
+    "Urteile:\n"
+    "- SUPPORTED: Die Evidence belegt den Claim vollständig (Zahl, "
+    "Bezugsgruppe, Aussage).\n"
+    "- CONTRADICTED: Die Evidence widerspricht dem Claim (falsche Zahl, "
+    "gegenläufige Richtung, andere Bezugsgruppe).\n"
+    "- RELATED_ONLY: Gleiche Thema, aber kein Beleg.\n"
+    "- INSUFFICIENT: Zu wenig Überschneidung für ein Urteil.\n\n"
+    "Sei konservativ: wenn die Evidence eine Zusatzbehauptung trägt, die der "
+    "Claim nicht abdeckt, wähle RELATED_ONLY oder CONTRADICTED — nie SUPPORTED."
+)
+
+
+def build_llm_judge(
+    client: LLMClient,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> EntailmentJudge:
+    """Baut einen ``EntailmentJudge`` aus einem ``LLMClient``.
+
+    Der Judge ist ein Callable ``(claim, evidence_text) -> verdict_name``. Er
+    nutzt ``chat_json`` mit dem ``EntailmentJudgeVerdict``-Schema, damit der
+    Provider strukturiert antwortet und Pydantic den Verdict-Wert validiert.
+
+    Raises werden im Klassifikator gefangen (``judge_failed``-Check), der
+    Builder selbst liefert immer ein Callable — fehlerhafte Calls fallen
+    kontrolliert auf den Regelpfad zurück.
+    """
+
+    log = logger or logging.getLogger(__name__)
+
+    def judge(claim: str, evidence_text: str) -> str:
+        messages: List[Dict[str, str]] = [
+            {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    f"Claim: {claim}\n\n"
+                    f"Evidence: {evidence_text}\n\n"
+                    "Urteil (verdict) und kurze Begründung (reason)."
+                ),
+            },
+        ]
+        try:
+            result = client.chat_json(
+                messages=messages,
+                schema=EntailmentJudgeVerdict,
+                schema_name="entailment_judge_verdict",
+                context="report",
+                temperature=0.0,
+                max_tokens=256,
+            )
+        except Exception as exc:  # noqa: BLE001 — Judge-Fehler fallen auf Regelpfad
+            log.debug("Entailment-Judge: chat_json fehlgeschlagen (%r)", exc)
+            raise
+
+        # chat_json mit Pydantic-Schema liefert ein validiertes Dict. Je nach
+        # Serialization-Mode kann verdict ein EntailmentVerdict-Enum (python)
+        # oder ein String (json) sein. Beide Fälle abdecken.
+        verdict_raw = result.get("verdict") if isinstance(result, dict) else None
+        if verdict_raw is None:
+            raise ValueError(f"Judge-Antwort ohne 'verdict': {result!r}")
+        if isinstance(verdict_raw, EntailmentVerdict):
+            return verdict_raw.value
+        return str(verdict_raw)
+
+    return judge
+
+
+__all__ = ["EntailmentJudgeVerdict", "build_llm_judge"]

--- a/backend/app/services/llm_entailment_judge.py
+++ b/backend/app/services/llm_entailment_judge.py
@@ -103,7 +103,12 @@ def build_llm_judge(
                 max_tokens=256,
             )
         except Exception as exc:  # noqa: BLE001 — Judge-Fehler fallen auf Regelpfad
-            log.debug("Entailment-Judge: chat_json fehlgeschlagen (%r)", exc)
+            # Nur den Exception-Typ loggen: repr(exc) kann Provider-Response-
+            # oder Prompt-Fragmente in die Logs ziehen.
+            log.debug(
+                "Entailment-Judge: chat_json fehlgeschlagen (%s)",
+                type(exc).__name__,
+            )
             raise
 
         # chat_json mit Pydantic-Schema liefert ein validiertes Dict. Je nach

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -669,7 +669,10 @@ class ReportAgent:
             claims: List[Dict[str, Any]] = []
             raw_hypotheses: List[Dict[str, Any]] = []
             data_gaps: List[Dict[str, Any]] = [{
-                "gap_id": f"gap_section_{section_index:02d}",
+                # ReportSectionDataGapModel.gap_id erzwingt ^gap_\d{2,}$ —
+                # ein sprechendes Präfix ("gap_section_03") lässt die gesamte
+                # EvidenceMap-Validierung scheitern (E2E-Lauf, Runde 4).
+                "gap_id": f"gap_{section_index:02d}",
                 "gap_reason": "Abschnitt konnte nicht generiert werden (LLM-Fehler).",
                 "claim_text": section_title,
             }]

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -717,6 +717,11 @@ class ReportAgent:
         raw_hypotheses = list(raw_hypotheses) + (
             getattr(self, "_pending_prose_hypotheses", {}) or {}
         ).get(section_index, [])
+        # IDs zentral neu vergeben: Claim-Routing und Fließtext-Prüfung zählen
+        # jeweils ab 1, zusammengeführt kollidieren sie sonst.
+        for _position, _hypothesis in enumerate(raw_hypotheses, start=1):
+            if isinstance(_hypothesis, dict):
+                _hypothesis["hypothesis_id"] = f"hypothesis_{_position:02d}"
         # Slice 3 (Issue #495): Dedup + Cap per Section.
         from .hypothesis_cap import dedup_and_cap_hypotheses  # noqa: PLC0415
         hypotheses_visible, hypotheses_appendix = dedup_and_cap_hypotheses(raw_hypotheses)

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -520,13 +520,25 @@ class ReportAgent:
 
         for claim in normalize_claims_for_contract(claims):
             evidence = claim.get("evidence") or []
-            score = float(claim.get("confidence_score") or 0.0)
             label = str(claim.get("confidence_label") or "").lower()
 
             # Reviewer-Floor (report_4fe2dacd80ba, Sub-Slice S1):
             # Claim braucht ≥2 unabhängige Evidence-Items, sonst Routing zur Hypothesis.
             # evidence_count==0 fällt durch zum Bestands-Low-Confidence-Branch (mit data_gap).
-            evidence_count = len(evidence) or len(claim.get("evidence_refs") or [])
+            #
+            # P0-5: Gezählt wird nur, was den Claim tatsächlich stützt
+            # (``supports_claim is True``, gesetzt von der Entailment-Stufe).
+            # Vorher zählte jedes thematisch ähnliche Item mit — dadurch
+            # erreichten Interpretationen den Claim-Floor, obwohl kein
+            # einziges Item sie belegte.
+            supporting = [
+                item for item in evidence
+                if isinstance(item, dict) and item.get("supports_claim") is True
+            ]
+            evidence_count = len(supporting) or (
+                len(claim.get("evidence_refs") or []) if not evidence else 0
+            )
+            related_only = len(evidence) - len(supporting)
             if 0 < evidence_count < CLAIM_MIN_EVIDENCE_FOR_CLAIM:
                 index = len(hypotheses) + 1
                 claim_text = (
@@ -534,20 +546,30 @@ class ReportAgent:
                     or "No evidence-bound claim text available."
                 )
                 claim_text = self._truncate(claim_text, 1000)
+                rationale = (
+                    f"Reviewer-Floor: nur {evidence_count} von "
+                    f"{CLAIM_MIN_EVIDENCE_FOR_CLAIM} geforderten stützenden "
+                    "Evidence-Items — als Hypothese geführt."
+                )
+                if related_only:
+                    rationale += (
+                        f" {related_only} weitere Quelle(n) sind thematisch "
+                        "verwandt, belegen die Aussage aber nicht."
+                    )
                 hypotheses.append({
                     "hypothesis_id": f"hypothesis_{index:02d}",
                     "hypothesis_text": claim_text,
-                    "rationale": (
-                        f"Reviewer-Floor: nur {evidence_count} von "
-                        f"{CLAIM_MIN_EVIDENCE_FOR_CLAIM} geforderten Evidence-Items "
-                        "— als Hypothese geführt."
-                    ),
+                    "rationale": rationale,
                     "suggested_evidence": [],
                 })
                 continue
 
-            if not evidence and score < 0.4:
-                # Low-confidence ohne Evidence → hypothesis + data_gap
+            # P0-5: Ohne eine einzige stützende Quelle ist die Aussage eine
+            # Hypothese — auch dann, wenn thematisch verwandte Evidence
+            # anhängt. Vorher griff dieser Zweig nur bei komplett leerer
+            # Evidence-Liste und niedrigem Score; Interpretationen mit
+            # dekorativer Evidence liefen als Claims durch.
+            if not supporting:
                 index = len(hypotheses) + 1
                 claim_text = (
                     str(claim.get("claim_text") or claim.get("claim") or "").strip()
@@ -555,19 +577,29 @@ class ReportAgent:
                 )
                 claim_text = self._truncate(claim_text, 1000)
                 suggestions = self._suggested_evidence_from_claim_audit(claim)
+                if related_only:
+                    rationale = (
+                        f"{related_only} Quelle(n) sind thematisch verwandt, "
+                        "belegen die Aussage aber nicht (kein SUPPORTED-Urteil) "
+                        "— deshalb als Hypothese geführt."
+                    )
+                else:
+                    rationale = (
+                        "Keine direkte Evidence gebunden; deshalb nicht als "
+                        "validierter Claim persistiert."
+                    )
                 hypotheses.append({
                     "hypothesis_id": f"hypothesis_{index:02d}",
                     "hypothesis_text": claim_text,
-                    "rationale": (
-                        "Keine direkte Evidence gebunden; deshalb nicht als "
-                        "validierter Claim persistiert."
-                    ),
+                    "rationale": rationale,
                     "suggested_evidence": suggestions,
                 })
                 data_gaps.append({
                     "gap_id": f"gap_{index:02d}",
                     "claim_text": claim_text,
-                    "gap_reason": "no_evidence_bound",
+                    "gap_reason": (
+                        "related_evidence_only" if related_only else "no_evidence_bound"
+                    ),
                     "suggested_fix": suggestions[0],
                 })
                 continue
@@ -602,16 +634,49 @@ class ReportAgent:
             logger=logger,
         )
 
+    def _record_section_metadata(self, section_index: int, metadata: Dict[str, Any]) -> None:
+        """Merkt die Struktur-Metadaten eines Abschnitts für ReportV3 vor.
+
+        Wird von der Section-Schleife aufgerufen, bevor
+        ``_save_evidence_section`` die Section persistiert.
+        """
+        if not metadata:
+            return
+        if not hasattr(self, "_pending_section_metadata") or self._pending_section_metadata is None:
+            self._pending_section_metadata = {}
+        self._pending_section_metadata[section_index] = metadata
+
     def _save_evidence_section(self, report_id: str, section_index: int, section_title: str, content: str) -> None:
+        from .output_contract import is_fallback_content  # noqa: PLC0415
+
         if self.evidence_map is None:
             self._init_evidence_map(report_id)
         self.evidence_map.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
         self.evidence_map.setdefault("global_evidence", self._collect_simulation_evidence_items())
         # schema_version gehört nur auf Map-Ebene, nicht auf Section-Ebene
         # (ReportSectionModel hat das Feld nicht).
-        claims, raw_hypotheses, data_gaps = self._finalize_section_claims(
-            self._build_claims_for_section(content)
-        )
+        #
+        # P0-7: Fehlgeschlagene Sections enthalten Fehlertext, keinen Bericht.
+        # Daraus dürfen weder Claims noch Evidence entstehen — sonst erscheint
+        # eine LLM-Fehlermeldung als Medium-Confidence-Aussage im Report.
+        generation_failed = is_fallback_content(content)
+        if generation_failed:
+            logger.warning(
+                "section %d (%r): Fallback-Inhalt — keine Claim-/Evidence-Extraktion.",
+                section_index,
+                section_title,
+            )
+            claims: List[Dict[str, Any]] = []
+            raw_hypotheses: List[Dict[str, Any]] = []
+            data_gaps: List[Dict[str, Any]] = [{
+                "gap_id": f"gap_section_{section_index:02d}",
+                "gap_reason": "Abschnitt konnte nicht generiert werden (LLM-Fehler).",
+                "claim_text": section_title,
+            }]
+        else:
+            claims, raw_hypotheses, data_gaps = self._finalize_section_claims(
+                self._build_claims_for_section(content)
+            )
         # Slice 3 (Issue #495): Dedup + Cap per Section.
         from .hypothesis_cap import dedup_and_cap_hypotheses  # noqa: PLC0415
         hypotheses_visible, hypotheses_appendix = dedup_and_cap_hypotheses(raw_hypotheses)
@@ -623,6 +688,10 @@ class ReportAgent:
             "hypotheses": hypotheses_visible,
             "hypotheses_appendix": hypotheses_appendix,
             "data_gaps": data_gaps,
+            "structured_metadata": (
+                getattr(self, "_pending_section_metadata", {}) or {}
+            ).get(section_index, {}),
+            "generation_failed": generation_failed,
         }
         # schema_version auf Section-Ebene entfernen — Überbleibsel von
         # migrate_v1_to_v2 oder alten Persistierungen; ReportSectionModel

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -634,6 +634,38 @@ class ReportAgent:
             logger=logger,
         )
 
+    def _prose_evidence_pool(self) -> List[Dict[str, Any]]:
+        """Evidence-Basis für die Fließtext-Faktenprüfung.
+
+        Der Abschnitts-Pool zuerst — dort liegen die Treffer, die der Agent für
+        genau diesen Abschnitt geholt hat. Die globale Simulationsevidence
+        ergänzt ihn, damit ein Seed-Fakt auch dann als Beleg zählt, wenn er in
+        diesem Abschnitt nicht erneut abgefragt wurde.
+        """
+        pool: List[Dict[str, Any]] = list(self._active_section_evidence or [])
+        if self.evidence_map:
+            pool.extend(self.evidence_map.get("global_evidence") or [])
+        return pool
+
+    def _record_prose_hypotheses(
+        self,
+        section_index: int,
+        rejected: List[Any],
+    ) -> None:
+        """Merkt aus dem Fließtext entfernte Aussagen als Hypothesen vor.
+
+        Sie werden in ``_save_evidence_section`` in den Hypothesen-Slot der
+        Section übernommen — entfernte Behauptungen verschwinden also nicht,
+        sie verlieren nur ihren Status als belegte Aussage.
+        """
+        if not rejected:
+            return
+        if not hasattr(self, "_pending_prose_hypotheses") or self._pending_prose_hypotheses is None:
+            self._pending_prose_hypotheses = {}
+        bucket = self._pending_prose_hypotheses.setdefault(section_index, [])
+        for offset, statement in enumerate(rejected, start=len(bucket) + 1):
+            bucket.append(statement.as_hypothesis(offset))
+
     def _record_section_metadata(self, section_index: int, metadata: Dict[str, Any]) -> None:
         """Merkt die Struktur-Metadaten eines Abschnitts für ReportV3 vor.
 
@@ -680,6 +712,11 @@ class ReportAgent:
             claims, raw_hypotheses, data_gaps = self._finalize_section_claims(
                 self._build_claims_for_section(content)
             )
+        # Aus dem Fließtext entfernte Faktenaussagen sind Hypothesen, keine
+        # gelöschten Sätze — sie bleiben für den Leser nachvollziehbar.
+        raw_hypotheses = list(raw_hypotheses) + (
+            getattr(self, "_pending_prose_hypotheses", {}) or {}
+        ).get(section_index, [])
         # Slice 3 (Issue #495): Dedup + Cap per Section.
         from .hypothesis_cap import dedup_and_cap_hypotheses  # noqa: PLC0415
         hypotheses_visible, hypotheses_appendix = dedup_and_cap_hypotheses(raw_hypotheses)

--- a/backend/app/services/report_agent/contract_validator.py
+++ b/backend/app/services/report_agent/contract_validator.py
@@ -14,4 +14,24 @@ def validate_required_sections(
     return [t for t in required if t.strip().casefold() not in have]
 
 
-__all__ = ["validate_required_sections"]
+def matches_known_preset(outline_titles: list[str]) -> bool:
+    """True, wenn die Outline einem bekannten Intent-Preset entspricht.
+
+    Ein Opinion- oder Risk-Report hat bewusst nicht die elf Pflichtabschnitte
+    des Full-Reports. Ohne diese Prüfung scheitert jede Outline eines
+    kompakten Presets am Pflichtabschnitt-Validator, und der Report wird leer.
+
+    Die Prüfung ist absichtlich streng: die Outline muss *alle* Titel genau
+    eines Presets enthalten. Eine beliebige Kurz-Outline besteht sie nicht —
+    der Full-Report bleibt damit gegen versehentliche Verkürzung geschützt.
+    """
+    from ..report_intent import INTENT_SECTION_PRESETS  # noqa: PLC0415 — zyklischer Import
+
+    for preset in INTENT_SECTION_PRESETS.values():
+        preset_titles = [title for title, _description in preset]
+        if not validate_required_sections(outline_titles, preset_titles):
+            return True
+    return False
+
+
+__all__ = ["matches_known_preset", "validate_required_sections"]

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -50,16 +50,27 @@ _TYPE_TO_SOURCE_KIND: Dict[str, str] = {
 }
 
 
+#: Kanonische ``EvidenceSourceKind``-Werte (ADR-0002 Anker 3). Ein explizit
+#: gesetztes ``source_kind`` muss gegen diese Menge geprüft werden, nicht gegen
+#: ``_TYPE_TO_SOURCE_KIND.values()`` — sonst schließt die Prüfung ``inferred``
+#: aus und ein Caller, der ein Modellableitungs-Fakt bewusst als ``inferred``
+#: markiert, wird ignoriert (CodeRabbit PR #929).
+_VALID_SOURCE_KINDS: frozenset[str] = frozenset(
+    {"seed_corpus", "agent_quote", "agent_action", "graph_relation", "web_source", "inferred"}
+)
+
+
 def normalize_source_kind(item: Dict[str, Any]) -> str:
     """Ermittelt die Provenance eines Evidence-Items.
 
-    Ein explizit gesetztes ``source_kind`` gewinnt. Sonst entscheidet der
-    interne ``type``. Was sich nicht zuordnen lässt, wird ``inferred`` —
-    niemals ``seed_corpus``: ein Simulations-Post ist kein Dokumentfakt, und
-    eine unbekannte Herkunft erst recht nicht.
+    Ein explizit gesetztes ``source_kind`` gewinnt — inklusive ``inferred``,
+    wenn ein Caller einen Modellableitungs-Fakt bewusst so markiert. Sonst
+    entscheidet der interne ``type``. Was sich nicht zuordnen lässt, wird
+    ``inferred`` — niemals ``seed_corpus``: ein Simulations-Post ist kein
+    Dokumentfakt, und eine unbekannte Herkunft erst recht nicht.
     """
     explicit = str(item.get("source_kind") or "").strip()
-    if explicit in _TYPE_TO_SOURCE_KIND.values():
+    if explicit in _VALID_SOURCE_KINDS:
         return explicit
 
     item_type = str(item.get("type") or "").strip().lower()

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -26,6 +26,10 @@ def init_evidence_map(
 #: Interner Evidence-`type` → Provenance-`source_kind`.
 #: Ohne diese Abbildung liefen Agentenaktionen, Interviews und Web-Treffer in
 #: den Default und wurden als Seed-Fakt persistiert.
+#: Deckt jeden Wert von ``EvidenceType`` ab (ausser
+#: ``model_generated_inference``, das ohnehin nicht als Evidence zulaessig ist).
+#: Ein fehlender Eintrag laesst echte Graph-Evidence als ``inferred`` gelten —
+#: der E2E-Lauf zeigte genau das fuer ``graph_fact`` (125 von 125 Items).
 _TYPE_TO_SOURCE_KIND: Dict[str, str] = {
     "seed_corpus": "seed_corpus",
     "seed_document": "seed_corpus",
@@ -34,6 +38,7 @@ _TYPE_TO_SOURCE_KIND: Dict[str, str] = {
     "agent_interview": "agent_quote",
     "agent_action": "agent_action",
     "agent_behavior": "agent_action",
+    "graph_fact": "graph_relation",
     "relationship_chain": "graph_relation",
     "entity_summary": "graph_relation",
     "graph_metric": "graph_relation",

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -23,12 +23,52 @@ def init_evidence_map(
     return EvidenceMapModel.model_validate(payload).model_dump(mode="json")
 
 
+#: Interner Evidence-`type` → Provenance-`source_kind`.
+#: Ohne diese Abbildung liefen Agentenaktionen, Interviews und Web-Treffer in
+#: den Default und wurden als Seed-Fakt persistiert.
+_TYPE_TO_SOURCE_KIND: Dict[str, str] = {
+    "seed_corpus": "seed_corpus",
+    "seed_document": "seed_corpus",
+    "agent_post": "agent_quote",
+    "agent_quote": "agent_quote",
+    "agent_interview": "agent_quote",
+    "agent_action": "agent_action",
+    "agent_behavior": "agent_action",
+    "relationship_chain": "graph_relation",
+    "entity_summary": "graph_relation",
+    "graph_metric": "graph_relation",
+    "graph_metric_status": "graph_relation",
+    "graph_relation": "graph_relation",
+    "web_search_result": "web_source",
+    "web_fetch": "web_source",
+    "web_source": "web_source",
+}
+
+
+def normalize_source_kind(item: Dict[str, Any]) -> str:
+    """Ermittelt die Provenance eines Evidence-Items.
+
+    Ein explizit gesetztes ``source_kind`` gewinnt. Sonst entscheidet der
+    interne ``type``. Was sich nicht zuordnen lässt, wird ``inferred`` —
+    niemals ``seed_corpus``: ein Simulations-Post ist kein Dokumentfakt, und
+    eine unbekannte Herkunft erst recht nicht.
+    """
+    explicit = str(item.get("source_kind") or "").strip()
+    if explicit in _TYPE_TO_SOURCE_KIND.values():
+        return explicit
+
+    item_type = str(item.get("type") or "").strip().lower()
+    return _TYPE_TO_SOURCE_KIND.get(item_type, "inferred")
+
+
 def record_evidence_item(
     active_section_evidence: Optional[List[Dict[str, Any]]],
     item: Dict[str, Any],
 ) -> List[Dict[str, Any]]:
     target = list(active_section_evidence or [])
-    target.append(item)
+    enriched = dict(item)
+    enriched.setdefault("source_kind", normalize_source_kind(item))
+    target.append(enriched)
     return target
 
 

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -11,6 +11,7 @@ from ...contracts.report_v3 import CLAIM_MIN_EVIDENCE_FOR_CLAIM, DEFAULT_REPORT_
 from ...contracts.report_v3 import Claim as ReportV3Claim
 from ...contracts.report_v3 import DataGap as ReportV3DataGap
 from ...contracts.report_v3 import Hypothesis as ReportV3Hypothesis
+from .metadata_merge import merge_section_metadata
 from ...config import Config
 from ...models.report import Report, ReportOutline, ReportSection, ReportStatus
 from ...utils.logger import get_logger
@@ -389,6 +390,17 @@ class ReportManager:
                         origin_section_index=origin_index,
                         confidence_score=max(0.0, min(1.0, confidence_score)),
                     ))
+        # P0-6: Die pro Abschnitt extrahierten Struktur-Daten sind die
+        # kanonische Quelle für Personas, Segmente, Reibungspunkte usw.
+        # Ohne diesen Schritt blieb ReportV3 leer, während der Prosa-Report
+        # dieselben Inhalte anzeigte ("Keine Personas im ReportV3-Artefakt").
+        merged = merge_section_metadata(evidence_map.get("sections") or [])
+        if merged.rejected:
+            logger.warning(
+                "build_report_v3: %d Metadaten-Eintrag/Einträge verworfen: %s",
+                len(merged.rejected),
+                "; ".join(merged.rejected[:5]),
+            )
         return ReportV3(
             report_id=report.report_id,
             generated_at=datetime.now(timezone.utc),
@@ -396,6 +408,7 @@ class ReportManager:
             claims=claims,
             data_gaps=data_gaps,
             hypotheses=hypotheses,
+            **merged.as_report_v3_kwargs(),
         )
     
     @classmethod

--- a/backend/app/services/report_agent/metadata_merge.py
+++ b/backend/app/services/report_agent/metadata_merge.py
@@ -1,0 +1,136 @@
+"""Section-Metadaten in ReportV3-DTOs überführen.
+
+``generate_section_metadata`` extrahiert pro Abschnitt strukturierte Daten
+(Personas, Segmente, Reibungspunkte …) — bisher landeten sie ausschließlich
+im Report-Logger. ReportV3 blieb leer, obwohl der Prosa-Report die Inhalte
+zeigte. Dieses Modul schließt die Lücke: es macht die validierten
+Section-Metadaten zur kanonischen Quelle für ReportV3 und damit für
+JSON, Markdown, HTML und Frontend gleichermaßen.
+
+Ungültige Einträge werden übersprungen statt den Report zu sprengen — ein
+halluziniertes Feld darf keinen sonst gültigen Report verhindern.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Sequence
+
+from pydantic import BaseModel, ValidationError
+
+from ...contracts.report_v3 import (
+    ChangeRecommendation,
+    ContentIdea,
+    FrictionPoint,
+    Multiplier,
+    Persona,
+    PositioningVariant,
+    ProjectImpact,
+    Segment,
+    TrustSignal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+#: Feldname in ReportV3 → DTO. Die Feldnamen entsprechen exakt den
+#: ReportV3-Slots, damit `merge_section_metadata(...)` direkt einsetzbar ist.
+STRUCTURED_SLOTS: Dict[str, type[BaseModel]] = {
+    "personas": Persona,
+    "segments": Segment,
+    "multipliers": Multiplier,
+    "friction_points": FrictionPoint,
+    "trust_signals": TrustSignal,
+    "change_recommendations": ChangeRecommendation,
+    "project_impacts": ProjectImpact,
+    "positioning_variants": PositioningVariant,
+    "content_ideas": ContentIdea,
+}
+
+
+@dataclass
+class MergedMetadata:
+    """Gesammelte, validierte Struktur-Daten über alle Abschnitte."""
+
+    personas: List[Persona] = field(default_factory=list)
+    segments: List[Segment] = field(default_factory=list)
+    multipliers: List[Multiplier] = field(default_factory=list)
+    friction_points: List[FrictionPoint] = field(default_factory=list)
+    trust_signals: List[TrustSignal] = field(default_factory=list)
+    change_recommendations: List[ChangeRecommendation] = field(default_factory=list)
+    project_impacts: List[ProjectImpact] = field(default_factory=list)
+    positioning_variants: List[PositioningVariant] = field(default_factory=list)
+    content_ideas: List[ContentIdea] = field(default_factory=list)
+    rejected: List[str] = field(default_factory=list)
+
+    def as_report_v3_kwargs(self) -> Dict[str, List[BaseModel]]:
+        """Nur befüllte Slots — leere Listen sind ohnehin der DTO-Default."""
+        return {
+            slot: getattr(self, slot)
+            for slot in STRUCTURED_SLOTS
+            if getattr(self, slot)
+        }
+
+
+def _coerce_items[T: BaseModel](
+    raw_items: Any,
+    model: type[T],
+    *,
+    slot: str,
+    seen_ids: set[str],
+    rejected: List[str],
+) -> List[T]:
+    if not isinstance(raw_items, Sequence) or isinstance(raw_items, (str, bytes)):
+        return []
+
+    result: List[T] = []
+    for raw in raw_items:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            item = model.model_validate(raw)
+        except ValidationError as exc:
+            rejected.append(f"{slot}: {exc.error_count()} Feldfehler")
+            logger.debug("metadata_merge: %s abgelehnt — %s", slot, exc.errors()[:2])
+            continue
+        item_id = str(getattr(item, "id", "") or "")
+        if item_id:
+            dedup_key = f"{slot}:{item_id}"
+            if dedup_key in seen_ids:
+                continue
+            seen_ids.add(dedup_key)
+        result.append(item)
+    return result
+
+
+def merge_section_metadata(sections: Iterable[Dict[str, Any]]) -> MergedMetadata:
+    """Sammelt ``structured_metadata`` aller Abschnitte zu einem Ergebnis.
+
+    Abschnitte werden in ihrer Reihenfolge verarbeitet; gleiche IDs aus
+    mehreren Abschnitten erscheinen nur einmal.
+    """
+    merged = MergedMetadata()
+    seen_ids: set[str] = set()
+
+    for section in sections or []:
+        if not isinstance(section, dict):
+            continue
+        metadata = section.get("structured_metadata")
+        if not isinstance(metadata, dict):
+            continue
+        for slot, model in STRUCTURED_SLOTS.items():
+            items = _coerce_items(
+                metadata.get(slot),
+                model,
+                slot=slot,
+                seen_ids=seen_ids,
+                rejected=merged.rejected,
+            )
+            if items:
+                getattr(merged, slot).extend(items)
+
+    return merged
+
+
+__all__ = ["MergedMetadata", "STRUCTURED_SLOTS", "merge_section_metadata"]

--- a/backend/app/services/report_agent/output_contract.py
+++ b/backend/app/services/report_agent/output_contract.py
@@ -103,6 +103,17 @@ FALLBACK_MARKERS: tuple[str, ...] = (
 )
 
 #: Ohne so viele Zeichen ist ein Abschnitt kein Abschnitt.
+#:
+#: Herleitung (Handover P2.9): Messung an den realen Sections der Läufe
+#: ``report_e2e_trust01`` (Opinion, COMPLETED) und ``report_e2e_full01``
+#: (Full, FAILED) — kürzester echter Section-Inhalt 4230 Zeichen, längster
+#: Fallback-Text 217 Zeichen. 40 liegt ~106x unter dem Minimum realer
+#: Sections und ist damit konservativ: die Schwelle fängt nur leer oder
+#: fast-leer gerenderte Outputs ab (z. B. ``## Titel`` ohne Body nach
+#: Protokoll-Strip), nicht den Fallback-Text — den filtert
+#: :func:`is_fallback_content` semantisch. 40 Zeichen entspricht etwa einem
+#: minimalen sinnvollen Satz (6–8 Wörter); darunter ist kein fachlicher
+#: Abschnittsinhalt möglich.
 MIN_CONTENT_CHARS = 40
 
 #: Ab so vielen Wiederholungen desselben Fragments gilt der Output als

--- a/backend/app/services/report_agent/output_contract.py
+++ b/backend/app/services/report_agent/output_contract.py
@@ -1,0 +1,229 @@
+"""Final-Content-Contract für generierte Report-Abschnitte.
+
+Der Report-Agent darf pro Antwort genau eines tun: ein Tool aufrufen oder
+finalen Abschnittstext liefern. Internes Überlegen, Toolplanung und
+Beobachtungsprotokolle sind Arbeitsspuren und gehören nicht in den Report.
+
+Die primäre Absicherung liegt im Prompt (siehe
+``report_prompts/sections.py``): dort wird kein "Thought" mehr angefordert.
+Dieses Modul ist die Durchsetzung dahinter — es ersetzt das frühere
+``final_answer = response.strip()``, das jeden Modelloutput ungeprüft zum
+Abschnittsinhalt gemacht hat.
+
+Gestaffelt statt als Regex-Halde:
+
+1. Strukturell — alles vor ``Final Answer:`` ist Arbeitsspur und entfällt.
+2. Zeilenweise — Zeilen, die ein ReACT-Protokollpräfix tragen, entfallen.
+3. Gate — bleibt danach nichts Berichtsfähiges übrig, ist der Output
+   ungültig und wird abgelehnt statt notdürftig weitergereicht.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Iterable, List, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - nur für Typprüfung
+    from ...models.report import ReportStatus
+
+
+class FinalContentRejected(ValueError):
+    """Der Modelloutput enthält keinen berichtsfähigen Abschnittsinhalt."""
+
+    def __init__(self, reason: str, *, removed_segments: Sequence[str] = ()) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.removed_segments = list(removed_segments)
+
+
+@dataclass
+class SanitizedContent:
+    content: str
+    removed_segments: List[str] = field(default_factory=list)
+
+
+#: Protokoll-Präfixe des ReACT-Formats. Eine Zeile, die so beginnt, ist
+#: Arbeitsspur — unabhängig davon, was dahinter steht.
+_PROTOCOL_PREFIXES: tuple[str, ...] = (
+    "thought:",
+    "thoughts:",
+    "action:",
+    "action input:",
+    "observation:",
+    "reflection:",
+    "plan:",
+    "reasoning:",
+    "gedanke:",
+    "beobachtung:",
+)
+
+#: Formulierungen, mit denen Modelle ihre nächste Arbeitshandlung ankündigen.
+#: Bewusst auf den Zeilenanfang verankert: "Ich werde" mitten in einem
+#: Persona-Zitat ist legitimer Berichtsinhalt.
+_PLANNING_OPENERS: tuple[str, ...] = (
+    "let me ",
+    "let's ",
+    "i need to ",
+    "i will ",
+    "i'll ",
+    "i should ",
+    "i am going to ",
+    "i'm going to ",
+    "first, i ",
+    "next, i ",
+    "now i ",
+    "ich werde jetzt ",
+    "ich muss zuerst ",
+    "lass mich ",
+)
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL | re.IGNORECASE)
+_TOOL_CALL_MENTION_RE = re.compile(r"^\s*(?:tool[ _]call|tool-call)\b.*$", re.IGNORECASE)
+_FINAL_ANSWER_RE = re.compile(r"final\s*answer\s*:", re.IGNORECASE)
+
+#: Marker der Fallback-Texte, die eingesetzt werden, wenn die Generierung
+#: eines Abschnitts fehlschlägt. Solcher Text darf niemals als Claim oder
+#: Evidence weiterverarbeitet werden.
+FALLBACK_MARKERS: tuple[str, ...] = (
+    "konnte nicht generiert werden",
+    "generate failed",
+    "generatefailed",
+    "llm returned empty",
+    "llm lieferte eine leere antwort",
+    "abschnitt konnte nicht",
+    "section generation failed",
+    "bitte später erneut",
+    "pleaselaterretry",
+)
+
+#: Ohne so viele Zeichen ist ein Abschnitt kein Abschnitt.
+MIN_CONTENT_CHARS = 40
+
+
+def _is_protocol_line(line: str) -> bool:
+    stripped = line.strip().lstrip("*_>-# ").lower()
+    if not stripped:
+        return False
+    if stripped.startswith(_PROTOCOL_PREFIXES):
+        return True
+    if stripped.startswith(_PLANNING_OPENERS):
+        return True
+    return bool(_TOOL_CALL_MENTION_RE.match(line))
+
+
+def _strip_protocol_lines(text: str) -> tuple[str, List[str]]:
+    kept: List[str] = []
+    removed: List[str] = []
+    for line in text.splitlines():
+        if _is_protocol_line(line):
+            removed.append(line.strip())
+        else:
+            kept.append(line)
+    return "\n".join(kept), removed
+
+
+def _collapse_blank_lines(text: str) -> str:
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
+def is_fallback_content(text: str) -> bool:
+    """True, wenn ``text`` ein Generierungs-Fehlertext statt Inhalt ist.
+
+    Aufrufer nutzen das, um Claim-Extraktion, Evidence-Bindung und
+    Metadaten-Extraktion für diesen Abschnitt zu überspringen.
+    """
+    lowered = (text or "").strip().lower()
+    if not lowered:
+        return True
+    return any(marker in lowered for marker in FALLBACK_MARKERS)
+
+
+def sanitize_final_content(raw: str) -> SanitizedContent:
+    """Macht aus einem Modelloutput berichtsfähigen Abschnittsinhalt.
+
+    Raises:
+        FinalContentRejected: wenn nach dem Entfernen aller Arbeitsspuren
+            kein tragfähiger Inhalt übrig bleibt. Der Aufrufer setzt dann
+            den Fallback-Text und markiert den Abschnitt als fehlgeschlagen —
+            er reicht nicht ungeprüft Modelloutput weiter.
+    """
+    text = raw or ""
+    removed: List[str] = []
+
+    # 1. Strukturell: alles vor dem letzten "Final Answer:" ist Arbeitsspur.
+    matches = list(_FINAL_ANSWER_RE.finditer(text))
+    if matches:
+        cut = matches[-1].end()
+        prefix = text[:cut].strip()
+        if prefix:
+            removed.append(prefix)
+        text = text[cut:]
+
+    # 2. Tool-Call-Blöcke entfernen.
+    for block in _TOOL_CALL_BLOCK_RE.findall(text):
+        removed.append(block.strip())
+    text = _TOOL_CALL_BLOCK_RE.sub("", text)
+
+    # 3. Zeilenweise Protokollspuren entfernen.
+    text, line_removals = _strip_protocol_lines(text)
+    removed.extend(line_removals)
+
+    content = _collapse_blank_lines(text)
+
+    if not content:
+        raise FinalContentRejected(
+            "Modelloutput bestand ausschließlich aus Arbeitsspuren",
+            removed_segments=removed,
+        )
+    if len(content) < MIN_CONTENT_CHARS:
+        raise FinalContentRejected(
+            f"Abschnittsinhalt zu kurz ({len(content)} < {MIN_CONTENT_CHARS} Zeichen)",
+            removed_segments=removed,
+        )
+    if is_fallback_content(content):
+        raise FinalContentRejected(
+            "Modelloutput ist ein Fehlertext, kein Abschnittsinhalt",
+            removed_segments=removed,
+        )
+
+    return SanitizedContent(content=content, removed_segments=removed)
+
+
+def resolve_report_status(
+    *,
+    total_sections: int,
+    failed_section_indices: Iterable[int],
+    required_section_indices: Iterable[int] = (),
+) -> "ReportStatus":
+    """Ermittelt den Report-Status aus dem Erfolg der Einzelabschnitte.
+
+    Eine fehlgeschlagene Pflichtsection macht den Report ``INCOMPLETE``. Der
+    Rest bleibt nutzbar — der Nutzer sieht, was fehlt, statt ein ``COMPLETED``
+    zu lesen, das der Report nicht einlöst.
+    """
+    from ...models.report import ReportStatus  # noqa: PLC0415 — zyklischer Import
+
+    failed = set(failed_section_indices)
+    if not failed:
+        return ReportStatus.COMPLETED
+
+    required = set(required_section_indices)
+    if required and failed & required:
+        return ReportStatus.INCOMPLETE
+    if not required:
+        return ReportStatus.INCOMPLETE
+    if len(failed) >= max(1, total_sections):
+        return ReportStatus.FAILED
+    return ReportStatus.INCOMPLETE
+
+
+__all__ = [
+    "FALLBACK_MARKERS",
+    "FinalContentRejected",
+    "MIN_CONTENT_CHARS",
+    "SanitizedContent",
+    "is_fallback_content",
+    "resolve_report_status",
+    "sanitize_final_content",
+]

--- a/backend/app/services/report_agent/output_contract.py
+++ b/backend/app/services/report_agent/output_contract.py
@@ -235,6 +235,14 @@ def resolve_report_status(
     Eine fehlgeschlagene Pflichtsection macht den Report ``INCOMPLETE``. Der
     Rest bleibt nutzbar — der Nutzer sieht, was fehlt, statt ein ``COMPLETED``
     zu lesen, das der Report nicht einlöst.
+
+    ``FAILED`` wird bewusst **nicht** hier erzeugt: der Workflow setzt ihn
+    direkt bei.schema-Validierungsfehlern oder Totalausfällen
+    (``workflow.py``), nicht aus der Section-Erfolgsbilanz. Jeder Aufrufer
+    übergibt ``required_section_indices=list(range(1, total+1))`` — damit ist
+    ``required`` nie leer und jede failed Section schlägt als ``INCOMPLETE``
+    durch. Ein früherer ``FAILED``-Zweig (``len(failed) >= total_sections``)
+    war unter dieser Aufruf invariant unreachable (CodeRabbit PR #929).
     """
     from ...models.report import ReportStatus  # noqa: PLC0415 — zyklischer Import
 
@@ -245,10 +253,6 @@ def resolve_report_status(
     required = set(required_section_indices)
     if required and failed & required:
         return ReportStatus.INCOMPLETE
-    if not required:
-        return ReportStatus.INCOMPLETE
-    if len(failed) >= max(1, total_sections):
-        return ReportStatus.FAILED
     return ReportStatus.INCOMPLETE
 
 

--- a/backend/app/services/report_agent/output_contract.py
+++ b/backend/app/services/report_agent/output_contract.py
@@ -79,6 +79,11 @@ _PLANNING_OPENERS: tuple[str, ...] = (
 )
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL | re.IGNORECASE)
+#: Ein geöffneter, nie geschlossener Tool-Call. Der E2E-Lauf produzierte genau
+#: das: das Modell lief in eine Endlosschleife und schrieb ein abgeschnittenes
+#: `<tool_call>` mit tausenden Wiederholungen in den Abschnitt. Alles ab dem
+#: offenen Tag ist Arbeitsspur.
+_UNCLOSED_TOOL_CALL_RE = re.compile(r"<tool_call>", re.IGNORECASE)
 _TOOL_CALL_MENTION_RE = re.compile(r"^\s*(?:tool[ _]call|tool-call)\b.*$", re.IGNORECASE)
 _FINAL_ANSWER_RE = re.compile(r"final\s*answer\s*:", re.IGNORECASE)
 
@@ -99,6 +104,24 @@ FALLBACK_MARKERS: tuple[str, ...] = (
 
 #: Ohne so viele Zeichen ist ein Abschnitt kein Abschnitt.
 MIN_CONTENT_CHARS = 40
+
+#: Ab so vielen Wiederholungen desselben Fragments gilt der Output als
+#: degeneriert. Fachsprache wiederholt Begriffe, aber kein Berichtstext
+#: wiederholt dieselbe 20-Zeichen-Sequenz zwanzigmal.
+MAX_FRAGMENT_REPEATS = 20
+_REPEAT_PROBE_LEN = 20
+
+
+def _is_degenerate(text: str) -> bool:
+    """Erkennt LLM-Endlosschleifen an exzessiver Selbstwiederholung."""
+    if len(text) < _REPEAT_PROBE_LEN * MAX_FRAGMENT_REPEATS:
+        return False
+    probe = text[:_REPEAT_PROBE_LEN]
+    if probe.strip() and text.count(probe) >= MAX_FRAGMENT_REPEATS:
+        return True
+    midpoint = len(text) // 2
+    probe = text[midpoint : midpoint + _REPEAT_PROBE_LEN]
+    return bool(probe.strip()) and text.count(probe) >= MAX_FRAGMENT_REPEATS
 
 
 def _is_protocol_line(line: str) -> bool:
@@ -160,10 +183,16 @@ def sanitize_final_content(raw: str) -> SanitizedContent:
             removed.append(prefix)
         text = text[cut:]
 
-    # 2. Tool-Call-Blöcke entfernen.
+    # 2. Tool-Call-Blöcke entfernen — erst die vollständigen, dann alles ab
+    #    einem offen gebliebenen Tag.
     for block in _TOOL_CALL_BLOCK_RE.findall(text):
         removed.append(block.strip())
     text = _TOOL_CALL_BLOCK_RE.sub("", text)
+
+    unclosed = _UNCLOSED_TOOL_CALL_RE.search(text)
+    if unclosed:
+        removed.append(text[unclosed.start():].strip()[:500])
+        text = text[: unclosed.start()]
 
     # 3. Zeilenweise Protokollspuren entfernen.
     text, line_removals = _strip_protocol_lines(text)
@@ -184,6 +213,11 @@ def sanitize_final_content(raw: str) -> SanitizedContent:
     if is_fallback_content(content):
         raise FinalContentRejected(
             "Modelloutput ist ein Fehlertext, kein Abschnittsinhalt",
+            removed_segments=removed,
+        )
+    if _is_degenerate(content):
+        raise FinalContentRejected(
+            "Modelloutput ist degeneriert (Endlosschleife mit Wiederholungen)",
             removed_segments=removed,
         )
 

--- a/backend/app/services/report_agent/planning.py
+++ b/backend/app/services/report_agent/planning.py
@@ -7,6 +7,7 @@ from ...config import Config
 from ...contracts.report_contract import ReportOutlineModel, ReportOutlineSectionModel
 from ...models.report import ReportOutline, ReportSection
 from ...utils.logger import get_logger
+from ..report_intent import ReportIntent, detect_report_intent, section_specs_for_intent
 from ..report_prompts import DEFAULT_REPORT_SECTIONS, format_required_sections
 from .prompts import PLAN_SYSTEM_PROMPT_TEMPLATE, PLAN_USER_PROMPT_TEMPLATE
 from .schemas import PlanResponse
@@ -32,7 +33,21 @@ def plan_outline(
     if progress_callback:
         progress_callback("planning", 30, "Generating report outline...")
 
-    sections = required_sections if required_sections is not None else DEFAULT_REPORT_SECTIONS
+    if required_sections is not None:
+        sections = required_sections
+    else:
+        # P1: Fragen wie "Was denken die Leute?" bekommen ein passendes,
+        # kompaktes Preset statt zwangsweise elf Marketingabschnitte. Ohne
+        # eindeutiges Intent bleibt es beim vollständigen Report.
+        intent = detect_report_intent(agent.simulation_requirement or "")
+        sections = section_specs_for_intent(intent)
+        if intent is not ReportIntent.FULL:
+            logger.info(
+                "plan_outline: Intent %r erkannt — %d statt %d Abschnitte.",
+                intent.value,
+                len(sections),
+                len(DEFAULT_REPORT_SECTIONS),
+            )
     system_prompt = PLAN_SYSTEM_PROMPT_TEMPLATE.replace("{language}", Config.REPORT_LANGUAGE)
     user_prompt = PLAN_USER_PROMPT_TEMPLATE.format(
         simulation_requirement=agent.simulation_requirement,

--- a/backend/app/services/report_agent/text_verification.py
+++ b/backend/app/services/report_agent/text_verification.py
@@ -1,0 +1,171 @@
+"""Faktenprüfung des sichtbaren Fließtexts.
+
+Bis hierher war die Pipeline asymmetrisch: Claims wurden gegen Evidence
+geprüft, der sichtbare Prosatext nicht. Der E2E-Lauf gegen
+``sim_7058c126da03`` machte die Folge sichtbar — die Aussage
+
+    "61 Prozent der Lehrkräfte bewerteten die zusätzliche Lernhilfe positiv
+     und berichteten von einer Zeitersparnis …"
+
+wurde vom Entailment korrekt verworfen, erzeugte null Claims und landete bei
+den Hypothesen. Im gelesenen Report stand sie trotzdem, weil der Abschnitt
+die rohe LLM-Prosa ist und die Claim-Extraktion nur ein nachgelagertes
+Nebenprodukt.
+
+Diese Stufe schließt die Lücke an derselben Engine, die auch die Claims
+prüft: Jeder Satz, der einen quantitativen Fakt behauptet, muss von der
+Evidence gedeckt sein. Was nicht gedeckt ist, verschwindet nicht still,
+sondern wandert als Hypothese in den dafür vorgesehenen Slot.
+
+Bewusst eng: Nur Sätze mit numerischen Fakten werden geprüft. Analytische
+Prosa ohne Zahlenbehauptung bleibt unangetastet — sie ist Einordnung, nicht
+Faktenbehauptung, und wird über das Confidence-Gating der Claims geführt.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from ..evidence_entailment import (
+    EntailmentJudge,
+    EntailmentVerdict,
+    classify_evidence,
+    extract_numeric_facts,
+)
+
+
+@dataclass
+class RejectedStatement:
+    """Eine aus dem Fließtext entfernte, unbelegte Faktenbehauptung."""
+
+    text: str
+    verdict: EntailmentVerdict
+    reason: str
+    block_index: int = 0
+
+    def as_hypothesis(self, index: int) -> Dict[str, Any]:
+        return {
+            "hypothesis_id": f"hypothesis_text_{index:02d}",
+            "hypothesis_text": self.text[:1000],
+            "rationale": (
+                f"Aus dem Fließtext entfernt: {self.reason} "
+                f"(Urteil: {self.verdict.value})."
+            ),
+            "suggested_evidence": [
+                "Quelle mit übereinstimmender Zahl, Bezugsgruppe und Aussage nachreichen."
+            ],
+        }
+
+
+@dataclass
+class VerifiedProse:
+    content: str
+    rejected: List[RejectedStatement] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.rejected)
+
+
+#: Satzgrenzen. Abkürzungen mit Punkt sind im Berichtsdeutsch selten genug,
+#: dass eine einfache Segmentierung trägt; ein falsch getrennter Satz führt
+#: höchstens dazu, dass ein Fragment ungeprüft bleibt, nie zu einem Fehlurteil.
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+#: Zeilen, die keine Fließtextaussage sind und deshalb nicht geprüft werden:
+#: Zitatblöcke tragen fremde Rede, Aufzählungsmarker und Fettschrift-Label
+#: sind Struktur.
+_QUOTE_PREFIXES = (">", "|")
+
+
+def _is_structural(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith(_QUOTE_PREFIXES):
+        return True
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return True
+    return bool(re.fullmatch(r"\*\*[^*]+\*\*:?", stripped))
+
+
+def _has_factual_claim(sentence: str) -> bool:
+    """Nur Sätze mit einer Zahl samt Bezugsgruppe sind prüfbare Faktenaussagen."""
+    return bool(extract_numeric_facts(sentence))
+
+
+def verify_prose(
+    content: str,
+    evidence_pool: Sequence[Dict[str, Any]],
+    *,
+    judge: Optional[EntailmentJudge] = None,
+) -> VerifiedProse:
+    """Entfernt quantitative Aussagen, die keine Quelle deckt.
+
+    Ein Satz bleibt, wenn mindestens ein Evidence-Item ihn mit ``SUPPORTED``
+    trägt. Findet sich kein Beleg, wird er entfernt und als
+    :class:`RejectedStatement` zurückgegeben — der Aufrufer routet ihn in die
+    Hypothesen.
+
+    Ohne Evidence-Pool bleibt der Text unverändert: eine Prüfung ohne
+    Vergleichsbasis darf nicht als bestandene Prüfung gelten und erst recht
+    nicht den halben Bericht löschen.
+    """
+    if not content or not evidence_pool:
+        return VerifiedProse(content=content or "")
+
+    rejected: List[RejectedStatement] = []
+    out_lines: List[str] = []
+
+    for line in content.splitlines():
+        if _is_structural(line):
+            out_lines.append(line)
+            continue
+
+        sentences = _SENTENCE_SPLIT.split(line)
+        kept: List[str] = []
+        for sentence in sentences:
+            if not sentence.strip() or not _has_factual_claim(sentence):
+                kept.append(sentence)
+                continue
+
+            best: Optional[Any] = None
+            for item in evidence_pool:
+                result = classify_evidence(sentence, item, judge=judge)
+                if result.verdict is EntailmentVerdict.SUPPORTED:
+                    best = result
+                    break
+                if best is None or (
+                    best.verdict is EntailmentVerdict.INSUFFICIENT
+                    and result.verdict is EntailmentVerdict.CONTRADICTED
+                ):
+                    best = result
+
+            if best is not None and best.verdict is EntailmentVerdict.SUPPORTED:
+                kept.append(sentence)
+                continue
+
+            rejected.append(
+                RejectedStatement(
+                    text=sentence.strip(),
+                    verdict=best.verdict if best else EntailmentVerdict.INSUFFICIENT,
+                    reason=best.reason if best else "keine Evidence geprüft",
+                    block_index=len(out_lines),
+                )
+            )
+
+        rebuilt = " ".join(part for part in kept if part.strip())
+        # Eine Zeile, deren Aussagen alle entfernt wurden, verschwindet ganz —
+        # ein leerer Aufzählungspunkt wäre schlechter als keiner.
+        if rebuilt.strip():
+            out_lines.append(rebuilt)
+        elif not sentences or not any(s.strip() for s in sentences):
+            out_lines.append(line)
+
+    cleaned = re.sub(r"\n{3,}", "\n\n", "\n".join(out_lines)).strip()
+    return VerifiedProse(content=cleaned, rejected=rejected)
+
+
+__all__ = ["RejectedStatement", "VerifiedProse", "verify_prose"]

--- a/backend/app/services/report_agent/text_verification.py
+++ b/backend/app/services/report_agent/text_verification.py
@@ -46,8 +46,11 @@ class RejectedStatement:
     block_index: int = 0
 
     def as_hypothesis(self, index: int) -> Dict[str, Any]:
+        # ReportSectionHypothesisModel.hypothesis_id erzwingt
+        # ^hypothesis_\d{2,}$ — ein sprechendes Präfix ("hypothesis_text_01")
+        # lässt die gesamte EvidenceMap-Validierung scheitern.
         return {
-            "hypothesis_id": f"hypothesis_text_{index:02d}",
+            "hypothesis_id": f"hypothesis_{index:02d}",
             "hypothesis_text": self.text[:1000],
             "rationale": (
                 f"Aus dem Fließtext entfernt: {self.reason} "

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -14,7 +14,7 @@ from ...utils.logger import get_logger
 from ..artifact_store import resolve_default_store
 from ..report_prompts import DEFAULT_REPORT_SECTIONS
 from .contract_constants import MIN_PERSONA_TABLE_ROWS
-from .contract_validator import validate_required_sections
+from .contract_validator import matches_known_preset, validate_required_sections
 from .evidence import validate_quote_anchors
 from .manager import ReportManager
 from .output_contract import (
@@ -914,7 +914,14 @@ def generate_report(
 
         required_titles = [title for title, _ in DEFAULT_REPORT_SECTIONS]
         outline_titles = [section.title for section in outline.sections]
-        missing = validate_required_sections(outline_titles, required_titles)
+        # Ein Intent-Preset (opinion, risk, …) ist ein vollständiger Report für
+        # seine Fragestellung — nur der Full-Report schuldet die elf
+        # Pflichtabschnitte. Spiegelt ReportOutlineModel.require_default_sections.
+        missing = (
+            []
+            if matches_known_preset(outline_titles)
+            else validate_required_sections(outline_titles, required_titles)
+        )
         if missing:
             report.status = ReportStatus.INCOMPLETE
             report.missing_sections = missing

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -17,6 +17,12 @@ from .contract_constants import MIN_PERSONA_TABLE_ROWS
 from .contract_validator import validate_required_sections
 from .evidence import validate_quote_anchors
 from .manager import ReportManager
+from .output_contract import (
+    FinalContentRejected,
+    is_fallback_content,
+    resolve_report_status,
+    sanitize_final_content,
+)
 from .planning import plan_outline as plan_outline_impl
 from .schemas import (
     CURRENT_SCHEMA_VERSION,
@@ -264,6 +270,49 @@ SECTION_FALLBACK_BODY = (
 )
 SECTION_FALLBACK_TITLE = "Section nicht generiert (LLM-Fehler)"
 
+SECTION_EMPTY_RESPONSE_BODY = (
+    "Dieser Abschnitt konnte nicht generiert werden: Das Modell lieferte eine "
+    "leere Antwort. Bitte später erneut versuchen."
+)
+
+SECTION_UNUSABLE_OUTPUT_BODY = (
+    "Dieser Abschnitt konnte nicht generiert werden: Das Modell lieferte "
+    "ausschließlich interne Arbeitsschritte statt Berichtsinhalt ({reason}). "
+    "Bitte später erneut versuchen."
+)
+
+
+def _finalize_content(response: str, *, section_title: str, section_index: int) -> str:
+    """Wendet den Final-Content-Contract auf einen Modelloutput an.
+
+    Ersetzt das frühere ``response.strip()``: interne Arbeitsschritte werden
+    entfernt, und wenn danach kein Berichtsinhalt übrig bleibt, liefert die
+    Funktion einen als solchen erkennbaren Fehlertext statt Modelloutput.
+    Dieser Text wird von :func:`is_fallback_content` erkannt und weder zu
+    Claims noch zu Evidence verarbeitet.
+    """
+    try:
+        sanitized = sanitize_final_content(response)
+    except FinalContentRejected as exc:
+        logger.warning(
+            "section %d (%r): Final-Content-Contract hat den Output abgelehnt (%s). "
+            "%d Arbeitsspur-Segment(e) verworfen.",
+            section_index,
+            section_title,
+            exc.reason,
+            len(exc.removed_segments),
+        )
+        return SECTION_UNUSABLE_OUTPUT_BODY.format(reason=exc.reason)
+
+    if sanitized.removed_segments:
+        logger.info(
+            "section %d (%r): %d Arbeitsspur-Segment(e) aus dem Abschnittsinhalt entfernt.",
+            section_index,
+            section_title,
+            len(sanitized.removed_segments),
+        )
+    return sanitized.content
+
 
 def _safe_generate_section_react(
     agent: Any,
@@ -489,7 +538,11 @@ def generate_section_react(
                 })
                 continue
 
-            final_answer = response.split("Final Answer:")[-1].strip()
+            final_answer = _finalize_content(
+                response,
+                section_title=section.title,
+                section_index=section_index,
+            )
             logger.info(f"Section {section.title} generation completed (tool calls: {tool_calls_count}times)")
             if agent.report_logger:
                 agent.report_logger.log_section_content(
@@ -565,8 +618,15 @@ def generate_section_react(
             })
             continue
 
-        final_answer = response.strip()
-        logger.info(f"Section {section.title} did not detectto 'Final Answer:' prefix, directlyadoptLLM outputas finalcontent（Tool call: {tool_calls_count}times)")
+        # Kein "Final Answer:"-Präfix: der Output geht trotzdem durch den
+        # Final-Content-Contract. Vorher wurde hier jeder Modelloutput
+        # ungeprüft zum Abschnittsinhalt — inklusive "Thought:"-Spuren.
+        final_answer = _finalize_content(
+            response,
+            section_title=section.title,
+            section_index=section_index,
+        )
+        logger.info(f"Section {section.title} did not detectto 'Final Answer:' prefix, sanitized LLM output adopted as final content（Tool call: {tool_calls_count}times)")
         if agent.report_logger:
             agent.report_logger.log_section_content(
                 section_title=section.title,
@@ -592,11 +652,13 @@ def generate_section_react(
     else:
         response = agent.llm.chat(messages=messages, temperature=0.5, max_tokens=4096)
     if response is None:
-        final_answer = "(ThisSectiongeneratefailed: LLM returnedemptyresponse, pleaselaterretry)"
-    elif "Final Answer:" in response:
-        final_answer = response.split("Final Answer:")[-1].strip()
+        final_answer = SECTION_EMPTY_RESPONSE_BODY
     else:
-        final_answer = response
+        final_answer = _finalize_content(
+            response,
+            section_title=section.title,
+            section_index=section_index,
+        )
     if agent.report_logger:
         agent.report_logger.log_section_content(
             section_title=section.title,
@@ -890,6 +952,9 @@ def generate_report(
         report.status = ReportStatus.GENERATING
         total_sections = len(outline.sections)
         generated_sections = []
+        # P0-7: Abschnitte, deren Generierung fehlgeschlagen ist. Eine
+        # fehlgeschlagene Pflichtsection macht den Report INCOMPLETE.
+        failed_section_indices: List[int] = []
         existing_sections = {item["section_index"]: item["content"] for item in ReportManager.get_generated_sections(report_id)}
         for section_info in ReportManager.get_generated_sections(report_id):
             title = outline.sections[section_info["section_index"] - 1].title if outline.sections and section_info["section_index"] <= len(outline.sections) else ""
@@ -1004,18 +1069,38 @@ def generate_report(
             # Fehler blockieren nicht die Hauptgenerierung (generate_section_metadata
             # gibt bei Exception {} zurück). Metadaten werden im Report-Logger
             # für Provenance-Tracking gespeichert.
-            section_meta = generate_section_metadata(
-                agent,
-                section_title=section.title,
-                section_content=section_content,
-                section_index=section_num,
-            )
+            # Fehlgeschlagene Sections liefern Fehlertext, keinen Inhalt: keine
+            # Metadaten-Extraktion, keine Claims, keine Evidence daraus.
+            section_failed = is_fallback_content(section_content)
+            if section_failed:
+                failed_section_indices.append(section_num)
+                logger.warning(
+                    "section %d (%r): Fallback-Inhalt erkannt — Metadaten- und "
+                    "Claim-Extraktion werden übersprungen.",
+                    section_num,
+                    section.title,
+                )
+                section_meta = {}
+            else:
+                section_meta = generate_section_metadata(
+                    agent,
+                    section_title=section.title,
+                    section_content=section_content,
+                    section_index=section_num,
+                )
             if section_meta and agent.report_logger and hasattr(agent.report_logger, "log_section_metadata"):
                 agent.report_logger.log_section_metadata(
                     section_title=section.title,
                     section_index=section_num,
                     metadata=section_meta,
                 )
+            if section_meta:
+                # P0-6: Die extrahierten Struktur-Daten sind ab hier die
+                # kanonische Quelle für ReportV3 — vorher endeten sie im Logger.
+                if not hasattr(section, "metadata") or section.metadata is None:
+                    section.metadata = {}
+                section.metadata["structured_metadata"] = section_meta
+                agent._record_section_metadata(section_num, section_meta)
             section.content = section_content
             generated_sections.append(f"## {section.title}\n\n{section_content}")
             ReportManager.save_section(report_id, section_num, section)
@@ -1033,7 +1118,22 @@ def generate_report(
             progress_callback("generating", 95, "generatingassemblecompletereport...")
         ReportManager.update_progress(report_id, "generating", 95, "generatingassemblecompletereport...", completed_sections=completed_section_titles)
         report.markdown_content = ReportManager.assemble_full_report(report_id, outline)
-        report.status = ReportStatus.COMPLETED
+        # P0-7: Status folgt dem tatsächlichen Erfolg der Abschnitte. Ein
+        # Report mit fehlgeschlagener Pflichtsection ist INCOMPLETE — der Rest
+        # bleibt nutzbar, aber der Nutzer sieht, was fehlt.
+        report.status = resolve_report_status(
+            total_sections=total_sections,
+            failed_section_indices=failed_section_indices,
+            required_section_indices=list(range(1, total_sections + 1)),
+        )
+        if failed_section_indices:
+            failed_note = (
+                f"{total_sections - len(failed_section_indices)}/{total_sections} "
+                f"Sections erfolgreich. Fehlgeschlagen: "
+                f"{', '.join(str(i) for i in sorted(failed_section_indices))}."
+            )
+            logger.warning("report %s: %s", report_id, failed_note)
+            report.error = failed_note if not getattr(report, "error", None) else report.error
         report.completed_at = datetime.now().isoformat()
         total_time_seconds = (datetime.now() - start_time).total_seconds()
         if agent.report_logger:

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -24,6 +24,7 @@ from .output_contract import (
     sanitize_final_content,
 )
 from .planning import plan_outline as plan_outline_impl
+from .text_verification import verify_prose
 from .schemas import (
     CURRENT_SCHEMA_VERSION,
     EvidenceMapModel,
@@ -1076,6 +1077,26 @@ def generate_report(
             # Fehler blockieren nicht die Hauptgenerierung (generate_section_metadata
             # gibt bei Exception {} zurück). Metadaten werden im Report-Logger
             # für Provenance-Tracking gespeichert.
+            # P0: Faktenprüfung des sichtbaren Fließtexts. Quantitative
+            # Aussagen ohne deckende Quelle werden entfernt und als Hypothese
+            # geführt — sonst steht im gelesenen Report weiter, was das
+            # Entailment längst verworfen hat.
+            if not is_fallback_content(section_content):
+                verified = verify_prose(
+                    section_content,
+                    agent._prose_evidence_pool(),
+                )
+                if verified.changed:
+                    logger.warning(
+                        "section %d (%r): %d ungedeckte Faktenaussage(n) aus dem "
+                        "Fließtext entfernt und als Hypothese geführt.",
+                        section_num,
+                        section.title,
+                        len(verified.rejected),
+                    )
+                    agent._record_prose_hypotheses(section_num, verified.rejected)
+                    section_content = verified.content
+
             # Fehlgeschlagene Sections liefern Fehlertext, keinen Inhalt: keine
             # Metadaten-Extraktion, keine Claims, keine Evidence daraus.
             section_failed = is_fallback_content(section_content)

--- a/backend/app/services/report_intent.py
+++ b/backend/app/services/report_intent.py
@@ -1,0 +1,187 @@
+"""Intent-Erkennung und Section-Presets für Reports.
+
+"Was denken die Leute?" verlangt keinen elfteiligen Marketingreport mit
+Content-Ideen und Positionierungsvarianten. Dieses Modul leitet aus der
+Fragestellung ein Preset ab und bestimmt damit, welche Abschnitte überhaupt
+erzeugt werden.
+
+Der ``FULL``-Report bleibt unverändert erhalten und ist der Default für alles,
+was sich nicht eindeutig zuordnen lässt.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Dict, List, Sequence, Tuple
+
+from .report_prompts import DEFAULT_REPORT_SECTIONS
+
+SectionSpec = Tuple[str, str]
+
+
+class ReportIntent(str, Enum):
+    OPINION = "opinion"
+    RISK = "risk"
+    COMPARISON = "comparison"
+    EXPLORATIVE = "explorative"
+    FULL = "full"
+
+
+#: Der vollständige Report bleibt unverändert und bezieht seine Abschnitte
+#: direkt aus der bestehenden Vertragskonstante — kein zweiter Ort, der
+#: driften kann.
+FULL_SECTIONS: tuple[SectionSpec, ...] = tuple(DEFAULT_REPORT_SECTIONS)
+
+OPINION_SECTIONS: tuple[SectionSpec, ...] = (
+    ("Kurzfazit", "Maximal 8 Sätze: Was denken die simulierten Gruppen, und wie eindeutig ist das Bild."),
+    ("Stakeholder- und Meinungsgruppen", "Welche Gruppen äußern sich, mit welcher Grundhaltung."),
+    ("Zentrale Zustimmungspunkte", "Worauf sich Zustimmung stützt, mit Quellenbezug."),
+    ("Zentrale Kritikpunkte", "Worauf sich Kritik stützt, mit Quellenbezug."),
+    ("Konfliktlinien", "Wo die Gruppen auseinandergehen und woran das liegt."),
+    ("Unsicherheiten und Datenlücken", "Was die Simulation nicht beantworten kann."),
+)
+
+RISK_SECTIONS: tuple[SectionSpec, ...] = (
+    ("Kurzfazit", "Maximal 8 Sätze: Welche Risiken die Simulation sichtbar macht."),
+    ("Betroffene Gruppen", "Wer von den Risiken wie betroffen ist."),
+    ("Zentrale Risiken", "Risiken mit Schwere, Auslöser und Quellenbezug."),
+    ("Reibungspunkte und Eskalationspfade", "Wie sich Risiken in der Simulation zuspitzen."),
+    ("Gegenmaßnahmen", "Konkrete Maßnahmen, priorisiert."),
+    ("Unsicherheiten und Datenlücken", "Was die Simulation nicht beantworten kann."),
+)
+
+COMPARISON_SECTIONS: tuple[SectionSpec, ...] = (
+    ("Kurzfazit", "Maximal 8 Sätze: Welche Variante in der Simulation wie abschneidet."),
+    ("Vergleichsdimensionen", "Nach welchen Kriterien verglichen wird."),
+    ("Bewertung je Variante", "Pro Variante: Reaktionen, Stärken, Schwächen."),
+    ("Unterschiede in den Reaktionsmustern", "Wo sich die Varianten in den Reaktionen unterscheiden."),
+    ("Abwägung", "Trade-offs zwischen den Varianten."),
+    ("Unsicherheiten und Datenlücken", "Was die Simulation nicht beantworten kann."),
+)
+
+EXPLORATIVE_SECTIONS: tuple[SectionSpec, ...] = (
+    ("Kurzfazit", "Maximal 8 Sätze: Was in der Simulation auffällt."),
+    ("Beobachtete Reaktionsmuster", "Wiederkehrende Muster in den Agentenreaktionen."),
+    ("Auffälligkeiten", "Unerwartete Beobachtungen mit Quellenbezug."),
+    ("Offene Fragen", "Was die Beobachtungen aufwerfen."),
+    ("Hypothesen", "Plausible, aber unbelegte Erklärungen — explizit als solche markiert."),
+    ("Datenlücken", "Was die Simulation nicht beantworten kann."),
+)
+
+INTENT_SECTION_PRESETS: Dict[ReportIntent, tuple[SectionSpec, ...]] = {
+    ReportIntent.OPINION: OPINION_SECTIONS,
+    ReportIntent.RISK: RISK_SECTIONS,
+    ReportIntent.COMPARISON: COMPARISON_SECTIONS,
+    ReportIntent.EXPLORATIVE: EXPLORATIVE_SECTIONS,
+    ReportIntent.FULL: FULL_SECTIONS,
+}
+
+
+#: Reihenfolge ist Priorität: Vergleich schlägt Risiko schlägt Meinung.
+_INTENT_PATTERNS: Sequence[tuple[ReportIntent, tuple[str, ...]]] = (
+    (
+        ReportIntent.COMPARISON,
+        (
+            r"\bvergleich",
+            r"\bgegenüberstell",
+            r"\bversus\b",
+            r"\bvs\.?\b",
+            r"\bwelche\s+variante",
+            r"\bbesser\s+als\b",
+            r"\bunterschied\w*\s+zwischen\b",
+            r"\bcompare\b",
+        ),
+    ),
+    (
+        ReportIntent.RISK,
+        (
+            r"\brisik",
+            r"\bgefahr",
+            r"\bdroh",
+            r"\bwas\s+kann\s+schiefgehen",
+            r"\bschwachstell",
+            r"\bbedenken\s+drohen",
+            r"\bworst[\s-]?case",
+            r"\brisks?\b",
+        ),
+    ),
+    (
+        ReportIntent.OPINION,
+        (
+            r"\bwas\s+denken\b",
+            r"\bwas\s+halten\b",
+            r"\bwie\s+reagieren\b",
+            r"\bwie\s+ist\s+die\s+stimmung",
+            r"\bstimmung\b",
+            r"\bmeinung",
+            r"\bwahrnehmung",
+            r"\bakzeptanz\b",
+            r"\bsentiment\b",
+            r"\bwhat\s+do\s+people\s+think\b",
+        ),
+    ),
+    (
+        ReportIntent.EXPLORATIVE,
+        (
+            r"\bexplorativ",
+            r"\bwas\s+fällt\s+auf",
+            r"\berkunde\b",
+            r"\boffene\s+fragen\b",
+        ),
+    ),
+)
+
+
+def detect_report_intent(question: str) -> ReportIntent:
+    """Leitet aus der Fragestellung das Report-Preset ab.
+
+    Ohne eindeutigen Treffer bleibt es beim vollständigen Report — im Zweifel
+    lieber zu viel Struktur als eine stillschweigend beschnittene Analyse.
+    """
+    text = (question or "").strip().lower()
+    if not text:
+        return ReportIntent.FULL
+
+    for intent, patterns in _INTENT_PATTERNS:
+        if any(re.search(pattern, text) for pattern in patterns):
+            return intent
+    return ReportIntent.FULL
+
+
+def section_specs_for_intent(intent: ReportIntent) -> List[SectionSpec]:
+    """(Titel, Beschreibung)-Paare für ein Intent-Preset.
+
+    Direkt als ``required_sections`` an ``plan_outline`` übergebbar.
+    """
+    return list(INTENT_SECTION_PRESETS.get(intent, FULL_SECTIONS))
+
+
+def sections_for_intent(intent: ReportIntent) -> List[str]:
+    """Nur die Abschnittstitel eines Intent-Presets."""
+    return [title for title, _description in section_specs_for_intent(intent)]
+
+
+def sections_for_question(question: str) -> List[str]:
+    return sections_for_intent(detect_report_intent(question))
+
+
+def section_specs_for_question(question: str) -> List[SectionSpec]:
+    return section_specs_for_intent(detect_report_intent(question))
+
+
+__all__ = [
+    "COMPARISON_SECTIONS",
+    "EXPLORATIVE_SECTIONS",
+    "FULL_SECTIONS",
+    "INTENT_SECTION_PRESETS",
+    "OPINION_SECTIONS",
+    "RISK_SECTIONS",
+    "ReportIntent",
+    "SectionSpec",
+    "detect_report_intent",
+    "section_specs_for_intent",
+    "section_specs_for_question",
+    "sections_for_intent",
+    "sections_for_question",
+]

--- a/backend/app/services/report_prompts/sections.py
+++ b/backend/app/services/report_prompts/sections.py
@@ -272,7 +272,7 @@ This section analyzes...
 Each reply you can only do one of two things (cannot do both):
 
 Option A - Call Tool:
-Output your thinking, then call a tool using the following format:
+Emit ONLY the tool call block, nothing else:
 <tool_call>
 {{"name": "Tool Name", "parameters": {{"parameter_name": "parameter_value"}}}}
 </tool_call>
@@ -285,6 +285,22 @@ When you have gathered enough information through tools, start with "Final Answe
 - Forbidden to include both tool calls and Final Answer in one reply
 - Forbidden to fabricate tool return results (Observation), all tool results are injected by the system
 - At most one tool call per reply
+
+[Internal Reasoning Is Never Report Content — MUST FOLLOW]
+Your deliberation about which tool to call, what is missing, or what to do
+next is working material, not report material. Do NOT write it out.
+
+❌ Never emit any of these into a reply:
+   "Thought:", "Action:", "Observation:", "Reasoning:", "Plan:"
+   "Let me …", "I need to …", "I will …", "I should …", "First I will …"
+   any prose describing which tool you are about to use or why a tool failed
+
+✅ A tool call reply contains the <tool_call> block and nothing else.
+✅ A final reply contains "Final Answer:" followed by pure report body text.
+
+If a tool returned nothing usable, do not narrate that in the section body.
+Record the gap as a data gap or an explicitly marked hypothesis instead —
+the reader gets the finding, not your working notes.
 
 ═══════════════════════════════════════════════════════════════
 [Section Content Requirements]
@@ -342,7 +358,20 @@ Every simulated persona statement MUST use the XML tag with BOTH attributes:
 <simulated_quote persona_id="<persona_id>" seed_anchor="<ev_id_or_seed_doc:...>">statement</simulated_quote>
 Plain Markdown quotes (> "...") for persona statements are NOT accepted.
 
+[⚠️ Provenance Reminder — Seed Facts vs. Simulation]
+Keep these apart in every sentence you write:
+- A number or statement from the uploaded seed document describes the
+  DOCUMENT. Attribute it as such: "Im Seed-Dokument bewerteten 72 % der
+  Schülerinnen und Schüler …"
+- A reaction produced by the simulated agents describes the SIMULATION:
+  "In den simulierten Agentenreaktionen konzentrierte sich die Kritik auf …"
+- Never present a seed percentage as if the simulated personas had produced
+  it, and never re-attribute a number to a different group, predicate, or
+  time frame than the source states.
+
 Please start:
-1. First think (Thought) what information this section needs
-2. Then call tools (Action) to get simulation data
-3. After collecting enough information, output Final Answer (pure body text, no titles)"""
+1. Call a tool to retrieve simulation data (the reply contains only the
+   <tool_call> block — no commentary, no "Thought:")
+2. Repeat until you have enough material
+3. Then output "Final Answer:" followed by pure body text (no titles, no
+   working notes)"""

--- a/backend/tests/contracts/test_evidence_source_kind.py
+++ b/backend/tests/contracts/test_evidence_source_kind.py
@@ -41,6 +41,7 @@ def _seed_evidence(*, supports: bool = True, score: float = 0.7) -> EvidenceItem
         snippet="Seed-Korpus-Datenpunkt.",
         match_score=score,
         supports_claim=supports,
+        source_kind=EvidenceSourceKind.seed_corpus,
     )
 
 
@@ -55,14 +56,21 @@ def _inferred(*, supports: bool = True, score: float = 0.6) -> EvidenceItemModel
     )
 
 
-def test_source_kind_default_seed_corpus() -> None:
-    """Default sichert Backward-Compat fuer Fixtures ohne explizites Feld."""
+def test_source_kind_default_is_inferred_not_seed_corpus() -> None:
+    """Ohne explizite Angabe ist die Herkunft unbekannt — also abgeleitet.
+
+    Vorher war der Default ``seed_corpus``: jedes Item ohne Angabe wurde damit
+    zum Dokumentfakt erklaert, auch Agentenaktionen und Web-Treffer. Der
+    konservative Default laesst alte Fixtures weiter laden, verweigert ihnen
+    aber den unverdienten Seed-Status (``reject_inferred_in_high_confidence``
+    greift dann, ADR-0002 Anker 5).
+    """
     item = EvidenceItemModel(
         type=EvidenceType.graph_metric,
         source="x",
         snippet="snippet",
     )
-    assert item.source_kind == EvidenceSourceKind.seed_corpus
+    assert item.source_kind == EvidenceSourceKind.inferred
     assert item.persona_stakeholder_group is None
 
 
@@ -198,8 +206,48 @@ def test_low_and_medium_unaffected() -> None:
 
 
 def test_enum_values_pinned() -> None:
-    """Drift-Guard: genau 4 Werte, exakt diese Strings."""
-    expected = {"seed_corpus", "agent_quote", "graph_relation", "inferred"}
+    """Drift-Guard: genau diese 6 Werte, exakt diese Strings.
+
+    Erweitert um ``agent_action`` und ``web_source`` (Report-Trust-Slice).
+    Additiv — die urspruenglichen vier Werte bleiben unveraendert und die
+    Confidence-Anker werten weiterhin nur ``agent_quote`` als
+    Stakeholder-Stimme und ``seed_corpus`` als Dokumentfakt.
+    """
+    expected = {
+        "seed_corpus",
+        "agent_quote",
+        "agent_action",
+        "graph_relation",
+        "web_source",
+        "inferred",
+    }
     actual = {kind.value for kind in EvidenceSourceKind}
     assert actual == expected
-    assert len(EvidenceSourceKind) == 4
+    assert len(EvidenceSourceKind) == 6
+
+
+def test_agent_action_does_not_count_as_stakeholder_voice() -> None:
+    """agent_action ist Simulationsverhalten, keine Stakeholder-Aussage.
+
+    Zwei Agentenaktionen aus unterschiedlichen Gruppen duerfen ein
+    high-Label nicht rechtfertigen — nur ``agent_quote`` zaehlt (Anker 4).
+    """
+    def _action(group: str) -> EvidenceItemModel:
+        return EvidenceItemModel(
+            type=EvidenceType.agent_action,
+            source="agent-log",
+            snippet=f"Agent aus {group} teilte den Beitrag.",
+            match_score=0.9,
+            supports_claim=True,
+            source_kind=EvidenceSourceKind.agent_action,
+            persona_stakeholder_group=group,
+        )
+
+    with pytest.raises(ValidationError, match="2 unterschiedlichen Stakeholder-Gruppen"):
+        ReportClaimModel(
+            claim_id="claim_80",
+            claim_text="High-Claim, der nur auf Agentenaktionen beruht.",
+            confidence_label=ConfidenceLabel.high,
+            confidence_score=0.78,
+            evidence=[_action("Lehrkraefte"), _action("Eltern")],
+        )

--- a/backend/tests/eval/test_evidence_gating_snapshot.py
+++ b/backend/tests/eval/test_evidence_gating_snapshot.py
@@ -93,9 +93,24 @@ def test_hedge_snapshot_anchor_vollstaendig():
 
 
 def test_evidence_source_kind_enum_werte():
-    """Anker 3: EvidenceSourceKind enthält genau die vier ADR-0002-Provenance-Stufen."""
+    """Anker 3: EvidenceSourceKind enthält genau diese Provenance-Stufen.
+
+    Report-Trust-Slice: additiv um ``agent_action`` und ``web_source``
+    erweitert. Die vier ursprünglichen ADR-0002-Stufen bleiben unverändert;
+    für die Confidence-Anker zählt weiterhin nur ``agent_quote`` als
+    Stakeholder-Stimme und nur ``seed_corpus`` als Dokumentfakt. Die
+    Erweiterung verschärft die Trennung von Seed, Simulation und Recherche,
+    statt das Gating zu schwächen.
+    """
     werte = {e.value for e in EvidenceSourceKind}
-    erwartet = {"seed_corpus", "agent_quote", "graph_relation", "inferred"}
+    erwartet = {
+        "seed_corpus",
+        "agent_quote",
+        "agent_action",
+        "graph_relation",
+        "web_source",
+        "inferred",
+    }
     assert werte == erwartet, (
         f"EvidenceSourceKind-Enum hat sich verändert — ADR-0002 Anker 3 verletzt. "
         f"Erwartet: {sorted(erwartet)}, Gefunden: {sorted(werte)}"

--- a/backend/tests/eval/test_evidence_routing.py
+++ b/backend/tests/eval/test_evidence_routing.py
@@ -28,21 +28,29 @@ FIXTURE_MIXED = (
 # _finalize_section_claims: medium/high ohne Evidence → data_gaps, nicht claims
 # ---------------------------------------------------------------------------
 
-def test_medium_high_orphans_route_to_data_gaps() -> None:
-    """medium + high Claims ohne Evidence landen in data_gaps, low in hypotheses."""
+def test_orphan_claims_route_to_hypotheses_and_data_gaps() -> None:
+    """Claims ohne stützende Evidence werden Hypothesen — unabhängig vom Label.
+
+    Vorher landeten medium/high-Orphans nur in ``data_gaps``: die Behauptung
+    selbst verschwand aus dem Report, obwohl sie inhaltlich weiter im Raum
+    stand. Ein unbelegtes ``high`` ist aber keine Datenlücke, sondern eine
+    unbelegte Behauptung — sie gehört sichtbar als Hypothese markiert
+    (P0-5). Das Label allein darf nicht darüber entscheiden, ob eine
+    Aussage ungeprüft aus dem Report fällt.
+    """
     raw = json.loads(FIXTURE_MIXED.read_text(encoding="utf-8"))
 
     agent = ReportAgent.__new__(ReportAgent)
     claims, hypotheses, data_gaps = agent._finalize_section_claims(raw["claims"])
 
-    # claim_03 ist low + score 0.18 < 0.4 → hypothesis + data_gap
-    # claim_01 ist medium + score 0.55 → data_gap only
-    # claim_02 ist high + score 0.72 → data_gap only
     assert claims == [], f"Erwartet keine finalisierten Claims, erhalten: {claims}"
-    assert len(hypotheses) == 1, f"Erwartet 1 hypothesis (low-Claim), erhalten: {len(hypotheses)}"
-    assert hypotheses[0]["hypothesis_text"].startswith("Datenschutzbedenken")
+    # claim_01 (medium), claim_02 (high), claim_03 (low) — alle ohne Evidence.
+    assert len(hypotheses) == 3, (
+        f"Erwartet 3 Hypothesen (alle Orphans), erhalten: {len(hypotheses)}"
+    )
+    hypothesis_texts = [h["hypothesis_text"] for h in hypotheses]
+    assert any(text.startswith("Datenschutzbedenken") for text in hypothesis_texts)
 
-    # data_gaps: low-orphan + medium + high = 3
     assert len(data_gaps) == 3, f"Erwartet 3 data_gaps, erhalten: {len(data_gaps)}"
     gap_reasons = {gap["gap_reason"] for gap in data_gaps}
     assert gap_reasons == {"no_evidence_bound"}
@@ -66,7 +74,7 @@ def test_medium_high_orphan_section_validates() -> None:
 
     assert len(section.claims) == 0
     assert len(section.data_gaps) == 3
-    assert len(section.hypotheses) == 1
+    assert len(section.hypotheses) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -79,6 +79,78 @@ def test_1c_training_target_is_not_approval():
     assert result.verdict is not EntailmentVerdict.SUPPORTED
 
 
+def test_1e_rendered_prose_must_not_carry_the_wrong_attribution():
+    """Der SICHTBARE Reporttext darf die Falschzuordnung nicht enthalten.
+
+    Der E2E-Lauf gegen sim_7058c126da03 zeigte: Das Entailment verwarf die
+    Aussage korrekt (0 Claims, Routing zur Hypothese) — im gelesenen Report
+    stand sie trotzdem, weil der Abschnitt die rohe LLM-Prosa ist. Dieser
+    Test prüft deshalb den gerenderten Text, nicht ``claims[]``.
+    """
+    from app.services.report_agent.text_verification import verify_prose
+
+    prose = (
+        "Im Zentrum der Lehrkräfte-Reaktionen steht eine positive Bewertung. "
+        "61 Prozent der Lehrkräfte bewerteten die zusätzliche Lernhilfe positiv "
+        "und berichteten von einer Zeitersparnis bei mindestens einer "
+        "wöchentlichen Routineaufgabe.\n"
+        "72 % der Schülerinnen und Schüler bewerteten die zusätzliche Lernhilfe positiv."
+    )
+    pool = [_seed_item(s) for s in SEED_SENTENCES]
+
+    result = verify_prose(prose, pool)
+
+    lowered = result.content.lower()
+    assert not (
+        "61" in lowered and "lernhilfe positiv" in lowered
+    ), (
+        "Der gerenderte Report enthält weiterhin die Falschzuordnung "
+        f"'61 % → Lernhilfe positiv':\n{result.content}"
+    )
+    # Der korrekt belegte Seed-Fakt muss erhalten bleiben.
+    assert "72" in result.content
+    assert result.rejected, "Die verworfene Aussage muss als Hypothese geführt werden"
+    assert result.rejected[0].verdict is not EntailmentVerdict.SUPPORTED
+
+
+def test_1f_rejected_prose_statement_becomes_a_hypothesis():
+    from app.services.report_agent.text_verification import verify_prose
+
+    prose = (
+        "61 Prozent der Lehrkräfte bewerteten die zusätzliche Lernhilfe positiv "
+        "und berichteten von einer Zeitersparnis bei mindestens einer "
+        "wöchentlichen Routineaufgabe."
+    )
+    result = verify_prose(prose, [_seed_item(s) for s in SEED_SENTENCES])
+    assert result.rejected
+    hypothesis = result.rejected[0].as_hypothesis(1)
+    assert hypothesis["hypothesis_text"]
+    assert "entfernt" in hypothesis["rationale"].lower()
+
+
+def test_1g_prose_without_evidence_pool_is_left_untouched():
+    """Ohne Vergleichsbasis darf die Prüfung den Bericht nicht leeren."""
+    from app.services.report_agent.text_verification import verify_prose
+
+    prose = "61 Prozent der Lehrkräfte bewerteten die Lernhilfe positiv."
+    result = verify_prose(prose, [])
+    assert result.content == prose
+    assert not result.rejected
+
+
+def test_1h_analytical_prose_without_numbers_survives():
+    """Nur quantitative Aussagen werden geprüft — Einordnung bleibt stehen."""
+    from app.services.report_agent.text_verification import verify_prose
+
+    prose = (
+        "Die Elternschaft reagiert spürbar zurückhaltender als die Lehrkräfte "
+        "und positioniert sich als Korrektiv gegenüber dem Vorhaben."
+    )
+    result = verify_prose(prose, [_seed_item(s) for s in SEED_SENTENCES])
+    assert result.content == prose
+    assert not result.rejected
+
+
 def test_1d_numeric_extraction_binds_number_to_group_and_predicate():
     facts = extract_numeric_facts(SEED_SENTENCES[1])
     assert facts, "Prozentwert muss erkannt werden"
@@ -120,6 +192,30 @@ def test_2b_mixed_content_keeps_only_the_report_body():
     assert "Action:" not in cleaned.content
     assert "Zeitersparnis" in cleaned.content
     assert cleaned.removed_segments
+
+
+def test_2d_unclosed_tool_call_is_rejected():
+    """Ein geöffneter, nie geschlossener Tool-Call darf nicht durchrutschen.
+
+    Aus dem Full-Report-E2E: das Modell lief in eine Endlosschleife und
+    schrieb ein abgeschnittenes '<tool_call>' in den Abschnitt. Der Sanitizer
+    entfernte nur vollständige Blöcke, das Fragment blieb im Report stehen.
+    """
+    raw = (
+        "Die simulierten Gruppen äußern sich überwiegend zurückhaltend zum Vorhaben.\n"
+        '<tool_call>\n{"name": "quick_search"'
+    )
+    cleaned = sanitize_final_content(raw)
+    assert "<tool_call>" not in cleaned.content
+    assert "quick_search" not in cleaned.content
+    assert "zurückhaltend" in cleaned.content
+
+
+def test_2e_degenerate_repetition_is_rejected():
+    """LLM-Endlosschleifen sind kein Abschnittsinhalt."""
+    raw = "Final Answer:\n" + ('function_calls>quick_search</invoke">' * 60)
+    with pytest.raises(FinalContentRejected):
+        sanitize_final_content(raw)
 
 
 def test_2c_clean_content_passes_unchanged():

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -128,6 +128,28 @@ def test_1f_rejected_prose_statement_becomes_a_hypothesis():
     assert "entfernt" in hypothesis["rationale"].lower()
 
 
+def test_1i_prose_hypothesis_ids_satisfy_the_contract():
+    """Die aus dem Fließtext erzeugten Hypothesen müssen valide sein.
+
+    Zweiter Fall desselben Fehlertyps wie bei gap_id: eine sprechende ID
+    ("hypothesis_text_01") verletzt ^hypothesis_\\d{2,}$ und ließ die gesamte
+    EvidenceMap-Validierung — und damit den ganzen Report — scheitern.
+    """
+    from app.contracts.report_contract import ReportSectionHypothesisModel
+    from app.services.report_agent.text_verification import verify_prose
+
+    prose = (
+        "61 Prozent der Lehrkräfte bewerteten die zusätzliche Lernhilfe positiv "
+        "und berichteten von einer Zeitersparnis bei mindestens einer "
+        "wöchentlichen Routineaufgabe."
+    )
+    result = verify_prose(prose, [_seed_item(s) for s in SEED_SENTENCES])
+    assert result.rejected
+
+    for position, statement in enumerate(result.rejected, start=1):
+        ReportSectionHypothesisModel.model_validate(statement.as_hypothesis(position))
+
+
 def test_1g_prose_without_evidence_pool_is_left_untouched():
     """Ohne Vergleichsbasis darf die Prüfung den Bericht nicht leeren."""
     from app.services.report_agent.text_verification import verify_prose

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -273,6 +273,34 @@ def test_2c_clean_content_passes_unchanged():
     assert not cleaned.removed_segments
 
 
+def test_2f_min_content_chars_threshold_is_conservative():
+    """MIN_CONTENT_CHARS muss konservativ sein (Handover P2.9).
+
+    Herleitung an realen Läufen: kürzester echter Section-Inhalt 4230
+    Zeichen (report_e2e_trust01), längster Fallback-Text 217 Zeichen
+    (report_e2e_full01/section_03). 40 liegt deutlich unter beiden —
+    es fängt nur leer/fast-leer gerenderte Outputs ab, nicht Fallback-Text
+    (den filtert is_fallback_content semantisch).
+    """
+    from app.services.report_agent.output_contract import (
+        MIN_CONTENT_CHARS,
+        is_fallback_content,
+    )
+
+    # Schwelle ist klein genug für kürzeste reale Section (4230 chars)
+    assert MIN_CONTENT_CHARS < 4230
+    # Schwelle ist groß genug, um leere Outputs abzufangen
+    assert MIN_CONTENT_CHARS >= 10
+    # Fallback-Text wird nicht durch MIN_CONTENT_CHARS gefangen, sondern
+    # durch is_fallback_content — das ist ein separater Guard.
+    fallback = (
+        "Dieser Abschnitt konnte nicht generiert werden: Das Modell "
+        "lieferte ausschließlich interne Arbeitsschritte."
+    )
+    assert len(fallback) > MIN_CONTENT_CHARS
+    assert is_fallback_content(fallback)
+
+
 # ---------------------------------------------------------------------------
 # Test 3 — Ähnlichkeit ist kein Beweis
 # ---------------------------------------------------------------------------

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -322,6 +322,21 @@ def test_4c_unknown_evidence_does_not_silently_default_to_seed_corpus():
     assert normalize_source_kind(item) != EvidenceSourceKind.seed_corpus.value
 
 
+def test_4e_explicit_inferred_source_kind_is_respected():
+    """Ein explizit gesetztes ``source_kind="inferred"`` muss gewonnen werden.
+
+    CodeRabbit PR #929: ``normalize_source_kind`` prüfte explizite Werte gegen
+    ``_TYPE_TO_SOURCE_KIND.values()`` — die Menge schloss ``inferred`` aus.
+    Ein Caller, der ein Modellableitungs-Fakt bewusst als ``inferred``
+    markierte, wurde ignoriert und der interne ``type`` übernahm. Der Docstring
+    sagt aber: „Ein explizit gesetztes source_kind gewinnt."
+    """
+    from app.services.report_agent.evidence import normalize_source_kind
+
+    item = {"type": "seed_corpus", "source_kind": "inferred", "snippet": "Vermutlich…"}
+    assert normalize_source_kind(item) == EvidenceSourceKind.inferred.value
+
+
 def test_4d_every_evidence_type_maps_to_a_real_provenance():
     """Kein produktiver EvidenceType darf als 'inferred' durchfallen.
 

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -204,6 +204,26 @@ def test_4c_unknown_evidence_does_not_silently_default_to_seed_corpus():
     assert normalize_source_kind(item) != EvidenceSourceKind.seed_corpus.value
 
 
+def test_4d_every_evidence_type_maps_to_a_real_provenance():
+    """Kein produktiver EvidenceType darf als 'inferred' durchfallen.
+
+    Der E2E-Lauf gegen sim_7058c126da03 lieferte 125 von 125 Evidence-Items
+    mit ``type='graph_fact'``. Weil das Mapping diesen Wert nicht kannte,
+    landeten alle auf ``inferred`` — echte Graph-Evidence sah damit aus wie
+    eine Modellableitung. Dieser Test pinnt die Vollstaendigkeit.
+    """
+    from app.contracts.report_contract import EvidenceType
+    from app.services.report_agent.evidence import normalize_source_kind
+
+    unmapped = [
+        t.value
+        for t in EvidenceType
+        if t is not EvidenceType.model_generated_inference
+        and normalize_source_kind({"type": t.value}) == EvidenceSourceKind.inferred.value
+    ]
+    assert not unmapped, f"EvidenceType(s) ohne Provenance-Zuordnung: {unmapped}"
+
+
 # ---------------------------------------------------------------------------
 # Test 5 — Fallback-Fehlertext erzeugt keinen Claim
 # ---------------------------------------------------------------------------

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -685,3 +685,128 @@ def test_10b_unspecific_question_defaults_to_full():
     assert detect_report_intent("Erstelle eine umfassende Analyse des Vorhabens.") is (
         ReportIntent.FULL
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — LLM-Judge: ADR-0002-Anker und Builder (P2.8)
+# ---------------------------------------------------------------------------
+
+
+def _qualitative_claim_and_evidence():
+    """Claim/Evidence-Paar, das im Regelpfad RELATED_ONLY liefert.
+
+    Ohne Zahl- oder Mengen-Claim fällt es in den qualitativen Pfad
+    (Regel 3 in classify_evidence). Nur hier greift der Judge.
+    """
+    claim = "Die Eltern sind besorgt wegen des Datenschutzes."
+    evidence = {
+        "snippet": (
+            "Eltern äußern in der Befragung Bedenken gegen die Datenverarbeitung "
+            "der neuen Plattform."
+        ),
+        "source_kind": "seed_corpus",
+    }
+    return claim, evidence
+
+
+def test_11a_judge_supported_is_downgraded_to_related_only():
+    """ADR-0002: Der LLM-Judge darf SUPPORTED nie erzeugen.
+
+    Im qualitativen Pfad gibt es kein regelbasiertes SUPPORTED. Ein
+    Judge-SUPPORTED wäre also ein ungedeckter Claim, der durch das Tor
+    geschlüpft wäre. Der Klassifikator muss es auf RELATED_ONLY abschwächen.
+    """
+    claim, evidence = _qualitative_claim_and_evidence()
+
+    def judge(_claim, _evidence):
+        return "SUPPORTED"
+
+    result = classify_evidence(claim, evidence, judge=judge)
+    assert result.verdict is EntailmentVerdict.RELATED_ONLY
+    assert "judge_downgraded" in result.checks
+
+
+def test_11b_judge_contradicted_is_passed_through():
+    """Judge-CONTRADICTED wird durchgereicht — Abschwächung ist erlaubt."""
+    claim, evidence = _qualitative_claim_and_evidence()
+
+    def judge(_claim, _evidence):
+        return "CONTRADICTED"
+
+    result = classify_evidence(claim, evidence, judge=judge)
+    assert result.verdict is EntailmentVerdict.CONTRADICTED
+    assert "judge" in result.checks
+
+
+def test_11c_judge_failure_falls_back_to_rule_path():
+    """Judge-Exception → judge_failed-Check, Regelpfad bleibt gültig."""
+    claim, evidence = _qualitative_claim_and_evidence()
+
+    def judge(_claim, _evidence):
+        raise RuntimeError("LLM nicht erreichbar")
+
+    result = classify_evidence(claim, evidence, judge=judge)
+    assert "judge_failed" in result.checks
+    # Regelpfad liefert RELATED_ONLY oder SUPPORTED für hohe Overlap — niemals
+    # einen Judge-Verdict.
+    assert result.verdict in {EntailmentVerdict.RELATED_ONLY, EntailmentVerdict.SUPPORTED}
+
+
+def test_11d_judge_invalid_verdict_is_ignored():
+    """Ein Judge-Output außerhalb der Enum wird still ignoriert (Regelpfad)."""
+    claim, evidence = _qualitative_claim_and_evidence()
+
+    def judge(_claim, _evidence):
+        return "MAYBE"
+
+    result = classify_evidence(claim, evidence, judge=judge)
+    # Kein judge-Check, weil der Verdict nicht in der Enum war.
+    assert "judge" not in result.checks
+    assert "judge_downgraded" not in result.checks
+
+
+def test_11e_build_llm_judge_uses_chat_json_with_verdict_schema():
+    """build_llm_judge liefert ein Callable, das chat_json mit dem
+    EntailmentJudgeVerdict-Schema aufruft und den verdict-Namen zurückgibt."""
+    from app.services.llm_entailment_judge import (
+        EntailmentJudgeVerdict,
+        build_llm_judge,
+    )
+
+    class _StubClient:
+        def __init__(self):
+            self.last_schema = None
+            self.last_messages = None
+            self.last_context = None
+
+        def chat_json(self, *, messages, schema, schema_name, context, temperature, max_tokens):
+            self.last_schema = schema
+            self.last_messages = messages
+            self.last_context = context
+            # Pydantic-Schema → chat_json liefert validiertes Dict.
+            return EntailmentJudgeVerdict(verdict=EntailmentVerdict.RELATED_ONLY, reason="test").model_dump()
+
+    stub = _StubClient()
+    judge = build_llm_judge(stub)  # type: ignore[arg-type]
+
+    verdict_name = judge("Ein Claim.", "Eine Evidence.")
+    assert verdict_name == "RELATED_ONLY"
+    assert stub.last_schema is EntailmentJudgeVerdict
+    assert stub.last_context == "report"
+    # System-Prompt erwähnt die Verdict-Typen.
+    assert stub.last_messages[0]["role"] == "system"
+    assert "SUPPORTED" in stub.last_messages[0]["content"]
+
+
+def test_11f_build_llm_judge_propagates_chat_json_errors():
+    """chat_json-Fehler propagieren — classify_evidence fängt sie als judge_failed."""
+    from app.services.llm_entailment_judge import build_llm_judge
+
+    class _FailingClient:
+        def chat_json(self, **_kwargs):
+            raise RuntimeError("provider down")
+
+    judge = build_llm_judge(_FailingClient())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="provider down"):
+        judge("Claim", "Evidence")

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -245,6 +245,23 @@ def test_5b_claim_extraction_skips_fallback_sections():
     assert is_fallback_content("Die simulierten Eltern äußern Datenschutzbedenken.") is False
 
 
+def test_5c_fallback_section_data_gap_satisfies_the_contract():
+    """Die Ersatz-Datenlücke einer fehlgeschlagenen Section muss valide sein.
+
+    Der E2E-Lauf scheiterte an ``gap_id='gap_section_03'``:
+    ReportSectionDataGapModel erzwingt ``^gap_\\d{2,}$``. Ein einziger
+    ungültiger Ersatz-Gap ließ die gesamte EvidenceMap-Validierung und damit
+    den kompletten Report fehlschlagen.
+    """
+    from app.contracts.report_contract import ReportSectionDataGapModel
+
+    ReportSectionDataGapModel.model_validate({
+        "gap_id": f"gap_{3:02d}",
+        "gap_reason": "Abschnitt konnte nicht generiert werden (LLM-Fehler).",
+        "claim_text": "Zentrale Kritikpunkte",
+    })
+
+
 # ---------------------------------------------------------------------------
 # Test 6 — fehlgeschlagene Pflichtsection ⇒ INCOMPLETE
 # ---------------------------------------------------------------------------

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -1,0 +1,391 @@
+"""Regressionstests für die Vertrauenswürdigkeit der Report-Pipeline.
+
+Referenz-Testlauf: report_d9023bd1f55a / sim_7058c126da03 (30 Agents,
+315 Interaktionen, 5 Cluster, Echo-Chamber-Index 0.4317, Modus balanced).
+
+Jeder Test hier bildet genau einen der P0-Defekte ab, die in diesem Lauf
+sichtbar wurden. Sie sind bewusst eng geschnitten: sie prüfen die
+Pipeline-Invariante, nicht die Formulierung eines konkreten LLM-Outputs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.contracts.report_contract import EvidenceSourceKind
+from app.services.evidence_binder import bind_evidence_to_claim
+from app.services.evidence_entailment import (
+    EntailmentVerdict,
+    classify_evidence,
+    extract_numeric_facts,
+)
+from app.services.report_agent.output_contract import (
+    FinalContentRejected,
+    sanitize_final_content,
+)
+from app.services.report_intent import ReportIntent, detect_report_intent, sections_for_intent
+
+
+# ---------------------------------------------------------------------------
+# Seed-Fixture: die Zahlen aus dem echten Testdokument
+# ---------------------------------------------------------------------------
+
+SEED_SENTENCES = [
+    "72 % der Schülerinnen und Schüler bewerteten die zusätzliche Lernhilfe positiv.",
+    "61 % der Lehrkräfte berichteten von Zeitersparnis bei mindestens einer "
+    "wöchentlichen Routineaufgabe.",
+    "48 % der Lehrkräfte berichteten zusätzlichen Aufwand durch Kontrolle von KI-Inhalten.",
+    "37 % der Eltern äußerten Datenschutz- und Abhängigkeitsbedenken.",
+    "70 % der Lehrkräfte sollen vor Einführung eine Basisschulung abgeschlossen haben.",
+]
+
+
+def _seed_item(text: str) -> dict:
+    return {
+        "snippet": text,
+        "source_kind": EvidenceSourceKind.seed_corpus.value,
+        "type": "seed_corpus",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Zahlen dürfen ihre Bezugsgruppe nicht wechseln
+# ---------------------------------------------------------------------------
+
+
+def test_1_percentage_may_not_migrate_to_wrong_stakeholder():
+    """61 % gehört zu Zeitersparnis der Lehrkräfte, nicht zur Lernhilfe-Bewertung."""
+    claim = "61 % der Lehrkräfte bewerten die zusätzliche Lernhilfe positiv."
+    evidence = [_seed_item(s) for s in SEED_SENTENCES]
+
+    results = [classify_evidence(claim, item) for item in evidence]
+
+    assert all(r.verdict is not EntailmentVerdict.SUPPORTED for r in results), (
+        "Ein Claim, der 61 % auf die Lernhilfe-Bewertung umdeutet, darf von "
+        "keinem Seed-Satz gestützt werden — 61 % steht dort für Zeitersparnis."
+    )
+
+
+def test_1b_correct_percentage_attribution_is_supported():
+    """Die korrekte Wiedergabe muss weiterhin als SUPPORTED durchgehen."""
+    claim = "72 % der Schülerinnen und Schüler bewerteten die zusätzliche Lernhilfe positiv."
+    result = classify_evidence(claim, _seed_item(SEED_SENTENCES[0]))
+    assert result.verdict is EntailmentVerdict.SUPPORTED
+
+
+def test_1c_training_target_is_not_approval():
+    """'70 % sollen geschult sein' ist eine Zielvorgabe, keine Zustimmungsquote."""
+    claim = "70 % der Lehrkräfte stimmen der Einführung zu."
+    result = classify_evidence(claim, _seed_item(SEED_SENTENCES[4]))
+    assert result.verdict is not EntailmentVerdict.SUPPORTED
+
+
+def test_1d_numeric_extraction_binds_number_to_group_and_predicate():
+    facts = extract_numeric_facts(SEED_SENTENCES[1])
+    assert facts, "Prozentwert muss erkannt werden"
+    fact = facts[0]
+    assert fact.value == pytest.approx(61.0)
+    assert "lehrkr" in fact.subject.lower()
+    assert "zeitersparnis" in fact.predicate.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — kein Thought-/Tool-Leak im sichtbaren Content
+# ---------------------------------------------------------------------------
+
+LEAK_SAMPLES = [
+    "Thought: The interview tool is unavailable.\nLet me use quick_search instead.",
+    "Action: quick_search\nObservation: nothing found",
+    "I need to ground claims in evidence before writing.",
+    "I will now call the tool_call block again.",
+    '<tool_call>{"name": "quick_search"}</tool_call>',
+]
+
+
+@pytest.mark.parametrize("raw", LEAK_SAMPLES)
+def test_2_thought_and_tool_planning_never_reaches_content(raw):
+    with pytest.raises(FinalContentRejected):
+        sanitize_final_content(raw)
+
+
+def test_2b_mixed_content_keeps_only_the_report_body():
+    raw = (
+        "Thought: I need to check the stakeholder positions first.\n"
+        "Action: quick_search\n"
+        "Final Answer:\n"
+        "**Zustimmung**\n\n"
+        "Die Lehrkräfte im Szenario bewerten die Zeitersparnis überwiegend positiv."
+    )
+    cleaned = sanitize_final_content(raw)
+    assert "Thought:" not in cleaned.content
+    assert "Action:" not in cleaned.content
+    assert "Zeitersparnis" in cleaned.content
+    assert cleaned.removed_segments
+
+
+def test_2c_clean_content_passes_unchanged():
+    raw = "Die simulierten Eltern äußern vor allem Datenschutzbedenken."
+    cleaned = sanitize_final_content(raw)
+    assert cleaned.content == raw
+    assert not cleaned.removed_segments
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Ähnlichkeit ist kein Beweis
+# ---------------------------------------------------------------------------
+
+
+def test_3_high_retrieval_score_alone_does_not_support_claim():
+    """Themengleiche, aber nicht belegende Evidence: hoher Score, kein Support."""
+
+    def embed(text: str):  # identische Vektoren => cosine 1.0
+        return [1.0, 0.0, 0.0]
+
+    claim = "Die Eltern lehnen die Plattform mehrheitlich ab."
+    candidates = [
+        {
+            "snippet": "37 % der Eltern äußerten Datenschutz- und Abhängigkeitsbedenken.",
+            "source_kind": EvidenceSourceKind.seed_corpus.value,
+        }
+    ]
+
+    bound = bind_evidence_to_claim(claim, candidates, embed, threshold=0.5)
+    assert bound, "Kandidat muss als Retrieval-Treffer erhalten bleiben"
+    item = bound[0]
+    assert item["retrieval_score"] >= 0.5
+    assert item["supports_claim"] is False, (
+        "Cosine-Similarity darf supports_claim nicht setzen — 37 % Bedenken "
+        "belegen keine mehrheitliche Ablehnung."
+    )
+    assert item["entailment"] in {
+        EntailmentVerdict.RELATED_ONLY.value,
+        EntailmentVerdict.INSUFFICIENT.value,
+        EntailmentVerdict.CONTRADICTED.value,
+    }
+
+
+def test_3b_retrieval_score_and_supports_claim_are_separate_fields():
+    def embed(text: str):
+        return [1.0, 0.0]
+
+    bound = bind_evidence_to_claim(
+        "72 % der Schülerinnen und Schüler bewerteten die zusätzliche Lernhilfe positiv.",
+        [_seed_item(SEED_SENTENCES[0])],
+        embed,
+        threshold=0.5,
+    )
+    assert bound
+    assert "retrieval_score" in bound[0]
+    assert "supports_claim" in bound[0]
+    assert bound[0]["supports_claim"] is True
+    assert bound[0]["entailment"] == EntailmentVerdict.SUPPORTED.value
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Provenance: Simulationsevidence ist kein Seed-Fakt
+# ---------------------------------------------------------------------------
+
+
+def test_4_agent_action_is_a_distinct_source_kind():
+    assert EvidenceSourceKind.agent_action.value == "agent_action"
+    assert EvidenceSourceKind.agent_action is not EvidenceSourceKind.seed_corpus
+
+
+def test_4b_agent_action_is_not_persisted_as_seed_corpus():
+    from app.services.report_agent.evidence import normalize_source_kind
+
+    item = {"type": "agent_action", "snippet": "Agent 12 teilte den Beitrag."}
+    assert normalize_source_kind(item) == EvidenceSourceKind.agent_action.value
+
+
+def test_4c_unknown_evidence_does_not_silently_default_to_seed_corpus():
+    from app.services.report_agent.evidence import normalize_source_kind
+
+    item = {"type": "model_generated_inference", "snippet": "Vermutlich…"}
+    assert normalize_source_kind(item) != EvidenceSourceKind.seed_corpus.value
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Fallback-Fehlertext erzeugt keinen Claim
+# ---------------------------------------------------------------------------
+
+
+def test_5_llm_fallback_error_text_produces_no_claims():
+    from app.services.report_agent.output_contract import is_fallback_content
+
+    fallback = (
+        "(Dieser Abschnitt konnte nicht generiert werden: LLM lieferte eine "
+        "leere Antwort. Report-ID: report_d9023bd1f55a, Abschnitt 7.)"
+    )
+    assert is_fallback_content(fallback) is True
+
+
+def test_5b_claim_extraction_skips_fallback_sections():
+    from app.services.report_agent.output_contract import is_fallback_content
+
+    assert is_fallback_content("Die simulierten Eltern äußern Datenschutzbedenken.") is False
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — fehlgeschlagene Pflichtsection ⇒ INCOMPLETE
+# ---------------------------------------------------------------------------
+
+
+def test_6_failed_required_section_yields_incomplete_status():
+    from app.models.report import ReportStatus
+    from app.services.report_agent.output_contract import resolve_report_status
+
+    status = resolve_report_status(
+        total_sections=11,
+        failed_section_indices=[10],
+        required_section_indices=[10],
+    )
+    assert status == ReportStatus.INCOMPLETE
+
+
+def test_6b_all_sections_ok_yields_completed():
+    from app.models.report import ReportStatus
+    from app.services.report_agent.output_contract import resolve_report_status
+
+    status = resolve_report_status(
+        total_sections=11,
+        failed_section_indices=[],
+        required_section_indices=list(range(1, 12)),
+    )
+    assert status == ReportStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — Section-Metadata landet in ReportV3
+# ---------------------------------------------------------------------------
+
+
+def test_7_section_metadata_reaches_report_v3():
+    from app.services.report_agent.metadata_merge import merge_section_metadata
+
+    sections = [
+        {
+            "section_index": 2,
+            "structured_metadata": {
+                "personas": [
+                    {
+                        "id": "persona_01",
+                        "voice_register": "neutral-de",
+                        "alter_range": "35–50",
+                        "beruf": "Lehrkraft",
+                        "region": "Sachsen-Anhalt",
+                    }
+                ],
+                "segments": [
+                    {
+                        "id": "seg_01",
+                        "name": "Lehrkräfte",
+                        "beschreibung": "Unterrichtende an Sekundarschulen",
+                    }
+                ],
+                "friction_points": [
+                    {
+                        "id": "fp_01",
+                        "beschreibung": "Kontrollaufwand für KI-Inhalte",
+                        "severity": "high",
+                    }
+                ],
+            },
+        }
+    ]
+
+    merged = merge_section_metadata(sections)
+    assert [p.id for p in merged.personas] == ["persona_01"]
+    assert [s.id for s in merged.segments] == ["seg_01"]
+    assert [f.id for f in merged.friction_points] == ["fp_01"]
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — ReportV3 → Markdown/HTML bleibt semantisch identisch
+# ---------------------------------------------------------------------------
+
+
+def test_8_markdown_and_json_render_the_same_structured_items():
+    """ReportV3 ist die kanonische Quelle: was im JSON steht, steht im Markdown.
+
+    HTML wird im Frontend aus genau diesem Markdown/JSON gerendert; der
+    Backend-seitig prüfbare Teil der Invariante ist JSON ≡ Markdown.
+    """
+    from datetime import datetime, timezone
+
+    from app.contracts.report_v3 import FrictionPoint, Persona, ReportV3
+    from app.services.report_agent.markdown_renderer import render_report_v3
+
+    report = ReportV3(
+        report_id="report_d9023bd1f55a",
+        generated_at=datetime.now(timezone.utc),
+        personas=[
+            Persona(
+                id="persona_01",
+                voice_register="neutral-de",
+                alter_range="35–50",
+                beruf="Lehrkraft",
+                region="Sachsen-Anhalt",
+            )
+        ],
+        friction_points=[
+            FrictionPoint(
+                id="fp_01",
+                beschreibung="Kontrollaufwand für KI-Inhalte",
+                severity="high",
+            )
+        ],
+    )
+
+    markdown = render_report_v3(report)
+    payload = report.model_dump(mode="json")
+
+    for needle in ("persona_01", "Kontrollaufwand für KI-Inhalte"):
+        assert needle in markdown, f"{needle} fehlt im Markdown"
+
+    assert [p["id"] for p in payload["personas"]] == ["persona_01"]
+    assert [f["id"] for f in payload["friction_points"]] == ["fp_01"]
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — "Was denken die Leute?" ⇒ kompakter Opinion-Report
+# ---------------------------------------------------------------------------
+
+
+def test_9_opinion_question_selects_compact_preset():
+    assert detect_report_intent("Was denken die Leute?") is ReportIntent.OPINION
+
+    sections = sections_for_intent(ReportIntent.OPINION)
+    assert len(sections) == 6
+    assert len(sections) < len(sections_for_intent(ReportIntent.FULL))
+    joined = " ".join(sections).lower()
+    for absent in ("content-idee", "positionierung", "multiplikator"):
+        assert absent not in joined, f"{absent} gehört nicht in den Opinion-Report"
+
+
+@pytest.mark.parametrize(
+    "question,expected",
+    [
+        ("Was denken die Leute über die Plattform?", ReportIntent.OPINION),
+        ("Wie ist die Stimmung bei den Eltern?", ReportIntent.OPINION),
+        ("Welche Risiken drohen bei der Einführung?", ReportIntent.RISK),
+        ("Vergleiche Variante A und Variante B.", ReportIntent.COMPARISON),
+    ],
+)
+def test_9b_intent_detection_matrix(question, expected):
+    assert detect_report_intent(question) is expected
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — Full-Report bleibt unverändert
+# ---------------------------------------------------------------------------
+
+
+def test_10_full_report_preset_keeps_all_eleven_sections():
+    sections = sections_for_intent(ReportIntent.FULL)
+    assert len(sections) == 11
+
+
+def test_10b_unspecific_question_defaults_to_full():
+    assert detect_report_intent("Erstelle eine umfassende Analyse des Vorhabens.") is (
+        ReportIntent.FULL
+    )

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -523,6 +523,78 @@ def test_7_section_metadata_reaches_report_v3():
     assert [f.id for f in merged.friction_points] == ["fp_01"]
 
 
+def test_7b_persona_table_schema_to_report_v3_chain():
+    """DoD-Punkt 7 Teilbeleg: Personas/Segmente in ReportV3 (Handover P1.3).
+
+    Der echte E2E-Beweis braucht einen Full-Report-Lauf gegen eine lebende
+    Simulation (report_e2e_full01 starb am gap_id-Bug vor Section 3).
+    Dieser Test pinnt die Kette, die im Lauf durchlaufen wird:
+
+      Section-Titel 'Persona-Tabelle'
+        → _section_schema_for wählt PersonaTable-DTO
+        → LLM liefert structured_metadata.personas
+        → merge_section_metadata sammelt sie in MergedMetadata.personas
+        → as_report_v3_kwargs() liefert sie für ReportV3
+
+    Die parametrisierten Schema-Tests in test_report_agent_strict_schema
+    decken Stufe 1 ab; hier wird Stufe 2+3 (Merge → ReportV3-Kwargs) für
+    Personas UND Segmente gepinnt.
+    """
+    from app.services.report_agent.metadata_merge import merge_section_metadata
+    from app.services.report_agent.schemas import _section_schema_for, _make_table_metadata
+    from app.contracts.report_v3 import Persona, Segment
+
+    # Stufe 1: Section-Titel → korrektes DTO
+    assert _section_schema_for("Persona-Tabelle") is _make_table_metadata(Persona)
+    assert _section_schema_for("Segment-Tabelle") is _make_table_metadata(Segment)
+
+    # Stufe 2+3: structured_metadata mit personas/segments → MergedMetadata → ReportV3-Kwargs
+    sections = [
+        {
+            "section_index": 3,
+            "section_title": "Persona-Tabelle",
+            "structured_metadata": {
+                "personas": [
+                    {
+                        "id": "persona_05",
+                        "voice_register": "formal-de",
+                        "alter_range": "45–60",
+                        "beruf": "Schulleitung",
+                        "region": "Sachsen-Anhalt",
+                    },
+                    {
+                        "id": "persona_07",
+                        "voice_register": "neutral-de",
+                        "alter_range": "30–45",
+                        "beruf": "Lehrkraft",
+                        "region": "Bayern",
+                    },
+                ],
+            },
+        },
+        {
+            "section_index": 2,
+            "section_title": "Segment-Tabelle",
+            "structured_metadata": {
+                "segments": [
+                    {"id": "seg_02", "name": "Schulleitungen", "beschreibung": "Administrative Ebene"},
+                ],
+            },
+        },
+    ]
+    merged = merge_section_metadata(sections)
+    assert [p.id for p in merged.personas] == ["persona_05", "persona_07"]
+    assert [s.id for s in merged.segments] == ["seg_02"]
+
+    # Stufe 3: ReportV3-Kwargs enthalten nur befüllte Slots
+    kwargs = merged.as_report_v3_kwargs()
+    assert "personas" in kwargs
+    assert "segments" in kwargs
+    assert "friction_points" not in kwargs  # leer → nicht befüllt
+    assert all(isinstance(p, Persona) for p in kwargs["personas"])
+    assert all(isinstance(s, Segment) for s in kwargs["segments"])
+
+
 # ---------------------------------------------------------------------------
 # Test 8 — ReportV3 → Markdown/HTML bleibt semantisch identisch
 # ---------------------------------------------------------------------------

--- a/backend/tests/regression/test_report_pipeline_trust.py
+++ b/backend/tests/regression/test_report_pipeline_trust.py
@@ -182,6 +182,32 @@ def test_1d_numeric_extraction_binds_number_to_group_and_predicate():
     assert "zeitersparnis" in fact.predicate.lower()
 
 
+def test_1d_en_english_seeds_yield_numeric_facts():
+    """Englische Seeds müssen ebenfalls Fakten liefern (Handover P2.7).
+
+    _split_subject_predicate war auf deutsche Nomen-Großschreibung
+    zugeschnitten; _PERCENT_RE kannte nur 'Prozent' und '%', nicht das
+    englische 'percent'. Englische Sätze lieferten subject='' → 0 Fakten
+    → die Fließtext-Prüfung übersprang sie still. Fix: Regex um 'percent'
+    und 'of' erweitert, Fallback nimmt Bezugsgruppe bis zum ersten
+    bekannten Report-Verb.
+    """
+    cases = [
+        ("61 percent of teachers rated the learning aid positively.", "teachers"),
+        ("48 percent of parents reported that control caused work.", "parents"),
+        ("61% of teachers reported time savings.", "teachers"),
+        ("70 percent of students stated they liked it.", "students"),
+    ]
+    for sentence, expected_subject in cases:
+        facts = extract_numeric_facts(sentence)
+        assert facts, f"kein Fakt extrahiert: {sentence!r}"
+        fact = facts[0]
+        assert fact.subject.lower() == expected_subject, (
+            f"subject={fact.subject!r} erwartet={expected_subject!r} — {sentence!r}"
+        )
+        assert fact.predicate, f"leeres Prädikat: {sentence!r}"
+
+
 # ---------------------------------------------------------------------------
 # Test 2 — kein Thought-/Tool-Leak im sichtbaren Content
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/report_agent/test_native_toolcalls.py
+++ b/backend/tests/services/report_agent/test_native_toolcalls.py
@@ -482,7 +482,12 @@ class TestReactLoopNativeToolCalls:
                 "raw_response": None,
             },
             {
-                "content": "Final Answer: Hier ist die Segment-Analyse.",
+                # Länge realistisch gewählt: der Final-Content-Contract lehnt
+                # Abschnitte unter MIN_CONTENT_CHARS als unbrauchbar ab.
+                "content": (
+                    "Final Answer: Hier ist die Segment-Analyse der simulierten "
+                    "Zielgruppen mit den beobachteten Reaktionsmustern."
+                ),
                 "tool_calls": [],
                 "finish_reason": "stop",
                 "raw_response": None,
@@ -524,7 +529,11 @@ class TestReactLoopNativeToolCalls:
             '<tool_call>{"name": "panorama_search", "parameters": {"query": "q1"}}</tool_call>',
             '<tool_call>{"name": "quick_search", "parameters": {"query": "q2"}}</tool_call>',
             '<tool_call>{"name": "insight_forge", "parameters": {"query": "q3"}}</tool_call>',
-            "Final Answer: Ergebnis der Analyse.",
+            # Siehe oben: MIN_CONTENT_CHARS des Final-Content-Contracts.
+            (
+                "Final Answer: Ergebnis der Analyse mit den zentralen "
+                "Reaktionsmustern der simulierten Gruppen."
+            ),
         ]
         agent.llm.chat.side_effect = chat_responses
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3731 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3732 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3730 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3731 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3729 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3730 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3728 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3729 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3732 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3733 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3690 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3720 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3720 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3721 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3722 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3728 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3733 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3739 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3721 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3722 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/decisions/0011-evidence-entailment-and-provenance.md
+++ b/docs/decisions/0011-evidence-entailment-and-provenance.md
@@ -1,0 +1,123 @@
+# ADR-0011: Evidence-Entailment, Provenance-Trennung und Final-Content-Contract
+
+- Status: akzeptiert
+- Datum: 2026-07-27
+- Bezug: ergänzt [ADR-0002](0002-evidence-gating.md) — ersetzt es nicht
+
+## Kontext
+
+Der Referenzlauf `report_d9023bd1f55a` (Simulation `sim_7058c126da03`, 30 Agents,
+315 Interaktionen, 5 Cluster, Echo-Chamber-Index 0.4317, Modus `balanced`)
+lieferte einen Report, der formal valide, inhaltlich aber nicht vertrauenswürdig
+war. Sieben Ursachen ließen sich im Code belegen:
+
+1. Der Section-Prompt forderte ausdrücklich `Output your thinking` und
+   `First think (Thought)`; `workflow.py` übernahm den Modelloutput per
+   `final_answer = response.strip()` ungeprüft. Interne Arbeitsschritte
+   erschienen als Berichtsinhalt und wurden zu Claims weiterverarbeitet.
+2. Seed-Zahlen wanderten zu falschen Bezugsgruppen (61 % Zeitersparnis der
+   Lehrkräfte wurde zu "61 % bewerten die Lernhilfe positiv"); eine Zielvorgabe
+   ("70 % sollen geschult sein") wurde als Zustimmungsquote gelesen.
+3. `evidence_binder.bind_evidence_to_claim` setzte `supports_claim = True`
+   allein aufgrund von Cosine-Similarity über einem Schwellwert.
+4. `EvidenceItemModel.source_kind` hatte den Default `seed_corpus`. Damit galt
+   jedes Item ohne explizite Angabe als Dokumentfakt — auch Agentenaktionen und
+   Web-Treffer.
+5. Interpretationen ohne Beleg liefen als Claims durch, weil der Claim-Floor
+   jedes thematisch ähnliche Evidence-Item mitzählte.
+6. `generate_section_metadata` extrahierte Personas, Segmente und
+   Reibungspunkte, gab sie aber nur an den Report-Logger weiter. `ReportV3`
+   blieb leer, während der Prosa-Report dieselben Inhalte zeigte.
+7. `report.status = ReportStatus.COMPLETED` wurde unabhängig davon gesetzt, ob
+   einzelne Abschnitte fehlgeschlagen waren.
+
+## Entscheidung
+
+### 1. Evidence-Binding ist zweistufig
+
+Retrieval und Beweis werden getrennt:
+
+- Stufe 1 schreibt `retrieval_score` (Cosine-Similarity). Sie beantwortet nur
+  "gleiches Thema?".
+- Stufe 2 (`evidence_entailment.classify_evidence`) schreibt `entailment` mit
+  einem von vier Urteilen: `SUPPORTED`, `CONTRADICTED`, `RELATED_ONLY`,
+  `INSUFFICIENT`.
+
+`supports_claim = True` wird ausschließlich bei `SUPPORTED` gesetzt.
+`RELATED_ONLY` und `INSUFFICIENT` erhöhen die Confidence nie;
+`CONTRADICTED` senkt sie und setzt `contradicts_claim`.
+
+Deterministische Checks haben Vorrang. Sobald ein Claim eine Zahl, eine
+Bezugsgruppe oder eine Mengenaussage trägt, entscheidet die Regel — nicht das
+Embedding. Ein optionaler LLM-Judge darf ein regelbasiertes `SUPPORTED` nur
+abschwächen, nie erzeugen.
+
+Ein numerischer Seed-Fakt gilt nur dann als übernommen, wenn Zahl,
+Bezugsgruppe, Aussage **und** Modalität zusammenpassen. Die Modalität trennt
+berichtete Ist-Werte von normativen Zielvorgaben ("sollen", "geplant").
+
+### 2. Provenance unterscheidet Seed, Simulation und Recherche
+
+`EvidenceSourceKind` wird additiv um `agent_action` und `web_source` erweitert.
+Der Default wechselt von `seed_corpus` zu `inferred`: unbekannte Herkunft ist
+abgeleitet, nicht belegt.
+
+Für die ADR-0002-Anker ändert sich nichts — `cross_stakeholder_for_high` wertet
+weiterhin ausschließlich `agent_quote` als Stakeholder-Stimme, und
+`reject_inferred_in_high_confidence` bleibt unverändert. Eine Agentenaktion ist
+Simulationsverhalten, keine Stakeholder-Aussage, und rechtfertigt kein `high`.
+
+### 3. Final-Content-Contract
+
+Der Section-Prompt fordert kein "Thought" mehr: eine Antwort enthält entweder
+nur den `<tool_call>`-Block oder nur `Final Answer:` plus Berichtstext. Die
+Durchsetzung liegt in `report_agent/output_contract.sanitize_final_content` —
+gestaffelt (strukturell vor zeilenweise vor Gate), nicht als Regex-Halde.
+Bleibt nach dem Entfernen aller Arbeitsspuren kein tragfähiger Inhalt übrig,
+wird der Output abgelehnt statt notdürftig weitergereicht.
+
+### 4. Fehlgeschlagene Abschnitte sind sichtbar
+
+Abschnitte mit Fallback-Text erzeugen weder Claims noch Evidence noch
+Metadaten. Eine fehlgeschlagene Pflichtsection setzt den Report auf
+`INCOMPLETE`; der Rest bleibt nutzbar.
+
+### 5. ReportV3 ist die kanonische Struktur-Quelle
+
+Validierte Section-Metadaten fließen über `report_agent/metadata_merge` in
+`ReportV3`. Markdown, HTML, JSON und Frontend rendern dieselbe Quelle, statt
+Inhalte unabhängig zu rekonstruieren.
+
+### 6. Confidence trennt Quellentreue von Simulationskonsens
+
+`compute_confidence` rechnet nur noch mit stützender Evidence.
+`compute_confidence_breakdown` liefert zusätzlich `source_fidelity` (wie
+quellentreu gibt der Claim wieder, was in den Quellen steht) und
+`simulation_consensus` (wie breit tragen unabhängige simulierte
+Stakeholder-Gruppen die Aussage). Ein korrekt wiedergegebener Seed-Fakt ist
+damit ausdrücklich keine Aussage über die reale Bevölkerung.
+
+## Konsequenzen
+
+- Reports enthalten weniger Claims und mehr explizit markierte Hypothesen. Das
+  ist beabsichtigt.
+- Bestehende Evidence-Daten ohne `entailment`-Feld gelten weiterhin als
+  stützend, damit Alt-Reports beim Neuberechnen nicht ihre Confidence verlieren.
+- Alte Fixtures ohne `source_kind` laden weiter, verlieren aber ihren
+  unverdienten Seed-Status.
+- Die Drift-Guards für ADR-0002 Anker 3 wurden auf sechs Werte gepinnt. Anker 1,
+  2, 4 und 5 sind unverändert.
+
+## Verworfene Alternativen
+
+**Nur eine Sanitizer-Regex gegen `Thought:`.** Behandelt das Symptom. Solange
+der Prompt Denkprotokolle anfordert, produziert das Modell sie weiter — in
+Varianten, die keine Regex-Liste vollständig erfasst.
+
+**Similarity-Schwelle anheben statt Entailment.** Ein höherer Schwellwert
+verschiebt nur, wo die Verwechslung von Ähnlichkeit und Beweis auftritt. Sie
+bleibt bestehen.
+
+**`EvidenceSourceKind` ersetzen statt erweitern.** Hätte ADR-0002 Anker 3
+gebrochen und alle bestehenden Reports invalidiert. Die additive Erweiterung
+verschärft die Trennung, ohne das Gating zu schwächen.

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -74,6 +74,11 @@ const emit = defineEmits(['add-log', 'update-status', 'stop'])
 const phase = ref(0)
 const reportPending = ref(false)
 const statusMsg = ref('')
+// Tatsaechlicher Backend-Status: 'pending' | 'planning' | 'generating' |
+// 'incomplete' | 'completed' | 'failed'. Wird im Status-Poll gesetzt und
+// steuert Badge-Text/Variant (P2.6: vorher fiel 'incomplete' durch den
+// else-Zweig und blieb als 'running' sichtbar).
+const reportStatus = ref<string>('')
 const reportOutline = ref<ReportOutline | null>(null)
 const generatedSections = ref<Record<string, unknown>>({})
 const currentSectionIndex = ref<number | null>(null)
@@ -269,10 +274,33 @@ async function pollStatus() {
       if (st.sections) generatedSections.value = st.sections
       currentSectionIndex.value = st.current_section_index ?? currentSectionIndex.value
       if (st.simulation_id && !resolvedSimulationId.value) resolvedSimulationId.value = st.simulation_id
+      // P2.6: Backend-Status separat merken — er treibt das Badge und die
+      // 'incomplete'-Transition. 'completed' und 'incomplete' sind beide
+      // Endzustände mit unterschiedlicher User-Botschaft.
+      reportStatus.value = st.status || ''
       if (st.status === 'completed') {
         const resolvedId = (st.report_id || props.reportId) as string
         isComplete.value = true; phase.value = 2
         emit('update-status', 'completed')
+        try {
+          const full = (await getReport(resolvedId)) as ApiResult
+          if (full?.success) {
+            try {
+              const parsed = ReportSchema.parse(full.data)
+              fullReport.value = parsed
+              syncOutlineFromReport(parsed)
+            } catch (err) { recordSchemaError('report', err); fullReport.value = null }
+            await loadEvidence()
+          }
+        } catch { /* report not yet flushed */ }
+        stopPolling()
+      } else if (st.status === 'incomplete') {
+        // Backend liefert fehlgeschlagene Pflichtsections → INCOMPLETE.
+        // Rest des Reports ist nutzbar; der Nutzer sieht, was fehlt.
+        const resolvedId = (st.report_id || props.reportId) as string
+        phase.value = 2
+        emit('update-status', 'incomplete')
+        addLog(t('step4.status.incomplete') || 'Report unvollständig — einige Abschnitte fehlen.')
         try {
           const full = (await getReport(resolvedId)) as ApiResult
           if (full?.success) {
@@ -299,6 +327,34 @@ function stopPolling() { statusPolling.stop(); agentLogPolling.stop(); consoleLo
 
 const reportMarkdown = computed((): string => fullReport.value?.markdown_content ?? '')
 const reportHtml = computed(() => renderMarkdown(reportMarkdown.value))
+
+// P2.6: Anzahl fehlgeschlagener Sections (generation_failed=true).
+// Backend-Hinweis: jede Section kann generation_failed=true tragen, auch
+// wenn der Gesamt-Report COMPLETED ist. Im INCOMPLETE-Fall zeigen wir
+// die Zahl im Badge, sonst zaehlen wir sie still.
+const failedSectionCount = computed((): number => {
+  let n = 0
+  for (const v of Object.values(generatedSections.value || {})) {
+    if (v && typeof v === 'object' && (v as { generation_failed?: boolean }).generation_failed) {
+      n++
+    }
+  }
+  return n
+})
+
+const reportBadgeLabel = computed((): string => {
+  if (phase.value !== 2) {
+    return phase.value === 1 ? t('common.running') : t('common.ready')
+  }
+  if (reportStatus.value === 'incomplete') return t('common.incomplete')
+  return t('common.completed')
+})
+
+const reportBadgeVariant = computed((): string => {
+  if (phase.value !== 2) return 'accent'
+  if (reportStatus.value === 'incomplete') return 'warning'
+  return 'solid'
+})
 const redTeamFindings = computed((): string[] => fullReport.value?.red_team_findings ?? [])
 
 const sectionHtml = computed((): Record<string, string> => {
@@ -429,8 +485,8 @@ onUnmounted(stopPolling)
         <header class="card-head">
           <Kicker num="01">{{ t('step4.title') }}</Kicker>
           <div class="card-head-actions">
-            <Badge :variant="phase === 2 ? 'solid' : 'accent'" :dot="phase === 1">
-              {{ phase === 2 ? t('common.completed') : phase === 1 ? t('common.running') : t('common.ready') }}
+            <Badge :variant="reportBadgeVariant" :dot="phase === 1">
+              {{ reportBadgeLabel }}
             </Badge>
             <span v-if="!props.cancelEndpointAvailable" :title="t('step4.reportConfirm.stopDisabledTip')" class="stop-btn-wrap">
               <Button variant="ghost" disabled class="stop-btn">{{ t('step4.reportConfirm.stopButton') }}</Button>
@@ -440,6 +496,12 @@ onUnmounted(stopPolling)
         </header>
         <p class="card-desc">{{ t('step4.sub') }}</p>
         <p v-if="statusMsg" class="meta">{{ statusMsg }}</p>
+        <!-- P2.6: Anzahl fehlgeschlagener Sections sichtbar machen. Auch bei
+             status=completed moeglich (z. B. wenn nur optionale Sections
+             fehlschlugen) — dann Hinweis statt harte Warnung. -->
+        <p v-if="failedSectionCount > 0" class="meta meta--warn" data-testid="report-failed-sections">
+          {{ t('step4.status.sectionFailed') }}: {{ failedSectionCount }}
+        </p>
 
         <div v-if="reportPending && phase === 0" class="report-confirm-block" data-testid="report-confirm-block">
           <p class="report-confirm-title">{{ t('step4.reportConfirm.title') }}</p>
@@ -530,6 +592,7 @@ onUnmounted(stopPolling)
 .card-head { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--rule); padding-bottom: var(--s-3); }
 .card-desc { color: var(--fg-body); margin: 0; }
 .meta { color: var(--fg-muted); font-family: var(--ff-mono); font-size: 11px; }
+.meta--warn { color: var(--status-warning, #b87a00); font-weight: 600; }
 .actions { display: flex; gap: var(--s-3); justify-content: flex-end; }
 .schema-error {
   background: color-mix(in srgb, var(--status-error, #c0392b) 10%, transparent);

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -298,7 +298,9 @@ async function pollStatus() {
         // Backend liefert fehlgeschlagene Pflichtsections → INCOMPLETE.
         // Rest des Reports ist nutzbar; der Nutzer sieht, was fehlt.
         const resolvedId = (st.report_id || props.reportId) as string
-        phase.value = 2
+        // INCOMPLETE ist terminal: isComplete verhindert, dass onMounted nach
+        // einem Reload erneut in den Polling-Pfad springt.
+        isComplete.value = true; phase.value = 2
         emit('update-status', 'incomplete')
         addLog(t('step4.status.incomplete') || 'Report unvollständig — einige Abschnitte fehlen.')
         try {

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -121,8 +121,11 @@ const i18n = createI18n({
       'step4.next': 'Weiter',
       'step4.quote.openSource': 'Quelle öffnen',
       'common.completed': 'Fertig',
+      'common.incomplete': 'Unvollständig',
       'common.running': 'Laufend',
       'common.ready': 'Bereit',
+      'step4.status.incomplete': 'Report unvollständig — einige Abschnitte sind fehlgeschlagen.',
+      'step4.status.sectionFailed': 'Abschnitt fehlgeschlagen',
       'errors.reportFailed': 'Fehler',
       'reportMode.label': 'Report-Modus',
       'reportMode.strict.label': 'Strikt',
@@ -259,6 +262,85 @@ describe('Step4Report — strict-Zod-Parse (Sub-Slice 15)', () => {
     expect(wrapper.find('.schema-error').exists()).toBe(true)
     expect(wrapper.find('.schema-error').text()).toContain('evidence')
   })
+})
+
+// P2.6: INCOMPLETE-Status sichtbar im Frontend (Status-Badge + Section-Counter).
+describe('Step4Report — INCOMPLETE-Status und generation_failed (P2.6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMockSelection()
+  })
+
+  it('zählt fehlgeschlagene Sections (generation_failed=true) und blendet einen Hinweis ein', async () => {
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: {
+        status: 'completed',
+        report_id: 'report_test01',
+        simulation_id: 'sim_test01',
+        sections: {
+          1: { content: '## Abschnitt 1\n\nInhalt.', generation_failed: false },
+          2: { content: '## Abschnitt 2\n\nInhalt.', generation_failed: true },
+          3: { content: '## Abschnitt 3\n\nInhalt.', generation_failed: true },
+        },
+      },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: VALID_REPORT,
+    })
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: VALID_EVIDENCE,
+    })
+
+    const wrapper = mountComponent()
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 80))
+    await wrapper.vm.$nextTick()
+
+    const failedNote = wrapper.find('[data-testid="report-failed-sections"]')
+    expect(failedNote.exists()).toBe(true)
+    expect(failedNote.text()).toContain('2')
+  })
+
+  it('blendet den Section-Hinweis NICHT ein, wenn keine generation_failed=true vorliegt', async () => {
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: {
+        status: 'completed',
+        report_id: 'report_test01',
+        simulation_id: 'sim_test01',
+        sections: {
+          1: { content: 'A', generation_failed: false },
+          2: { content: 'B', generation_failed: false },
+        },
+      },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: VALID_REPORT,
+    })
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: VALID_EVIDENCE,
+    })
+
+    const wrapper = mountComponent()
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 80))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="report-failed-sections"]').exists()).toBe(false)
+  })
+
+  // Hinweis: die Report-Badge-Variante/-Text für status='incomplete' wird in
+  // production code über reportBadgeLabel/reportBadgeVariant computed values
+  // gerendert, getrieben von reportStatus (ref). Der Text-Pfad ist hier
+  // absichtlich NICHT getestet, weil Badge-Stub + i18n-Mock + jsdom-Microtask-
+  // Reihenfolge den Test flaky machen. Verifikation erfolgt stattdessen über
+  // unit-level test_3 (status_polling_handles_incomplete) im Backend — der
+  // dortige resolve_report_status-Branch ist der Source-of-Truth.
 })
 
 // Sub-Slice 16b: klickbare Quotes + source_id_anchor-Scroll (Refs #173)

--- a/frontend/src/components/step4/__tests__/ReportEvidencePanel.spec.ts
+++ b/frontend/src/components/step4/__tests__/ReportEvidencePanel.spec.ts
@@ -45,6 +45,8 @@ const mockSection: ReportSection = {
   hypotheses: [1, 2, 3, 4, 5].map(makeHypothesis),
   hypotheses_appendix: [6, 7, 8].map(makeHypothesis),
   data_gaps: [],
+  structured_metadata: {},
+  generation_failed: false,
 }
 
 describe('ReportEvidencePanel — Hypothesen-Accordion', () => {

--- a/frontend/src/contracts/reportContract.ts
+++ b/frontend/src/contracts/reportContract.ts
@@ -35,13 +35,36 @@ export type EvidenceType = z.infer<typeof EvidenceTypeSchema>;
 
 // ADR-0002 Anker 3 (Sub-Slice M11.7b): Quellengattung pro Evidence-Item.
 // Spiegelt EvidenceSourceKind aus backend/app/contracts/report_contract.py.
+// Report-Trust-Slice: um "agent_action" und "web_source" erweitert, damit
+// Seed-Dokument, Simulation und Web-Recherche nicht mehr in einer einzigen
+// Gattung verschmelzen.
 export const EvidenceSourceKindSchema = z.enum([
   "seed_corpus",
   "agent_quote",
+  "agent_action",
   "graph_relation",
+  "web_source",
   "inferred",
 ]);
 export type EvidenceSourceKind = z.infer<typeof EvidenceSourceKindSchema>;
+
+// Quellengattungen aus der Simulation — nie ein Seed-Fakt.
+// Pendant zu SIMULATION_SOURCE_KINDS im Backend.
+export const SIMULATION_SOURCE_KINDS: ReadonlySet<EvidenceSourceKind> = new Set([
+  "agent_quote",
+  "agent_action",
+]);
+
+// Urteil der zweiten Binding-Stufe. Spiegelt EntailmentVerdict aus
+// backend/app/services/evidence_entailment.py. Nur "SUPPORTED" darf
+// supports_claim=true begruenden — Retrieval-Aehnlichkeit allein nicht.
+export const EntailmentVerdictSchema = z.enum([
+  "SUPPORTED",
+  "CONTRADICTED",
+  "RELATED_ONLY",
+  "INSUFFICIENT",
+]);
+export type EntailmentVerdict = z.infer<typeof EntailmentVerdictSchema>;
 
 export const ReportStatusSchema = z.enum([
   "pending", "planning", "generating", "incomplete", "completed", "failed",
@@ -66,7 +89,14 @@ export const EvidenceItemSchema = z.object({
   raw: z.unknown().optional().nullable(),
   agent_log_ref: AgentLogRefSchema.optional().nullable(),
   match_score: z.number().min(0).max(1).optional().nullable(),
+  // Retrieval-Score der ersten Binding-Stufe (Cosine-Similarity). Alias von
+  // match_score — beantwortet "gleiches Thema?", nicht "belegt?".
+  retrieval_score: z.number().min(0).max(1).optional().nullable(),
+  // Urteil der zweiten Stufe. supports_claim ist nur bei "SUPPORTED" true.
+  entailment: EntailmentVerdictSchema.optional().nullable(),
+  entailment_reason: z.string().max(500).optional().nullable(),
   supports_claim: z.boolean().optional().nullable(),
+  contradicts_claim: z.boolean().optional().nullable(),
   // MAI-14 (backend) + Sub-Slice 05.8 (Zod-Spiegel):
   // Sentiment des Quellen-Snippets (-1 negativ, 0 neutral, +1 positiv).
   // confidence_calculator._has_contradiction nutzt es, um widersprüchliche
@@ -74,8 +104,9 @@ export const EvidenceItemSchema = z.object({
   sentiment_score: z.number().min(-1).max(1).optional().nullable(),
   quote: z.string().min(1).max(500).optional().nullable(),
   source_id_anchor: z.string().min(1).max(200).optional().nullable(),
-  // ADR-0002 Anker 3 (Sub-Slice M11.7b)
-  source_kind: EvidenceSourceKindSchema.default("seed_corpus"),
+  // ADR-0002 Anker 3 (Sub-Slice M11.7b). Default "inferred": unbekannte
+  // Herkunft ist abgeleitet, nicht belegt. Spiegelt den Backend-Default.
+  source_kind: EvidenceSourceKindSchema.default("inferred"),
   persona_stakeholder_group: z.string().min(1).max(200).optional().nullable(),
   // Slice 8 (2026-05-16) — Provider+Modell, das diese Evidence-Zeile
   // extrahiert hat. Pendant zu EvidenceItemModel.source_model. Format
@@ -195,6 +226,12 @@ export const ReportSectionSchema = z.object({
   // Slice 3 (Issue #495): Überhang nach Cap von 5 — spiegelt backend ReportSectionModel.hypotheses_appendix.
   hypotheses_appendix: z.array(ReportSectionHypothesisSchema).max(50).default([]),
   data_gaps: z.array(ReportSectionDataGapSchema).default([]),
+  // P0-6: Von generate_section_metadata extrahierte ReportV3-Strukturdaten.
+  // Sie sind die kanonische Quelle fuer Personas/Segmente/Reibungspunkte in
+  // ReportV3 — bewusst unstrukturiert, die Einzel-DTOs validiert das Backend.
+  structured_metadata: z.record(z.string(), z.unknown()).default({}),
+  // P0-7: true, wenn dieser Abschnitt nur Fallback-/Fehlertext enthaelt.
+  generation_failed: z.boolean().default(false),
 }).strict();
 export type ReportSection = z.infer<typeof ReportSectionSchema>;
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -41,6 +41,7 @@
     "ready": "Bereit",
     "running": "Läuft",
     "completed": "Abgeschlossen",
+    "incomplete": "Unvollständig",
     "failed": "Fehlgeschlagen",
     "error": "Fehler",
     "yes": "Ja",
@@ -581,6 +582,10 @@
       "startButton": "Report starten",
       "stopButton": "Abbrechen",
       "stopDisabledTip": "Abbruch verfügbar nach Backend-Slice 6"
+    },
+    "status": {
+      "incomplete": "Report unvollständig — einige Abschnitte sind fehlgeschlagen.",
+      "sectionFailed": "Abschnitt fehlgeschlagen"
     },
     "next": "Weiter zum Gespräch →"
   },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -41,6 +41,7 @@
     "ready": "Ready",
     "running": "Running",
     "completed": "Completed",
+    "incomplete": "Incomplete",
     "failed": "Failed",
     "error": "Error",
     "yes": "Yes",
@@ -581,6 +582,10 @@
       "startButton": "Start report",
       "stopButton": "Cancel",
       "stopDisabledTip": "Cancel available after backend slice 6"
+    },
+    "status": {
+      "incomplete": "Report incomplete — some sections failed.",
+      "sectionFailed": "Section failed"
     },
     "next": "Next: conversation →"
   },

--- a/schemas/evidence-map.schema.json
+++ b/schemas/evidence-map.schema.json
@@ -42,6 +42,17 @@
       "title": "ConfidenceLabel",
       "type": "string"
     },
+    "EntailmentVerdict": {
+      "description": "Urteil der zweiten Binding-Stufe.\n\nSpiegelt ``app.services.evidence_entailment.EntailmentVerdict``. Nur\n``SUPPORTED`` rechtfertigt ``supports_claim=True``; ``RELATED_ONLY`` und\n``INSUFFICIENT`` erh\u00f6hen die Confidence nie.",
+      "enum": [
+        "SUPPORTED",
+        "CONTRADICTED",
+        "RELATED_ONLY",
+        "INSUFFICIENT"
+      ],
+      "title": "EntailmentVerdict",
+      "type": "string"
+    },
     "EvidenceItemModel": {
       "additionalProperties": false,
       "description": "Bestehende EvidenceItem-Felder aus report_agent.py, jetzt typsicher.",
@@ -56,6 +67,42 @@
             }
           ],
           "default": null
+        },
+        "contradicts_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contradicts Claim"
+        },
+        "entailment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntailmentVerdict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entailment_reason": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entailment Reason"
         },
         "match_score": {
           "anyOf": [
@@ -120,6 +167,20 @@
           ],
           "default": null,
           "title": "Raw"
+        },
+        "retrieval_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Score"
         },
         "sentiment_score": {
           "anyOf": [

--- a/schemas/evidence-map.schema.json
+++ b/schemas/evidence-map.schema.json
@@ -163,7 +163,7 @@
         },
         "source_kind": {
           "$ref": "#/$defs/EvidenceSourceKind",
-          "default": "seed_corpus"
+          "default": "inferred"
         },
         "source_model": {
           "anyOf": [
@@ -237,11 +237,13 @@
       "type": "object"
     },
     "EvidenceSourceKind": {
-      "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Genau diese 4 Werte sind im Prompt-Block\n``backend/app/services/report_prompts.py`` referenziert (Anker 1).",
+      "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Diese Werte sind im Prompt-Block\n``backend/app/services/report_prompts/sections.py`` referenziert (Anker 1).\n\nErweiterung (Report-Trust-Slice): ``agent_action`` und ``web_source``\nerg\u00e4nzen die urspr\u00fcnglichen vier Werte. Das ist additiv und versch\u00e4rft\nADR-0002, statt es zu schw\u00e4chen \u2014 vorher liefen Agentenaktionen und\nWeb-Treffer \u00fcber den Default ``seed_corpus`` und verschmolzen damit\nSeed-Dokument, Simulation und Recherche zu einer einzigen Quellengattung.\nF\u00fcr die Confidence-Anker gilt weiterhin: nur ``agent_quote`` z\u00e4hlt als\nStakeholder-Stimme, nur ``seed_corpus`` als Dokumentfakt.",
       "enum": [
         "seed_corpus",
         "agent_quote",
+        "agent_action",
         "graph_relation",
+        "web_source",
         "inferred"
       ],
       "title": "EvidenceSourceKind",
@@ -423,6 +425,11 @@
           "title": "Data Gaps",
           "type": "array"
         },
+        "generation_failed": {
+          "default": false,
+          "title": "Generation Failed",
+          "type": "boolean"
+        },
         "hypotheses": {
           "items": {
             "$ref": "#/$defs/ReportSectionHypothesisModel"
@@ -452,6 +459,11 @@
           "minLength": 3,
           "title": "Section Title",
           "type": "string"
+        },
+        "structured_metadata": {
+          "additionalProperties": true,
+          "title": "Structured Metadata",
+          "type": "object"
         }
       },
       "required": [

--- a/schemas/report-contract.schema.json
+++ b/schemas/report-contract.schema.json
@@ -42,6 +42,17 @@
       "title": "ConfidenceLabel",
       "type": "string"
     },
+    "EntailmentVerdict": {
+      "description": "Urteil der zweiten Binding-Stufe.\n\nSpiegelt ``app.services.evidence_entailment.EntailmentVerdict``. Nur\n``SUPPORTED`` rechtfertigt ``supports_claim=True``; ``RELATED_ONLY`` und\n``INSUFFICIENT`` erh\u00f6hen die Confidence nie.",
+      "enum": [
+        "SUPPORTED",
+        "CONTRADICTED",
+        "RELATED_ONLY",
+        "INSUFFICIENT"
+      ],
+      "title": "EntailmentVerdict",
+      "type": "string"
+    },
     "EvidenceItemModel": {
       "additionalProperties": false,
       "description": "Bestehende EvidenceItem-Felder aus report_agent.py, jetzt typsicher.",
@@ -56,6 +67,42 @@
             }
           ],
           "default": null
+        },
+        "contradicts_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contradicts Claim"
+        },
+        "entailment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntailmentVerdict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entailment_reason": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entailment Reason"
         },
         "match_score": {
           "anyOf": [
@@ -120,6 +167,20 @@
           ],
           "default": null,
           "title": "Raw"
+        },
+        "retrieval_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Score"
         },
         "sentiment_score": {
           "anyOf": [

--- a/schemas/report-contract.schema.json
+++ b/schemas/report-contract.schema.json
@@ -163,7 +163,7 @@
         },
         "source_kind": {
           "$ref": "#/$defs/EvidenceSourceKind",
-          "default": "seed_corpus"
+          "default": "inferred"
         },
         "source_model": {
           "anyOf": [
@@ -279,11 +279,13 @@
       "type": "object"
     },
     "EvidenceSourceKind": {
-      "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Genau diese 4 Werte sind im Prompt-Block\n``backend/app/services/report_prompts.py`` referenziert (Anker 1).",
+      "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Diese Werte sind im Prompt-Block\n``backend/app/services/report_prompts/sections.py`` referenziert (Anker 1).\n\nErweiterung (Report-Trust-Slice): ``agent_action`` und ``web_source``\nerg\u00e4nzen die urspr\u00fcnglichen vier Werte. Das ist additiv und versch\u00e4rft\nADR-0002, statt es zu schw\u00e4chen \u2014 vorher liefen Agentenaktionen und\nWeb-Treffer \u00fcber den Default ``seed_corpus`` und verschmolzen damit\nSeed-Dokument, Simulation und Recherche zu einer einzigen Quellengattung.\nF\u00fcr die Confidence-Anker gilt weiterhin: nur ``agent_quote`` z\u00e4hlt als\nStakeholder-Stimme, nur ``seed_corpus`` als Dokumentfakt.",
       "enum": [
         "seed_corpus",
         "agent_quote",
+        "agent_action",
         "graph_relation",
+        "web_source",
         "inferred"
       ],
       "title": "EvidenceSourceKind",
@@ -640,6 +642,11 @@
           "title": "Data Gaps",
           "type": "array"
         },
+        "generation_failed": {
+          "default": false,
+          "title": "Generation Failed",
+          "type": "boolean"
+        },
         "hypotheses": {
           "items": {
             "$ref": "#/$defs/ReportSectionHypothesisModel"
@@ -669,6 +676,11 @@
           "minLength": 3,
           "title": "Section Title",
           "type": "string"
+        },
+        "structured_metadata": {
+          "additionalProperties": true,
+          "title": "Structured Metadata",
+          "type": "object"
         }
       },
       "required": [


### PR DESCRIPTION
Behebt die im Lauf `report_d9023bd1f55a` (Simulation `sim_7058c126da03`) sichtbaren Vertrauensdefekte der Report-Pipeline. Alle Ursachen wurden im Code verifiziert, nicht aus der Fehlerbeschreibung übernommen.

## Root Causes

| # | Ursache | Fundstelle |
|---|---|---|
| 1 | Prompt forderte `Output your thinking` / `First think (Thought)`; `final_answer = response.strip()` übernahm alles ungeprüft | `report_prompts/sections.py`, `report_agent/workflow.py` |
| 2 | Kein Abgleich Zahl ↔ Bezugsgruppe ↔ Aussage; Modalität („sollen") ignoriert | fehlte |
| 3 | `if score >= threshold: supports_claim = True` | `evidence_binder.py` |
| 4 | `source_kind` defaultete auf `seed_corpus` | `contracts/report_contract.py` |
| 5 | Claim-Floor zählte auch nicht-stützende Evidence | `report_agent/agent.py` |
| 6 | `section_meta` ging nur in den Logger, nie nach ReportV3 | `workflow.py`, `manager.py` |
| 7 | `report.status = COMPLETED` unbedingt | `workflow.py` |

## Architektur

**Binding ist zweistufig.** Stufe 1 schreibt `retrieval_score` (Cosine — „gleiches Thema?"), Stufe 2 schreibt `entailment` ∈ {SUPPORTED, CONTRADICTED, RELATED_ONLY, INSUFFICIENT}. Nur SUPPORTED setzt `supports_claim=True`. Deterministische Checks (Zahl, Bezugsgruppe, Modalität) haben Vorrang; ein optionaler LLM-Judge darf SUPPORTED nur abschwächen, nie erzeugen.

**Provenance** additiv um `agent_action` und `web_source` erweitert, Default `seed_corpus` → `inferred`. ADR-0002-Anker 1, 2, 4, 5 unverändert — `agent_action` zählt ausdrücklich nicht als Stakeholder-Stimme.

**Final-Content-Contract** statt `response.strip()`: gestaffelt (strukturell → zeilenweise → Gate), kein Regex-Wildwuchs.

**Intent-Presets:** „Was denken die Leute?" ergibt einen 6-teiligen Opinion-Report. Der 11-teilige Full-Report bleibt Default und unverändert.

Entscheidung dokumentiert in `docs/decisions/0011-evidence-entailment-and-provenance.md`.

## Echter E2E-Lauf

Gegen `sim_7058c126da03` durchgeführt (563 s, `COMPLETED`). Er deckte vier Integrationsfehler auf, die 29 grüne Unit-Tests nicht sehen konnten — alle behoben und mit Regressionstests gepinnt:

1. Pflichtabschnitt-Validator existiert an zwei Stellen und erzwang beide Male die elf Full-Titel → Opinion-Report ohne Abschnitte
2. Neue Evidence-Felder fehlten in `EvidenceItemModel` (`extra="forbid"`) → 45 Validation-Errors
3. `graph_fact` fiel durchs Provenance-Mapping → 125/125 Items fälschlich `inferred`
4. Fallback-`gap_id` verletzte `^gap_\d{2,}$` → kompletter Report `failed`

### Ergebnis gegen die Baseline

| Kennzahl | vorher (`d9023bd1f55a`) | nachher |
|---|---|---|
| Claims | 119 | 25 |
| `supports_claim` | 594× true / 0× false | 54 true / 71 false |
| Entailment | — | 54 SUPPORTED, 32 RELATED_ONLY, 39 INSUFFICIENT |
| Hypothesen | 0 | 30 sichtbar (+145 Appendix) |
| Data Gaps | 0 | 129 |
| `Thought:` / `Let me` | 4× / 4× | **0** |
| Fallbacktext im Report | ja | **nein** |
| „Lernraum AI" als EdTech-Firma | ja | **nein** (0 Treffer) |
| `source_kind` | 594× `seed_corpus` | `graph_relation` korrekt getrennt |

Thresholds wurden **nicht** angefasst — der Lauf gab keinen Anlass: SUPPORTED entsteht regulär mit `retrieval_score` 0.78–0.92.

## Bekannt offen

- **Der Prosatext wird nicht faktengeprüft.** Die Falschzuordnung „61 % der Lehrkräfte bewerteten die Lernhilfe positiv" steht weiterhin im Fließtext. Als *Claim* kommt sie nicht mehr durch (0 Claims mit 61), sie landet korrekt unter Hypothesen. Der Wissensgraph enthält den Satz korrekt — der Fehler entsteht rein in der LLM-Prosa.
- `confidence_label` bleibt bei allen Claims `medium`.
- Personas/Segmente in ReportV3 sind am Opinion-Preset nicht prüfbar (das Preset hat diese Abschnitte nicht); der Full-Report-Gegentest steht noch aus.
- Frontend rendert `entailment`, `retrieval_score`, `structured_metadata`, `generation_failed` noch nicht.

## Gate

`bash scripts/pre-push-gate.sh` → ALL GREEN. Backend 3481 passed (14 pre-existing Failures, gegen `main` verifiziert: 401-Netzwerkcalls). Frontend 1587 passed. `ruff`/`mypy`/`dump_schemas --check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Zweistufige Evidence-Bindung mit Entailment (unterstützend, widersprechend, thematisch passend, unzureichend) inkl. Begründungen.
  * Erweiterte Evidence-Quellarten (u. a. neue Kategorien) sowie zusätzlicher Entailment-Status im Datenvertrag.
  * Abschnittsstruktur-Metadaten werden jetzt in den Report übernommen; fehlgeschlagene Abschnitte werden markiert.
* **Verbesserungen**
  * Confidence-Berechnung nutzt unterstützende vs. widersprechende Evidence getrennt; neue Breakdown-Ansicht.
  * Strengere Ausgabe-Bereinigung; Pflichtabschnitte mit Fehlern führen zu „unvollständig“.
  * Intent-/Preset-basierte Abschnittsauswahl verbessert, inklusive UI-Warnhinweis für fehlgeschlagene Abschnitte.
* **Dokumentation & Tests**
  * Umfangreiche Anpassungen an Vertrags-/Snapshot-Tests und neue End-to-End-Regressionen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->