### PR TITLE
fix(budget): lokaler Verarbeitungsfehler nach HTTP 200 zählt als Providerattempt (Refs #764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Budget-Telemetrie — 2026-08-01, PR #998, Refs #764)
+
+- **Ein lokaler Verarbeitungsfehler nach HTTP 200 zählte nicht als Providerattempt.** Nach erfolgreichem `create()` kann die Antwortverarbeitung noch scheitern — leeres `choices`, `message` ohne `content`, fehlende `usage`-Attribute. Diese Exception flog bisher am Telemetriepfad vorbei: `_provider_attempt` hatte den HTTP-Attempt bereits als Success verbucht, für den anschließend fehlgeschlagenen lokalen Schritt entstand aber weder Failure-Event noch `_budget_record`. Der weiche `max_llm_calls`-Limit zählte den Call damit nicht mit, und die Invocation-Telemetrie verlor ihn still. Jetzt entsteht genau **ein** Failure-Event und **ein** Record, die Exception bleibt unverändert — kein zusätzlicher Providerrequest, kein doppeltes Event.
+- **Abgerechnete Tokens bleiben im Fehlerfall erhalten.** `usage` wird vor dem `choices`-Zugriff gelesen: eine malformed Antwort kann trotzdem Prompt- und Completion-Totals tragen. `run_usage_ledger._Bucket.add` leitet Verbrauch und Kosten ausschließlich aus den Event-Feldern ab — fehlen sie, ist der Call zwar gezählt, sein Verbrauch aber unbekannt, und nachfolgende harte Token- und Kostenchecks lassen zu viele Folgecalls durch. Nicht-numerische Providerwerte werden per `isinstance`-Guard verworfen statt als Tokenzahl ins Ledger zu wandern.
+- **Herkunft:** Restpunkt aus dem Review zu #764. Der Fix lag als uncommittete Änderung in einem Worktree und ist beim Abschluss von PR #975/#976 nie in einen PR gewandert; beim Branch-Cleanup aufgefallen.
+
 ### Fixed (Durchlauf-Blocker aus dem Browser-Test — 2026-08-01, PR #997)
 
 - **Interview-Chat antwortete nach Simulationsende nie und lief in einen 120-Sekunden-Timeout.** Zwei Ursachen, von denen nur die erste offensichtlich war: `SimulationIPCServer.poll_commands()` wird vom regulären Simulations-Worker nie aufgerufen (einzige Aufrufer sind Tests und `run_parallel_simulation.py`), ein Interview-Kommando wurde also nie beantwortet. Zusätzlich meldete `check_env_alive()` weiterhin `alive`: `env_status.json` bleibt nach dem Lauf auf diesem Stand stehen, und ohne `pid` im Status lief auch die PID-Gegenprobe ins Leere. Der zweite Punkt ist der entscheidende — ohne ihn hätte jede Umleitung weiter auf den toten IPC-Pfad gezeigt.

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -742,21 +742,39 @@ class LLMClient:
                 # die Telemetrie verliert ihn. ``BudgetExceededError`` ist
                 # hier nicht erreichbar (Check liegt VOR ``create()`` in
                 # ``_provider_attempt``).
+                #
+                # Issue #764 (Codex P2): ``usage`` wird VOR dem
+                # ``choices``-Zugriff gelesen. Eine malformed Antwort kann
+                # trotzdem abgerechnete Prompt-/Completion-Tokens tragen
+                # (``choices=[]`` neben gefuellten Totals).
+                # ``run_usage_ledger._Bucket.add`` leitet Verbrauch und Kosten
+                # ausschliesslich aus den Event-Feldern ab — fehlen sie, ist
+                # der Call zwar gezaehlt, sein Verbrauch aber unbekannt, und
+                # nachfolgende harte Token-/Kostenchecks lassen zu viele
+                # Folgecalls durch.
+                usage = None
                 try:
-                    choice = _response.choices[0]
-                    finish_reason = getattr(choice, "finish_reason", None)
                     usage = getattr(_response, "usage", None)
                     completion_tokens = (
                         getattr(usage, "completion_tokens", None) if usage else None
                     )
                     _usage_for_counter = usage
+                    choice = _response.choices[0]
+                    finish_reason = getattr(choice, "finish_reason", None)
                     content = choice.message.content or ""
                 except Exception as exc:  # noqa: BLE001 — Failure-Telemetrie, weiterreichen
+                    # isinstance-Guard wie im Erfolgspfad: MagicMock-Attribute
+                    # in Tests und nicht-numerische Providerwerte duerfen nicht
+                    # als Tokenzahl ins Ledger.
+                    _p = getattr(usage, "prompt_tokens", None)
+                    _c = getattr(usage, "completion_tokens", None)
                     self._log_invocation_event(
                         stage=context,
                         latency_ms=_latency_ms,
                         success=False,
                         error_type=type(exc).__name__,
+                        prompt_tokens=_p if isinstance(_p, int) else None,
+                        completion_tokens=_c if isinstance(_c, int) else None,
                     )
                     self._budget_record()
                     raise

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -731,12 +731,35 @@ class LLMClient:
                 content = "".join(chunks)
             else:
                 _response, _latency_ms = _call_with_token_key_fallback(kwargs)
-                choice = _response.choices[0]
-                finish_reason = getattr(choice, "finish_reason", None)
-                usage = getattr(_response, "usage", None)
-                completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
-                _usage_for_counter = usage
-                content = choice.message.content or ""
+                # Issue #764 (Review): die lokale Verarbeitung einer
+                # HTTP-erfolgreichen Antwort kann fehlschlagen (leeres
+                # ``choices``, ``message`` ohne ``content``, fehlende
+                # ``usage``-Attribute). Damit der fehlgeschlagene
+                # lokale Schritt trotzdem als ein Providerattempt
+                # sichtbar wird, muss GENAU EIN Failure-Event + GENAU
+                # EIN ``_budget_record`` entstehen — sonst zaehlt der
+                # weiche ``max_llm_calls``-Limit diesen Call nicht und
+                # die Telemetrie verliert ihn. ``BudgetExceededError`` ist
+                # hier nicht erreichbar (Check liegt VOR ``create()`` in
+                # ``_provider_attempt``).
+                try:
+                    choice = _response.choices[0]
+                    finish_reason = getattr(choice, "finish_reason", None)
+                    usage = getattr(_response, "usage", None)
+                    completion_tokens = (
+                        getattr(usage, "completion_tokens", None) if usage else None
+                    )
+                    _usage_for_counter = usage
+                    content = choice.message.content or ""
+                except Exception as exc:  # noqa: BLE001 — Failure-Telemetrie, weiterreichen
+                    self._log_invocation_event(
+                        stage=context,
+                        latency_ms=_latency_ms,
+                        success=False,
+                        error_type=type(exc).__name__,
+                    )
+                    self._budget_record()
+                    raise
         except Exception:
             # ``_provider_attempt`` hat fuer create()-Fehler bereits geloggt +
             # recordet. Streaming-Iterationsfehler wurden im inneren try-Block

--- a/backend/tests/test_llm_client_budget_helpers.py
+++ b/backend/tests/test_llm_client_budget_helpers.py
@@ -703,6 +703,69 @@ class TestChatExceptionPathRecordsBudget:
 
 
 # ---------------------------------------------------------------------------
+# 8b. Regression Issue #764 (Review-Restpunkt): HTTP-200-Antwort ohne
+#     verarbeitbare ``choices`` muss EIN Failure-Event + EIN Budget-Record
+#     erzeugen, KEIN zusaetzlicher Providerrequest, KEIN doppeltes Event.
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedResponseLocalFailure:
+    """Nach erfolgreichem ``create()`` kann die lokale Verarbeitung der
+    Antwort fehlschlagen (leeres ``choices``, ``message`` ohne ``content``
+    o.ae.). Der ``_provider_attempt`` hat den HTTP-Attempt bereits als
+    Success geloggt — die Telemetrie fuer die anschliessende lokale
+    Verarbeitung muss aber konsistent bleiben.
+    """
+
+    def test_http_200_without_choices_records_one_failure_event_and_one_record(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from app.llm.client import LLMClient
+
+        enforcer = _RecordingEnforcer()
+        client = _make_client(enforcer)
+        recorder = _wire_invocation_recorder(client)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+        monkeypatch.setattr(
+            LLMClient, "_publish_model_active", lambda self, *a, **k: None
+        )
+        # Force den OpenAI-kompatiblen Pfad (kein Ollama).
+        object.__setattr__(client, "_is_ollama", lambda: False)
+        # Streaming-Pfad umgehen — wir wollen den nicht-streaming-Zweig.
+        monkeypatch.setattr(
+            "app.llm.client.os.environ.get",
+            lambda k, default=None: "false" if k == "LLM_FORCE_STREAM" else default,
+        )
+
+        # HTTP 200-Antwort, aber ohne verarbeitbare ``choices``-Liste.
+        malformed = SimpleNamespace(choices=[])
+
+        create_calls = {"n": 0}
+
+        def _create(**kwargs):
+            create_calls["n"] += 1
+            return malformed
+
+        TestRetryAndFallbackTracking._install_create(client, _create)
+
+        with pytest.raises(IndexError):
+            client.chat(messages=[{"role": "user", "content": "x"}])
+
+        # Genau ein Providerrequest — kein Retry nach lokalem Fehler.
+        assert create_calls["n"] == 1
+        # Genau ein Budgetcheck (im ``_provider_attempt`` VOR ``create()``).
+        assert enforcer.check_calls == 1
+        # Genau ein Budgetrecord nach lokalem Fehler (der Fix).
+        assert enforcer.record_calls == 1
+        # Genau ein Failure-Event, success=False — KEIN Success-Event daneben.
+        assert len(recorder.calls) == 1
+        assert recorder.calls[0]["success"] is False
+        assert recorder.calls[0]["error_type"] == "IndexError"
+
+
+# ---------------------------------------------------------------------------
 # 9. Retry- und Fallback-Tracking (Issue #764, letzter Review-Punkt):
 #    Jeder tatsaechliche Providerrequest (Initial, Retry, Token-Key-Fallback,
 #    Streaming) erhaelt GENAU EINE ``_budget_check`` / ``_log_invocation_event``

--- a/backend/tests/test_llm_client_budget_helpers.py
+++ b/backend/tests/test_llm_client_budget_helpers.py
@@ -764,6 +764,81 @@ class TestMalformedResponseLocalFailure:
         assert recorder.calls[0]["success"] is False
         assert recorder.calls[0]["error_type"] == "IndexError"
 
+    def test_malformed_response_keeps_reported_usage_in_failure_event(
+        self, monkeypatch
+    ):
+        """Codex P2: abgerechnete Tokens duerfen beim lokalen Fehler nicht verloren gehen.
+
+        ``run_usage_ledger._Bucket.add`` leitet Verbrauch und Kosten allein aus
+        den Event-Feldern ab. Traegt das Failure-Event keine Tokenzahlen, ist
+        der Call zwar gezaehlt, sein Verbrauch aber unbekannt — harte Token-
+        und Kostenlimits lassen dann zu viele Folgecalls durch.
+        """
+        from types import SimpleNamespace
+
+        from app.llm.client import LLMClient
+
+        enforcer = _RecordingEnforcer()
+        client = _make_client(enforcer)
+        recorder = _wire_invocation_recorder(client)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+        monkeypatch.setattr(
+            LLMClient, "_publish_model_active", lambda self, *a, **k: None
+        )
+        object.__setattr__(client, "_is_ollama", lambda: False)
+        monkeypatch.setattr(
+            "app.llm.client.os.environ.get",
+            lambda k, default=None: "false" if k == "LLM_FORCE_STREAM" else default,
+        )
+
+        # Leeres ``choices``, aber der Provider hat abgerechnet.
+        malformed = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=1200, completion_tokens=340),
+        )
+        TestRetryAndFallbackTracking._install_create(client, lambda **kw: malformed)
+
+        with pytest.raises(IndexError):
+            client.chat(messages=[{"role": "user", "content": "x"}])
+
+        assert len(recorder.calls) == 1
+        event = recorder.calls[0]
+        assert event["success"] is False
+        assert event["prompt_tokens"] == 1200
+        assert event["completion_tokens"] == 340
+
+    def test_non_numeric_usage_does_not_leak_into_failure_event(self, monkeypatch):
+        """Nicht-numerische Providerwerte bleiben None statt als Tokenzahl zu zaehlen."""
+        from types import SimpleNamespace
+
+        from app.llm.client import LLMClient
+
+        enforcer = _RecordingEnforcer()
+        client = _make_client(enforcer)
+        recorder = _wire_invocation_recorder(client)
+        monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+        monkeypatch.setattr(
+            LLMClient, "_publish_model_active", lambda self, *a, **k: None
+        )
+        object.__setattr__(client, "_is_ollama", lambda: False)
+        monkeypatch.setattr(
+            "app.llm.client.os.environ.get",
+            lambda k, default=None: "false" if k == "LLM_FORCE_STREAM" else default,
+        )
+
+        malformed = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens="n/a", completion_tokens=None),
+        )
+        TestRetryAndFallbackTracking._install_create(client, lambda **kw: malformed)
+
+        with pytest.raises(IndexError):
+            client.chat(messages=[{"role": "user", "content": "x"}])
+
+        event = recorder.calls[0]
+        assert event["prompt_tokens"] is None
+        assert event["completion_tokens"] is None
+
 
 # ---------------------------------------------------------------------------
 # 9. Retry- und Fallback-Tracking (Issue #764, letzter Review-Punkt):

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4145 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4148 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 177 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Herkunft

