### PR TITLE
fix(frontend/i18n): transition hardcoded PageHeader strings in v4 views to vue-i18n

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1534,5 +1534,34 @@
       "submit": "Download starten",
       "modelRequired": "Modell-Name ist erforderlich"
     }
+  },
+  "views": {
+    "history": {
+      "title": "Verlauf",
+      "subtitle": "Run- und Branch-Historie"
+    },
+    "compare": {
+      "title": "Compare"
+    },
+    "stepEnvSetup": {
+      "title": "Personas",
+      "subtitle": "Zielgruppenquoten und Umgebungsparameter konfigurieren"
+    },
+    "stepReport": {
+      "title": "Report",
+      "subtitle": "Simulationsergebnisse und Quellenbelege einsehen"
+    },
+    "stepInteraction": {
+      "title": "Interaktion",
+      "subtitle": "Gezielte Nachfragen an die simulierten Personas stellen"
+    },
+    "stepGraphBuild": {
+      "title": "Graph Build",
+      "subtitle": "Wissensgraph aus hochgeladenen Dokumenten aufbauen"
+    },
+    "stepSimulation": {
+      "title": "Simulation",
+      "subtitle": "Multi-Agent-Simulationslauf starten und beobachten"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1534,5 +1534,34 @@
       "submit": "Start download",
       "modelRequired": "Model name is required"
     }
+  },
+  "views": {
+    "history": {
+      "title": "History",
+      "subtitle": "Run and Branch History"
+    },
+    "compare": {
+      "title": "Compare"
+    },
+    "stepEnvSetup": {
+      "title": "Personas",
+      "subtitle": "Configure target group quotas and environment parameters"
+    },
+    "stepReport": {
+      "title": "Report",
+      "subtitle": "View simulation results and source citations"
+    },
+    "stepInteraction": {
+      "title": "Interaction",
+      "subtitle": "Ask targeted questions to the simulated personas"
+    },
+    "stepGraphBuild": {
+      "title": "Graph Build",
+      "subtitle": "Build knowledge graph from uploaded documents"
+    },
+    "stepSimulation": {
+      "title": "Simulation",
+      "subtitle": "Start and observe multi-agent simulation run"
+    }
   }
 }

--- a/frontend/src/views/v4/CompareView.vue
+++ b/frontend/src/views/v4/CompareView.vue
@@ -7,7 +7,7 @@
 -->
 <template>
   <AppShell :breadcrumbs="crumbs">
-    <PageHeader title="Compare" />
+    <PageHeader :title="$t('views.compare.title')" />
 
     <div v-if="loadError" class="compare-view-error" role="alert">
       {{ loadError }}

--- a/frontend/src/views/v4/HistoryView.vue
+++ b/frontend/src/views/v4/HistoryView.vue
@@ -4,16 +4,19 @@
 -->
 <template>
   <AppShell :breadcrumbs="crumbs">
-    <PageHeader title="Verlauf" subtitle="Run- und Branch-Historie" />
+    <PageHeader :title="$t('views.history.title')" :subtitle="$t('views.history.subtitle')" />
     <HistoryDatabase />
   </AppShell>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import HistoryDatabase from '@/components/HistoryDatabase.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
 
-const crumbs: BreadcrumbItem[] = [{ label: 'Verlauf' }]
+const { t } = useI18n()
+const crumbs = computed<BreadcrumbItem[]>(() => [{ label: t('views.history.title') }])
 </script>

--- a/frontend/src/views/v4/__tests__/CompareView.spec.ts
+++ b/frontend/src/views/v4/__tests__/CompareView.spec.ts
@@ -45,7 +45,7 @@ const router = makeTestRouter([
   { path: '/v4/compare/:simulationId', name: 'CompareV4', component: stubComponent, props: true },
 ])
 
