### PR TITLE
ci(workflow): build-only triggers on docs/** + *.md; lock worktree path to T7

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,8 @@ on:
       - "deploy/**"
       - "backend/**"
       - "frontend/**"
+      - "docs/**"
+      - "**/*.md"
       - ".github/workflows/docker-image.yml"
   workflow_dispatch:
     inputs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ Runbooks:
 - [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md)
 - [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md)
 
+## Worktree-Pfad
+
+**Pflicht:** Alle Agora-Worktrees liegen unter `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` ist verboten. T7-Mount vor dem Anlegen prüfen (`test -d /Volumes/T7`). Volle Strategie in [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md).
+
 ## Tool-Pipeline
 
 Für Architektur-, Delta- und Codebase-Analysen:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (build-only startet jetzt auch bei Docs-PRs — 2026-07-28)
+
+- `.github/workflows/docker-image.yml` `pull_request.paths` um `docs/**` und `**/*.md` erweitert. `build-only` war als Required Check in den Branch-Protection-Settings eingetragen, der paths-Filter schloss aber Doku- und Workflow-Änderungen aus — Docs-PRs hingen dauerhaft in „Expected — Waiting for status to be reported". Pro: jeder PR triggert den Build. Con: ~2 Min Extra-CI pro reiner Doku-PR.
+
+### Changed (Worktree-Pfad auf T7 festgeschrieben — 2026-07-28)
+
+- `CLAUDE.md` und `AGENTS.md` mit expliziter Pflicht-Sektion „Worktree-Pfad" ergänzt: `/Volumes/T7/Worktrees/agora/<slice-id>/`, `/private/tmp` verboten, T7-Mount vor `git worktree add` prüfen. `docs/runbooks/worktree-strategy.md` bleibt SSoT für Details. Globale `~/.claude/CLAUDE.md` analog angepasst.
+
 ### Removed (Unused Composables `useWorkspaceMode` und `useWorkspaceStatus` entfernt — 2026-07-28, Issue #908)
 
 - `frontend/src/composables/useWorkspaceMode.ts` und `frontend/src/composables/useWorkspaceStatus.ts` mitsamt ihrer Specs unter `frontend/src/composables/__tests__/` entfernt. Beide Composables hatten nach der v4-Routen-Konsolidierung (ADR-0010) keine Importeure mehr.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ Kein `--no-verify`-Bypass. Runbook: [`docs/runbooks/pre-push-gate.md`](docs/runb
 | [`docs/runbooks/subagent-routing.md`](docs/runbooks/subagent-routing.md) | Dispatch-, Parallelitäts- und Review-Workflow |
 | [`docs/runbooks/architecture-layers.md`](docs/runbooks/architecture-layers.md) | Layer 0–10 |
 
+## Worktree-Pfad
+
+**Pflicht:** Alle Agora-Worktrees liegen unter `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` ist für Agora-Worktrees verboten — `git worktree add` ohne T7-Pfad wird vom Lead zurückgewiesen. T7-Mount wird vor dem Anlegen verifiziert (`test -d /Volumes/T7`). Volle Strategie in [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md).
+
 ## Provider-Detection-SSoT
 
 Bei Provider-Detection-Fragen („welcher Provider für diese URL/Modell", `ollama.com`-Handling, `think`/`num_ctx`-Gate) ist [`backend/app/llm/providers/registry.py`](backend/app/llm/providers/registry.py) → `detect_provider(base_url, model, *, mode="http"|"oasis")` die Single Source of Truth. Keine neuen lokalen Detection-Heuristiken pflegen.


### PR DESCRIPTION
## Kontext

PR #950 hing im Required-Check `build-only` fest: "Expected — Waiting for status to be reported". Diagnose: `build-only` ist in den Branch-Protection-Settings als Required eingetragen, aber `.github/workflows/docker-image.yml` `pull_request.paths` schließt Doku- und Workflow-Änderungen aus. Docs-PRs triggern den Workflow nie → kein Status → Required hängt für immer.

PR #951 (inzwischen gemerged) hat den damals parallel laufenden STATUS.md-Drift mitgefixt und den self-hosted Runner registriert, aber den paths-Filter unangetastet gelassen. PR #950 (mein Vorversuch) wurde obsolet und geschlossen.

## Was dieser PR ändert

- `.github/workflows/docker-image.yml`: `pull_request.paths` um `docs/**` und `**/*.md` erweitert. Jeder PR triggert jetzt `build-only`.
- `CLAUDE.md`, `AGENTS.md`: explizite Worktree-Pflicht `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` verboten, T7-Mount vor Anlegen prüfen. Repo-Runbook `docs/runbooks/worktree-strategy.md` bleibt SSoT für Details.
- `CHANGELOG.md`: zwei Einträge unter `[Unreleased]` (build-only-Fix + Worktree-Docs).

## CI-Erwartung

`build-only` startet bei diesem PR selbst (ändert `AGENTS.md` + `CLAUDE.md` + Workflow) und reportet einen Status. Nach Merge triggert jeder zukünftige PR den Check — kein „Expected — Waiting"-Hänger mehr.

## Trade-off

Reine Doku-PRs (nur `*.md` oder `docs/**` geändert) kosten jetzt ~2 Min Docker-Build extra. Bewusst akzeptiert für konsistente Required-Check-Semantik.