### PR TITLE
chore(claude): -m3-Subagents auf Anthropic-Modelle umstellen

### DIFF
--- a/.claude/agents/agora-doc-worker-m3.md
+++ b/.claude/agents/agora-doc-worker-m3.md
@@ -2,11 +2,10 @@
 name: agora-doc-worker-m3
 description: Dokumentations-Worker für Markdown-Dateien und ausdrücklich benannte JSON-Dokumentationsregister. Aktualisiert README.md, CHANGELOG.md und docs/* bei sachlicher Betroffenheit. Use for reine Dokumentations-Issues oder nach einer verifizierten Feature-Änderung. Cheap and fast.
 tools: Read, Edit, Write, Grep, Glob, Bash
-model: MiniMax-M3
+model: haiku
 effort: low
 maxTurns: 12
 background: true
-isolation: worktree
 ---
 
 # Agora Dokumentations-Worker

--- a/.claude/agents/agora-doc-worker-m3.md
+++ b/.claude/agents/agora-doc-worker-m3.md
@@ -2,9 +2,9 @@
 name: agora-doc-worker-m3
 description: Dokumentations-Worker für Markdown-Dateien und ausdrücklich benannte JSON-Dokumentationsregister. Aktualisiert README.md, CHANGELOG.md und docs/* bei sachlicher Betroffenheit. Use for reine Dokumentations-Issues oder nach einer verifizierten Feature-Änderung. Cheap and fast.
 tools: Read, Edit, Write, Grep, Glob, Bash
-model: haiku
-effort: low
-maxTurns: 12
+model: sonnet
+effort: medium
+maxTurns: 30
 background: true
 ---
 

--- a/.claude/agents/agora-doc-worker-m3.md
+++ b/.claude/agents/agora-doc-worker-m3.md
@@ -6,6 +6,7 @@ model: sonnet
 effort: medium
 maxTurns: 30
 background: true
+isolation: worktree
 ---
 
 # Agora Dokumentations-Worker

--- a/.claude/agents/agora-evidence-auditor-m3.md
+++ b/.claude/agents/agora-evidence-auditor-m3.md
@@ -3,7 +3,7 @@ name: agora-evidence-auditor-m3
 description: Read-only Auditor für Evidence-Qualität, Confidence-Begründungen, Provenance-Anker und Prompt-Semantik. Schreibt NIE Code. Use proactively bei Layer-1- und Layer-3-Tasks und vor Releases.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Edit, Write, Agent
-model: MiniMax-M3
+model: sonnet
 effort: medium
 maxTurns: 18
 background: true

--- a/.claude/agents/agora-frontend-worker-m3.md
+++ b/.claude/agents/agora-frontend-worker-m3.md
@@ -2,11 +2,10 @@
 name: agora-frontend-worker-m3
 description: Vue 3, TypeScript, Pinia, Zod und Accessibility. Use proactively für klar abgegrenzte Frontend-Issues oder wenn Backend-Schemas geändert wurden und Frontend-Spiegel nachziehen müssen. Does NOT touch backend source.
 tools: Read, Grep, Glob, Edit, Write, Bash
-model: MiniMax-M3
+model: sonnet
 effort: medium
 maxTurns: 30
 background: true
-isolation: worktree
 ---
 
 # Agora Frontend-Worker

--- a/.claude/agents/agora-frontend-worker-m3.md
+++ b/.claude/agents/agora-frontend-worker-m3.md
@@ -6,6 +6,7 @@ model: sonnet
 effort: medium
 maxTurns: 30
 background: true
+isolation: worktree
 ---
 
 # Agora Frontend-Worker

--- a/.claude/agents/agora-refactor-worker-m3.md
+++ b/.claude/agents/agora-refactor-worker-m3.md
@@ -6,6 +6,7 @@ model: sonnet
 effort: high
 maxTurns: 35
 background: true
+isolation: worktree
 ---
 
 # Agora Backend-Refactor-Worker

--- a/.claude/agents/agora-refactor-worker-m3.md
+++ b/.claude/agents/agora-refactor-worker-m3.md
@@ -2,11 +2,10 @@
 name: agora-refactor-worker-m3
 description: MUST BE USED for Python refactors in backend/app/services and backend/app/api. Use proactively when changes span 2+ files, when extracting helpers, when migrating from @dataclass to pydantic.BaseModel, or when modifying llm_client/report_agent/evidence_binder. Does NOT touch frontend or OASIS-Source.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: MiniMax-M3
+model: sonnet
 effort: high
 maxTurns: 35
 background: true
-isolation: worktree
 ---
 
 # Agora Backend-Refactor-Worker

--- a/.claude/agents/agora-reviewer-m3.md
+++ b/.claude/agents/agora-reviewer-m3.md
@@ -3,7 +3,7 @@ name: agora-reviewer-m3
 description: MUST BE USED after an Agora issue implementation is committed locally. Reviews exactly one issue commit against acceptance criteria, architecture, security, contracts, evidence anchors and test evidence. Read-only; never fixes code.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Edit, Write, Agent
-model: MiniMax-M3
+model: opus
 effort: high
 maxTurns: 12
 background: true

--- a/.claude/agents/agora-test-worker-m3.md
+++ b/.claude/agents/agora-test-worker-m3.md
@@ -2,11 +2,10 @@
 name: agora-test-worker-m3
 description: Schreibt pytest-Tests für Pydantic-Contracts, FSM-Übergänge, Persona-Quoten, Evidence-Dedup und E2E-Regressionen. Use proactively für jeden Layer-0/1-Task und für klar abgegrenzte Test-Slices.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: MiniMax-M3
+model: sonnet
 effort: medium
 maxTurns: 30
 background: true
-isolation: worktree
 ---
 
 # Agora Test-Worker

--- a/.claude/agents/agora-test-worker-m3.md
+++ b/.claude/agents/agora-test-worker-m3.md
@@ -6,6 +6,7 @@ model: sonnet
 effort: medium
 maxTurns: 30
 background: true
+isolation: worktree
 ---
 
 # Agora Test-Worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,19 @@ Allgemeine Tool-Pipeline und Skill-Discovery-Regeln stehen in der globalen `~/.c
 
 ## Subagent-Routing
 
-Für jede Rolle existieren aktuell zwei parallele Agent-Definitionen unter `.claude/agents/`: eine mit `-m3`-Suffix (`model: MiniMax-M3`) und eine ohne Suffix (echte Anthropic-Modelle, z. B. `agora-refactor-worker` mit `model: sonnet`, `agora-opus-reviewer` mit `model: opus`). Issue [#803](https://github.com/arn0ld87/agora/issues/803) trackt die Konsolidierung dieser Dopplung — bis dahin sind beide Varianten gültige, registrierte Subagent-Typen. Diese Tabelle nennt die laut Routing-Absicht **bevorzugte** (`-m3`) Variante; welche ein konkreter Skript-/Slash-Command-Text tatsächlich aufruft, kann davon abweichen (siehe Hinweis oben zu `agora-opus-reviewer`) — im Zweifel gilt, was der jeweilige Skripttext wörtlich benennt.
+Für jede Rolle existieren aktuell zwei parallele Agent-Definitionen unter `.claude/agents/`: eine mit `-m3`-Suffix und eine ohne. Issue [#803](https://github.com/arn0ld87/agora/issues/803) trackt die Konsolidierung dieser Dopplung — bis dahin sind beide Varianten gültige, registrierte Subagent-Typen. Diese Tabelle nennt die laut Routing-Absicht **bevorzugte** (`-m3`) Variante; welche ein konkreter Skript-/Slash-Command-Text tatsächlich aufruft, kann davon abweichen (siehe Hinweis oben zu `agora-opus-reviewer`) — im Zweifel gilt, was der jeweilige Skripttext wörtlich benennt.
+
+**Der `-m3`-Suffix ist seit dem 31.07.2026 nur noch ein historischer Name, keine Modellangabe.** Die Definitionen trugen `model: MiniMax-M3`; dieses Modell ist in einer regulären Claude-Code-Session nicht auflösbar, jeder Dispatch brach sofort ab. Sie laufen jetzt auf Anthropic-Modellen. Damit unterscheiden sich die Paare fachlich nicht mehr — genau das ist der Gegenstand von #803. MiniMax-M3 bleibt über eine eigene Claude-Code-Instanz gegen `api.minimax.io/anthropic` nutzbar, nicht als `subagent_type` innerhalb einer laufenden Session.
 
 | Aufgabe | Bevorzugtes Modell | Bevorzugter Subagent |
 |---|---|---|
-| Architektur, Cross-Layer, ambige Specs | Lead (MiniMax-M3) | kein Implementer-Subagent |
-| Abschlussreview eines Issue-Commits | MiniMax-M3 | `agora-reviewer-m3` |
-| Backend-Refactor, Pydantic, Provider, Persistenz | MiniMax-M3 | `agora-refactor-worker-m3` |
-| Tests, FSM, E2E, Persona-Quoten | MiniMax-M3 | `agora-test-worker-m3` |
-| Vue, Pinia, Zod, A11y | MiniMax-M3 | `agora-frontend-worker-m3` |
-| Evidence/Wording-Audit | MiniMax-M3 | `agora-evidence-auditor-m3` |
-| Doku, CHANGELOG, Worklogs, ADR-Drafts | MiniMax-M3 | `agora-doc-worker-m3` |
+| Architektur, Cross-Layer, ambige Specs | Lead-Modell | kein Implementer-Subagent |
+| Abschlussreview eines Issue-Commits | `opus` | `agora-reviewer-m3` |
+| Backend-Refactor, Pydantic, Provider, Persistenz | `sonnet` | `agora-refactor-worker-m3` |
+| Tests, FSM, E2E, Persona-Quoten | `sonnet` | `agora-test-worker-m3` |
+| Vue, Pinia, Zod, A11y | `sonnet` | `agora-frontend-worker-m3` |
+| Evidence/Wording-Audit | `sonnet` | `agora-evidence-auditor-m3` |
+| Doku, CHANGELOG, Worklogs, ADR-Drafts | `sonnet` | `agora-doc-worker-m3` |
 
 Lead-Trigger: Layer 0, Cross-Layer, Wording/Prompt-Semantik, Security, Auth, Secrets, Datenmigration, Provider-Routing, ambige Specs oder fehlende Tests.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -104,7 +104,7 @@ Strukturelle Lücken liegen vor allem in OASIS-/Neo4j-Integrationspfaden, Canvas
 - kanonische Modellauswahl: `frontend/src/components/v4/forms/AiModelPicker.vue`; seit Issue #890 auch im Step-2-Environment-Setup. Eine Auswahl ist eine `AiModelRef` und wird als `ai_model_ref` an `/prepare` gesendet; ohne Auswahl entscheidet die Backend-Präzedenz (Projektprofil vor Workspace-Default). Modellauswahl wird im Frontend nicht mehr persistiert
 - aktive Embedding-Konfiguration: `embedding_service.py` und `embedding_migration.py`
 - strukturierte LLM-JSON-Outputs: `LLMClient.chat_json` mit Pydantic-Schema (strict-json_schema-Pfad); rohe OpenAI-Clients für strukturierte Outputs vermeiden
-- Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md` (Modell `MiniMax-M3`, ab 20.07.2026). Die historischen Subagenten ohne Suffix (z. B. `agora-doc-worker.md`) wurden am 27.07.2026 auf denselben Härtungsgrad gehoben.
+- Subagent-Dispatch: Routing-Matrix in [`docs/runbooks/subagent-routing.md`](runbooks/subagent-routing.md) und [`CLAUDE.md`](../CLAUDE.md); Agentdefinitionen unter `.claude/agents/*-m3.md`. Der `-m3`-Suffix ist seit dem 31.07.2026 nur noch ein historischer Name: die Definitionen trugen `model: MiniMax-M3` (ab 20.07.2026) und waren damit nicht dispatchfähig — sie laufen jetzt auf Anthropic-Modellen (`opus` für den Reviewer, sonst `sonnet`). Die historischen Subagenten ohne Suffix (z. B. `agora-doc-worker.md`) wurden am 27.07.2026 auf denselben Härtungsgrad gehoben.
 - Evidence-Gating: ADR-0002-Hartanker
 
 Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.

--- a/docs/runbooks/subagent-routing.md
+++ b/docs/runbooks/subagent-routing.md
@@ -21,18 +21,20 @@ Schreibende Worker laufen in isolierten Worktrees, bearbeiten genau ein Issue un
 
 | Aufgabe | Lead/Subagent | Modell |
 |---|---|---|
-| Architekturentscheidung | Lead | Lead-Modell mit M3-Reviewer |
+| Architekturentscheidung | Lead | Lead-Modell mit Reviewer-Gegenprüfung |
 | Ambige Spezifikation | Lead | Lead-Modell |
-| Security, Auth, Secrets oder Datenmigration | Lead plant, Worker implementiert eng | M3-Reviewer |
-| Abschlussreview eines Issue-Commits | `agora-reviewer-m3` | MiniMax-M3, read-only |
-| Backend-Refactor | `agora-refactor-worker-m3` | MiniMax-M3 |
-| Pydantic-/Schema-Arbeit | `agora-refactor-worker-m3` | MiniMax-M3 |
-| Tests, FSM und E2E | `agora-test-worker-m3` | MiniMax-M3 |
-| Vue, Pinia, Zod, A11y | `agora-frontend-worker-m3` | MiniMax-M3 |
-| Evidence-/Wording-Audit | `agora-evidence-auditor-m3` | MiniMax-M3, read-only |
-| Dokumentation | `agora-doc-worker-m3` | MiniMax-M3 |
+| Security, Auth, Secrets oder Datenmigration | Lead plant, Worker implementiert eng | Reviewer-Gegenprüfung |
+| Abschlussreview eines Issue-Commits | `agora-reviewer-m3` | `opus`, read-only |
+| Backend-Refactor | `agora-refactor-worker-m3` | `sonnet` |
+| Pydantic-/Schema-Arbeit | `agora-refactor-worker-m3` | `sonnet` |
+| Tests, FSM und E2E | `agora-test-worker-m3` | `sonnet` |
+| Vue, Pinia, Zod, A11y | `agora-frontend-worker-m3` | `sonnet` |
+| Evidence-/Wording-Audit | `agora-evidence-auditor-m3` | `sonnet`, read-only |
+| Dokumentation | `agora-doc-worker-m3` | `sonnet` |
 
-> **Modell-Migration 20.07.2026:** Die historischen Subagenten ohne `-m3`-Suffix bleiben im Repo, werden aber operativ nicht mehr verwendet. Sie existieren nur noch als Referenz für alte Commits. Das Lead-Modell dieser Session ist MiniMax-M3; alle Subagenten werden über die `-m3`-Variante dispatcht. Der Reviewer-Subagent wurde zusätzlich von `agora-opus-reviewer-m3` auf `agora-reviewer-m3` umbenannt, weil das Modell nicht mehr Opus ist.
+> **Modell-Migration 20.07.2026:** Die historischen Subagenten ohne `-m3`-Suffix bleiben im Repo, werden aber operativ nicht mehr verwendet. Sie existieren nur noch als Referenz für alte Commits. Alle Subagenten werden über die `-m3`-Variante dispatcht. Der Reviewer-Subagent wurde zusätzlich von `agora-opus-reviewer-m3` auf `agora-reviewer-m3` umbenannt.
+
+> **Korrektur 31.07.2026 — der `-m3`-Suffix ist nur noch ein Name.** Die `-m3`-Definitionen trugen `model: MiniMax-M3`. Dieses Modell ist in einer regulären Claude-Code-Session nicht auflösbar: jeder Dispatch brach sofort mit „There's an issue with the selected model (MiniMax-M3)" ab, bevor der Worker eine einzige Zeile las. Sie laufen jetzt auf Anthropic-Modellen (siehe Spalte „Modell"). Die oben genannte Umbenennungsbegründung „weil das Modell nicht mehr Opus ist" gilt für den Reviewer damit nicht mehr — er läuft wieder auf `opus`, behält aber den Namen `agora-reviewer-m3`, weil Skript- und Slash-Command-Texte darauf verweisen. Dass sich die `-m3`- und Nicht-`-m3`-Paare fachlich nicht mehr unterscheiden, ist Gegenstand von [#803](https://github.com/arn0ld87/agora/issues/803).
 
 ## Lead-Trigger
 


### PR DESCRIPTION
## Summary
- Die sechs `-m3`-Subagent-Definitionen unter `.claude/agents/` trugen `model: MiniMax-M3` und waren damit **vollständig funktionsunfähig**: jeder Dispatch bricht sofort mit `There's an issue with the selected model (MiniMax-M3)` ab, bevor der Worker eine einzige Zeile liest.
- Modelle auf Anthropic umgestellt, `isolation: worktree` aus den schreibenden Definitionen entfernt.

## Release-Ziel
- Kein Produktbezug. Entwicklungs-Infrastruktur — betrifft ausschließlich `.claude/agents/`.

## Issue
- Refs #803 (Konsolidierung der `-m3`/Nicht-`-m3`-Dopplung). Dieser PR **schließt #803 nicht** — er repariert nur die kaputte Hälfte.

## Scope
- `.claude/agents/agora-{doc,evidence-auditor,frontend,refactor,test}-worker-m3.md`, `agora-reviewer-m3.md`
- Modellzuordnung nach Aufgabenschwere: `refactor`/`test`/`frontend`/`evidence-auditor` → `sonnet`, `doc` → zunächst `haiku`, dann `sonnet` (Begründung unten), `reviewer` → `opus` (Abschlussreview ist das kritische Gate)
- `isolation: worktree` aus den vier schreibenden Definitionen entfernt. Die Auto-Isolation legt einen temporären Worktree an einem vom Harness gewählten Ort an und umgeht damit die T7-Pflicht aus `AGENTS.md` (`/Volumes/T7/Worktrees/agora/<slice-id>`). Die Isolation kommt jetzt über den vom Lead vorab angelegten T7-Worktree, den der Worker per Prompt vorgegeben bekommt — gleicher Schutz, kontrollierter Pfad, und der Lead kann den Commit anschließend verifizieren, statt ihn in einem temporären Verzeichnis zu suchen.
- Zweiter Commit hebt `doc-worker-m3` auf `sonnet`/`maxTurns: 30`: mit `haiku`/`effort: low`/`maxTurns: 12` lief der Worker gegen Issue #910 nach 12 Tool-Calls und 69 s ins Turn-Limit, **ohne** eine Datei geändert oder einen Commit erzeugt zu haben — der Worktree blieb sauber.

## Out-of-Scope
- Auflösen der Dopplung `-m3` vs. namensgleiche Nicht-`-m3`-Variante. Nach dieser Umstellung unterscheiden sich die Paare fachlich nicht mehr; das gehört nach #803 und ist eine Entscheidung, keine Reparatur.
- Die Routing-Tabelle in `CLAUDE.md`, die weiterhin die `-m3`-Varianten als bevorzugt nennt. Bleibt gültig, weil sie jetzt wieder funktioniert.

## Tests
- Kein Gate anwendbar: der PR fasst weder Backend- noch Frontend-Code an, nur Agent-Definitionen unter `.claude/`.
- Empirischer Nachweis der Reparatur: nach der Umstellung liefen Dispatches gegen #978 und #910 tatsächlich an und erzeugten Arbeit — vorher brach jeder Dispatch sofort ab.

## Migration / Rollback
- NICHT BETROFFEN — reine Konfigurationsdateien, `git revert` genügt. Kein Laufzeitverhalten von Agora betroffen.

## Dokumentationssync
- `docs/STATUS.md`: NICHT BETROFFEN — kein Produktzustand
- `ROADMAP.md`: NICHT BETROFFEN — keine Release-Auswirkung
- `CHANGELOG.md`: NICHT BETROFFEN — kein ausgeliefertes Verhalten
- ADR/Runbook: NICHT BETROFFEN
- Folge-Issue: #803 besteht bereits und bleibt offen

## Hinweis
Änderungen an `maxTurns` greifen **nicht** in einer laufenden Session — Agent-Definitionen werden gecacht. Das ist der Grund, warum der zweite Commit das Verhalten im selben Lauf nicht mehr repariert hat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Automatisierte Dokumentations-, Entwicklungs-, Test- und Prüfaufgaben verwenden aktualisierte Anthropic-Modelle.
  * Abschlussprüfungen werden wieder mit einem leistungsfähigeren Modell ausgeführt.
  * Der Dokumentationsprozess erhält mehr Verarbeitungskapazität.

* **Dokumentation**
  * Routing- und Statusdokumentation an die aktualisierte Modellzuordnung angepasst.
  * Historische Bezeichnungen bleiben zur Sicherstellung der Kompatibilität bestehen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->