### PR TITLE
perf(scripts): Backend-Testanzahl in sync-status.sh cachen

### DIFF
--- a/backend/tests/test_sync_status_cache.py
+++ b/backend/tests/test_sync_status_cache.py
@@ -1,0 +1,183 @@
+"""Cache-Verhalten von ``scripts/sync-status.sh``.
+
+Die Backend-Testanzahl in ``docs/STATUS.md`` kostet einen vollständigen
+``pytest --collect-only``-Lauf — auf einer Entwicklermaschine Minuten. Das
+Skript speichert die Zahl deshalb zwischen und misst nur neu, wenn eine
+Python-Datei unter ``backend/`` oder die pytest-Konfiguration jünger ist als
+der Cache.
+
+Bricht diese Invalidierung, veraltet ``STATUS.md`` still — der teure Lauf würde
+schlicht nie wieder stattfinden. Diese Tests nageln beide Richtungen fest.
+
+Sie kommen ohne den teuren Collect aus: mit einem PATH ohne ``uv`` kann das
+Skript gar nicht messen und meldet im ``--check``-Modus Exit-Code 2
+(„Messfehler"). Ein Cache-Treffer liefert dagegen 0 oder 1. Der Exit-Code
+verrät damit, welchen Zweig das Skript genommen hat.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sync-status.sh"
+CACHE_FILE = REPO_ROOT / "backend" / ".cache" / "sync-status" / "backend-tests-collected"
+
+MEASUREMENT_FAILED = 2
+
+
+def _run_check_without_uv() -> subprocess.CompletedProcess[str]:
+    """``--check`` mit einem PATH ohne ``uv``.
+
+    Ohne ``uv`` ist eine Messung unmöglich. Exit 2 heißt deshalb „der Cache hat
+    nicht getragen", jeder andere Code „die Zahl kam aus dem Cache".
+    """
+    env = dict(os.environ)
+    uv_path = shutil.which("uv")
+    if uv_path:
+        pruned = [
+            entry
+            for entry in env.get("PATH", "").split(os.pathsep)
+            if entry and not (Path(entry) / "uv").exists()
+        ]
+        env["PATH"] = os.pathsep.join(pruned)
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--check"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+class _CacheHarness:
+    """Cache-Datei stellen und mtimes berührter Repo-Dateien zurückgeben.
+
+    Ohne das Zurückgeben bliebe eine Quelldatei mit Zeitstempel in der Zukunft
+    liegen — der Cache waere danach dauerhaft als veraltet zu lesen und der
+    teure Collect-Lauf faende bei jedem Aufruf statt.
+    """
+
+    def __init__(self) -> None:
+        self._touched: list[tuple[Path, float, float]] = []
+
+    def write_fresh(self, value: str = "4321") -> None:
+        """Cache mit Zeitstempel in der Zukunft — nichts ist jünger."""
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(f"{value}\n", encoding="utf-8")
+        future = CACHE_FILE.stat().st_mtime + 3600
+        os.utime(CACHE_FILE, (future, future))
+
+    def make_newer_than_cache(self, path: Path) -> None:
+        stat = path.stat()
+        self._touched.append((path, stat.st_atime, stat.st_mtime))
+        newer = CACHE_FILE.stat().st_mtime + 60
+        os.utime(path, (newer, newer))
+
+    def restore(self) -> None:
+        for path, atime, mtime in reversed(self._touched):
+            os.utime(path, (atime, mtime))
+        self._touched.clear()
+
+
+@pytest.fixture
+def cache_state():
+    """Sichert Cache und berührte Quelldateien und stellt beide wieder her."""
+    original = CACHE_FILE.read_bytes() if CACHE_FILE.exists() else None
+    original_mtime = CACHE_FILE.stat().st_mtime if CACHE_FILE.exists() else None
+    harness = _CacheHarness()
+    try:
+        yield harness
+    finally:
+        harness.restore()
+        if original is None:
+            CACHE_FILE.unlink(missing_ok=True)
+        else:
+            CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            CACHE_FILE.write_bytes(original)
+            if original_mtime is not None:
+                os.utime(CACHE_FILE, (original_mtime, original_mtime))
+
+
+def test_fresh_cache_skips_the_expensive_collect(cache_state):
+    """Ist der Cache jünger als alle Quellen, wird nicht gemessen."""
+    cache_state.write_fresh()
+
+    result = _run_check_without_uv()
+
+    assert result.returncode != MEASUREMENT_FAILED, (
+        "Skript hat gemessen statt den Cache zu nutzen: " + result.stderr
+    )
+
+
+def test_touched_test_file_invalidates_the_cache(cache_state):
+    """Eine jüngere Testdatei erzwingt eine Neumessung."""
+    cache_state.write_fresh()
+    cache_state.make_newer_than_cache(REPO_ROOT / "backend" / "tests" / "conftest.py")
+
+    result = _run_check_without_uv()
+
+    assert result.returncode == MEASUREMENT_FAILED, (
+        "Cache galt trotz jüngerer Testdatei als frisch — STATUS.md würde still veralten"
+    )
+
+
+def test_touched_app_file_invalidates_the_cache(cache_state):
+    """Auch Produktivcode zählt: Parametrisierungen lesen aus ``app/``."""
+    cache_state.write_fresh()
+    cache_state.make_newer_than_cache(REPO_ROOT / "backend" / "app" / "config.py")
+
+    result = _run_check_without_uv()
+
+    assert result.returncode == MEASUREMENT_FAILED, (
+        "Cache galt trotz jüngerer App-Datei als frisch"
+    )
+
+
+def test_touched_pytest_config_invalidates_the_cache(cache_state):
+    """Eine jüngere pytest-Konfiguration erzwingt eine Neumessung.
+
+    Dieser Fall lief zuvor über ``[[ -nt ]]``. Die macOS-Systembash (3.2)
+    vergleicht dort nur sekundengenau und verschluckte eine Änderung, die in
+    derselben Sekunde wie der Cache-Schreibvorgang passierte.
+    """
+    cache_state.write_fresh()
+    cache_state.make_newer_than_cache(REPO_ROOT / "backend" / "pyproject.toml")
+
+    result = _run_check_without_uv()
+
+    assert result.returncode == MEASUREMENT_FAILED, (
+        "Cache galt trotz jüngerer pytest-Konfiguration als frisch"
+    )
+
+
+def test_no_cache_flag_forces_measurement(cache_state):
+    """``--no-cache`` ignoriert einen frischen Cache."""
+    cache_state.write_fresh()
+    env = dict(os.environ)
+    uv_path = shutil.which("uv")
+    if uv_path:
+        env["PATH"] = os.pathsep.join(
+            entry
+            for entry in env.get("PATH", "").split(os.pathsep)
+            if entry and not (Path(entry) / "uv").exists()
+        )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--check", "--no-cache"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == MEASUREMENT_FAILED, (
+        "--no-cache hat trotzdem den Cache verwendet"
+    )

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4477 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4482 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/scripts/sync-status.sh
+++ b/scripts/sync-status.sh
@@ -9,17 +9,34 @@ set -euo pipefail
 # Aktualisierungs-Protokoll) are left untouched.
 #
 # Usage:
-#   bash scripts/sync-status.sh           # update STATUS.md in-place
-#   bash scripts/sync-status.sh --check   # drift-check only (exit 1 on drift)
+#   bash scripts/sync-status.sh              # update STATUS.md in-place
+#   bash scripts/sync-status.sh --check      # drift-check only (exit 1 on drift)
+#   bash scripts/sync-status.sh --no-cache   # Testanzahl erzwungen neu messen
+#
+# Die einzige teure Groesse ist die Backend-Testanzahl: `pytest --collect-only`
+# importiert jedes Testmodul und damit die komplette App (Flask, Neo4j-Treiber,
+# OpenTelemetry, sentence-transformers) — je nach Maschine Minuten. Das Ergebnis
+# haengt aber nur an den Python-Dateien unter backend/. Es wird deshalb
+# zwischengespeichert und nur dann neu gemessen, wenn eine dieser Dateien juenger
+# ist als der Cache. Ein direkt folgender `--check`-Lauf kostet damit
+# Millisekunden statt eines zweiten Volldurchlaufs.
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 STATUS_FILE="$REPO_ROOT/docs/STATUS.md"
+# backend/.cache/ ist bereits gitignored.
+CACHE_DIR="$REPO_ROOT/backend/.cache/sync-status"
+CACHE_FILE="$CACHE_DIR/backend-tests-collected"
 
 CHECK_MODE=false
-if [[ "${1:-}" == "--check" ]]; then
-  CHECK_MODE=true
-fi
+USE_CACHE=true
+for arg in "$@"; do
+  case "$arg" in
+    --check) CHECK_MODE=true ;;
+    --no-cache) USE_CACHE=false ;;
+    *) echo "WARNING: unbekanntes Argument '$arg' ignoriert" >&2 ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -45,7 +62,43 @@ BACKEND_TESTS="unknown"
 # weil "unknown" gegen die dokumentierte Zahl diffed.
 BACKEND_TESTS_MEASURED=false
 COLLECT_FAILURE_REASON=""
-if command -v uv &>/dev/null; then
+
+# ---------------------------------------------------------------------------
+# cache_is_fresh: Cache gilt, solange keine Python-Datei unter backend/ und
+# keine pytest-Konfiguration juenger ist als die Cache-Datei. Genau diese
+# Dateien bestimmen die gesammelte Testanzahl — ein Testlauf, ein Branch-Wechsel
+# ohne Python-Aenderung oder ein erneuter Skriptaufruf tun es nicht.
+# ---------------------------------------------------------------------------
+cache_is_fresh() {
+  [[ "$USE_CACHE" == true ]] || return 1
+  [[ -s "$CACHE_FILE" ]] || return 1
+
+  local cached
+  cached=$(<"$CACHE_FILE")
+  [[ "$cached" =~ ^[0-9]+$ ]] || return 1
+
+  local newer
+  newer=$(find "$REPO_ROOT/backend/tests" "$REPO_ROOT/backend/app" \
+            -name '*.py' -newer "$CACHE_FILE" -print -quit 2>/dev/null || true)
+  [[ -z "$newer" ]] || return 1
+
+  # pytest-Konfiguration ebenfalls ueber find pruefen, nicht ueber `[[ -nt ]]`:
+  # die macOS-Systembash (3.2) vergleicht dort nur auf Sekunden genau und
+  # verschluckt eine Aenderung, die in derselben Sekunde wie der
+  # Cache-Schreibvorgang passiert. `find -newer` vergleicht sub-sekundengenau.
+  newer=$(find "$REPO_ROOT/backend" -maxdepth 1 \
+            \( -name 'pyproject.toml' -o -name 'conftest.py' -o -name 'pytest.ini' \) \
+            -newer "$CACHE_FILE" -print -quit 2>/dev/null || true)
+  [[ -z "$newer" ]] || return 1
+
+  BACKEND_TESTS="$cached"
+  BACKEND_TESTS_MEASURED=true
+  return 0
+}
+
+if cache_is_fresh; then
+  : # Zahl kommt aus dem Cache — kein Collect-Lauf noetig.
+elif command -v uv &>/dev/null; then
   # Optional timeout: GNU coreutils auf Linux/CI, gtimeout auf macOS, sonst kein Wrapper.
   if command -v timeout &>/dev/null; then
     TIMEOUT_CMD=(timeout 180)
@@ -62,6 +115,8 @@ if command -v uv &>/dev/null; then
     if [[ -n "$MATCH" ]]; then
       BACKEND_TESTS="$MATCH"
       BACKEND_TESTS_MEASURED=true
+      mkdir -p "$CACHE_DIR"
+      printf '%s\n' "$MATCH" > "$CACHE_FILE"
     else
       echo "WARNING: pytest --collect-only ran but no count found" >&2
       COLLECT_FAILURE_REASON="pytest --collect-only lieferte keine auswertbare Testanzahl"


### PR DESCRIPTION
## Problem

`sync-status.sh` misst die Zahl „Backend Tests (collected)" mit einem vollen `pytest --collect-only` ([scripts/sync-status.sh:59](scripts/sync-status.sh:59)). Collect importiert jedes der ~4400 Testmodule und damit die komplette App — Flask, Neo4j-Treiber, OpenTelemetry, sentence-transformers. Auf einer Entwicklermaschine sind das rund **zwei Minuten**, nur für eine Zahl in einer Markdown-Tabelle. Wer nach dem Sync noch `--check` fährt (der dokumentierte Tipp am Ende des Skripts), zahlt sie ein zweites Mal. Das Skript hat deshalb ein 180-s-Timeout, nach dem die Zahl auf `unknown` fällt.

## Änderung

Die Zahl hängt ausschließlich an den Python-Dateien unter `backend/` und an der pytest-Konfiguration. Sie liegt jetzt in `backend/.cache/sync-status/` (bereits gitignored) und wird nur neu gemessen, wenn eine dieser Quellen jünger ist als der Cache. `--no-cache` erzwingt die Messung.

| Lauf | vorher | nachher |
|---|---|---|
| kalt (echte Messung) | ~120 s | ~120 s |
| warm | ~120 s | **0,2 s** |

## Ein Fallstrick, der beim Bauen aufgetreten ist

Die erste Fassung prüfte die pytest-Konfiguration mit `[[ pyproject.toml -nt $CACHE ]]`. Das griff nicht: die macOS-Systembash ist **3.2** und vergleicht dort nur sekundengenau — eine Änderung in derselben Sekunde wie der Cache-Schreibvorgang wurde verschluckt. Der Cache hätte gegolten, obwohl er veraltet war, und `STATUS.md` wäre still stehen geblieben. Die Prüfung läuft jetzt durchgängig über `find -newer`, das sub-sekundengenau vergleicht.

## Tests

`backend/tests/test_sync_status_cache.py` nagelt beide Richtungen fest: Cache-Treffer, Invalidierung durch Testdatei / App-Datei / pytest-Konfiguration, und `--no-cache`.

Die Tests kommen ohne den teuren Collect aus — mit einem PATH ohne `uv` kann das Skript nicht messen und meldet Exit 2 („Messfehler"), während ein Cache-Treffer 0 oder 1 liefert. Der Exit-Code verrät damit, welchen Zweig das Skript genommen hat. Laufzeit: ~2 s.

Berührte mtimes werden wiederhergestellt. Ohne das bliebe eine Quelldatei mit Zeitstempel in der Zukunft liegen und der Cache wäre dauerhaft wertlos — genau dieser Fehler ist beim Entwickeln einmal passiert.

## Hinweis zum Merge

`docs/STATUS.md` trägt hier 4482 (die fünf neuen Tests). #1097 bringt zwei weitere Tests mit und ändert dieselbe Zeile — der zuletzt gemergte PR braucht einen `bash scripts/sync-status.sh`-Nachzug. Mit warmem Cache kostet der jetzt 0,2 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Der Statusabgleich unterstützt jetzt Prüf- und No-Cache-Optionen.
  * Ergebnisse werden zwischengespeichert und bei relevanten Änderungen automatisch aktualisiert.
  * Unbekannte Optionen werden mit einer Warnung ignoriert.

* **Fehlerbehebungen**
  * Fehlende Messmöglichkeiten führen nun zu einem klaren Fehlerstatus.

* **Dokumentation**
  * Die dokumentierte Anzahl der Backend-Tests wurde auf 4.482 aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->