### PR TITLE
refactor(api): start_simulation in Phasen zerlegen (#1079)

### DIFF
--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -3,6 +3,8 @@ Run-control and live-status routes split from the main simulation API module.
 """
 
 import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 from flask import jsonify, request
 
@@ -16,7 +18,7 @@ from ..services.llm_routing_seed import (
     seed_run_stage_routing,
 )
 from ..utils.endpoints import is_local_endpoint
-from ..services.llm_runtime import parse_runtime_llm_config
+from ..services.llm_runtime import RuntimeLlmConfig, parse_runtime_llm_config
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
 from ..services.stage_model_router import StageModelRouter
@@ -34,6 +36,11 @@ from .simulation_common import (
     simulation_run_artifacts as _simulation_run_artifacts,
 )
 from .simulation_prepare import _check_simulation_prepared
+
+if TYPE_CHECKING:  # pragma: no cover — nur für Typprüfung
+    from ..contracts.ai_provider_contract import AiModelRef
+    from ..contracts.llm_routing_contract import ResolvedRoute
+    from ..contracts.run_budget_contract import RunBudgetConfig
 
 
 def _evaluate_persona_review_gate(simulation_id: str):
@@ -96,71 +103,106 @@ def _apply_budget_to_simulation(simulation_id, run_id, budget_config, set_config
                     logger.warning("Konnte veraltetes Budget-Artefakt nicht löschen: %s", stale)
 
 
-@simulation_bp.route('/start', methods=['POST'])
-@require_scope("simulation:control")
-@handle_api_errors(logger=logger, log_prefix="Failed to start simulation")
-def start_simulation():
-    """Start running a prepared simulation."""
-    data = request.get_json() or {}
+class _StartRejected(Exception):
+    """Bricht eine Start-Phase mit einer fertig gebauten Fehler-Response ab.
 
-    simulation_id = data.get('simulation_id')
-    if not simulation_id:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            message="Please provide simulation_id",
-        )
-    if not validate_simulation_id(simulation_id):
-        return json_error(
-            ApiErrorCode.INVALID_ID,
-            message="Invalid simulation_id format",
-        )
+    Die Phasen unterhalb von :func:`start_simulation` sind einzeln testbar und
+    müssen ihren Ablehnungsfall deshalb selbst formulieren können. Sie tragen
+    die bereits gebaute ``json_error``-Response, damit Status-Code, Fehlercode
+    und Meldung wortgleich das bleiben, was der monolithische Handler vorher
+    zurückgegeben hat (#1079).
+    """
 
-    platform = data.get('platform', 'parallel')
-    max_rounds = data.get('max_rounds')
-    simulation_days = data.get('simulation_days')
-    llm_model_override = (data.get('llm_model') or '').strip() or None
+    def __init__(self, response: Any) -> None:
+        super().__init__("simulation start rejected")
+        self.response = response
+
+
+@dataclass(frozen=True)
+class _StartRequest:
+    """Validierte Eingaben eines ``POST /api/simulation/start``.
+
+    Interner Parameter-Container zwischen den Start-Phasen, **kein**
+    API-Vertrag: die Wire-Validierung bleibt feldweise in
+    :func:`_parse_start_request`, und nichts an dieser Klasse wird serialisiert.
+    """
+
+    simulation_id: str
+    platform: str
+    max_rounds: "int | None"
+    simulation_days: "int | None"
+    llm_model_override: "str | None"
+    llm_runtime: RuntimeLlmConfig
+    ai_model_ref: "AiModelRef | None"
+    budget_config: "RunBudgetConfig | None"
+    enable_graph_memory_update: bool
+    force: bool
+
+
+def _parse_bounded_int(
+    raw: Any,
+    *,
+    minimum: int,
+    maximum: "int | None",
+    range_message: str,
+    type_message: str,
+) -> int:
+    """Ganzzahl mit Grenzen parsen; wirft :class:`_StartRejected` bei Verstoß."""
     try:
-        llm_runtime = parse_runtime_llm_config(data)
-    except ValueError as exc:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=400,
-            message=str(exc),
+        value = int(raw)
+    except (ValueError, TypeError):
+        raise _StartRejected(
+            json_error(ApiErrorCode.VALIDATION_FAILED, message=type_message)
+        ) from None
+    if value < minimum or (maximum is not None and value > maximum):
+        raise _StartRejected(
+            json_error(ApiErrorCode.VALIDATION_FAILED, message=range_message)
         )
-    # Explizite UI-Auswahl (AiModelRef) ist die autoritative Sim-Route und darf
-    # nicht still mit Legacy-Feldern kombiniert werden (Issue #817, analog
-    # /api/report/generate). Wenn gesetzt, wird die ProviderConnection zur
-    # Single Source of Truth für Modell, Base-URL und gebundenen Key — kein
-    # .env-Fallback. Root Cause des OASIS-404 ``model MiniMax-M3 not found``:
-    # der Legacy-Pfad reichte nur den nackten Modellnamen weiter und produzierte
-    # eine Route ohne Base-URL + Default-Provider-Key → CAMEL traf den
-    # OpenAI-Default-Endpoint. Der ai_model_ref-Pfad bindet Connection-URL und
-    # -Secret atomar (connection_only=True).
-    ai_model_ref = None
-    raw_ref = data.get('ai_model_ref')
-    if raw_ref is not None:
-        from pydantic import ValidationError as _ValidationError
+    return value
 
-        from ..contracts.ai_provider_contract import AiModelRef as _AiModelRef
-        try:
-            ai_model_ref = _AiModelRef.model_validate(raw_ref)
-        except _ValidationError:
-            return json_error(
+
+def _parse_ai_model_ref(data: "dict[str, Any]") -> "AiModelRef | None":
+    """Explizite UI-Auswahl (``AiModelRef``) lesen und gegen Legacy-Felder sperren.
+
+    Die AiModelRef ist die autoritative Sim-Route und darf nicht still mit
+    Legacy-Feldern kombiniert werden (Issue #817, analog /api/report/generate).
+    Wenn gesetzt, wird die ProviderConnection zur Single Source of Truth für
+    Modell, Base-URL und gebundenen Key — kein .env-Fallback. Root Cause des
+    OASIS-404 ``model MiniMax-M3 not found``: der Legacy-Pfad reichte nur den
+    nackten Modellnamen weiter und produzierte eine Route ohne Base-URL +
+    Default-Provider-Key → CAMEL traf den OpenAI-Default-Endpoint. Der
+    ai_model_ref-Pfad bindet Connection-URL und -Secret atomar
+    (connection_only=True).
+    """
+    raw_ref = data.get('ai_model_ref')
+    if raw_ref is None:
+        return None
+
+    from pydantic import ValidationError as _ValidationError
+
+    from ..contracts.ai_provider_contract import AiModelRef as _AiModelRef
+    try:
+        ai_model_ref = _AiModelRef.model_validate(raw_ref)
+    except _ValidationError:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message="ai_model_ref ist ungültig",
             )
-        # Nur die Legacy-Felder prüfen, die dieser Handler auch ausliest und
-        # weiterreicht (llm_model → llm_model_override, llm_provider →
-        # llm_runtime). llm_profile_id wird im Sim-Start nicht unterstützt und
-        # daher nicht als Konfliktgrund geführt — ein Profilpfad ist hier nicht
-        # implementiert (CodeRabbit PR #852).
-        conflicting = [
-            key for key in ('llm_model', 'llm_provider')
-            if data.get(key)
-        ]
-        if conflicting:
-            return json_error(
+        ) from None
+    # Nur die Legacy-Felder prüfen, die dieser Handler auch ausliest und
+    # weiterreicht (llm_model → llm_model_override, llm_provider →
+    # llm_runtime). llm_profile_id wird im Sim-Start nicht unterstützt und
+    # daher nicht als Konfliktgrund geführt — ein Profilpfad ist hier nicht
+    # implementiert (CodeRabbit PR #852).
+    conflicting = [
+        key for key in ('llm_model', 'llm_provider')
+        if data.get(key)
+    ]
+    if conflicting:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message=(
@@ -168,80 +210,152 @@ def start_simulation():
                     "kombiniert werden"
                 ),
             )
-        # Legacy-Override stummschalten: die Connection ist maßgeblich.
-        llm_model_override = None
-        llm_runtime = parse_runtime_llm_config({})
-    enable_graph_memory_update = data.get('enable_graph_memory_update', False)
-    force = data.get('force', False)
+        )
+    return ai_model_ref
 
-    # Run-Budget (Issue #764): optionale Token-/Kosten-/Zeit-/Aufruflimits.
-    budget_config = None
+
+def _parse_budget_config(data: "dict[str, Any]") -> "RunBudgetConfig | None":
+    """Run-Budget (Issue #764): optionale Token-/Kosten-/Zeit-/Aufruflimits."""
     raw_budget = data.get('budget')
-    if raw_budget is not None:
-        from pydantic import ValidationError as _BudgetValidationError
+    if raw_budget is None:
+        return None
 
-        from ..contracts.run_budget_contract import RunBudgetConfig as _RunBudgetConfig
-        try:
-            budget_config = _RunBudgetConfig.model_validate(raw_budget)
-        except _BudgetValidationError as exc:
-            return json_error(
+    from pydantic import ValidationError as _BudgetValidationError
+
+    from ..contracts.run_budget_contract import RunBudgetConfig as _RunBudgetConfig
+    try:
+        return _RunBudgetConfig.model_validate(raw_budget)
+    except _BudgetValidationError as exc:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message=f"budget ist ungültig: {exc.errors()[0].get('msg', 'validation error')}",
             )
+        ) from exc
 
-    if max_rounds is not None:
-        try:
-            max_rounds = int(max_rounds)
-            if max_rounds <= 0:
-                return json_error(
-                    ApiErrorCode.VALIDATION_FAILED,
-                    message="max_rounds must be a positive integer",
-                )
-        except (ValueError, TypeError):
-            return json_error(
-                ApiErrorCode.VALIDATION_FAILED,
-                message="max_rounds must be a valid integer",
-            )
 
-    if simulation_days is not None:
-        try:
-            simulation_days = int(simulation_days)
-            if simulation_days <= 0 or simulation_days > 365:
-                return json_error(
-                    ApiErrorCode.VALIDATION_FAILED,
-                    message="simulation_days must be between 1 and 365",
-                )
-        except (ValueError, TypeError):
-            return json_error(
+def _parse_start_request(data: "dict[str, Any]") -> _StartRequest:
+    """Phase 1 — Request-Payload validieren und in einen Container überführen.
+
+    Die Prüfreihenfolge ist Teil des API-Verhaltens: bei mehreren fehlerhaften
+    Feldern entscheidet sie, welche Meldung der Aufrufer sieht.
+    """
+    simulation_id = data.get('simulation_id')
+    if not simulation_id:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
-                message="simulation_days must be a valid integer",
+                message="Please provide simulation_id",
             )
+        )
+    if not validate_simulation_id(simulation_id):
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.INVALID_ID,
+                message="Invalid simulation_id format",
+            )
+        )
+
+    platform = data.get('platform', 'parallel')
+    llm_model_override = (data.get('llm_model') or '').strip() or None
+    try:
+        llm_runtime = parse_runtime_llm_config(data)
+    except ValueError as exc:
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            )
+        ) from exc
+
+    ai_model_ref = _parse_ai_model_ref(data)
+    if ai_model_ref is not None:
+        # Legacy-Override stummschalten: die Connection ist maßgeblich.
+        llm_model_override = None
+        llm_runtime = parse_runtime_llm_config({})
+
+    budget_config = _parse_budget_config(data)
+
+    raw_max_rounds = data.get('max_rounds')
+    max_rounds = None if raw_max_rounds is None else _parse_bounded_int(
+        raw_max_rounds,
+        minimum=1,
+        maximum=None,
+        range_message="max_rounds must be a positive integer",
+        type_message="max_rounds must be a valid integer",
+    )
+
+    raw_simulation_days = data.get('simulation_days')
+    simulation_days = None if raw_simulation_days is None else _parse_bounded_int(
+        raw_simulation_days,
+        minimum=1,
+        maximum=365,
+        range_message="simulation_days must be between 1 and 365",
+        type_message="simulation_days must be a valid integer",
+    )
 
     if platform not in ['twitter', 'reddit', 'parallel']:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            message=f"Invalid platform type: {platform}. Allowed: twitter/reddit/parallel",
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                message=f"Invalid platform type: {platform}. Allowed: twitter/reddit/parallel",
+            )
         )
 
