### PR TITLE
refactor(api): prepare_simulation in Phasen zerlegen (#1080)

### DIFF
--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -3,7 +3,8 @@ Preparation-related simulation API routes split from the main module.
 """
 
 import os
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from flask import request
 from pydantic import ValidationError
@@ -38,6 +39,11 @@ from .simulation_common import (
 
 
 from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
+
+if TYPE_CHECKING:  # pragma: no cover — nur für Typprüfung
+    from ..contracts.ai_provider_contract import AiModelRef
+    from ..contracts.run_budget_contract import RunBudgetConfig
+    from ..services.llm_runtime import RuntimeLlmConfig
 
 
 def _parse_quota_plan(data: dict) -> Optional[PersonaQuotaPlan]:
@@ -195,50 +201,109 @@ def _check_simulation_prepared(simulation_id: str) -> tuple:
         return False, {"reason": f"Failed to read state file: {str(exc)}"}
 
 
-@simulation_bp.route('/prepare', methods=['POST'])
-@handle_api_errors(log_prefix="Failed to start preparation task")
-def prepare_simulation():
-    """Prepare a simulation environment as an async task."""
-    from ..models.task import TaskManager, TaskStatus
+class _PrepareRejected(Exception):
+    """Bricht eine Prepare-Phase mit einer fertig gebauten Fehler-Response ab.
 
-    data = request.get_json() or {}
+    Die Phasen unterhalb von :func:`prepare_simulation` sind einzeln testbar
+    und müssen ihren Ablehnungsfall deshalb selbst formulieren können. Sie
+    tragen die bereits gebaute ``json_error``-Response, damit Status-Code,
+    Fehlercode und Meldung wortgleich das bleiben, was der monolithische
+    Handler vorher zurückgegeben hat (#1080).
+    """
 
+    def __init__(self, response: Any) -> None:
+        super().__init__("simulation prepare rejected")
+        self.response = response
+
+
+@dataclass(frozen=True)
+class _PrepareRequest:
+    """Validierte Eingaben eines ``POST /api/simulation/prepare``.
+
+    Interner Parameter-Container zwischen den Prepare-Phasen, **kein**
+    API-Vertrag: die Wire-Validierung bleibt feldweise in den Parse-Phasen.
+    """
+
+    simulation_id: str
+    ai_model_ref: "AiModelRef | None"
+    budget_config: "RunBudgetConfig | None"
+    force_regenerate: bool
+
+
+@dataclass(frozen=True)
+class _PrepareRouting:
+    """Ergebnis der Routing-Auflösung (Profil, Modell-Override, Runtime)."""
+
+    llm_model_override: "str | None"
+    llm_runtime: "RuntimeLlmConfig"
+    routed_profile_id: "str | None"
+    client_requested_override: bool
+
+
+@dataclass(frozen=True)
+class _PrepareInputs:
+    """Fachliche Eingaben des Vorbereitungslaufs jenseits des Routings."""
+
+    simulation_requirement: str
+    document_text: str
+    entity_types: Any
+    use_llm_for_profiles: Any
+    parallel_profile_count: Any
+    max_agents: "int | None"
+    quota_plan: Optional[PersonaQuotaPlan]
+    agent_language_override: "str | None"
+
+
+def _parse_prepare_identity(data: "dict[str, Any]") -> "tuple[str, AiModelRef | None]":
+    """Phase 1a — ``simulation_id`` und optionale ``ai_model_ref`` validieren.
+
+    Eine explizite Ref ist die alleinige Routing-Quelle und darf deshalb nicht
+    mit Legacy-Feldern kombiniert werden (Issue #817).
+    """
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=400,
-            message="Please provide simulation_id",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message="Please provide simulation_id",
+            )
         )
 
     if not validate_simulation_id(simulation_id):
-        return json_error(
-            ApiErrorCode.INVALID_ID,
-            status=400,
-            message="Invalid simulation_id format",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.INVALID_ID,
+                status=400,
+                message="Invalid simulation_id format",
+            )
         )
 
-    ai_model_ref = None
     raw_ai_model_ref = data.get("ai_model_ref")
-    if raw_ai_model_ref is not None:
-        from ..contracts.ai_provider_contract import AiModelRef
+    if raw_ai_model_ref is None:
+        return simulation_id, None
 
-        try:
-            ai_model_ref = AiModelRef.model_validate(raw_ai_model_ref)
-        except ValidationError:
-            return json_error(
+    from ..contracts.ai_provider_contract import AiModelRef
+
+    try:
+        ai_model_ref = AiModelRef.model_validate(raw_ai_model_ref)
+    except ValidationError:
+        raise _PrepareRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message="ai_model_ref ist ungültig",
             )
+        ) from None
 
-        conflicting = [
-            key
-            for key in ("llm_model", "llm_profile_id", "llm_provider", "llm_runtime")
-            if data.get(key)
-        ]
-        if conflicting:
-            return json_error(
+    conflicting = [
+        key
+        for key in ("llm_model", "llm_profile_id", "llm_provider", "llm_runtime")
+        if data.get(key)
+    ]
+    if conflicting:
+        raise _PrepareRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message=(
@@ -246,80 +311,121 @@ def prepare_simulation():
                     "kombiniert werden"
                 ),
             )
-
-    manager = SimulationManager()
-    state = manager.get_simulation(simulation_id)
-    if not state:
-        return json_error(
-            ApiErrorCode.NOT_FOUND,
-            status=404,
-            message=f"Simulation does not exist: {simulation_id}",
         )
+    return simulation_id, ai_model_ref
 
-    # Run-Budget (Issue #764): optionale Limits für den Prepare-Run.
-    budget_config = None
+
+def _parse_prepare_budget(data: "dict[str, Any]") -> "RunBudgetConfig | None":
+    """Phase 1b — Run-Budget (Issue #764): optionale Limits für den Prepare-Run."""
     raw_budget = data.get('budget')
-    if raw_budget is not None:
-        from ..contracts.run_budget_contract import RunBudgetConfig
+    if raw_budget is None:
+        return None
 
-        try:
-            budget_config = RunBudgetConfig.model_validate(raw_budget)
-        except ValidationError:
-            return json_error(
+    from ..contracts.run_budget_contract import RunBudgetConfig
+
+    try:
+        return RunBudgetConfig.model_validate(raw_budget)
+    except ValidationError:
+        raise _PrepareRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message="budget ist ungültig",
             )
+        ) from None
 
-    force_regenerate = data.get('force_regenerate', False)
 
-    # Project einmalig laden — wird sowohl für den P5.3-Profil-Fallback als
-    # auch für die Anforderungs-Validierung (simulation_requirement) und das
-    # nachfolgende Lesen weiterer Felder benötigt (Gemini-MEDIUM auf PR #528:
-    # vorher wurde derselbe Datensatz zwei Mal aus dem ProjectManager geholt).
+def _load_prepare_project(state):
+    """Projekt einmalig laden — für Profil-Fallback, Anforderung und Metadaten.
+
+    (Gemini-MEDIUM auf PR #528: vorher wurde derselbe Datensatz zwei Mal aus
+    dem ProjectManager geholt.)
+    """
     project = ProjectManager.get_project(state.project_id)
     if not project:
-        return json_error(
-            ApiErrorCode.NOT_FOUND,
-            status=404,
-            message=f"Project does not exist: {state.project_id}",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.NOT_FOUND,
+                status=404,
+                message=f"Project does not exist: {state.project_id}",
+            )
         )
+    return project
 
-    # Profil-Routing (Issue #888). `llm_profile_id` ist eine Routing-Anweisung,
-    # kein Fallback-Unterdrücker — analog graph.py / report.py, wo das Feld
-    # ebenfalls echtes Routing auslöst.
-    #
-    # Vorher kehrte das Feld seine eigene Absicht um: ein mitgeschicktes
-    # `llm_profile_id` übersprang den P5.3-Fallback, ohne selbst irgendetwas
-    # aufzulösen (`expand_profile_in_data` reagiert nur auf ein `llm_model` mit
-    # `profile:`-Präfix). Der Standardfall — Projekt hat ein Profil, User lässt
-    # die Modellauswahl auf "default" — landete damit still im
-    # Server-Default-Modell.
-    #
-    # Das Profil wird bewusst NICHT hier zu `llm_model` expandiert, sondern als
-    # `llm_profile_id` an `seed_run_stage_routing` durchgereicht. Dessen
-    # Profil-Branch löst die aktivierte ProviderConnection auf und koppelt sie an
-    # deren gebundenes Secret (SSoT, Issue #817); die lokale Expansion würde
-    # stattdessen Endpoint und Key aus dem Legacy-Profil einbrennen und damit
-    # nach einer Connection- oder Secret-Rotation auf veraltete Credentials
-    # zeigen. Ein unauflösbares Profil wirft dort `ValueError` → HTTP 400 über
-    # `@handle_api_errors`, statt mit dem literalen Modellnamen `profile:<id>`
-    # in die Queue zu laufen.
-    #
-    # `default` ist die UI-Platzhalterwahl (`useEnvForm.effectiveModel()` liefert
-    # dafür `null`) und zählt deshalb nicht als explizite Modellwahl.
-    _data_profile = (data.get('llm_profile_id') or '').strip() or None
-    _project_profile = (getattr(project, 'llm_profile_id', None) or '').strip() or None
-    _data_model = (data.get('llm_model') or '').strip() or None
-    explicit_model_override = bool(_data_model and _data_model.lower() != 'default')
-    # Vor der Expansion festhalten: `expand_profile_in_data` schreibt einen
-    # `llm_provider`-Block aus dem Profil (Provider/Key/Base-URL) und würde
-    # `llm_runtime.enabled` sonst ununterscheidbar von einem echten
-    # Client-Provider-Override machen.
-    explicit_runtime_request = bool(data.get('llm_provider'))
+
+@dataclass(frozen=True)
+class _ClientChoice:
+    """Was der Client an Routing *explizit* gewählt hat.
+
+    Wird vor der Profil-Expansion festgehalten: ``expand_profile_in_data``
+    schreibt einen `llm_provider`-Block aus dem Profil (Provider/Key/Base-URL)
+    und würde `llm_runtime.enabled` sonst ununterscheidbar von einem echten
+    Client-Provider-Override machen.
+    """
+
+    data_profile: "str | None"
+    project_profile: "str | None"
+    explicit_model_override: bool
+    explicit_runtime_request: bool
+
+    @property
+    def explicit_profile_override(self) -> bool:
+        return bool(self.data_profile and self.data_profile != self.project_profile)
+
+
+def _read_client_choice(data: "dict[str, Any]", project) -> _ClientChoice:
+    """Explizite Client-Wahl aus Body und Projekt lesen.
+
+    `default` ist die UI-Platzhalterwahl (`useEnvForm.effectiveModel()` liefert
+    dafür `null`) und zählt deshalb nicht als explizite Modellwahl.
+    """
+    data_profile = (data.get('llm_profile_id') or '').strip() or None
+    project_profile = (getattr(project, 'llm_profile_id', None) or '').strip() or None
+    data_model = (data.get('llm_model') or '').strip() or None
+    return _ClientChoice(
+        data_profile=data_profile,
+        project_profile=project_profile,
+        explicit_model_override=bool(data_model and data_model.lower() != 'default'),
+        explicit_runtime_request=bool(data.get('llm_provider')),
+    )
+
+
+def _resolve_prepare_routing(
+    data: "dict[str, Any]", project, ai_model_ref: "AiModelRef | None"
+) -> _PrepareRouting:
+    """Phase 2 — Profil-, Modell- und Runtime-Routing auflösen.
+
+    Profil-Routing (Issue #888). `llm_profile_id` ist eine Routing-Anweisung,
+    kein Fallback-Unterdrücker — analog graph.py / report.py, wo das Feld
+    ebenfalls echtes Routing auslöst.
+
+    Vorher kehrte das Feld seine eigene Absicht um: ein mitgeschicktes
+    `llm_profile_id` übersprang den P5.3-Fallback, ohne selbst irgendetwas
+    aufzulösen (`expand_profile_in_data` reagiert nur auf ein `llm_model` mit
+    `profile:`-Präfix). Der Standardfall — Projekt hat ein Profil, User lässt
+    die Modellauswahl auf "default" — landete damit still im
+    Server-Default-Modell.
+
+    Das Profil wird bewusst NICHT hier zu `llm_model` expandiert, sondern als
+    `llm_profile_id` an `seed_run_stage_routing` durchgereicht. Dessen
+    Profil-Branch löst die aktivierte ProviderConnection auf und koppelt sie an
+    deren gebundenes Secret (SSoT, Issue #817); die lokale Expansion würde
+    stattdessen Endpoint und Key aus dem Legacy-Profil einbrennen und damit
+    nach einer Connection- oder Secret-Rotation auf veraltete Credentials
+    zeigen. Ein unauflösbares Profil wirft dort `ValueError` → HTTP 400 über
+    `@handle_api_errors`, statt mit dem literalen Modellnamen `profile:<id>`
+    in die Queue zu laufen.
+
+    Die explizite Client-Wahl selbst liest :func:`_read_client_choice`.
+    """
+    choice = _read_client_choice(data, project)
     # Request-Profil schlägt Projekt-Profil (Single-Run-Override), beide schlagen
     # das Server-Default-Modell. Eine explizite Modellwahl schlägt alles.
-    routed_profile_id = None if explicit_model_override else (_data_profile or _project_profile)
+    routed_profile_id = (
+        None
+        if choice.explicit_model_override
+        else (choice.data_profile or choice.project_profile)
+    )
     if ai_model_ref is not None:
         # Eine explizite Ref ist die alleinige Routing-Quelle: kein Legacy-
         # Profil, kein Runtime-Override und kein Projektprofil-Fallback.
@@ -337,15 +443,13 @@ def prepare_simulation():
         try:
             llm_runtime = parse_runtime_llm_config(data)
         except ValueError as exc:
-            return json_error(
-                ApiErrorCode.VALIDATION_FAILED,
-                status=400,
-                message=str(exc),
-            )
-    logger.info(
-        f"Start processing /prepare Request: simulation_id={simulation_id}, force_regenerate={force_regenerate}",
-        extra={'simulation_id': simulation_id},
-    )
+            raise _PrepareRejected(
+                json_error(
+                    ApiErrorCode.VALIDATION_FAILED,
+                    status=400,
+                    message=str(exc),
+                )
+            ) from exc
 
     # Der "bereits vorbereitet"-Kurzschluss hängt bewusst an der *expliziten*
     # Client-Wahl, nicht an `llm_model_override`/`llm_runtime.enabled` (Issue
@@ -358,42 +462,53 @@ def prepare_simulation():
     # zurück und die Personas blieben die des vorherigen Modells — im Widerspruch
     # zur Präzedenz "Request-Profil schlägt Projekt-Profil". Dasselbe Profil
     # erneut zu schicken bleibt der billige Revisit.
-    explicit_profile_override = bool(_data_profile and _data_profile != _project_profile)
-    client_requested_override = (
-        explicit_model_override
-        or explicit_profile_override
-        or (llm_runtime.enabled and explicit_runtime_request)
+    client_requested_override = bool(
+        choice.explicit_model_override
+        or choice.explicit_profile_override
+        or (llm_runtime.enabled and choice.explicit_runtime_request)
         or ai_model_ref is not None
     )
-    if not force_regenerate and not client_requested_override:
-        logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
-        is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
-        logger.debug(f"Check result: is_prepared={is_prepared}, prepare_info={prepare_info}")
-        if is_prepared:
-            logger.info(f"Simulation {simulation_id} has preparation complete, no need to regenerate")
-            return json_success({
-                "simulation_id": simulation_id,
-                "status": "ready",
-                "message": "Preparation already completed, no need to regenerate",
-                "already_prepared": True,
-                "prepare_info": prepare_info,
-            })
-        logger.info(f"Simulation {simulation_id} has no preparation complete, preparing now")
+    return _PrepareRouting(
+        llm_model_override=llm_model_override,
+        llm_runtime=llm_runtime,
+        routed_profile_id=routed_profile_id,
+        client_requested_override=client_requested_override,
+    )
 
+
+def _already_prepared_response(simulation_id: str):
+    """Phase 3 — Kurzschluss, wenn alle Vorbereitungs-Artefakte schon liegen.
+
+    Gibt ``None`` zurück, wenn regulär vorbereitet werden muss.
+    """
+    logger.debug(f"Check simulation {simulation_id} Is preparation complete...")
+    is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
+    logger.debug(f"Check result: is_prepared={is_prepared}, prepare_info={prepare_info}")
+    if not is_prepared:
+        logger.info(f"Simulation {simulation_id} has no preparation complete, preparing now")
+        return None
+
+    logger.info(f"Simulation {simulation_id} has preparation complete, no need to regenerate")
+    return json_success({
+        "simulation_id": simulation_id,
+        "status": "ready",
+        "message": "Preparation already completed, no need to regenerate",
+        "already_prepared": True,
+        "prepare_info": prepare_info,
+    })
+
+
+def _collect_prepare_inputs(data: "dict[str, Any]", project, state) -> _PrepareInputs:
+    """Phase 4 — fachliche Eingaben des Laufs einsammeln und validieren."""
     simulation_requirement = project.simulation_requirement or ""
     if not simulation_requirement:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=400,
-            message="Project missing simulation requirement description (simulation_requirement)",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message="Project missing simulation requirement description (simulation_requirement)",
+            )
         )
-
-    document_text = ProjectManager.get_extracted_text(state.project_id) or ""
-    entity_types_list = data.get('entity_types')
-    use_llm_for_profiles = data.get('use_llm_for_profiles', True)
-    parallel_profile_count = data.get('parallel_profile_count') or None
-
-    max_agents = _resolve_max_agents_with_floor(data.get("max_agents"))
 
     # Sub-Slice 20a: optional PersonaQuotaPlan aus Body. ValidationError →
     # HTTP 400 mit Pydantic-Fehlermessage; sonst wird der Plan an den
@@ -403,24 +518,42 @@ def prepare_simulation():
     try:
         quota_plan = _parse_quota_plan(data)
     except (ValidationError, ValueError, TypeError) as exc:
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=400,
-            message=f"Invalid quota_plan: {exc}",
-        )
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=f"Invalid quota_plan: {exc}",
+            )
+        ) from exc
 
     agent_language_override = (data.get('language') or '').strip().lower() or None
     if agent_language_override and agent_language_override not in ('de', 'en'):
         agent_language_override = None
 
