### PR TITLE
fix(budget,report): CodeRabbit-Findings aus #975 — Proxy-Typtransparenz + runId in Report-Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Budget-Guard-Proxy und Report-Navigation — 2026-07-30, PR #975-Review)
+
+- **Budget-Guard-Proxy blieb für CAMEL unsichtbar.** `_UsageTrackingModelProxy` in `backend/scripts/sim_runtime/budget_guard.py` delegierte ausschließlich über `__getattr__`. CAMEL prüft vorinstanziierte Backends aber in `ChatAgent._resolve_models` per `isinstance(model, BaseModelBackend)` und wirft sonst `TypeError: Unsupported type for model parameter` — jede Simulation mit gesetztem `AGORA_RUN_ID` wäre beim Agent-Graph-Aufbau gestorben. Der Proxy delegiert jetzt zusätzlich `__class__` an das Target; der reale Typ (und damit die Instrumentierung von `run`/`_run`/`arun`/`_arun`) bleibt unverändert. Der Protokoll-Audit im Docstring nannte außerdem zwei nicht existierende Testnamen — auf die tatsächlichen Anker korrigiert.
+- **`runId` überlebt die Report-Navigation.** `Step4Report.vue` navigierte bei Report-Start und Regenerierung mit `router.push({ name: 'Report', params: … })` ohne Query. Damit ging die Registry-Run-ID verloren und `loadRunUsage()` fiel still auf die `simulationId` zurück, obwohl `/api/runs/<id>` seit #764 die Run-Registry-ID braucht. Neue Utility `frontend/src/utils/reportRoute.ts` (`buildReportRoute`) hängt `?runId=<id>` an, sofern bekannt.
+- **Tests.** 3 neue Backend-Tests (`isinstance`-Transparenz, echter `ChatAgent._resolve_models`-Pfad, Proxy-Typ bleibt distinct) sowie 3 Utility- und 3 Komponententests für die Query-Weitergabe bei Start, Regenerierung und fehlender `runId`.
+
 ### Added (Kosten-, Token- und Zeitbudgets für Runs — 2026-07-29, Issue #764)
 
 - **Kanonischer Budget-Vertrag (v1).** Neuer Pydantic-Contract `backend/app/contracts/run_budget_contract.py` mit Schema-Dump (`run-budget-config`, `run-usage`, `run-budget-status`, `run-preflight-estimate`) und Zod-Spiegel `frontend/src/contracts/runBudgetContract.ts` inkl. Drift-Test. Geldbeträge ausschließlich als Integer-Micros; unbekannte Werte sind nullable mit ehrlichem Status (`unknown`/`estimated`/`free`/`measured`) statt 0. Architektur: [ADR-0012](docs/decisions/0012-run-budgets.md).

--- a/backend/scripts/sim_runtime/budget_guard.py
+++ b/backend/scripts/sim_runtime/budget_guard.py
@@ -225,13 +225,31 @@ class _UsageTrackingModelProxy:
         die vier Methoden explizit durch und reichen alles andere via
         ``__getattr__`` / ``__setattr__`` an das Target durch. Copy,
         Pickle und ``__call__`` werden absichtlich NICHT implementiert —