Restpunkt aus dem Review zu #764. Der Fix lag als uncommittete Änderung im Worktree `i764-run-budgets` und ist beim Abschluss von PR #975/#976 nie in einen PR gewandert. Beim Branch-Cleanup aufgefallen und hier nachgezogen.

## Problem

Im nicht-streamenden OpenAI-Pfad von `LLMClient.chat` kann die lokale Verarbeitung einer HTTP-erfolgreichen Antwort noch fehlschlagen:

- `choices` ist leer → `IndexError`
- `message` ohne `content`
- fehlende `usage`-Attribute

Diese Exception flog bisher am Telemetriepfad vorbei. `_provider_attempt` hatte den HTTP-Attempt schon als Success geloggt, für den anschließend fehlgeschlagenen lokalen Schritt entstand aber weder ein Failure-Event noch ein `_budget_record`. Folge: der weiche `max_llm_calls`-Limit zählte den Call nicht mit, und die Invocation-Telemetrie verlor ihn still.

## Änderung

`backend/app/llm/client.py`: try/except um die Antwortverarbeitung. Im Fehlerfall genau **ein** Failure-Event (`success=False`, `error_type`) und genau **ein** `_budget_record`, danach `raise` — die Exception bleibt unverändert. Kein zusätzlicher Providerrequest, kein doppeltes Event.

