### PR TITLE
ci(docker): arm64 build-only auf self-hosted meinserver-Runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,12 +40,22 @@ jobs:
     # relevanten Pfad-Änderungen (siehe pull_request.paths oben) und auf
     # workflow_dispatch. Kein if:-Guard — Build+Trivy ist blocking für alle
     # Trigger. Smoke-/Push-Gating siehe prod-proxy-smoke/publish weiter unten.
-    runs-on: ubuntu-latest
+    # Fork-PRs laufen immer auf ubuntu-latest (Trigger: pull_request, pfadgefiltert
+    # oben). Nur push (main/release/rc/tags) und workflow_dispatch dürfen auf den
+    # self-hosted arm64-Runner (meinserver) — dort läuft produktiver Traffic, ein
+    # fremder Fork-PR darf diesen Host nie erreichen. Siehe docs/runbooks/
+    # self-hosted-runner-meinserver.md.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted", "arm64", "meinserver"]') }}
     permissions:
       contents: read
       security-events: write
     steps:
       - name: Harden Runner
+        # Nur auf ubuntu-latest (PR-Läufe): harden-runner setzt maschinenweite
+        # Egress-iptables-Regeln. Auf dem self-hosted meinserver-Runner (push/
+        # workflow_dispatch) läuft produktiver Agora-Traffic auf demselben Host —
+        # der Step würde dessen Netzwerk während des CI-Laufs einschränken.
+        if: github.event_name == 'pull_request'
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,7 +28,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 | Kategorie | Anzahl | Methode |
 |---|---|---|
 | Backend Tests (collected) | 3751 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 169 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Frontend Test-Files | 167 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:

--- a/docs/runbooks/self-hosted-runner-meinserver.md
+++ b/docs/runbooks/self-hosted-runner-meinserver.md
@@ -1,0 +1,56 @@
+# Self-hosted Runner `meinserver-arm64`
+
+Ein GitHub-Actions-Self-hosted-Runner läuft als systemd-Dienst auf `armserver`
+(Tailscale, arm64) und ist im Repo `arn0ld87/agora` registriert.
+
+## Sicherheitskontext (public Repo)
+
+`agora` ist ein **public** Repository. Self-hosted Runner auf public Repos sind
+laut GitHub ein bekanntes Risiko: Fork-PRs können Code ausführen, der dann auf
+dem eigenen Host läuft. `meinserver`/`armserver` betreibt daneben produktiven
+Agora-Traffic (Compose-Stack hinter Traefik, Neo4j, Ollama) — ein kompromittierter
+CI-Job hätte Netzwerkzugriff auf diese Dienste.
+
+Gegenmaßnahmen:
+
+1. **Repository-Settings → Actions → General → "Fork pull request workflows
+   from outside collaborators"** ist auf **"Require approval for all outside
+   collaborators"** gesetzt (nicht über die REST-API erreichbar, nur UI).
+2. Kein Workflow-Job darf `runs-on: [self-hosted, ...]` für den
+   `pull_request`-Trigger verwenden — nur für `push` (main/release/rc/tags)
+   und `workflow_dispatch`. Siehe `.github/workflows/docker-image.yml`,
+   Job `build-only`: `runs-on` wählt `ubuntu-latest` für `pull_request` und
+   den self-hosted Runner nur für die übrigen Trigger.
+3. `step-security/harden-runner` läuft nur auf `ubuntu-latest`
+   (`if: github.event_name == 'pull_request'`) — auf dem self-hosted Runner
+   würde der Step maschinenweite Egress-iptables-Regeln setzen und damit
+   den produktiven Traffic auf `meinserver` während des CI-Laufs einschränken.
+
+## Runner-Details
+
+- Name: `meinserver-arm64`
+- Labels: `self-hosted`, `Linux`, `ARM64`, `meinserver`
+- Host: `armserver` (SSH-Alias), Pfad `~/actions-runner`
+- Betrieb: systemd-Dienst `actions.runner.arn0ld87-agora.meinserver-arm64.service`
+- Zweck: native arm64-Docker-Builds ohne QEMU-Emulation; potenziell künftig
+  Tests gegen bereits laufende interne Dienste (Neo4j/Ollama auf meinserver)
+
+## Erweiterung auf weitere Jobs
+
+Bevor ein weiterer Job auf diesen Runner umgestellt wird: prüfen, ob er auf
+`pull_request` von Forks läuft (dann NICHT self-hosted verwenden) und ob er
+Steps enthält, die Host-weite Änderungen vornehmen (Netzwerk, Firewall,
+System-Pakete) — solche Steps müssen wie `harden-runner` auf
+`ubuntu-latest`-Läufe beschränkt bleiben.
+
+## Rollback
+
+```bash
+ssh armserver "cd ~/actions-runner && sudo ./svc.sh stop && sudo ./svc.sh uninstall"
+gh api --method DELETE repos/arn0ld87/agora/actions/runners/<runner-id>
+```
+
+## Siehe auch
+
+- [`docs/runbooks/e2e-required-check.md`](e2e-required-check.md)
+- [`.github/workflows/docker-image.yml`](../../.github/workflows/docker-image.yml)