-        wäre das nötig, würden die Tests ``test_copy_not_required_for_oasis``
-        und ``test_proxy_has_no_dunder_call`` fehlschlagen.
+        wäre das nötig, würden die Tests
+        ``test_proxy_has_no_copy_or_reduce_protocol`` und
+        ``test_proxy_does_not_implement_call`` fehlschlagen.
+
+    PR #975 (CodeRabbit) — Typ-Transparenz:
+        Der Aufruf-Audit oben war unvollständig: CAMEL prüft das
+        übergebene Backend in ``ChatAgent._resolve_models`` per
+        ``isinstance(model, BaseModelBackend)`` und wirft sonst
+        ``TypeError: Unsupported type for model parameter``. Da
+        ``__getattr__`` erst nach der regulären Attributsuche greift,
+        liefert ein nackter Proxy sein eigenes ``__class__`` und fällt
+        durch den Check — die Simulation stirbt beim Agent-Graph-Aufbau,
+        sobald ``AGORA_RUN_ID`` gesetzt ist. Deshalb delegiert
+        ``__class__`` an das Target: ``isinstance`` prüft nach dem
+        ``type()``-Treffer auch ``obj.__class__``. Der reale Typ bleibt
+        der Proxy, die Instrumentierung damit erhalten.
     """
 
     def __init__(self, target: Any, guard: SubprocessBudgetGuard):
         object.__setattr__(self, "_target", target)
         object.__setattr__(self, "_guard", guard)
+
+    @property  # type: ignore[misc]
+    def __class__(self) -> Any:  # type: ignore[override]
+        return object.__getattribute__(self, "_target").__class__
 
     def __getattr__(self, name: str) -> Any:
         return getattr(object.__getattribute__(self, "_target"), name)

--- a/backend/tests/scripts/test_budget_guard.py
+++ b/backend/tests/scripts/test_budget_guard.py
@@ -8,6 +8,10 @@ from pathlib import Path
 
 import pytest
 
+# camel-ai ist harte Dependency (pyproject) — die echte Basisklasse wird für
+# den Typ-Transparenz-Test des Proxys gebraucht (PR #975).
+from camel.models.base_model import BaseModelBackend as _BaseModelBackend  # type: ignore[import]
+
 # backend/scripts auf sys.path, wie zur Laufzeit des OASIS-Subprozesses
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
@@ -73,6 +77,26 @@ class _FakeModel:
     async def _arun(self, messages, *args, **kwargs):
         self.calls += 1
         return _FakeCompletion(self._usage)
+
+
+class _TypedFakeModel(_FakeModel, _BaseModelBackend):  # type: ignore[misc]
+    """``_FakeModel`` mit echter CAMEL-Vererbung.
+
+    CAMEL akzeptiert vorinstanziierte Backends nur, wenn sie
+    ``isinstance(model, BaseModelBackend)`` erfüllen (siehe
+    ``ChatAgent._resolve_models``). Für den Typ-Transparenz-Test des Proxys
+    reicht ein struktureller Fake deshalb nicht.
+    """
+
+    def __init__(self, usage=None):
+        _FakeModel.__init__(self, usage)
+
+    @property
+    def token_counter(self):  # pragma: no cover — von CAMEL nie aufgerufen
+        raise NotImplementedError
+
+    def check_model_config(self):  # pragma: no cover — s.o.
+        pass
 
 
 class _RaiseModel:
@@ -318,6 +342,39 @@ class TestProxyProtocolSurface:
         proxy = guard.wrap_model(_FakeModel(_FakeUsage(1, 1)))
         with pytest.raises(TypeError):
             proxy([])  # type: ignore[call-arg]
+
+    def test_proxy_stays_isinstance_of_base_model_backend(self, run_ledger):
+        # PR #975 (CodeRabbit): CAMEL prüft das übergebene Backend in
+        # ``ChatAgent._resolve_models`` per ``isinstance(model,
+        # BaseModelBackend)`` und wirft sonst ``TypeError: Unsupported type
+        # for model parameter``. Ein Proxy, der nur ``__getattr__``
+        # delegiert, fällt durch diesen Check — die Simulation stirbt beim
+        # Agent-Graph-Aufbau, sobald AGORA_RUN_ID gesetzt ist.
+        guard = SubprocessBudgetGuard(str(run_ledger), "run_sim1")
+        proxy = guard.wrap_model(_TypedFakeModel(_FakeUsage(1, 1)))
+        assert isinstance(proxy, _BaseModelBackend)
+
+    def test_proxy_resolves_through_camel_chat_agent(self, run_ledger):
+        # Regressionsanker am echten CAMEL-Aufrufpfad statt nur am
+        # isinstance-Verhalten (PR #975).
+        from camel.agents.chat_agent import ChatAgent
+
+        guard = SubprocessBudgetGuard(str(run_ledger), "run_sim1")
+        proxy = guard.wrap_model(_TypedFakeModel(_FakeUsage(1, 1)))
+        resolved = ChatAgent._resolve_models(object.__new__(ChatAgent), proxy)
+        assert resolved is proxy
+
+    def test_proxy_type_stays_distinct_from_target(self, run_ledger):
+        # Die ``__class__``-Delegation darf nur den *gemeldeten* Typ
+        # angleichen — der reale Typ bleibt der Proxy, sonst wäre die
+        # Instrumentierung weg.
+        from sim_runtime.budget_guard import _UsageTrackingModelProxy
+
+        guard = SubprocessBudgetGuard(str(run_ledger), "run_sim1")
+        proxy = guard.wrap_model(_TypedFakeModel(_FakeUsage(1, 1)))
+        assert type(proxy) is _UsageTrackingModelProxy
+        proxy.run([])
+        assert self._events(run_ledger)[-1]["success"] is True
 
     def test_proxy_has_no_copy_or_reduce_protocol(self, run_ledger):
         # Issue #764 (Review): CAMEL/OASIS pickelt/copied ModelBackends

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,8 +27,8 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4065 | `cd backend && uv run pytest --collect-only -q` |
-| Frontend Test-Files | 173 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
+| Backend Tests (collected) | 4068 | `cd backend && uv run pytest --collect-only -q` |
+| Frontend Test-Files | 174 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
 Hinweise:

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -379,8 +379,6 @@ describe('Step4Report — INCOMPLETE-Status und generation_failed (P2.6)', () =>
 })
 
 // Sub-Slice 16b: klickbare Quotes + source_id_anchor-Scroll (Refs #173)
-import { parseSourceAnchor, entryAnchorId } from '../../utils/sourceAnchor'
-
 describe('Quote + Anchor (Sub-Slice 16b)', () => {
   // EvidenceMap mit einem Item, das quote + source_id_anchor hat
   const EVIDENCE_WITH_QUOTE = {
@@ -876,6 +874,8 @@ describe('Step4Report — runId ueberlebt die Report-Navigation (PR #975)', () =
     await (wrapper.vm as unknown as { startReportConfirmed: () => Promise<void> }).startReportConfirmed()
     await flushPromises()
 
+    expect(router.currentRoute.value.name).toBe('Report')
+    expect(router.currentRoute.value.params.reportId).toBe('report_test01')
     expect(router.currentRoute.value.query.runId).toBe('run_registry_02')
   })
 

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -845,6 +845,52 @@ describe('Step4Report — Report-Modus-Persistenz und API-Übergabe (P4.1)', () 
   })
 })
 
+// PR #975 (CodeRabbit): Die Report-Navigation darf die Registry-Run-ID nicht
+// verlieren. simulation_id und run_id sind seit #764 verschieden — ohne
+// ?runId=<id> faellt loadRunUsage() auf die simulationId zurueck und
+// /api/runs/<id> trifft die falsche Ressource.
+describe('Step4Report — runId ueberlebt die Report-Navigation (PR #975)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    resetMockSelection()
+    await router.push('/')
+  })
+
+  it('haengt die runId als Query an, wenn die Regenerierung eine neue reportId liefert', async () => {
+    const wrapper = mountComponent({ simulationId: 'sim_test01', runId: 'run_registry_01' })
+    await wrapper.vm.$nextTick()
+
+    await (wrapper.vm as unknown as { regenerateWithModel: () => Promise<void> }).regenerateWithModel()
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('Report')
+    expect(router.currentRoute.value.params.reportId).toBe('report_test01')
+    expect(router.currentRoute.value.query.runId).toBe('run_registry_01')
+  })
+
+  it('haengt die runId auch beim Report-Start an', async () => {
+    const wrapper = mountComponent({ simulationId: 'sim_test01', runId: 'run_registry_02' })
+    await wrapper.vm.$nextTick()
+
+    await (wrapper.vm as unknown as { startReportConfirmed: () => Promise<void> }).startReportConfirmed()
+    await flushPromises()
+
+    expect(router.currentRoute.value.query.runId).toBe('run_registry_02')
+  })
+
+  it('navigiert ohne Query, wenn keine Registry-Run-ID bekannt ist', async () => {
+    const wrapper = mountComponent({ simulationId: 'sim_test01' })
+    await wrapper.vm.$nextTick()
+
+    await (wrapper.vm as unknown as { regenerateWithModel: () => Promise<void> }).regenerateWithModel()
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('Report')
+    expect(router.currentRoute.value.query.runId).toBeUndefined()
+  })
+})
+
 // Sub-Slice Confirm-Dialog + Stop-Button (2026-05-16)
 describe('Step4Report — Confirm-Dialog + Stop-Button', () => {
   beforeEach(() => {

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -33,6 +33,7 @@ import type { AiModelRef } from '../../../contracts/aiModelRef'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import { parseAgentEntry } from '../../../utils/reportAgentLog'
 import { parseSourceAnchor } from '../../../utils/sourceAnchor'
+import { buildReportRoute } from '../../../utils/reportRoute'
 import {
   ReportSchema,
   ReportOutlineSchema,
@@ -308,6 +309,14 @@ function buildModelSelection(): Pick<GenerateReportData, 'ai_model_ref'> {
   return {}
 }
 
+// PR #975 (CodeRabbit): Beim Start und beim Regenerieren wechselt die Route
+// auf die neue reportId. Ohne den ?runId=<id>-Query verliert StepReportView
+// die Registry-Run-ID und Step4Report faellt auf simulationId zurueck —
+// /api/runs/<simulation_id> ist aber nicht dieselbe ID (siehe props.runId).
+function reportNavigationTarget(reportId: string) {
+  return buildReportRoute(reportId, props.runId)
+}
+
 async function regenerateWithModel() {
   const simId = resolvedSimulationId.value || props.simulationId
   if (!simId) { addLog('simulationId fehlt — Regenerieren nicht möglich.'); return }
@@ -327,7 +336,7 @@ async function regenerateWithModel() {
       generatedSections.value = {}; currentSectionIndex.value = null
       resetAgentLogs(); resetConsoleLogs(); fullReport.value = null
       emit('update-status', 'processing')
-      router.push({ name: 'Report', params: { reportId: res.data.report_id as string } })
+      router.push(reportNavigationTarget(res.data.report_id as string))
       startPolling()
     } else { addLog(`Fehler: ${res?.error || 'unbekannt'}`) }
   } catch (err) { addLog((err as Error).message) }
@@ -353,7 +362,7 @@ async function startReportConfirmed() {
       generatedSections.value = {}; currentSectionIndex.value = null
       resetAgentLogs(); resetConsoleLogs(); fullReport.value = null
       emit('update-status', 'processing')
-      router.push({ name: 'Report', params: { reportId: res.data.report_id as string } })
+      router.push(reportNavigationTarget(res.data.report_id as string))
       startPolling()
     } else { addLog(`Fehler: ${res?.error || 'unbekannt'}`); reportPending.value = true }
   } catch (err) { addLog((err as Error).message); reportPending.value = true }

--- a/frontend/src/utils/__tests__/reportRoute.spec.ts
+++ b/frontend/src/utils/__tests__/reportRoute.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildReportRoute } from '../reportRoute'
+
+describe('buildReportRoute', () => {
+  it('haengt die runId als Query an, wenn sie bekannt ist', () => {
+    // PR #975 (CodeRabbit): Ohne den Query verliert StepReportView beim
+    // Wechsel auf die neue reportId die Registry-Run-ID und Step4Report
+    // faellt auf simulationId zurueck — /api/runs/<id> braucht aber die
+    // Run-Registry-ID.
+    expect(buildReportRoute('rep-1', 'run-42')).toEqual({
+      name: 'Report',
+      params: { reportId: 'rep-1' },
+      query: { runId: 'run-42' },
+    })
+  })
+
+  it('laesst den Query weg, wenn keine runId vorliegt', () => {
+    // Direktaufruf der Report-Route ohne ?runId — die Legacy-Aufloesung
+    // ueber simulationId bleibt aktiv, ein leerer Query-Key wuerde sie
+    // nur verschleiern.
+    expect(buildReportRoute('rep-1')).toEqual({
+      name: 'Report',
+      params: { reportId: 'rep-1' },
+    })
+  })
+
+  it('behandelt leere Strings wie fehlende runId', () => {
+    expect(buildReportRoute('rep-1', '')).toEqual({
+      name: 'Report',
+      params: { reportId: 'rep-1' },
+    })
+  })
+})

--- a/frontend/src/utils/reportRoute.ts
+++ b/frontend/src/utils/reportRoute.ts
@@ -1,0 +1,19 @@
+import type { RouteLocationRaw } from 'vue-router'
+
+/**
+ * Zielroute fuer die Report-Ansicht.
+ *
+ * Issue #764 / PR #975: `simulation_id` und `run_id` sind nicht identisch —
+ * die Run-Registry vergibt beim Start eine eigene UUID, die `/api/runs/<id>`
+ * zwingend braucht. Sie erreicht `StepReportView` ausschliesslich ueber den
+ * Query-Parameter `?runId=<id>`. Jede Navigation auf eine neue `reportId`
+ * (Report-Start, Regenerieren) muss ihn deshalb mitfuehren, sonst faellt
+ * `Step4Report.loadRunUsage()` still auf die `simulationId` zurueck.
+ */
+export function buildReportRoute(reportId: string, runId?: string): RouteLocationRaw {
+  return {
+    name: 'Report',
+    params: { reportId },
+    ...(runId ? { query: { runId } } : {}),
+  }
+}


### PR DESCRIPTION
Arbeitet die CodeRabbit-Findings aus #975 ab. Zwei Fixes, eine begründete Ablehnung.

## Finding 1 — Proxy-Dunder / Typtransparenz (Major, bestätigt)

`_UsageTrackingModelProxy` in `backend/scripts/sim_runtime/budget_guard.py` delegierte ausschließlich über `__getattr__`. Der Protokoll-Audit im Docstring hatte nur nach Dunder-*Aufrufen* gesucht — CAMEL prüft vorinstanziierte Backends aber in `ChatAgent._resolve_models` per `isinstance(model, BaseModelBackend)` und wirft sonst:

```
TypeError: Unsupported type for model parameter: <class 'sim_runtime.budget_guard._UsageTrackingModelProxy'>
```

Da `__getattr__` erst nach der regulären Attributsuche greift, liefert ein nackter Proxy sein eigenes `__class__` und fällt durch den Check. Konsequenz: **jede Simulation mit gesetztem `AGORA_RUN_ID` wäre beim Agent-Graph-Aufbau gestorben** (`platform_runner.py:378` → `GRAPH_GENERATOR(model=…)` → `oasis/social_agent/agent.py` → `ChatAgent`).

Gegen die echte camel-Klasse reproduziert, dann `__class__` an das Target delegiert. `type(proxy)` bleibt der Proxy, die Instrumentierung von `run`/`_run`/`arun`/`_arun` damit erhalten. Copy/Pickle/`__call__` bleiben bewusst undefiniert — dafür gibt es weiterhin keinen Beleg im Aufrufpfad, und die bestehenden Audit-Anker-Tests decken das ab. Der Docstring nannte zwei Testnamen, die es nie gab (`test_copy_not_required_for_oasis`, `test_proxy_has_no_dunder_call`) — auf die tatsächlichen korrigiert.

## Finding 3 — `runId` bei Report-Navigation (Major, bestätigt)

`Step4Report.vue` navigierte bei Report-Start und Regenerierung mit `router.push({ name: 'Report', params: … })` ohne Query. `StepReportView` liest die Registry-Run-ID aber ausschließlich aus `?runId=<id>`; ohne sie fällt `loadRunUsage()` still auf die `simulationId` zurück, obwohl `/api/runs/<id>` seit #764 die Run-Registry-ID braucht. Neue Utility `frontend/src/utils/reportRoute.ts` (`buildReportRoute`) hängt den Query an, sofern bekannt.

## Finding 2 — ROADMAP/STATUS-Sync (nicht übernommen)

Der Widerspruch besteht nicht mehr: #975 hat `docs/STATUS.md` „Nächste Prioritäten" bereits entflochten (`2. Reproduzierbarkeit, ehrliche Hardware-Tiers … Die Kosten- und Ressourcenbudgets selbst stehen via #764`). Das deckt sich mit den drei gesetzten Haken in ROADMAP `Kosten und Ressourcen` und dem weiterhin offenen `[ ]` für Hardware-Tiers. Kein Edit nötig.

## Tests

- Backend: `isinstance`-Transparenz gegen `camel.models.base_model.BaseModelBackend`, Regression am echten `ChatAgent._resolve_models`-Pfad, und ein Test, dass der reale Typ Proxy bleibt (sonst wäre die Instrumentierung weg).
- Frontend: 3 Utility-Tests plus 3 Komponententests für Regenerierung, Start und den Fall ohne `runId`.
- Beide Fixes per Gegenprobe als RED verifiziert (Fix rückgängig → neue Tests rot).

## Verifikation

`bash scripts/pre-push-gate.sh` → ALL GREEN. `docs/STATUS.md`-Testcounts über `scripts/sync-status.sh` nachgezogen.

Der Segfault in `backend/tests/scripts/` (torch auf Py3.14/aarch64) und das eine Failure dort sind auf dem Baseline-Stand identisch — pre-existing, nicht von diesem Branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpEp3rpvD2cxQtPMHvhF67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Fehlerbehebungen**
  - Simulationen mit gesetzter Lauf-ID funktionieren wieder zuverlässig mit CAMEL-Modellen.
  - Die Report-Navigation bewahrt die Lauf-ID beim Starten und erneuten Generieren eines Reports.
  - Dadurch werden auch bei unterschiedlichen Simulations- und Lauf-IDs die korrekten Nutzungsdaten geladen.

- **Tests**
  - Abdeckung für Modellkompatibilität, Report-Routen und die Weitergabe der Lauf-ID erweitert.
  - Zusätzliche Prüfungen für fehlende oder leere Lauf-IDs ergänzt.

- **Dokumentation**
  - Teststatistiken und Changelog-Einträge aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->