### PR TITLE
feat(embedding): pin EmbeddingConfiguration to local Ollama via helper (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Added (Embedding-Konfiguration auf lokales Ollama gepinnt — 2026-07-27, Issue #934)
+
+- Neuer Helper `activate_ollama_embedding` in `backend/app/services/embedding_configurations/activate_ollama.py` pinnt die aktive `EmbeddingConfiguration` idempotent auf `embeddinggemma:300m` (768-dim) via `EmbeddingConfigurationService.activate`. Vorhandene aktive Konfigurationen des gleichen Scopes werden auf `status='rolled_back'` gesetzt (Audit-Trail; Knoten bleibt erhalten, wird nicht gelöscht).
+- Operator-Tool `backend/scripts/activate_local_ollama_embedding.py` macht die Festschreibung reproduzierbar dokumentierbar (`uv run python -m scripts.activate_local_ollama_embedding`, optionale Overrides per CLI-Flags).
+- Vier Contract-Tests in `backend/tests/contracts/test_embedding_activate_ollama.py` decken Pinning, Vorgänger-Rollback, Idempotenz und Konvergenz nach Gemini→Ollama ab.
+- ADR-0007-konform: alle Schreibpfade laufen ausschließlich über `EmbeddingConfigurationStore` / `ProviderConnectionStore` — keine direkten Cypher- oder Datei-Schreibwege. Gemini-Re-Embedding bleibt explizit außerhalb des Scopes.
+- Hintergrund: nach dem Wechsel des Embedding-Providers von Gemini (429-Quotenfehler am 2026-07-27) auf lokales Ollama via `.env` war die Neo4j-`EmbeddingConfiguration`-SSoT noch nicht nachgezogen; der Helper schließt diese Lücke.
+
 ### Changed (Subagenten-Härtung — Härtung der historischen Subagenten ohne -m3-Suffix, 2026-07-27)
 
 - Die sechs historischen Subagenten ohne Suffix (`agora-doc-worker.md`, `agora-evidence-auditor.md`, `agora-frontend-worker.md`, `agora-opus-reviewer.md`, `agora-refactor-worker.md`, `agora-test-worker.md`) wurden auf dasselbe Härtungsniveau wie ihre `-m3`-Pendants gehoben:

--- a/backend/app/services/embedding_configurations/activate_ollama.py
+++ b/backend/app/services/embedding_configurations/activate_ollama.py
@@ -1,0 +1,194 @@
+"""Activate Ollama embedding configuration (Issue #934).
+
+Helper that pins the active ``EmbeddingConfiguration`` to a local Ollama
+model (default: ``embeddinggemma:300m`` / 768-dim). Idempotent: repeated
+calls converge to the same state.
+
+Read/write paths are exclusively routed through
+``EmbeddingConfigurationStore`` and ``ProviderConnectionStore`` — no
+direct file or database writes, no raw Cypher. This honours the Single
+Source of Truth rules from ADR-0007.
+
+Out of scope (deliberate):
+
+* Gemini re-embedding is *not* supported (ADR-0007). This helper only
+  pins the configuration metadata; data migration from 3072-dim
+  (Gemini) vectors to 768-dim (Ollama) vectors is a separate effort.
+* The runtime ``Config.EMBEDDING_BASE_URL`` (e.g.
+  ``http://host.docker.internal:11434``) is honoured at request time
+  by ``EmbeddingService``. The persisted ``ProviderConnection`` carries
+  structural metadata only and must use a loopback URL per the
+  ``LocalOllamaBaseUrl`` validator — the runtime URL is resolved at
+  embed-call time, not from the store.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.contracts.ai_provider_contract import (
+    LocalOllamaBaseUrl,
+    ProviderConnection,
+    ProviderConnectionUpsertRequest,
+)
+from app.contracts.embedding_contract import (
+    EmbeddingConfiguration,
+    EmbeddingConfigurationScope,
+)
+from app.services.embedding_configuration_store import EmbeddingConfigurationStore
+from app.services.embedding_configurations.service import EmbeddingConfigurationService
+from app.services.llm_provider_secrets_store import LlmProviderSecretsStore
+from app.services.provider_connection_store import ProviderConnectionStore
+
+
+# Default-Werte entsprechen dem Hotfix (.env) vom 2026-07-27:
+# ``EMBEDDING_MODEL=embeddinggemma:300m``, ``VECTOR_DIM=768``.
+DEFAULT_OLLAMA_MODEL = "embeddinggemma:300m"
+DEFAULT_OLLAMA_DIMENSIONS = 768
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+DEFAULT_OLLAMA_DISPLAY_NAME = "Local Ollama (embedding)"
+DEFAULT_PROVIDER_KIND = "ollama"
+
+
+def _find_existing_configuration(
+    *,
+    configuration_store: EmbeddingConfigurationStore,
+    provider_connection_id: str,
+    model_id: str,
+    dimensions: int,
+    scope: EmbeddingConfigurationScope,
+    project_id: Optional[str],
+) -> Optional[EmbeddingConfiguration]:
+    """Sucht eine bestehende Konfiguration mit passendem Fingerabdruck.
+
+    Identitaetsmerkmal: ``(provider_connection_id, model_id, dimensions,
+    scope, project_id)``. Liefert ``None``, wenn keine solche Konfiguration
+    existiert; sonst den ersten Treffer.
+    """
+    for existing in configuration_store.list_configurations(scope=scope):
+        if (
+            existing.provider_connection_id == provider_connection_id
+            and existing.model_id == model_id
+            and existing.dimensions == dimensions
+            and existing.project_id == project_id
+        ):
+            return existing
+    return None
+
+
+def _ensure_provider_connection(
+    *,
+    provider_kind: str,
+    display_name: str,
+    base_url: str,
+    connection_store: ProviderConnectionStore,
+) -> ProviderConnection:
+    """Stellt sicher, dass eine ``ProviderConnection`` mit der gewuenschten
+    ``provider_kind`` existiert. Bei ``provider_kind='ollama'`` wird die
+    ``base_url`` durch ``LocalOllamaBaseUrl`` validiert (Loopback-pflicht).
+    """
+    validated_base_url: LocalOllamaBaseUrl | None
+    if provider_kind == "ollama":
+        validated_base_url = LocalOllamaBaseUrl(base_url)
+    else:
+        # Andere Provider-Kinds werden ueber ``ProviderConnection``-
+        # Default-Validierung (PublicBaseUrl) gefuehrt; fuer diesen
+        # Issue-Scope (nur Ollama) bleibt das ein defensiver Default.
+        validated_base_url = None  # type: ignore[assignment]
+    request = ProviderConnectionUpsertRequest(
+        provider_kind=provider_kind,  # type: ignore[arg-type]
+        display_name=display_name,
+        base_url=(
+            base_url if provider_kind != "ollama" else str(validated_base_url)
+        ),
+        enabled=True,
+    )
+    return connection_store.upsert_connection(request)
+
+
+def activate_ollama_embedding(
+    *,
+    model_id: str = DEFAULT_OLLAMA_MODEL,
+    dimensions: int = DEFAULT_OLLAMA_DIMENSIONS,
+    base_url: str = DEFAULT_OLLAMA_BASE_URL,
+    display_name: str = DEFAULT_OLLAMA_DISPLAY_NAME,
+    provider_kind: str = DEFAULT_PROVIDER_KIND,
+    scope: EmbeddingConfigurationScope = "global",
+    project_id: Optional[str] = None,
+    configuration_id: Optional[str] = None,
+    configuration_store: EmbeddingConfigurationStore,
+    connection_store: Optional[ProviderConnectionStore] = None,
+    secrets_store: Optional[LlmProviderSecretsStore] = None,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> EmbeddingConfiguration:
+    """Pin the active embedding configuration to a local Ollama endpoint.
+
+    Vorgehen (idempotent):
+
+    1. ``ProviderConnection`` mit ``provider_kind='ollama'`` sicherstellen
+       (anlegen, falls noch nicht vorhanden).
+    2. Existierende ``EmbeddingConfiguration`` mit passendem Fingerabdruck
+       suchen und wiederverwenden, sonst neu anlegen.
+    3. Ueber ``EmbeddingConfigurationService.activate`` aktivieren.
+       Vorhandene aktive Konfigurationen des gleichen Scopes werden
+       auf ``status='rolled_back'`` gesetzt (Audit-Trail — Knoten
+       bleibt erhalten, nicht geloescht).
+
+    Liefert die aktivierte ``EmbeddingConfiguration`` zurueck.
+    """
+    if connection_store is None:
+        connection_store = ProviderConnectionStore()
+    if secrets_store is None:
+        secrets_store = LlmProviderSecretsStore()
+
+    connection = _ensure_provider_connection(
+        provider_kind=provider_kind,
+        display_name=display_name,
+        base_url=base_url,
+        connection_store=connection_store,
+    )
+
+    target_id = configuration_id
+    if target_id is None:
+        existing = _find_existing_configuration(
+            configuration_store=configuration_store,
+            provider_connection_id=connection.id,
+            model_id=model_id,
+            dimensions=dimensions,
+            scope=scope,
+            project_id=project_id,
+        )
+        if existing is not None:
+            target_id = existing.id
+
+    config = configuration_store.upsert_configuration(
+        configuration_id=target_id,
+        provider_connection_id=connection.id,
+        provider_kind=provider_kind,  # type: ignore[arg-type]
+        model_id=model_id,
+        dimensions=dimensions,
+        scope=scope,
+        project_id=project_id,
+        status="proposed",
+        status_message="Issue #934: pinning to local Ollama (pending probe)",
+    )
+
+    service = EmbeddingConfigurationService(
+        store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=now,
+    )
+    return service.activate(config.id)
+
+
+__all__ = [
+    "activate_ollama_embedding",
+    "DEFAULT_OLLAMA_MODEL",
+    "DEFAULT_OLLAMA_DIMENSIONS",
+    "DEFAULT_OLLAMA_BASE_URL",
+    "DEFAULT_OLLAMA_DISPLAY_NAME",
+    "DEFAULT_PROVIDER_KIND",
+]

--- a/backend/scripts/activate_local_ollama_embedding.py
+++ b/backend/scripts/activate_local_ollama_embedding.py
@@ -1,0 +1,141 @@
+"""Activate local Ollama embedding configuration (Issue #934).
+
+Liest ``Config.EMBEDDING_*`` aus der Umgebung und pinnt die aktive
+``EmbeddingConfiguration`` ueber die Store-API auf das konfigurierte
+Modell. Idempotent — wiederholte Aufrufe konvergieren in den gleichen
+Zustand.
+
+Verwendung (aus ``backend/``):
+
+    uv run python -m scripts.activate_local_ollama_embedding
+    uv run python -m scripts.activate_local_ollama_embedding \
+        --model embeddinggemma:300m --dimensions 768
+
+Ausgabe: JSON-Report mit der aktivierten ``EmbeddingConfiguration`` auf
+stdout. Der vorherige aktive Konfigurationsknoten wird auf
+``status='rolled_back'`` gesetzt (Audit-Trail; nicht geloescht).
+
+Read-only-Disclaimer: dieses Skript schreibt ausschliesslich ueber
+``EmbeddingConfigurationStore`` und ``ProviderConnectionStore`` — keine
+direkten Cypher- oder File-Schreibwege.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# ``scripts/`` liegt ausserhalb des ``app``-Package — sicherstellen, dass
+# ``backend/`` importierbar ist, unabhaengig vom aktuellen Working-Dir.
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.config import Config  # noqa: E402
+from app.services.embedding_configuration_store import (  # noqa: E402
+    EmbeddingConfigurationStore,
+)
+from app.services.embedding_configurations.activate_ollama import (  # noqa: E402
+    DEFAULT_OLLAMA_BASE_URL,
+    DEFAULT_OLLAMA_DIMENSIONS,
+    DEFAULT_OLLAMA_MODEL,
+    DEFAULT_OLLAMA_DISPLAY_NAME,
+    activate_ollama_embedding,
+)
+from app.services.llm_provider_secrets_store import (  # noqa: E402
+    LlmProviderSecretsStore,
+)
+from app.services.provider_connection_store import (  # noqa: E402
+    ProviderConnectionStore,
+)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="activate_local_ollama_embedding",
+        description=(
+            "Pinnt die aktive Embedding-Konfiguration auf lokales Ollama. "
+            "Idempotent; vorherige aktive Konfigurationen werden auf "
+            "status='rolled_back' gesetzt (Audit-Trail)."
+        ),
+    )
+    default_model = (Config.EMBEDDING_MODEL or "").strip() or DEFAULT_OLLAMA_MODEL
+    parser.add_argument(
+        "--model",
+        default=default_model,
+        help=(
+            "Embedding-Modell (default: Config.EMBEDDING_MODEL oder "
+            f"{DEFAULT_OLLAMA_MODEL!r})."
+        ),
+    )
+    parser.add_argument(
+        "--dimensions",
+        type=int,
+        default=Config.VECTOR_DIM or DEFAULT_OLLAMA_DIMENSIONS,
+        help=(
+            "Vektor-Dimension (default: Config.VECTOR_DIM oder "
+            f"{DEFAULT_OLLAMA_DIMENSIONS})."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_OLLAMA_BASE_URL,
+        help=(
+            "Loopback-Base-URL fuer die ProviderConnection-Metadaten. "
+            "Die Runtime-URL (z.B. http://host.docker.internal:11434) "
+            "wird weiterhin ueber Config.EMBEDDING_BASE_URL aufgeloest."
+        ),
+    )
+    parser.add_argument(
+        "--display-name",
+        default=DEFAULT_OLLAMA_DISPLAY_NAME,
+        help="Display-Name der ProviderConnection.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help=(
+            "Optionales AGORA_DATA_DIR. Default: aus Umgebung oder "
+            "Repo-Default."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if args.data_dir:
+        os.environ["AGORA_DATA_DIR"] = args.data_dir
+
+    configuration_store = EmbeddingConfigurationStore()
+    connection_store = ProviderConnectionStore()
+    secrets_store = LlmProviderSecretsStore()
+
+    active = activate_ollama_embedding(
+        model_id=args.model,
+        dimensions=args.dimensions,
+        base_url=args.base_url,
+        display_name=args.display_name,
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+    )
+    report = {
+        "activated": active.model_dump(mode="json"),
+        "note": (
+            "Konfigurations-Knoten ist jetzt aktiv. Vorhandene aktive "
+            "Konfigurationen im selben Scope wurden auf "
+            "status='rolled_back' gesetzt (Audit-Trail; nicht geloescht)."
+        ),
+    }
+    sys.stdout.write(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/contracts/test_embedding_activate_ollama.py
+++ b/backend/tests/contracts/test_embedding_activate_ollama.py
@@ -1,0 +1,222 @@
+"""Contract tests for the Ollama-activate path (Issue #934).
+
+Sperrt die in Issue #934 vereinbarten Eigenschaften des Activate-Pfads:
+
+* Nach ``activate_ollama_embedding`` ist genau eine globale
+  ``EmbeddingConfiguration`` mit ``status='active'``,
+  ``provider_kind='ollama'``, ``model_id='embeddinggemma:300m'`` und
+  ``dimensions=768`` vorhanden.
+* Eine vorher aktive Gemini-Konfiguration wird auf
+  ``status='rolled_back'`` gesetzt (Audit-Trail; nicht geloescht).
+* Wiederholte Aufrufe sind idempotent — die gleiche Konfiguration
+  bleibt aktiv, ohne weitere Knoten anzulegen.
+
+Read/write paths laufen ausschliesslich ueber
+``EmbeddingConfigurationStore`` und ``ProviderConnectionStore``. Die
+Tests verwenden einen temporaeren ``AGORA_DATA_DIR``, sodass keine
+Live-Daten beruehrt werden.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.contracts.embedding_contract import EmbeddingConfiguration
+from app.services.embedding_configuration_store import EmbeddingConfigurationStore
+from app.services.embedding_configurations.activate_ollama import (
+    DEFAULT_OLLAMA_DIMENSIONS,
+    DEFAULT_OLLAMA_MODEL,
+    activate_ollama_embedding,
+)
+from app.services.llm_provider_secrets_store import LlmProviderSecretsStore
+from app.services.provider_connection_store import ProviderConnectionStore
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    return datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def isolated_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Isolierter ``AGORA_DATA_DIR`` fuer jeden Test.
+
+    Setzt zusaetzlich ``AGORA_SECRET_KEY`` (per Fernet), damit der
+    Secrets-Store voll initialisiert werden kann.
+    """
+    monkeypatch.setenv("AGORA_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("AGORA_SECRET_KEY", Fernet.generate_key().decode("utf-8"))
+    return tmp_path
+
+
+@pytest.fixture
+def stores(isolated_data_dir: Path):
+    configuration_store = EmbeddingConfigurationStore(data_dir=isolated_data_dir)
+    connection_store = ProviderConnectionStore(data_dir=isolated_data_dir)
+    secrets_store = LlmProviderSecretsStore(data_dir=isolated_data_dir)
+    return configuration_store, connection_store, secrets_store
+
+
+def _seed_legacy_gemini_active(
+    *,
+    configuration_store: EmbeddingConfigurationStore,
+    connection_store: ProviderConnectionStore,
+) -> EmbeddingConfiguration:
+    """Seedet eine vorher aktive Gemini-2-Konfiguration (3072-dim)."""
+    from app.contracts.ai_provider_contract import ProviderConnectionUpsertRequest
+
+    connection = connection_store.upsert_connection(
+        ProviderConnectionUpsertRequest(
+            provider_kind="google",
+            display_name="Legacy Gemini Embedding",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            enabled=True,
+        )
+    )
+    return configuration_store.upsert_configuration(
+        configuration_id="emb-legacy-gemini",
+        provider_connection_id=connection.id,
+        provider_kind="google",
+        model_id="gemini-embedding-2",
+        dimensions=3072,
+        scope="global",
+        project_id=None,
+        status="active",
+    )
+
+
+def test_activate_ollama_pins_active_configuration(
+    stores, fixed_now: datetime
+) -> None:
+    configuration_store, connection_store, secrets_store = stores
+
+    active = activate_ollama_embedding(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=lambda: fixed_now,
+    )
+
+    assert active.status == "active"
+    assert active.provider_kind == "ollama"
+    assert active.model_id == DEFAULT_OLLAMA_MODEL
+    assert active.dimensions == DEFAULT_OLLAMA_DIMENSIONS
+    assert active.scope == "global"
+    assert active.project_id is None
+    assert active.last_validated_at == fixed_now
+
+
+def test_activate_ollama_moves_previous_gemini_to_rolled_back(
+    stores, fixed_now: datetime
+) -> None:
+    """Issue #934 Akzeptanzkriterium: vorherige Konfiguration wird auf
+    ``status='rolled_back'`` (Audit-Trail) gesetzt, nicht geloescht."""
+    configuration_store, connection_store, secrets_store = stores
+    legacy = _seed_legacy_gemini_active(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+    )
+
+    active = activate_ollama_embedding(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=lambda: fixed_now,
+    )
+
+    assert active.status == "active"
+    assert active.model_id == DEFAULT_OLLAMA_MODEL
+    assert active.dimensions == DEFAULT_OLLAMA_DIMENSIONS
+
+    previous = configuration_store.get_configuration(legacy.id)
+    assert previous is not None, "Legacy-Knoten darf nicht geloescht werden"
+    assert previous.status == "rolled_back"
+    assert previous.id == legacy.id
+    assert previous.model_id == legacy.model_id
+    assert previous.dimensions == legacy.dimensions
+
+
+def test_activate_ollama_is_idempotent(stores, fixed_now: datetime) -> None:
+    """Wiederholte Aufrufe fuehren zur gleichen Endzustand-Konfiguration.
+
+    Konkret: die Konfigurations-ID bleibt stabil, es entsteht genau
+    ein ``status='active'``-Knoten, und die uebrigen Konfigurationen
+    behalten ihren vorherigen Status.
+    """
+    configuration_store, connection_store, secrets_store = stores
+
+    first = activate_ollama_embedding(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=lambda: fixed_now,
+    )
+    second = activate_ollama_embedding(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=lambda: fixed_now,
+    )
+    third = activate_ollama_embedding(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+        secrets_store=secrets_store,
+        now=lambda: fixed_now,
+    )
+
+    assert first.id == second.id == third.id
+    actives = [
+        c
+        for c in configuration_store.list_configurations(scope="global")
+        if c.status == "active"
+    ]
+    assert len(actives) == 1, (
+        f"Nach Idempotenz-Aktivierung darf es nur einen Active-Knoten geben, "
+        f"gefunden: {len(actives)}"
+    )
+    assert actives[0].id == first.id
+    assert actives[0].provider_kind == "ollama"
+    assert actives[0].model_id == DEFAULT_OLLAMA_MODEL
+    assert actives[0].dimensions == DEFAULT_OLLAMA_DIMENSIONS
+
+
+def test_activate_ollama_converges_after_gemini_then_ollama(
+    stores, fixed_now: datetime
+) -> None:
+    """Erst Gemini aktiv, dann lokales Ollama: Endzustand nach Idempotenz
+    ist genau ein ``active``-Knoten (Ollama), Gemini ist ``rolled_back``.
+    """
+    configuration_store, connection_store, secrets_store = stores
+    _seed_legacy_gemini_active(
+        configuration_store=configuration_store,
+        connection_store=connection_store,
+    )
+
+    for _ in range(2):
+        activate_ollama_embedding(
+            configuration_store=configuration_store,
+            connection_store=connection_store,
+            secrets_store=secrets_store,
+            now=lambda: fixed_now,
+        )
+
+    actives = [
+        c
+        for c in configuration_store.list_configurations(scope="global")
+        if c.status == "active"
+    ]
+    rolled_back = [
+        c
+        for c in configuration_store.list_configurations(scope="global")
+        if c.status == "rolled_back"
+    ]
+    assert len(actives) == 1
+    assert actives[0].model_id == DEFAULT_OLLAMA_MODEL
+    assert len(rolled_back) == 1
+    assert rolled_back[0].model_id == "gemini-embedding-2"

--- a/backend/tests/contracts/test_embedding_activate_ollama.py
+++ b/backend/tests/contracts/test_embedding_activate_ollama.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 from cryptography.fernet import Fernet
+from pydantic import ValidationError
 
 from app.contracts.embedding_contract import EmbeddingConfiguration
 from app.services.embedding_configuration_store import EmbeddingConfigurationStore
@@ -220,3 +221,22 @@ def test_activate_ollama_converges_after_gemini_then_ollama(
     assert actives[0].model_id == DEFAULT_OLLAMA_MODEL
     assert len(rolled_back) == 1
     assert rolled_back[0].model_id == "gemini-embedding-2"
+
+
+def test_activate_ollama_rejects_non_loopback_base_url(
+    stores, fixed_now: datetime
+) -> None:
+    """Issue #934 Akzeptanzkriterium (Negativ-Test): ein nicht-Loopback
+    ``base_url`` wird fuer ``provider_kind='ollama'`` als ValidationError
+    abgelehnt — Loopback-Pflicht aus ``LocalOllamaBaseUrl`` und
+    ``ProviderConnectionUpsertRequest.model_validator``.
+    """
+    configuration_store, connection_store, secrets_store = stores
+    with pytest.raises(ValidationError):
+        activate_ollama_embedding(
+            base_url="http://example.com:11434",
+            configuration_store=configuration_store,
+            connection_store=connection_store,
+            secrets_store=secrets_store,
+            now=lambda: fixed_now,
+        )

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 3739 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 3744 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 171 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Was

Pinnt die aktive Neo4j-`EmbeddingConfiguration` (ADR-0007 Single Source of Truth) auf das lokale Ollama-Modell `embeddinggemma:300m` (768-dim). Bisher zeigte der SSoT-Knoten noch auf Gemini 2 (3072-dim), während die `.env`-Konfiguration bereits umgestellt war — der Boot lief grün, aber alle Systempfade, die an der Neo4j-Config andocken (Provider-Detection, Re-Embedding, Validation), griffen ins Leere.

## Warum

Hotfix am 2026-07-27: Gemini Embedding 2 fiel mit `429 quota exceeded` aus, der lokale Boot-Check schlug fehl. Wechsel auf `EMBEDDING_MODEL=embeddinggemma:300m` / `VECTOR_DIM=768` via `.env` brachte den Stack zurück, aber ADR-0007 verlangt, dass die Neo4j-`EmbeddingConfiguration` die kanonische Quelle ist, nicht die Env-Variablen. Diese PR schließt diese Lücke.

## Wie

- **Helper** `activate_ollama_embedding` ([backend/app/services/embedding_configurations/activate_ollama.py](backend/app/services/embedding_configurations/activate_ollama.py)): idempotenter Pinning-Pfad. Liest Defaults aus `Config.EMBEDDING_*`, stellt `ProviderConnection` (Loopback-validiert via `LocalOllamaBaseUrl`) sicher, legt `EmbeddingConfiguration` per Fingerabdruck `(provider_connection_id, model_id, dimensions, scope, project_id)` an oder findet sie, aktiviert via `EmbeddingConfigurationService.activate`. Letzteres setzt vorhandene aktive Konfigurationen des gleichen Scopes automatisch auf `status='rolled_back'` (Audit-Trail; Knoten bleibt erhalten, wird nicht gelöscht).
- **Operator-Tool** [backend/scripts/activate_local_ollama_embedding.py](backend/scripts/activate_local_ollama_embedding.py): `uv run python -m scripts.activate_local_ollama_embedding [--model …] [--dimensions …]`. JSON-Report auf stdout.
- **Tests** [backend/tests/contracts/test_embedding_activate_ollama.py](backend/tests/contracts/test_embedding_activate_ollama.py): 4 Contract-Tests — Pinning, Vorgänger-Rollback (Legacy-Knoten bleibt), Idempotenz (3×), Konvergenz nach Gemini→Ollama. Isolierte Fixtures (`tmp_path` + Fernet-`AGORA_SECRET_KEY`).

## Test-Befund (Lead-verifiziert)

- `cd backend && uv run pytest tests/contracts/ -x -q` → **427 passed**, 5.84s
- `uv run python -m app.contracts.dump_schemas --check` → **46/46 matchen**, exit 0
- `uv run ruff check app/ tests/` → **All checks passed**
- `uv run mypy app` → **Success: no issues found in 237 source files**
- `bash scripts/pre-push-gate.sh backend` → exit 0

`agora-opus-reviewer` (read-only) auf `7384121f` → **APPROVE**. Drei nicht-blockierende Hinweise (Doppel-Loopback-Validierung defensiv, `EmbeddingConfigurationScope`-Default harmlos, optionaler `--quiet`-Flag für späteres Folge-Issue) — alle außerhalb des Issue-Scopes.

## Hartanker / ADR-Konformität

- **ADR-0007 Embedding-Configuration SSoT**: Schreibpfade ausschließlich über `EmbeddingConfigurationStore` und `ProviderConnectionStore` — keine direkten Cypher, MERGE, CREATE, SET oder File-Writes (außer `sys.stdout` im Operator-Tool). Gemini-Re-Embedding explizit außerhalb des Scopes; der Helper-Docstring [Z. 14-16](backend/app/services/embedding_configurations/activate_ollama.py#L14) ehrt das.
- **ADR-0002 Evidence-Gating**: Diff berührt keine der 5 Hartanker (`report_prompts.py`-Block, Hedge-Snapshot, `EvidenceSourceKind`, `cross_stakeholder_for_high`, `reject_inferred_in_high_confidence`).
- **Provider-Detection-SSoT**: kein neuer Detection-Code; Helper nutzt den existierenden `LocalOllamaBaseUrl`-Loopback-Validator.

## Out of Scope (separate Baustellen)

- **Gemini→Ollama-Datenmigration** (3072→768 Vektor-Re-Embedding): ADR-0007 sagt explizit „noch nicht unterstützt — nicht vortäuschen". Folge-Issue.
- **Bolt-Socket-Storm** beim parallelen 30-Agent-Simulationsstart: Issue #933, separate Diagnose.
- **Chat-Provider-Switch** (LLM_BASE_URL / LLM_MODEL_NAME): unverändert.

Closes #934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Lokale Ollama-Embedding-Konfiguration lässt sich idempotent aktivieren und auf eine Standardkonfiguration „pinnen“.
  * Bereits aktive Embedding-Konfigurationen gleicher Scope werden statusbasiert zurückgesetzt statt gelöscht.
  * Neues Kommandozeilen-Skript zur reproduzierbaren Aktivierung inkl. JSON-Report und anpassbaren Parametern (Modell, Dimensionen, Base-URL, Anzeige).

* **Tests**
  * Contract-Tests erweitern Abdeckung für Aktivierung, Rollback, Idempotenz, Konvergenz sowie Ablehnung ungültiger (nicht-loopback) Base-URLs.

* **Dokumentation**
  * Changelog-Eintrag für die neue lokale Ollama-Embedding-Aktivierung im Unreleased-Bereich ergänzt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->