### PR TITLE
🧹 Remove unused Optional import in container.py

### DIFF
--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -20,7 +20,7 @@ exercise services without a Flask app context.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .services.artifact_store import SimulationArtifactStore
@@ -55,9 +55,9 @@ class AgoraContainer:
     def __init__(
         self,
         *,
-        neo4j_storage: "Optional[Neo4jStorage]" = None,
-        artifact_store: "Optional[SimulationArtifactStore]" = None,
-        event_bus: "Optional[SimulationEventBus]" = None,
+        neo4j_storage: "Neo4jStorage | None" = None,
+        artifact_store: "SimulationArtifactStore | None" = None,
+        event_bus: "SimulationEventBus | None" = None,
     ) -> None:
         self._neo4j_storage = neo4j_storage
         self._artifact_store = artifact_store


### PR DESCRIPTION
🎯 What: Removed the unused Optional import from backend/app/container.py and updated type annotations to use modern union syntax.
💡 Why: Removes dead code, modernizes type hints for readability, and prevents future linting errors.
✅ Verification: Verified that linting with ruff and running pytest tests/test_container.py both pass without issue.
✨ Result: Cleaner code and modernized type annotations.

---
*PR created automatically by Jules for task [12017164419512065005](https://jules.google.com/task/12017164419512065005) started by @arn0ld87*