-    manager = SimulationManager()
-    state = manager.get_simulation(simulation_id)
-    if not state:
-        return json_error(
-            ApiErrorCode.NOT_FOUND,
-            status=404,
-            message=f"Simulation does not exist: {simulation_id}",
+    return _StartRequest(
+        simulation_id=simulation_id,
+        platform=platform,
+        max_rounds=max_rounds,
+        simulation_days=simulation_days,
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+        ai_model_ref=ai_model_ref,
+        budget_config=budget_config,
+        enable_graph_memory_update=data.get('enable_graph_memory_update', False),
+        force=data.get('force', False),
+    )
+
+
+def _stop_running_simulation(simulation_id: str, force: bool) -> None:
+    """Laufenden Sim-Prozess für einen Force-Restart beenden.
+
+    Ohne ``force`` ist ein laufender Run ein 409 — der Aufrufer muss erst
+    ``/stop`` rufen.
+    """
+    run_state = SimulationRunner.get_run_state(simulation_id)
+    if not (run_state and run_state.runner_status.value == 'running'):
+        return
+    if not force:
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.SIMULATION_ALREADY_RUNNING,
+                status=409,
+                message=(
+                    "Simulation is running. Please call /stop first or use force=true to force restart."
+                ),
+            )
         )
+    logger.info(f"Force mode: stopping running simulation {simulation_id}")
+    try:
+        SimulationRunner.stop_simulation(simulation_id)
+    except Exception as exc:  # noqa: BLE001 — exception is logged; swallowed intentionally
+        logger.warning(f"Warning when stopping simulation: {exc}")
 
