### PR TITLE
fix(frontend/i18n): #796 — hartkodierte PageHeader-Texte auf vue-i18n umstellen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (hartkodierte PageHeader-Texte auf vue-i18n umgestellt — 2026-07-28, Issue #796)
+
+- `title`/`subtitle`/`label`-Literale in `HistoryView.vue`, `CompareView.vue`, `StepEnvSetupView.vue`, `StepReportView.vue`, `StepInteractionView.vue`, `StepGraphBuildView.vue` und `StepSimulationView.vue` laufen jetzt über `$t()` statt hartkodierter deutscher Strings, mit neuen Keys in `de.json` und `en.json`.
+- Betroffene Specs prüfen den i18n-Key gegen befüllte `messages` statt das deutsche Literal gegen leere `messages`.
+
 ### Changed (v3-Inhaltskomponenten nach v4 migriert — 2026-07-28, PR #938, Issue #922)
 
 - Die drei verbleibenden v3-Inhaltskomponenten `Step2EnvSetup.vue`, `Step3Simulation.vue` und `Step4Report.vue` sind nach `frontend/src/components/v4/steps/` migriert (RENAMED, Inhalt an v4-Typografie und -Ordnerstruktur angepasst). Die v3-Originale sind entfernt; die v4-Wrapper-Views binden die v4-Komponenten direkt ein.

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1534,5 +1534,34 @@
       "submit": "Download starten",
       "modelRequired": "Modell-Name ist erforderlich"
     }
+  },
+  "views": {
+    "history": {
+      "title": "Verlauf",
+      "subtitle": "Run- und Branch-Historie"
+    },
+    "compare": {
+      "title": "Compare"
+    },
+    "stepEnvSetup": {
+      "title": "Personas",
+      "subtitle": "Zielgruppenquoten und Umgebungsparameter konfigurieren"
+    },
+    "stepReport": {
+      "title": "Report",
+      "subtitle": "Simulationsergebnisse und Quellenbelege einsehen"
+    },
+    "stepInteraction": {
+      "title": "Interaktion",
+      "subtitle": "Gezielte Nachfragen an die simulierten Personas stellen"
+    },
+    "stepGraphBuild": {
+      "title": "Graph Build",
+      "subtitle": "Wissensgraph aus hochgeladenen Dokumenten aufbauen"
+    },
+    "stepSimulation": {
+      "title": "Simulation",
+      "subtitle": "Multi-Agent-Simulationslauf starten und beobachten"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1534,5 +1534,34 @@
       "submit": "Start download",
       "modelRequired": "Model name is required"
     }
+  },
+  "views": {
+    "history": {
+      "title": "History",
+      "subtitle": "Run and Branch History"
+    },
+    "compare": {
+      "title": "Compare"
+    },
+    "stepEnvSetup": {
+      "title": "Personas",
+      "subtitle": "Configure target group quotas and environment parameters"
+    },
+    "stepReport": {
+      "title": "Report",
+      "subtitle": "View simulation results and source citations"
+    },
+    "stepInteraction": {
+      "title": "Interaction",
+      "subtitle": "Ask targeted questions to the simulated personas"
+    },
+    "stepGraphBuild": {
+      "title": "Graph Build",
+      "subtitle": "Build knowledge graph from uploaded documents"
+    },
+    "stepSimulation": {
+      "title": "Simulation",
+      "subtitle": "Start and observe multi-agent simulation run"
+    }
   }
 }

--- a/frontend/src/views/v4/CompareView.vue
+++ b/frontend/src/views/v4/CompareView.vue
@@ -7,7 +7,7 @@
 -->
 <template>
   <AppShell :breadcrumbs="crumbs">
-    <PageHeader title="Compare" />
+    <PageHeader :title="$t('views.compare.title')" />
 
     <div v-if="loadError" class="compare-view-error" role="alert">
       {{ loadError }}

--- a/frontend/src/views/v4/HistoryView.vue
+++ b/frontend/src/views/v4/HistoryView.vue
@@ -4,16 +4,19 @@
 -->
 <template>
   <AppShell :breadcrumbs="crumbs">
-    <PageHeader title="Verlauf" subtitle="Run- und Branch-Historie" />
+    <PageHeader :title="$t('views.history.title')" :subtitle="$t('views.history.subtitle')" />
     <HistoryDatabase />
   </AppShell>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import HistoryDatabase from '@/components/HistoryDatabase.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
-const crumbs: BreadcrumbItem[] = [{ label: 'Verlauf' }]
+const { t } = useI18n()
+const crumbs = computed<BreadcrumbItem[]>(() => [{ label: t('views.history.title') }])
 </script>

--- a/frontend/src/views/v4/__tests__/CompareView.spec.ts
+++ b/frontend/src/views/v4/__tests__/CompareView.spec.ts
@@ -45,7 +45,7 @@ const router = makeTestRouter([
   { path: '/v4/compare/:simulationId', name: 'CompareV4', component: stubComponent, props: true },
 ])
 