--- a/docs/runbooks/self-hosted-runner-meinserver.md
+++ b/docs/runbooks/self-hosted-runner-meinserver.md
@@ -26,6 +26,20 @@ Gegenmaßnahmen:
    würde der Step maschinenweite Egress-iptables-Regeln setzen und damit
    den produktiven Traffic auf `meinserver` während des CI-Laufs einschränken.
 
+**Bekannte, noch offene Lücke:** Der Event-Filter (`pull_request` vs. `push`/
+`workflow_dispatch`) steuert nur, *welche* Jobs den Runner erreichen — er
+schafft keine echte Laufzeit-Isolation. Der Runner läuft persistent als
+systemd-Dienst, nicht ephemer und nicht containerisiert. Jeder Job, der ihn
+erreicht (auch ein legitimer `push` auf `main`), hat vollen Zugriff auf den
+Host und auf Zustand, den vorherige Jobs hinterlassen haben. **Mandatory
+Security-Requirement für dieses Setup:** Bevor der Runner für sicherheits-
+kritische oder von mehreren Personen auslösbare Workflows genutzt wird, muss
+er entweder (a) mit `--ephemeral` (Neu-Registrierung nach jedem Job) oder
+(b) containerisiert/als Wegwerf-VM pro Job betrieben werden. Bis dahin gilt
+der aktuelle Event-Filter als Mindestschutz, nicht als vollständige Isolation.
+Tracking: siehe „Erweiterung auf weitere Jobs" unten — kein Job darf ergänzt
+werden, ohne diese Lücke erneut zu bewerten.
+
 ## Runner-Details
 
 - Name: `meinserver-arm64`
@@ -47,7 +61,8 @@ System-Pakete) — solche Steps müssen wie `harden-runner` auf
 
 ```bash
 ssh armserver "cd ~/actions-runner && sudo ./svc.sh stop && sudo ./svc.sh uninstall"
-gh api --method DELETE repos/arn0ld87/agora/actions/runners/<runner-id>
+RUNNER_ID=$(gh api repos/arn0ld87/agora/actions/runners -q '.runners[] | select(.name=="meinserver-arm64") | .id')
+gh api --method DELETE "repos/arn0ld87/agora/actions/runners/${RUNNER_ID}"
 ```
 
 ## Siehe auch

--- a/docs/runbooks/self-hosted-runner-meinserver.md
+++ b/docs/runbooks/self-hosted-runner-meinserver.md
@@ -1,7 +1,8 @@
 # Self-hosted Runner `meinserver-arm64`
 
-Ein GitHub-Actions-Self-hosted-Runner läuft als systemd-Dienst auf `armserver`
-(Tailscale, arm64) und ist im Repo `arn0ld87/agora` registriert.
+Ein GitHub-Actions-Self-hosted-Runner läuft als Docker-Container
+(`myoung34/github-runner`) auf `armserver` (Tailscale, arm64) und ist im Repo
+`arn0ld87/agora` registriert.
 
 ## Sicherheitskontext (public Repo)
 
@@ -26,26 +27,32 @@ Gegenmaßnahmen:
    würde der Step maschinenweite Egress-iptables-Regeln setzen und damit
    den produktiven Traffic auf `meinserver` während des CI-Laufs einschränken.
 
-**Bekannte, noch offene Lücke:** Der Event-Filter (`pull_request` vs. `push`/
-`workflow_dispatch`) steuert nur, *welche* Jobs den Runner erreichen — er
-schafft keine echte Laufzeit-Isolation. Der Runner läuft persistent als
-systemd-Dienst, nicht ephemer und nicht containerisiert. Jeder Job, der ihn
-erreicht (auch ein legitimer `push` auf `main`), hat vollen Zugriff auf den
-Host und auf Zustand, den vorherige Jobs hinterlassen haben. **Mandatory
-Security-Requirement für dieses Setup:** Bevor der Runner für sicherheits-
-kritische oder von mehreren Personen auslösbare Workflows genutzt wird, muss
-er entweder (a) mit `--ephemeral` (Neu-Registrierung nach jedem Job) oder
-(b) containerisiert/als Wegwerf-VM pro Job betrieben werden. Bis dahin gilt
-der aktuelle Event-Filter als Mindestschutz, nicht als vollständige Isolation.
-Tracking: siehe „Erweiterung auf weitere Jobs" unten — kein Job darf ergänzt
-werden, ohne diese Lücke erneut zu bewerten.
+4. Der Runner läuft in einem Docker-Container (`myoung34/github-runner`),
+   nicht direkt auf dem Host-Betriebssystem — Prozess- und Dateisystem-Zugriff
+   eines Jobs sind damit vom restlichen `armserver`-Host (Compose-Stacks,
+   Vaultwarden, n8n u. a.) isoliert.
+
+**Bekannte, noch offene Lücke:** Der Container ist persistent
+(`--restart unless-stopped`), nicht ephemer. Ein Job bekommt zwar ein vom
+Host getrenntes Dateisystem, aber *innerhalb* des Containers bleibt Zustand
+zwischen aufeinanderfolgenden Jobs erhalten (kein Reset pro Job). Für volle
+Job-zu-Job-Isolation müsste der Container mit `EPHEMERAL=true` laufen plus
+einem Wrapper, der ihn nach jedem Job neu erstellt (der Container dereg-
+istriert sich sonst nach einem Job und bleibt dann offline). Das ist noch
+nicht umgesetzt — Tracking: siehe „Erweiterung auf weitere Jobs" unten,
+kein weiterer Job darf ergänzt werden, ohne diese Abwägung erneut zu treffen.
 
 ## Runner-Details
 
 - Name: `meinserver-arm64`
 - Labels: `self-hosted`, `Linux`, `ARM64`, `meinserver`
