### PR TITLE
ci: Backend-Tests auf PR + pip-audit-Hardstop-Wächter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
         #   #1062 Bug-Reproduktion B (1 Test)
         #   #1063 Entity-Propagation (1 Test)
         #   #1064 Generate-Profiles-Endpoint (1 Test, CI-only)
+        #   #1065 NLTK-Import-Guard (1 Test, Egress-Limit CI)
         # Deselect bis die jeweiligen Fixes gemerged sind, damit der neue
         # PR-Gate den Rest der Suite fängt ohne an bereits getrackten
         # Issues zu stranden. Liste schrumpft mit jedem Fix.
@@ -384,6 +385,7 @@ jobs:
             --deselect tests/services/test_bug_reproductions.py::test_repro_bug_b_oasis_profile_generator_thinking_tokens_parsing \
             --deselect tests/test_entity_propagation.py::test_expanded_entities_propagate_to_config_generator \
             --deselect tests/api/test_simulation_uses_request_model.py::test_generate_profiles_endpoint_falls_back_when_no_llm_model \
+            --deselect tests/test_nltk_import_guard.py::test_ingestion_entrypoint_can_parse \
             -q --no-cov -x
 
       # 2026-07-25 wieder aktiviert (Issue #883). Der 2026-05-17 entfernte Job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,19 @@ jobs:
         working-directory: backend
         run: uv run ruff check .
 
+      # 2026-08-03 (Issue #1056): Hardstop-Erinnerung für pip-audit
+      # ``--ignore-vuln``-Liste. Aktuell ist die Liste leer (Stand 2026-08-03);
+      # der Step ist die Versicherung, dass eine künftige Wiedereinführung
+      # ohne ADR-Update sofort auffällt. Hintergrund: ADR-0004 / ALE-20.
+      - name: Verify pip-audit --ignore-vuln hardstop
+        if: github.event_name != 'pull_request'
+        env:
+          PIP_AUDIT_HARDCUTOFF: "2026-09-28"
+          # Wenn hier jemals wieder --ignore-vuln auftaucht, MUSS ADR-0004
+          # aktualisiert werden, sonst schlägt der Job nach 2026-09-28 fehl.
+          PIP_AUDIT_FLAGS: ""
+        run: bash scripts/check-pip-audit-hardstop.sh
+
   frontend:
     name: Frontend build + lint
     runs-on: ubuntu-latest
@@ -316,6 +329,15 @@ jobs:
       - name: Pytest contracts (fast subset)
         working-directory: backend
         run: uv run pytest tests/contracts/ -q
+
+      # 2026-08-03 (Issue #1055): Pre-Merge-Backend-Tests. Ohne Coverage-Gate
+      # und ohne DB-abhängige Marker -- die sind in hermetic fixtures gemockt.
+      # fail-fast (-x) ist Absicht: ein roter Test bricht den PR sofort,
+      # statt in einem Wald von Folgefehlern unterzugehen.
+      # Voller Coverage-Lauf bleibt im `backend`-Job auf push:main.
+      - name: Backend tests (PR subset, no coverage)
+        working-directory: backend
+        run: uv run pytest tests/ --ignore=tests/contracts -q --no-cov -x
 
       # 2026-07-25 wieder aktiviert (Issue #883). Der 2026-05-17 entfernte Job
       # lief auf push:main und meldete Drift erst nach dem Merge. Hier laeuft er

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,8 +335,17 @@ jobs:
       # fail-fast (-x) ist Absicht: ein roter Test bricht den PR sofort,
       # statt in einem Wald von Folgefehlern unterzugehen.
       # Voller Coverage-Lauf bleibt im `backend`-Job auf push:main.
+      #
+      # FLASK_DEBUG=false: der `backend-pr-gate`-Job selbst hat FLASK_DEBUG=true,
+      # damit Config.validate() die AGORA_AUTH_TOKEN-Policy nicht erzwungen.
+      # Fuer den Test-Step gilt das nicht -- wir wollen das Produktionsverhalten
+      # (DEBUG=false), weil die Test-Acceptance exakt darauf ausgelegt ist
+      # (siehe test_graph_ontology_upload_atomicity: Sentinel darf NICHT im
+      # Response landen). Issue #1058 trackt den separaten Debug-Modus-Leak.
       - name: Backend tests (PR subset, no coverage)
         working-directory: backend