-    storage = get_simulation_storage()
+    return _PrepareInputs(
+        simulation_requirement=simulation_requirement,
+        document_text=ProjectManager.get_extracted_text(state.project_id) or "",
+        entity_types=data.get('entity_types'),
+        use_llm_for_profiles=data.get('use_llm_for_profiles', True),
+        parallel_profile_count=data.get('parallel_profile_count') or None,
+        max_agents=_resolve_max_agents_with_floor(data.get("max_agents")),
+        quota_plan=quota_plan,
+        agent_language_override=agent_language_override,
+    )
 
+
+def _preview_entity_counts(state, storage, inputs: _PrepareInputs) -> None:
+    """Phase 5 — Entitätenzahl für die Antwort vorab schätzen (best effort).
+
+    Fehler sind hier bewusst nicht fatal: der Hintergrund-Task liest dieselbe
+    Menge erneut.
+    """
     try:
         logger.info(f"Synchronously get entity count: graph_id={state.graph_id}")
         reader = EntityReader(storage)
         filtered_preview = reader.filter_defined_entities(
             graph_id=state.graph_id,
-            defined_entity_types=entity_types_list,
+            defined_entity_types=inputs.entity_types,
             enrich_with_edges=False,
         )
         # Issue #1034: derselbe Eignungsfilter wie im Laufpfad
