### PR TITLE
refactor(api): Move _is_local_endpoint out of simulation_prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (Local-Endpoint-Erkennung in neutrales Modul verschoben — 2026-07-28, Issue #800)
+
+- `_is_local_endpoint` und `LOCAL_NO_AUTH_API_KEY` waren als private Symbole in `backend/app/api/simulation_prepare.py` beheimatet, wurden aber bereits aus `runs.py`, `simulation_history.py` und `simulation_run.py` importiert. Beides zieht jetzt nach `backend/app/utils/endpoints.py` und wird öffentlich (`is_local_endpoint`, `LOCAL_HOSTS`).
+- Whitelist-Logik (`urlparse`-basierter Hostname-Vergleich gegen `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `host.docker.internal`) und der Subdomain-Smuggling-Schutz (Gemini-Review PR #466) bleiben unverändert erhalten.
+- Alle Aufrufer und Tests auf den neuen Importpfad umgestellt, kein Verhaltensunterschied.
+
 ### Changed (hartkodierte PageHeader-Texte auf vue-i18n umgestellt — 2026-07-28, Issue #796)
 
 - `title`/`subtitle`/`label`-Literale in `HistoryView.vue`, `CompareView.vue`, `StepEnvSetupView.vue`, `StepReportView.vue`, `StepInteractionView.vue`, `StepGraphBuildView.vue` und `StepSimulationView.vue` laufen jetzt über `$t()` statt hartkodierter deutscher Strings, mit neuen Keys in `de.json` und `en.json`.

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -542,7 +542,7 @@ def _restart_simulation_prepare(run: dict):
     # Config.LLM_API_KEY/LLM_BASE_URL aus der lokalen .env zurückfällt (#798,
     # Opus-Review-Folgebefund zu #778). Exakt derselbe Resolver-Pfad wie
     # simulation_prepare.py::prepare_simulation (Zeilen 401-431).
-    from ..api.simulation_prepare import LOCAL_NO_AUTH_API_KEY, _is_local_endpoint
+    from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
 
     seed_run_stage_routing(
         run_id,
@@ -555,7 +555,7 @@ def _restart_simulation_prepare(run: dict):
     route_router.lock_stage("persona_generation", resolved_route)
     resolved_api_key = resolve_route_api_key(resolved_route, None)
 
-    if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
+    if resolved_api_key is None and not is_local_endpoint(resolved_route.base_url_sanitized):
         guard_message = (
             f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
             f"für Provider '{resolved_route.provider_id}'. "
@@ -592,7 +592,7 @@ def _restart_simulation_prepare(run: dict):
             raise RuntimeError(ApiErrorCode.INTERNAL_ERROR) from persistence_error
         raise ValueError(guard_message)
 
-    if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):
+    if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
         resolved_api_key = LOCAL_NO_AUTH_API_KEY
 
     effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -10,7 +10,7 @@ from typing import Optional
 from flask import current_app, request
 
 from . import simulation_bp
-from ..api.simulation_prepare import LOCAL_NO_AUTH_API_KEY, _is_local_endpoint
+from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
 from ..models.project import ProjectManager
 from ..services.ai_route_resolver import AiRouteResolutionError
 from ..services.entity_reader import EntityReader
@@ -212,7 +212,7 @@ def generate_profiles():
 
     api_key = resolve_route_api_key(resolved_route, llm_runtime)
     base_url = resolved_route.base_url_sanitized
-    if api_key is None and not _is_local_endpoint(base_url):
+    if api_key is None and not is_local_endpoint(base_url):
         return json_error(
             ApiErrorCode.VALIDATION_FAILED,
             status=422,
@@ -223,7 +223,7 @@ def generate_profiles():
                 "oder im Sitzungsfeld eingeben."
             ),
         )
-    if api_key is None and _is_local_endpoint(base_url):
+    if api_key is None and is_local_endpoint(base_url):
         # Lokaler Endpoint ohne Key ist zulaessig (#778) — Platzhalter statt
         # `None`, damit der Generator-Vertrag "Key + Base-URL aus derselben
         # Quelle" hier nicht faelschlich einen ValueError wirft.

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -34,38 +34,7 @@ from .simulation_common import (
 )
 
 
-_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal"})
-
-# Lokale OpenAI-kompatible Server (z. B. Ollama) ignorieren den API-Key
-# vollstaendig, das OpenAI-SDK verlangt aber einen nicht-leeren String (#778).
-# Dieser Platzhalter macht die No-Auth-Freigabe fuer lokale Endpoints explizit
-# sichtbar, statt still `None` an die Generatoren durchzureichen — deren
-# Vertrag "Key und Base-URL aus derselben Quelle" (#778) wuerde sonst bei
-# String-Mismatch (z. B. host.docker.internal vs. localhost) faelschlich
-# einen ValueError werfen, obwohl die API-Schicht den Lauf bereits freigegeben hat.
-LOCAL_NO_AUTH_API_KEY = "local-no-auth"
-
-
-def _is_local_endpoint(base_url: Optional[str]) -> bool:
-    """Prüft, ob eine Base-URL auf einen lokalen Endpunkt zeigt.
-
-    Nutzt ``urllib.parse.urlparse`` und vergleicht den Hostnamen explizit gegen
-    eine Whitelist (``localhost``, ``127.0.0.1``, ``::1``, ``0.0.0.0``,
-    ``host.docker.internal``). Das verhindert Subdomain-Smuggling wie
-    ``http://not-localhost.com`` oder ``http://remote-server:11434``, die ein
-    reines Substring-Match fälschlich als lokal akzeptiert hätte
-    (Gemini-Review PR #466).
-    """
-    if not base_url:
-        return False
-    from urllib.parse import urlparse
-
-    try:
-        parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
-    except ValueError:
-        return False
-    host = (parsed.hostname or "").lower()
-    return host in _LOCAL_HOSTS
+from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
 
 
 def _parse_quota_plan(data: dict) -> Optional[PersonaQuotaPlan]:
@@ -552,7 +521,7 @@ def prepare_simulation():
     route_router.lock_stage("persona_generation", resolved_route)
     resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
 
-    if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
+    if resolved_api_key is None and not is_local_endpoint(resolved_route.base_url_sanitized):
         guard_message = (
             f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
             f"für Provider '{resolved_route.provider_id}'. "
@@ -602,7 +571,7 @@ def prepare_simulation():
             message=guard_message,
         )
 
-    if resolved_api_key is None and _is_local_endpoint(resolved_route.base_url_sanitized):
+    if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
         # Lokaler Endpoint ohne Key ist explizit freigegeben (siehe Guard oben) —
         # der Platzhalter ersetzt `None`, damit der Generator-Vertrag aus #778
         # (Key und Base-URL aus derselben Quelle) nicht faelschlich einen

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -15,7 +15,7 @@ from ..services.llm_routing_seed import (
     resolve_route_api_key,
     seed_run_stage_routing,
 )
-from ..api.simulation_prepare import _is_local_endpoint
+from ..utils.endpoints import is_local_endpoint
 from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
@@ -264,7 +264,7 @@ def start_simulation():
             descriptor = next((p for p in registry.get_providers() if p.id == provider_id_preview), None)
             p_type = descriptor.type if descriptor else "openai_compatible"
             stored_key = SecretResolver().get_api_key(provider_id_preview, p_type)
-            if not stored_key and not _is_local_endpoint(
+            if not stored_key and not is_local_endpoint(
                 (descriptor.base_url if descriptor else None) or llm_runtime.base_url
             ):
                 return json_error(
@@ -328,7 +328,7 @@ def start_simulation():
     route_router.lock_stage("simulation_rounds", resolved_route)
     resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
 
-    if resolved_api_key is None and not _is_local_endpoint(resolved_route.base_url_sanitized):
+    if resolved_api_key is None and not is_local_endpoint(resolved_route.base_url_sanitized):
         # Fallback-422 bleibt für Workspace-Default-Fälle (kein Frontend-Override) —
         # da kann die Run-Record schon erstellt sein; markiere sie als failed,
         # damit keine Phantom-Runs in der Liste landen.

--- a/backend/app/utils/endpoints.py
+++ b/backend/app/utils/endpoints.py
@@ -1,0 +1,39 @@
+"""
+Utility functions for endpoint resolution and validation.
+"""
+
+from typing import Optional
+
+
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal"})
+
+# Lokale OpenAI-kompatible Server (z. B. Ollama) ignorieren den API-Key
+# vollstaendig, das OpenAI-SDK verlangt aber einen nicht-leeren String (#778).
+# Dieser Platzhalter macht die No-Auth-Freigabe fuer lokale Endpoints explizit
+# sichtbar, statt still `None` an die Generatoren durchzureichen — deren
+# Vertrag "Key und Base-URL aus derselben Quelle" (#778) wuerde sonst bei
+# String-Mismatch (z. B. host.docker.internal vs. localhost) faelschlich
+# einen ValueError werfen, obwohl die API-Schicht den Lauf bereits freigegeben hat.
+LOCAL_NO_AUTH_API_KEY = "local-no-auth"
+
+
+def is_local_endpoint(base_url: Optional[str]) -> bool:
+    """Prüft, ob eine Base-URL auf einen lokalen Endpunkt zeigt.
+
+    Nutzt ``urllib.parse.urlparse`` und vergleicht den Hostnamen explizit gegen
+    eine Whitelist (``localhost``, ``127.0.0.1``, ``::1``, ``0.0.0.0``,
+    ``host.docker.internal``). Das verhindert Subdomain-Smuggling wie
+    ``http://not-localhost.com`` oder ``http://remote-server:11434``, die ein
+    reines Substring-Match fälschlich als lokal akzeptiert hätte
+    (Gemini-Review PR #466).
+    """
+    if not base_url:
+        return False
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
+    except ValueError:
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in LOCAL_HOSTS

--- a/backend/tests/api/test_provider_override_key_fallback.py
+++ b/backend/tests/api/test_provider_override_key_fallback.py
@@ -552,34 +552,34 @@ def test_has_key_endpoint_returns_false_when_no_key(llm_client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Gemini-Followup PR #466 — Subdomain-Smuggling-Schutz für _is_local_endpoint
+# Gemini-Followup PR #466 — Subdomain-Smuggling-Schutz für is_local_endpoint
 # ---------------------------------------------------------------------------
 
 
 def test_is_local_endpoint_accepts_real_local_hosts():
-    """``_is_local_endpoint`` erkennt echte lokale Hostnamen unabhängig vom Port."""
-    from app.api.simulation_prepare import _is_local_endpoint
+    """``is_local_endpoint`` erkennt echte lokale Hostnamen unabhängig vom Port."""
+    from app.utils.endpoints import is_local_endpoint
 
-    assert _is_local_endpoint("http://localhost:11434/v1") is True
-    assert _is_local_endpoint("http://127.0.0.1:11434/v1") is True
-    assert _is_local_endpoint("http://host.docker.internal:11434/v1") is True
-    assert _is_local_endpoint("http://localhost") is True
-    assert _is_local_endpoint("http://[::1]:11434/v1") is True
+    assert is_local_endpoint("http://localhost:11434/v1") is True
+    assert is_local_endpoint("http://127.0.0.1:11434/v1") is True
+    assert is_local_endpoint("http://host.docker.internal:11434/v1") is True
+    assert is_local_endpoint("http://localhost") is True
+    assert is_local_endpoint("http://[::1]:11434/v1") is True
 
 
 def test_is_local_endpoint_rejects_subdomain_smuggling():
     """Cloud-URLs, die ``localhost`` oder ``11434`` als Substring enthalten, dürfen
     nicht fälschlich als lokal gelten — Gemini-MEDIUM auf PR #466.
     """
-    from app.api.simulation_prepare import _is_local_endpoint
+    from app.utils.endpoints import is_local_endpoint
 
     # Hostname enthält ``localhost`` als Substring → kein echter Local-Host.
-    assert _is_local_endpoint("http://not-localhost.com/v1") is False
-    assert _is_local_endpoint("https://localhost.evil.example/v1") is False
+    assert is_local_endpoint("http://not-localhost.com/v1") is False
+    assert is_local_endpoint("https://localhost.evil.example/v1") is False
     # Port 11434 auf einem Remote-Host darf nicht reichen.
-    assert _is_local_endpoint("http://remote-server.example:11434/v1") is False
+    assert is_local_endpoint("http://remote-server.example:11434/v1") is False
     # 127-Subdomain-Smuggling.
-    assert _is_local_endpoint("http://127.0.0.1.evil.example/v1") is False
+    assert is_local_endpoint("http://127.0.0.1.evil.example/v1") is False
     # Leerstring / None bleiben False.
-    assert _is_local_endpoint("") is False
-    assert _is_local_endpoint(None) is False
+    assert is_local_endpoint("") is False
+    assert is_local_endpoint(None) is False

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -365,7 +365,7 @@ def test_resume_simulation_prepare_falls_back_to_local_no_auth_key(env):
     """Restart gegen einen lokalen No-Auth-Endpoint ohne Store-Key darf keinen
     ValueError werfen und muss den lokalen Platzhalter-Key setzen.
     """
-    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+    from app.utils.endpoints import LOCAL_NO_AUTH_API_KEY
 
     run = _create_run(
         env["registry"],

--- a/backend/tests/api/test_simulation_history_provider_passing.py
+++ b/backend/tests/api/test_simulation_history_provider_passing.py
@@ -24,7 +24,7 @@ import pytest
 from flask import Flask
 
 from app.api import simulation_bp
-from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+from app.utils.endpoints import LOCAL_NO_AUTH_API_KEY
 
 
 @pytest.fixture
@@ -220,7 +220,7 @@ def test_generate_profiles_local_endpoint_without_key_uses_no_auth_placeholder(
     sein — ein evtl. real persistierter Store-Key auf dem Entwicklerrechner
     darf das Ergebnis nicht beeinflussen.
     """
-    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+    from app.utils.endpoints import LOCAL_NO_AUTH_API_KEY
 
     monkeypatch.setattr(
         "app.services.llm_routing_seed.SecretResolver.get_api_key",

--- a/backend/tests/api/test_simulation_prepare_routing.py
+++ b/backend/tests/api/test_simulation_prepare_routing.py
@@ -211,7 +211,7 @@ def test_prepare_local_route_without_store_key_uses_no_auth_placeholder(client, 
     (`host.docker.internal` vs. `localhost` ist der klassische Container-Fall).
     """
     from app.config import Config
-    from app.api.simulation_prepare import LOCAL_NO_AUTH_API_KEY
+    from app.utils.endpoints import LOCAL_NO_AUTH_API_KEY
 
     monkeypatch.setattr(Config, "LLM_BASE_URL", "http://localhost:11434/v1")
 


### PR DESCRIPTION
refactor(api): _is_local_endpoint und LOCAL_NO_AUTH_API_KEY in ein neutrales Modul ziehen

Problem: `_is_local_endpoint` was a private function in `backend/app/api/simulation_prepare.py`, but over time began to be imported and used in other API modules (`runs.py`, `simulation_history.py`, and `simulation_run.py`).

Scope:
- Moved the `_is_local_endpoint` predicate, the `LOCAL_NO_AUTH_API_KEY` constant, and the `_LOCAL_HOSTS` set into a new neutral utility module `backend/app/utils/endpoints.py`.
- Renamed the elements to make them public (`is_local_endpoint`, `LOCAL_HOSTS`).
- Updated all callers in the backend API layer and corresponding tests.
- Retained the strict exact-hostname whitelist logic using `urlparse` to ensure the security property (no subdomain smuggling) is preserved.

---
*PR created automatically by Jules for task [15722375333064124629](https://jules.google.com/task/15722375333064124629) started by @arn0ld87*