### PR TITLE
fix(status): sync Frontend Test-Files 169→167, lock worktree path to T7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ Runbooks:
 - [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md)
 - [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md)
 
+## Worktree-Pfad
+
+**Pflicht:** Alle Agora-Worktrees liegen unter `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` ist verboten. T7-Mount vor dem Anlegen prüfen (`test -d /Volumes/T7`). Volle Strategie in [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md).
+
 ## Tool-Pipeline
 
 Für Architektur-, Delta- und Codebase-Analysen:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (STATUS.md-Drift: Frontend Test-Files-Zähler 169 → 167 — 2026-07-28)
+
+- `docs/STATUS.md` Abschnitt `## Tests` zeigte `Frontend Test-Files | 169`, die `find`-basierte Messung im Repo liefert jedoch 167. Ursprung: PR #938 (`refactor(0.9): migrate v3 content components to v4 steps`) konsolidierte zwei Spec-Dateien, ohne den Drift-Check nachzuziehen. Fix bringt das Backend-PR-smoke-Gate wieder auf grün.
+- Auto-Generator `scripts/sync-status.sh` und Drift-Check unverändert; manuelle Anpassung ist hier ausreichend, weil die Diskrepanz genau ein Spec-File-Pair betrifft.
+
 ### Removed (Unused Composables `useWorkspaceMode` und `useWorkspaceStatus` entfernt — 2026-07-28, Issue #908)
 
 - `frontend/src/composables/useWorkspaceMode.ts` und `frontend/src/composables/useWorkspaceStatus.ts` mitsamt ihrer Specs unter `frontend/src/composables/__tests__/` entfernt. Beide Composables hatten nach der v4-Routen-Konsolidierung (ADR-0010) keine Importeure mehr.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ Kein `--no-verify`-Bypass. Runbook: [`docs/runbooks/pre-push-gate.md`](docs/runb
 | [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md) | Dispatch-, Parallelitäts- und Review-Workflow |
 | [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.md) | Layer 0–10 |
 
+## Worktree-Pfad
+
+**Pflicht:** Alle Agora-Worktrees liegen unter `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` ist für Agora-Worktrees verboten — `git worktree add` ohne T7-Pfad wird vom Lead zurückgewiesen. T7-Mount wird vor dem Anlegen verifiziert (`test -d /Volumes/T7`). Volle Strategie in [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md).
+
 ## Provider-Detection-SSoT
 
 Bei Provider-Detection-Fragen („welcher Provider für diese URL/Modell", `ollama.com`-Handling, `think`/`num_ctx`-Gate) ist [`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py) → `detect_provider(base_url, model, *, mode="http"|"oasis")` die Single Source of Truth. Keine neuen lokalen Detection-Heuristiken pflegen.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,7 +28,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3751 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 169 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 167 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:


### PR DESCRIPTION
## Kontext

PR #947 (Accessibility-Fix, Frontend-Test-Code) wurde gemerged während das Backend-PR-smoke-Gate rot war. Diagnose: der rote CI kommt **nicht** von PR #947 — PR #947 ändert kein Backend-Code. Ursache ist eine unabhängige Doku-Drift in `docs/STATUS.md` aus PR #938 (`refactor(0.9): migrate v3 content components to v4 steps`, der zwei Spec-Dateien konsolidierte ohne Drift nachzuziehen).

## Was dieser PR ändert

- `docs/STATUS.md`: Frontend Test-Files 169 → 167 (tatsächlicher Stand). Backend-PR-smoke-Gate wieder grün.
- `CLAUDE.md`, `AGENTS.md`: explizite Worktree-Pflicht `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` verboten, T7-Mount vor Anlegen prüfen (`test -d /Volumes/T7`). Repo-Runbook `docs/runbooks/worktree-strategy.md` bleibt SSoT für Details.
- `CHANGELOG.md`: Eintrag unter `[Unreleased]`.

## CI-Erwartung

Nach diesem PR sollte `Backend PR smoke gate (ruff + mypy + pytest-contracts)` wieder grün laufen — der Drift-Check schlägt nicht mehr an.

PR #947 bleibt unverändert auf main; der Accessibility-Fix war sauber.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dokumentation**
  - Verbindliche Worktree-Pfade und Prüfungen des erforderlichen Laufwerks dokumentiert.
  - Verweis auf die vollständige Worktree-Strategie ergänzt.

- **Behobene Fehler**
  - Angezeigte Anzahl der Frontend-Testdateien auf den tatsächlichen Stand von 167 korrigiert.
  - Teststatus und Änderungsprotokoll entsprechend aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->