@@ -442,8 +575,8 @@ def prepare_simulation():
                 for entity in filtered_preview.entities
             }
         preview_count = filtered_preview.filtered_count
-        if max_agents is not None and max_agents > 0:
-            preview_count = min(preview_count, max_agents)
+        if inputs.max_agents is not None and inputs.max_agents > 0:
+            preview_count = min(preview_count, inputs.max_agents)
         state.entities_count = preview_count
         state.entity_types = list(filtered_preview.entity_types)
         logger.info(
@@ -456,29 +589,41 @@ def prepare_simulation():
             "Synchronous entity count failed (will retry in the background task): %s", exc
         )
 
-    task_manager = TaskManager()
-    if ai_model_ref is not None:
-        from ..services.llm_routing_seed import prevalidate_ai_model_ref
 
-        try:
-            prevalidate_ai_model_ref(ai_model_ref)
-        except ValueError as exc:
-            return json_error(
+def _precheck_prepare_ai_model_ref(ai_model_ref: "AiModelRef | None") -> None:
+    """Phase 6a — Connection der expliziten ``AiModelRef`` vorab prüfen."""
+    if ai_model_ref is None:
+        return
+
+    from ..services.llm_routing_seed import prevalidate_ai_model_ref
+
+    try:
+        prevalidate_ai_model_ref(ai_model_ref)
+    except ValueError as exc:
+        raise _PrepareRejected(
+            json_error(
                 ApiErrorCode.VALIDATION_FAILED,
                 status=400,
                 message=str(exc),
             )
+        ) from exc
+
+
+def _register_prepare_run(
+    req: _PrepareRequest, state, routing: _PrepareRouting, task_manager
+) -> "tuple[dict[str, Any], str]":
+    """Phase 6b — Run-Record und Task für den Vorbereitungslauf anlegen."""
     run_record = run_registry.create_run(
         run_type="simulation_prepare",
-        entity_id=simulation_id,
+        entity_id=req.simulation_id,
         status="pending",
         progress=0,
         message="Simulation preparation queued",
         linked_ids={
-            "simulation_id": simulation_id,
+            "simulation_id": req.simulation_id,
             "project_id": state.project_id,
         },
-        artifacts=_simulation_run_artifacts(simulation_id),
+        artifacts=_simulation_run_artifacts(req.simulation_id),
         resume_capability={"available": True, "action": "restart", "label": "Restart preparation"},
         branch_label=state.branch_name,
         metadata={
@@ -488,76 +633,132 @@ def prepare_simulation():
             "root_simulation_id": state.root_simulation_id,
             "branch_name": state.branch_name,
             "branch_depth": state.branch_depth,
-            "llm_model": llm_model_override,
-            "llm_provider": llm_runtime.redacted_metadata() or None,
+            "llm_model": routing.llm_model_override,
+            "llm_provider": routing.llm_runtime.redacted_metadata() or None,
             # Budget-Config (Issue #764) — nur Limits, keine Secrets
-            **({"budget": budget_config.model_dump(mode="json")} if budget_config else {}),
+            **({"budget": req.budget_config.model_dump(mode="json")} if req.budget_config else {}),
         },
     )
     task_id = task_manager.create_task(
         task_type="simulation_prepare",
         metadata={
-            "simulation_id": simulation_id,
+            "simulation_id": req.simulation_id,
             "project_id": state.project_id,
             "run_id": run_record["run_id"],
         },
     )
-    if ai_model_ref is not None:
-        try:
-            seed_run_stage_routing(
-                run_record["run_id"],
-                "persona_generation",
-                llm_model_override=llm_model_override,
-                llm_runtime=llm_runtime,
-                llm_profile_id=routed_profile_id,
-                ai_model_ref=ai_model_ref,
-            )
-        except ValueError as exc:
-            routing_error = str(exc)
-            task_manager.fail_task(task_id, routing_error)
+    return run_record, task_id
 
-            persistence_error: Optional[Exception] = None
-            try:
-                updated_run = run_registry.update_run(
-                    run_record["run_id"],
-                    status="failed",
-                    message=routing_error,
-                    error=routing_error,
-                )
-            except Exception as update_exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
-                updated_run = None
-                persistence_error = update_exc
 
-            if updated_run is None:
-                logger.error(
-                    "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
-                    "failed nach AiModelRef-Routingfehler: %s",
-                    run_record["run_id"],
-                    task_id,
-                    persistence_error
-                    or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
-                )
-                return json_error(
-                    ApiErrorCode.INTERNAL_ERROR,
-                    status=500,
-                    message=(
-                        "Interner Fehler beim Markieren des Runs als fehlgeschlagen. "
-                        "Bitte erneut versuchen."
-                    ),
-                )
-            return json_error(
-                ApiErrorCode.VALIDATION_FAILED,
-                status=400,
-                message=routing_error,
+def _reject_and_fail_prepare_run(
+    run_record: "dict[str, Any]",
+    task_id: str,
+    task_manager,
+    message: str,
+    *,
+    status: int,
+    context: str,
+) -> _PrepareRejected:
+    """Run und Task als ``failed`` markieren und die Ablehnung bauen.
+
+    Issue #841: run_record und task_id existieren an den Aufrufstellen bereits —
+    ohne dieses Markieren bliebe der Datensatz dauerhaft als "pending" in der
+    Registry verwaist. Die Reihenfolge ist bewusst: ``fail_task()`` setzt intern
+    per ``sync_task()`` eine generische Task-Message ("Task failed") auf den Run
+    zurück — der detaillierte ``update_run()``-Aufruf muss deshalb zuletzt
+    laufen, sonst überschreibt ``sync_task()`` die Meldung.
+
+    Issue #844: ``update_run()`` liefert ``None``, wenn das Run-Manifest
+    zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception werfen
+    (``write_json_atomic`` ist ungeschützt). Beide Fälle dürfen NICHT wie eine
+    erfolgreich persistierte Ablehnung behandelt werden — sonst bleibt der Run
+    unbemerkt "pending" (siehe #841), obwohl der Client bereits eine scheinbar
+    abschließende Antwort erhalten hat. ``fail_task()`` selbst hat keine
+    prüfbare Fehlersemantik (siehe ``TaskManager.update_task``) und bleibt
+    daher best-effort.
+    """
+    task_manager.fail_task(task_id, message)
+
+    persistence_error: Optional[Exception] = None
+    try:
+        updated_run = run_registry.update_run(
+            run_record["run_id"], status="failed", message=message, error=message
+        )
+    except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
+        updated_run = None
+        persistence_error = exc
+
+    if updated_run is None:
+        logger.error(
+            "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
+            "failed %s: %s",
+            run_record["run_id"],
+            task_id,
+            context,
+            persistence_error
+            or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+        )
+        return _PrepareRejected(
+            json_error(
+                ApiErrorCode.INTERNAL_ERROR,
+                status=500,
+                message=(
+                    "Interner Fehler beim Markieren des Runs als fehlgeschlagen. "
+                    "Bitte erneut versuchen."
+                ),
             )
-    else:
+        )
+    return _PrepareRejected(
+        json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            status=status,
+            message=message,
+        )
+    )
+
+
+def _seed_prepare_routing(
+    run_record: "dict[str, Any]",
+    task_id: str,
+    task_manager,
+    routing: _PrepareRouting,
+    ai_model_ref: "AiModelRef | None",
+) -> None:
+    """Phase 7 — Stage-Routing für ``persona_generation`` seeden."""
+    if ai_model_ref is None:
         seed_run_stage_routing(
             run_record["run_id"],
             "persona_generation",
-            llm_model_override=llm_model_override,
-            llm_runtime=llm_runtime,
-            llm_profile_id=routed_profile_id,
+            llm_model_override=routing.llm_model_override,
+            llm_runtime=routing.llm_runtime,
+            llm_profile_id=routing.routed_profile_id,
         )
+        return
+
+    try:
+        seed_run_stage_routing(
+            run_record["run_id"],
+            "persona_generation",
+            llm_model_override=routing.llm_model_override,
+            llm_runtime=routing.llm_runtime,
+            llm_profile_id=routing.routed_profile_id,
+            ai_model_ref=ai_model_ref,
+        )
+    except ValueError as exc:
+        raise _reject_and_fail_prepare_run(
+            run_record,
+            task_id,
+            task_manager,
+            str(exc),
+            status=400,
+            context="nach AiModelRef-Routingfehler",
+        ) from exc
+
+
+def _resolve_prepare_route(
+    run_record: "dict[str, Any]", task_id: str, task_manager, llm_runtime
+):
+    """Phase 8 — Stage-Route auflösen, sperren und den API-Key bestimmen."""
     route_router = StageModelRouter(run_record["run_id"])
     resolved_route = route_router.resolve("persona_generation")
     route_router.lock_stage("persona_generation", resolved_route)
@@ -570,47 +771,13 @@ def prepare_simulation():
             "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
             "oder im Sitzungsfeld eingeben."
         )
