### PR TITLE
perf(gate): PR-Subset mit pytest-xdist parallelisieren (#1106)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -109,6 +109,7 @@ dev = [
     "jsonschema>=4.0.0",
     "fakeredis[lua]>=2.30.0",
     "radon>=6.0.1",
+    "pytest-xdist>=3.8.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -78,6 +78,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "radon" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -134,6 +135,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "radon", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "types-requests", specifier = ">=2.32.0" },
@@ -598,6 +600,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1933,7 +1944,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2279,6 +2290,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -2996,13 +3020,13 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'linux'" },
+    { name = "fsspec", marker = "sys_platform != 'linux'" },
+    { name = "jinja2", marker = "sys_platform != 'linux'" },
+    { name = "networkx", marker = "sys_platform != 'linux'" },
+    { name = "setuptools", marker = "sys_platform != 'linux'" },
+    { name = "sympy", marker = "sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
@@ -3019,13 +3043,13 @@ resolution-markers = [
     "sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "jinja2", marker = "sys_platform == 'linux'" },
+    { name = "networkx", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
+    { name = "sympy", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:dec241fef3984c0d1edadd1f58708e218d4eae881ceef7bc10cf9964d41b68b9", upload-time = "2026-07-08T19:30:20Z" },
@@ -3229,8 +3253,8 @@ name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -63,8 +63,18 @@ run_backend() {
   # #1059 (LLM-Client-Metriken-Tests) ist mit #1066 gefixt; die fünf
   # Tests dort sind aus dem Deselect raus. Deselect bis die übrigen
   # Fixes gemerged sind; Liste schrumpft weiter.
+  # 2026-08-05 (Issue #1106): pytest-xdist parallelisiert den Subset-Lauf;
+  # identische Testmenge (--deselect/--ignore unveraendert), Contract-Tests-
+  # Step bleibt seriell. Gemessen auf M3/16GB: seriell 117s; `-n 4` mit
+  # Warning-Capture 270s+ bzw. Shutdown-Hang (>1.6 Mio Warnings werden pro
+  # Worker ueber die execnet-Pipe serialisiert), `-n 4 -p no:warnings` 33s.
+  # `-p no:warnings` ist hier keine Abschwaechung: das Repo definiert keine
+  # filterwarnings-Regeln (insb. kein `error`), Warnings sind im Smoke reine
+  # Anzeige. `-n auto` (=8) bewusst nicht: acht App-Importe sprengen 16 GB.
+  # Gezielte Warning-Filter bleiben Issue #1090.
   step "Backend: tests (PR subset, no coverage)"
   (cd backend && FLASK_DEBUG=false uv run pytest tests/ \
+      -n 4 -p no:warnings \
       --ignore=tests/contracts \
       --deselect tests/scripts/test_oasis_preflight.py::TestPreflightSkipSwitch::test_skip_env_skips_probe_and_warns \
       --deselect tests/services/test_oasis_voice_register.py::test_llm_valid_voice_register_lands_in_profile \


### PR DESCRIPTION
## Summary
- Der PR-Subset-Step in `scripts/pre-push-gate.sh backend` (3969 Tests) lief single-threaded in 117.51s. Mit `pytest-xdist -n 4 -p no:warnings` läuft er in ~33s — identische Testmenge, alle `--deselect`/`--ignore` unverändert, Contract-Tests-Step bleibt seriell.
- Die Flag-Wahl ist messbasiert (M3, 16 GB): `-n auto` (=8) und `-n 4` **mit** Warning-Capture hängen nach `[100%]` im Worker-Shutdown bzw. brauchen 270s+ — die >1,6 Mio Upstream-Warnings der Suite werden pro Worker über die execnet-Pipe serialisiert und dominieren Laufzeit und Speicher.
- `-p no:warnings` ist keine Abschwächung: Das Repo definiert keine pytest-`filterwarnings`-Regeln (insbesondere kein `error`); Warnings sind im Smoke reine Anzeige. Gezielte Filter bleiben #1090.

## Release-Ziel
- Entwickler-Tooling, kein Produktverhalten

## Issue
- Closes #1106

## Scope
- `backend/pyproject.toml` + `backend/uv.lock` (pytest-xdist Dev-Dependency)
- `scripts/pre-push-gate.sh` (nur der PR-Subset-Step)

## Out-of-Scope
- `.github/workflows/ci.yml` (CI-Seite separat: #1107), Warning-Filter (#1090), Frontend-/Schemas-Pfade

## Tests
- Collect-Only-Nachweis: identische Testmenge vor/nach der Änderung (3981/3988, 7 deselected)
- Parallel-Safety: voller Subset-Lauf mehrfach grün (u. a. 3970 passed in 32.98s), keine Deselects/Skips ergänzt
- `scripts/pre-push-gate.sh backend` — PASS, frisch auf diesem Branch (Subset 32.57s, zuvor 117.51s)

## Dokumentationssync
- `docs/STATUS.md`: NICHT BETROFFEN — Testanzahl unverändert
- `ROADMAP.md`: NICHT BETROFFEN
- `CHANGELOG.md`: NICHT BETROFFEN — reines Entwickler-Tooling, kein ausgeliefertes Nutzer-/Betriebsverhalten
- Folge-Issue: #1107 (CI-STATUS-Check), bereits angelegt

## Orchestrierung
- Lead, Planung, Diagnose (Shutdown-Hang → Warning-Pipe-Ursache) und Fertigstellung: Fable (Worker-Vorarbeit `agora-test-worker`/Sonnet, nach Systemabsturz vom Lead übernommen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Qualitätssicherung**
  * Die automatisierten Prüfungen vor Änderungen laufen künftig schneller und zuverlässiger durch parallele Testausführung.
  * Vertragsprüfungen werden weiterhin unverändert und nacheinander ausgeführt.
  * Die Testausgabe wurde übersichtlicher gestaltet, damit relevante Fehler schneller erkennbar sind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->