### PR TITLE
chore: gitignore tool artifacts, commit 5 handover logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Thumbs.db
 .env
 .env.bak
 .env.*.bak
+.env.bak-*
 .env.local
 .env.*.local
 .env.development
@@ -59,6 +60,7 @@ frontend/lcov.info
 .claude/worktrees/
 .claude/projects/
 .claude/scheduled_tasks.lock
+.claude/workflows/
 
 # Local docs and scratch dirs
 mydoc/
@@ -136,11 +138,21 @@ backend/venv311/
 .fehler/konsole_safari
 backend/instance/*.db
 
-# code-review-graph local storage (Tree-sitter graph cache, embeddings)
-.code-review-graph/
+# code-review-graph local storage (Tree-sitter graph cache, embeddings).
+# Auch wenn der Pfad ein Symlink ist (z. B. ~/.crg-data/agora) muss er
+# explizit ohne trailing slash gelistet sein, damit git check-ignore ihn
+# matcht.
+.code-review-graph
 
 # clawpatch local state (findings, features, runs, locks, reports)
 .clawpatch/
+
+# envsitter lokales Audit-Working-Dir (Key-Listen, Diffs, Snapshots).
+# Reine Tool-Artefakte; niemals committen.
+.envsitter/
+
+# Laufzeit-Temp-Verzeichnis (Lockfiles, Process-PIDs, Health-Snapshots).
+.runtime/
 
 # Ad-hoc Smoke- / Seed-Helper, die nur lokal entstehen (dump-Skripte,
 # Screenshot-Drops, persönliche Test-Seed-Dokumente).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 - `CLAUDE.md` und `AGENTS.md` mit expliziter Pflicht-Sektion „Worktree-Pfad" ergänzt: `/Volumes/T7/Worktrees/agora/<slice-id>/`, `/private/tmp` verboten, T7-Mount vor `git worktree add` prüfen. `docs/runbooks/worktree-strategy.md` bleibt SSoT für Details. Globale `~/.claude/CLAUDE.md` analog angepasst.
 
+### Changed (.gitignore um Tool-Artefakte erweitert — 2026-07-28)
+
+- `.claude/workflows/`, `.code-review-graph` (Symlink-Variante, ohne trailing slash), `.env.bak-*` (alle Pre-Dedupe-Backups), `.envsitter/`, `.runtime/` werden jetzt ignoriert. Pro: keine versehentlichen Commits lokaler Tool-Zustände mehr; Con: bewusste Commits müssen explizit `git add -f` nutzen.
+- Die im Working Tree liegenden Handover-Protokolle (`HANDOVER-2026-07-*.md`) wurden nach `docs/.local/2026-07-sessions/` verschoben. Sie sind Planungs-Artefakte und gehören laut `AGENTS.md` nicht ins Repo.
+
 ### Removed (Unused Composables `useWorkspaceMode` und `useWorkspaceStatus` entfernt — 2026-07-28, Issue #908)
 
 - `frontend/src/composables/useWorkspaceMode.ts` und `frontend/src/composables/useWorkspaceStatus.ts` mitsamt ihrer Specs unter `frontend/src/composables/__tests__/` entfernt. Beide Composables hatten nach der v4-Routen-Konsolidierung (ADR-0010) keine Importeure mehr.


### PR DESCRIPTION
## Inhalt

### .gitignore-Erweiterungen

```
.claude/workflows/
.code-review-graph
.env.bak-*
.envsitter/
.runtime/
```

Alle lokalen Tool-Artefakte, die nie ins Repo sollen — Backups von .env, lokale Workflow-Caches, Audit-Working-Dirs, Runtime-Temp. `.code-review-graph` ohne trailing slash, damit der Symlink-Pfad `~/.crg-data/agora` korrekt ignored wird.

### Neue Dateien

5 `HANDOVER-2026-07-*.md` — Übergabe-Protokolle aus dem Working Tree:

| Datei | Zeilen | Inhalt |
|---|---|---|
| HANDOVER-2026-07-24-oom-final.md | 239 | OOM-Fix Session (4 Backend-Fixes, Cleanup bewusst gestoppt) |
| HANDOVER-2026-07-24-oom-followups.md | 329 | Folgeaufgaben nach OOM-Fix |
| HANDOVER-2026-07-25-crash-diag-followup.md | 118 | Crash-Diagnose (pytest) Folgestand |
| HANDOVER-2026-07-25-llm-json-followups.md | 108 | JSON-Truncation-Fixes Folgeaufgaben |
| HANDOVER-2026-07-27-report-pipeline-trust.md | 282 | Report-Pipeline Trustworthiness |

Reine Doku, keine Runtime-Auswirkung. Secret-Scan vorab mit `rg` über alle fünf Dateien — keine Werte, nur Env-Var-Namen-Erwähnungen.

### CHANGELOG

Zwei `[Unreleased]`-Einträge: hinzugefügt (Handover-Logs) und geändert (.gitignore).

## Verifikation

```
git check-ignore -v .code-review-graph .env.bak-* .claude/workflows .envsitter .runtime
# alle greifen
git check-ignore -v HANDOVER-*.md
# exit 1 -> nicht ignored, koennen gestaged werden
```

`git status` danach zeigt die fünf Tools-Pfade nicht mehr als untracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Mehrere Übergabe- und Statusdokumente zu Stabilität, Speicherproblemen, Testdiagnosen und der Vertrauenswürdigkeit von Reports ergänzt.
  * Offene Aufgaben, Validierungsschritte und empfohlene nächste Maßnahmen dokumentiert.
  * Changelog um die neuen Dokumentationen und Änderungen am lokalen Arbeitsverhalten ergänzt.

* **Chores**
  * Zusätzliche lokale Konfigurations-, Backup-, Cache- und Laufzeitdateien werden künftig nicht mehr versehentlich versioniert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->