-- Host: `armserver` (SSH-Alias), Pfad `~/actions-runner`
-- Betrieb: systemd-Dienst `actions.runner.arn0ld87-agora.meinserver-arm64.service`
+- Host: `armserver` (SSH-Alias)
+- Betrieb: Docker-Container `gh-runner-meinserver-arm64`
+  (Image `myoung34/github-runner:latest`), `--restart unless-stopped`
+- Registrierung: kurzlebiges Registrierungstoken (`RUNNER_TOKEN`, 1 Std.
+  gültig) bei Container-Start — bewusst kein dauerhaftes PAT im Container.
+  Bei Neuerstellung des Containers muss ein frisches Token besorgt werden
+  (siehe „Neu erstellen" unten).
 - Zweck: native arm64-Docker-Builds ohne QEMU-Emulation; potenziell künftig
   Tests gegen bereits laufende interne Dienste (Neo4j/Ollama auf meinserver)
 
@@ -57,10 +64,27 @@ Steps enthält, die Host-weite Änderungen vornehmen (Netzwerk, Firewall,
 System-Pakete) — solche Steps müssen wie `harden-runner` auf
 `ubuntu-latest`-Läufe beschränkt bleiben.
 
-## Rollback
+## Neu erstellen (z. B. nach Image-Update oder Registrierungsverlust)
 
 ```bash
-ssh armserver "cd ~/actions-runner && sudo ./svc.sh stop && sudo ./svc.sh uninstall"
+ssh armserver "docker rm -f gh-runner-meinserver-arm64"
+TOKEN=$(gh api --method POST repos/arn0ld87/agora/actions/runners/registration-token -q .token)
+ssh armserver "docker run -d \
+  --name gh-runner-meinserver-arm64 \
+  --restart unless-stopped \
+  -e REPO_URL=https://github.com/arn0ld87/agora \
+  -e RUNNER_NAME=meinserver-arm64 \
+  -e RUNNER_TOKEN='$TOKEN' \
+  -e LABELS=self-hosted,arm64,meinserver \
+  -e RUNNER_WORKDIR=/tmp/gh-runner-work \
+  -v /tmp/gh-runner-work:/tmp/gh-runner-work \
+  myoung34/github-runner:latest"
+```
+
+## Rollback (Runner komplett entfernen)
+
+```bash
+ssh armserver "docker rm -f gh-runner-meinserver-arm64"
 RUNNER_ID=$(gh api repos/arn0ld87/agora/actions/runners -q '.runners[] | select(.name=="meinserver-arm64") | .id')
 gh api --method DELETE "repos/arn0ld87/agora/actions/runners/${RUNNER_ID}"
 ```


### PR DESCRIPTION
## Summary
- Registriert Self-hosted Runner `meinserver-arm64` (arm64, Tailscale-Host `armserver`) für native arm64-Docker-Builds ohne QEMU-Emulation.
- `build-only`-Job in `docker-image.yml` läuft auf `push`/`workflow_dispatch` jetzt auf dem self-hosted Runner; `pull_request` (inkl. Fork-PRs) bleibt strikt auf `ubuntu-latest`.
- `harden-runner`-Step läuft nur noch auf `ubuntu-latest`, da er auf dem produktiven meinserver-Host maschinenweite Egress-Regeln setzen würde.
- Neues Runbook `docs/runbooks/self-hosted-runner-meinserver.md` dokumentiert Sicherheitskontext, Rollback und Erweiterungsregeln.

Voraussetzung "Require approval for all outside collaborators" (Settings → Actions → General) ist bereits gesetzt.

## Test plan
- [ ] Push auf diesen Branch triggert `build-only` weiterhin auf `ubuntu-latest` (pull_request-Event) — beobachten, dass der PR-Check grün wird
- [ ] Nach Merge: nächster main-Push beobachten, ob `build-only` auf `meinserver-arm64` läuft (Job-Log zeigt Runner-Name)
- [ ] `actionlint`-Check auf diesem PR bleibt grün (Workflow-Datei geändert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Builds werden je nach Auslöser auf passenden Standard- oder ARM64-Ausführungsumgebungen verarbeitet.
  * Sicherheitsprüfungen werden gezielter auf Pull-Request-Läufe angewendet, ohne produktionsnahe Abläufe unnötig einzuschränken.

* **Dokumentation**
  * Neue Anleitung zur Einrichtung, Absicherung, Erweiterung und Deaktivierung der selbst gehosteten Build-Umgebung hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->