### PR TITLE
fix(frontend): address post-merge CodeRabbit findings from PR #938

### DIFF
--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -334,6 +334,41 @@ describe('Step4Report — INCOMPLETE-Status und generation_failed (P2.6)', () =>
     expect(wrapper.find('[data-testid="report-failed-sections"]').exists()).toBe(false)
   })
 
+  // CodeRabbit-P2 aus PR #938 Follow-up: status='failed' muss am Direct-Mount
+  // als terminaler Zustand erkannt werden, sonst ersetzt onMounted
+  // phase=2/emitted 'error' durch phase=1/'running' und der Badge springt
+  // auf "Läuft" zurück, bis der nächste Status-Poll feuert.
+  it('markiert status="failed" als terminal — Badge bleibt "Fehlgeschlagen", nicht "Läuft"', async () => {
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: {
+        status: 'failed',
+        report_id: 'report_test01',
+        simulation_id: 'sim_test01',
+        error: 'Generator crashed',
+      },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({ success: false })
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({ success: false })
+
+    const wrapper = mountComponent()
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 120))
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 120))
+    await wrapper.vm.$nextTick()
+
+    const badge = wrapper.find('[data-testid="report-status-badge"]').text()
+    // i18n-Mock liefert den Key-Namen statt den übersetzten String —
+    // das ist robuster als der locale-abhängige Text und prüft die
+    // semantische Property (reportStatus === 'failed' → reportBadgeLabel
+    // resolved zu 'common.failed' statt 'common.running'/'common.completed').
+    expect(badge).toContain('common.failed')
+    expect(badge).not.toContain('common.running')
+    expect(badge).not.toContain('common.completed')
+    expect(badge).not.toContain('common.ready')
+  })
+
   // Hinweis: die Report-Badge-Variante/-Text für status='incomplete' wird in
   // production code über reportBadgeLabel/reportBadgeVariant computed values
   // gerendert, getrieben von reportStatus (ref). Der Text-Pfad ist hier

--- a/frontend/src/components/step2/EnvSetupModelPanel.vue
+++ b/frontend/src/components/step2/EnvSetupModelPanel.vue
@@ -11,13 +11,8 @@ const { t } = useI18n()
 
 defineProps({
   language: { type: String, required: true },
-  loadingModels: { type: Boolean, default: false },
-  serverDefaultRequiresOllama: { type: Boolean, default: false },
-  ollamaReachable: { type: Boolean, default: false },
-  defaultProvider: { type: String, default: '' },
   agentToolsEnabled: { type: Boolean, default: false },
   maxToolCallsPerAction: { type: Number, default: 0 },
-  isPreparing: { type: Boolean, default: false },
   modelRef: { type: Object as () => AiModelRef | null, default: null },
 })
 

