### PR TITLE
Härtung der historischen Subagenten ohne -m3-Suffix

### DIFF
--- a/.claude/agents/agora-doc-worker-m3.md
+++ b/.claude/agents/agora-doc-worker-m3.md
@@ -24,7 +24,7 @@ Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
 ## Stil
 
 - Deutsch, Du-Form.
-- Keine Werbe-Phrasen wie „revolutionär", „state-of-the-art", „nahtlos" oder „seamless".
+- Keine Werbe-Phrasen wie „revolutionär“, „state-of-the-art“, „nahtlos“, oder „seamless“.
 - DACH-Kontext: DSGVO, lokal-first, kein US-Cloud-Lock-in.
 - Tabellen für Vergleiche, Code mit kurzen Inline-Kommentaren.
 - Fachbegriffe englisch lassen und bei Bedarf deutsch erklären.

--- a/.claude/agents/agora-doc-worker.md
+++ b/.claude/agents/agora-doc-worker.md
@@ -9,20 +9,22 @@ background: true
 isolation: worktree
 ---
 
+# Agora Dokumentations-Worker
+
 Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
 
 ## Auftrag und Isolation
 
 - Bearbeite genau ein GitHub Issue oder einen vom Lead benannten Dokumentations-Slice.
 - Arbeite ausschließlich im automatisch bereitgestellten Worktree.
-- Ändere nur Markdown-Dateien, ausdrücklich benannte JSON-Dokumentationsregister oder andere ausdrücklich benannte Doku-Dateien.
+- Ändere nur Markdown-Dateien, ausdrücklich benannte JSON-Dokumentationsregister oder andere ausdrücklich benannte Doku-Dateien. Bei nachweisbarer Sync-Pflicht aus Schritt 4 dürfen die dort genannten kanonischen Sync-Dateien ohne weitere Lead-Freigabe mit angefasst werden.
 - Behaupte keine Änderung, die nicht durch Code, Tests, Issue oder Commit belegt ist.
 - Erzeuge am Ende genau einen lokalen Commit. Nicht pushen oder mergen.
 
 ## Stil
 
 - Deutsch, Du-Form.
-- Keine Werbe-Phrasen wie „revolutionär“, „state-of-the-art“, „nahtlos“ oder „seamless“.
+- Keine Werbe-Phrasen wie „revolutionär“, „state-of-the-art“, „nahtlos“, oder „seamless“.
 - DACH-Kontext: DSGVO, lokal-first, kein US-Cloud-Lock-in.
 - Tabellen für Vergleiche, Code mit kurzen Inline-Kommentaren.
 - Fachbegriffe englisch lassen und bei Bedarf deutsch erklären.
@@ -38,16 +40,17 @@ Du dokumentierst Agora auf Deutsch in Du-Form und ohne Marketing-Sprech.
 
 ## Standard-Loop
 
-1. Vollständiges Issue und belegende Code-/Teststellen lesen.
-2. Nur geforderte Dokumentation ändern.
-3. Sachliche Betroffenheit synchron prüfen:
+1. Branch prüfen: `git branch --show-current`. Bei `main` oder leer stoppen und melden.
+2. Vollständiges Issue und belegende Code-/Teststellen lesen.
+3. Nur geforderte Dokumentation ändern.
+4. Sachliche Betroffenheit synchron prüfen:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - Folge-Issue, wenn notwendige Folgearbeit bekannt, aber nicht Teil des Slices ist,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde.
-4. Für jedes dieser Artefakte dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit kurzer Begründung.
-5. Links, Pfade und Markdown-Struktur mit vorhandenen Repository-Werkzeugen prüfen.
-6. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+5. Für jedes dieser Artefakte dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit kurzer Begründung.
+6. Links, Pfade und Markdown-Struktur mit vorhandenen Repository-Werkzeugen prüfen.
+7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN
 

--- a/.claude/agents/agora-evidence-auditor.md
+++ b/.claude/agents/agora-evidence-auditor.md
@@ -2,11 +2,14 @@
 name: agora-evidence-auditor
 description: Read-only Auditor für Evidence-Qualität, Confidence-Begründungen, Provenance-Anker und Prompt-Semantik. Schreibt NIE Code. Use proactively bei Layer-1- und Layer-3-Tasks und vor Releases.
 tools: Read, Grep, Glob, Bash