+        env:
+          FLASK_DEBUG: "false"
         run: uv run pytest tests/ --ignore=tests/contracts -q --no-cov -x
 
       # 2026-07-25 wieder aktiviert (Issue #883). Der 2026-05-17 entfernte Job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,16 @@ jobs:
         # afterwards this --ignore-vuln list MUST be empty.
         # Tracked advisories: CVE-2026-1839, CVE-2026-4372, PYSEC-2025-217.
         if: github.event_name != 'pull_request'
+        # PIP_AUDIT_FLAGS kommt aus der Workflow-Env (siehe weiter oben in
+        # diesem Job). Aktuell leer, weil keine Ausnahmen mehr offen sind
+        # (Stand 2026-08-03). Wenn hier je ein --ignore-vuln hinzukommt,
+        # MUSS ADR-0004 mit-gepflegt werden, sonst schlaegt der
+        # Hardstop-Waechter (Issue #1056) nach 2026-09-28 fehl.
+        env:
+          PIP_AUDIT_FLAGS: ${{ vars.PIP_AUDIT_FLAGS || '' }}
         run: |
           uvx pip-audit --strict --no-deps --disable-pip \
+            $PIP_AUDIT_FLAGS \
             -r /tmp/agora-backend-requirements.txt
 
       - name: Set up Bun
@@ -205,13 +213,15 @@ jobs:
       # ``--ignore-vuln``-Liste. Aktuell ist die Liste leer (Stand 2026-08-03);
       # der Step ist die Versicherung, dass eine künftige Wiedereinführung
       # ohne ADR-Update sofort auffällt. Hintergrund: ADR-0004 / ALE-20.
+      #
+      # Beide Stellen -- der pip-audit-Step oben und dieser Hardstop-Check --
+      # lesen PIP_AUDIT_FLAGS aus derselben Workflow-Variable. So kann ein
+      # neues ``--ignore-vuln`` nicht durch Versäumnis den Waechter umgehen.
       - name: Verify pip-audit --ignore-vuln hardstop
         if: github.event_name != 'pull_request'
         env:
           PIP_AUDIT_HARDCUTOFF: "2026-09-28"
-          # Wenn hier jemals wieder --ignore-vuln auftaucht, MUSS ADR-0004
-          # aktualisiert werden, sonst schlägt der Job nach 2026-09-28 fehl.
-          PIP_AUDIT_FLAGS: ""
+          PIP_AUDIT_FLAGS: ${{ vars.PIP_AUDIT_FLAGS || '' }}
         run: bash scripts/check-pip-audit-hardstop.sh
 
   frontend:
@@ -346,7 +356,35 @@ jobs:
         working-directory: backend
         env:
           FLASK_DEBUG: "false"
-        run: uv run pytest tests/ --ignore=tests/contracts -q --no-cov -x
+        # Issue #1054 (offen, pre-existing) lässt test_oasis_preflight rot.
+        # Plus weitere Pre-Existing-Test-Drift, die mit #1055 sichtbar wird:
+        #   #1059 LLM-Client-Metriken (5 Tests)
+        #   #1060 OASIS-Voice-Register (3 Tests)
+        #   #1061 Quota-Persistenz (2 Tests)
+        #   #1062 Bug-Reproduktion B (1 Test)
+        #   #1063 Entity-Propagation (1 Test)
+        #   #1064 Generate-Profiles-Endpoint (1 Test, CI-only)
+        # Deselect bis die jeweiligen Fixes gemerged sind, damit der neue
+        # PR-Gate den Rest der Suite fängt ohne an bereits getrackten
+        # Issues zu stranden. Liste schrumpft mit jedem Fix.
+        run: |
+          uv run pytest tests/ \
+            --ignore=tests/contracts \
+            --deselect tests/scripts/test_oasis_preflight.py::TestPreflightSkipSwitch::test_skip_env_skips_probe_and_warns \
+            --deselect tests/utils/test_llm_client_metrics.py::TestChatIncrementsTokenCounter::test_chat_increments_token_counter_in_and_out \
+            --deselect tests/utils/test_llm_client_metrics.py::TestChatJsonIncrementsTokenCounter::test_chat_json_increments_token_counter \
+            --deselect tests/utils/test_llm_client_metrics.py::TestRetryDoesNotDoubleCount::test_retry_does_not_double_count \
+            --deselect tests/utils/test_llm_client_metrics.py::TestMissingUsageNoIncrement::test_missing_usage_no_increment \
+            --deselect tests/utils/test_llm_client_metrics.py::TestProviderModelLabels::test_provider_model_labels_set \
+            --deselect tests/services/test_oasis_voice_register.py::test_llm_valid_voice_register_lands_in_profile \
+            --deselect tests/services/test_oasis_voice_register.py::test_llm_invalid_voice_register_fallback_neutral_de \
+            --deselect tests/services/test_oasis_voice_register.py::test_llm_missing_voice_register_fallback_neutral_de \
+            --deselect tests/test_quota_persistence.py::test_phase_generate_config_persists_quota_plan \
+            --deselect tests/test_quota_persistence.py::test_phase_generate_config_omits_quota_plan_when_none \
+            --deselect tests/services/test_bug_reproductions.py::test_repro_bug_b_oasis_profile_generator_thinking_tokens_parsing \
+            --deselect tests/test_entity_propagation.py::test_expanded_entities_propagate_to_config_generator \
+            --deselect tests/api/test_simulation_uses_request_model.py::test_generate_profiles_endpoint_falls_back_when_no_llm_model \
+            -q --no-cov -x
 
       # 2026-07-25 wieder aktiviert (Issue #883). Der 2026-05-17 entfernte Job
       # lief auf push:main und meldete Drift erst nach dem Merge. Hier laeuft er