-    gate_response = _evaluate_persona_review_gate(simulation_id)
-    if gate_response is not None:
-        return gate_response
 
-    force_restarted = False
-    if state.status != SimulationStatus.READY:
-        is_prepared, _prepare_info = _check_simulation_prepared(simulation_id)
-        if not is_prepared:
-            return json_error(
+def _ensure_startable_state(manager, state, req: _StartRequest) -> bool:
+    """Phase 2 — sicherstellen, dass die Simulation startbar ist.
+
+    Gibt zurück, ob dafür ein Force-Restart nötig war (``force_restarted``).
+    """
+    if state.status == SimulationStatus.READY:
+        return False
+
+    is_prepared, _prepare_info = _check_simulation_prepared(req.simulation_id)
+    if not is_prepared:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.SIMULATION_NOT_PREPARED,
                 status=409,
                 message=(
@@ -249,138 +363,162 @@ def start_simulation():
                     "Please call /prepare first"
                 ),
             )
-
-        if state.status == SimulationStatus.RUNNING:
-            run_state = SimulationRunner.get_run_state(simulation_id)
-            if run_state and run_state.runner_status.value == 'running':
-                if not force:
-                    return json_error(
-                        ApiErrorCode.SIMULATION_ALREADY_RUNNING,
-                        status=409,
-                        message=(
-                            "Simulation is running. Please call /stop first or use force=true to force restart."
-                        ),
-                    )
-                logger.info(f"Force mode: stopping running simulation {simulation_id}")
-                try:
-                    SimulationRunner.stop_simulation(simulation_id)
-                except Exception as exc:  # noqa: BLE001 — exception is logged; swallowed intentionally
-                    logger.warning(f"Warning when stopping simulation: {exc}")
-
-        if force:
-            logger.info(f"Force mode: cleaning simulation runtime files for {simulation_id}")
-            cleanup_result = SimulationRunner.cleanup_simulation_logs(simulation_id)
-            if not cleanup_result.get("success"):
-                logger.warning(f"Warning when cleaning logs: {cleanup_result.get('errors')}")
-            force_restarted = True
-
-        manager._reset_to_ready(
-            state,
-            reason=f"force start_run after status={state.status.value}",
         )
 
-    graph_id = None
-    if enable_graph_memory_update:
-        graph_id = state.graph_id
-        if not graph_id:
-            project = ProjectManager.get_project(state.project_id)
-            if project:
-                graph_id = project.graph_id
-        if not graph_id:
-            return json_error(
+    if state.status == SimulationStatus.RUNNING:
+        _stop_running_simulation(req.simulation_id, req.force)
+
+    force_restarted = False
+    if req.force:
+        logger.info(f"Force mode: cleaning simulation runtime files for {req.simulation_id}")
+        cleanup_result = SimulationRunner.cleanup_simulation_logs(req.simulation_id)
+        if not cleanup_result.get("success"):
+            logger.warning(f"Warning when cleaning logs: {cleanup_result.get('errors')}")
+        force_restarted = True
+
+    manager._reset_to_ready(
+        state,
+        reason=f"force start_run after status={state.status.value}",
+    )
+    return force_restarted
+
+
+def _resolve_graph_memory_id(state, req: _StartRequest) -> "str | None":
+    """Phase 3 — Graph-ID für das Knowledge-Graph-Memory-Update auflösen."""
+    if not req.enable_graph_memory_update:
+        return None
+
+    graph_id = state.graph_id
+    if not graph_id:
+        project = ProjectManager.get_project(state.project_id)
+        if project:
+            graph_id = project.graph_id
+    if not graph_id:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 message=(
                     "Enable knowledge graph memory update requires valid graph_id. "
                     "Please ensure project graph is built."
                 ),
             )
-        logger.info(
-            f"Enable knowledge graph memory update: simulation_id={simulation_id}, graph_id={graph_id}",
-            extra={'simulation_id': simulation_id},
+        )
+    logger.info(
+        f"Enable knowledge graph memory update: simulation_id={req.simulation_id}, graph_id={graph_id}",
+        extra={'simulation_id': req.simulation_id},
+    )
+    return graph_id
+
+
+def _precheck_runtime_provider_key(llm_runtime: RuntimeLlmConfig) -> None:
+    """Phase 4a — Key-Verfügbarkeit für einen Legacy-Provider-Override prüfen.
+
+    Pre-Check VOR der Run-Record-Creation, damit kein orphaned Run entsteht
+    (Copilot PR #466, simulation_run.py:247). Dafür simulieren wir die
+    Stage-Auflösung ohne Persistenz: ein leerer Routing-Stub reicht für die
+    Provider/Key-Bestimmung, weil ``seed_run_stage_routing`` nichts anderes
+    tut als Workspace-Default + Override zusammenzuführen.
+    """
+    if not (llm_runtime.enabled and not llm_runtime.api_key):
+        return
+
+    from ..services.llm_routing_seed import map_runtime_provider_to_route_provider
+    from ..services.secret_resolver import SecretResolver
+    from ..services.llm_provider_registry import LlmProviderRegistry
+    provider_id_preview = map_runtime_provider_to_route_provider(llm_runtime.provider)
+    if not provider_id_preview:
+        return
+
+    registry = LlmProviderRegistry()
+    descriptor = next((p for p in registry.get_providers() if p.id == provider_id_preview), None)
+    p_type = descriptor.type if descriptor else "openai_compatible"
+    stored_key = SecretResolver().get_api_key(provider_id_preview, p_type)
+    if not stored_key and not is_local_endpoint(
+        (descriptor.base_url if descriptor else None) or llm_runtime.base_url
+    ):
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=422,
+                message=(
+                    f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
+                    f"für Provider '{provider_id_preview}'. "
+                    "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+                    "oder im Sitzungsfeld eingeben."
+                ),
+            )
         )
 
-    # Pre-Check VOR der Run-Record-Creation, damit kein orphaned Run entsteht
-    # (Copilot PR #466, simulation_run.py:247). Dafür simulieren wir die
-    # Stage-Auflösung ohne Persistenz: ein leerer Routing-Stub reicht für die
-    # Provider/Key-Bestimmung, weil ``seed_run_stage_routing`` nichts anderes
-    # tut als Workspace-Default + Override zusammenzuführen.
-    if llm_runtime.enabled and not llm_runtime.api_key:
-        from ..services.llm_routing_seed import map_runtime_provider_to_route_provider
-        from ..services.secret_resolver import SecretResolver
-        from ..services.llm_provider_registry import LlmProviderRegistry
-        provider_id_preview = map_runtime_provider_to_route_provider(llm_runtime.provider)
-        if provider_id_preview:
-            registry = LlmProviderRegistry()
-            descriptor = next((p for p in registry.get_providers() if p.id == provider_id_preview), None)
-            p_type = descriptor.type if descriptor else "openai_compatible"
-            stored_key = SecretResolver().get_api_key(provider_id_preview, p_type)
-            if not stored_key and not is_local_endpoint(
-                (descriptor.base_url if descriptor else None) or llm_runtime.base_url
-            ):
-                return json_error(
-                    ApiErrorCode.VALIDATION_FAILED,
-                    status=422,
-                    message=(
-                        f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
-                        f"für Provider '{provider_id_preview}'. "
-                        "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
-                        "oder im Sitzungsfeld eingeben."
-                    ),
-                )
 
