### PR TITLE
ci(playwright): cache chromium to avoid apt timeout on Report-Modes-Smoke (#1070)

### DIFF
--- a/.github/actions/setup-playwright-chromium/action.yml
+++ b/.github/actions/setup-playwright-chromium/action.yml
@@ -1,0 +1,23 @@
+name: 'Setup Playwright Chromium (with cache)'
+description: >-
+  Install Playwright Chromium browser + system dependencies with cache.
+  Restores ~/.cache/ms-playwright from actions/cache so subsequent runs skip
+  the ~120MB browser download. Replaces the inline
+  ``npx playwright install --with-deps chromium`` step and gives the apt-get
+  portion 15 minutes instead of 8.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore Playwright browser cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ hashFiles('frontend/package.json') }}
+        restore-keys: |
+          playwright-chromium-${{ runner.os }}-
+
+    - name: Install Playwright Chromium (browser + system deps)
+      working-directory: frontend
+      run: npx playwright install --with-deps chromium
+      shell: bash

--- a/.github/workflows/e2e-smokes.yml
+++ b/.github/workflows/e2e-smokes.yml
@@ -106,17 +106,14 @@ jobs:
         # — das schlug in Health-Smoke Test 3 als Page-Title durch.
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Health-Smoke
         working-directory: frontend
         run: npx playwright test health.spec.ts --reporter=list,github
@@ -203,17 +200,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Upload+Graph-Smoke
         working-directory: frontend
         run: npx playwright test upload-graph.spec.ts --reporter=list,github
@@ -303,17 +297,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Minimalreport-Smoke
         working-directory: frontend
         run: npx playwright test minimal-report.spec.ts --reporter=list,github
@@ -395,17 +386,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Report-Modes-Smoke
         working-directory: frontend
         run: npx playwright test report-modes.spec.ts --reporter=list,github
@@ -492,17 +480,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Golden-Gate-Accessibility-Smoke
         working-directory: frontend
         # drawer-focus-trap.spec.ts laeuft hier mit, NICHT in einem eigenen Job:
@@ -593,17 +578,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright AiModelPicker-Smoke
         working-directory: frontend
         run: npx playwright test ai-model-picker.spec.ts --reporter=list,github
@@ -700,17 +682,14 @@ jobs:
       - name: Build frontend bundle
         working-directory: frontend
         run: bun run build
-      - name: Install Playwright browsers (Chromium-only)
-        # Der Download dauert auf einem gesunden Runner 20-30 s. Am 2026-08-03
-        # brauchte er in einem Job 10m48s, waehrend die sechs Geschwister
-        # desselben Laufs bei 31 s lagen; der Rest des 25-min-Budgets reichte
-        # danach nicht mehr, und der Job endete nach 30 min als "cancelled" —
-        # ohne Hinweis darauf, welcher Schritt die Zeit verbraucht hatte.
-        # 8 min sind das Sechzehnfache des beobachteten Normalfalls und
-        # trennen einen langsamen Spiegel von einem defekten Runner.
-        timeout-minutes: 8
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium-only, with cache)
+        # Issue #1070: apt-get fuer Playwright-deps lief am 2026-08-04
+        # auf Microsoft-/Chrome-Repos in den 8-min-Step-Timeout; der
+        # Job brach ab, bevor Chromium ueberhaupt geladen war.
+        # Composite-Action cacht ~/.cache/ms-playwright ueber
+        # actions/cache@v4; Cold-Install verträgt 15 min,
+        # Warm-Cache faellt auf apt-deps unter 60 s zurueck.
+        uses: ./.github/actions/setup-playwright-chromium
       - name: Run Playwright Run-Budget-Smoke
         working-directory: frontend
         run: npx playwright test run-budget.spec.ts --reporter=list,github


### PR DESCRIPTION
Closes #1070

## Symptom
`Playwright Report-Modes-Smoke (P4.4)` rot in den letzten main-Runs. Log zeigt 8-min-Step-Timeout in `Install Playwright browsers (Chromium-only)` — apt-get fuer fonts blieb auf Microsoft-/Chrome-Repos hängen.

## Fix
Composite-Action `/.github/actions/setup-playwright-chromium`:
- `actions/cache@v4` fuer `~/.cache/ms-playwright` (Key aus `package.json`-Hash)
- `timeout-minutes: 15` (Cold-Install)
- Warm-Cache: nur apt-deps, <60 s

## Diff
- `.github/workflows/e2e-smokes.yml`: 7 inline Steps ersetzt
- `.github/actions/setup-playwright-chromium/action.yml`: neu, 26 Z.

## Akzeptanz
- [ ] Report-Modes-Smoke wird gruen
- [ ] andere Playwright-Workflows unveraendert gruen
- [ ] Warm-Cache-Lauf unter 90 s pro Install-Step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * End-to-End-Smoke-Tests werden zuverlässiger und schneller vorbereitet.
  * Chromium-Installationen profitieren von einem wiederverwendbaren Cache.
  * Erstinstallationen erhalten ein erweitertes Zeitfenster für die Einrichtung.
  * Wiederholte Testläufe starten durch die optimierte Einrichtung schneller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->