### PR TITLE
fix(e2e): update checkFocusVisible and re-enable feed route accessibility gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
   erstmals die v4-Step-Routen mit echter Projekt- und Simulations-ID. Vier Routen bleiben
   begründet ausgenommen und sind in den Issues #920 und #921 sowie im Testkopf
   dokumentiert.
+
+### Fixed (E2E-Helper `checkFocusVisible` erkennt implizite Tab-Stops — 2026-07-28, PR #947, Issue #921)
+
+- `frontend/tests/e2e/helpers/accessibility.ts::checkFocusVisible` wertet `document.activeElement` jetzt direkt aus und presst bis zu zwanzig Tab-Tokens, bis ein echtes Element (nicht `document.body`) fokussiert ist. Damit greift der Helper auch auf Routen mit impliziten Tab-Stops (scrollbare Container ohne `tabindex`, z. B. `.fc-scroll` in `FeedColumn.vue`), die per CSS-Selektor nicht vorab erfassbar sind.
+- Der Golden-Gate-Test für `/v4/simulation/:simulationId/feed` (Issue #921) ist reaktiviert; die Accessibility-Coverage steigt damit von 17 auf 18 produktive Routen, drei weitere Ausnahmen verbleiben in Issue #920 und im Testkopf.
 - **Verlässlichkeit der Gates:** Die Prüfung lief bisher an, bevor Stylesheets und
   Schriften angewendet waren, und meldete dadurch auf schnellen CI-Läufen massenhaft
   Kontrastfehler auf unveränderten Seiten. Die Gates warten jetzt auf einen stabilen

--- a/frontend/tests/accessibility-helpers.spec.ts
+++ b/frontend/tests/accessibility-helpers.spec.ts
@@ -168,13 +168,29 @@ describe('checkFocusVisible', () => {
     };
 
     const handles = [first, target].map((element) => ({
-      evaluate: async (fn: (node: Element, arg?: unknown) => unknown, arg?: unknown) =>
-        fn(element, arg),
+      evaluate: async (fn: (node: Element, arg?: unknown) => unknown, arg?: unknown) => {
+        // the actual page.evaluate runs `window.getComputedStyle(node)` if arg is FOCUS_STYLE_PROPERTIES
+        // so we need to run it in the context of the document.
+        if (fn.toString().includes('node.blur')) {
+          (element as HTMLElement).blur();
+          element.style.outlineStyle = 'none';
+          element.style.outlineWidth = '0px';
+          element.style.outlineColor = 'rgb(0, 0, 0)';
+          return undefined;
+        }
+        return fn(element, arg);
+      },
       dispose: async () => undefined,
     }));
     const page = {
-      evaluate: async (fn: (arg?: unknown) => unknown, arg?: unknown) => fn(arg),
-      keyboard: { press: async () => target.focus() },
+      evaluate: async (fn: (arg?: unknown) => unknown, arg?: unknown) => {
+        if (fn.toString().includes('requestAnimationFrame')) {
+          return fn();
+        }
+        return fn(arg);
+      },
+      evaluateHandle: async (fn: (arg?: unknown) => unknown, arg?: unknown) => handles[1],
+      keyboard: { press: async () => { target.focus(); return undefined; } },
       locator: () => ({ elementHandles: async () => handles }),
     } as unknown as Page;
 

--- a/frontend/tests/e2e/golden-gate-accessibility.spec.ts
+++ b/frontend/tests/e2e/golden-gate-accessibility.spec.ts
@@ -236,23 +236,9 @@ test.describe('Slice 7.2 · Golden-Gate Accessibility Gates', () => {
       await checkAccessibilityGate(page, `/v4/simulation/${simulationId}`);
     });
 
-    // DOKUMENTIERTE AUSNAHME — /v4/simulation/:id/feed ist bewusst NICHT
-    // gegatet.
-    //
-    // Ursache ist eine Lücke im geteilten Helper, kein Mangel der Route:
-    // checkFocusVisible erfasst die fokussierbaren Elemente vorab per
-    // Selektor und sucht darin das nach Tab fokussierte Element. Die
-    // Feed-Spalten enthalten scrollbare Container (.fc-scroll in
-    // FeedColumn.vue), denen Chromium automatisch einen Tab-Stop gibt —
-    // ohne tabindex-Attribut und damit per Selektor nicht erfassbar. Der
-    // erste Tab landet dort, focusedIndex bleibt -1, der Check schlägt fehl.
-    // Die Route ist die einzige gegatete ohne AppShell und deshalb die
-    // einzige, bei der ein impliziter Scroll-Stop als erstes drankommt.
-    //
-    // Der Helper müsste dafür document.activeElement direkt auswerten statt
-    // gegen eine Vorab-Liste zu matchen. Das ist eine Änderung an geteilter
-    // Testinfrastruktur mit Wirkung auf alle Routen und gehört nicht in
-    // diesen Slice. Nachverfolgt in Issue #921.
+    test('Step Simulation Feed passes accessibility gates', async ({ page }) => {
+      await checkAccessibilityGate(page, `/v4/simulation/${simulationId}/feed`);
+    });
 
     test('Compare (v4) passes accessibility gates', async ({ page }) => {
       // CompareView.vue:12 zeigt bei fehlenden Branches einen role="alert"-

--- a/frontend/tests/e2e/helpers/accessibility.ts
+++ b/frontend/tests/e2e/helpers/accessibility.ts
@@ -265,26 +265,26 @@ export async function checkFocusVisible(page: Page): Promise<void> {
     }
   });
 
-  const focusableElements = (await page.locator(FOCUSABLE_SELECTOR).elementHandles()) as ElementHandle<HTMLElement>[];
-  try {
-    expect(focusableElements.length).toBeGreaterThan(0);
-    const beforeStyles = await Promise.all(focusableElements.map(captureFocusStyle));
+  await page.keyboard.press('Tab');
+  await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 
-    await page.keyboard.press('Tab');
+  const target = await page.evaluateHandle(() => document.activeElement as HTMLElement | null);
+
+  try {
+    const isElement = await target.evaluate((node) => node !== null && node !== document.body);
+    expect(isElement).toBe(true);
+    if (!isElement) return;
+
+    const afterStyle = await captureFocusStyle(target as ElementHandle<HTMLElement>);
+
+    await target.evaluate((node) => node.blur());
     await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 
-    let focusedIndex = -1;
-    for (let index = 0; index < focusableElements.length; index += 1) {
-      if (await focusableElements[index].evaluate((element) => element === document.activeElement)) {
-        focusedIndex = index;
-        break;
-      }
-    }
+    const beforeStyle = await captureFocusStyle(target as ElementHandle<HTMLElement>);
 
-    const afterStyle = focusedIndex >= 0 ? await captureFocusStyle(focusableElements[focusedIndex]) : undefined;
-    expect(afterStyle ? diffFocusStyle(beforeStyles[focusedIndex], afterStyle) : false).toBe(true);
+    expect(diffFocusStyle(beforeStyle, afterStyle)).toBe(true);
   } finally {
-    await Promise.all(focusableElements.map((element) => element.dispose()));
+    await target.dispose();
   }
 }
 

--- a/frontend/tests/e2e/helpers/accessibility.ts
+++ b/frontend/tests/e2e/helpers/accessibility.ts
@@ -265,26 +265,43 @@ export async function checkFocusVisible(page: Page): Promise<void> {
     }
   });
 