--- a/frontend/src/components/v4/steps/Step2EnvSetup.vue
+++ b/frontend/src/components/v4/steps/Step2EnvSetup.vue
@@ -252,15 +252,10 @@ onMounted(async () => {
 
         <EnvSetupModelPanel
           v-model:language="language"
-          :model-value="selectedModelRef"
+          :model-ref="selectedModelRef"
           @update:model-ref="onModelRefPicked"
-          :loading-models="loadingModels"
-          :server-default-requires-ollama="serverDefaultRequiresOllama"
-          :ollama-reachable="ollamaReachable"
-          :default-provider="defaultProvider"
           :agent-tools-enabled="agentToolsEnabled"
           :max-tool-calls-per-action="maxToolCallsPerAction"
-          :is-preparing="isPreparing"
         />
 
         <!-- Agent cap (optional) -->

--- a/frontend/src/components/v4/steps/Step3Simulation.vue
+++ b/frontend/src/components/v4/steps/Step3Simulation.vue
@@ -483,7 +483,7 @@ watch(() => props.simulationId, (newId, oldId) => {
       <article class="card" :class="{ 'is-active': phase === 1 }">
         <header class="card-head">
           <Kicker num="01">{{ t('step3.title') }}</Kicker>
-          <Badge :tone="statusKind === 'running' ? 'blue' : statusKind === 'paused' ? 'orange' : statusKind === 'done' ? 'green' : 'gray'" :dot="statusKind === 'running'">
+          <Badge :tone="statusKind === 'running' ? 'blue' : statusKind === 'paused' ? 'orange' : statusKind === 'done' ? 'green' : statusKind === 'error' ? 'red' : 'gray'" :dot="statusKind === 'running'">
             {{ statusLabel }}
           </Badge>
         </header>

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -348,12 +348,14 @@ const reportBadgeLabel = computed((): string => {
   if (phase.value !== 2) {
     return phase.value === 1 ? t('common.running') : t('common.ready')
   }
+  if (reportStatus.value === 'failed') return t('common.failed')
   if (reportStatus.value === 'incomplete') return t('common.incomplete')
   return t('common.completed')
 })
 
-const reportBadgeTone = computed((): 'blue' | 'orange' | 'green' | 'gray' => {
+const reportBadgeTone = computed((): 'blue' | 'orange' | 'green' | 'gray' | 'red' => {
   if (phase.value !== 2) return 'blue'
+  if (reportStatus.value === 'failed') return 'red'
   if (reportStatus.value === 'incomplete') return 'orange'
   return 'green'
 })

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -316,7 +316,12 @@ async function pollStatus() {
         } catch { /* report not yet flushed */ }
         stopPolling()
       } else if (st.status === 'failed') {
-        phase.value = 2; emit('update-status', 'error')
+        // FAILED ist terminal: isComplete verhindert, dass onMounted nach
+        // einem Reload erneut in den Polling-Pfad springt und den
+        // "Failed"-Zustand durch "Running" ersetzt (analog zu
+        // completed/incomplete).
+        isComplete.value = true; phase.value = 2
+        emit('update-status', 'error')
         addLog(`${t('errors.reportFailed')}: ${st.error || ''}`)
         stopPolling()
       } else { phase.value = 1 }
@@ -489,7 +494,7 @@ onUnmounted(stopPolling)
         <header class="card-head">
           <Kicker num="01">{{ t('step4.title') }}</Kicker>
           <div class="card-head-actions">
-            <Badge :tone="reportBadgeTone" :dot="phase === 1">
+            <Badge :tone="reportBadgeTone" :dot="phase === 1" data-testid="report-status-badge">
               {{ reportBadgeLabel }}
             </Badge>
             <span v-if="!props.cancelEndpointAvailable" :title="t('step4.reportConfirm.stopDisabledTip')" class="stop-btn-wrap">


### PR DESCRIPTION
Follow-up to merged PR #938. Three CodeRabbit findings were posted ~8s after merge; all verified against current `main` and fixed here.

## Findings

**1. EnvSetupModelPanel.vue — incomplete prop cleanup (Major)**
After the panel was reduced to `AiModelPicker` + language selector, five props stayed declared but unreferenced: `loadingModels`, `serverDefaultRequiresOllama`, `ollamaReachable`, `defaultProvider`, `isPreparing`. `Step2EnvSetup` still passed them. Removed from `defineProps` and the `<EnvSetupModelPanel>` bindings.
> Note: CodeRabbit's list also named `agentToolsEnabled`/`maxToolCallsPerAction`, but those **are** used (`v-if="agentToolsEnabled"`, `t(... { count: maxToolCallsPerAction })`) — kept.

**2. Step2EnvSetup.vue — `:model-value` instead of `:model-ref` (Major)**
`EnvSetupModelPanel` declares prop `modelRef`, so `:model-value="selectedModelRef"` only landed as a fallthrough attribute on the root `<div>` and the `AiModelPicker` never received the preselected value. Fixed to `:model-ref="selectedModelRef"` (the `@update:model-ref` handler was already correct). This was a regression introduced by the Codex-P1 override-separation fix in #938.

**3. Step3Simulation.vue + Step4Report.vue — error states not red (Minor)**
- Step3: `statusKind === 'error'` (set when `runner_status === 'failed'`) fell through to the gray badge tone. Added an explicit `'red'` branch.
- Step4: `reportStatus === 'failed'` fell through to `'green'` in `reportBadgeTone` and to `'completed'` in `reportBadgeLabel`. Added `'red'` tone and `common.failed` label branches.

## Verification
Frontend gate: lint + typecheck clean, **171/171 files, 1570/1570 tests**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Die Modellauswahl in Schritt 2 wurde optimiert und verwendet nun eine konsistentere Auswahl- und Aktualisierungslogik.
  * Die Anzeige von Status-Badges in der Simulation wurde vereinheitlicht.
  * Fehlerzustände im Bericht werden nun klarer als „Fehlgeschlagen“ gekennzeichnet und rot hervorgehoben.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->