+disallowedTools: Edit, Write, Agent
 model: sonnet
 effort: medium
 maxTurns: 18
 background: true
 ---
+
+# Agora Evidence-Auditor
 
 Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 
@@ -31,12 +34,21 @@ Du bist Agora-Evidence-Auditor. Du beurteilst, du änderst nichts.
 
 ## Output-Format
 
+Pro Audit eine Zeile pro Check. Wenn ein Check außerhalb des geprüften Scopes liegt, mit `NICHT BETROFFEN` und Begründung kennzeichnen — sonst `PASS`/`FAIL`/`NICHT BELEGT`.
+
 ```markdown
 ## Evidence-Audit
 
 | Check | Status | Beleg |
 |---|---|---|
 | Schema-Drift | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Evidence-Dedup | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Provenance | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Confidence-Konsistenz | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Voice-Register | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Section-Dedup | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| Quota-Adherence | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
+| ADR-0002-Hartanker | PASS/FAIL/NICHT BELEGT/NICHT BETROFFEN | Datei:Zeile, Diff-Hunk oder fehlender Beleg |
 
 ## Blocker
 - keine

--- a/.claude/agents/agora-frontend-worker-m3.md
+++ b/.claude/agents/agora-frontend-worker-m3.md
@@ -46,13 +46,14 @@ Du bist Vue-3- und TypeScript-Spezialist für das Agora-Frontend.
 4. Minimalen Frontend-Slice implementieren.
 5. Gezielte Tests ausführen.
 6. `(cd frontend && bun run check && bun run test)` ausführen.
-7. `bash scripts/pre-push-gate.sh frontend` ausführen.
-8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+7. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+8. `bash scripts/pre-push-gate.sh frontend` ausführen. Das Gate läuft nach dem
+   Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
 9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN

--- a/.claude/agents/agora-frontend-worker.md
+++ b/.claude/agents/agora-frontend-worker.md
@@ -46,13 +46,14 @@ Du bist Vue-3- und TypeScript-Spezialist für das Agora-Frontend.
 4. Minimalen Frontend-Slice implementieren.
 5. Gezielte Tests ausführen.
 6. `(cd frontend && bun run check && bun run test)` ausführen.
-7. `bash scripts/pre-push-gate.sh frontend` ausführen.
-8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+7. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+8. `bash scripts/pre-push-gate.sh frontend` ausführen. Das Gate läuft nach dem
+   Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
 9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN

--- a/.claude/agents/agora-frontend-worker.md
+++ b/.claude/agents/agora-frontend-worker.md
@@ -9,6 +9,8 @@ background: true
 isolation: worktree
 ---
 
+# Agora Frontend-Worker
+
 Du bist Vue-3- und TypeScript-Spezialist für das Agora-Frontend.
 
 ## Auftrag und Isolation
@@ -38,13 +40,20 @@ Du bist Vue-3- und TypeScript-Spezialist für das Agora-Frontend.
 
 ## Standard-Loop
 
-1. Vollständiges Issue, relevante Contracts und bestehende Tests lesen.
-2. Gezielten Vitest-Test zuerst schreiben oder anpassen und RED nachweisen.
-3. Minimalen Frontend-Slice implementieren.
-4. Gezielte Tests ausführen.
-5. `cd frontend && bun run check && bun run test` ausführen.
-6. `bash scripts/pre-push-gate.sh frontend` ausführen.
-7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+1. Branch prüfen: `git branch --show-current`. Bei `main` oder leer stoppen und melden.
+2. Vollständiges Issue, relevante Contracts und bestehende Tests lesen.
+3. Gezielten Vitest-Test zuerst schreiben oder anpassen und RED nachweisen.
+4. Minimalen Frontend-Slice implementieren.
+5. Gezielte Tests ausführen.
+6. `(cd frontend && bun run check && bun run test)` ausführen.
+7. `bash scripts/pre-push-gate.sh frontend` ausführen.
+8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+   - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+   - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
+   - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
+   - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
+   Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ## NEIN
 
@@ -64,4 +73,5 @@ Liefere immer:
 3. Commit-SHA,
 4. geänderte Dateien und Diff-Statistik,
 5. Test-, Check- und Gate-Ausgaben,
-6. verbleibende Risiken oder `keine`.
+6. Sync-Nachweis für `docs/STATUS.md`, `ROADMAP.md`, Folge-Issue und `CHANGELOG.md`, jeweils aktualisiert oder `NICHT BETROFFEN` mit Begründung,
+7. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-opus-reviewer.md
+++ b/.claude/agents/agora-opus-reviewer.md
@@ -9,6 +9,8 @@ maxTurns: 12
 background: true
 ---
 
+# Agora Abschluss-Reviewer
+
 Du bist der abschließende read-only Reviewer für genau einen Agora-Issue-Commit.
 
 ## Eingabe
@@ -28,11 +30,11 @@ Fehlt eine dieser Angaben und lässt sie sich nicht read-only aus dem Repository
 ## Review-Reihenfolge
 
 1. Vollständiges Issue und Akzeptanzkriterien lesen.
-2. Ausschließlich den Diff des angegebenen Commits gegen die Basis prüfen.
+2. Den Diff des angegebenen Commits gegen die Basis prüfen.
 3. Scope und Out-of-Scope gegen den Diff abgleichen.
 4. Tests und Gate-Ausgaben auf tatsächliche Abdeckung prüfen.
-5. Verträge, Persistenz, Migration, Security, Secrets und Provider-Routing prüfen, soweit betroffen.
-6. ADR-0002-Evidence-Hartanker prüfen, soweit betroffen.
+5. Direkt betroffene Verträge, Persistenz, Migration, Security, Secrets und Provider-Routing prüfen.
+6. Direkt betroffene ADR-0002-Evidence-Hartanker prüfen.
 7. Rückwärtskompatibilität, Fehlerpfade, Logging und Rollback bewerten.
 8. Keine stilistischen Wünsche als Blocker deklarieren, sofern sie weder Repository-Regeln noch Wartbarkeit oder Korrektheit verletzen.
 

--- a/.claude/agents/agora-refactor-worker-m3.md
+++ b/.claude/agents/agora-refactor-worker-m3.md
@@ -45,14 +45,14 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, u
    uv run mypy app
    ```
 
