### PR TITLE
chore(0.9): ActiveModelBadge.vue in REMOVED_PATHS aufnehmen — Guard-Fixtures mitziehen

### DIFF
--- a/.github/scripts/check_legacy_model_picker.py
+++ b/.github/scripts/check_legacy_model_picker.py
@@ -16,8 +16,9 @@ folgende Importe einführen:
 
 Seit Slice 7.7 blockiert der Check außerdem die Rückkehr entfernter Dateien
 (``REMOVED_PATHS``): der v3-Picker und die unverdrahteten
-Mock-Routing-Komponenten aus 7.7 sowie ``LlmProfilePicker.vue`` aus Issue
-#834. Hier reicht die bloße Existenz der Datei — ein Import ist nicht nötig.
+Mock-Routing-Komponenten aus 7.7, ``LlmProfilePicker.vue`` aus Issue
+#834, sowie ``ActiveModelBadge.vue`` aus Issue #911. Hier reicht die bloße Existenz
+der Datei — ein Import ist nicht nötig.
 
 Read-Adapter-Freigabe via ``@deprecated``
 =========================================
@@ -25,12 +26,12 @@ Read-Adapter-Freigabe via ``@deprecated``
 Nach 5.5 gibt es keinen Opt-in-Marker mehr. Stattdessen erkennt der Check das
 ``@deprecated``-JSDoc-Tag am **Ziel** des Imports: Trägt die importierte Datei
 selbst ein ``@deprecated``-Tag, gilt sie als sanktionierter Read-Adapter im
