### PR TITLE
test(llm): Abdeckung für heuristic_num_ctx_for_model und Error-Normalisierung (ersetzt #971, #972)

### DIFF
--- a/backend/tests/llm/test_context.py
+++ b/backend/tests/llm/test_context.py
@@ -1,0 +1,27 @@
+from app.llm.context import heuristic_num_ctx_for_model
+
+def test_heuristic_empty_model() -> None:
+    """Test that an empty model name returns None."""
+    assert heuristic_num_ctx_for_model("") is None
+
+def test_heuristic_unknown_model() -> None:
+    """Test that an unknown model returns None."""
+    assert heuristic_num_ctx_for_model("unknown-model-xyz") is None
+    assert heuristic_num_ctx_for_model("random-123") is None
+
+def test_heuristic_exact_match() -> None:
+    """Test exact matches from the heuristic table."""
+    assert heuristic_num_ctx_for_model("gemini-3") == 1_048_576
+    assert heuristic_num_ctx_for_model("deepseek-v3") == 131_072
+    assert heuristic_num_ctx_for_model("nemotron") == 131_072
+
+def test_heuristic_substring_match_and_case_insensitive() -> None:
+    """Test substring matches and case insensitivity."""
+    # Substring matches
+    assert heuristic_num_ctx_for_model("my-gemini-3-pro") == 1_048_576
+    assert heuristic_num_ctx_for_model("qwen3-coder:latest") == 262_144
+
+    # Case insensitivity
+    assert heuristic_num_ctx_for_model("GEMINI-3") == 1_048_576
+    assert heuristic_num_ctx_for_model("DeepSeek-R1:32b") == 131_072
+    assert heuristic_num_ctx_for_model("LLAMA-3.3-70B") == 131_072

--- a/backend/tests/llm/test_errors.py
+++ b/backend/tests/llm/test_errors.py
@@ -1,0 +1,162 @@
+import httpx
+import openai
+from unittest import mock
+
+from app.contracts.provider_types import PROVIDER_OLLAMA, PROVIDER_OPENAI
+from app.llm.errors import normalize_provider_error
+
+
+class DummyRequest:
+    pass
+
+
+class DummyResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.request = DummyRequest()
+        self.headers = {}
+
+
+class DummyExceptionWithStatus(Exception):
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        super().__init__("DummyExceptionWithStatus")
+
+
+def test_normalize_openai_timeout():
+    exc = openai.APITimeoutError(request=DummyRequest())
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "timeout"
+    assert err.retryable is True
+
+
+def test_normalize_openai_connection():
+    exc = openai.APIConnectionError(request=DummyRequest())
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "connection_error"
+    assert err.retryable is True
+
+
+def test_normalize_openai_rate_limit():
+    exc = openai.RateLimitError(
+        message="Too Many Requests", response=DummyResponse(429), body=None
+    )
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "rate_limited"
+    assert err.status == 429
+    assert err.retryable is True
+
+
+def test_normalize_openai_server_error():
+    exc = openai.APIStatusError(
+        message="Internal Server Error", response=DummyResponse(500), body=None
+    )
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "server_error"
+    assert err.status == 500
+    assert err.retryable is True
+
+
+def test_normalize_openai_client_error():
+    exc = openai.APIStatusError(
+        message="Bad Request", response=DummyResponse(400), body=None
+    )
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "client_error"
+    assert err.status == 400
+    assert err.retryable is False
+
+
+def test_normalize_openai_status_408():
+    exc = openai.APIStatusError(
+        message="Request Timeout", response=DummyResponse(408), body=None
+    )
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "client_error"
+    assert err.status == 408
+    assert err.retryable is True
+
+
+def test_normalize_httpx_timeout():
+    exc = httpx.TimeoutException("timeout")
+    err = normalize_provider_error(exc, provider=PROVIDER_OLLAMA)
+    assert err.provider == PROVIDER_OLLAMA
+    assert err.code == "timeout"
+    assert err.retryable is True
+
+
+def test_normalize_httpx_error():
+    exc = httpx.ConnectError("connection failed")
+    err = normalize_provider_error(exc, provider=PROVIDER_OLLAMA)
+    assert err.provider == PROVIDER_OLLAMA
+    assert err.code == "connection_error"
+    assert err.retryable is True
+
+
+def test_normalize_unknown_error():
+    exc = ValueError("unknown error")
+    err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+    assert err.provider == PROVIDER_OPENAI
+    assert err.code == "unknown"
+    assert err.retryable is False
+
+
+def test_status_extraction_from_status_code_property():
+    exc = DummyExceptionWithStatus(418)
+
+    original_isinstance = isinstance
+
+    def mock_isinstance(obj, class_or_tuple):
+        if class_or_tuple == openai.APIStatusError and isinstance(
+            obj, DummyExceptionWithStatus
+        ):
+            return True
+        return original_isinstance(obj, class_or_tuple)
+
+    with mock.patch("app.llm.errors.isinstance", side_effect=mock_isinstance, create=True):
+        err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+        assert err.status == 418
+
+
+def test_status_extraction_from_response_status_code_property():
+    class DummyExceptionWithResponse(Exception):
+        def __init__(self, response):
+            self.response = response
+            super().__init__("DummyExceptionWithResponse")
+
+    exc = DummyExceptionWithResponse(DummyResponse(419))
+
+    original_isinstance = isinstance
+
+    def mock_isinstance(obj, class_or_tuple):
+        if class_or_tuple == openai.APIStatusError and isinstance(
+            obj, DummyExceptionWithResponse
+        ):
+            return True
+        return original_isinstance(obj, class_or_tuple)
+
+    with mock.patch("app.llm.errors.isinstance", side_effect=mock_isinstance, create=True):
+        err = normalize_provider_error(exc, provider=PROVIDER_OPENAI)
+        assert err.status == 419
+
+
+def test_llm_provider_error_exception():
+    from app.contracts.llm_request import NormalizedLlmError
+    from app.llm.errors import LlmProviderError
+
+    normalized = NormalizedLlmError(
+        provider=PROVIDER_OPENAI,
+        code="rate_limited",
+        message="Too many requests",
+        retryable=True,
+    )
+
+    exc = LlmProviderError(normalized)
+    assert str(exc) == "[openai:rate_limited] Too many requests"
+    assert exc.normalized == normalized

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4369 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4385 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Ersetzt #971 und #972.

## Warum ein neuer PR

Beide Jules-Branches waren nicht mergebar. Ihr Merge-Diff gegen aktuelles `main` betrug 86 bzw. 92 Dateien mit −10.113 bzw. −12.055 Zeilen: sie hätten das komplette Run-Budget-Feature (ADR-0012, #764) samt seiner acht Testdateien gelöscht, dazu Workflows und Contracts. Zustande kam das durch mehrfache Merge-Commits von `main` in die Jules-Branches, die den Zustand jeweils zurückgedreht haben.

Der eigentliche Nutzinhalt war in beiden Fällen genau eine neue Datei. Die ist hier auf aktuellem `main` neu aufgesetzt, ohne den destruktiven Rest.

## Inhalt

- `backend/tests/llm/test_context.py` — Kontextfenster-Heuristik: leerer Modellname, unbekanntes Modell, Präfix-Treffer
- `backend/tests/llm/test_errors.py` — Normalisierung von Provider-Fehlern
- `docs/STATUS.md` — Backend-Testzahl 4369 → 4385

## Verifikation

```
uv run pytest tests/llm/test_context.py tests/llm/test_errors.py -q   # 16 passed
uv run ruff check tests/llm/test_context.py tests/llm/test_errors.py  # All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)