### PR TITLE
fix(evidence): kollisionsfreie gap_id-Vergabe in migrate_legacy_claims_to_anchored (#986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (kollidierende `gap_id`-Vergabe bei der Legacy-Claim-Migration — 2026-08-05)
+
+- **`migrate_legacy_claims_to_anchored` vergab neue `gap_id`-Werte über `len(data_gaps) + 1` statt über den tatsächlichen Bestand.** Bei lückenhaft nummerierten Bestands-Gaps (z. B. `gap_01`, `gap_03`) erzeugte das erneut `gap_03` — ein Duplikat. Die Vergabe ermittelt jetzt pro Section das höchste vorhandene `gap_<n>`-Suffix und sichert zusätzlich gegen das Set der bereits vergebenen IDs ab, auch bei mehreren neuen Gaps in derselben Migration. (#986)
+
 ### Fixed (GPT-5-/o-Reasoning-Modelle brachen jeden Run mit 400 `unsupported_value` ab — 2026-08-05)
 
 - **Jeder Run gegen OpenAI-Reasoning-Modelle (GPT-5-Familie, o1/o3/o4) scheiterte sofort mit `400 unsupported_value` auf `param=temperature`.** `LLMClient` sendet feste `temperature`-Werte (`chat` 0.7, `describe_image` 0.3, `chat_json` 0.3); diese Modelle akzeptieren ausschließlich den Default (1) und lehnen jeden expliziten Wert ab. `chat()`, `describe_image()` und `chat_json()` lassen den `temperature`-Key jetzt weg, wenn das Zielmodell zur GPT-5-/o-Familie gehört (`omits_temperature`, analog zur bestehenden `max_completion_tokens`-Heuristik) — für noch unbekannte Modelle fängt ein einmaliger Retry ohne `temperature` denselben 400 zusätzlich ab. (#1096)

--- a/backend/app/services/evidence_migrations.py
+++ b/backend/app/services/evidence_migrations.py
@@ -20,6 +20,7 @@ P3.1-Followup — Echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -37,6 +38,11 @@ _TRUST_KEYWORDS = frozenset({"vertrauenssignal", "vertrauens", "trust", "cialdin
 
 # Signal-Type-Fallback für TrustSignals aus Section-Claims.
 _DEFAULT_TRUST_SIGNAL_TYPE = "authority"
+
+# Issue #986: Erkennt vorhandene ``gap_<n>``-IDs, um bei der Neuvergabe in
+# ``migrate_legacy_claims_to_anchored`` Kollisionen mit lückenhaft nummerierten
+# Bestands-Gaps (z. B. gap_01, gap_03) zu vermeiden.
+_GAP_ID_SUFFIX_RE = re.compile(r"^gap_(\d+)$")
 
 # Erlaubte voice_register-Werte (gespiegelt aus report_v3.Persona).
 _VALID_VOICE_REGISTERS = frozenset({"formal-de", "neutral-de", "technical-de", "skeptisch-de"})
@@ -94,6 +100,24 @@ def migrate_legacy_claims_to_anchored(raw: Optional[dict]) -> Optional[dict]:
         section.setdefault("hypotheses", [])
         section.setdefault("data_gaps", [])
 
+        # Issue #986: Bestands-gap_ids der Section einsammeln, damit neue IDs
+        # weder mit lückenhaft nummerierten Bestands-Gaps (gap_01, gap_03)
+        # noch untereinander kollidieren. Malformed/nicht-dict-Einträge
+        # werden toleriert (kein Crash), einfach ignoriert.
+        existing_gap_ids: set[str] = set()
+        next_gap_index = 1
+        for existing_gap in section["data_gaps"]:
+            if not isinstance(existing_gap, dict):
+                continue
+            gap_id = existing_gap.get("gap_id")
+            if gap_id is None:
+                continue
+            gap_id = str(gap_id)
+            existing_gap_ids.add(gap_id)
+            match = _GAP_ID_SUFFIX_RE.match(gap_id)
+            if match:
+                next_gap_index = max(next_gap_index, int(match.group(1)) + 1)
+
         claims = section.get("claims") or []
         surviving_claims = []
 
@@ -106,13 +130,19 @@ def migrate_legacy_claims_to_anchored(raw: Optional[dict]) -> Optional[dict]:
             label = str(claim.get("confidence_label") or "").lower()
 
             if not evidence and label in _ANCHOR_REQUIRED_LABELS:
-                index = len(section["data_gaps"]) + 1
+                new_gap_id = f"gap_{next_gap_index:02d}"
+                while new_gap_id in existing_gap_ids:
+                    next_gap_index += 1
+                    new_gap_id = f"gap_{next_gap_index:02d}"
+                existing_gap_ids.add(new_gap_id)
+                next_gap_index += 1
+
                 claim_text = (
                     str(claim.get("claim_text") or claim.get("claim") or "").strip()
                     or "Legacy claim ohne Evidence-Text."
                 )[:1000]
                 section["data_gaps"].append({
-                    "gap_id": f"gap_{index:02d}",
+                    "gap_id": new_gap_id,
                     "claim_text": claim_text,
                     "gap_reason": "no_evidence_bound",
                     "suggested_fix": "Evidence per Graph- oder Agent-Tool nachreichen.",

--- a/backend/tests/eval/test_evidence_routing.py
+++ b/backend/tests/eval/test_evidence_routing.py
@@ -209,3 +209,90 @@ def test_migrate_legacy_mixed_section() -> None:
     assert section["claims"][0]["claim_id"] == "claim_02"
     assert len(section["data_gaps"]) == 1
     assert section["data_gaps"][0]["gap_reason"] == "no_evidence_bound"
+
+
+def test_migrate_legacy_new_gap_id_avoids_collision_with_gapped_existing_ids() -> None:
+    """Issue #986: Bestands-Gaps gap_01/gap_03 duerfen keine gap_03-Kollision erzeugen.
+
+    ``index = len(data_gaps) + 1`` zaehlte hier vorher naiv die Bestandsliste
+    (2 Eintraege) hoch und vergab ``gap_03`` erneut — ein Duplikat mit dem
+    bereits vorhandenen ``gap_03``. Der Test prueft die tatsaechliche
+    Invariante direkt: alle gap_id-Werte der Section sind nach der Migration
+    paarweise verschieden, und die neue ID liegt hinter dem hoechsten
+    Bestands-Suffix.
+    """
+    raw = {
+        "schema_version": 2,
+        "sections": [{
+            "section_index": 1,
+            "section_title": "Test",
+            "section_summary": "summary",
+            "data_gaps": [
+                {"gap_id": "gap_01", "claim_text": "Bestand 1", "gap_reason": "manual"},
+                {"gap_id": "gap_03", "claim_text": "Bestand 2", "gap_reason": "manual"},
+            ],
+            "claims": [{
+                "claim_id": "claim_01",
+                "claim_text": "Mittlere Konfidenz ohne Beleg, nicht haltbar.",
+                "confidence_label": "medium",
+                "confidence_score": 0.5,
+                "evidence": [],
+                "audit_trail": [],
+            }],
+        }],
+    }
+
+    result = migrate_legacy_claims_to_anchored(raw)
+    assert result is not None
+    section = result["sections"][0]
+    gap_ids = [gap["gap_id"] for gap in section["data_gaps"]]
+    assert len(gap_ids) == len(set(gap_ids)), (
+        f"gap_id-Kollision nach Migration: {gap_ids}"
+    )
+    assert "gap_04" in gap_ids
+
+
+def test_migrate_legacy_two_new_gaps_in_same_section_are_collision_free() -> None:
+    """Issue #986: Zwei ankerlose Claims in derselben Section erzeugen
+
+    untereinander kollisionsfreie neue gap_ids, auch gegen den Bestand.
+    """
+    raw = {
+        "schema_version": 2,
+        "sections": [{
+            "section_index": 1,
+            "section_title": "Test",
+            "section_summary": "summary",
+            "data_gaps": [
+                {"gap_id": "gap_01", "claim_text": "Bestand", "gap_reason": "manual"},
+            ],
+            "claims": [
+                {
+                    "claim_id": "claim_01",
+                    "claim_text": "Erste Behauptung ohne Beleg, mittlere Konfidenz.",
+                    "confidence_label": "medium",
+                    "confidence_score": 0.5,
+                    "evidence": [],
+                    "audit_trail": [],
+                },
+                {
+                    "claim_id": "claim_02",
+                    "claim_text": "Zweite Behauptung ohne Beleg, hohe Konfidenz.",
+                    "confidence_label": "high",
+                    "confidence_score": 0.7,
+                    "evidence": [],
+                    "audit_trail": [],
+                },
+            ],
+        }],
+    }
+
+    result = migrate_legacy_claims_to_anchored(raw)
+    assert result is not None
+    section = result["sections"][0]
+    assert section["claims"] == []
+    gap_ids = [gap["gap_id"] for gap in section["data_gaps"]]
+    assert len(gap_ids) == 3
+    assert len(gap_ids) == len(set(gap_ids)), (
+        f"gap_id-Kollision nach Migration: {gap_ids}"
+    )

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4511 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4513 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- `migrate_legacy_claims_to_anchored` vergab neue `gap_id`-Werte über `len(data_gaps) + 1`; bei lückenhaft nummerierten Bestands-Gaps (`gap_01`, `gap_03`) entstand ein Duplikat. Die Vergabe ermittelt jetzt pro Section das höchste vorhandene `gap_<n>`-Suffix und sichert zusätzlich gegen das Set der bereits vergebenen IDs ab — auch mehrere neue Gaps derselben Migration sind untereinander kollisionsfrei.
- Entscheidung (im Commit-Body begründet): keine Uniqueness-Validierung im `ReportSectionModel` — bereits persistierte Bestands-Duplikate würden Lese-Endpunkte auf HTTP 400 werfen; Bestandsreparatur ist laut Issue explizit out-of-scope.

## Issue
- Closes #986

## Scope
- `backend/app/services/evidence_migrations.py` (nur ID-Vergabe in `migrate_legacy_claims_to_anchored`)
- `backend/tests/eval/test_evidence_routing.py` (2 Regressionstests)
- `CHANGELOG.md`, `docs/STATUS.md` (autogenerierte Testanzahl)

## Out of Scope
- Contract-/Schema-Änderungen (`report_contract.py`), übrige Migrationsschritte, Reparatur bereits persistierter Duplikate, Frontend

## Tests
- `uv run pytest tests/eval/test_evidence_routing.py -x -q` — PASS (12 passed; Regressionstest vor Fix rot verifiziert)
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS (ALL GREEN, frisch auf dem cherry-gepickten Branch)

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert (autogenerierte Backend-Testanzahl 4511→4513)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate, keine strategische Reihenfolge geändert
- `CHANGELOG.md`: aktualisiert (Fixed-Eintrag Unreleased)
- Folge-Issue: NICHT BETROFFEN — keine offene Folgearbeit im Scope

## Orchestrierung
- Lead, Planung und Verifikation: Fable
- Implementierung: `agora-refactor-worker` auf `sonnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)