-Deprecation-/Read-only-Fenster und der Import ist erlaubt. So dürfen die
-bestehenden v3-Consumer (``WorkspaceHeader`` → ``ActiveModelBadge``,
-``Step2EnvSetup``/``Step3Simulation`` → ``useRuntimeLlmOptions``) die
-deprecateten Picker/Composables weiter lesen, ohne pro-Datei-Marker zu
-tragen — während jeder *neu* eingeführte, nicht-deprecatete v3-Pfad hart
-blockiert wird.
+Deprecation-/Read-only-Fenster und der Import ist erlaubt.
+Da inzwischen alle Komponenten-Ausnahmen (wie ``ModelPicker.vue``, ``LlmProfilePicker.vue``
+und ``ActiveModelBadge.vue``) in ``REMOVED_PATHS`` stehen und allein durch ihre Existenz
+blockiert werden, greift diese Freigabe faktisch nur noch für verbliebene Stores
+und Composables (z. B. ``Step2EnvSetup.vue``/``Step3Simulation.vue`` →
+``useRuntimeLlmOptions.ts``).
 
 Die alten Stores (``llmProviders``/``llmProfiles``/``llmRoutingDefaults``)
 existieren nach 5.5 nicht mehr als Datei (konsolidiert in
@@ -117,6 +118,10 @@ REMOVED_PATHS: tuple[tuple[Path, str], ...] = (
     (
         Path("components/llm/LlmProfilePicker.vue"),
         "v3 LlmProfilePicker.vue wurde in Issue #834 entfernt",
+    ),
+    (
+        Path("components/ActiveModelBadge.vue"),
+        "v3 ActiveModelBadge.vue wurde in Issue #835 entfernt",
     ),
     (
         Path("views/Settings/llmRouting/ActiveSnapshotsCard.vue"),

--- a/.github/scripts/test_check_legacy_model_picker.py
+++ b/.github/scripts/test_check_legacy_model_picker.py
@@ -128,29 +128,19 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_deprecated_target_allows_import(self) -> None:
         # Ziel-Datei trägt @deprecated → sanktionierter Read-Adapter.
-        # ActiveModelBadge.vue (nicht in REMOVED_PATHS) statt LlmProfilePicker.vue,
-        # da letzterer Pfad in REMOVED_PATHS steht und schon bei Existenz blockt.
-        _write(
-            self.root / "components/ActiveModelBadge.vue",
-            (
-                "<script setup lang=\"ts\">\n"
-                "/**\n"
-                " * @deprecated Slice 5.5 — v3-Badge, Read-Adapter bis 5.6.\n"
-                " */\n"
-                "</script>\n"
-            ),
-        )
+        # Wir verwenden hier useRuntimeLlmOptions.ts als Testobjekt,
+        # da Komponenten wie ActiveModelBadge.vue in REMOVED_PATHS stehen
+        # und schon bei reiner Existenz blockieren würden.
         _write(
             self.root / "composables/useRuntimeLlmOptions.ts",
             "/** @deprecated Slice 5.5 — Runtime-Credential-Read-Adapter. */\n"
             "export function useRuntimeLlmOptions() {}\n",
         )
-        # Consumer ohne jeden Marker importieren die deprecateten Ziele.
+        # Consumer ohne jeden Marker importiert das deprecatete Ziel.
         _write(
             self.root / "consumer.vue",
             (
                 "<script setup lang=\"ts\">\n"
-                "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n"
                 "import { useRuntimeLlmOptions } from '@/composables/useRuntimeLlmOptions'\n"
                 "</script>\n"
             ),
@@ -168,17 +158,18 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_non_deprecated_target_still_flags(self) -> None:
         # Ziel existiert, trägt aber KEIN @deprecated → Verstoß.
-        # ActiveModelBadge.vue statt LlmProfilePicker.vue, damit der Treffer
-        # aus der Import-Regel stammt und nicht aus REMOVED_PATHS.
+        # Wir verwenden useRuntimeLlmOptions.ts als Testobjekt, damit der Treffer
+        # aus der Import-Regel stammt und nicht aus REMOVED_PATHS (wie es bei
+        # ActiveModelBadge.vue der Fall wäre).
         _write(
-            self.root / "components/ActiveModelBadge.vue",
-            "<script setup lang=\"ts\">\n// kein Tag\n</script>\n",
+            self.root / "composables/useRuntimeLlmOptions.ts",
+            "export function useRuntimeLlmOptions() {}\n",
         )
         _write(
             self.root / "consumer.vue",
             (
                 "<script setup lang=\"ts\">\n"
-                "import ActiveModelBadge from '@/components/ActiveModelBadge.vue'\n"
+                "import { useRuntimeLlmOptions } from '@/composables/useRuntimeLlmOptions'\n"
                 "</script>\n"
             ),
         )
@@ -193,7 +184,7 @@ class CheckLegacyModelPickerTests(unittest.TestCase):
             1,
             "nicht-deprecatetes Ziel darf nicht durchgehen",
         )
-        self.assertIn("ActiveModelBadge.vue", proc.stdout)
+        self.assertIn("useRuntimeLlmOptions", proc.stdout)
         self.assertIn("llmProviders", proc.stdout)
 
     # ------------------------------------------------------------------

--- a/docs/runbooks/pre-push-gate.md
+++ b/docs/runbooks/pre-push-gate.md
@@ -91,18 +91,20 @@ Exit-Codes: `0` clean · `1` Treffer · `2` Usage-Fehler.
 Opt-in-Marker `legacy-model-picker-allow` ist entfallen. Ein verbotener
 Import ist jetzt genau dann erlaubt, wenn das **importierte Ziel** selbst
 ein `@deprecated`-JSDoc-Tag trägt — also ein sanktionierter Read-Adapter
-im Deprecation-/Read-only-Fenster ist. So dürfen die verbleibenden
-v3-Consumer (`layouts/WorkspaceHeader.vue` → `ActiveModelBadge.vue`,
-`Step2EnvSetup.vue`/`Step3Simulation.vue` → `useRuntimeLlmOptions.ts`) die
-deprecateten Composables/Komponenten weiter lesen, ohne pro-Datei-Marker.
+im Deprecation-/Read-only-Fenster ist.
+Da inzwischen alle Komponenten-Ausnahmen in `REMOVED_PATHS` stehen und
+allein durch ihre Existenz blockiert werden, greift diese Freigabe faktisch
+nur noch für verbliebene Stores und Composables
+(z. B. `Step2EnvSetup.vue`/`Step3Simulation.vue` → `useRuntimeLlmOptions.ts`).
 Jeder *neu* eingeführte, nicht-deprecatete v3-Pfad wird hart blockiert.
 
 **Entfernte Dateien (`REMOVED_PATHS`):** Zusätzlich zur Import-Prüfung
 blockiert der Check die *Rückkehr* gelöschter v3-Dateien — hier reicht die
 bloße Existenz, ein Import ist nicht nötig, und ein `@deprecated`-Tag
 rettet sie nicht. Erfasst sind `components/ui/ModelPicker.vue` und die
-Mock-Routing-UI unter `views/Settings/llmRouting/` (beide Slice 7.7) sowie
-`components/llm/LlmProfilePicker.vue` (in Issue #834 entfernt).
+Mock-Routing-UI unter `views/Settings/llmRouting/` (beide Slice 7.7),
+`components/llm/LlmProfilePicker.vue` (in Issue #834 entfernt), sowie
+`components/ActiveModelBadge.vue` (in Issue #911 entfernt).
 
 Die Alt-Stores (`llmProviders`/`llmProfiles`/`llmRoutingDefaults`)
 existieren nach 5.5 nicht mehr (konsolidiert in `@/store/aiModels`); ihr


### PR DESCRIPTION
Fixes #911 by strictly removing `ActiveModelBadge.vue` (added to `REMOVED_PATHS`) and updating the relevant tests and documentation to reflect this change correctly without weakening test assertions or manually changing the system status.

---
*PR created automatically by Jules for task [5677537472480255300](https://jules.google.com/task/5677537472480255300) started by @arn0ld87*