`BudgetExceededError` ist an dieser Stelle nicht erreichbar; der Check liegt in `_provider_attempt` vor `create()`.

## Test

Neu: `TestMalformedResponseLocalFailure` in `backend/tests/test_llm_client_budget_helpers.py`. Prüft bei einer HTTP-200-Antwort mit leerem `choices`:

- `create_calls == 1` (kein Retry nach lokalem Fehler)
- `check_calls == 1`
- `record_calls == 1`
- genau ein Event, `success=False`, `error_type == "IndexError"`

## Verifikation lokal

| Prüfung | Ergebnis |
|---|---|
| `pytest tests/test_llm_client_budget_helpers.py` | 26 passed |
| RED-Check: Fix gestasht, nur der neue Test | 1 failed — der Test sichert den Fix nachweislich ab |
| `ruff check app/ tests/` | All checks passed |
| `mypy app` | Success, 247 source files |

Das vollständige Pre-Push-Gate ist lokal **nicht** gelaufen; CI deckt es ab.

Refs #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuJiwPjeGLad2Ci3F5ih7G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Nicht-streamende Chat-Antworten werden jetzt auch bei unvollständigen oder unerwarteten Inhalten zuverlässig als fehlgeschlagen verarbeitet.
  * Fehler erzeugen genau einen passenden Status- und Budgeteintrag, ohne zusätzliche Wiederholungsanfragen.

* **Tests**
  * Regressionstests für erfolgreiche HTTP-Antworten ohne verarbeitbare Ergebnisse ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->