-    # ai_model_ref-Pre-Check VOR der Run-Record-Creation: die Connection muss
-    # existieren, aktiviert sein und (für api_key-Connections) ein gebundenes
-    # Secret tragen — sonst kein .env-Fallback, sondern 422 (analog dem
-    # Legacy-Pre-Check, kein orphaned Run). Die volle Model-Discovery
-    # (Connection/Model-Mismatch, Issue #819) läuft später in
-    # ``seed_run_stage_routing``; deren ValueError wird am Endpunkt zu 4xx.
-    if ai_model_ref is not None:
-        from ..services.llm_routing_seed import prevalidate_ai_model_ref
-        try:
-            prevalidate_ai_model_ref(ai_model_ref)
-        except ValueError as exc:
-            return json_error(
+def _precheck_ai_model_ref(ai_model_ref: "AiModelRef | None") -> None:
+    """Phase 4b — Connection der expliziten ``AiModelRef`` vorab prüfen.
+
+    Pre-Check VOR der Run-Record-Creation: die Connection muss existieren,
+    aktiviert sein und (für api_key-Connections) ein gebundenes Secret tragen —
+    sonst kein .env-Fallback, sondern 422 (analog dem Legacy-Pre-Check, kein
+    orphaned Run). Die volle Model-Discovery (Connection/Model-Mismatch, Issue
+    #819) läuft später in ``seed_run_stage_routing``; deren ValueError wird am
+    Endpunkt zu 4xx.
+    """
+    if ai_model_ref is None:
+        return
+
+    from ..services.llm_routing_seed import prevalidate_ai_model_ref
+    try:
+        prevalidate_ai_model_ref(ai_model_ref)
+    except ValueError as exc:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=422,
                 message=str(exc),
             )
+        ) from exc
 
+
+def _register_start_run(req: _StartRequest, state) -> "dict[str, Any]":
+    """Phase 5 — Run-Record anlegen, Routing seeden, Budget verankern."""
     run_record = run_registry.create_run(
         run_type="simulation_run",
-        entity_id=simulation_id,
+        entity_id=req.simulation_id,
         status="pending",
         progress=0,
         message="Simulation run queued",
-        linked_ids={"simulation_id": simulation_id, "project_id": state.project_id},
-        artifacts=_simulation_run_artifacts(simulation_id),
-        resume_capability=_simulation_resume_capability(simulation_id, state),
+        linked_ids={"simulation_id": req.simulation_id, "project_id": state.project_id},
+        artifacts=_simulation_run_artifacts(req.simulation_id),
+        resume_capability=_simulation_resume_capability(req.simulation_id, state),
         branch_label=state.branch_name,
         metadata={
             "graph_id": state.graph_id,
-            "platform": platform,
+            "platform": req.platform,
             "source_simulation_id": state.source_simulation_id,
             "root_simulation_id": state.root_simulation_id,
             "branch_name": state.branch_name,
             "branch_depth": state.branch_depth,
-            "llm_model": llm_model_override,
-            "llm_provider": llm_runtime.redacted_metadata() or None,
+            "llm_model": req.llm_model_override,
+            "llm_provider": req.llm_runtime.redacted_metadata() or None,
         },
     )
     seed_run_stage_routing(
         run_record["run_id"],
         "simulation_rounds",
-        llm_model_override=llm_model_override,
-        llm_runtime=llm_runtime,
-        ai_model_ref=ai_model_ref,
+        llm_model_override=req.llm_model_override,
+        llm_runtime=req.llm_runtime,
+        ai_model_ref=req.ai_model_ref,
     )
     # Budget am Run verankern + Subprozess-Config schreiben (Issue #764).
     # Alt-Artefakte (budget_abort.json eines früheren Runs) werden entfernt,
     # damit ein Neustart nicht sofort wieder abbricht.
     from ..services.run_budget import set_run_budget_config as _set_run_budget_config
     _apply_budget_to_simulation(
-        simulation_id, run_record["run_id"], budget_config, _set_run_budget_config
+        req.simulation_id, run_record["run_id"], req.budget_config, _set_run_budget_config
     )
-    route_router = StageModelRouter(run_record["run_id"])
+    return run_record
+
+
+def _resolve_start_route(run_id: str, llm_runtime: RuntimeLlmConfig):
+    """Phase 6 — Stage-Route auflösen, sperren und den API-Key bestimmen."""
+    route_router = StageModelRouter(run_id)
     resolved_route = route_router.resolve("simulation_rounds")
     route_router.lock_stage("simulation_rounds", resolved_route)
     resolved_api_key = resolve_route_api_key(resolved_route, llm_runtime)
@@ -391,47 +529,133 @@ def start_simulation():
         # damit keine Phantom-Runs in der Liste landen.
         try:
             run_registry.update_run(
-                run_record["run_id"],
+                run_id,
                 status="failed",
                 message=f"Missing API key for provider {resolved_route.provider_id}",
             )
         except Exception:  # noqa: BLE001 — best effort
             logger.warning("Failed to mark orphaned run as failed", exc_info=True)
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=422,
-            message=(
-                f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
-                f"für Provider '{resolved_route.provider_id}'. "
-                "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
-                "oder im Sitzungsfeld eingeben."
-            ),
+        raise _StartRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=422,
+                message=(
+                    f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
+                    f"für Provider '{resolved_route.provider_id}'. "
+                    "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+                    "oder im Sitzungsfeld eingeben."
+                ),
+            )
         )
+    return resolved_route, resolved_api_key
 
