### PR TITLE
docs(0.9): irreführende Stellen im frontend-next-Verzeichnis bereinigen

### DIFF
--- a/docs/epics/frontend-next/2026-STATUS.md
+++ b/docs/epics/frontend-next/2026-STATUS.md
@@ -104,6 +104,22 @@ Der Dateiname `PHASE-5-VERIFICATION-HANDOVER.md` trägt keine Aussage über tats
 
 `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` liegt zwar hier, behandelt aber ausschließlich **Vue**-Komponenten (`EnvSetupModelPanel.vue`, `Step2EnvSetup.vue`, `AiModelPicker.vue`) und gehört zu [Issue #890](https://github.com/arn0ld87/agora/issues/890) am bestehenden Produktfrontend. Es ist als einziges Dokument des Verzeichnisses am 2026-07-26 geändert worden, alle übrigen stammen vom 2026-07-18. Es zählt nicht zum React-Vorhaben.
 
+Die Datei trägt seit Issue #910 einen entsprechenden Hinweis im Dokumentkopf. Sie wurde bewusst **nicht** verschoben: auf ihren Pfad verweisen `CHANGELOG.md` (Eintrag zu #890) sowie `PHASE-2-ONBOARDING-HANDOVER.md` an zwei Stellen, und ein CHANGELOG-Eintrag ist Auslieferungshistorie, die nicht nachträglich umgeschrieben wird.
+
+### Irreführende Branch-Benennung
+
+Die Branchnamen `feat/frontend-next`, `origin/feat/frontend-next-phase12` und `origin/feat/frontend-next-phase2-onboarding-granularity` legen React-Arbeit nahe. Tatsächlich enthält keiner der drei eine einzige `.tsx`-Datei — es ist durchgehend Vue-Arbeit am bestehenden Frontend.
+
+Beleg via `git ls-tree -r --name-only <branch> | grep -c '\.tsx$'`, erhoben 2026-07-31:
+
+| Branch | `.tsx`-Dateien |
+|---|---|
+| `feat/frontend-next` | 0 |
+| `origin/feat/frontend-next-phase12` | 0 |
+| `origin/feat/frontend-next-phase2-onboarding-granularity` | 0 |
+
+Wer in diesen Branches React-Code sucht, sucht vergeblich. Der React-Code liegt im separaten, privaten Repository `arn0ld87/agora-runs-dashboard` (siehe „Belegt").
+
 ---
 
 ## Unklar

--- a/docs/epics/frontend-next/2026-STATUS.md
+++ b/docs/epics/frontend-next/2026-STATUS.md
@@ -90,7 +90,7 @@ Was ausschließlich in Planungs- und Übergabedokumenten steht. Diese Dokumente 
 
 | Dokument | Typ | Inhalt |
 |---|---|---|
-| `brief.md` | Konzept | vollständiger Architektur-Brief für die React-SPA; Stand-Zeile veraltet (siehe oben) |
+| `brief.md` | Konzept | vollständiger Architektur-Brief für die React-SPA; die veraltete Stand-Zeile ist seit Issue #910 korrigiert und verweist für den Ist-Stand auf dieses Dokument |
 | `HANDOVER.md` | Übergabe-Prompt | nennt Projekt-ID, Editor-, Preview- und GitHub-Sync-URL; bezeichnet Slices 1–3 als „live in der Preview" |
 | `HANDOVER-GLM-MMX.md` | Übergabe-Prompt | Übergabe Phase 1+2 an eine Folge-Session |
 | `PHASE-1-2-OPUS-HANDOVER.md` | Übergabe-Prompt | Kanon-Entscheidung `routing/defaults.global_default` als SSoT |
@@ -108,7 +108,9 @@ Die Datei trägt seit Issue #910 einen entsprechenden Hinweis im Dokumentkopf. S
 
 ### Irreführende Branch-Benennung
 
-Die Branchnamen `feat/frontend-next`, `origin/feat/frontend-next-phase12` und `origin/feat/frontend-next-phase2-onboarding-granularity` legen React-Arbeit nahe. Tatsächlich enthält keiner der drei eine einzige `.tsx`-Datei — es ist durchgehend Vue-Arbeit am bestehenden Frontend.
+Die Branchnamen `feat/frontend-next`, `origin/feat/frontend-next-phase12` und `origin/feat/frontend-next-phase2-onboarding-granularity` legen React-Arbeit nahe. Tatsächlich enthält keiner der drei eine einzige `.tsx`-Datei.
+
+Der Beleg zählt ausschließlich die Dateiendung `.tsx`. Er schließt damit React-Komponenten in JSX-Syntax aus, **nicht** React-Code in reinen `.ts`-Dateien. Für die praktische Frage „liegt hier eine React-SPA?" reicht das: eine React-Oberfläche ohne eine einzige `.tsx`-Datei ist unrealistisch. Eine erschöpfende Framework-Inventur der drei Branches ist damit aber nicht erbracht.
 
 Beleg via `git ls-tree -r --name-only <branch> | grep -c '\.tsx$'`, erhoben 2026-07-31:
 
@@ -118,7 +120,7 @@ Beleg via `git ls-tree -r --name-only <branch> | grep -c '\.tsx$'`, erhoben 2026
 | `origin/feat/frontend-next-phase12` | 0 |
 | `origin/feat/frontend-next-phase2-onboarding-granularity` | 0 |
 
-Wer in diesen Branches React-Code sucht, sucht vergeblich. Der React-Code liegt im separaten, privaten Repository `arn0ld87/agora-runs-dashboard` (siehe „Belegt").
+Wer in diesen Branches eine React-SPA sucht, sucht vergeblich. Der React-Code entsteht im Lovable-Projekt und wird ins separate, private Repository `arn0ld87/agora-runs-dashboard` synchronisiert (siehe „Belegt“).
 
 ---
 

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -7,8 +7,8 @@
 > `docs/epics/frontend-next/`, behandelt aber ausschließlich **Vue**-Komponenten des bestehenden
 > Produktfrontends (`EnvSetupModelPanel.vue`, `Step2EnvSetup.vue`, `AiModelPicker.vue`) und gehört zu
 > [Issue #890](https://github.com/arn0ld87/agora/issues/890). Der Ablageort ist bewusst beibehalten,
-> weil auf diesen Pfad aus `CHANGELOG.md` und zwei Handover-Dokumenten verwiesen wird. Wer hier
-> React-Code sucht, ist falsch (Issue #910).
+> weil auf diesen Pfad aus `CHANGELOG.md` sowie aus `PHASE-2-ONBOARDING-HANDOVER.md` (Zeile 5 und 78)
+> verwiesen wird. Wer hier React-Code sucht, ist falsch (Issue #910).
 
 > **Nachtrag 2026-07-26:** Die Umsetzung weicht in zwei Punkten bewusst von §3(b) und §4
 > ab. Verbindlich ist ab jetzt **§6 (Umsetzungsstand)** am Ende dieses Dokuments; §3 und §4

--- a/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
+++ b/docs/epics/frontend-next/SLICE-5.2-ENVSETUP-KANON-MIGRATION.md
@@ -3,6 +3,13 @@
 **Status:** umgesetzt in Issue #890 (2026-07-26) · **Vorgänger:** Phase 1 (PR feat/frontend-next-phase12) ·
 **Datum:** 2026-07-17 · **Quelle:** Scout-Workflow `frontend-next-scout` (CRG + Spec-Gap-Analyse) + Alex-Entscheidung 2026-07-17.
 
+> **Gehört nicht zum React-/Lovable-Vorhaben.** Dieses Dokument liegt aus historischen Gründen in
+> `docs/epics/frontend-next/`, behandelt aber ausschließlich **Vue**-Komponenten des bestehenden
+> Produktfrontends (`EnvSetupModelPanel.vue`, `Step2EnvSetup.vue`, `AiModelPicker.vue`) und gehört zu
+> [Issue #890](https://github.com/arn0ld87/agora/issues/890). Der Ablageort ist bewusst beibehalten,
+> weil auf diesen Pfad aus `CHANGELOG.md` und zwei Handover-Dokumenten verwiesen wird. Wer hier
+> React-Code sucht, ist falsch (Issue #910).
+
 > **Nachtrag 2026-07-26:** Die Umsetzung weicht in zwei Punkten bewusst von §3(b) und §4
 > ab. Verbindlich ist ab jetzt **§6 (Umsetzungsstand)** am Ende dieses Dokuments; §3 und §4
 > bleiben als Planungsstand von 2026-07-17 erhalten.

--- a/docs/epics/frontend-next/brief.md
+++ b/docs/epics/frontend-next/brief.md
@@ -1,6 +1,10 @@
 # Frontend-Next-Brief — Agora React-Redesign
 
-**Status:** Entwurf / Analyse-Ergebnis, noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet.
+**Status:** Historischer Entwurf vom 2026-07-16 — **überholt**. Entgegen der ursprünglichen Zeile existiert
+inzwischen ein Lovable-Projekt mit substanzieller Umsetzung; der verifizierte Ist-Stand steht in
+[`2026-STATUS.md`](2026-STATUS.md) (erhoben 2026-07-26, Issue #836). Unabhängig davon ist ein
+React-/Lovable-Rewrite vor 1.0.0 **nicht freigegeben** ([Issue #837](https://github.com/arn0ld87/agora/issues/837),
+[`AGENTS.md`](../../../AGENTS.md)). Dieses Dokument beschreibt eine Zielarchitektur, keine beschlossene Umsetzung.
 **Erstellt:** 2026-07-16, Branch `feat/frontend-next`.
 **Quelle:** code-review-graph + gezielte Datei-Reads gegen `main`-Stand von `frontend/`, `backend/app/api/`, `backend/app/contracts/`, `docs/auth.md`, `README.md`, `deploy/nginx/agora.conf`.
 


### PR DESCRIPTION
## Summary
- `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md` trägt jetzt im Dokumentkopf den Hinweis, dass sie nicht zum React-/Lovable-Vorhaben gehört, sondern Vue-Komponenten des bestehenden Produktfrontends behandelt (#890)
- `2026-STATUS.md` hält die irreführende `feat/frontend-next-*`-Branch-Benennung mit Zählbeleg fest
- `brief.md` — die widerlegte Statuszeile „noch kein Lovable-Projekt angelegt, keine Umsetzung gestartet" ist auf den belegten Stand korrigiert

## Release-Ziel
- `0.9` — Wartungs-/Dokumentationsschuld mit Release-Bezug. Kein Produktverhalten betroffen, kein Release-Gate berührt.

## Issue
- Closes #910

## Scope
- ausschließlich Markdown unter `docs/epics/frontend-next/`: `brief.md`, `2026-STATUS.md`, `SLICE-5.2-ENVSETUP-KANON-MIGRATION.md`
- kein Quellcode, keine Contracts, keine Schemas, keine Workflows

## Out-of-Scope
- Verschieben der SLICE-5.2-Datei. Das Issue ließ „verschieben **oder** im Dokumentkopf kennzeichnen" ausdrücklich beides zu. Gewählt wurde die Kennzeichnung, weil auf den Pfad aus `CHANGELOG.md:482` (Eintrag zu #890) sowie `PHASE-2-ONBOARDING-HANDOVER.md:5` und `:78` verwiesen wird — ein CHANGELOG-Eintrag ist Auslieferungshistorie und wird nicht nachträglich umgeschrieben, um eine Datei zu verschieben.
- Umbenennen oder Löschen der `feat/frontend-next-*`-Branches. Das Issue verlangt nur, den Sachverhalt festzuhalten.
- Inhaltliche Neubewertung der Frontend-Strategie, Zusammenlegen der HANDOVER-/PHASE-Dateien.

## Tests
- Gate-Scope laut Issue: **keiner** (reine Dokumentation). Der Reviewer hat gegengeprüft, dass `scripts/pre-push-gate.sh` keinen Markdown-/Link-Step kennt und ein Gate hier nichts geprüft hätte.
- `bash scripts/pre-push-gate.sh schemas` - PASS (freiwillig als Drift-Nachweis: 51/51 Schemas matchen, Version-Drift `0.8.0` konsistent, `docs/STATUS.md` in sync)
- Zählbeleg reproduziert, `git ls-tree -r --name-only <branch> | grep -c '\.tsx$'`, erhoben 2026-07-31:
  ```
  feat/frontend-next: 0
  origin/feat/frontend-next-phase12: 0
  origin/feat/frontend-next-phase2-onboarding-granularity: 0
  ```
- Link-Integrität: Datei nicht verschoben, alle vier eingehenden Verweise intakt; neue relative Links (`2026-STATUS.md`, `../../../AGENTS.md`) aufgelöst
- `git diff --check` sauber, Secret-Grep über den Diff ohne Treffer

## Migration / Rollback
- NICHT BETROFFEN — drei additive Markdown-Hunks, ein `git revert` genügt, keine Folgeabhängigkeit.

## Dokumentationssync
- `docs/STATUS.md`: NICHT BETROFFEN — trägt den korrigierten Stand bereits aus #837 und widerspricht den neuen Zeilen nicht
- `ROADMAP.md`: NICHT BETROFFEN — keine strategische Release-Auswirkung
- `CHANGELOG.md`: NICHT BETROFFEN — kein Produktverhalten, keine Auslieferung
- ADR/Runbook: NICHT BETROFFEN. Nebenbefund des Reviewers: `docs/decisions/0010-vue-v4-route-consolidation.md:245` verwies für die Aussage „Rewrite vor 1.0.0 nicht freigegeben" auf `brief.md`, wo sie bis zu diesem Commit gar nicht stand — diese Dangling-Referenz schließt der PR mit.
- Folge-Issue: NICHT BETROFFEN

## Review
- `agora-opus-reviewer` - APPROVE

Zwei redaktionelle Hinweise aus dem Review, bewusst nicht umgesetzt (kein Korrekturzwang, würden den atomaren Scope aufweichen):
1. Der neue Abschnitt steht unter `## Planung`; sachlich läge er unter `## Lokal` etwas richtiger, wo der Befund in Zeile 61/66 bereits in Kurzform steht. Das Issue verlangte nur „festhalten (z. B. in `2026-STATUS.md`)".
2. Die Formulierung „Der React-Code liegt im separaten, privaten Repository `arn0ld87/agora-runs-dashboard`" verkürzt: primärer Ablageort ist das Lovable-Projekt, das GitHub-Repo dessen Sync-Ziel. Inhaltlich unschädlich und deckungsgleich mit `docs/STATUS.md:125`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Statusinformationen zur Frontend-Next-Planung aktualisiert und den aktuellen Stand präzisiert.
  * Geltungsbereiche bestehender Dokumente klarer abgegrenzt.
  * Irreführende Branch-Bezeichnungen und der tatsächliche Ablageort des React-Codes dokumentiert.
  * Festgehalten, dass eine React-/Lovable-Neuentwicklung weiterhin nicht freigegeben ist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->