-        # Issue #841: run_record und task_id existieren an dieser Stelle
-        # bereits (Zeilen 369/393) — ohne dieses Markieren bleibt der
-        # Datensatz dauerhaft als "pending" in der Registry verwaist.
-        # Reihenfolge ist bewusst: fail_task() setzt intern per sync_task()
-        # eine generische Task-Message ("Task failed") auf den Run zurück —
-        # der detaillierte update_run()-Aufruf muss deshalb zuletzt laufen,
-        # sonst überschreibt sync_task() die provider_override-Meldung.
-        task_manager.fail_task(task_id, guard_message)
-        # Issue #844: update_run() liefert None, wenn das Run-Manifest
-        # zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception
-        # werfen (write_json_atomic ist ungeschützt). Beide Fälle dürfen
-        # NICHT wie eine erfolgreich persistierte Ablehnung behandelt werden
-        # — sonst bleibt der Run unbemerkt "pending" (siehe #841), obwohl der
-        # Client bereits eine scheinbar abschließende 422-Antwort erhalten
-        # hat. fail_task() selbst hat keine prüfbare Fehlersemantik (siehe
-        # TaskManager.update_task) und bleibt daher best-effort.
-        persistence_error: Optional[Exception] = None
-        try:
-            updated_run = run_registry.update_run(
-                run_record["run_id"], status="failed", message=guard_message, error=guard_message
-            )
-        except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
-            updated_run = None
-            persistence_error = exc
-
-        if updated_run is None:
-            logger.error(
-                "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
-                "failed im Provider-Key-Guard: %s",
-                run_record["run_id"], task_id,
-                persistence_error or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
-            )
-            return json_error(
-                ApiErrorCode.INTERNAL_ERROR,
-                status=500,
-                message="Interner Fehler beim Markieren des Runs als fehlgeschlagen. Bitte erneut versuchen.",
-            )
-        return json_error(
-            ApiErrorCode.VALIDATION_FAILED,
+        raise _reject_and_fail_prepare_run(
+            run_record,
+            task_id,
+            task_manager,
+            guard_message,
             status=422,
-            message=guard_message,
+            context="im Provider-Key-Guard",
         )
 
     if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
@@ -620,11 +787,87 @@ def prepare_simulation():
         # ValueError wirft.
         resolved_api_key = LOCAL_NO_AUTH_API_KEY
 
-    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
+    return resolved_route, resolved_api_key
 
-    manager._set_status(state, SimulationStatus.PREPARING)
 
-    def run_prepare():
+def _build_progress_callback(task_manager, task_id: str) -> "Callable[..., None]":
+    """Fortschritts-Callback über die vier Vorbereitungs-Stages."""
+    stage_details: "dict[str, dict[str, Any]]" = {}
+
+    def progress_callback(stage, progress, message, **kwargs):
+        stage_weights = {
+            "reading": (0, 20),
+            "generating_profiles": (20, 70),
+            "generating_config": (70, 90),
+            "copying_scripts": (90, 100),
+        }
+
+        start, end = stage_weights.get(stage, (0, 100))
+        current_progress = int(start + (end - start) * progress / 100)
+
+        stage_names = {
+            "reading": "Read knowledge graph entities",
+            "generating_profiles": "GenerateAgentpersona",
+            "generating_config": "Generate simulation configuration",
+            "copying_scripts": "Prepare simulation scripts",
+        }
+
+        stage_index = list(stage_weights.keys()).index(stage) + 1 if stage in stage_weights else 1
+        total_stages = len(stage_weights)
+
+        stage_details[stage] = {
+            "stage_name": stage_names.get(stage, stage),
+            "stage_progress": progress,
+            "current": kwargs.get("current", 0),
+            "total": kwargs.get("total", 0),
+            "item_name": kwargs.get("item_name", ""),
+        }
+
+        detail = stage_details[stage]
+        progress_detail_data = {
+            "current_stage": stage,
+            "current_stage_name": stage_names.get(stage, stage),
+            "stage_index": stage_index,
+            "total_stages": total_stages,
+            "stage_progress": progress,
+            "current_item": detail["current"],
+            "total_items": detail["total"],
+            "item_description": message,
+        }
+
+        if detail["total"] > 0:
+            detailed_message = (
+                f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: "
+                f"{detail['current']}/{detail['total']} - {message}"
+            )
+        else:
+            detailed_message = f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: {message}"
+
+        task_manager.update_task(
+            task_id,
+            progress=current_progress,
+            message=detailed_message,
+            progress_detail=progress_detail_data,
+        )
+
+    return progress_callback
+
+
+def _make_prepare_job(
+    *,
+    manager,
+    task_manager,
+    task_id: str,
+    simulation_id: str,
+    inputs: _PrepareInputs,
+    storage,
+    llm_model: str,
+    effective_llm_runtime,
+) -> "Callable[[], None]":
+    """Phase 9 — den Hintergrund-Job bauen, der die Vorbereitung ausführt."""
+    from ..models.task import TaskStatus
+
+    def run_prepare() -> None:
         # Issue #1034: Der Collector gehört dem Task, nicht dem Service —
         # gleiches Muster wie im Graph-Build (``services/graph_build.py``).
         # Nur so überlebt ein stiller Teilausfall bis ins Task-Ergebnis;
@@ -638,78 +881,20 @@ def prepare_simulation():
                 message="Start preparing simulation environment...",
             )
 
-            stage_details = {}
-
-            def progress_callback(stage, progress, message, **kwargs):
-                stage_weights = {
-                    "reading": (0, 20),
-                    "generating_profiles": (20, 70),
-                    "generating_config": (70, 90),
-                    "copying_scripts": (90, 100),
-                }
-
-                start, end = stage_weights.get(stage, (0, 100))
-                current_progress = int(start + (end - start) * progress / 100)
-
-                stage_names = {
-                    "reading": "Read knowledge graph entities",
-                    "generating_profiles": "GenerateAgentpersona",
-                    "generating_config": "Generate simulation configuration",
-                    "copying_scripts": "Prepare simulation scripts",
-                }
-
-                stage_index = list(stage_weights.keys()).index(stage) + 1 if stage in stage_weights else 1
-                total_stages = len(stage_weights)
-
-                stage_details[stage] = {
-                    "stage_name": stage_names.get(stage, stage),
-                    "stage_progress": progress,
-                    "current": kwargs.get("current", 0),
-                    "total": kwargs.get("total", 0),
-                    "item_name": kwargs.get("item_name", ""),
-                }
-
-                detail = stage_details[stage]
-                progress_detail_data = {
-                    "current_stage": stage,
-                    "current_stage_name": stage_names.get(stage, stage),
-                    "stage_index": stage_index,
-                    "total_stages": total_stages,
-                    "stage_progress": progress,
-                    "current_item": detail["current"],
-                    "total_items": detail["total"],
-                    "item_description": message,
-                }
-
-                if detail["total"] > 0:
-                    detailed_message = (
-                        f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: "
-                        f"{detail['current']}/{detail['total']} - {message}"
-                    )
-                else:
-                    detailed_message = f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: {message}"
-
-                task_manager.update_task(
-                    task_id,
-                    progress=current_progress,
-                    message=detailed_message,
-                    progress_detail=progress_detail_data,
-                )
-
             result_state = manager.prepare_simulation(
                 simulation_id=simulation_id,
-                simulation_requirement=simulation_requirement,
-                document_text=document_text,
-                defined_entity_types=entity_types_list,
-                use_llm_for_profiles=use_llm_for_profiles,
-                progress_callback=progress_callback,
-                parallel_profile_count=parallel_profile_count,
+                simulation_requirement=inputs.simulation_requirement,
+                document_text=inputs.document_text,
+                defined_entity_types=inputs.entity_types,
+                use_llm_for_profiles=inputs.use_llm_for_profiles,
+                progress_callback=_build_progress_callback(task_manager, task_id),
+                parallel_profile_count=inputs.parallel_profile_count,
                 storage=storage,
-                llm_model=resolved_route.model,
+                llm_model=llm_model,
                 llm_runtime=effective_llm_runtime,
-                language=agent_language_override,
-                max_agents=max_agents,
-                quota_plan=quota_plan,
+                language=inputs.agent_language_override,
+                max_agents=inputs.max_agents,
+                quota_plan=inputs.quota_plan,
                 degradations=degradations,
             )
 