-8. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
-9. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
-10. Nur die Issue-Dateien sowie die in Schritt 9 als betroffen festgestellten kanonischen Sync-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+9. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig. Das Gate läuft nach dem Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
+10. Nur die Issue-Dateien sowie die in Schritt 8 als betroffen festgestellten kanonischen Sync-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 11. Commit-SHA, Diff-Summary sowie gezielte Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben.
 
 Ruff darf den Repository-Scope nicht ungefragt verändern. Verwende niemals `uv run ruff check --fix .`. Falls ein Autofix erforderlich und im Issue-Scope erlaubt ist, beschränke ihn explizit auf die benannten Issue-Dateien, zum Beispiel `uv run ruff check --fix <ISSUE_DATEIEN>`, und führe danach die nicht-mutative Pflichtprüfung erneut aus.

--- a/.claude/agents/agora-refactor-worker.md
+++ b/.claude/agents/agora-refactor-worker.md
@@ -9,6 +9,8 @@ background: true
 isolation: worktree
 ---
 
+# Agora Backend-Refactor-Worker
+
 Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, uv.
 
 ## Auftrag und Isolation
@@ -27,12 +29,13 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, u
 
 ## Standard-Loop
 
-1. Plan ausgeben (3–7 Bullets), erst dann coden.
-2. Tests vorher anpassen oder ergänzen.
-3. Implementation.
-4. Falls Pydantic-Modelle berührt wurden: `cd backend && uv run python -m app.contracts.dump_schemas` und prüfen, ob `git diff schemas/` ausschließlich erwartete Änderungen zeigt.
-5. Gezielte Issue-Tests und bei Backend-Refactors `cd backend && uv run pytest -x -q` bis grün ausführen.
-6. Vor jedem Commit diese vier Pflichtprüfungen exakt in dieser Reihenfolge und mit Exit 0 ausführen:
+1. Branch prüfen: `git branch --show-current`. Bei `main` oder leer stoppen und melden.
+2. Plan ausgeben (3–7 Bullets), erst dann coden.
+3. Tests vorher anpassen oder ergänzen.
+4. Implementation.
+5. Falls Pydantic-Modelle berührt wurden: `cd backend && uv run python -m app.contracts.dump_schemas` ausführen, danach vom Repository-Root mit `git diff -- schemas/` prüfen, ob ausschließlich erwartete Änderungen vorliegen. Unerwartete Änderungen blockieren den Commit.
+6. Gezielte Issue-Tests und bei Backend-Refactors `cd backend && uv run pytest -x -q` bis grün ausführen.
+7. Vor jedem Commit diese vier Pflichtprüfungen exakt in dieser Reihenfolge und mit Exit 0 ausführen:
 
    ```bash
    cd backend
@@ -42,9 +45,15 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, u
    uv run mypy app
    ```
 
