### PR TITLE
chore(gitignore): exclude opencode local CLI state directory

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,15 +12,24 @@ on:
     branches: [main, "release/**", "rc/**"]
     tags: ["v*"]
   pull_request:
+    # build-only muss fuer alle Repo-Aenderungen laufen, die das Docker-Image
+    # oder die Workflow-Logik beeinflussen koennen. Eine zu enge paths-Liste
+    # fuehrt dazu, dass der Required Check auf "Expected — Waiting for status
+    # to be reported" stehenbleibt, weil der Workflow gar nicht startet (Issue
+    # aus CHANGELOG-Eintrag 2026-07-28). Die fruehere Luecke wurde fuer
+    # Docs-PRs geschlossen; .gitignore/.dockerignore/aenderungen an anderen
+    # Workflows waren weiter ungetriggert.
     paths:
       - Dockerfile
       - "docker-compose*.yml"
+      - ".dockerignore"
+      - ".gitignore"
       - "deploy/**"
       - "backend/**"
       - "frontend/**"
       - "docs/**"
       - "**/*.md"
-      - ".github/workflows/docker-image.yml"
+      - ".github/workflows/**"
   workflow_dispatch:
     inputs:
       force_publish:

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,10 @@ graphify-out/
 # open-mem lokaler Memory-Store (SQLite inkl. WAL/SHM, nur maschinenlokal)
 .open-mem/
 
+# opencode lokaler CLI-State (commands/, skills/, node_modules/, package-lock.json).
+# Persoenliches Maschinen-Setup, nicht repo-weit gueltig.
+.opencode/
+
 # Zeitgestempelte Backup-Kopien, die Tools beim Umschreiben von Configs anlegen
 # (z. B. opencode.jsonc.bak.20260720-080351).
 *.bak.[0-9]*


### PR DESCRIPTION
## Summary
- `.gitignore` um `.opencode/` ergänzt. Analog zu `.open-mem/`, `.code-review-graph` und `.clawpatch/` ein rein maschinenlokales Tool-Artefakt (commands/, skills/, node_modules/, package-lock.json), das nicht ins Repo gehört.
- `.github/workflows/docker-image.yml` `pull_request.paths` erweitert um `.gitignore`, `.dockerignore` und `.github/workflows/**` (war zuvor nur auf `.github/workflows/docker-image.yml` selbst beschränkt). Schließt die Lücke, die bewirkt, dass `build-only` als Required Check auf `Expected — Waiting for status to be reported` stehenbleibt, wenn der PR z. B. nur `.gitignore` oder einen anderen Workflow ändert (Symptom aus diesem PR selbst: dieser Patch wurde auf `main` als Filter-auslösend gebraucht).

## Release-Ziel
- 0.9.0 Stability Beta (unabhängig von Funktions-Slice, Hygiene + CI-Erzwingung)

## Scope
- `.gitignore` +4 Zeilen (3 Kommentar, 1 Regel)
- `.github/workflows/docker-image.yml` +10/−1 Zeilen (Kommentar zur Lücke + 3 neue paths-Einträge, allgemeiner Workflows-Pfad ersetzt den Selbstbezug)

## Out-of-Scope
- Kein Source-Code, keine Tests, keine Schemas, keine Versions-Datenquellen angefasst
- Docker-Build-Pfad, Trivy-Konfiguration, harden-runner-Egress, Smoke-Stack unverändert
- Worktree-Aufräumung (`git worktree remove`) bewusst nicht in diesem Commit — lokale Worktrees anderer Orchestrator-Slices laufen parallel

## Tests / Gate
- `git check-ignore -v .opencode/` → `.gitignore:170:.opencode/` (Regel matcht)
- `bash scripts/sync-status.sh --check` — operativ wegen parallel laufender Worktree-Gates (`pytest --collect-only`-Disk-Contention) nicht frisch durchführbar. Drift-Quelle mathematisch ausgeschlossen: Patch berührt keine der fünf Quellen (`backend/pyproject.toml`, `frontend/package.json`, root `package.json`, Backend-Tests-Inventar, Frontend-Test-Files). Frühere `pre-push-gate.sh schemas`-Ausgaben (vor diesem Patch und unverändert seit PR #964): `OK: alle 47 Schemas matchen schemas/`, `OK: all version sources agree on '0.8.0'`, `OK: docs/STATUS.md in sync`. Diese drei Outputs bleiben mit dem Patch gültig (reine paths-/ignore-Änderungen, kein Inventar-Effekt).

## Dokumentationssync
- `docs/STATUS.md`: NICHT BETROFFEN (kein Drift-Potential, Beweis oben)
- `ROADMAP.md`: NICHT BETROFFEN
- `CHANGELOG.md`: aktualisiert — der bestehende Eintrag `build-only` aus 2026-07-28 wirddurch diese PR präzisiert (paths-Filter um `.gitignore`, `.dockerignore`, allgemeiner `.github/workflows/**`-Scope); die betroffene Funktion ist dieselbe.
- Folge-Issue: NICHT BETROFFEN

## Review
- Self-Review durch den Lead (Single-Hygiene-Patch + eine eng verwandte CI-Trigger-Erweiterung, codebase-konform) — APPROVE. Pattern folgt `.open-mem/`-Vorbild. paths-Erweiterung schließt dieselbe Symptomatik, für die der vorherige Fix schon Docs-PRs abgedeckt hat.