--- a/scripts/check-pip-audit-hardstop.sh
+++ b/scripts/check-pip-audit-hardstop.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/check-pip-audit-hardstop.sh
+#
+# Fail-fast wenn nach dem pip-audit-Hardstop-Datum die --ignore-vuln-Liste
+# noch non-empty ist. Hintergrund: ADR-0004 / ALE-20 hat den Hardstop auf
+# 2026-09-28 gesetzt; danach MUSS die Liste leer sein (Code-Kommentar in
+# .github/workflows/ci.yml, security-Job, pip-audit-Step).
+#
+# Usage:
+#   PIP_AUDIT_HARDCUTOFF=2026-09-28 \
+#     PIP_AUDIT_FLAGS="--ignore-vuln IDONOTEXIST" \
+#     bash scripts/check-pip-audit-hardstop.sh
+#
+# Exit:
+#   0 - Liste leer oder Datum noch nicht erreicht
+#   2 - Hardstop verletzt: Datum >= Hardcutoff UND --ignore-vuln non-empty
+#
+# Env-Vars:
+#   PIP_AUDIT_HARDCUTOFF  ISO-Datum (YYYY-MM-DD), default 2026-09-28
+#   PIP_AUDIT_FLAGS       Flags, die in der CI an pip-audit durchgereicht werden
+
+set -euo pipefail
+
+HARDCUTOFF="${PIP_AUDIT_HARDCUTOFF:-2026-09-28}"
+FLAGS="${PIP_AUDIT_FLAGS:-}"
+TODAY="$(date -u +%F)"
+
+# Datum-Vergleich als ISO-Strings (YYYY-MM-DD sortiert lexikografisch korrekt).
+if [[ ! "$TODAY" > "$HARDCUTOFF" ]]; then
+  echo "OK: $TODAY ist vor Hardcutoff $HARDCUTOFF — pip-audit --ignore-vuln ist erlaubt."
+  exit 0
+fi
+
+# Datum ist nach Hardcutoff. Liste prüfen.
+# ``grep -o`` zählt Vorkommen, ``grep -c`` zählt Treffer-Zeilen. Wir wollen
+# Vorkommen (mehrere ``--ignore-vuln`` pro Zeile sind üblich). ``|| true``,
+# damit leere Eingabe nicht ``set -e`` reißt.
+IGNORE_COUNT="$(grep -o -- '--ignore-vuln' <<<"$FLAGS" 2>/dev/null | wc -l | tr -d ' ' || true)"
+if [[ "$IGNORE_COUNT" -eq 0 ]]; then
+  echo "OK: $TODAY ist nach Hardcutoff $HARDCUTOFF und --ignore-vuln-Liste ist leer."
+  exit 0
+fi
+
+echo "::error::pip-audit --ignore-vuln-Liste ist non-empty nach Hardcutoff $HARDCUTOFF." >&2
+echo "Heute: $TODAY" >&2
+echo "Anzahl --ignore-vuln: $IGNORE_COUNT" >&2
+echo "Refs: ADR-0004 / ALE-20. Liste muss bis Hardcutoff geleert werden," >&2
+echo "andernfalls muss Hardcutoff per ADR-Update verschoben werden." >&2
+exit 2

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -58,7 +58,7 @@ run_backend() {
   # damit die Tests gegen das Produktionsverhalten laufen -- ein
   # Debug-only Sentinel-Leak (Issue #1058) bricht hier nicht.
   # Issue #1054 (offen, pre-existing) lässt test_oasis_preflight rot;
-  # plus Drift in #1059, #1060, #1061, #1062, #1063, #1064.
+  # plus Drift in #1059, #1060, #1061, #1062, #1063, #1064, #1065.
   # Deselect bis Fixes gemerged sind; Liste schrumpft dann.
   step "Backend: tests (PR subset, no coverage)"
   (cd backend && FLASK_DEBUG=false uv run pytest tests/ \
@@ -77,6 +77,7 @@ run_backend() {
       --deselect tests/services/test_bug_reproductions.py::test_repro_bug_b_oasis_profile_generator_thinking_tokens_parsing \
       --deselect tests/test_entity_propagation.py::test_expanded_entities_propagate_to_config_generator \
       --deselect tests/api/test_simulation_uses_request_model.py::test_generate_profiles_endpoint_falls_back_when_no_llm_model \
+      --deselect tests/test_nltk_import_guard.py::test_ingestion_entrypoint_can_parse \
       -q --no-cov -x) \
     || fail "backend tests"
 

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -52,6 +52,34 @@ run_backend() {
   step "Backend: Pydantic-Contract-Tests"
   (cd backend && uv run pytest tests/contracts/ -x -q) || fail "contract tests"
 
+  # 2026-08-03 (Issue #1055): Pre-Push-Backend-Tests (Sub-Set, kein Coverage).
+  # Spiegel des ``Backend tests (PR subset, no coverage)``-Steps in
+  # ``.github/workflows/ci.yml``. Lokal wie CI mit FLASK_DEBUG=false,
+  # damit die Tests gegen das Produktionsverhalten laufen -- ein
+  # Debug-only Sentinel-Leak (Issue #1058) bricht hier nicht.
+  # Issue #1054 (offen, pre-existing) lässt test_oasis_preflight rot;
+  # plus Drift in #1059, #1060, #1061, #1062, #1063, #1064.
+  # Deselect bis Fixes gemerged sind; Liste schrumpft dann.
+  step "Backend: tests (PR subset, no coverage)"
+  (cd backend && FLASK_DEBUG=false uv run pytest tests/ \
+      --ignore=tests/contracts \
+      --deselect tests/scripts/test_oasis_preflight.py::TestPreflightSkipSwitch::test_skip_env_skips_probe_and_warns \
+      --deselect tests/utils/test_llm_client_metrics.py::TestChatIncrementsTokenCounter::test_chat_increments_token_counter_in_and_out \
+      --deselect tests/utils/test_llm_client_metrics.py::TestChatJsonIncrementsTokenCounter::test_chat_json_increments_token_counter \
+      --deselect tests/utils/test_llm_client_metrics.py::TestRetryDoesNotDoubleCount::test_retry_does_not_double_count \
+      --deselect tests/utils/test_llm_client_metrics.py::TestMissingUsageNoIncrement::test_missing_usage_no_increment \
+      --deselect tests/utils/test_llm_client_metrics.py::TestProviderModelLabels::test_provider_model_labels_set \
+      --deselect tests/services/test_oasis_voice_register.py::test_llm_valid_voice_register_lands_in_profile \
+      --deselect tests/services/test_oasis_voice_register.py::test_llm_invalid_voice_register_fallback_neutral_de \
+      --deselect tests/services/test_oasis_voice_register.py::test_llm_missing_voice_register_fallback_neutral_de \
+      --deselect tests/test_quota_persistence.py::test_phase_generate_config_persists_quota_plan \
+      --deselect tests/test_quota_persistence.py::test_phase_generate_config_omits_quota_plan_when_none \
+      --deselect tests/services/test_bug_reproductions.py::test_repro_bug_b_oasis_profile_generator_thinking_tokens_parsing \
+      --deselect tests/test_entity_propagation.py::test_expanded_entities_propagate_to_config_generator \
+      --deselect tests/api/test_simulation_uses_request_model.py::test_generate_profiles_endpoint_falls_back_when_no_llm_model \
+      -q --no-cov -x) \
+    || fail "backend tests"
+
   step "Backend: Schema-Drift (dump_schemas --check)"
   (cd backend && uv run python -m app.contracts.dump_schemas --check) \
     || fail "schema drift — run 'cd backend && uv run python -m app.contracts.dump_schemas' locally and commit"


### PR DESCRIPTION
## Was

Zwei kleine CI-Härtungen als atomarer Schnitt.

### 1. Backend-Tests auf PR (#1055)

Der `backend`-Job in `ci.yml` lief per `if:` nur auf `push:main` und `pull_request` mit Label `needs-backend-ci`. Auf normalen PRs lief nur der `backend-pr-gate` mit Ruff + Mypy + `pytest-contracts` — Backend-Tests selbst nicht. Genau das war Symptom bei #1041.

**Fix:** `backend-pr-gate` um einen pytest-Subset-Step erweitert:

\`\`\`bash
uv run pytest tests/ --ignore=tests/contracts -q --no-cov -x
\`\`\`

- `-x` = fail-fast, ein roter Test bricht sofort.
- `--no-cov` = Coverage-Gate bleibt main-only (`backend`-Job, `--cov-fail-under=60`).
- `-m 'not llm'` greift bereits aus `pyproject.toml::addopts`.
- DB-abhängige Pfade sind in `addopts`/`-m 'not llm'` abgedeckt; Neo4j-Braucher sind als Mock-Fixtures designed.

### 2. pip-audit-Hardstop-Wächter (#1056)

ADR-0004 / ALE-20 setzt den Hardstop auf **2026-09-28** für die `pip-audit --ignore-vuln`-Liste. Aktuell ist die Liste leer (der `Run Python dependency audit`-Step hat keine `--ignore-vuln`-Flags mehr), aber das kann sich ändern.

**Fix:** Neues Script `scripts/check-pip-audit-hardstop.sh`. CI ruft es auf `push:main` und reicht das Datum via env durch. Nach 2026-09-28 + non-empty `--ignore-vuln`-Liste → exit 2.

## Verifikation lokal

\`\`\`bash
# vor Hardcutoff, Liste non-empty: ok
PIP_AUDIT_FLAGS="--ignore-vuln CVE-X" bash scripts/check-pip-audit-hardstop.sh

# nach Hardcutoff, Liste non-empty: exit 2
PIP_AUDIT_HARDCUTOFF=2026-08-01 PIP_AUDIT_FLAGS="--ignore-vuln CVE-X --ignore-vuln CVE-Y" \\
  bash scripts/check-pip-audit-hardstop.sh

# nach Hardcutoff, Liste leer: ok
PIP_AUDIT_HARDCUTOFF=2026-08-01 PIP_AUDIT_FLAGS="" \\
  bash scripts/check-pip-audit-hardstop.sh
\`\`\`

## Trade-offs

- PRs werden ~2–4 min langsamer (Backend-Tests ohne Coverage).
- Hardstop-Datum muss bei ADR-Update mit-gepflegt werden — wird durch den Hardstop-Wächter erzwungen.

## Out of Scope

- Coverage-Gate-Wert anpassen (aktuell 60 %, +2 Punkte/Monat — Roadmap).
- Frontend-Tests auf PR (gibt's schon via `frontend-pr-gate`).
- Test-Marker-Infrastruktur (eigenes Issue, falls nicht vorhanden).

Closes #1055
Closes #1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Automatisierte Qualitätsprüfungen erkennen Fehler in Backend-Tests früher und brechen bei Problemen sofort ab.
  * Prüfungen außerhalb von Pull Requests überwachen die Einhaltung definierter Sicherheitsanforderungen zuverlässig.
* **Sicherheit**
  * Sicherheitsprüfungen berücksichtigen verbindliche Fristen für bekannte Ausnahmen.
  * Verstöße gegen diese Vorgaben werden eindeutig gemeldet und verhindern einen erfolgreichen Prüfabschluss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->