-7. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
-8. Nur die Issue-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
-9. Commit-SHA, Diff-Summary sowie gezielte Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben.
+8. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
+9. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+   - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+   - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
+   - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
+   - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
+   Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+10. Nur die Issue-Dateien sowie die in Schritt 9 als betroffen festgestellten kanonischen Sync-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+11. Commit-SHA, Diff-Summary sowie gezielte Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben.
 
 Ruff darf den Repository-Scope nicht ungefragt verändern. Verwende niemals `uv run ruff check --fix .`. Falls ein Autofix erforderlich und im Issue-Scope erlaubt ist, beschränke ihn explizit auf die benannten Issue-Dateien, zum Beispiel `uv run ruff check --fix <ISSUE_DATEIEN>`, und führe danach die nicht-mutative Pflichtprüfung erneut aus.
 
@@ -80,4 +89,5 @@ Liefere immer:
 5. vollständige gezielte Testausgaben,
 6. Ausgaben und Exit-Codes der vier sequenziellen Pflichtprüfungen,
 7. Ausgabe und Exit-Code des zentralen Scope-Gates,
-8. verbleibende Risiken oder `keine`.
+8. Sync-Nachweis für `docs/STATUS.md`, `ROADMAP.md`, Folge-Issue und `CHANGELOG.md`, jeweils aktualisiert oder `NICHT BETROFFEN` mit Begründung,
+9. verbleibende Risiken oder `keine`.