@@ -738,11 +923,18 @@ def prepare_simulation():
                 failed_state.error = str(exc)
                 manager._set_status(failed_state, SimulationStatus.FAILED)
 
-    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
-    from ..jobs import enqueue
-    enqueue("simulation_prepare", run_prepare)
+    return run_prepare
 
-    return json_success({
+
+def _build_prepare_response(
+    simulation_id: str,
+    task_id: str,
+    run_record: "dict[str, Any]",
+    state,
+    inputs: _PrepareInputs,
+) -> "dict[str, Any]":
+    """Phase 10 — Antwort-Payload des angestoßenen Vorbereitungslaufs."""
+    return {
         "simulation_id": simulation_id,
         "task_id": task_id,
         "run_id": run_record["run_id"],
@@ -757,10 +949,88 @@ def prepare_simulation():
         # auch `_phase_generate_profiles` im Laufpfad verwendet.
         "persona_target": compute_persona_target(
             state.entities_count,
-            max_agents=max_agents,
-            quota_plan=quota_plan,
+            max_agents=inputs.max_agents,
+            quota_plan=inputs.quota_plan,
         ).model_dump(mode="json"),
-    })
+    }
+
+
+@simulation_bp.route('/prepare', methods=['POST'])
+@handle_api_errors(log_prefix="Failed to start preparation task")
+def prepare_simulation():
+    """Prepare a simulation environment as an async task."""
+    from ..models.task import TaskManager
+
+    data = request.get_json() or {}
+    try:
+        simulation_id, ai_model_ref = _parse_prepare_identity(data)
+
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            raise _PrepareRejected(
+                json_error(
+                    ApiErrorCode.NOT_FOUND,
+                    status=404,
+                    message=f"Simulation does not exist: {simulation_id}",
+                )
+            )
+
+        req = _PrepareRequest(
+            simulation_id=simulation_id,
+            ai_model_ref=ai_model_ref,
+            budget_config=_parse_prepare_budget(data),
+            force_regenerate=data.get('force_regenerate', False),
+        )
+        project = _load_prepare_project(state)
+        routing = _resolve_prepare_routing(data, project, ai_model_ref)
+
+        logger.info(
+            f"Start processing /prepare Request: simulation_id={simulation_id}, "
+            f"force_regenerate={req.force_regenerate}",
+            extra={'simulation_id': simulation_id},
+        )
+
+        if not req.force_regenerate and not routing.client_requested_override:
+            already_prepared = _already_prepared_response(simulation_id)
+            if already_prepared is not None:
+                return already_prepared
+
+        inputs = _collect_prepare_inputs(data, project, state)
+        storage = get_simulation_storage()
+        _preview_entity_counts(state, storage, inputs)
+
+        task_manager = TaskManager()
+        _precheck_prepare_ai_model_ref(ai_model_ref)
+        run_record, task_id = _register_prepare_run(req, state, routing, task_manager)
+        _seed_prepare_routing(run_record, task_id, task_manager, routing, ai_model_ref)
+        resolved_route, resolved_api_key = _resolve_prepare_route(
+            run_record, task_id, task_manager, routing.llm_runtime
+        )
+    except _PrepareRejected as rejected:
+        return rejected.response
+
+    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
+
+    manager._set_status(state, SimulationStatus.PREPARING)
+
+    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
+    from ..jobs import enqueue
+    enqueue(
+        "simulation_prepare",
+        _make_prepare_job(
+            manager=manager,
+            task_manager=task_manager,
+            task_id=task_id,
+            simulation_id=simulation_id,
+            inputs=inputs,
+            storage=storage,
+            llm_model=resolved_route.model,
+            effective_llm_runtime=effective_llm_runtime,
+        ),
+    )
+
+    return json_success(_build_prepare_response(simulation_id, task_id, run_record, state, inputs))
 
 
 @simulation_bp.route('/prepare/status', methods=['POST'])

--- a/backend/radon-allowlist.txt
+++ b/backend/radon-allowlist.txt
@@ -3,13 +3,16 @@
 # Format: <rel-path>::<func>  (rel-path relativ zu backend/, func = radon-Ausgabe-Name)
 #
 # Gemessen: 2026-05-14, radon 6.0.1, radon cc --min C --no-assert -j app/
-# Anzahl Einträge: 30 (5 x Class F, 1 x Class E, 24 x Class D)
+# Anzahl Einträge bei dieser Messung: 30 (5 x Class F, 1 x Class E, 24 x Class D).
+# Seither entfallen, weil die Funktion zerlegt wurde:
+#   app/api/simulation_run.py::start_simulation (#1079)
+#   app/api/simulation_prepare.py::prepare_simulation (#1080)
 #
-# Top-5 nach Cyclomatic Complexity:
+# Top-5 nach Cyclomatic Complexity (Stand der Messung):
 #   F (cc=50)  app/services/evidence_migrations.py::migrate_v2_to_v3
 #   F (cc=44)  app/api/report.py::get_generate_status
 #   E (cc=38)  app/services/report_agent/workflow.py::generate_report
-#   E (cc=33)  app/api/simulation_run.py::start_simulation
+#   E (cc=33)  app/api/simulation_run.py::start_simulation — zerlegt (#1079)
 #   E (cc=33)  app/services/oasis_profile_generator.py::OasisProfileGenerator.generate_profiles_from_entities
 #
 # Refactor-Kandidaten (eigene Sub-Slices nötig):
@@ -31,7 +34,6 @@ app/utils/file_parser.py::FileParser._extract_from_pdf
 # nur Pfad neu. Refactoring der Funktionen selbst: #590.
 app/llm/client.py::LLMClient.chat_json
 app/api/simulation_profiles.py::add_simulation_profile
-app/api/simulation_prepare.py::prepare_simulation
 app/api/runs.py::_build_run_summary
 app/api/report.py::get_generate_status
 app/services/branching_service.py::create_branch
@@ -116,13 +118,13 @@ app/services/sim/process_manager.py::start_simulation
 #   D cc=24  app/services/report_agent/text_verification.py::verify_prose
 #   D cc=23  app/services/sim/monitor.py::monitor_simulation
 #
-# NICHT neu aufgenommen wurden die beiden Rang-F-Handler. Sie stehen bereits
-# seit 2026-05-14 weiter oben in dieser Datei (Zeilen 33/34), damals mit
-# E (cc=33) vermessen — inzwischen F (cc=68) bzw. F (cc=65). Die Allowlist
-# prueft nur, *ob* eine Funktion geduldet ist, nicht *wie stark* sie gewachsen
-# ist; dieser Zuwachs ist deshalb nie aufgefallen. Refactor-Auftrag:
-#   app/api/simulation_run.py::start_simulation      → https://github.com/arn0ld87/agora/issues/1079
-#   app/api/simulation_prepare.py::prepare_simulation → https://github.com/arn0ld87/agora/issues/1080
+# NICHT neu aufgenommen wurden die beiden Rang-F-Handler. Sie standen bereits
+# seit 2026-05-14 weiter oben in dieser Datei, damals mit E (cc=33) vermessen —
+# inzwischen F (cc=68) bzw. F (cc=65). Die Allowlist prueft nur, *ob* eine
+# Funktion geduldet ist, nicht *wie stark* sie gewachsen ist; dieser Zuwachs ist
+# deshalb nie aufgefallen. Refactor-Auftrag:
+#   app/api/simulation_run.py::start_simulation      → erledigt (#1079), Eintrag entfernt
+#   app/api/simulation_prepare.py::prepare_simulation → erledigt (#1080), Eintrag entfernt
 # Beide Issues schlagen dieselbe Zerlegung vor: Validierung, Routen-/Key-
 # Aufloesung, Budget-Preflight, Run-Registrierung, Prozessstart.
 app/api/graph_build.py::generate_ontology

