### PR TITLE
chore(docs): STATUS-Testanzahl nach den Refactor-Merges nachziehen

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4482 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4484 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Reiner Nachzug der generierten Zahl. #1097 und #1098 haben beide Tests ergänzt und dieselbe Zeile geändert — der zuletzt gemergte PR konnte die Summe nicht kennen.

`bash scripts/sync-status.sh` → 4482 → 4484. `--check` ist danach grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)