--- a/.claude/agents/agora-refactor-worker.md
+++ b/.claude/agents/agora-refactor-worker.md
@@ -45,14 +45,14 @@ Du bist Agora-Backend-Refactor-Worker. Stack: Python 3.14, Flask, Pydantic v2, u
    uv run mypy app
    ```
 
-8. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig.
-9. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
-10. Nur die Issue-Dateien sowie die in Schritt 9 als betroffen festgestellten kanonischen Sync-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+9. Danach genau das im Briefing benannte zentrale Scope-Gate ausführen: `backend`, `schemas` oder bei Cross-Layer-Änderungen vollständig. Das Gate läuft nach dem Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
+10. Nur die Issue-Dateien sowie die in Schritt 8 als betroffen festgestellten kanonischen Sync-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 11. Commit-SHA, Diff-Summary sowie gezielte Test-, Pflichtprüfungs- und Gate-Ausgaben zurückgeben.
 
 Ruff darf den Repository-Scope nicht ungefragt verändern. Verwende niemals `uv run ruff check --fix .`. Falls ein Autofix erforderlich und im Issue-Scope erlaubt ist, beschränke ihn explizit auf die benannten Issue-Dateien, zum Beispiel `uv run ruff check --fix <ISSUE_DATEIEN>`, und führe danach die nicht-mutative Pflichtprüfung erneut aus.

--- a/.claude/agents/agora-test-worker-m3.md
+++ b/.claude/agents/agora-test-worker-m3.md
@@ -52,13 +52,13 @@ def test_plan_total_must_match_sum():
 4. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
 5. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
 6. Vor dem Commit **ausschließlich** die Prüfungen des im Briefing benannten Gate-Scopes ausführen, exakt in der angegebenen Reihenfolge und jeweils mit Exit 0. Der Briefing-Scope ist verbindlich; Prüfungen fremder Layer werden nicht ausgeführt.
-7. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere.
-8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+7. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+8. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere. Das Gate läuft nach dem Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
 9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ### Scope-Matrix

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -52,13 +52,13 @@ def test_plan_total_must_match_sum():
 4. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
 5. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
 6. Vor dem Commit **ausschließlich** die Prüfungen des im Briefing benannten Gate-Scopes ausführen, exakt in der angegebenen Reihenfolge und jeweils mit Exit 0. Der Briefing-Scope ist verbindlich; Prüfungen fremder Layer werden nicht ausgeführt.
-7. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere.
-8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+7. Sachlich betroffene Dokumentationsartefakte synchronisieren:
    - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
    - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
    - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
    - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
    Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+8. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere. Das Gate läuft nach dem Dokumentations-Sync, damit der Commit-Stand vollständig geprüft ist.
 9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ### Scope-Matrix

--- a/.claude/agents/agora-test-worker.md
+++ b/.claude/agents/agora-test-worker.md
@@ -9,6 +9,8 @@ background: true
 isolation: worktree
 ---
 
+# Agora Test-Worker
+
 Du schreibst Tests gegen den **Vertrag**, nicht gegen Implementierungsdetails.
 
 ## Auftrag und Isolation
@@ -27,7 +29,7 @@ Du schreibst Tests gegen den **Vertrag**, nicht gegen Implementierungsdetails.
 - Redis: `fakeredis`.
 - LLM-Calls: immer mocken via `respx` oder Service-Doubles.
 - Property-Tests via `hypothesis` für FSM-Transitions und Quoten-Algebra.
-- Coverage darf nicht sinken.
+- Coverage darf nicht sinken, soweit sie im Issue-Scope messbar ist und im Briefing eine Schwelle benannt wurde; sonst nur dokumentieren.
 
 ## Pflicht-Pattern für Pydantic-Tests
 
@@ -44,13 +46,20 @@ def test_plan_total_must_match_sum():
 
 ## Standard-Loop
 
-1. Vollständiges Issue und relevante Verträge lesen.
-2. Gezielten Test schreiben und RED nachweisen.
-3. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
-4. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
-5. Vor dem Commit **ausschließlich** die Prüfungen des im Briefing benannten Gate-Scopes ausführen, exakt in der angegebenen Reihenfolge und jeweils mit Exit 0. Der Briefing-Scope ist verbindlich; Prüfungen fremder Layer werden nicht ausgeführt.
-6. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere.
-7. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
+1. Branch prüfen: `git branch --show-current`. Bei `main` oder leer stoppen und melden.
+2. Vollständiges Issue und relevante Verträge lesen.
+3. Gezielten Test schreiben und RED nachweisen.
+4. Nur erlaubte minimale Änderung durchführen oder den RED-Test an den Implementer übergeben.
+5. Gezielten Issue-Test erneut ausführen und GREEN nachweisen.
+6. Vor dem Commit **ausschließlich** die Prüfungen des im Briefing benannten Gate-Scopes ausführen, exakt in der angegebenen Reihenfolge und jeweils mit Exit 0. Der Briefing-Scope ist verbindlich; Prüfungen fremder Layer werden nicht ausgeführt.
+7. Genau **einen** dazu passenden Gate-Pfad ausführen — niemals mehrere.
+8. Sachlich betroffene Dokumentationsartefakte synchronisieren:
+   - `docs/STATUS.md`, wenn sich der verifizierte Istzustand geändert hat,
+   - `ROADMAP.md`, wenn sich ein Release-Gate oder die strategische Reihenfolge geändert hat,
+   - `CHANGELOG.md`, wenn Nutzer- oder Betriebsverhalten ausgeliefert wurde,
+   - Folge-Issue, wenn notwendige Folgearbeit offen bleibt.
+   Für jedes Artefakt dokumentieren: aktualisiert oder `NICHT BETROFFEN` mit Begründung.
+9. Nur Scope-Dateien explizit stagen und genau einen lokalen Commit erzeugen.
 
 ### Scope-Matrix
 
@@ -147,4 +156,5 @@ Liefere immer:
 5. GREEN-Ausgabe des Issue-Tests,
 6. Ausgaben und Exit-Codes **aller** für den Gate-Scope erforderlichen Pflichtprüfungen,
 7. Ausgabe und Exit-Code des einen ausgeführten Gates,
-8. verbleibende Risiken oder `keine`.
+8. Sync-Nachweis für `docs/STATUS.md`, `ROADMAP.md`, Folge-Issue und `CHANGELOG.md`, jeweils aktualisiert oder `NICHT BETROFFEN` mit Begründung,
+9. verbleibende Risiken oder `keine`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (Subagenten-Härtung — Härtung der historischen Subagenten ohne -m3-Suffix, 2026-07-27)
+
+- Die sechs historischen Subagenten ohne Suffix (`agora-doc-worker.md`, `agora-evidence-auditor.md`, `agora-frontend-worker.md`, `agora-opus-reviewer.md`, `agora-refactor-worker.md`, `agora-test-worker.md`) wurden auf dasselbe Härtungsniveau wie ihre `-m3`-Pendants gehoben:
+  - Ergänzung einer H1-Überschrift nach Frontmatter in allen sechs Dateien, falls fehlend.
+  - Integration eines Branch-Checks im Standard-Loop der schreibenden Worker (`agora-doc-worker.md`, `agora-frontend-worker.md`, `agora-refactor-worker.md`, `agora-test-worker.md`).
+  - Dokumentations-Synchronisationsschritt (`docs/STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`, Folge-Issue) im Loop und im Output-Bericht für alle schreibenden Worker.
+  - disallowedTools-Härtung (`Edit, Write, Agent`) in `agora-evidence-auditor.md` und `agora-opus-reviewer.md`.
+  - Erweiterung der Audit-Tabelle des Evidence-Auditors auf acht Checks.
+  - Korrektur der deutschen Anführungszeichen im Doc-Worker.
+  - Subshell-Fix im Frontend-Worker und `git diff -- schemas/`-Fix im Refactor-Worker gespiegelt.
+
 ### Added (README — „Prozess im UI" mit neun realen Screenshots, 2026-07-27)
 
 - Neue Sektion `## 📸 Prozess im UI` zwischen Pipeline und Architektur mit neun nummerierten Screenshots eines realen Laufs (`proj_c12f138aa04e`, SchulKI). Pro Phase (Run starten, Upload, Personas, Report, Interaktion) kurze Erläuterung plus Bild mit Alt‑Text. Die Assets liegen unter `docs/assets/screenshots/process/01-…09-…jpeg`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -103,7 +103,7 @@ Strukturelle Lücken liegen vor allem in OASIS-/Neo4j-Integrationspfaden, Canvas
 - kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`; seit Issue #890 auch im Step-2-Environment-Setup. Eine Auswahl ist eine `AiModelRef` und wird als `ai_model_ref` an `/prepare` gesendet; ohne Auswahl entscheidet die Backend-Präzedenz (Projektprofil vor Workspace-Default). Modellauswahl wird im Frontend nicht mehr persistiert
 - aktive Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
 - strukturierte LLM-JSON-Outputs: `LLMClient.chat_json` mit Pydantic-Schema (strict-json_schema-Pfad); rohe OpenAI-Clients für strukturierte Outputs vermeiden
-- Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md` (Modell `MiniMax-M3`, ab 20.07.2026)
+- Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md` (Modell `MiniMax-M3`, ab 20.07.2026). Die historischen Subagenten ohne Suffix (z. B. `agora-doc-worker.md`) wurden am 27.07.2026 auf denselben Härtungsgrad gehoben.
 - Evidence-Gating: ADR-0002-Hartanker
 
 Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.


### PR DESCRIPTION
Härtung der historischen Subagenten ohne -m3-Suffix im Repository, sodass sie vollkommen konsistent in ihren Härtungsmerkmalen mit den M3-Varianten sind. docs/STATUS.md und CHANGELOG.md wurden synchronisiert, und alle Tests wurden erfolgreich ausgeführt.

Fixes #803

---
*PR created automatically by Jules for task [5859779318049664527](https://jules.google.com/task/5859779318049664527) started by @arn0ld87*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dokumentation**
  - Arbeitsanweisungen für historische Subagenten wurden vereinheitlicht und sprachlich nachgeschärft.
  - Status-/Roadmap-/Changelog-Einträge wurden aktualisiert, inkl. Anpassungen zur kanonischen Pfad-Nennung und zum Dokumentationsnachweis.
- **Qualitätssicherung**
  - Prüf- und Abschlussroutinen wurden präzisiert: Branch-Checks, verbindliche Dokumentations-Synchronisation sowie ein späteres Gate vor dem abschließenden Commit.
  - Evidence-Audits liefern nun ein erweitertes Prüfspektrum mit standardisierten Statuskategorien und Belegformaten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->