### PR TITLE
fix(llm): temperature-Quirk der GPT-5-/o-Reasoning-Familie behandeln (#1096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (GPT-5-/o-Reasoning-Modelle brachen jeden Run mit 400 `unsupported_value` ab — 2026-08-05)
+
+- **Jeder Run gegen OpenAI-Reasoning-Modelle (GPT-5-Familie, o1/o3/o4) scheiterte sofort mit `400 unsupported_value` auf `param=temperature`.** `LLMClient` sendet feste `temperature`-Werte (`chat` 0.7, `describe_image` 0.3, `chat_json` 0.3); diese Modelle akzeptieren ausschließlich den Default (1) und lehnen jeden expliziten Wert ab. `chat()`, `describe_image()` und `chat_json()` lassen den `temperature`-Key jetzt weg, wenn das Zielmodell zur GPT-5-/o-Familie gehört (`omits_temperature`, analog zur bestehenden `max_completion_tokens`-Heuristik) — für noch unbekannte Modelle fängt ein einmaliger Retry ohne `temperature` denselben 400 zusätzlich ab. (#1096)
+- **`chat_json()` deutete denselben 400er bisher als fehlenden Strict-Schema-Support und fiel grundlos auf `json_object` zurück.** OpenAIs Fehlertext für den `temperature`-Quirk enthält dieselben Wörter ("unsupported", "not supported") wie die Heuristik für "Provider kann kein `json_schema`" — die irreführende Warnung `strict json_schema not supported by provider` erschien, obwohl das Schema nie das Problem war. Ein `temperature`-400 wird jetzt vor der Schema-Fallback-Prüfung erkannt und löst stattdessen einen Retry im selben `json_schema`-Modus aus.
+- **Fehlerdiagnose für zukünftige 400er verbessert:** Ein `BadRequestError` loggt jetzt `message`, `code` und `param` aus dem strukturierten API-Fehlerbody, statt nur `error_type=BadRequestError`.
+
 ### Fixed (ein fertig geschriebener Report starb nach 35 Minuten an sechs Hypothesen zu viel — 2026-08-04)
 
 - **`Report generation failed: 1 validation error for EvidenceMapModel`, nachdem alle sechs Abschnitte bereits persistiert waren.** `dedup_and_cap_hypotheses` kappt die sichtbaren Hypothesen auf fünf, reichte den Überhang aber ungekappt als Appendix weiter. `ReportSectionModel.hypotheses_appendix` erlaubt fünfzig; ein Abschnitt mit 56 Hypothesen ließ die abschließende Validierung scheitern und damit den gesamten Lauf.

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -317,6 +317,16 @@ class LLMClient:
         """Siehe ``app.llm.providers.openai.swap_token_kwargs``."""
         return _provider_openai.swap_token_kwargs(kwargs)
 
+    @staticmethod
+    def _omits_temperature(model: str) -> bool:
+        """Siehe ``app.llm.providers.openai.omits_temperature`` (#1096)."""
+        return _provider_openai.omits_temperature(model)
+
+    @staticmethod
+    def _is_temperature_400(exc: Exception) -> bool:
+        """Siehe ``app.llm.providers.openai.is_temperature_400`` (#1096)."""
+        return _provider_openai.is_temperature_400(exc)
+
     def _completion_token_kwargs(
         self, max_tokens: int, model: Optional[str] = None
     ) -> Dict[str, int]:
@@ -517,6 +527,20 @@ class LLMClient:
             raise
         except Exception as exc:  # noqa: BLE001 — Failure-Telemetrie, weiterreichen
             latency_ms = (_time_mod.monotonic() - started) * 1000.0
+            # #1096: bei einem BadRequestError liefert das OpenAI-SDK den
+            # entpackten Fehlerbody (message/code/param) ueber ``exc.body`` —
+            # ohne das landete bisher nur "error_type=BadRequestError" im
+            # Log, was 400s wie den temperature-unsupported_value-Quirk
+            # ununterscheidbar von jedem anderen 400 macht.
+            body = getattr(exc, "body", None)
+            if isinstance(body, dict):
+                logger.warning(
+                    "LLM provider 400 detail model=%s message=%s code=%s param=%s",
+                    self.model,
+                    body.get("message"),
+                    body.get("code"),
+                    body.get("param"),
+                )
             self._log_invocation_event(
                 stage=context,
                 latency_ms=latency_ms,
@@ -616,8 +640,12 @@ class LLMClient:
         kwargs: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
-            "temperature": temperature,
         }
+        # #1096: GPT-5-/o-Reasoning-Familie akzeptiert nur den Default-Wert
+        # (1) und antwortet sonst 400 unsupported_value — kein temperature-
+        # Key im Request statt jedes Mal auf den 400 zu warten.
+        if not self._omits_temperature(self.model or ""):
+            kwargs["temperature"] = temperature
         kwargs.update(self._completion_token_kwargs(max_tokens))
 
         if response_format:
@@ -689,8 +717,38 @@ class LLMClient:
                 )
                 return _create(swapped)
 
+        def _call_with_temperature_fallback(call_kwargs: Dict[str, Any]) -> Tuple[Any, float]:
+            """Fallback-Retry (#1096): bei 400 wg. einem nicht unterstuetzten
+            ``temperature``-Wert (GPT-5-/o-Reasoning-Familie akzeptiert nur
+            den Default) einmalig ohne ``temperature`` retryen.
+            ``_omits_temperature`` deckt die bekannten Familien bereits
+            proaktiv ab (kein ``temperature``-Key im Request); dieser
+            Fallback ist das Netz fuer neue Modelle/Proxies, die wir noch
+            nicht kennen — komponiert mit dem Token-Key-Fallback statt ihn
+            zu ersetzen, damit beide Retries unabhaengig voneinander
+            greifen koennen.
+
+            Jeder Aufruf von ``_call_with_token_key_fallback`` zaehlt als
+            separater Providerattempt mit eigener Check/Event/Record-Triplet.
+            """
+            try:
+                return _call_with_token_key_fallback(call_kwargs)
+            except Exception as exc:  # noqa: BLE001 — wir filtern selbst
+                if not self._is_temperature_400(exc):
+                    raise
+                if "temperature" not in call_kwargs:
+                    raise
+                dropped = dict(call_kwargs)
+                dropped.pop("temperature", None)
+                logger.warning(
+                    "LLM 400 on temperature param — retrying once without temperature (model=%s, msg=%s)",
+                    self.model,
+                    str(exc)[:200],
+                )
+                return _call_with_token_key_fallback(dropped)
+
         # Provider-Pfad: jeder physische Request (erster Call, jeder Retry,
-        # Token-Key-Fallback) erhaelt GENAU EINE
+        # Token-Key-Fallback, Temperature-Fallback) erhaelt GENAU EINE
         # _budget_check / _log_invocation_event / _budget_record-Triplet.
         # ``_provider_attempt`` kuemmert sich um Check + Failure-Telemetrie;
         # ``_record_provider_success`` finalisiert die Success-Telemetrie
@@ -704,7 +762,7 @@ class LLMClient:
         try:
             if force_stream:
                 kwargs["stream"] = True
-                _response, _latency_ms = _call_with_token_key_fallback(kwargs)
+                _response, _latency_ms = _call_with_temperature_fallback(kwargs)
                 chunks: List[str] = []
                 try:
                     for event in _response:  # type: ignore[union-attr]
@@ -737,7 +795,7 @@ class LLMClient:
                     raise
                 content = "".join(chunks)
             else:
-                _response, _latency_ms = _call_with_token_key_fallback(kwargs)
+                _response, _latency_ms = _call_with_temperature_fallback(kwargs)
                 # Issue #764 (Review): die lokale Verarbeitung einer
                 # HTTP-erfolgreichen Antwort kann fehlschlagen (leeres
                 # ``choices``, ``message`` ohne ``content``, fehlende
@@ -865,8 +923,11 @@ class LLMClient:
         kwargs: Dict[str, Any] = {
             "model": vision_model,
             "messages": messages,
-            "temperature": temperature,
         }
+        # #1096: siehe chat() — GPT-5-/o-Reasoning-Familie akzeptiert nur den
+        # Default-``temperature``-Wert (1).
+        if not self._omits_temperature(vision_model or ""):
+            kwargs["temperature"] = temperature
         kwargs.update(self._completion_token_kwargs(max_tokens, model=vision_model))
         if self._is_ollama():
             extra_body: Dict[str, Any] = {"options": {"num_ctx": max(self._num_ctx, 8192)}}
@@ -974,7 +1035,11 @@ class LLMClient:
                 format a single fallback to ``json_object`` is attempted with a
                 warning log.  When *schema* is a Pydantic model the returned
                 dict is also validated against it so that callers can rely on
-                field types matching the model.
+                field types matching the model. A 400 caused by the GPT-5-/o-
+                reasoning-family ``temperature`` quirk (#1096) is NOT treated
+                as unsupported-schema: it retries once without ``temperature``
+                in the same response_format mode instead of degrading to
+                ``json_object``.
             schema_name: Name embedded in the strict json_schema request
                 (used by some providers for caching / routing).
             context: Logical call context label for observability (forwarded
@@ -1181,24 +1246,46 @@ class LLMClient:
                     require_complete=True,
                 )
             except Exception as exc:
-                exc_lower = str(exc).lower()
-                if any(hint in exc_lower for hint in _STRICT_UNSUPPORTED_HINTS):
-                    logger.warning(
-                        "LLMClient.chat_json: strict json_schema not supported by "
-                        "provider, falling back to json_object (caller should not "
-                        "rely on schema enforcement here)"
-                    )
+                # #1096: ein 400 auf param=temperature ist KEIN Hinweis auf
+                # fehlenden strict-json_schema-Support — die Wortlaut-Hints
+                # unten ("unsupported", "not supported") matchen ihn aber
+                # faelschlich, weil OpenAIs unsupported_value-Fehlertext
+                # dieselben Woerter enthaelt. Ohne diese Weiche waere die
+                # Warnung "strict json_schema not supported by provider"
+                # irrefuehrend, und der Retry wuerde grundlos auf
+                # json_object statt auf denselben Schema-Modus wechseln.
+                # ``chat()`` faengt den Quirk bereits proaktiv (Shaping) und
+                # per eigenem Retry ab — dieser Zweig ist das Netz fuer den
+                # Fall, dass die Ausnahme trotzdem bis hierher durchreicht.
+                if self._is_temperature_400(exc):
                     response = self.chat(
                         messages=messages,
                         temperature=temperature,
                         max_tokens=max_tokens,
-                        response_format={"type": "json_object"},
+                        response_format=response_format,
                         context=context,
                         force_no_thinking=force_no_thinking,
                         require_complete=True,
                     )
                 else:
-                    raise
+                    exc_lower = str(exc).lower()
+                    if any(hint in exc_lower for hint in _STRICT_UNSUPPORTED_HINTS):
+                        logger.warning(
+                            "LLMClient.chat_json: strict json_schema not supported by "
+                            "provider, falling back to json_object (caller should not "
+                            "rely on schema enforcement here)"
+                        )
+                        response = self.chat(
+                            messages=messages,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                            response_format={"type": "json_object"},
+                            context=context,
+                            force_no_thinking=force_no_thinking,
+                            require_complete=True,
+                        )
+                    else:
+                        raise
         else:
             response = self.chat(
                 messages=messages,

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -3,12 +3,16 @@ OpenAI-spezifische Request-Quirks + OpenAI-Adapter (Issue #590).
 
 Zwei Rollen koexistieren in diesem Modul, klar getrennt:
 
-1. Token-Key-Quirks (main, #582): ``uses_max_completion_tokens``,
-   ``is_token_key_400`` und ``swap_token_kwargs`` — extrahiert aus dem
-   ehemaligen ``LLMClient``-Monolith, werden als ``LLMClient``-staticmethods
-   re-exportiert und von ``app/llm/tool_calls.py`` sowie dem Shim
-   ``app/utils/llm_client.py`` konsumiert. Unangetastet bei der
-   #590-Portierung (nur Docstring-Kommentar zur Divergenz).
+1. Token-Key-/Temperature-Quirks (main, #582 + #1096):
+   ``uses_max_completion_tokens``, ``is_token_key_400`` und
+   ``swap_token_kwargs`` — extrahiert aus dem ehemaligen ``LLMClient``-
+   Monolith, werden als ``LLMClient``-staticmethods re-exportiert und von
+   ``app/llm/tool_calls.py`` sowie dem Shim ``app/utils/llm_client.py``
+   konsumiert. Unangetastet bei der #590-Portierung (nur Docstring-Kommentar
+   zur Divergenz). ``omits_temperature`` und ``is_temperature_400`` (#1096)
+   sind das analoge Gegenstueck fuer den ``temperature``-Quirk derselben
+   GPT-5-/o-Reasoning-Familie: diese Modelle akzeptieren ausschliesslich den
+   Default-Wert (1) und antworten sonst 400 ``unsupported_value``.
 2. Provider-Adapter (PR-Vorlage, #590): :class:`OpenAIAdapter` — kapselt
    das Payload-Shaping fuer den OpenAI-kompatiblen Client-Pfad.
    ``completion_token_param`` delegiert an :func:`uses_max_completion_tokens`
@@ -102,6 +106,72 @@ def swap_token_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         swapped["max_tokens"] = value
         return swapped
     return None
+
+
+def omits_temperature(model: str) -> bool:
+    """Whether *model* rejects any non-default ``temperature`` value (#1096).
+
+    GPT-5 / o1 / o3 / o4 akzeptieren ausschliesslich den Default (1) und
+    antworten sonst 400 "Unsupported value: 'temperature' does not support
+    0.7 with this model. Only the default (1) value is supported." Gleiche
+    Prefix-Grenzen-Logik wie :func:`uses_max_completion_tokens` — bewusst
+    dupliziert statt geteilt, um die bestehende Token-Key-Heuristik nicht
+    anzufassen (Scope #1096: nur der ``temperature``-Quirk).
+    """
+    lowered = (model or "").strip().lower()
+    for prefix in ("gpt-5", "o1", "o3", "o4"):
+        if lowered == prefix or lowered.startswith(f"{prefix}-") or lowered.startswith(f"{prefix}."):
+            return True
+    return False
+
+
+def is_temperature_400(exc: Exception) -> bool:
+    """True wenn ein OpenAI-/Proxy-400 auf eine ``temperature``-Param-Inkompatibilität hindeutet.
+
+    Erkennt zuerst strukturiert ueber ``exc.body`` (OpenAI-SDK entpackt den
+    Fehlerbody bereits auf ``{"message", "type", "param", "code"}` —
+    siehe ``openai._client.OpenAI._make_status_error``), faellt sonst auf
+    Wortlaut-Matching zurueck — Netz fuer Proxies, die den strukturierten
+    Body nicht durchreichen oder ein noch unbekanntes Reasoning-Modell.
+
+    Wird von ``chat()`` (und transitiv ``chat_json()``) als Fallback-Retry-
+    Trigger genutzt, analog zu :func:`is_token_key_400`.
+    """
+    try:
+        from openai import APIStatusError
+    except ImportError:
+        APIStatusError = ()  # type: ignore[assignment]
+
+    if APIStatusError and isinstance(exc, APIStatusError):
+        status = getattr(exc, "status_code", None)
+        if status is None:
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+        if status != 400:
+            return False
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        param = body.get("param")
+        code = str(body.get("code") or "").lower()
+        message = str(body.get("message") or "").lower()
+        if param == "temperature" and (
+            code == "unsupported_value"
+            or "not supported" in message
+            or "does not support" in message
+            or "only the default" in message
+        ):
+            return True
+
+    msg = str(exc).lower()
+    if "temperature" not in msg:
+        return False
+    return (
+        "unsupported_value" in msg
+        or "does not support" in msg
+        or "only the default (1) value is supported" in msg
+        or "not supported" in msg
+    )
 
 
 # ----------------------------------------------------------------------

--- a/backend/tests/llm/test_temperature_quirk.py
+++ b/backend/tests/llm/test_temperature_quirk.py
@@ -1,0 +1,323 @@
+"""GPT-5-/o-Reasoning-Familie akzeptiert nur den Default-``temperature``-Wert (#1096).
+
+Jeder Run gegen diese Modelle brach bisher mit 400 ``unsupported_value`` /
+``param=temperature`` ab, weil ``LLMClient`` feste ``temperature``-Werte
+sendet (chat 0.7, describe_image 0.3, chat_json 0.3). Zweiter Defekt:
+``chat_json()`` deutete diesen 400er faelschlich als fehlenden
+Strict-Schema-Support und fiel grundlos auf ``json_object`` zurueck.
+
+Vier Szenarien:
+    (a) Request-Shaping fuer gpt-5.6-luna enthaelt kein ``temperature``.
+    (b) Request-Shaping fuer gpt-4o behaelt ``temperature``.
+    (c) Ein gemockter unsupported_value/temperature-400 loest in ``chat()``
+        einen Retry ohne ``temperature`` aus (Netz fuer unbekannte
+        Reasoning-Modelle, die die Heuristik noch nicht kennt).
+    (d) Derselbe gemockte 400 in ``chat_json()`` loest NICHT den
+        json_object-Fallback aus — response_format bleibt json_schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from app.llm.providers.openai import is_temperature_400, omits_temperature
+from app.utils.llm_client import LLMClient
+
+
+# ---------------------------------------------------------------------------
+# Heuristik-Unit-Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5",
+        "gpt-5-nano",
+        "gpt-5.6-luna",
+        "o1-preview",
+        "o3",
+        "o4.1",
+    ],
+)
+def test_omits_temperature_matches_reasoning_family(model: str) -> None:
+    assert omits_temperature(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-500",  # striktes Prefix-Matching — kein Match auf "gpt-5"
+        "qwen3:8b",
+        "",
+    ],
+)
+def test_omits_temperature_ignores_unrelated_models(model: str) -> None:
+    assert omits_temperature(model) is False
+
+
+class _FakeBadRequestWithBody(Exception):
+    """Ersatz fuer openai.BadRequestError mit strukturiertem ``.body`` (SDK-Shape).
+
+    Das OpenAI-SDK entpackt den Fehlerbody bereits auf
+    ``{"message", "type", "param", "code"}`` (siehe
+    ``openai._client.OpenAI._make_status_error``) — kein ``{"error": {...}}``-
+    Wrapper mehr auf Exception-Ebene.
+    """
+
+    def __init__(self, message: str, *, body: dict | None = None) -> None:
+        super().__init__(message)
+        self.body = body
+
+
+def test_is_temperature_400_matches_structured_body() -> None:
+    exc = _FakeBadRequestWithBody(
+        "Error code: 400 - {'error': {'message': \"Unsupported value: "
+        "'temperature' does not support 0.7 with this model. Only the "
+        "default (1) value is supported.\", 'type': 'invalid_request_error', "
+        "'param': 'temperature', 'code': 'unsupported_value'}}",
+        body={
+            "message": "Unsupported value: 'temperature' does not support 0.7 "
+            "with this model. Only the default (1) value is supported.",
+            "type": "invalid_request_error",
+            "param": "temperature",
+            "code": "unsupported_value",
+        },
+    )
+    assert is_temperature_400(exc) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Unsupported value: 'temperature' does not support 0.7 with this "
+        "model. Only the default (1) value is supported.",
+        "BadRequest: temperature is not supported with this model",
+    ],
+)
+def test_is_temperature_400_matches_known_wordings_without_body(message: str) -> None:
+    exc = _FakeBadRequestWithBody(message, body=None)
+    assert is_temperature_400(exc) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Connection reset by peer",
+        "Rate limit exceeded (429)",
+        "Invalid API key",
+        "'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+        "",
+    ],
+)
+def test_is_temperature_400_ignores_unrelated_errors(message: str) -> None:
+    exc = _FakeBadRequestWithBody(message, body=None)
+    assert is_temperature_400(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: Request-Shaping + Retry ueber LLMClient
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    completion_tokens = 42
+
+
+class _FakeMessage:
+    content = '{"ok": true}'
+
+
+class _FakeChoice:
+    finish_reason = "stop"
+    message = _FakeMessage()
+
+
+class _FakeResponse:
+    choices = [_FakeChoice()]
+    usage = _FakeUsage()
+
+
+class _FlakyCompletions:
+    """Wirft beim ersten Call einen 400-Temperature-Error; beim zweiten 200."""
+
+    def __init__(self, fail_first_with: str) -> None:
+        self.calls: list[dict] = []
+        self._fail_first_with = fail_first_with
+
+    def create(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        if len(self.calls) == 1:
+            raise _FakeBadRequestWithBody(
+                self._fail_first_with,
+                body={
+                    "message": self._fail_first_with,
+                    "param": "temperature",
+                    "code": "unsupported_value",
+                },
+            )
+        return _FakeResponse()
+
+
+class _StableCompletions:
+    """Gibt immer 200 zurueck — fuer reine Shaping-Assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return _FakeResponse()
+
+
+class _FakeChat:
+    def __init__(self, completions) -> None:
+        self.completions = completions
+
+
+class _FakeOpenAI:
+    def __init__(self, completions) -> None:
+        self.chat = _FakeChat(completions)
+
+
+@pytest.fixture()
+def fake_client(monkeypatch):
+    obj = LLMClient.__new__(LLMClient)
+    obj._max_retries = 0
+    obj._retry_initial_delay = 0.0
+    obj._retry_max_delay = 0.0
+    obj._num_ctx = 8192
+    obj._think = False
+    obj.api_key = "test"
+    obj.base_url = "https://api.openai.com/v1"
+    obj.model = "gpt-4o"
+    monkeypatch.setenv("LLM_FORCE_STREAM", "false")
+    monkeypatch.delenv("AGORA_E2E_LLM_MODE", raising=False)
+    return obj
+
+
+def test_chat_omits_temperature_for_gpt5_family(fake_client) -> None:
+    """(a) gpt-5.6-luna: temperature darf gar nicht erst in den Kwargs landen."""
+    fake_client.model = "gpt-5.6-luna"
+    completions = _StableCompletions()
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.chat(messages=[{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert len(completions.calls) == 1
+    assert "temperature" not in completions.calls[0]
+
+
+def test_chat_keeps_temperature_for_gpt4o(fake_client) -> None:
+    """(b) gpt-4o: temperature bleibt unveraendert erhalten."""
+    completions = _StableCompletions()
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.chat(messages=[{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert len(completions.calls) == 1
+    assert completions.calls[0].get("temperature") == 0.7
+
+
+def test_describe_image_omits_temperature_for_gpt5_family(fake_client) -> None:
+    fake_client.model = "gpt-5.6-luna"
+    completions = _StableCompletions()
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.describe_image(image_b64="aGVsbG8=", prompt="describe")
+
+    assert len(completions.calls) == 1
+    assert "temperature" not in completions.calls[0]
+
+
+def test_describe_image_keeps_temperature_for_gpt4o(fake_client) -> None:
+    completions = _StableCompletions()
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.describe_image(image_b64="aGVsbG8=", prompt="describe")
+
+    assert len(completions.calls) == 1
+    assert completions.calls[0].get("temperature") == 0.3
+
+
+def test_chat_retries_without_temperature_on_400(fake_client) -> None:
+    """(c) Unbekanntes Reasoning-Modell (noch nicht in der Heuristik) sendet
+    temperature, bekommt den unsupported_value-400 und retried einmalig ohne
+    ``temperature`` — kein dritter Versuch, keine Endlosschleife.
+    """
+    fake_client.model = "gpt-6-preview"  # (noch) nicht in omits_temperature()
+    completions = _FlakyCompletions(
+        fail_first_with=(
+            "Unsupported value: 'temperature' does not support 0.7 with "
+            "this model. Only the default (1) value is supported."
+        )
+    )
+    fake_client.client = _FakeOpenAI(completions)
+
+    fake_client.chat(messages=[{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert len(completions.calls) == 2, "must retry exactly once"
+    assert completions.calls[0].get("temperature") == 0.7
+    assert "temperature" not in completions.calls[1]
+
+
+def test_chat_does_not_retry_on_unrelated_400(fake_client) -> None:
+    """Gegenprobe: ein 400, der nichts mit temperature zu tun hat, propagiert
+    sofort — kein Endlos-Retry, kein Verschleiern echter Validation-Fehler."""
+
+    class _AlwaysFail:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def create(self, **kwargs):
+            self.calls += 1
+            raise _FakeBadRequestWithBody("Invalid API key", body=None)
+
+    completions = _AlwaysFail()
+    fake_client.client = _FakeOpenAI(completions)
+
+    with pytest.raises(_FakeBadRequestWithBody):
+        fake_client.chat(messages=[{"role": "user", "content": "hi"}], temperature=0.7)
+    assert completions.calls == 1, "must NOT retry unrelated 400"
+
+
+# ---------------------------------------------------------------------------
+# Integration: chat_json() faellt bei temperature-400 NICHT auf json_object zurueck
+# ---------------------------------------------------------------------------
+
+
+class PersonaSchema(BaseModel):
+    ok: bool
+
+
+def test_chat_json_does_not_fall_back_to_json_object_on_temperature_400(fake_client) -> None:
+    """(d) Derselbe gemockte temperature-400 darf in chat_json() NICHT den
+    strict->json_object-Fallback ausloesen. Der zweite (erfolgreiche)
+    Providerattempt muss weiterhin im json_schema-Modus laufen, nicht
+    json_object.
+    """
+    fake_client.model = "gpt-6-preview"
+    completions = _FlakyCompletions(
+        fail_first_with=(
+            "Unsupported value: 'temperature' does not support 0.3 with "
+            "this model. Only the default (1) value is supported."
+        )
+    )
+    fake_client.client = _FakeOpenAI(completions)
+
+    result = fake_client.chat_json(
+        [{"role": "user", "content": "hi"}],
+        temperature=0.3,
+        schema=PersonaSchema,
+    )
+
+    assert result == {"ok": True}
+    assert len(completions.calls) == 2, "must retry exactly once, not degrade to a 3rd call"
+    # 1. Versuch: temperature gesetzt, strict json_schema angefragt.
+    assert completions.calls[0].get("temperature") == 0.3
+    assert completions.calls[0]["response_format"]["type"] == "json_schema"
+    # 2. Versuch: temperature entfernt, WEITERHIN json_schema (kein json_object-Fallback).
+    assert "temperature" not in completions.calls[1]
+    assert completions.calls[1]["response_format"]["type"] == "json_schema"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4484 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4509 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- \`chat()\`, \`describe_image()\` und \`chat_json()\` schreiben den \`temperature\`-Parameter nicht mehr in den Request, wenn das Zielmodell zur GPT-5-/o-Reasoning-Familie gehört (\`omits_temperature\`, analog \`uses_max_completion_tokens\`).
- \`is_temperature_400()\` (strukturiert über \`exc.body\`, Wortlaut-Fallback) löst in \`chat()\` einen einmaligen Retry ohne \`temperature\` aus — Netz für künftige Modelle; komponiert mit dem bestehenden Token-Key-Fallback.
- \`chat_json()\` deutet einen \`temperature\`-400 nicht mehr als fehlenden Strict-Schema-Support: Retry im selben \`json_schema\`-Modus statt Degradierung auf \`json_object\`, die irreführende Warnung entfällt.
- \`BadRequestError\` loggt jetzt \`message\`, \`code\` und \`param\` aus dem API-Fehlerbody statt nur \`error_type\`.

## Issue
- Closes #1096

## Scope
- \`backend/app/llm/providers/openai.py\`, \`backend/app/llm/client.py\`, \`backend/tests/llm/test_temperature_quirk.py\` (neu), \`CHANGELOG.md\`, \`docs/STATUS.md\` (autogen Testanzahl)

## Out of Scope
- \`backend/app/services/ontology_generator.py\` (harter Aufrufer-Wert wird durch zentrales Shaping unschädlich), \`registry.py\` (Provider-Detection-SSoT unberührt), \`scripts/_sim_common.py\`, Frontend.

## Tests
- \`cd backend && uv run pytest tests/llm/ -q\` — PASS (243 passed, 25 neue Tests)
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- \`scripts/pre-push-gate.sh backend\` — PASS (ALL GREEN)

## Dokumentationssync
- \`docs/STATUS.md\`: aktualisiert (autogen Backend-Testanzahl 4484 → 4509)
- \`ROADMAP.md\`: NICHT BETROFFEN — kein Release-Gate, keine strategische Reihenfolge geändert
- \`CHANGELOG.md\`: aktualisiert (Unreleased/Fixed)
- Folge-Issue: NICHT BETROFFEN — Slice vollständig, keine ausgelagerte Arbeit

## Orchestrierung
- Lead, Planung und Verifikation: Fable
- Implementierung: \`agora-refactor-worker\` auf \`sonnet\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)