### PR TITLE
test(oasis): fix caplog propagation for skip-preflight test (#1054)

### DIFF
--- a/backend/tests/scripts/test_oasis_preflight.py
+++ b/backend/tests/scripts/test_oasis_preflight.py
@@ -13,6 +13,7 @@ deaktivierbar, damit die Simulation ohne erreichbares Ollama starten kann.
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -153,6 +154,19 @@ class TestPreflightSkipSwitch:
         nie aufgerufen, Warnung geloggt."""
         monkeypatch.setenv("AGORA_SKIP_PREFLIGHT", "1")
         model = MagicMock()
+
+        # ``caplog`` haengt seinen Handler am Root-Logger. Der ``agora``-Baum
+        # propagiert dorthin bewusst nicht: ``app/utils/logger.py::setup_logger``
+        # setzt ``logging.getLogger("agora").propagate = False``, damit die
+        # eigenen Datei- und Konsolen-Handler nicht zusaetzlich ueber
+        # Root-Handler doppelt ausgeben. Sobald irgendein zuvor importiertes
+        # Testmodul ``setup_logger`` ausgefuehrt hat, endet der Record von
+        # ``agora._sim_common`` deshalb beim Parent ``agora`` und erreicht
+        # ``caplog.records`` nie — der Test war dadurch reihenfolgeabhaengig.
+        # Das ist gewolltes Produktionsverhalten und wird nicht geaendert;
+        # die Propagation wird nur fuer die Dauer dieses Tests
+        # wiederhergestellt (``monkeypatch`` setzt sie danach zurueck).
+        monkeypatch.setattr(logging.getLogger("agora"), "propagate", True)
 
         with caplog.at_level("WARNING", logger="agora._sim_common"):
             preflight_model_probe(model, max_retries=3)


### PR DESCRIPTION
Closes #1054

## Symptom
`backend/tests/scripts/test_oasis_preflight.py::TestPreflightSkipSwitch::test_skip_env_skips_probe_and_warns` blieb rot: `caplog.records` leer, obwohl `preflight_model_probe(...)` (über `logging.getLogger("agora._sim_common")`) ein WARNING emittiert.

## Root Cause
`app/utils/logger.py::setup_logger` setzt `logging.getLogger("agora").propagate = False`. Wird `setup_logger` von einem vorher importierten Testmodul (Reihenfolge-abhängig) aufgerufen, enden Records aus `agora._sim_common` beim Parent `agora` und erreichen `caplog`'s Root-Handler nie.

## Fix
`monkeypatch.setattr(logging.getLogger("agora"), "propagate", True)` für die Dauer des Tests — stellt die Production-Konfiguration nach dem Test wieder her.

## Verifikation
```
$ uv run pytest tests/scripts/test_oasis_preflight.py::TestPreflightSkipSwitch::test_skip_env_skips_probe_and_warns
1 passed, 153 warnings in 4.00s
```