### PR TITLE
fix(routing): base_url der Provider-Connection in ResolvedRoute auflösen (#1104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 ### Fixed (kollidierende `gap_id`-Vergabe bei der Legacy-Claim-Migration — 2026-08-05)
 
 - **`migrate_legacy_claims_to_anchored` vergab neue `gap_id`-Werte über `len(data_gaps) + 1` statt über den tatsächlichen Bestand.** Bei lückenhaft nummerierten Bestands-Gaps (z. B. `gap_01`, `gap_03`) erzeugte das erneut `gap_03` — ein Duplikat. Die Vergabe ermittelt jetzt pro Section das höchste vorhandene `gap_<n>`-Suffix und sichert zusätzlich gegen das Set der bereits vergebenen IDs ab, auch bei mehreren neuen Gaps in derselben Migration. (#986)
+### Fixed (Persona-Generierung schickte das Routing-Modell an den `.env`-Endpoint — 2026-08-05)
+
+- **Eine über das Workspace-Routing gewählte Provider-Route (z. B. OpenAI) lief bei der Persona-Generierung trotzdem gegen den `.env`-Endpoint (lokaler Ollama-Gateway) — HTTP 404 und stiller regelbasierter Fallback für alle Personas.** `workspace_llm_routing.json` persistiert pro Route nur `provider_id` + `model`; die Base-URL gehört zur Provider-Connection, wurde aber nirgends aufgelöst: `ResolvedRoute.base_url_sanitized` blieb `None`, und `OasisProfileGenerator` füllte die Lücke mit `Config.LLM_BASE_URL`, während Modell und API-Key aus der Route stammten. `StageModelRouter` löst die Base-URL jetzt aus der Provider-Connection im Store auf (derselbe Lookup, den der OASIS-Subprozess-Pfad bereits nutzt); eine explizite `provider_options.base_url` behält Vorrang. Findet auch der Store keine URL, bricht `_resolve_llm_connection` mit einer handlungsleitenden Meldung ab, statt still `(key, None)` zurückzugeben. Nachfolger von #1101/#1102, die nur den `LLMClient`-Konstruktor fixten. Bestehende Runs behalten ihre gelockte Route — der Fix greift für neue Runs. (#1104)
 
 ### Fixed (GPT-5-/o-Reasoning-Modelle brachen jeden Run mit 400 `unsupported_value` ab — 2026-08-05)
 

--- a/backend/app/services/llm_routing_seed.py
+++ b/backend/app/services/llm_routing_seed.py
@@ -488,7 +488,7 @@ def build_runtime_llm_config(route: ResolvedRoute, api_key: Optional[str]) -> Ru
     )
 
 
-def _store_base_url_for_provider(provider_id: Optional[str]) -> Optional[str]:
+def store_base_url_for_provider(provider_id: Optional[str]) -> Optional[str]:
     """Liefert die im Store gepflegte Base-URL einer aktivierten Connection.
 
     ``LlmProviderRegistry.get_providers()`` ist laut eigenem Docstring eine
@@ -511,7 +511,7 @@ def _store_base_url_for_provider(provider_id: Optional[str]) -> Optional[str]:
         connections = ProviderConnectionStore().list_connections()
     except Exception:  # noqa: BLE001 — ein Store-Ausfall darf keinen Run kippen
         logger.warning(
-            "_store_base_url_for_provider: Store nicht lesbar für provider_id=%s "
+            "store_base_url_for_provider: Store nicht lesbar für provider_id=%s "
             "— Registry-Default gilt",
             provider_id,
         )
@@ -567,10 +567,10 @@ def build_route_subprocess_env(
     # Zwischen Route und Registry-Default liegt seit diesem Fix der Store: die
     # in der UI gepflegte Connection-Base-URL gewinnt gegen den hartkodierten
     # ``default_base_url``. Ohne diese Stufe war das UI-Feld fuer Simulationen
-    # wirkungslos — siehe ``_store_base_url_for_provider``.
+    # wirkungslos — siehe ``store_base_url_for_provider``.
     base_url = (
         route.base_url_sanitized
-        or _store_base_url_for_provider(route.provider_id)
+        or store_base_url_for_provider(route.provider_id)
         or (provider.base_url if provider else None)
     )
     if not base_url and route.provider_id:

--- a/backend/app/services/prepare_service.py
+++ b/backend/app/services/prepare_service.py
@@ -83,10 +83,24 @@ def _resolve_llm_connection(
 
     Raises:
         ValueError: ``require`` ist gesetzt und weder eine ``ResolvedRoute``
-            noch ein aktiver Runtime-Override liegt vor.
+            noch ein aktiver Runtime-Override liegt vor, oder die
+            ``ResolvedRoute`` selbst keine aufloesbare ``base_url_sanitized``
+            traegt (#1104: zweite Verteidigungslinie gegen die Halb-Uebergabe,
+            falls der Store-Lookup in ``StageModelRouter`` keine Base-URL
+            findet — z. B. eine deaktivierte oder geloeschte Connection).
     """
     if isinstance(llm_runtime, ResolvedRoute):
-        return resolve_route_api_key(llm_runtime), llm_runtime.base_url_sanitized
+        base_url = llm_runtime.base_url_sanitized
+        if require and not base_url:
+            raise ValueError(
+                f"kein Endpoint für Provider '{llm_runtime.provider_id}' aufgelöst: die "
+                "Route nennt Modell und Provider, aber keine Basis-URL. Ohne Endpoint "
+                "würde die Anfrage an die .env-Konfiguration statt an die konfigurierte "
+                "Verbindung gehen, während Modell und Schlüssel aus der Route stammen — "
+                "diese Mischung erreicht den falschen Provider. Bitte unter Einstellungen "
+                f"→ LLM-Anbieter die Verbindung '{llm_runtime.provider_id}' prüfen."
+            )
+        return resolve_route_api_key(llm_runtime), base_url
     if llm_runtime and llm_runtime.enabled:
         return llm_runtime.api_key, llm_runtime.base_url
     if require:

--- a/backend/app/services/stage_model_router.py
+++ b/backend/app/services/stage_model_router.py
@@ -26,6 +26,7 @@ from .runtime_run_config import RuntimeRunConfig, _detect_default_provider_id
 from .secret_resolver import SecretResolver
 from .ai_route_audit import AiRouteAudit
 from .ai_route_resolver import resolve_ai_route
+from .llm_routing_seed import store_base_url_for_provider
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.stage_model_router")
@@ -177,6 +178,18 @@ class StageModelRouter:
         options = dict(route.provider_options)
         legacy = options.pop("__legacy_stage_route__", None) or {}
         base_url = options.get("base_url")
+        if not base_url and route.provider_connection_id:
+            # workspace_llm_routing.json persistiert pro Route nur
+            # provider_id + model — keine base_url (die gehoert zur
+            # Connection, nicht zur Route). Ohne diese Auflösung blieb
+            # ``ResolvedRoute.base_url_sanitized`` None; die zweite
+            # Verteidigungslinie in ``prepare_service._resolve_llm_connection``
+            # liess das durch, und ``OasisProfileGenerator`` fuellte die
+            # Luecke mit ``Config.LLM_BASE_URL`` (.env-Endpoint), waehrend
+            # Modell und Key aus der Route stammten (#1104). Store-Lookup
+            # analog zum bereits existierenden OASIS-Subprozess-Env-Pfad in
+            # ``llm_routing_seed.build_route_subprocess_env``.
+            base_url = store_base_url_for_provider(route.provider_connection_id)
         provider_id = route.provider_connection_id or _detect_default_provider_id(
             base_url, route.model_id
         )

--- a/backend/tests/services/test_provider_resolution_store_precedence.py
+++ b/backend/tests/services/test_provider_resolution_store_precedence.py
@@ -148,6 +148,63 @@ class TestStoreBaseUrlBeatsRegistryDefault:
         assert env["LLM_MODEL_NAME"] == "deepseek-v4-flash:0731"
 
 
+class TestResolvedRouteFromAiRouteFillsBaseUrlFromStore:
+    """#1104: ``workspace_llm_routing.json`` persistiert pro Route nur
+    ``provider_id``/``model`` — keine ``base_url`` (die gehoert zur
+    Provider-Connection). Ohne Store-Lookup blieb ``base_url_sanitized``
+    ``None``, und ``OasisProfileGenerator`` fuellte die Luecke mit
+    ``Config.LLM_BASE_URL`` (.env-Endpoint), waehrend Modell und Key aus der
+    Route stammten — Nachfolge-Defekt von #1101/#1102, die nur den
+    ``LLMClient``-Konstruktor fixten, nicht diesen kanonischen Routing-Pfad.
+    """
+
+    def test_store_base_url_fills_resolved_route(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_store(
+            monkeypatch,
+            [_StubConnection("openai", "openai", "https://store.example/openai/v1")],
+        )
+        from app.contracts.ai_provider_contract import AiRoute
+        from app.services.stage_model_router import StageModelRouter
+
+        route = AiRoute(
+            provider_connection_id="openai",
+            model_id="gpt-5.6-luna",
+            source="workspace",
+        )
+
+        resolved = StageModelRouter(run_id="run-1")._resolved_route_from_ai_route(
+            "persona_generation", route, 1
+        )
+
+        assert resolved.base_url_sanitized == "https://store.example/openai/v1"
+
+    def test_route_provider_options_base_url_still_wins_over_store(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Praezedenz bleibt Route-Option > Store, analog zu Defekt A."""
+        _patch_store(
+            monkeypatch,
+            [_StubConnection("openai", "openai", "https://store.example/openai/v1")],
+        )
+        from app.contracts.ai_provider_contract import AiRoute
+        from app.services.stage_model_router import StageModelRouter
+
+        route = AiRoute(
+            provider_connection_id="openai",
+            model_id="gpt-5.6-luna",
+            source="workspace",
+            provider_options={"base_url": "https://explicit.example/v1"},
+        )
+
+        resolved = StageModelRouter(run_id="run-1")._resolved_route_from_ai_route(
+            "persona_generation", route, 1
+        )
+
+        assert resolved.base_url_sanitized == "https://explicit.example/v1"
+
+
 class TestPrepareRequiresResolvedRoute:
     """Defekt C: keine Route → lauter Abbruch statt stiller ``.env``-Uebernahme."""
 
@@ -178,3 +235,25 @@ class TestPrepareRequiresResolvedRoute:
         _, base_url = _resolve_llm_connection(route)
 
         assert base_url == "https://ollama.com/v1"
+
+    def test_resolved_route_without_base_url_raises(self) -> None:
+        """#1104, zweite Verteidigungslinie: findet auch der Store-Lookup in
+        ``StageModelRouter`` keine base_url (z. B. geloeschte/deaktivierte
+        Connection), darf ``_resolve_llm_connection`` niemals still
+        ``(key, None)`` zurueckgeben — das war die Eintrittskarte fuer den
+        ``.env``-Fallback im Generator-Konstruktor.
+        """
+        route = _route("openai", base_url=None)
+
+        with pytest.raises(ValueError, match="kein Endpoint"):
+            _resolve_llm_connection(route)
+
+    def test_resolved_route_without_base_url_and_require_false_does_not_raise(
+        self,
+    ) -> None:
+        """``require=False`` bleibt wie bisher: kein Abbruch, nur kein Endpoint."""
+        route = _route("openai", base_url=None)
+
+        _, base_url = _resolve_llm_connection(route, require=False)
+
+        assert base_url is None

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4513 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4517 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
## Summary
- Der kanonische Routing-Pfad löste für Provider-Connection-Routen keine `base_url` auf: `workspace_llm_routing.json` persistiert nur `provider_id` + `model`, `ResolvedRoute.base_url_sanitized` blieb `None`, und `OasisProfileGenerator` füllte die Lücke mit `Config.LLM_BASE_URL` — das UI-Routing-Modell samt Provider-Key ging an den `.env`-Ollama-Gateway (404, stiller regelbasierter Persona-Fallback, live auf armserver diagnostiziert).
- `StageModelRouter._resolved_route_from_ai_route` löst die Base-URL jetzt über den bestehenden Store-Lookup `store_base_url_for_provider` auf (vormals privat, bereits vom OASIS-Subprozess-Env-Pfad genutzt); eine explizite `provider_options.base_url` behält Vorrang.
- Zweite Verteidigungslinie: `_resolve_llm_connection` wirft bei einer Route ohne auflösbare Base-URL (`require=True`) einen handlungsleitenden `ValueError` statt still `(key, None)` durchzureichen.
- Warum #1101/#1102 nicht reichte: deren Fix sitzt im `LLMClient`-Konstruktor und füllt nur fehlende Werte — im Persona-Pfad waren aus Client-Sicht alle Werte „explizit übergeben".

## Release-Ziel
- 0.8.x Bugfix-Linie, Backend-Gate

## Issue
- Closes #1104

## Scope
- `backend/app/services/stage_model_router.py`, `prepare_service.py`, `llm_routing_seed.py` (Rename privat→public, keine Logikänderung)
- 4 Regressionstests in `backend/tests/services/test_provider_resolution_store_precedence.py`
- `CHANGELOG.md`, `docs/STATUS.md` (autogenerierte Testanzahl 4513→4517)

## Out-of-Scope
- Frontend-Override-Ablösung (#903), `fallback_reason`-Audit (#992), Reparatur gelockter Snapshots bestehender Runs (Fix greift für neue Runs), Generator-Konstruktoren (`or Config.LLM_BASE_URL` bleibt für Standalone-Nutzung)

## Tests
- `uv run pytest tests/services/test_provider_resolution_store_precedence.py -x -q` — PASS (12 passed; die 2 neuen Kern-Regressionstests vor Fix rot verifiziert)
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS (frisch auf diesem Branch nach Rebase-cherry-pick auf `21a11ea7`)

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert (Testanzahl 4517)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate geändert
- `CHANGELOG.md`: aktualisiert (Fixed-Eintrag Unreleased)
- Folge-Issue: NICHT BETROFFEN — #903/#992 existieren bereits und sind verlinkt

## Orchestrierung
- Lead, Planung, Verifikation und Fertigstellung: Fable (Worker-Vorarbeit `agora-refactor-worker`/Sonnet, nach Systemabsturz vom Lead übernommen)

## Deploy-Hinweis armserver
- Nach Merge: pull + rebuild + **neue Simulation anlegen** — bestehende Runs behalten ihre gelockte, defekte Route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Die Base-URL wird zuverlässig aus der konfigurierten Routing-Verbindung ermittelt.
  * Explizite Routen-Einstellungen haben Vorrang vor Standardwerten.
  * Fehlt eine erforderliche URL oder Verbindung, wird nun eine verständliche Fehlermeldung angezeigt.
  * Bestehende Ausführungen behalten ihre gespeicherte Route.

* **Dokumentation**
  * Die Anzahl der erfassten Backend-Tests wurde aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->