--- a/backend/tests/api/test_simulation_prepare_phases.py
+++ b/backend/tests/api/test_simulation_prepare_phases.py
@@ -1,0 +1,710 @@
+"""Unit-Tests der Prepare-Phasen von ``POST /api/simulation/prepare`` (#1080).
+
+``prepare_simulation`` war ein ~560-Zeilen-Handler mit radon-Rang F (cc 65),
+inklusive der kompletten Hintergrund-Job-Closure. Er ist jetzt ein Orchestrator
+über einzeln testbare Phasen; diese Datei deckt jede Phase direkt ab. Die
+HTTP-Ebene bleibt in ``test_simulation_prepare_routing.py`` und den
+benachbarten Endpunkt-Tests abgedeckt.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_prepare as mod
+from app.contracts.llm_routing_contract import ResolvedRoute
+from app.services.llm_runtime import RuntimeLlmConfig
+from app.services.simulation_manager import SimulationStatus
+
+VALID_SIM_ID = "sim_0123456789ab"
+AI_MODEL_REF = {
+    "provider_connection_id": "conn-x",
+    "model_id": "m-1",
+    "source": "explicit",
+}
+
+
+@pytest.fixture
+def app_ctx():
+    """``json_error``/``json_success`` bauen echte Flask-Responses."""
+    app = Flask(__name__)
+    with app.test_request_context():
+        yield app
+
+
+@pytest.fixture(autouse=True)
+def _no_profile_expansion(monkeypatch):
+    """Profil-Expansion ist ein eigener Codepfad (Issue #888) und hier stumm."""
+    monkeypatch.setattr(
+        "app.utils.llm_profile_resolver.expand_profile_in_data", lambda _data: None
+    )
+
+
+def _status(excinfo) -> int:
+    return excinfo.value.response[1]
+
+
+def _body(excinfo) -> dict:
+    return excinfo.value.response[0].get_json()
+
+
+def _project(**overrides):
+    return SimpleNamespace(
+        llm_profile_id=overrides.get("llm_profile_id"),
+        simulation_requirement=overrides.get("simulation_requirement", "Requirement text"),
+    )
+
+
+def _state(**overrides):
+    return SimpleNamespace(
+        project_id=overrides.get("project_id", "proj-x"),
+        graph_id=overrides.get("graph_id", "graph-1"),
+        branch_name=None,
+        branch_depth=0,
+        source_simulation_id=None,
+        root_simulation_id=None,
+        entities_count=overrides.get("entities_count", 0),
+        entity_types=overrides.get("entity_types", []),
+        error=None,
+    )
+
+
+def _routing(**overrides) -> mod._PrepareRouting:
+    return mod._PrepareRouting(
+        llm_model_override=overrides.get("llm_model_override"),
+        llm_runtime=overrides.get("llm_runtime", RuntimeLlmConfig()),
+        routed_profile_id=overrides.get("routed_profile_id"),
+        client_requested_override=overrides.get("client_requested_override", False),
+    )
+
+
+def _inputs(**overrides) -> mod._PrepareInputs:
+    return mod._PrepareInputs(
+        simulation_requirement=overrides.get("simulation_requirement", "Requirement text"),
+        document_text=overrides.get("document_text", ""),
+        entity_types=overrides.get("entity_types"),
+        use_llm_for_profiles=overrides.get("use_llm_for_profiles", True),
+        parallel_profile_count=overrides.get("parallel_profile_count"),
+        max_agents=overrides.get("max_agents"),
+        quota_plan=overrides.get("quota_plan"),
+        agent_language_override=overrides.get("agent_language_override"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Validierung
+# ---------------------------------------------------------------------------
+
+def test_parse_prepare_identity_returns_id_without_ref(app_ctx):
+    assert mod._parse_prepare_identity({"simulation_id": VALID_SIM_ID}) == (VALID_SIM_ID, None)
+
+
+def test_parse_prepare_identity_requires_simulation_id(app_ctx):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._parse_prepare_identity({})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "Please provide simulation_id"
+
+
+def test_parse_prepare_identity_rejects_malformed_id(app_ctx):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._parse_prepare_identity({"simulation_id": "../etc/passwd"})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["code"] == "invalid_id"
+
+
+def test_parse_prepare_identity_rejects_invalid_ai_model_ref(app_ctx):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._parse_prepare_identity(
+            {"simulation_id": VALID_SIM_ID, "ai_model_ref": {"model_id": "only"}}
+        )
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "ai_model_ref ist ungültig"
+
+
+@pytest.mark.parametrize(
+    "legacy_field", ["llm_model", "llm_profile_id", "llm_provider", "llm_runtime"]
+)
+def test_parse_prepare_identity_rejects_legacy_combination(app_ctx, legacy_field):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._parse_prepare_identity(
+            {
+                "simulation_id": VALID_SIM_ID,
+                "ai_model_ref": AI_MODEL_REF,
+                legacy_field: "something",
+            }
+        )
+
+    assert _status(excinfo) == 400
+    assert legacy_field in _body(excinfo)["error"]
+
+
+def test_parse_prepare_identity_accepts_valid_ref(app_ctx):
+    simulation_id, ref = mod._parse_prepare_identity(
+        {"simulation_id": VALID_SIM_ID, "ai_model_ref": AI_MODEL_REF}
+    )
+
+    assert simulation_id == VALID_SIM_ID
+    assert ref is not None and ref.model_id == "m-1"
+
+
+def test_parse_prepare_budget_returns_none_without_budget(app_ctx):
+    assert mod._parse_prepare_budget({}) is None
+
+
+def test_parse_prepare_budget_rejects_invalid_budget(app_ctx):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._parse_prepare_budget({"budget": {"max_tokens": -1}})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "budget ist ungültig"
+
+
+def test_load_prepare_project_rejects_missing_project(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_project", staticmethod(lambda _pid: None))
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._load_prepare_project(_state())
+
+    assert _status(excinfo) == 404
+    assert "Project does not exist" in _body(excinfo)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Routing
+# ---------------------------------------------------------------------------
+
+def test_read_client_choice_ignores_default_placeholder(app_ctx):
+    choice = mod._read_client_choice({"llm_model": "default"}, _project())
+
+    assert choice.explicit_model_override is False
+    assert choice.explicit_runtime_request is False
+
+
+def test_read_client_choice_detects_explicit_model(app_ctx):
+    choice = mod._read_client_choice(
+        {"llm_model": "gpt-4o", "llm_provider": {"provider": "openai"}}, _project()
+    )
+
+    assert choice.explicit_model_override is True
+    assert choice.explicit_runtime_request is True
+
+
+def test_client_choice_profile_override_only_when_differing(app_ctx):
+    same = mod._read_client_choice({"llm_profile_id": "p1"}, _project(llm_profile_id="p1"))
+    differing = mod._read_client_choice({"llm_profile_id": "p2"}, _project(llm_profile_id="p1"))
+
+    assert same.explicit_profile_override is False
+    assert differing.explicit_profile_override is True
+
+
+def test_resolve_prepare_routing_falls_back_to_project_profile(app_ctx):
+    routing = mod._resolve_prepare_routing({}, _project(llm_profile_id="proj-profile"), None)
+
+    assert routing.routed_profile_id == "proj-profile"
+    assert routing.client_requested_override is False
+
+
+def test_resolve_prepare_routing_prefers_request_profile(app_ctx):
+    routing = mod._resolve_prepare_routing(
+        {"llm_profile_id": "req-profile"}, _project(llm_profile_id="proj-profile"), None
+    )
+
+    assert routing.routed_profile_id == "req-profile"
+    assert routing.client_requested_override is True
+
+
+def test_resolve_prepare_routing_explicit_model_wins_over_profile(app_ctx):
+    routing = mod._resolve_prepare_routing(
+        {"llm_model": "gpt-4o"}, _project(llm_profile_id="proj-profile"), None
+    )
+
+    assert routing.routed_profile_id is None
+    assert routing.llm_model_override == "gpt-4o"
+    assert routing.client_requested_override is True
+
+
+def test_resolve_prepare_routing_ai_model_ref_silences_legacy(app_ctx):
+    routing = mod._resolve_prepare_routing(
+        {}, _project(llm_profile_id="proj-profile"), MagicMock(name="AiModelRef")
+    )
+
+    assert routing.routed_profile_id is None
+    assert routing.llm_model_override is None
+    assert routing.llm_runtime.enabled is False
+    assert routing.client_requested_override is True
+
+
+def test_resolve_prepare_routing_maps_runtime_value_error_to_400(app_ctx):
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._resolve_prepare_routing({"llm_provider": "not-an-object"}, _project(), None)
+
+    assert _status(excinfo) == 400
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Kurzschluss
+# ---------------------------------------------------------------------------
+
+def test_already_prepared_response_returns_none_when_unprepared(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod, "_check_simulation_prepared", lambda _sid: (False, {"reason": "x"}))
+
+    assert mod._already_prepared_response(VALID_SIM_ID) is None
+
+
+def test_already_prepared_response_short_circuits(app_ctx, monkeypatch):
+    monkeypatch.setattr(
+        mod, "_check_simulation_prepared", lambda _sid: (True, {"status": "ready"})
+    )
+
+    response, status = mod._already_prepared_response(VALID_SIM_ID)
+
+    assert status == 200
+    payload = response.get_json()
+    assert payload["data"]["already_prepared"] is True
+    assert payload["data"]["status"] == "ready"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Eingaben
+# ---------------------------------------------------------------------------
+
+def test_collect_prepare_inputs_requires_simulation_requirement(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_extracted_text", staticmethod(lambda _pid: ""))
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._collect_prepare_inputs({}, _project(simulation_requirement=""), _state())
+
+    assert _status(excinfo) == 400
+    assert "simulation_requirement" in _body(excinfo)["error"]
+
+
+def test_collect_prepare_inputs_rejects_invalid_quota_plan(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_extracted_text", staticmethod(lambda _pid: ""))
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._collect_prepare_inputs(
+            {"quota_plan": {"total": 5, "targets": []}}, _project(), _state()
+        )
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"].startswith("Invalid quota_plan")
+
+
+def test_collect_prepare_inputs_defaults_and_language_guard(app_ctx, monkeypatch):
+    monkeypatch.setattr(
+        mod.ProjectManager, "get_extracted_text", staticmethod(lambda _pid: "doc text")
+    )
+
+    inputs = mod._collect_prepare_inputs({"language": "FR"}, _project(), _state())
+
+    assert inputs.document_text == "doc text"
+    assert inputs.use_llm_for_profiles is True
+    assert inputs.parallel_profile_count is None
+    assert inputs.max_agents is None
+    assert inputs.agent_language_override is None
+
+
+def test_collect_prepare_inputs_keeps_supported_language(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_extracted_text", staticmethod(lambda _pid: ""))
+
+    inputs = mod._collect_prepare_inputs({"language": " DE "}, _project(), _state())
+
+    assert inputs.agent_language_override == "de"
+
+
+def test_collect_prepare_inputs_applies_max_agents_floor(app_ctx, monkeypatch):
+    monkeypatch.setattr(mod.ProjectManager, "get_extracted_text", staticmethod(lambda _pid: ""))
+
+    inputs = mod._collect_prepare_inputs({"max_agents": 3}, _project(), _state())
+
+    assert inputs.max_agents == mod.MIN_SIMULATION_AGENTS
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Entitäten-Vorschau
+# ---------------------------------------------------------------------------
+
+def _patch_entity_preview(monkeypatch, *, count=7, types=("Person",), exclusions=()):
+    preview = SimpleNamespace(
+        entities=[MagicMock() for _ in range(count)],
+        filtered_count=count,
+        entity_types=set(types),
+    )
+    reader = MagicMock()
+    reader.filter_defined_entities.return_value = preview
+    monkeypatch.setattr(mod, "EntityReader", lambda _storage: reader)
+    monkeypatch.setattr(
+        mod,
+        "filter_eligible_entities",
+        lambda entities, degradations=None: SimpleNamespace(
+            eligible=entities, exclusions=list(exclusions)
+        ),
+    )
+    return preview
+
+
+def test_preview_entity_counts_writes_state(app_ctx, monkeypatch):
+    _patch_entity_preview(monkeypatch, count=7)
+    state = _state()
+
+    mod._preview_entity_counts(state, MagicMock(), _inputs())
+
+    assert state.entities_count == 7
+    assert state.entity_types == ["Person"]
+
+
+def test_preview_entity_counts_caps_at_max_agents(app_ctx, monkeypatch):
+    _patch_entity_preview(monkeypatch, count=30)
+    state = _state()
+
+    mod._preview_entity_counts(state, MagicMock(), _inputs(max_agents=12))
+
+    assert state.entities_count == 12
+
+
+def test_preview_entity_counts_swallows_reader_errors(app_ctx, monkeypatch):
+    def _boom(_storage):
+        raise RuntimeError("neo4j down")
+
+    monkeypatch.setattr(mod, "EntityReader", _boom)
+    state = _state(entities_count=0)
+
+    mod._preview_entity_counts(state, MagicMock(), _inputs())
+
+    assert state.entities_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — Precheck und Registrierung
+# ---------------------------------------------------------------------------
+
+def test_precheck_prepare_ai_model_ref_skips_when_absent(app_ctx):
+    mod._precheck_prepare_ai_model_ref(None)
+
+
+def test_precheck_prepare_ai_model_ref_maps_value_error_to_400(app_ctx, monkeypatch):
+    def _raise(_ref):
+        raise ValueError("connection disabled")
+
+    monkeypatch.setattr("app.services.llm_routing_seed.prevalidate_ai_model_ref", _raise)
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._precheck_prepare_ai_model_ref(MagicMock(name="AiModelRef"))
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "connection disabled"
+
+
+def test_register_prepare_run_creates_run_and_task(app_ctx, monkeypatch):
+    registry = MagicMock()
+    registry.create_run.return_value = {"run_id": "run-1"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-1"
+    req = mod._PrepareRequest(
+        simulation_id=VALID_SIM_ID,
+        ai_model_ref=None,
+        budget_config=None,
+        force_regenerate=False,
+    )
+
+    run_record, task_id = mod._register_prepare_run(
+        req, _state(), _routing(llm_model_override="gpt-4o"), task_manager
+    )
+
+    assert run_record == {"run_id": "run-1"}
+    assert task_id == "task-1"
+    create_kwargs = registry.create_run.call_args.kwargs
+    assert create_kwargs["run_type"] == "simulation_prepare"
+    assert create_kwargs["metadata"]["llm_model"] == "gpt-4o"
+    assert "budget" not in create_kwargs["metadata"]
+    assert task_manager.create_task.call_args.kwargs["metadata"]["run_id"] == "run-1"
+
+
+def test_register_prepare_run_carries_budget_metadata(app_ctx, monkeypatch):
+    from app.contracts.run_budget_contract import RunBudgetConfig
+
+    registry = MagicMock()
+    registry.create_run.return_value = {"run_id": "run-1"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
+    task_manager = MagicMock()
+    task_manager.create_task.return_value = "task-1"
+    req = mod._PrepareRequest(
+        simulation_id=VALID_SIM_ID,
+        ai_model_ref=None,
+        budget_config=RunBudgetConfig(max_tokens=1000),
+        force_regenerate=False,
+    )
+
+    mod._register_prepare_run(req, _state(), _routing(), task_manager)
+
+    metadata = registry.create_run.call_args.kwargs["metadata"]
+    assert metadata["budget"]["max_tokens"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Fehlerpfad — Run/Task als failed markieren
+# ---------------------------------------------------------------------------
+
+def test_reject_and_fail_prepare_run_marks_run_failed(app_ctx, monkeypatch):
+    registry = MagicMock()
+    registry.update_run.return_value = {"run_id": "run-1", "status": "failed"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    task_manager = MagicMock()
+
+    rejected = mod._reject_and_fail_prepare_run(
+        {"run_id": "run-1"}, "task-1", task_manager, "kaputt", status=422, context="im Test"
+    )
+
+    assert rejected.response[1] == 422
+    task_manager.fail_task.assert_called_once_with("task-1", "kaputt")
+    assert registry.update_run.call_args.kwargs["status"] == "failed"
+
+
+def test_reject_and_fail_prepare_run_returns_500_when_run_vanished(app_ctx, monkeypatch):
+    registry = MagicMock()
+    registry.update_run.return_value = None
+    monkeypatch.setattr(mod, "run_registry", registry)
+
+    rejected = mod._reject_and_fail_prepare_run(
+        {"run_id": "run-1"}, "task-1", MagicMock(), "kaputt", status=422, context="im Test"
+    )
+
+    assert rejected.response[1] == 500
+    assert rejected.response[0].get_json()["code"] == "internal_error"
+
+
+def test_reject_and_fail_prepare_run_returns_500_on_persistence_error(app_ctx, monkeypatch):
+    registry = MagicMock()
+    registry.update_run.side_effect = OSError("disk full")
+    monkeypatch.setattr(mod, "run_registry", registry)
+
+    rejected = mod._reject_and_fail_prepare_run(
+        {"run_id": "run-1"}, "task-1", MagicMock(), "kaputt", status=400, context="im Test"
+    )
+
+    assert rejected.response[1] == 500
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — Routing-Seed
+# ---------------------------------------------------------------------------
+
+def test_seed_prepare_routing_without_ref_passes_profile(app_ctx, monkeypatch):
+    seed = MagicMock()
+    monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
+
+    mod._seed_prepare_routing(
+        {"run_id": "run-1"}, "task-1", MagicMock(), _routing(routed_profile_id="p1"), None
+    )
+
+    assert seed.call_args.args == ("run-1", "persona_generation")
+    assert seed.call_args.kwargs["llm_profile_id"] == "p1"
+    assert "ai_model_ref" not in seed.call_args.kwargs
+
+
+def test_seed_prepare_routing_with_ref_forwards_ref(app_ctx, monkeypatch):
+    seed = MagicMock()
+    monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
+    ref = MagicMock(name="AiModelRef")
+
+    mod._seed_prepare_routing({"run_id": "run-1"}, "task-1", MagicMock(), _routing(), ref)
+
+    assert seed.call_args.kwargs["ai_model_ref"] is ref
+
+
+def test_seed_prepare_routing_failure_marks_run_failed(app_ctx, monkeypatch):
+    def _raise(*_args, **_kwargs):
+        raise ValueError("model not on connection")
+
+    monkeypatch.setattr(mod, "seed_run_stage_routing", _raise)
+    registry = MagicMock()
+    registry.update_run.return_value = {"run_id": "run-1"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    task_manager = MagicMock()
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._seed_prepare_routing(
+            {"run_id": "run-1"}, "task-1", task_manager, _routing(), MagicMock()
+        )
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"] == "model not on connection"
+    task_manager.fail_task.assert_called_once_with("task-1", "model not on connection")
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — Routen-Auflösung
+# ---------------------------------------------------------------------------
+
+def _resolved_route(base_url="https://api.openai.com/v1"):
+    return ResolvedRoute(
+        stage="persona_generation",
+        provider_id="openai",
+        model="gpt-4o",
+        base_url_sanitized=base_url,
+        routing_version=1,
+        provider_options={},
+    )
+
+
+def _patch_router(monkeypatch, route):
+    router = MagicMock()
+    router.resolve.return_value = route
+    router.lock_stage.return_value = route
+    monkeypatch.setattr(mod, "StageModelRouter", lambda _run_id: router)
+    return router
+
+
+def test_resolve_prepare_route_locks_stage_and_returns_key(app_ctx, monkeypatch):
+    route = _resolved_route()
+    router = _patch_router(monkeypatch, route)
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: "sk-bound")
+
+    resolved, api_key = mod._resolve_prepare_route(
+        {"run_id": "run-1"}, "task-1", MagicMock(), RuntimeLlmConfig()
+    )
+
+    assert resolved is route
+    assert api_key == "sk-bound"
+    router.lock_stage.assert_called_once_with("persona_generation", route)
+
+
+def test_resolve_prepare_route_guards_missing_key_with_422(app_ctx, monkeypatch):
+    _patch_router(monkeypatch, _resolved_route())
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
+    registry = MagicMock()
+    registry.update_run.return_value = {"run_id": "run-1"}
+    monkeypatch.setattr(mod, "run_registry", registry)
+    task_manager = MagicMock()
+
+    with pytest.raises(mod._PrepareRejected) as excinfo:
+        mod._resolve_prepare_route(
+            {"run_id": "run-1"}, "task-1", task_manager, RuntimeLlmConfig()
+        )
+
+    assert _status(excinfo) == 422
+    assert "provider_override" in _body(excinfo)["error"]
+    task_manager.fail_task.assert_called_once()
+
+
+def test_resolve_prepare_route_uses_placeholder_for_local_endpoint(app_ctx, monkeypatch):
+    _patch_router(monkeypatch, _resolved_route(base_url="http://localhost:11434/v1"))
+    monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
+
+    _resolved, api_key = mod._resolve_prepare_route(
+        {"run_id": "run-1"}, "task-1", MagicMock(), RuntimeLlmConfig()
+    )
+
+    assert api_key == mod.LOCAL_NO_AUTH_API_KEY
+
+
+# ---------------------------------------------------------------------------
+# Phase 9 — Hintergrund-Job
+# ---------------------------------------------------------------------------
+
+def test_progress_callback_scales_stage_progress(app_ctx):
+    task_manager = MagicMock()
+
+    callback = mod._build_progress_callback(task_manager, "task-1")
+    callback("generating_profiles", 50, "Persona 5", current=5, total=10)
+
+    kwargs = task_manager.update_task.call_args.kwargs
+    assert kwargs["progress"] == 45  # 20 + (70-20) * 0.5
+    assert kwargs["message"] == "[2/4] GenerateAgentpersona: 5/10 - Persona 5"
+    assert kwargs["progress_detail"]["current_stage"] == "generating_profiles"
+
+
+def test_progress_callback_handles_unknown_stage(app_ctx):
+    task_manager = MagicMock()
+
+    callback = mod._build_progress_callback(task_manager, "task-1")
+    callback("mystery", 10, "läuft")
+
+    kwargs = task_manager.update_task.call_args.kwargs
+    assert kwargs["progress"] == 10
+    assert kwargs["message"] == "[1/4] mystery: läuft"
+
+
+def test_prepare_job_runs_service_and_completes_task(app_ctx):
+    manager = MagicMock()
+    manager.prepare_simulation.return_value = MagicMock(
+        to_simple_dict=MagicMock(return_value={"simulation_id": VALID_SIM_ID})
+    )
+    task_manager = MagicMock()
+
+    job = mod._make_prepare_job(
+        manager=manager,
+        task_manager=task_manager,
+        task_id="task-1",
+        simulation_id=VALID_SIM_ID,
+        inputs=_inputs(document_text="doc", max_agents=10),
+        storage=MagicMock(),
+        llm_model="gpt-4o",
+        effective_llm_runtime=RuntimeLlmConfig(),
+    )
+    job()
+
+    service_kwargs = manager.prepare_simulation.call_args.kwargs
+    assert service_kwargs["simulation_id"] == VALID_SIM_ID
+    assert service_kwargs["document_text"] == "doc"
+    assert service_kwargs["llm_model"] == "gpt-4o"
+    assert service_kwargs["max_agents"] == 10
+    result = task_manager.complete_task.call_args.kwargs["result"]
+    assert result["simulation_id"] == VALID_SIM_ID
+    assert result["degradations"] is not None
+
+
+def test_prepare_job_marks_simulation_failed_on_error(app_ctx):
+    manager = MagicMock()
+    manager.prepare_simulation.side_effect = RuntimeError("kein Graph")
+    failed_state = _state()
+    manager.get_simulation.return_value = failed_state
+    task_manager = MagicMock()
+
+    job = mod._make_prepare_job(
+        manager=manager,
+        task_manager=task_manager,
+        task_id="task-1",
+        simulation_id=VALID_SIM_ID,
+        inputs=_inputs(),
+        storage=MagicMock(),
+        llm_model="gpt-4o",
+        effective_llm_runtime=RuntimeLlmConfig(),
+    )
+    job()
+
+    task_manager.fail_task.assert_called_once_with("task-1", "kein Graph")
+    assert failed_state.error == "kein Graph"
+    manager._set_status.assert_called_once_with(failed_state, SimulationStatus.FAILED)
+    assert "degradations" in task_manager.update_task.call_args.kwargs["result"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 10 — Response
+# ---------------------------------------------------------------------------
+
+def test_build_prepare_response_reports_queued_run(app_ctx):
+    state = _state(entities_count=12, entity_types=["Person", "Org"])
+
+    payload = mod._build_prepare_response(
+        VALID_SIM_ID, "task-1", {"run_id": "run-1"}, state, _inputs()
+    )
+
+    assert payload["simulation_id"] == VALID_SIM_ID
+    assert payload["task_id"] == "task-1"
+    assert payload["run_id"] == "run-1"
+    assert payload["status"] == "preparing"
+    assert payload["already_prepared"] is False
+    assert payload["expected_entities_count"] == 12
+    assert payload["entity_types"] == ["Person", "Org"]
+    assert payload["persona_target"]["entity_count"] == 12

--- a/backend/tests/test_persona_target.py
+++ b/backend/tests/test_persona_target.py
@@ -231,5 +231,8 @@ def test_preview_and_run_path_share_one_target_function(monkeypatch):
     run_path_source = inspect.getsource(ps_mod._phase_generate_profiles)
     assert "compute_persona_target(" in run_path_source
 
-    preview_source = inspect.getsource(sp_mod.prepare_simulation)
+    # Der Preview-Nenner entsteht seit #1080 in der Response-Phase des
+    # /prepare-Endpunkts statt im Handler selbst — die Invariante ist
+    # dieselbe: keine zweite, eigene Rechnung neben compute_persona_target.
+    preview_source = inspect.getsource(sp_mod._build_prepare_response)
     assert "compute_persona_target(" in preview_source

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4429 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4477 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Schließt #1080. Schwesterarbeit zu #1093 (#1079), gleiche Technik, disjunkte Dateien.

## Was

`prepare_simulation` war ein ~560-Zeilen-Handler mit radon-Rang **F (cc 65)** — inklusive der kompletten Hintergrund-Job-Closure samt Fortschritts-Callback. Der Handler ist jetzt ein Orchestrator ohne eigene Verzweigungslogik:

| Phase | Funktion |
|---|---|
| Validierung | `_parse_prepare_identity`, `_parse_prepare_budget`, `_load_prepare_project` |
| Routing | `_read_client_choice` + `_resolve_prepare_routing` (Profil-Präzedenz aus #888) |
| Kurzschluss | `_already_prepared_response` |
| Fachliche Eingaben | `_collect_prepare_inputs` |
| Entitäten-Vorschau | `_preview_entity_counts` |
| Precheck / Registrierung | `_precheck_prepare_ai_model_ref`, `_register_prepare_run` |
| Routing-Seed / Route | `_seed_prepare_routing`, `_resolve_prepare_route` |
| Hintergrund-Job | `_build_progress_callback`, `_make_prepare_job` |
| Antwort | `_build_prepare_response` |

Die beiden Fehlerpfade nach der Run-Erzeugung (AiModelRef-Routingfehler → 400, Provider-Key-Guard → 422) teilen sich jetzt `_reject_and_fail_prepare_run`. Sie waren vorher zweimal fast identisch ausgeschrieben; die Invarianten aus #841/#844 — Run *und* Task als `failed` markieren, `fail_task()` vor `update_run()`, verschwundenes Manifest bleibt ein 500 — stehen damit an einer Stelle statt an zwei.

## Kein Verhaltenswechsel

Die Phasen lehnen über `_PrepareRejected` mit einer **fertig gebauten** `json_error`-Response ab; Status-Code, Fehlercode und Meldung bleiben wortgleich. Die Prüfreihenfolge ist unverändert — insbesondere bleibt der `already_prepared`-Kurzschluss **vor** der Validierung von `quota_plan` und `simulation_requirement`, sonst würde ein billiger Revisit plötzlich 400er werfen.

## Akzeptanzkriterien

- [x] `prepare_simulation` erreicht radon-Rang C oder besser — die Funktion taucht bei `radon cc --min C` nicht mehr auf.
- [x] Jede extrahierte Phase hat mindestens einen eigenen Test (48 neue Tests in `tests/api/test_simulation_prepare_phases.py`).
- [x] Kein Verhaltenswechsel an der HTTP-Schnittstelle — die 96 bestehenden Tests des Prepare-Endpunkts laufen unverändert grün.
- [x] Allowlist-Eintrag `app/api/simulation_prepare.py::prepare_simulation` entfernt.

## Angefasst, aber nicht abgeschwächt

`tests/test_persona_target.py::test_preview_and_run_path_share_one_target_function` inspiziert Quelltext und erwartete den Aufruf `compute_persona_target(` in `prepare_simulation`. Der Aufruf sitzt jetzt in `_build_prepare_response` — die Assertion zeigt auf diese Funktion, die Invariante („keine zweite, eigene Rechnung neben `compute_persona_target`") bleibt gleich streng.

## Gate

`bash scripts/pre-push-gate.sh backend` — ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)