### PR TITLE
test(api): Budget-Test auf das echte Contract-Feld ziehen

### DIFF
--- a/backend/tests/api/test_simulation_start_phases.py
+++ b/backend/tests/api/test_simulation_start_phases.py
@@ -164,12 +164,28 @@ def test_parse_start_request_silences_legacy_fields_for_ai_model_ref(app_ctx):
     assert req.llm_runtime.enabled is False
 
 
-def test_parse_budget_config_rejects_invalid_budget(app_ctx):
+def test_parse_budget_config_rejects_limit_below_one(app_ctx):
+    """`max_tokens` hat `ge=1` — ein negatives Limit ist keine Konfiguration."""
     with pytest.raises(mod._StartRejected) as excinfo:
-        mod._parse_budget_config({"budget": {"max_total_tokens": -5}})
+        mod._parse_budget_config({"budget": {"max_tokens": -5}})
 
     assert _status(excinfo) == 400
     assert _body(excinfo)["error"].startswith("budget ist ungültig")
+
+
+def test_parse_budget_config_rejects_unknown_field(app_ctx):
+    """`RunBudgetConfig` ist strict — ein vertippter Feldname faellt auf."""
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._parse_budget_config({"budget": {"max_total_tokens": 500}})
+
+    assert _status(excinfo) == 400
+    assert _body(excinfo)["error"].startswith("budget ist ungültig")
+
+
+def test_parse_budget_config_accepts_valid_budget(app_ctx):
+    budget = mod._parse_budget_config({"budget": {"max_tokens": 5000}})
+
+    assert budget is not None and budget.max_tokens == 5000
 
 
 def test_parse_budget_config_returns_none_without_budget(app_ctx):

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4477 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4479 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Follow-up zu #1093 (CodeRabbit-Finding).

## Problem

`test_parse_budget_config_rejects_invalid_budget` schickte `{"max_total_tokens": -5}`. Dieses Feld existiert in `RunBudgetConfig` nicht — es heißt `max_tokens` (`Field(None, ge=1)`). Da das Modell `_STRICT` (`extra="forbid"`) nutzt, bestand der Test wegen eines Extra-Feld-Fehlers statt wegen der beabsichtigten Untergrenzen-Verletzung. Die `ge=1`-Grenze war damit faktisch ungeprüft.

## Änderung

Drei getrennte Fälle statt einem doppeldeutigen:

- `max_tokens: -5` → Untergrenze verletzt
- `max_total_tokens: 500` → unbekanntes Feld, deckt den strict-Modus explizit ab
- `max_tokens: 5000` → gültiges Budget kommt als `RunBudgetConfig` zurück

Kein Produktivcode angefasst; der Endpunkt antwortet in allen Ablehnungsfällen unverändert mit HTTP 400 und `budget ist ungültig`.

## Verifikation

`uv run pytest tests/api/test_simulation_start_phases.py` — 43 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)