-    if simulation_days is not None or llm_model_override or llm_runtime.enabled or ai_model_ref is not None:
-        store = get_artifact_store()
-        config = store.read_json(simulation_id, "simulation_config", default=None)
-        if not config:
-            return json_error(
+
+def _has_config_overrides(req: _StartRequest) -> bool:
+    """Ob der Request die persistierte Sim-Config überhaupt anfasst."""
+    return bool(
+        req.simulation_days is not None
+        or req.llm_model_override
+        or req.llm_runtime.enabled
+        or req.ai_model_ref is not None
+    )
+
+
+def _apply_route_to_simulation_config(
+    req: _StartRequest, resolved_route: "ResolvedRoute"
+) -> None:
+    """Phase 7 — Laufzeit-Overrides in die persistierte Sim-Config schreiben."""
+    if not _has_config_overrides(req):
+        return
+
+    store = get_artifact_store()
+    config = store.read_json(req.simulation_id, "simulation_config", default=None)
+    if not config:
+        raise _StartRejected(
+            json_error(
                 ApiErrorCode.SIMULATION_NOT_PREPARED,
                 status=404,
                 message="Simulation configuration does not exist. Please call /prepare first",
             )
-        if simulation_days is not None:
-            time_config = dict(config.get("time_config") or {})
-            time_config["total_simulation_hours"] = simulation_days * 24
-            config["time_config"] = time_config
-        if llm_model_override or ai_model_ref is not None:
-            config["llm_model"] = resolved_route.model
-        if (llm_runtime.enabled or ai_model_ref is not None) and resolved_route.base_url_sanitized:
-            config["llm_base_url"] = resolved_route.base_url_sanitized
-        store.write_json(simulation_id, "simulation_config", config)
+        )
+    if req.simulation_days is not None:
+        time_config = dict(config.get("time_config") or {})
+        time_config["total_simulation_hours"] = req.simulation_days * 24
+        config["time_config"] = time_config
+    if req.llm_model_override or req.ai_model_ref is not None:
+        config["llm_model"] = resolved_route.model
+    if (req.llm_runtime.enabled or req.ai_model_ref is not None) and resolved_route.base_url_sanitized:
+        config["llm_base_url"] = resolved_route.base_url_sanitized
+    store.write_json(req.simulation_id, "simulation_config", config)
+
+
+def _build_start_response(
+    req: _StartRequest,
+    run_state,
+    run_id: str,
+    graph_id: "str | None",
+    force_restarted: bool,
+) -> "dict[str, Any]":
+    """Phase 8 — Antwort-Payload aus Runner-State und Request-Overrides bauen."""
+    response_data = run_state.to_dict()
+    if req.max_rounds:
+        response_data['max_rounds_applied'] = req.max_rounds
+    if req.simulation_days:
+        response_data['simulation_days_applied'] = req.simulation_days
+    response_data['graph_memory_update_enabled'] = req.enable_graph_memory_update
+    response_data['force_restarted'] = force_restarted
+    response_data['run_id'] = run_id
+    if req.enable_graph_memory_update:
+        response_data['graph_id'] = graph_id
+    return response_data
+
+
+@simulation_bp.route('/start', methods=['POST'])
+@require_scope("simulation:control")
+@handle_api_errors(logger=logger, log_prefix="Failed to start simulation")
+def start_simulation():
+    """Start running a prepared simulation.
+
+    Der Handler orchestriert nur noch die Phasen: Validierung → Startbarkeit →
+    Graph-Memory → Provider-Prechecks → Run-Registrierung → Routen-Auflösung →
+    Config-Overrides → Prozessstart (#1079). Jede Phase lehnt über
+    :class:`_StartRejected` mit einer fertigen Fehler-Response ab.
+    """
+    try:
+        req = _parse_start_request(request.get_json() or {})
+
+        manager = SimulationManager()
+        state = manager.get_simulation(req.simulation_id)
+        if not state:
+            raise _StartRejected(
+                json_error(
+                    ApiErrorCode.NOT_FOUND,
+                    status=404,
+                    message=f"Simulation does not exist: {req.simulation_id}",
+                )
+            )
+
+        gate_response = _evaluate_persona_review_gate(req.simulation_id)
+        if gate_response is not None:
+            return gate_response
+
+        force_restarted = _ensure_startable_state(manager, state, req)
+        graph_id = _resolve_graph_memory_id(state, req)
+        _precheck_runtime_provider_key(req.llm_runtime)
+        _precheck_ai_model_ref(req.ai_model_ref)
+
+        run_record = _register_start_run(req, state)
+        resolved_route, resolved_api_key = _resolve_start_route(
+            run_record["run_id"], req.llm_runtime
+        )
+        _apply_route_to_simulation_config(req, resolved_route)
+    except _StartRejected as rejected:
+        return rejected.response
 
     run_state = SimulationRunner.start_simulation(
-        simulation_id=simulation_id,
-        platform=platform,
-        max_rounds=max_rounds,
-        enable_graph_memory_update=enable_graph_memory_update,
+        simulation_id=req.simulation_id,
+        platform=req.platform,
+        max_rounds=req.max_rounds,
+        enable_graph_memory_update=req.enable_graph_memory_update,
         graph_id=graph_id,
         runtime_env=build_route_subprocess_env(
             resolved_route,
@@ -446,21 +670,14 @@ def start_simulation():
         status="processing",
         progress=0,
         message="Simulation run started",
-        resume_capability=_simulation_resume_capability(simulation_id, state),
+        resume_capability=_simulation_resume_capability(req.simulation_id, state),
     )
 
-    response_data = run_state.to_dict()
-    if max_rounds:
-        response_data['max_rounds_applied'] = max_rounds
-    if simulation_days:
-        response_data['simulation_days_applied'] = simulation_days
-    response_data['graph_memory_update_enabled'] = enable_graph_memory_update
-    response_data['force_restarted'] = force_restarted
-    response_data['run_id'] = run_record["run_id"]
-    if enable_graph_memory_update:
-        response_data['graph_id'] = graph_id
-
-    return json_success(response_data)
+    return json_success(
+        _build_start_response(
+            req, run_state, run_record["run_id"], graph_id, force_restarted
+        )
+    )
 
 
 @simulation_bp.route('/stop', methods=['POST'])

--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -15,7 +15,8 @@
 # Refactor-Kandidaten (eigene Sub-Slices nötig):
 #   - app/api/report.py (F/E): Kandidat für API-Envelope-Refactor (M11.6)
 #   - app/services/report_agent/workflow.py (E/D): Kandidat für Report-Agent-Refactor
-#   - app/api/simulation_run.py (E): Kandidat für Sim-Run-Refactor
+#   - app/api/simulation_run.py (E): erledigt (#1079) — start_simulation ist in
+#     Phasen zerlegt und aus der Allowlist entfernt.
 #   - app/services/oasis_profile_generator.py (E): Kandidat für OASIS-Profil-Refactor
 #   - app/services/evidence_migrations.py (F/D): aus P3.1-Followup (Commit 83b7488),
 #     echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation. Eigener
@@ -30,7 +31,6 @@ app/utils/file_parser.py::FileParser._extract_from_pdf
 # nur Pfad neu. Refactoring der Funktionen selbst: #590.
 app/llm/client.py::LLMClient.chat_json
 app/api/simulation_profiles.py::add_simulation_profile
-app/api/simulation_run.py::start_simulation
 app/api/simulation_prepare.py::prepare_simulation
 app/api/runs.py::_build_run_summary
 app/api/report.py::get_generate_status

--- a/backend/tests/api/test_simulation_start_phases.py
+++ b/backend/tests/api/test_simulation_start_phases.py
@@ -1,0 +1,551 @@
+"""Unit-Tests der Start-Phasen von ``POST /api/simulation/start`` (#1079).
+
+``start_simulation`` war ein 361-Zeilen-Handler mit radon-Rang F (cc 68). Er ist
+jetzt ein Orchestrator über einzeln testbare Phasen; diese Datei deckt jede
+Phase direkt ab. Die HTTP-Ebene (Status-Codes, Response-Shape) bleibt in
+``test_simulation_api_routes.py`` und ``test_simulation_start_provider_route_api.py``
+abgedeckt — hier geht es um das Verhalten der Phasen selbst.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_run as mod
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.services.llm_runtime import RuntimeLlmConfig
+from app.services.simulation_manager import SimulationStatus
+
+VALID_SIM_ID = "sim_0123456789ab"
+
+
+@pytest.fixture
+def app_ctx():
+    """``json_error`` baut echte Flask-Responses und braucht einen App-Kontext."""
+    app = Flask(__name__)
+    with app.test_request_context():
+        yield app
+
+
+def _status(excinfo) -> int:
+    return excinfo.value.response[1]
+
+
+def _body(excinfo) -> dict:
+    return excinfo.value.response[0].get_json()
+
+
+def _state(status=SimulationStatus.READY, **overrides):
+    state = MagicMock()
+    state.status = status
+    state.project_id = overrides.get("project_id", "proj-x")
+    state.graph_id = overrides.get("graph_id")
+    state.branch_name = overrides.get("branch_name")
+    state.source_simulation_id = None
+    state.root_simulation_id = None
+    state.branch_depth = 0
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Validierung
+# ---------------------------------------------------------------------------
+
+def test_parse_start_request_returns_defaults(app_ctx):
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    assert req.simulation_id == VALID_SIM_ID
+    assert req.platform == "parallel"
+    assert req.max_rounds is None
+    assert req.simulation_days is None
+    assert req.llm_model_override is None
+    assert req.ai_model_ref is None
+    assert req.budget_config is None
+    assert req.enable_graph_memory_update is False
+    assert req.force is False
+
+
+def test_parse_start_request_requires_simulation_id(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_start_request({})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "Please provide simulation_id"
+
+
+def test_parse_start_request_rejects_malformed_id(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_start_request({"simulation_id": "../etc/passwd"})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["code"] == "invalid_id"
+
+
+def test_parse_start_request_rejects_unknown_platform(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_start_request({"simulation_id": VALID_SIM_ID, "platform": "mastodon"})
+
+    assert _status(excinfo) == 400
+    assert "Invalid platform type" in _body(excinfo)["error"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"max_rounds": 0}, "max_rounds must be a positive integer"),
+        ({"max_rounds": "abc"}, "max_rounds must be a valid integer"),
+        ({"simulation_days": 366}, "simulation_days must be between 1 and 365"),
+        ({"simulation_days": 0}, "simulation_days must be between 1 and 365"),
+        ({"simulation_days": "x"}, "simulation_days must be a valid integer"),
+    ],
+)
+def test_parse_start_request_bounded_ints(app_ctx, payload, message):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_start_request({"simulation_id": VALID_SIM_ID, **payload})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == message
+
+
+def test_parse_start_request_accepts_numeric_strings(app_ctx):
+    req = mod._parse_start_request(
+        {"simulation_id": VALID_SIM_ID, "max_rounds": "5", "simulation_days": "7"}
+    )
+
+    assert req.max_rounds == 5
+    assert req.simulation_days == 7
+
+
+def test_parse_ai_model_ref_returns_none_when_absent(app_ctx):
+    assert mod._parse_ai_model_ref({"simulation_id": VALID_SIM_ID}) is None
+
+
+def test_parse_ai_model_ref_rejects_invalid_payload(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_ai_model_ref({"ai_model_ref": {"model_id": "only-model"}})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "ai_model_ref ist ungültig"
+
+
+def test_parse_ai_model_ref_rejects_legacy_combination(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_ai_model_ref(
+            {
+                "ai_model_ref": {
+                    "provider_connection_id": "conn-x",
+                    "model_id": "m-1",
+                    "source": "explicit",
+                },
+                "llm_model": "gemini-1.5-pro",
+            }
+        )
+
+    assert _status(excinfo) == 400
+    assert "llm_model" in _body(excinfo)["error"]
+
+
+def test_parse_start_request_silences_legacy_fields_for_ai_model_ref(app_ctx):
+    req = mod._parse_start_request(
+        {
+            "simulation_id": VALID_SIM_ID,
+            "ai_model_ref": {
+                "provider_connection_id": "conn-x",
+                "model_id": "m-1",
+                "source": "explicit",
+            },
+        }
+    )
+
+    assert req.ai_model_ref is not None
+    assert req.llm_model_override is None
+    assert req.llm_runtime.enabled is False
+
+
+def test_parse_budget_config_rejects_invalid_budget(app_ctx):
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_budget_config({"budget": {"max_total_tokens": -5}})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"].startswith("budget ist ungültig")
+
+
+def test_parse_budget_config_returns_none_without_budget(app_ctx):
+    assert mod._parse_budget_config({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Startbarkeit
+# ---------------------------------------------------------------------------
+
+def test_ensure_startable_state_passes_ready_state_untouched(app_ctx):
+    manager = MagicMock()
+    state = _state(SimulationStatus.READY)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    assert mod._ensure_startable_state(manager, state, req) is False
+    manager._reset_to_ready.assert_not_called()
+
+
+def test_ensure_startable_state_rejects_unprepared_simulation(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod, "_check_simulation_prepared", lambda _sid: (False, {}))
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._ensure_startable_state(MagicMock(), _state(SimulationStatus.CREATED), req)
+
+    assert _status(excinfo) == 409
+    assert _body(excinfo)["code"] == "simulation_not_prepared"
+
+
+def test_ensure_startable_state_rejects_running_simulation_without_force(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod, "_check_simulation_prepared", lambda _sid: (True, {}))
+    runner = MagicMock()
+    runner.get_run_state.return_value = MagicMock(runner_status=MagicMock(value="running"))
+    monkeypatch.setattr(mod, "SimulationRunner", runner)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._ensure_startable_state(MagicMock(), _state(SimulationStatus.RUNNING), req)
+
+    assert _status(excinfo) == 409
+    assert _body(excinfo)["code"] == "simulation_already_running"
+    runner.stop_simulation.assert_not_called()
+
+
+def test_ensure_startable_state_force_restarts_running_simulation(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod, "_check_simulation_prepared", lambda _sid: (True, {}))
+    runner = MagicMock()
+    runner.get_run_state.return_value = MagicMock(runner_status=MagicMock(value="running"))
+    runner.cleanup_simulation_logs.return_value = {"success": True}
+    monkeypatch.setattr(mod, "SimulationRunner", runner)
+    manager = MagicMock()
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "force": True})
+
+    assert mod._ensure_startable_state(manager, _state(SimulationStatus.RUNNING), req) is True
+    runner.stop_simulation.assert_called_once_with(VALID_SIM_ID)
+    runner.cleanup_simulation_logs.assert_called_once_with(VALID_SIM_ID)
+    manager._reset_to_ready.assert_called_once()
+
+
+def test_stop_running_simulation_ignores_idle_runner(app_ctx, monkeypatch):
+    runner = MagicMock()
+    runner.get_run_state.return_value = None
+    monkeypatch.setattr(mod, "SimulationRunner", runner)
+
+    mod._stop_running_simulation(VALID_SIM_ID, force=False)
+
+    runner.stop_simulation.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Graph-Memory
+# ---------------------------------------------------------------------------
+
+def test_resolve_graph_memory_id_returns_none_when_disabled(app_ctx):
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    assert mod._resolve_graph_memory_id(_state(graph_id="graph-1"), req) is None
+
+
+def test_resolve_graph_memory_id_prefers_simulation_graph(app_ctx):
+    req = mod._parse_start_request(
+        {"simulation_id": VALID_SIM_ID, "enable_graph_memory_update": True}
+    )
+
+    assert mod._resolve_graph_memory_id(_state(graph_id="graph-1"), req) == "graph-1"
+
+
+def test_resolve_graph_memory_id_falls_back_to_project_graph(app_ctx, monkeypatch):
+    monkeypatch.setattr(
+        mod.ProjectManager, "get_project", staticmethod(lambda _pid: MagicMock(graph_id="graph-proj"))
+    )
+    req = mod._parse_start_request(
+        {"simulation_id": VALID_SIM_ID, "enable_graph_memory_update": True}
+    )
+
+    assert mod._resolve_graph_memory_id(_state(), req) == "graph-proj"
+
+
+def test_resolve_graph_memory_id_rejects_missing_graph(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_project", staticmethod(lambda _pid: None))
+    req = mod._parse_start_request(
+        {"simulation_id": VALID_SIM_ID, "enable_graph_memory_update": True}
+    )
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._resolve_graph_memory_id(_state(), req)
+
+    assert _status(excinfo) == 400
+    assert "graph_id" in _body(excinfo)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Provider-Prechecks
+# ---------------------------------------------------------------------------
+
+def test_precheck_runtime_provider_key_skips_without_override(app_ctx):
+    mod._precheck_runtime_provider_key(RuntimeLlmConfig())
+
+
+def test_precheck_runtime_provider_key_skips_when_key_present(app_ctx):
+    mod._precheck_runtime_provider_key(
+        RuntimeLlmConfig(provider="openai", api_key="sk-from-payload")
+    )
+
+
+def test_precheck_runtime_provider_key_rejects_remote_without_stored_key(app_ctx, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.map_runtime_provider_to_route_provider",
+        lambda _provider: "openai",
+    )
+    monkeypatch.setattr(
+        "app.services.llm_provider_registry.LlmProviderRegistry",
+        lambda: MagicMock(
+            get_providers=lambda: [
+                MagicMock(id="openai", type="openai", base_url="https://api.openai.com/v1")
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.secret_resolver.SecretResolver",
+        lambda: MagicMock(get_api_key=lambda _pid, _ptype: None),
+    )
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._precheck_runtime_provider_key(RuntimeLlmConfig(provider="openai"))
+
+    assert _status(excinfo) == 422
+    assert "provider_override" in _body(excinfo)["error"]
+
+
+def test_precheck_runtime_provider_key_allows_local_endpoint(app_ctx, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.llm_routing_seed.map_runtime_provider_to_route_provider",
+        lambda _provider: "ollama",
+    )
+    monkeypatch.setattr(
+        "app.services.llm_provider_registry.LlmProviderRegistry",
+        lambda: MagicMock(
+            get_providers=lambda: [
+                MagicMock(id="ollama", type="openai_compatible", base_url="http://localhost:11434/v1")
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.secret_resolver.SecretResolver",
+        lambda: MagicMock(get_api_key=lambda _pid, _ptype: None),
+    )
+
+    mod._precheck_runtime_provider_key(RuntimeLlmConfig(provider="ollama"))
+
+
+def test_precheck_ai_model_ref_skips_when_absent(app_ctx):
+    mod._precheck_ai_model_ref(None)
+
+
+def test_precheck_ai_model_ref_maps_value_error_to_422(app_ctx, monkeypatch):
+    def _raise(_ref):
+        raise ValueError("connection disabled")
+
+    monkeypatch.setattr("app.services.llm_routing_seed.prevalidate_ai_model_ref", _raise)
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._precheck_ai_model_ref(MagicMock(name="AiModelRef"))
+
+    assert _status(excinfo) == 422
+    assert _body(excinfo)["error"] == "connection disabled"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Run-Registrierung
+# ---------------------------------------------------------------------------
+
+def test_register_start_run_creates_run_and_seeds_routing(app_ctx, monkeypatch):
+    registry = MagicMock()
+    registry.create_run.return_value = {"run_id": "run-1"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
+    monkeypatch.setattr(mod, "_simulation_resume_capability", lambda _sid, _state: {"resumable": False})
+    seed = MagicMock()
+    monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
+    applied = {}
+    monkeypatch.setattr(
+        mod,
+        "_apply_budget_to_simulation",
+        lambda sid, rid, budget, _fn: applied.update(sid=sid, rid=rid, budget=budget),
+    )
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "platform": "reddit"})
+
+    run_record = mod._register_start_run(req, _state(graph_id="graph-1"))
+
+    assert run_record == {"run_id": "run-1"}
+    create_kwargs = registry.create_run.call_args.kwargs
+    assert create_kwargs["run_type"] == "simulation_run"
+    assert create_kwargs["entity_id"] == VALID_SIM_ID
+    assert create_kwargs["metadata"]["platform"] == "reddit"
+    assert seed.call_args.args == ("run-1", "simulation_rounds")
+    assert applied == {"sid": VALID_SIM_ID, "rid": "run-1", "budget": None}
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — Routen-Auflösung
+# ---------------------------------------------------------------------------
+
+def _resolved_route(base_url="https://api.openai.com/v1"):
+    return ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized=base_url,
+        routing_version=1,
+        provider_options={},
+    )
+
+
+def _patch_router(monkeypatch, route):
+    router = MagicMock()
+    router.resolve.return_value = route
+    router.lock_stage.return_value = route
+    monkeypatch.setattr(mod, "StageModelRouter", lambda _run_id: router)
+    return router
+
+
+def test_resolve_start_route_locks_stage_and_returns_key(app_ctx, monkeypatch):
+    route = _resolved_route()
+    router = _patch_router(monkeypatch, route)
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: "sk-bound")
+
+    resolved, api_key = mod._resolve_start_route("run-1", RuntimeLlmConfig())
+
+    assert resolved is route
+    assert api_key == "sk-bound"
+    router.lock_stage.assert_called_once_with("simulation_rounds", route)
+
+
+def test_resolve_start_route_marks_run_failed_when_key_missing(app_ctx, monkeypatch):
+    _patch_router(monkeypatch, _resolved_route())
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
+    registry = MagicMock()
+    monkeypatch.setattr(mod, "run_registry", registry)
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._resolve_start_route("run-1", RuntimeLlmConfig())
+
+    assert _status(excinfo) == 422
+    assert registry.update_run.call_args.kwargs["status"] == "failed"
+
+
+def test_resolve_start_route_allows_local_endpoint_without_key(app_ctx, monkeypatch):
+    route = _resolved_route(base_url="http://localhost:11434/v1")
+    _patch_router(monkeypatch, route)
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
+
+    resolved, api_key = mod._resolve_start_route("run-1", RuntimeLlmConfig())
+
+    assert resolved is route
+    assert api_key is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — Config-Overrides
+# ---------------------------------------------------------------------------
+
+def test_apply_route_to_simulation_config_skips_without_overrides(app_ctx, monkeypatch):
+    store = MagicMock()
+    monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+
+    mod._apply_route_to_simulation_config(req, _resolved_route())
+
+    store.read_json.assert_not_called()
+    store.write_json.assert_not_called()
+
+
+def test_apply_route_to_simulation_config_writes_simulation_hours(app_ctx, monkeypatch):
+    store = MagicMock()
+    store.read_json.return_value = {"time_config": {"total_simulation_hours": 24}}
+    monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
+
+    mod._apply_route_to_simulation_config(req, _resolved_route())
+
+    written = store.write_json.call_args.args[2]
+    assert written["time_config"]["total_simulation_hours"] == 72
+
+
+def test_apply_route_to_simulation_config_rejects_missing_config(app_ctx, monkeypatch):
+    store = MagicMock()
+    store.read_json.return_value = None
+    monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._apply_route_to_simulation_config(req, _resolved_route())
+
+    assert _status(excinfo) == 404
+    assert _body(excinfo)["code"] == "simulation_not_prepared"
+
+
+def test_apply_route_to_simulation_config_writes_model_for_ai_model_ref(app_ctx, monkeypatch):
+    store = MagicMock()
+    store.read_json.return_value = {"llm_model": "stale-model"}
+    monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    req = mod._parse_start_request(
+        {
+            "simulation_id": VALID_SIM_ID,
+            "ai_model_ref": {
+                "provider_connection_id": "conn-x",
+                "model_id": "m-1",
+                "source": "explicit",
+            },
+        }
+    )
+
+    mod._apply_route_to_simulation_config(req, _resolved_route())
+
+    written = store.write_json.call_args.args[2]
+    assert written["llm_model"] == "gpt-4o"
+    assert written["llm_base_url"] == "https://api.openai.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — Response
+# ---------------------------------------------------------------------------
+
+def test_build_start_response_carries_applied_overrides(app_ctx):
+    req = mod._parse_start_request(
+        {
+            "simulation_id": VALID_SIM_ID,
+            "max_rounds": 4,
+            "simulation_days": 2,
+            "enable_graph_memory_update": True,
+        }
+    )
+    run_state = MagicMock(to_dict=MagicMock(return_value={"simulation_id": VALID_SIM_ID}))
+
+    payload = mod._build_start_response(req, run_state, "run-1", "graph-1", True)
+
+    assert payload == {
+        "simulation_id": VALID_SIM_ID,
+        "max_rounds_applied": 4,
+        "simulation_days_applied": 2,
+        "graph_memory_update_enabled": True,
+        "force_restarted": True,
+        "run_id": "run-1",
+        "graph_id": "graph-1",
+    }
+
+
+def test_build_start_response_omits_unset_overrides(app_ctx):
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
+    run_state = MagicMock(to_dict=MagicMock(return_value={"simulation_id": VALID_SIM_ID}))
+
+    payload = mod._build_start_response(req, run_state, "run-1", None, False)
+
+    assert "max_rounds_applied" not in payload
+    assert "simulation_days_applied" not in payload
+    assert "graph_id" not in payload
+    assert payload["graph_memory_update_enabled"] is False

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4385 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4429 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Schließt #1079.

## Was

`start_simulation` war ein 361-Zeilen-Handler mit radon-Rang **F (cc 68)** — 68 linear unabhängige Pfade im Einstiegspunkt jedes Simulationslaufs. Der Handler ist jetzt ein Orchestrator ohne eigene Verzweigungslogik; jede fachliche Phase ist eine eigene, einzeln testbare Funktion:

| Phase | Funktion |
|---|---|
| Validierung | `_parse_start_request` (+ `_parse_bounded_int`, `_parse_ai_model_ref`, `_parse_budget_config`) |
| Startbarkeit / Force-Restart | `_ensure_startable_state` (+ `_stop_running_simulation`) |
| Graph-Memory | `_resolve_graph_memory_id` |
| Provider-Prechecks | `_precheck_runtime_provider_key`, `_precheck_ai_model_ref` |
| Run-Registrierung | `_register_start_run` |
| Routen-Auflösung | `_resolve_start_route` |
| Config-Overrides | `_apply_route_to_simulation_config` (+ `_has_config_overrides`) |
| Antwort | `_build_start_response` |

## Kein Verhaltenswechsel

Die Phasen lehnen über `_StartRejected` mit einer **fertig gebauten** `json_error`-Response ab. Status-Code, Fehlercode und Meldung bleiben dadurch wortgleich, statt neu formuliert zu werden. Die Prüfreihenfolge der Validierung ist unverändert — sie entscheidet bei mehreren fehlerhaften Feldern, welche Meldung der Aufrufer sieht.

## Akzeptanzkriterien

- [x] `start_simulation` erreicht radon-Rang C oder besser — die Funktion taucht bei `radon cc --min C` nicht mehr auf.
- [x] Jede extrahierte Phase hat mindestens einen eigenen Test (41 neue Tests in `tests/api/test_simulation_start_phases.py`).
- [x] Kein Verhaltenswechsel an der HTTP-Schnittstelle — die 96 bestehenden API-Tests des Start-Endpunkts laufen unverändert grün.
- [x] Allowlist-Eintrag `app/api/simulation_run.py::start_simulation` entfernt.

## Gate

`bash scripts/pre-push-gate.sh backend` — grün (3887 passed, 3 skipped).

Nebenbefund, **nicht** in diesem PR behoben: `SimulationRunner.start_simulation` hat implizit-optionale Annotationen (`max_rounds: int = None`, `graph_id: str = None`). mypy stört sich nicht daran, strengere Checker schon. Eigene Datei, eigener Scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Verbesserungen**
  - Der Start von Simulationen verarbeitet Eingaben und Konfigurationen nun konsistenter.
  - Modell-, Budget- und Laufzeitparameter werden umfassender validiert und verständlicher abgelehnt.
  - Fehlende API-Schlüssel führen zuverlässig zu einem fehlgeschlagenen Simulationslauf mit passender Fehlermeldung.
  - Antworten beim Simulationsstart enthalten konsistent den aktuellen Laufstatus und angewendete Einstellungen.

- **Tests**
  - Die verschiedenen Phasen des Simulationsstarts werden umfassend getestet, einschließlich Neustarts, Provider-Prüfungen, Routing und Fehlerfällen.

- **Dokumentation**
  - Die dokumentierte Anzahl der Backend-Tests wurde aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->