-  await page.keyboard.press('Tab');
-  await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
-
-  const target = await page.evaluateHandle(() => document.activeElement as HTMLElement | null);
+  // Issue #921 — Implizite Tab-Stops (scrollbare Container ohne tabindex)
+  // erscheinen erst nach genügend Tab-Presses im Tab-Zyklus. Auf einer Route
+  // ohne echte interaktive Elemente (z. B. /v4/simulation/:id/feed mit
+  // leeren Feed-Spalten) wandert der Fokus nach dem ersten Tab in den
+  // Browser-Chrome und activeElement wird wieder body. Wir probieren daher
+  // bis zu MAX_TAB_ATTEMPTS Tabs, bevor wir aufgeben.
+  const MAX_TAB_ATTEMPTS = 20;
+  let target: ElementHandle<HTMLElement> | null = null;
+  for (let attempt = 0; attempt < MAX_TAB_ATTEMPTS; attempt += 1) {
+    await page.keyboard.press('Tab');
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+    const handle = await page.evaluateHandle(() => document.activeElement as HTMLElement | null);
+    const isElement = await handle.evaluate((node) => node !== null && node !== document.body);
+    if (isElement) {
+      target = handle as ElementHandle<HTMLElement>;
+      break;
+    }
+    await handle.dispose();
+  }
 
   try {
-    const isElement = await target.evaluate((node) => node !== null && node !== document.body);
-    expect(isElement).toBe(true);
-    if (!isElement) return;
+    expect(
+      target,
+      'checkFocusVisible: nach bis zu MAX_TAB_ATTEMPTS Tab-Presses landet der Fokus nicht in einem echten Element der Seite (vermutlich Route ohne sichtbare Tab-Stops)',
+    ).not.toBeNull();
+    if (!target) return;
 
-    const afterStyle = await captureFocusStyle(target as ElementHandle<HTMLElement>);
+    const afterStyle = await captureFocusStyle(target);
 
     await target.evaluate((node) => node.blur());
     await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 
-    const beforeStyle = await captureFocusStyle(target as ElementHandle<HTMLElement>);
+    const beforeStyle = await captureFocusStyle(target);
 
     expect(diffFocusStyle(beforeStyle, afterStyle)).toBe(true);
   } finally {
-    await target.dispose();
+    await target?.dispose();
   }
 }
 


### PR DESCRIPTION
Fixes the E2E helper `checkFocusVisible` to support checking focus visibility on elements that receive focus implicitly (like scrollable regions) without relying on a static CSS selector. Also re-enabled the accessibility test for the `/v4/simulation/:simulationId/feed` route as the issue with implicit scroll tab stops has been resolved.

---
*PR created automatically by Jules for task [6191675826829986313](https://jules.google.com/task/6191675826829986313) started by @arn0ld87*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Barrierefreiheit**
  - Fokus-Sichtbarkeit wird auch in scrollbaren Bereichen und bei impliziten Tab-Stopps zuverlässiger geprüft.
  - Falsch-negative Accessibility-Prüfungen auf Routen ohne sichtbare fokussierbare Elemente werden reduziert.

- **Tests**
  - Die Accessibility-Abdeckung wurde um die Simulations-Feed-Route erweitert und umfasst nun 18 produktive Routen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->