-const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: { views: { compare: { title: 'Compare' } } }, en: {} } })
 
 describe('CompareView (v4)', () => {
   beforeEach(() => {

--- a/frontend/src/views/v4/__tests__/HistoryView.spec.ts
+++ b/frontend/src/views/v4/__tests__/HistoryView.spec.ts
@@ -39,7 +39,7 @@ const router = makeTestRouter([
   { path: '/v4/history', name: 'HistoryV4', component: stubComponent },
 ])
 
-const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'de', messages: { de: { views: { history: { title: 'Verlauf', subtitle: 'Run- und Branch-Historie' } } }, en: {} } })
 
 describe('HistoryView (v4)', () => {
   beforeEach(() => {

--- a/frontend/src/views/v4/steps/StepEnvSetupView.vue
+++ b/frontend/src/views/v4/steps/StepEnvSetupView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Personas"
-      subtitle="Zielgruppenquoten und Umgebungsparameter konfigurieren"
+      :title="$t('views.stepEnvSetup.title')"
+      :subtitle="$t('views.stepEnvSetup.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="persona_generation" />

--- a/frontend/src/views/v4/steps/StepGraphBuildView.vue
+++ b/frontend/src/views/v4/steps/StepGraphBuildView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Graph Build"
-      subtitle="Wissensgraph aus hochgeladenen Dokumenten aufbauen"
+      :title="$t('views.stepGraphBuild.title')"
+      :subtitle="$t('views.stepGraphBuild.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="graph_build" />

--- a/frontend/src/views/v4/steps/StepInteractionView.vue
+++ b/frontend/src/views/v4/steps/StepInteractionView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Interaktion"
-      subtitle="Gezielte Nachfragen an die simulierten Personas stellen"
+      :title="$t('views.stepInteraction.title')"
+      :subtitle="$t('views.stepInteraction.subtitle')"
     />
     <PipelineStepper :current-step="5" />
     <Step5Interaction :report-id="reportId" />

--- a/frontend/src/views/v4/steps/StepReportView.vue
+++ b/frontend/src/views/v4/steps/StepReportView.vue
@@ -6,8 +6,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Report"
-      subtitle="Simulationsergebnisse und Quellenbelege einsehen"
+      :title="$t('views.stepReport.title')"
+      :subtitle="$t('views.stepReport.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="report_generation" />

--- a/frontend/src/views/v4/steps/StepSimulationView.vue
+++ b/frontend/src/views/v4/steps/StepSimulationView.vue
@@ -12,8 +12,8 @@
 <template>
   <AppShell :breadcrumbs="crumbs">
     <PageHeader
-      title="Simulation"
-      subtitle="Multi-Agent-Simulationslauf starten und beobachten"
+      :title="$t('views.stepSimulation.title')"
+      :subtitle="$t('views.stepSimulation.subtitle')"
     >
       <template #right>
         <StepModelOverrideChip stage-id="simulation_rounds" />

--- a/frontend/src/views/v4/steps/__tests__/StepEnvSetupView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepEnvSetupView.spec.ts
@@ -24,6 +24,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -55,6 +56,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -81,6 +83,7 @@ describe('StepEnvSetupView — Navigation', () => {
     const wrapper = mount(StepEnvSetupView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
@@ -37,6 +37,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -68,6 +69,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'new' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -88,6 +90,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_a' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -110,6 +113,7 @@ describe('StepGraphBuildView', () => {
     const wrapper = mount(StepGraphBuildView, {
       props: { projectId: 'project_42' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepSimulationView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepSimulationView.spec.ts
@@ -37,6 +37,7 @@ describe('StepSimulationView — Navigation', () => {
     const wrapper = mount(StepSimulationView, {
       props: { simulationId: 'sim_x' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
@@ -81,6 +82,7 @@ describe('StepSimulationView — Navigation', () => {
     const wrapper = mount(StepSimulationView, {
       props: { simulationId: 'sim_x' },
       global: {
+        mocks: { $t: (key: any) => key },
         stubs: {
           AppShell: { template: '<main><slot /></main>' },
           PageHeader: { template: '<header><slot /><slot name="right" /></header>' },

--- a/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepWrapperViews.spec.ts
@@ -212,6 +212,7 @@ async function mountView<T extends object>(
   return mount(component as Parameters<typeof mount>[0], {
     props,
     global: {
+        mocks: { $t: (key: any) => key },
       plugins: [router, createPinia()],
       stubs: {
         // Step-Komponenten als Stubs — ihre Inhalte sind Folge-Slice


### PR DESCRIPTION
This updates `PageHeader` in v4 views to use `vue-i18n` strings, solving #796.

- Introduced top-level `views` key for locale namespaces (`views.history`, `views.stepGraphBuild`, etc.) in `de.json` and `en.json`.
- Updated `HistoryView.vue`, `CompareView.vue`, `StepEnvSetupView.vue`, `StepReportView.vue`, `StepInteractionView.vue`, `StepGraphBuildView.vue`, and `StepSimulationView.vue`.
- Updated vitest configuration in components' `spec.ts` files to mock/provide valid `vue-i18n` structures and satisfy existing UI checks. `AppShellDemoView.vue` was skipped as the component is deleted from the codebase.

---
*PR created automatically by Jules for task [15595036901582738528](https://jules.google.com/task/15595036901582738528) started by @arn0ld87*