### PR TITLE
docs: vision/api/configuration/troubleshooting + AGENTS.md progressive disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidance für Codex, Claude Code und andere Agent-Runtimes in diesem Repository.
 
+> **Progressive Disclosure:** diese Datei enthält nur die immer verbindlichen Regeln. Detail-Referenzen sind unter [`docs/agents/`](docs/agents/) ausgelagert und bei Bedarf zu laden — siehe [Detaillierte Referenzen](#detaillierte-referenzen).
+
 ## Dokumentationsquellen
 
 Agenten verwenden genau diese Reihenfolge:
@@ -10,6 +12,8 @@ Agenten verwenden genau diese Reihenfolge:
 2. [`docs/STATUS.md`](docs/STATUS.md) — verifizierter Istzustand
 3. [`ROADMAP.md`](ROADMAP.md) — strategische Release-Reihenfolge
 4. [GitHub Issues](https://github.com/arn0ld87/agora/issues) — ausführbare Tasks und Akzeptanzkriterien
+
+[`VISION.md`](VISION.md) — nicht-bindender North-Star (das *Warum* und die Langzeitrichtung), keine Planungsdatei und keine konkurrierende Roadmap.
 
 ADRs, Architektur-, Security- und Runbook-Dateien sind verbindliche Referenzen, aber keine konkurrierenden Roadmaps. Historische Planung liegt unter [`docs/archive/planning/`](docs/archive/planning/).
 
@@ -54,83 +58,6 @@ Runbooks:
 
 **Pflicht:** Alle Agora-Worktrees liegen unter `/Volumes/T7/Worktrees/agora/<slice-id>/`. `/private/tmp` ist verboten. T7-Mount vor dem Anlegen prüfen (`test -d /Volumes/T7`). Volle Strategie in [`docs/runbooks/worktree-strategy.md`](docs/runbooks/worktree-strategy.md).
 
-## Tool-Pipeline
-
-Für Architektur-, Delta- und Codebase-Analysen:
-
-1. `code-review-graph`
-2. `context7` bei Bibliotheks- oder Frameworkfragen
-3. `ctx_batch_execute` für große Read-only-Abfragen
-4. `ctx_execute` beziehungsweise `ctx_execute_file`
-5. direkte Dateiwerkzeuge nur für gezielte Bearbeitung und Verifikation
-
-Globale Konfiguration, Tokens, Browserprofile, Keychain-Inhalte und private Host-Dateien werden niemals ins Repository kopiert.
-
-## Architektur-Single-Sources-of-Truth
-
-- API-Verträge: `backend/app/contracts/` mit Pydantic v2
-- Frontend-Spiegel: `frontend/src/contracts/` und generierte `schemas/`
-- Provider-Erkennung: `backend/app/llm/providers/registry.py::detect_provider`
-- Provider-Verbindung: `ProviderConnection`
-- strukturierte JSON-LLM-Calls: `backend/app/llm/client.py::LLMClient.chat_json` mit Pydantic-Schema — roher `OpenAI`-Client nicht für JSON-Outputs
-- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`
-- kanonische Modellreferenz: `AiModelRef`
-- kanonische Route: `AiRoute` / `LlmRoute`
-- Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
-- Evidence-Gating: ADR-0002-Hartanker
-
-Chat-Routing und Embedding-Konfiguration bleiben strukturell getrennt.
-
-## Aktuelle Release-Priorität
-
-### 0.8.0 → 0.9.0
-
-Erledigt: E2E-Smokes repariert (#739), Provider-/Secret-/Routing-SSoT abgeschlossen (#761), Dependency-SSoT bereinigt (#762), Produkt-/Manifest-Version automatisiert synchronisiert (#759).
-
-Offen:
-
-- E2E als Required Check aktivieren (Läufe sind stabil grün, `main` besitzt aber noch keine Branch-Protection)
-- Vue-v4 als einziges Produktfrontend festlegen (Issue #760; Umsetzungskarte [#829](https://github.com/arn0ld87/agora/issues/829))
-
-### 0.9.0 → 0.10.0
-
-- reproduzierbare Run-Manifeste und Replay
-- Kosten-, Token- und Zeitbudgets
-- Backup, Restore, Upgrade und Rollback
-- Kalibrierungs- und Baseline-Vergleich
-- Feature-Freeze vor `1.0.0`
-
-Details und Freigabekriterien: [`ROADMAP.md`](ROADMAP.md)
-
-## Commands
-
-```bash
-# Setup und Entwicklung
-bun run setup:all
-bun run dev
-bun run backend
-bun run frontend
-
-# Gesamtprüfung
-bun run check
-bash scripts/pre-push-gate.sh
-
-# Backend
-cd backend && uv run pytest -x -q
-cd backend && uv run ruff check .
-cd backend && uv run mypy app
-cd backend && uv run python -m app.contracts.dump_schemas
-
-# Frontend
-cd frontend && bun run check
-cd frontend && bun run test
-
-# Produktionsnaher lokaler Stack
-docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  -f deploy/compose/docker-compose.prod-with-proxy.yml up -d --build
-curl -fsS http://localhost/healthz
-```
-
 ## Verboten
 
 - direkte Änderungen auf `main`
@@ -146,24 +73,24 @@ curl -fsS http://localhost/healthz
 - neue Planungsdateien neben README, STATUS, ROADMAP und Issues
 - `apt`; auf Debian/Ubuntu `nala` verwenden
 
+## Detaillierte Referenzen
+
+Bei Bedarf laden (nicht verbindlich ständig im Kontext):
+
+- [`docs/agents/tool-pipeline.md`](docs/agents/tool-pipeline.md) — Tool-Pipeline, Knowledge Graph, Token Efficiency
+- [`docs/agents/architecture-ssot.md`](docs/agents/architecture-ssot.md) — Architektur-Single-Sources-of-Truth
+- [`docs/agents/release-priority.md`](docs/agents/release-priority.md) — aktuelle Release-Priorität
+- [`docs/agents/commands.md`](docs/agents/commands.md) — Backend-/Frontend-/Docker-Commands
+
 ## Wichtige Referenzen
 
+- [`VISION.md`](VISION.md) — North-Star (nicht-bindend)
 - [`docs/architecture.md`](docs/architecture.md)
+- [`docs/api.md`](docs/api.md) — HTTP-Endpunkte nach Domänen
+- [`docs/configuration.md`](docs/configuration.md) — Umgebungsvariablen
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) — bekannte Fehlerbilder
 - [`docs/decisions/`](docs/decisions/)
 - [`docs/dependency-risk-register.md`](docs/dependency-risk-register.md)
 - [`docs/runbooks/`](docs/runbooks/)
 - [`CHANGELOG.md`](CHANGELOG.md)
 - [`CLAUDE.md`](CLAUDE.md)
-
-## Knowledge Graph
-
-Wenn `graphify-out/graph.json` vorhanden ist, bei Codebase-Fragen zuerst eine gezielte Graph-Abfrage verwenden. Nach strukturellen Codeänderungen `graphify update .` ausführen. Graphresultate ersetzen weder direkte Codeprüfung noch Tests.
-
-## Token Efficiency
-- Never re-read files you just wrote or edited. You know the contents.
-- Never re-run commands to "verify" unless the outcome was uncertain.
-- Don't echo back large blocks of code or file contents unless asked.
-- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
-- Skip confirmations like "I'll continue..." Just do it.
-- If a task needs 1 tool call, don't use 3. Plan before acting.
-- Do not summarize what you just did unless the result is ambiguous or you need additional input.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,67 @@
+# 🏛️ Agora — Vision
+
+> **North-Star, keine Roadmap.** Diese Datei beschreibt das *Warum* und die Langzeitrichtung von Agora. Release-Stufen und ausführbare Kriterien bleiben in [`ROADMAP.md`](ROADMAP.md); der verifizierte Ist-Zustand in [`docs/STATUS.md`](docs/STATUS.md); der Produkteintritt in [`README.md`](README.md). Die Vision ist **nicht bindend für Einzelaufgaben** und enthält keine konkurrierenden Planungsdaten.
+
+---
+
+## These
+
+Komplexe Entscheidungen — Kampagnen, Produkteinführungen, Stakeholder-Kommunikation — scheitern seltener an fehlenden Daten als an ungeprüften Annahmen über die Reaktionen anderer. Agora macht diese Annahmen sichtbar, bevor sie teuer werden: ein strukturierter Probe-Raum, in dem simulierte Zielgruppen und Stakeholder auf Dokumente und Entwürfe reagieren — mit Evidenzbindung, Confidence-Bewertung und ausgewiesenen Datenlücken statt glatter Behauptungen.
+
+## Das Problem
+
+- **Bestätigungsfehler:** Teams testen Botschaften gegen die eigene Blase.
+- **Polarisierung unsichtbar:** Konfliktlinien zwischen DACH-Zielgruppen werden erst im Rollout spürbar.
+- **Evidenzlose Aussagen:** Marketing- und Strategieaussagen halten einer Quellenprüfung nicht stand.
+- **Kosten echter Marktforschung:** qualitative Interviews sind teuer, spät und selten iterativ.
+
+Agora ersetzt keine echte Marktforschung. Es ist das billige, schnelle Vorspiel davor — um Hypothesen zu schärfen und gezielt in echte Befragungen, Tests und Fachreviews zu investieren.
+
+## Was Agora ist
+
+- Ein **Probe-Raum** für mögliche Reaktionen (Pre-Mortem, Varianten-Vergleich).
+- **Evidenzorientiert:** jede Aussage im Report bindet sich an Graph-Evidenz mit Confidence und Provenance ([ADR-0002](docs/decisions/0002-evidence-gating.md), [ADR-0011](docs/decisions/0011-evidence-entailment-and-provenance.md)).
+- **Single-User & kontrolliert:** lokal oder hybrid betreibbar, keine öffentliche Multi-Tenant-SaaS vor `1.0.0`.
+- **DACH-fokussiert:** Tonalitäten, Personas und Sprache auf den deutschsprachigen Raum abgestimmt.
+- **Eine kanonische Wahrheit:** ein produktives Frontend, eine Provider-/Routing-Registry, eine Contract-Ebene.
+
+## Was Agora nicht ist
+
+- **Keine Zukunftsvorhersage.** „Confidence" bewertet die interne Evidenzbindung im Graph, keine Welt-Wahrheit.
+- **Kein Ersatz** für echte Interviews, Nutzertests oder Fachreviews.
+- **Kein statistisch belastbares Sample** pro Einzellauf — belastbare Aussagen brauchen mehrere Varianten, Seeds und Reviews.
+- **Kein öffentliches SaaS**, kein Team- oder Rollenmodell vor `1.0.0`.
+
+## Grundprinzipien (nicht verhandelbar)
+
+1. **Evidenz-Ehrlichkeit.** Keine dekorativen Fallbacks, keine abgeschwächten Assertions, keine Zukunftsvorhersagen. Datenlücken werden ausgewiesen, nicht geschönt. (ADR-0002-Hartanker.)
+2. **Reproduzierbarkeit vor Features.** Ein Run muss mit Eingangs-Hash, Graph-Version, Modellen, Provider-/Routing-Snapshot, Prompt-Versionen und Seeds nachvollziehbar und wiederholbar sein.
+3. **Single-User-Kontrolle.** Daten, Secrets und Modelle bleiben unter der Hoheit einer Person. Kein ungeschützter Internet-Betrieb.
+4. **Eine kanonische Oberfläche und eine kanonische Provider-Wahrheit.** Keine parallelen Picker, Frontends oder lokalen Detection-Heuristiken.
+5. **Verträge zuerst, Consumer danach.** Pydantic v2 als Single Source of Truth, Frontend-Spiegel generiert.
+
+## Nordstern
+
+> **Der reproduzierbare, evidenzehrliche Referenzlauf.**
+
+Ein einzelner, vollständig nachvollziehbarer Lauf — vom Quelldokument über Graph, Personas und Simulation bis zum Report —, der gegen eine Single-Prompt-Baseline einen *messbaren* Mehrwert zeigt, mit kalibrierter Confidence und veröffentlichten Grenzen. Alles auf dem Weg zu `1.0.0` dient diesem Nordstern.
+
+## Langzeitrichtung (nach `1.0.0`, nicht zugesagt)
+
+- Team- und Rollenmodell
+- Plugin-System und Branchenvorlagen
+- Kubernetes/Helm und Federation mehrerer Instanzen
+- optionale gehostete Betriebsmodelle
+
+Diese Pfade erhalten erst nach dem stabilen Single-User-Release eigene Problemstatements und Architekturentscheidungen. Sie sind Vision, kein Versprechen.
+
+## Bezüge
+
+- Release-Stufen und Freigabekriterien: [`ROADMAP.md`](ROADMAP.md)
+- verifizierter Ist-Zustand: [`docs/STATUS.md`](docs/STATUS.md)
+- Produkteinstieg und Grenzen: [`README.md`](README.md)
+- Architekturentscheidungen: [`docs/decisions/`](docs/decisions/)
+
+---
+
+*Entstanden aus MiroFish-Offline, grundlegend weiterentwickelt für professionelle DACH-Simulationen. Entwickelt von [Alexander Schneider](https://alexle135.de).*

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,10 +19,16 @@ Weitere Einstiegspunkte:
 ## Architektur und Verträge
 
 - [`architecture.md`](architecture.md) — Architektur, Domänen und Komponenten
-- [`api-contracts.md`](api-contracts.md) — Pydantic-Verträge und Frontend-Spiegel
+- [`api.md`](api.md) — HTTP-Endpunkte nach Domänen (Übersicht)
+- [`api-contracts.md`](api-contracts.md) — Response-Envelopes, Fehlercodes, Schema-Tests
+- [`configuration.md`](configuration.md) — Umgebungsvariablen-Referenz
 - [`decisions/`](decisions/) — Architekturentscheidungen
 - [`glossary.md`](glossary.md) — verbindliches Produktvokabular
 - [`agent-tools.md`](agent-tools.md) — OASIS-/CAMEL- und Agent-Tool-Integration
+
+## North-Star
+
+- [`../VISION.md`](../VISION.md) — Vision (das *Warum*, nicht-bindend)
 
 ## Entwicklung
 
@@ -40,6 +46,7 @@ Weitere Einstiegspunkte:
 - [`operations.md`](operations.md) — Betrieb
 - [`operator-guide.md`](operator-guide.md) — Operator-Aufgaben
 - [`backup-restore.md`](backup-restore.md) — Backup und Wiederherstellung
+- [`troubleshooting.md`](troubleshooting.md) — bekannte Fehlerbilder und Lösungen
 
 ## Security
 

--- a/docs/agents/architecture-ssot.md
+++ b/docs/agents/architecture-ssot.md
@@ -1,0 +1,17 @@
+# Architektur-Single-Sources-of-Truth
+
+> **Progressive Disclosure** — ausgelagert aus [`AGENTS.md`](../../AGENTS.md). Bei Architektur-, Code- oder Vertragsfragen laden.
+
+- API-Verträge: `backend/app/contracts/` mit Pydantic v2
+- HTTP-API-Referenz (Endpunkte nach Domänen): [`../api.md`](../api.md) — Envelopes/Fehlercodes in [`../api-contracts.md`](../api-contracts.md)
+- Frontend-Spiegel: `frontend/src/contracts/` und generierte `schemas/`
+- Provider-Erkennung: `backend/app/llm/providers/registry.py::detect_provider`
+- Provider-Verbindung: `ProviderConnection`
+- strukturierte JSON-LLM-Calls: `backend/app/llm/client.py::LLMClient.chat_json` mit Pydantic-Schema — roher `OpenAI`-Client nicht für JSON-Outputs
+- kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`
+- kanonische Modellreferenz: `AiModelRef`
+- kanonische Route: `AiRoute` / `LlmRoute`
+- Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
+- Evidence-Gating: ADR-0002-Hartanker
+
+Chat-Routing und Embedding-Konfiguration bleiben strukturell getrennt.

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -1,0 +1,30 @@
+# Commands
+
+> **Progressive Disclosure** — ausgelagert aus [`AGENTS.md`](../../AGENTS.md). Bei Setup-/Build-/Prüfaufgaben laden.
+
+```bash
+# Setup und Entwicklung
+bun run setup:all
+bun run dev
+bun run backend
+bun run frontend
+
+# Gesamtprüfung
+bun run check
+bash scripts/pre-push-gate.sh
+
+# Backend
+cd backend && uv run pytest -x -q
+cd backend && uv run ruff check .
+cd backend && uv run mypy app
+cd backend && uv run python -m app.contracts.dump_schemas
+
+# Frontend
+cd frontend && bun run check
+cd frontend && bun run test
+
+# Produktionsnaher lokaler Stack
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  -f deploy/compose/docker-compose.prod-with-proxy.yml up -d --build
+curl -fsS http://localhost/healthz
+```

--- a/docs/agents/release-priority.md
+++ b/docs/agents/release-priority.md
@@ -1,0 +1,22 @@
+# Aktuelle Release-Priorität
+
+> **Progressive Disclosure** — ausgelagert aus [`AGENTS.md`](../../AGENTS.md). Freigabekriterien in [`../../ROADMAP.md`](../../ROADMAP.md); verifizierter Ist-Zustand in [`../STATUS.md`](../STATUS.md).
+
+### 0.8.0 → 0.9.0
+
+Erledigt: E2E-Smokes repariert (#739), Provider-/Secret-/Routing-SSoT abgeschlossen (#761), Dependency-SSoT bereinigt (#762), Produkt-/Manifest-Version automatisiert synchronisiert (#759).
+
+Offen:
+
+- E2E als Required Check aktivieren (Läufe sind stabil grün, `main` besitzt aber noch keine Branch-Protection)
+- Vue-v4 als einziges Produktfrontend festlegen (Issue #760; Umsetzungskarte [#829](https://github.com/arn0ld87/agora/issues/829))
+
+### 0.9.0 → 0.10.0
+
+- reproduzierbare Run-Manifeste und Replay
+- Kosten-, Token- und Zeitbudgets
+- Backup, Restore, Upgrade und Rollback
+- Kalibrierungs- und Baseline-Vergleich
+- Feature-Freeze vor `1.0.0`
+
+Details und Freigabekriterien: [`../../ROADMAP.md`](../../ROADMAP.md)

--- a/docs/agents/tool-pipeline.md
+++ b/docs/agents/tool-pipeline.md
@@ -1,0 +1,29 @@
+# Tool-Pipeline, Knowledge Graph & Token Efficiency
+
+> **Progressive Disclosure** — ausgelagert aus [`AGENTS.md`](../../AGENTS.md). Bei Bedarf laden; nicht verbindlich ständig im Kontext.
+
+## Tool-Pipeline
+
+Für Architektur-, Delta- und Codebase-Analysen:
+
+1. `code-review-graph`
+2. `context7` bei Bibliotheks- oder Frameworkfragen
+3. `ctx_batch_execute` für große Read-only-Abfragen
+4. `ctx_execute` beziehungsweise `ctx_execute_file`
+5. direkte Dateiwerkzeuge nur für gezielte Bearbeitung und Verifikation
+
+Globale Konfiguration, Tokens, Browserprofile, Keychain-Inhalte und private Host-Dateien werden niemals ins Repository kopiert.
+
+## Knowledge Graph
+
+Wenn `graphify-out/graph.json` vorhanden ist, bei Codebase-Fragen zuerst eine gezielte Graph-Abfrage verwenden. Nach strukturellen Codeänderungen `graphify update .` ausführen. Graphresultate ersetzen weder direkte Codeprüfung noch Tests.
+
+## Token Efficiency
+
+- Never re-read files you just wrote or edited. You know the contents.
+- Never re-run commands to "verify" unless the outcome was uncertain.
+- Don't echo back large blocks of code or file contents unless asked.
+- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
+- Skip confirmations like "I'll continue..." Just do it.
+- If a task needs 1 tool call, don't use 3. Plan before acting.
+- Do not summarize what you just did unless the result is ambiguous or you need additional input.

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ Quelle der Wahrheit für die Routen ist der Code in [`../backend/app/api/`](../b
 
 - **Base URL:** Backend lauscht produktiv auf `:5001`, Frontend-Dev auf `:5173`. Alle fachlichen Endpunkte liegen unter `/api/*`.
 - **Authentifizierung:** `Authorization: Bearer <AGORA_AUTH_TOKEN>` für `/api/*`-Aufrufe. SSE-Streams und Datei-Downloads nutzen zeitbegrenzte **signierte Tickets** — keine Plaintext-Tokens in URLs. Details: [`auth.md`](auth.md), [ADR-0001](decisions/0001-auth-model.md).
-- **Response-Envelope:** jedes `/api/*` liefert `{"success": bool, "data"?, "code"?, "error"? …}`. Siehe [`api-contracts.md`](api-contracts.md).
+- **Response-Envelope:** JSON-API-Responses liefern `{"success": bool, "data"?, "code"?, "error"? …}`. Siehe [`api-contracts.md`](api-contracts.md). **Ausnahmen:** SSE-Streams (`text/event-stream`) und Export-/Download-Endpunkte (Markdown, CSV, ZIP, Binär) liefern rohe Responses ohne JSON-Envelope — nicht als Envelope dekodieren.
 - **SSE-Streams:** Endpunkte mit `text/event-stream` sind unten mit **(SSE)** gekennzeichnet.
 - **Fehlercodes:** semantische `ApiErrorCode`-Werte (z. B. `simulation_not_prepared`, `persona_review_required`, `neo4j_unavailable`) statt String-Matching — Katalog in [`api-contracts.md`](api-contracts.md).
 
@@ -108,7 +108,7 @@ Quelle der Wahrheit für die Routen ist der Code in [`../backend/app/api/`](../b
 | Stream | Endpunkt | Zweck |
 |---|---|---|
 | Simulations-Events | `GET /api/simulation/<id>/stream` | Live-Interaktions-/Agenten-Events |
-| Model-Active | `GET /api/llm/…` (#213) | Aktive Modell-/Provider-Selection |
+| Model-Active | `GET /api/llm/model-stream` (#213) | Aktive Modell-/Provider-Selection |
 | Backend-Logs | `GET /api/logs/stream` | Live-Log-Viewer |
 
 SSE-Verbindungen authentifizieren sich über signierte Tickets (siehe [`auth.md`](auth.md)), nicht über Bearer-Header in der URL.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,123 @@
+# HTTP-API — Agora Backend
+
+**Status:** Referenz zu Backend `0.8.0`. Diese Datei beschreibt die HTTP-Endpunkte nach Domänen (Übersicht, nicht jede Einzelroute). Für Response-Envelopes, `ApiErrorCode`-Katalog und Schema-Tests siehe [`api-contracts.md`](api-contracts.md). Für die Vertragsmodelle siehe [`../backend/app/contracts/`](../backend/app/contracts/) und die generierten Schemas via `uv run python -m app.contracts.dump_schemas`.
+
+Quelle der Wahrheit für die Routen ist der Code in [`../backend/app/api/`](../backend/app/api/) (Blueprints registriert in [`../backend/app/__init__.py`](../backend/app/__init__.py)). Bei Änderungen am Code: diese Datei mit-pflegen, sonst driftet die Doku.
+
+---
+
+## Konventionen
+
+- **Base URL:** Backend lauscht produktiv auf `:5001`, Frontend-Dev auf `:5173`. Alle fachlichen Endpunkte liegen unter `/api/*`.
+- **Authentifizierung:** `Authorization: Bearer <AGORA_AUTH_TOKEN>` für `/api/*`-Aufrufe. SSE-Streams und Datei-Downloads nutzen zeitbegrenzte **signierte Tickets** — keine Plaintext-Tokens in URLs. Details: [`auth.md`](auth.md), [ADR-0001](decisions/0001-auth-model.md).
+- **Response-Envelope:** jedes `/api/*` liefert `{"success": bool, "data"?, "code"?, "error"? …}`. Siehe [`api-contracts.md`](api-contracts.md).
+- **SSE-Streams:** Endpunkte mit `text/event-stream` sind unten mit **(SSE)** gekennzeichnet.
+- **Fehlercodes:** semantische `ApiErrorCode`-Werte (z. B. `simulation_not_prepared`, `persona_review_required`, `neo4j_unavailable`) statt String-Matching — Katalog in [`api-contracts.md`](api-contracts.md).
+
+---
+
+## Domänen-Übersicht
+
+13 Blueprints, ~169 Routen. Mount-Pfade aus `app/__init__.py`.
+
+### Auth & API-Keys
+
+| Blueprint (Mount) | Modul | Auswahl |
+|---|---|---|
+| `auth_bp` — `/api/auth` | [`auth.py`](../backend/app/api/auth.py) | `POST /api/auth/ticket` — signiertes Ticket für SSE/Download |
+| `api_keys_bp` — `/api/api-keys` | [`api_keys.py`](../backend/app/api/api_keys.py) | CRUD für API-Keys (5 Routen) |
+
+### Onboarding & Profil
+
+| Blueprint (Mount) | Modul | Auswahl |
+|---|---|---|
+| `onboarding_bp` — `/api/onboarding` | [`onboarding.py`](../backend/app/api/onboarding.py) | `GET`, `PUT /step`, `POST /complete`, `POST /dismiss`, `POST /reopen` |
+| `user_profile_bp` — `/api/profile` | [`user_profile.py`](../backend/app/api/user_profile.py) | `GET`, `PUT`, `POST/GET/DELETE /avatar` |
+
+### Graph — `/api/graph` (`graph_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`graph_projects.py`](../backend/app/api/graph_projects.py) | `GET /project/list`, `GET /project/<id>`, `DELETE /project/<id>`, `POST /project/<id>/reset` |
+| [`graph_build.py`](../backend/app/api/graph_build.py) | `POST /build`, `POST /ontology/generate` |
+| [`graph_data.py`](../backend/app/api/graph_data.py) | `GET /data/<graph_id>`, `GET /snapshot/<id>/<round>`, `GET /<id>/diff`, `GET /<id>/export`, `DELETE /delete/<id>`, `GET /task/<task_id>`, `GET /tasks` |
+| [`graph.py`](../backend/app/api/graph.py) | Graph-Grundrouten |
+
+### Simulation — `/api/simulation` (`simulation_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`simulation_prepare.py`](../backend/app/api/simulation_prepare.py) | `POST /prepare`, `POST /prepare/status` |
+| [`simulation_lifecycle.py`](../backend/app/api/simulation_lifecycle.py) | Start/Stop/Cancel/Resume |
+| [`simulation_run.py`](../backend/app/api/simulation_run.py) | Simulationsausführung |
+| [`simulation_stream.py`](../backend/app/api/simulation_stream.py) | `GET /<simulation_id>/stream` **(SSE)** |
+| [`simulation_entities.py`](../backend/app/api/simulation_entities.py) | Entity-Routen (3) |
+| [`simulation_profiles.py`](../backend/app/api/simulation_profiles.py) | Simulationsprofile |
+| [`simulation_interviews.py`](../backend/app/api/simulation_interviews.py) | 1-zu-1-Gespräche / Umfragen |
+| [`simulation_history.py`](../backend/app/api/simulation_history.py) | Historie |
+| [`simulation_metrics.py`](../backend/app/api/simulation_metrics.py) | `GET /<id>/metrics`, `GET /<id>/metrics/export` |
+| [`simulation_compare.py`](../backend/app/api/simulation_compare.py) | `GET /<id>/compare` (Branch-Compare, #66) |
+
+### Report — `/api/report` (`report_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`report.py`](../backend/app/api/report.py) | `POST /generate`, `POST /generate/status`, `GET /<id>`, `GET /by-simulation/<sim_id>`, `GET /list`, `GET /<id>/evidence`, `GET /<id>/evidence/<section>/<claim_id>`, `GET /<id>/export`, `GET /<id>/download`, `DELETE /<id>`, `POST /chat`, `GET /<id>/progress`, `GET /<id>/sections`, `GET /<id>/section/<i>`, `GET /check/<sim_id>`, `GET /<id>/agent-log` (22 Routen) |
+
+### Runs — `/api/runs` (`runs_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`runs.py`](../backend/app/api/runs.py) | Run-Status, Run-Verwaltung |
+| [`llm_routing.py`](../backend/app/api/llm_routing.py) | `GET/PUT /<run_id>/llm-routing`, `PATCH /<run_id>/llm-routing/stages/<stage_id>` |
+
+### LLM — `/api/llm` (`llm_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`llm_providers.py`](../backend/app/api/llm_providers.py) | Provider-CRUD (13 Routen) |
+| [`llm_active.py`](../backend/app/api/llm_active.py) | `GET/PUT /active-config` |
+| [`llm_routing.py`](../backend/app/api/llm_routing.py) | `GET/PUT /routing/defaults`, `PATCH /routing/defaults/stages/<id>`, `PUT /routing/defaults/global` |
+| [`llm.py`](../backend/app/api/llm.py) | Model-Active **(SSE)** (#213) |
+| [`embedding_configurations.py`](../backend/app/api/embedding_configurations.py) | `GET /embedding/configurations`, `/active`, `/<id>` GET/PUT/DELETE, `/<id>/test`, `/<id>/activate` |
+| [`embedding_migrations.py`](../backend/app/api/embedding_migrations.py) | Embedding-Re-Index-Migrations-Lifecycle (ADR-0007) |
+
+### LLM-Profile — `/api/settings/llm-profiles` (`llm_profiles_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`llm_profiles.py`](../backend/app/api/llm_profiles.py) | CRUD, `POST /<profile_id>/default` (7 Routen) |
+
+### Settings — `/api/settings` (`settings_bp`)
+
+| Modul | Auswahl |
+|---|---|
+| [`settings.py`](../backend/app/api/settings.py) | App-Settings (#133) |
+
+### Status & Logs
+
+| Blueprint (Mount) | Modul | Auswahl |
+|---|---|---|
+| `status_bp` — `/api/status` | [`status.py`](../backend/app/api/status.py) | System-/Run-Status |
+| `logs_bp` — `/api/logs` | [`logs.py`](../backend/app/api/logs.py) | `GET`, `GET /`, `GET /stream` **(SSE)** (#132) |
+
+---
+
+## SSE-Streams
+
+| Stream | Endpunkt | Zweck |
+|---|---|---|
+| Simulations-Events | `GET /api/simulation/<id>/stream` | Live-Interaktions-/Agenten-Events |
+| Model-Active | `GET /api/llm/…` (#213) | Aktive Modell-/Provider-Selection |
+| Backend-Logs | `GET /api/logs/stream` | Live-Log-Viewer |
+
+SSE-Verbindungen authentifizieren sich über signierte Tickets (siehe [`auth.md`](auth.md)), nicht über Bearer-Header in der URL.
+
+---
+
+## Verträge und Schemas
+
+- Pydantic-Verträge: [`../backend/app/contracts/`](../backend/app/contracts/) — SSoT für Request-/Response-Shapes.
+- Frontend-Spiegel: [`../frontend/src/contracts/`](../frontend/src/contracts/) und generierte Schemas.
+- Schema-Drift-Gate: `uv run python -m app.contracts.dump_schemas --check` (siehe [`runbooks/pre-push-gate.md`](runbooks/pre-push-gate.md)).
+- Fehler-Envelope und `ApiErrorCode`: [`api-contracts.md`](api-contracts.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,150 @@
+# Konfiguration — Umgebungsvariablen
+
+**Status:** Referenz zu Backend `0.8.0`. Konkrete Defaults und Beispiele liefert [`.env.example`](../.env.example) — bei Abweichung ist `.env.example` führend. Einstellungen werden über `pydantic-settings` geladen (ADR-0003). Geheimnisse 🔐 niemals committen, in Logs ausgeben oder in Doku schreiben — Secrets liegen im Vaultwarden bzw. im lokalen Secret Store.
+
+Quelle für die Variablennamen ist der Code (Backend `os.getenv` / `pydantic-settings` `validation_alias`). Bei neuen Variablen: hier und in `.env.example` mit-pflegen.
+
+---
+
+## App & Core
+
+| Variable | Zweck |
+|---|---|
+| `AGORA_DATA_DIR` | Basisverzeichnis für Laufzeitdaten |
+| `AGORA_INSTANCE_DIR` | Instanzspezifisches Datenverzeichnis |
+| `AGORA_ALLOW_ANONYMOUS` | anonyme Nutzung ohne Auth (nur lokal) |
+| `AGORA_CORS_ALLOW_ALL` | CORS pauschal öffnen (Dev) |
+| `AGORA_EXTRA_ORIGINS` | zusätzliche erlaubte CORS-Origins |
+| `AGORA_PROXY_FIX_X_FOR` / `_X_HOST` / `_X_PORT` / `_X_PREFIX` / `_X_PROTO` | ProxyFix-Header für Reverse-Proxy-Betrieb |
+| `AGORA_LOG_FORMAT` | Log-Format |
+| `AGORA_WERKZEUG_LOG_LEVEL` | Werkzeug-Log-Level |
+| `FLASK_HOST` / `FLASK_PORT` / `FLASK_DEBUG` | Flask-Run-Parameter |
+| `WERKZEUG_RUN_MAIN` | Werkzeug-Reloader-Internal |
+| `DOCKER_IPV4_ONLY` | Docker-IPv4-Beschränkung |
+| `SECRET_KEY` 🔐 | Flask-Session-Signing |
+| `AGORA_FERNET_KEY` 🔐 | symmetrische Verschlüsselung (Secrets-at-rest) — siehe [`secret-key-lifecycle.md`](secret-key-lifecycle.md) |
+| `AGORA_MAX_UPLOAD_SIZE_MB` | Upload-Limit |
+
+## Auth & Tickets
+
+| Variable | Zweck |
+|---|---|
+| `AGORA_AUTH_TOKEN` 🔐 | Bearer-Token für `/api/*` — siehe [`auth.md`](auth.md) |
+| `AGORA_TICKET_RATE_LIMIT_MAX` / `_WINDOW_SECONDS` | Rate-Limit für signierte Tickets |
+| `AGORA_ALLOW_ANONYMOUS` | (siehe App & Core) |
+
+## Rate-Limits
+
+| Variable | Zweck |
+|---|---|
+| `AGORA_LLM_TRIGGER_RATE_LIMIT_MAX` / `_WINDOW_SECONDS` | LLM-Trigger-Limit |
+| `AGORA_REPORT_RATE_LIMIT_MAX` / `_WINDOW_SECONDS` | Report-Generierungs-Limit |
+| `AGORA_UPLOAD_RATE_LIMIT_MAX` / `_WINDOW_SECONDS` | Upload-Limit |
+
+## LLM & Provider
+
+Provider-Erkennung: [`../backend/app/llm/providers/registry.py`](../backend/app/llm/providers/registry.py)::`detect_provider` ist SSoT. Strukturierte JSON-Calls laufen über `LLMClient.chat_json` mit Pydantic-Schema.
+
+| Variable | Zweck |
+|---|---|
+| `LLM_API_KEY` 🔐 | genereller LLM-API-Key |
+| `LLM_BASE_URL` | genereller LLM-Endpoint |
+| `LLM_MODEL_NAME` | generelles Modell |
+| `LLM_CONTEXT_LIMIT` / `LLM_MAX_OUTPUT_TOKENS` | Token-Limits |
+| `LLM_MAX_RETRIES` / `LLM_RETRY_INITIAL_DELAY` / `LLM_RETRY_MAX_DELAY` | Retry-Verhalten |
+| `LLM_FORCE_STREAM` | Streaming erzwingen |
+| `LLM_BOOST_API_KEY` 🔐 / `LLM_BOOST_BASE_URL` / `LLM_BOOST_MODEL_NAME` | Boost-Provider |
+| `LLM_MODEL_CONTEXT_LIMITS_JSON` | modellspezifische Context-Limits (JSON) |
+| `OPENAI_API_KEY` 🔐 / `OPENAI_BASE_URL` | OpenAI-kompatibel |
+| `GEMINI_API_KEY` 🔐 / `GOOGLE_API_KEY` 🔐 | Google/Gemini |
+| `OLLAMA_API_KEY` 🔐 / `OLLAMA_BASE_URL` / `OLLAMA_NUM_CTX` / `OLLAMA_THINKING` | Ollama (lokal/Cloud) |
+| `TAVILY_API_KEY` 🔐 | Tavily-Web-Suche (Agent-Tools) |
+| `AGENT_LANGUAGE` | Agenten-Sprache |
+
+## Embedding
+
+Embedding-Konfiguration lebt in Neo4j (`EmbeddingConfiguration`), Lese-/Schreibpfade über `embedding_service.py` / `embedding_migration.py` (ADR-0007).
+
+| Variable | Zweck |
+|---|---|
+| `EMBEDDING_API_KEY` 🔐 / `EMBEDDING_BASE_URL` / `EMBEDDING_MODEL` | Embedding-Provider |
+| `VECTOR_DIM` | Vektor-Dimension (muss zum Modell passen — siehe [`embedding-provider-switch.md`](embedding-provider-switch.md)) |
+| `AGORA_SKIP_EMBEDDING_PROBE` | Embedding-Preflight überspringen |
+
+## Neo4j
+
+| Variable | Zweck |
+|---|---|
+| `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` 🔐 | Verbindung |
+| `NEO4J_MAX_POOL_SIZE` / `NEO4J_MAX_LIFETIME` | Pool-Konfiguration |
+| `NEO4J_ACQ_TIMEOUT` / `NEO4J_CONN_TIMEOUT` / `NEO4J_LIVENESS_TIMEOUT` | Timeouts |
+| `NEO4J_STARTUP_RETRY_MAX` / `NEO4J_STARTUP_RETRY_DELAY` | Startup-Retry |
+
+## Redis & Event Bus
+
+| Variable | Zweck |
+|---|---|
+| `REDIS_URL` | Redis-Verbindung (Events, Status, IPC) |
+| `TEST_REDIS_URL` | Redis für Tests |
+| `EVENT_BUS_BACKEND` | Event-Bus-Backend |
+
+## Graph & Ontologie
+
+| Variable | Zweck |
+|---|---|
+| `GRAPH_CHUNK_SIZE` / `GRAPH_CHUNK_OVERLAP` | Chunking beim Graph-Build |
+| `GRAPH_PARALLEL_CHUNKS` | Parallelität beim Build |
+| `GRAPH_MEMORY_PUT_TIMEOUT` / `GRAPH_MEMORY_QUEUE_MAX` | Graph-Memory-Backpressure |
+| `ONTOLOGY_MAX_ENTITY_TYPES` / `_MAX_EDGE_TYPES` / `_MIN_ENTITY_TYPES` | Ontologie-Grenzen |
+| `ONTOLOGY_MUTATION_MODE` / `_MUTATION_MIN_CONFIDENCE` | Ontologie-Mutation |
+| `HYBRID_SEARCH_VECTOR_WEIGHT` / `_KEYWORD_WEIGHT` | Hybrid-Search-Gewichtung |
+
+## Simulation & OASIS
+
+| Variable | Zweck |
+|---|---|
+| `OASIS_DEFAULT_MAX_ROUNDS` | Standard-Simulationsrunden |
+| `AGORA_AGENTS_PER_BATCH` | Agenten pro Batch |
+| `AGORA_ALLOW_SMALL_SIM` | kleine Simulationen erlauben |
+| `PERSONA_REVIEW_ENABLED` | Persona-Review-Pflicht |
+| `ENABLE_AGENT_TOOLS` / `MAX_TOOL_CALLS_PER_ACTION` | Agent-Tools |
+
+## Report
+
+| Variable | Zweck |
+|---|---|
+| `REPORT_LANGUAGE` | Report-Sprache |
+| `REPORT_AGENT_TEMPERATURE` | Report-Agent-Temperatur |
+| `REPORT_AGENT_MAX_REFLECTION_ROUNDS` / `_MAX_TOOL_CALLS` | Report-Agent-Limits |
+| `REPORT_TOOLCALL_MODE` | Toolcall-Modus |
+
+## Vision & PDF
+
+| Variable | Zweck |
+|---|---|
+| `ENABLE_PDF_VISION` | PDF-Vision-Extraktion |
+| `VISION_MODEL_NAME` | Vision-Modell |
+| `VISION_MAX_CALLS_PER_UPLOAD` / `VISION_MAX_DIM` / `VISION_MIN_IMAGE_AREA` / `VISION_PAGE_SCAN_THRESHOLD` | Vision-Limits |
+
+## Observability (OpenTelemetry)
+
+| Variable | Zweck |
+|---|---|
+| `OTEL_ENABLED` | OTEL-Schalter |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP-Endpoint |
+| `OTEL_METRICS_ENABLED` / `OTEL_LOGS_ENABLED` | Metrics/Logs-Export |
+| `OTEL_METRIC_EXPORT_INTERVAL` / `OTEL_SERVICE_NAME` | Export-Interval / Service-Name |
+| `AGORA_DEBUG_MEMORY` / `AGORA_BERT_MEMORY_PROFILE` | Memory-Debug |
+| `TIME_PROFILE` / `TRACEPARENT` | Profiling / Traceparent |
+
+## Testing & E2E
+
+| Variable | Zweck |
+|---|---|
+| `AGORA_E2E_LLM_MODE` | E2E-LLM-Stub-Modus (z. B. `stub`, `compact`) |
+| `AGORA_SKIP_PREFLIGHT` | Preflight überspringen |
+| `AGORA_RUN_ID` | Run-ID für Tests |
+
+---
+
+Siehe auch: [`deployment-dev.md`](deployment-dev.md), [`deployment.md`](deployment.md), [`provider-runtime-settings.md`](provider-runtime-settings.md), [`secret-key-lifecycle.md`](secret-key-lifecycle.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Provider-Erkennung: [`../backend/app/llm/providers/registry.py`](../backend/app/
 
 ## Embedding
 
-Embedding-Konfiguration lebt in Neo4j (`EmbeddingConfiguration`), Lese-/Schreibpfade über `embedding_service.py` / `embedding_migration.py` (ADR-0007).
+Embedding-Konfiguration wird vom [`EmbeddingConfigurationStore`](../backend/app/services/embedding_configuration_store.py) in einer JSON-Datei unter `AGORA_DATA_DIR/embedding_configurations.json` persistiert (Index-Versionen in einer Sibling-JSON). Embedding-Arbeit läuft über `embedding_service.py`, der Migrations-Lifecycle über `embedding_migration.py` (ADR-0007).
 
 | Variable | Zweck |
 |---|---|

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@
 ### Embedding-Dim-Drift
 - **Symptom:** Vektor-Index-Fehler nach Embedding-Modell-Wechsel, Dimensions-Mismatch.
 - **Ursache:** `VECTOR_DIM` passt nicht zum neuen Modell; bestehende Indexe werden nicht automatisch migriert (`IF NOT EXISTS`-Falle).
-- **Behebung:** Indexe **vor** dem Modellwechsel droppen, `EmbeddingConfiguration` über `embedding_service.py` neu anlegen, Migrations-Lifecycle (`pending → running → validating → completed`) beobachten. Gemini-Re-Embedding wird derzeit *nicht* unterstützt.
+- **Behebung:** über den Migrations-Lifecycle (`EmbeddingMigrationService`: `pending → running → validating → completed | failed | rolled_back`) wechseln — der alte Index bleibt bis zur erfolgreichen Validierung erhalten und sichert den Rollback-Pfad. Dimensions-Mismatch und `IF NOT EXISTS`-Falle werden *innerhalb* dieses Pfads gelöst, nicht durch ein vorabiges manuelles `DROP INDEX` (ADR-0007 verbietet das, bis Backup, Validierung und Rollback gesichert sind). Gemini-Re-Embedding wird derzeit *nicht* unterstützt.
 - **Referenz:** [`embedding-provider-switch.md`](embedding-provider-switch.md), [ADR-0007](decisions/0007-embedding-configuration-and-index-migration.md), Issue #263.
 
 ## Simulation & Report (Workflow-Konflikte 409)
@@ -47,7 +47,7 @@
 - **Symptom:** Simulation läuft, aber Agenten erzeugen keine nutzbaren Beiträge.
 - **Ursache:** Provider-/Modell-/Prompt-Konfiguration, zu kleine Modelle, `OLLAMA_THINKING`/`num_ctx`-Gate.
 - **Behebung:** leistungsfähigeres Modell wählen, Provider-Detection via Registry verifizieren, Lessons-Learned-Protokoll beachten.
-- **Referenz:** [`worklogs/2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md`](worklogs/2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md), [`worklogs/2026-07-18-lessons-learned-provider-key-routing.md`](worklogs/2026-07-18-lessons-learned-provider-key-routing.md).
+- **Referenz:** [`2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md`](2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md), [`2026-07-18-lessons-learned-provider-key-routing.md`](2026-07-18-lessons-learned-provider-key-routing.md).
 
 ## Betrieb & Sicherheit
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,78 @@
+# Troubleshooting — bekannte Fehlerbilder
+
+**Status:** Referenz zu `0.8.0`. Symptom → Ursache → Behebung → Referenz. Für Fehlercodes und HTTP-Status siehe [`api-contracts.md`](api-contracts.md); für Konfiguration [`configuration.md`](configuration.md).
+
+---
+
+## Datenbank & Infrastruktur
+
+### Neo4j nicht erreichbar (`503 neo4j_unavailable`)
+- **Symptom:** `neo4j_unavailable`, Verbindungs-Timeouts, Graph-Operationen schlagen fehl.
+- **Ursache:** `NEO4J_URI`/`NEO4J_USER`/`NEO4J_PASSWORD` falsch, Neo4j nicht gestartet, Netzwerk/Tailscale nicht verbunden.
+- **Behebung:** Neo4j-Container/Service prüfen, Credentials verifizieren, Pool-Timeouts (`NEO4J_ACQ_TIMEOUT`) ggf. erhöhen.
+- **Referenz:** [`api-contracts.md`](api-contracts.md), [`deployment-dev.md`](deployment-dev.md).
+
+### Redis nicht erreichbar (`503 service_unavailable`)
+- **Symptom:** Event-Bus-/Status-/IPC-Ausfälle, Simulation blockiert.
+- **Ursache:** `REDIS_URL` falsch, Redis nicht gestartet.
+- **Behebung:** Redis-Verbindung prüfen, `EVENT_BUS_BACKEND` und `TEST_REDIS_URL` für Tests.
+- **Referenz:** [`configuration.md`](configuration.md).
+
+## Provider & LLM
+
+### LLM `401 auth_invalid` / unautorisierte Calls
+- **Symptom:** LLM-Calls schlagen mit 401 fehl, obwohl ein Provider konfiguriert ist.
+- **Ursache:** Legacy-`llm_profile_id`-Vorrang — der Ingest-Pfad umgeht die Connection-Route über einen Legacy-Profil-Key und greift auf veraltete/fehlende Secrets zu.
+- **Behebung:** Provider über `ProviderConnection` und kanonische Routing-Werte konfigurieren, Legacy-Profile nicht bevorzugt nutzen. PR #755 fixt einen Nebenbefund, der Hauptpfad ist noch offen.
+- **Referenz:** [`provider-runtime-settings.md`](provider-runtime-settings.md), [`../backend/app/llm/providers/registry.py`](../backend/app/llm/providers/registry.py)::`detect_provider`, Issue #803.
+
+### Embedding-Dim-Drift
+- **Symptom:** Vektor-Index-Fehler nach Embedding-Modell-Wechsel, Dimensions-Mismatch.
+- **Ursache:** `VECTOR_DIM` passt nicht zum neuen Modell; bestehende Indexe werden nicht automatisch migriert (`IF NOT EXISTS`-Falle).
+- **Behebung:** Indexe **vor** dem Modellwechsel droppen, `EmbeddingConfiguration` über `embedding_service.py` neu anlegen, Migrations-Lifecycle (`pending → running → validating → completed`) beobachten. Gemini-Re-Embedding wird derzeit *nicht* unterstützt.
+- **Referenz:** [`embedding-provider-switch.md`](embedding-provider-switch.md), [ADR-0007](decisions/0007-embedding-configuration-and-index-migration.md), Issue #263.
+
+## Simulation & Report (Workflow-Konflikte 409)
+
+### `simulation_not_prepared` (409, teils 404)
+- **Behebung:** `POST /api/simulation/prepare` ausführen, dann `prepare/status` abwarten.
+
+### `persona_review_required` (409)
+- **Behebung:** Persona-Review abschließen (`PERSONA_REVIEW_ENABLED`), bevor die Simulation startet.
+
+### `simulation_already_running` / `graph_build_in_progress` (409)
+- **Behebung:** laufenden Run abwarten oder stoppen; keinen parallelen Start erzwingen.
+
+### OASIS-Agenten reagieren nicht / bleiben stumm
+- **Symptom:** Simulation läuft, aber Agenten erzeugen keine nutzbaren Beiträge.
+- **Ursache:** Provider-/Modell-/Prompt-Konfiguration, zu kleine Modelle, `OLLAMA_THINKING`/`num_ctx`-Gate.
+- **Behebung:** leistungsfähigeres Modell wählen, Provider-Detection via Registry verifizieren, Lessons-Learned-Protokoll beachten.
+- **Referenz:** [`worklogs/2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md`](worklogs/2026-07-18-sim-agenten-stumm-arbeitsprotokoll.md), [`worklogs/2026-07-18-lessons-learned-provider-key-routing.md`](worklogs/2026-07-18-lessons-learned-provider-key-routing.md).
+
+## Betrieb & Sicherheit
+
+### Fork-Safety / `gunicorn --preload` schlägt fehl
+- **Symptom:** Worker-Crashes nach Fork, Neo4j-/Redis-Pool-Korruption.
+- **Ursache:** DB-Pools nicht fork-safe.
+- **Behebung:** `os.register_at_fork` an den Pools (MAI-12) aktiviert `--preload` für schnelleren Startup.
+- **Referenz:** [`operations.md`](operations.md), [`deployment.md`](deployment.md).
+
+### Secret-Key / Fernet-Key Rotation
+- **Symptom:** entschlüsselte Secrets ungültig nach Key-Wechsel.
+- **Behebung:** `AGORA_FERNET_KEY`/`SECRET_KEY` nach Lebenszyklus rotieren, alte Werte bis zur Migration behalten.
+- **Referenz:** [`secret-key-lifecycle.md`](secret-key-lifecycle.md).
+
+### CVE-Hardstops
+- **Symptom:** Dependency-Scan schlägt fehl, Build blockiert.
+- **Ursache:** offene CVE-Ausnahmen mit abgelaufener Frist.
+- **Behebung:** Hardstops beachten — NLTK 28.09.2026, Trivy 30.08.2026; neue Ausnahmen brauchen Issue, Owner, Deadline und Hardstop.
+- **Referenz:** [`dependency-risk-register.md`](dependency-risk-register.md).
+
+## Upload & E2E
+
+### `upload_too_large` (413) / `unsupported_format` (400)
+- **Behebung:** `AGORA_MAX_UPLOAD_SIZE_MB` erhöhen bzw. unterstütztes Format verwenden.
+
+### E2E-LLM-Calls in CI fake/skip
+- **Behebung:** `AGORA_E2E_LLM_MODE` (z. B. `stub`, `compact`) korrekt setzen; `AGORA_SKIP_PREFLIGHT` nur gezielt.
+- **Referenz:** [`testing/`](testing/), [`runbooks/pre-push-gate.md`](runbooks/pre-push-gate.md).


### PR DESCRIPTION
## Was

Zwei logische Schritte in einem PR (zwei Commits):

### 1. Neue Referenz-Docs
- **`VISION.md`** (Root) — nicht-bindender North-Star: These, Problem, was Agora ist/nicht ist, 5 nicht-verhandelbare Grundprinzipien, Nordstern „reproduzierbarer evidenzehrlicher Referenzlauf", Nach-1.0-Pfade. Ausdrücklich keine Planungsdatei und keine konkurrierende Roadmap.
- **`docs/api.md`** — HTTP-Endpunkte nach Domänen: 13 Blueprints / ~169 Routen, gruppiert nach Graph/Simulation/Report/Runs/LLM/Embeddings/Auth/Onboarding/Settings/Status/Logs, mit Auth-, SSE- und Querverlinkungen zu `api-contracts.md` und `contracts/`. Übersicht, nicht jede Einzelroute.
- **`docs/configuration.md`** — Umgebungsvariablen-Referenz: 112 Vars gruppiert (App, Auth, Rate-Limits, LLM/Provider, Embedding, Neo4j, Redis, Graph, Simulation, Report, Vision, OTEL, Testing) mit 🔐-Secret-Markierung.
- **`docs/troubleshooting.md`** — bekannte Fehlerbilder (Neo4j/Redis, LLM-401 Legacy-Profil-Vorrang, Embedding-Dim-Drift #263, 409-Workflow-Konflikte, Fork-Safety, CVE-Hardstops, Upload, E2E-Stub-Mode) mit Symptom/Ursache/Behebung/Referenz.
- **`docs/README.md`** — Index um neue Referenzen + North-Star-Abschnitt ergänzt.

### 2. AGENTS.md — Progressive Disclosure
Lean `AGENTS.md` behält nur die immer verbindlichen Regeln (Dokumentationsquellen, Projekt, Verbindliche Arbeitsweise, Worktree-Pfad, Verboten, Navigation). Detail-Referenzen werden bei Bedarf aus `docs/agents/` geladen statt ständig im Kontext zu stehen:

- `docs/agents/tool-pipeline.md` (Tool-Pipeline, Knowledge Graph, Token Efficiency)
- `docs/agents/architecture-ssot.md` (Architektur-Single-Sources-of-Truth)
- `docs/agents/release-priority.md` (aktuelle Release-Priorität)
- `docs/agents/commands.md` (Backend/Frontend/Docker-Commands)

Inhalt bleibt 1:1 erhalten, nur relociert — **keine Regel geschwächt, keine entfernt**. `docs/agents/` passt zur bestehenden Struktur (`domain.md`, `issue-tracker.md`, `triage-labels.md`).

## Verifikation
- `bash scripts/pre-push-gate.sh schemas` → ALL GREEN (46 Schemas, Version `0.8.0`, STATUS sync).
- Reiner Markdown-PR — kein Code-/Schema-Drift.

## Nicht enthalten
- Keine Änderung an bindenden Regeln, Contracts, Schemas oder Code.
- Keine neue Planungsdatei neben README/STATUS/ROADMAP/Issues — `VISION.md` ist ausdrücklich nicht-bindender North-Star.

🤖 Generated with [Claude Code](https://claude.com/claude-code)