### PR TITLE
fix(test): sync fake_add_text_batches signature with #1030 (#1041)

### DIFF
--- a/backend/tests/api/test_graph_endpoints.py
+++ b/backend/tests/api/test_graph_endpoints.py
@@ -285,9 +285,19 @@ def test_add_progress_callback_sets_progress_detail_on_task_manager(monkeypatch)
     fake_project.llm_profile_id = None
 
     def fake_add_text_batches(
-        graph_id, chunks, batch_size=3, progress_callback=None, ner_extractor=None
+        graph_id,
+        chunks,
+        batch_size=3,
+        progress_callback=None,
+        ner_extractor=None,
+        degradations=None,
+        extraction_tally=None,
     ):
-        # Simulate two chunks completing
+        # Simulate two chunks completing. ``degradations`` and
+        # ``extraction_tally`` wurden mit PR #1030 (Issue #1029) an
+        # ``add_text_batches`` angefuegt; der Test akzeptiert sie explizit,
+        # damit eine kuenftige Signatur-Erweiterung hier wieder laut
+        # aufschlaegt statt unbemerkt durchzurutschen.
         if progress_callback:
             progress_callback("Processed 1/2 chunks...", 0.5, 1, 2)
             progress_callback("Processed 2/2 chunks...", 1.0, 2, 2)


### PR DESCRIPTION
## Was

PR #1030 hat `add_text_batches` um die Parameter `degradations` und `extraction_tally` erweitert. Das Mock in `test_add_progress_callback_sets_progress_detail_on_task_manager` war noch auf der alten Signatur und brach deshalb auf `main` rot.

## Fix

Die zwei neuen Parameter werden **explizit** akzeptiert, statt per `**kwargs` zu schlucken — eine künftige Signatur-Erweiterung schlägt hier wieder laut auf, statt unbemerkt durchzurutschen.

## Test

`bash scripts/pre-push-gate.sh backend` — grün.

`backend/uv run pytest tests/api/test_graph_endpoints.py::test_add_progress_callback_sets_progress_detail_on_task_manager` — grün.

`backend/uv run pytest tests/api/test_graph_endpoints.py` — grün (keine Regression).

## Out of Scope

- Mocks in anderen Tests, die eventuell dieselbe Drift haben — bitte in Folge-Issues, damit der Schnitt hier atomar bleibt.
- Allgemeine Aufräumarbeit an `test_graph_endpoints.py` (`monkeypatch` vs. direktes Patching, Fixture-Wiederverwendung).

Closes #1041