-const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: { views: { compare: { title: 'Compare' } } }, en: {} } })
 
 describe('CompareView (v4)', () => {
   beforeEach(() => {

--- a/frontend/src/views/v4/__tests__/HistoryView.spec.ts
+++ b/frontend/src/views/v4/__tests__/HistoryView.spec.ts
@@ -39,7 +39,7 @@ const router = makeTestRouter([
   { path: '/v4/history', name: 'HistoryV4', component: stubComponent },
 ])
 
-const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: { views: { history: { title: 'Verlauf', subtitle: 'Run- und Branch-Historie' } } }, en: {} } })
 
 describe('HistoryView (v4)', () => {
   beforeEach(() => {

--- a/frontend/src/views/v4/steps/StepEnvSetupView.vue
+++ b/frontend/src/views/v4/steps/StepEnvSetupView.vue
@@ -4,8 +4,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Personas"
-      subtitle="Zielgruppenquoten und Umgebungsparameter konfigurieren"
+      :title="$t('views.stepEnvSetup.title')"
+      :subtitle="$t('views.stepEnvSetup.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="persona_generation" />

--- a/frontend/src/views/v4/steps/StepGraphBuildView.vue
+++ b/frontend/src/views/v4/steps/StepGraphBuildView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Graph Build"
-      subtitle="Wissensgraph aus hochgeladenen Dokumenten aufbauen"
+      :title="$t('views.stepGraphBuild.title')"
+      :subtitle="$t('views.stepGraphBuild.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="graph_build" />

--- a/frontend/src/views/v4/steps/StepInteractionView.vue
+++ b/frontend/src/views/v4/steps/StepInteractionView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Interaktion"
-      subtitle="Gezielte Nachfragen an die simulierten Personas stellen"
+      :title="$t('views.stepInteraction.title')"
+      :subtitle="$t('views.stepInteraction.subtitle')"
     />
     <PipelineStepper :current-step="5" />
     <Step5Interaction :report-id="reportId" />

--- a/frontend/src/views/v4/steps/StepReportView.vue
+++ b/frontend/src/views/v4/steps/StepReportView.vue
@@ -4,8 +4,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Report"
-      subtitle="Simulationsergebnisse und Quellenbelege einsehen"
+      :title="$t('views.stepReport.title')"
+      :subtitle="$t('views.stepReport.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="report_generation" />

--- a/frontend/src/views/v4/steps/StepSimulationView.vue
+++ b/frontend/src/views/v4/steps/StepSimulationView.vue
@@ -12,8 +12,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Simulation"
-      subtitle="Multi-Agent-Simulationslauf starten und beobachten"
+      :title="$t('views.stepSimulation.title')"
+      :subtitle="$t('views.stepSimulation.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="simulation_rounds" />

--- a/frontend/src/views/v4/steps/__tests__/StepEnvSetupView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepEnvSetupView.spec.ts
@@ -24,6 +24,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -55,6 +56,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -81,6 +83,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
@@ -37,6 +37,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -68,6 +69,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'new' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -88,6 +90,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_a' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -110,6 +113,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepSimulationView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepSimulationView.spec.ts
@@ -37,6 +37,7 @@ describe('StepSimulationView — Navigation', () => {
     const wrapper = mount(StepSimulationView, {
       props: { simulationId: 'sim_x' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -81,6 +82,7 @@ describe('StepSimulationView — Navigation', () => {
     const wrapper = mount(StepSimulationView, {
       props: { simulationId: 'sim_x' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
@@ -202,6 +202,7 @@ async function mountView<T extends object>(
   return mount(component as Parameters<typeof mount>[0], {
     props,
     global: {
+        mocks: { $t: (key: any) => key },
       plugins: [router, createPinia()],
       stubs: {
         // Step-Komponenten als Stubs — ihre Inhalte sind Folge-Slice


### PR DESCRIPTION
## Zusammenfassung
Behebt #796: `title`/`subtitle`/`label`-Literale in mehreren v4-Views liefen an `PageHeader` als hartkodierte deutsche Strings statt über `$t()`, entgegen der `AGENTS.md`-Vorgabe. Betrifft `HistoryView.vue`, `CompareView.vue`, `StepEnvSetupView.vue`, `StepReportView.vue`, `StepInteractionView.vue`, `StepGraphBuildView.vue`, `StepSimulationView.vue` sowie den Breadcrumb-Eintrag in `HistoryView.vue`.

`AppShellDemoView.vue` (im Issue als 8. Fundstelle genannt) existiert nicht mehr — wurde durch #833 (nach Issue-Erstellung) bereits gelöscht, entsprechend hier nicht angefasst.

Alle betroffenen `title`/`subtitle`/`label`-Werte laufen jetzt über `$t()` mit neuen Keys in `de.json` und `en.json`. Betroffene Specs prüfen jetzt den i18n-Key mit befüllten `messages` statt das deutsche Literal gegen leere `messages`.

## Herkunft
Implementiert von Google Jules (Session `15595036901582738528`), lokal von mir verifiziert und gepusht — Jules' MCP-Sessions erzeugen keinen PR automatisch, nur einen Patch.

## Test plan
- [x] `cd frontend && bun run test` — 171/171 Testdateien, 1570/1570 Tests grün
- [x] `cd frontend && bun run check` — grün (Typecheck + Build)
- [x] `docs/STATUS.md` unverändert
- [x] Kein Dateiüberlapp mit dem zwischenzeitlich gemergten #939 (Post-Merge-CodeRabbit-Fixes zu #938)

🤖 Generated with Google Jules, verifiziert und veröffentlicht via Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Mehr UI-Texte in Verlauf, Vergleich und den einzelnen Arbeitsschritten werden jetzt über die Übersetzungen gesteuert.
  * Deutsche und englische Übersetzungen für Seitentitel, Untertitel und Labels wurden ergänzt.
  * Breadcrumbs und Überschriften passen sich dadurch konsistent an die gewählte Sprache an.

* **Tests**
  * Die automatisierten Tests wurden an die lokalisierte Darstellung angepasst.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->