### PR TITLE
security(llm): HTTPS für credential-behaftete LLM-Endpoints erzwingen (#1103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,10 @@ LLM_API_KEY=ollama
 LLM_MODEL_NAME=qwen2.5:32b
 # Lighter model for development (less VRAM):
 # LLM_MODEL_NAME=qwen2.5:14b
+# Transport-Gate (#1103): credential-behaftete LLM-Requests erzwingen HTTPS;
+# http:// ist nur fuer lokale/private Hosts (localhost, Compose-Servicenamen,
+# RFC1918, Tailscale/CGNAT) erlaubt. Nur fuer dokumentierte Ausnahmen setzen:
+# AGORA_LLM_ALLOW_INSECURE_HTTP=true
 
 # ===== Neo4j Configuration =====
 # Aktiver Default ist auskommentiert — die Setup-Datei deines Pfades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Security (HTTPS für credential-behaftete LLM-Endpoints erzwingen — 2026-08-05)
+
+- **`LLMClient` und die LLM-Discovery-Pfade (`ModelCatalogService`, Provider-Connection-Adapter) sendeten `Authorization: Bearer <api_key>` auch an `http://`-Endpoints, ohne den Host zu prüfen (CWE-319) — bei einer öffentlich erreichbaren, versehentlich auf `http://` konfigurierten `base_url` ginge der API-Key im Klartext über die Leitung.** Ein neues, zentrales Gate (`ensure_credentialed_transport_security`, `backend/app/llm/transport_security.py`) läuft jetzt vor jedem credential-behafteten Request und lässt `http://` nur für nachweislich lokale/private Hosts zu (`localhost`, Docker-Compose-Servicenamen, Docker-Host-Gateway-Namen, Loopback, RFC1918, CGNAT/Tailscale-Bereich, Link-Local). Gegen alle anderen Hosts bricht ein unverschlüsselter Request mit einem credential-behafteten Key jetzt mit `InsecureTransportError` ab — fail-closed auch bei unparsebaren URLs. Für dokumentierte Ausnahmen (z. B. ein bewusst unverschlüsseltes internes Gateway ohne TLS-Terminierung) steht `AGORA_LLM_ALLOW_INSECURE_HTTP` zur Verfügung; Default bleibt sicher, die Ausnahme loggt eine sanitisierte Warnung statt still durchzulassen. (#1103)
+
 ### Fixed (kollidierende `gap_id`-Vergabe bei der Legacy-Claim-Migration — 2026-08-05)
 
 - **`migrate_legacy_claims_to_anchored` vergab neue `gap_id`-Werte über `len(data_gaps) + 1` statt über den tatsächlichen Bestand.** Bei lückenhaft nummerierten Bestands-Gaps (z. B. `gap_01`, `gap_03`) erzeugte das erneut `gap_03` — ein Duplikat. Die Vergabe ermittelt jetzt pro Section das höchste vorhandene `gap_<n>`-Suffix und sichert zusätzlich gegen das Set der bereits vergebenen IDs ab, auch bei mehreren neuen Gaps in derselben Migration. (#986)

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -43,6 +43,7 @@ from .providers import ollama as _provider_ollama
 from .providers import openai as _provider_openai
 from .providers.registry import openai_compat_base_url
 from .tool_calls import _chat_with_tools
+from .transport_security import ensure_credentialed_transport_security
 
 logger = get_logger("agora.llm_client")
 
@@ -155,6 +156,12 @@ class LLMClient:
 
         if not self.api_key:
             raise ValueError("LLM_API_KEY not configured")
+
+        # Issue #1103 (CWE-319): credential-behaftete Requests duerfen nicht
+        # unverschluesselt an oeffentliche Hosts gehen. Muss vor dem
+        # OpenAI(...)-Client-Bau laufen, sonst geht der erste Request schon
+        # unverschluesselt raus.
+        ensure_credentialed_transport_security(self.base_url, self.api_key)
 
         # Track 1c Audit-Log: einmalig pro LLMClient-Init. Niemals den Key-Wert
         # selbst loggen — nur die Quelle (session/store/env:NAME/config_fallback/

--- a/backend/app/llm/transport_security.py
+++ b/backend/app/llm/transport_security.py
@@ -1,0 +1,131 @@
+"""Transport-Security-Gate fuer credential-behaftete LLM-Endpoints (Issue #1103, CWE-319).
+
+``LLMClient`` und die Discovery-Adapter senden ``Authorization: Bearer <api_key>``
+an eine konfigurierbare ``base_url``. Ist die ``http://`` statt ``https://`` und
+zeigt auf einen oeffentlichen Host, geht der Key im Klartext ueber die Leitung.
+
+Diese Policy ist fail-closed: ``http`` ist nur erlaubt, wenn der Host nachweislich
+lokal oder privat ist (loopback, RFC1918, CGNAT/Tailscale, Link-Local, Docker-
+Compose-Servicenamen). Alles andere loest ``InsecureTransportError`` aus, es sei
+denn die dokumentierte Ausnahme ``AGORA_LLM_ALLOW_INSECURE_HTTP`` ist gesetzt.
+"""
+from __future__ import annotations
+
+import ipaddress
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+from ..utils.logger import get_logger
+
+logger = get_logger("agora.llm_transport_security")
+
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Docker Desktop/Compose stellt diese festen Hostnamen bereit, um vom
+# Container aus die Docker-Host-Gateway-Adresse zu erreichen (z. B. lokales
+# Ollama auf dem Host, waehrend das Backend containerisiert laeuft). Beide
+# loesen ausschliesslich innerhalb des lokalen Docker-Netzwerks auf und sind
+# nie oeffentlich routbar — fachlich dieselbe Vertrauensstufe wie ein
+# Single-Label-Compose-Servicename, nur mit Punkten im Namen.
+_DOCKER_HOST_GATEWAY_NAMES = {"host.docker.internal", "gateway.docker.internal"}
+
+
+class InsecureTransportError(ValueError):
+    """Ein credential-behafteter LLM-Request ginge unverschluesselt ueber http://."""
+
+
+def _env_flag_allow_insecure_http() -> bool:
+    return os.environ.get("AGORA_LLM_ALLOW_INSECURE_HTTP", "").strip().lower() in _TRUTHY
+
+
+def _sanitize_for_log(base_url: str) -> str:
+    """Strippt userinfo/query/fragment fuer Log- und Fehlermeldungen.
+
+    Eigenstaendige, minimale Implementierung statt eines Imports aus
+    ``SecretResolver`` — vermeidet einen Zyklus zwischen ``app.llm`` und
+    ``app.services`` und bleibt robust gegenueber unparsebaren URLs.
+    """
+    try:
+        parsed = urlparse(base_url)
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        scheme = parsed.scheme or ""
+        return f"{scheme}://{host}{port}{parsed.path}" if scheme else host
+    except Exception:  # noqa: BLE001 — Sanitizing darf nie selbst crashen
+        return "<unparsable-url>"
+
+
+def _is_private_host(host: str) -> bool:
+    """True, wenn *host* lokal/privat ist und ein unverschluesselter http-Transport
+    des Credentials tolerierbar ist."""
+    if not host:
+        return False
+    normalized = host.strip().lower().rstrip(".")
+    if normalized == "localhost" or normalized.endswith(".localhost"):
+        return True
+    if normalized in _DOCKER_HOST_GATEWAY_NAMES:
+        return True
+    try:
+        ip = ipaddress.ip_address(normalized)
+    except ValueError:
+        # Kein IP-Literal. Docker-Compose-Servicenamen (z. B. "ollama") sind
+        # Single-Label-Hostnamen ohne Punkt — im internen Compose-Netz vertrauenswürdig.
+        return "." not in normalized
+    if ip.is_loopback or ip.is_link_local:
+        return True
+    if isinstance(ip, ipaddress.IPv4Address):
+        if ip.is_private:
+            return True
+        return ip in _CGNAT_NETWORK
+    # IPv6: ULA (fc00::/7) faellt unter is_private in modernen Python-Versionen;
+    # is_loopback/is_link_local sind oben bereits abgedeckt.
+    return ip.is_private
+
+
+def ensure_credentialed_transport_security(
+    base_url: Optional[str], api_key: Optional[str]
+) -> None:
+    """Verweigert unverschluesseltes http:// fuer credential-behaftete Requests
+    an oeffentliche Hosts (CWE-319).
+
+    Kein ``api_key`` oder keine ``base_url`` → nichts zu schuetzen, sofortiger
+    Return. ``https`` sowie Schemes ausser ``http``/``https`` sind out of scope.
+    ``http`` ist nur fuer lokale/private Hosts erlaubt (siehe ``_is_private_host``).
+    Eine unparsebare URL wird wie ein unbekannt-oeffentlicher Host behandelt
+    (fail-closed). Die Policy laesst sich per ``AGORA_LLM_ALLOW_INSECURE_HTTP``
+    explizit ausschalten (dokumentierte Ausnahme, dann nur ``logger.warning``).
+    """
+    if not api_key or not base_url:
+        return
+
+    try:
+        parsed = urlparse(base_url)
+    except Exception:  # noqa: BLE001 — unparsebare URL faellt unten durch
+        parsed = None
+
+    scheme = (parsed.scheme or "").lower() if parsed is not None else ""
+    if scheme and scheme != "http":
+        return
+
+    host = parsed.hostname if parsed is not None else None
+    if scheme == "http" and host and _is_private_host(host):
+        return
+
+    sanitized = _sanitize_for_log(base_url)
+    if _env_flag_allow_insecure_http():
+        logger.warning(
+            "AGORA_LLM_ALLOW_INSECURE_HTTP aktiv: erlaube credential-behafteten "
+            "http-Transport zu oeffentlichem Host base_url=%s",
+            sanitized,
+        )
+        return
+
+    raise InsecureTransportError(
+        f"Unverschluesselter http-Transport zu einem oeffentlichen Host mit "
+        f"API-Key ist nicht erlaubt (base_url={sanitized}). Verwende https:// "
+        f"oder setze AGORA_LLM_ALLOW_INSECURE_HTTP fuer eine dokumentierte "
+        f"Ausnahme."
+    )

--- a/backend/app/services/model_catalog_service.py
+++ b/backend/app/services/model_catalog_service.py
@@ -26,6 +26,7 @@ from ..contracts import (
     PROVIDER_OPENAI_COMPATIBLE,
 )
 from ..contracts.llm_routing_contract import ModelEntry
+from ..llm.transport_security import ensure_credentialed_transport_security
 from ..utils.logger import get_logger
 
 logger = get_logger("agora.model_catalog")
@@ -78,6 +79,9 @@ def _http_get_json(url: str, *, api_key: Optional[str] = None) -> Optional[dict]
     Helper direkt oder ``_HTTP.request``. Wichtig: keine Verwendung von
     ``requests`` (siehe Modul-Docstring, OTel-Rekursion #529).
     """
+    # Issue #1103 (CWE-319): vor dem Request pruefen, sonst geht der Bearer-
+    # Header ggf. unverschluesselt an einen oeffentlichen Host raus.
+    ensure_credentialed_transport_security(url, api_key)
     headers: Dict[str, str] = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"

--- a/backend/app/services/provider_connections/adapters.py
+++ b/backend/app/services/provider_connections/adapters.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Literal, Protocol
 
 from app.contracts.ai_provider_contract import AiModel, ProviderConnection
+from app.llm.transport_security import ensure_credentialed_transport_security
 from app.services.model_catalog_service import CatalogHttpResponse, fetch_catalog_json
 
 ProviderProbeStatus = Literal[
@@ -88,6 +89,9 @@ class _HttpModelsAdapter:
             return ProviderProbeResult(
                 status="unavailable", status_message="Base-URL fehlt"
             )
+        # Issue #1103 (CWE-319): vor dem Request pruefen, sonst geht der
+        # Auth-Header ggf. unverschluesselt an einen oeffentlichen Host raus.
+        ensure_credentialed_transport_security(base_url, api_key)
         try:
             response = self._get_json(
                 f"{base_url.rstrip('/')}{self._protocol.endpoint_path}", headers=headers

--- a/backend/tests/llm/test_transport_security.py
+++ b/backend/tests/llm/test_transport_security.py
@@ -134,7 +134,11 @@ def test_env_override_logs_warning_with_sanitized_url(
     message = warnings[0].getMessage()
     assert "secret-token" not in message
     assert "token=leak" not in message
-    assert "api.example.com" in message
+    # Gleichheit statt Substring-Match auf die Domain: CodeQL wertet
+    # ``"<domain>" in <str>`` als unvollstaendige URL-Sanitization
+    # (py/incomplete-url-substring-sanitization), und die Gleichheit prueft
+    # zugleich, dass exakt die sanitisierte Form geloggt wird.
+    assert warnings[0].args == ("http://api.example.com/v1",)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/llm/test_transport_security.py
+++ b/backend/tests/llm/test_transport_security.py
@@ -1,0 +1,188 @@
+"""Regression-Tests für Issue #1103 (CWE-319): HTTPS für credential-behaftete
+LLM-Endpoints erzwingen.
+
+``ensure_credentialed_transport_security`` ist fail-closed: http:// mit einem
+api_key ist nur erlaubt, wenn der Host nachweislich lokal/privat ist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.llm.transport_security import (
+    InsecureTransportError,
+    ensure_credentialed_transport_security,
+)
+
+
+# ---------------------------------------------------------------------------
+# Policy-Matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.example.com/v1",
+        "http://localhost:11434",
+        "http://localhost:11434/v1",
+        "http://sub.localhost:11434",
+        "http://127.0.0.1:8080/v1",
+        "http://192.168.1.10:11434",
+        "http://10.0.0.5:11434",
+        "http://172.16.0.1:11434",
+        "http://100.64.0.1:11434",
+        "http://100.127.255.254:11434",
+        "http://[::1]:11434",
+        "http://ollama:11434",  # Docker-Compose-Servicename, single-label
+        "http://host.docker.internal:11434",  # Docker-Host-Gateway
+    ],
+)
+def test_allowed_transports_with_credential_do_not_raise(base_url: str) -> None:
+    ensure_credentialed_transport_security(base_url, "sk-test")
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://api.example.com/v1",
+        "http://172.32.0.1:11434",  # knapp ausserhalb 172.16.0.0/12
+        "http://100.128.0.1:11434",  # knapp ausserhalb 100.64.0.0/10
+        "not a url with a key",  # kaputte/unparsebare URL
+    ],
+)
+def test_public_http_with_credential_raises(base_url: str) -> None:
+    with pytest.raises(InsecureTransportError):
+        ensure_credentialed_transport_security(base_url, "sk-test")
+
+
+def test_public_http_without_credential_does_not_raise() -> None:
+    ensure_credentialed_transport_security("http://api.example.com/v1", None)
+
+
+def test_no_base_url_does_not_raise() -> None:
+    ensure_credentialed_transport_security(None, "sk-test")
+
+
+def test_error_message_never_contains_the_api_key() -> None:
+    with pytest.raises(InsecureTransportError) as exc_info:
+        ensure_credentialed_transport_security(
+            "http://api.example.com/v1", "sk-super-secret-value"
+        )
+    assert "sk-super-secret-value" not in str(exc_info.value)
+
+
+def test_error_message_strips_userinfo_and_query() -> None:
+    with pytest.raises(InsecureTransportError) as exc_info:
+        ensure_credentialed_transport_security(
+            "http://user:pw@api.example.com/v1?token=leak", "sk-test"
+        )
+    message = str(exc_info.value)
+    assert "user:pw" not in message
+    assert "token=leak" not in message
+
+
+# ---------------------------------------------------------------------------
+# Env-Override: AGORA_LLM_ALLOW_INSECURE_HTTP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag_value", ["1", "true", "True", "YES", "on"])
+def test_env_override_allows_public_http_with_credential(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+) -> None:
+    monkeypatch.setenv("AGORA_LLM_ALLOW_INSECURE_HTTP", flag_value)
+    ensure_credentialed_transport_security("http://api.example.com/v1", "sk-test")
+
+
+def test_env_override_absent_still_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGORA_LLM_ALLOW_INSECURE_HTTP", raising=False)
+    with pytest.raises(InsecureTransportError):
+        ensure_credentialed_transport_security("http://api.example.com/v1", "sk-test")
+
+
+@pytest.mark.parametrize("flag_value", ["0", "false", "no", "off", ""])
+def test_env_override_falsy_values_still_raise(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+) -> None:
+    monkeypatch.setenv("AGORA_LLM_ALLOW_INSECURE_HTTP", flag_value)
+    with pytest.raises(InsecureTransportError):
+        ensure_credentialed_transport_security("http://api.example.com/v1", "sk-test")
+
+
+def test_env_override_logs_warning_with_sanitized_url(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    # ``setup_logger`` setzt ``propagate=False`` (app/utils/logger.py) — caplog
+    # haengt am Root-Handler, muss also Propagation entlang der Logger-Kette
+    # explizit erlauben (siehe tests/llm/test_init_logging.py).
+    monkeypatch.setattr(logging.getLogger("agora"), "propagate", True)
+    monkeypatch.setattr(
+        logging.getLogger("agora.llm_transport_security"), "propagate", True
+    )
+    monkeypatch.setenv("AGORA_LLM_ALLOW_INSECURE_HTTP", "true")
+    with caplog.at_level(logging.WARNING, logger="agora.llm_transport_security"):
+        ensure_credentialed_transport_security(
+            "http://user:secret-token@api.example.com/v1?token=leak", "sk-test"
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "secret-token" not in message
+    assert "token=leak" not in message
+    assert "api.example.com" in message
+
+
+# ---------------------------------------------------------------------------
+# LLMClient-Integration
+# ---------------------------------------------------------------------------
+
+
+def _patch_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.llm.client.OpenAI", lambda **_kw: MagicMock())
+
+
+class TestLLMClientEnforcesTransportSecurity:
+    def test_https_with_key_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_openai(monkeypatch)
+        from app.llm.client import LLMClient
+
+        client = LLMClient(
+            api_key="k",
+            base_url="https://api.example.com/v1",
+            model="m",
+            use_active_config=False,
+        )
+        assert client.base_url == "https://api.example.com/v1"
+
+    def test_http_public_host_with_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_openai(monkeypatch)
+        monkeypatch.delenv("AGORA_LLM_ALLOW_INSECURE_HTTP", raising=False)
+        from app.llm.client import LLMClient
+        from app.llm.transport_security import InsecureTransportError
+
+        with pytest.raises(InsecureTransportError):
+            LLMClient(
+                api_key="k",
+                base_url="http://api.example.com/v1",
+                model="m",
+                use_active_config=False,
+            )
+
+    def test_http_localhost_with_key_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_openai(monkeypatch)
+        from app.llm.client import LLMClient
+
+        client = LLMClient(
+            api_key="k",
+            base_url="http://localhost:11434",
+            model="m",
+            use_active_config=False,
+        )
+        assert client.base_url == "http://localhost:11434"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -140,6 +140,7 @@ Chat-Routing und Embedding-Konfiguration bleiben getrennte Vertragswelten.
 - API-Auth über `AGORA_AUTH_TOKEN`
 - SSE und Downloads über signierte Tickets
 - Secrets werden nicht in Report-/Simulation-Artefakte serialisiert
+- Credential-behaftete LLM-Requests erzwingen HTTPS; `http://` ist nur für lokale/private Hosts zulässig, dokumentierte Ausnahme über `AGORA_LLM_ALLOW_INSECURE_HTTP` (Issue #1103)
 - Readiness prüft Neo4j, Redis, Upload-Verzeichnis und Embedding-Konfiguration
 - Dependency-Ausnahmen werden im [`dependency-risk-register.md`](dependency-risk-register.md) geführt
 - Ontology-Upload (`/ontology/generate`) räumt bei Datei-I/O-Fehlern zwischen Projektanlage und Service-Übergabe das halb angelegte Projekt zuverlässig auf (Issue #899); ein scheiterndes Aufräumen wird protokolliert, ohne die Fehlerantwort zu verfälschen

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4517 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4553 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ Provider-Erkennung: [`../backend/app/llm/providers/registry.py`](../backend/app/
 | `OLLAMA_API_KEY` 🔐 / `OLLAMA_BASE_URL` / `OLLAMA_NUM_CTX` / `OLLAMA_THINKING` | Ollama (lokal/Cloud) |
 | `TAVILY_API_KEY` 🔐 | Tavily-Web-Suche (Agent-Tools) |
 | `AGENT_LANGUAGE` | Agenten-Sprache |
+| `AGORA_LLM_ALLOW_INSECURE_HTTP` | dokumentierte Ausnahme (CWE-319, [`app/llm/transport_security.py`](../backend/app/llm/transport_security.py)): erlaubt `http://` mit API-Key gegen einen öffentlichen Host. Default aus/sicher — `http://` mit Credential ist sonst nur für lokale/private Hosts (loopback, RFC1918, CGNAT/Tailscale, Docker-Compose-/Host-Gateway-Namen) zulässig, alles andere bricht mit `InsecureTransportError` ab. |
 
 ## Embedding
 


### PR DESCRIPTION
## Summary
- Neues zentrales Transport-Security-Gate `backend/app/llm/transport_security.py::ensure_credentialed_transport_security` (CWE-319): `http://` mit API-Key ist nur noch für nachweislich lokale/private Hosts erlaubt (localhost, Single-Label-Compose-Servicenamen, Docker-Host-Gateway-Namen, Loopback, RFC1918, CGNAT/Tailscale 100.64/10, Link-Local, IPv6 ULA). Öffentliche Hosts über `http://` mit Credential werfen `InsecureTransportError` — fail-closed auch bei unparsebaren URLs.
- Dokumentierte Ausnahme via `AGORA_LLM_ALLOW_INSECURE_HTTP` (Default sicher; loggt sanitisierte Warnung).
- Wiring an allen drei credential-tragenden LLM-Pfaden: `LLMClient.__init__`, `ModelCatalogService._http_get_json`, `_HttpModelsAdapter.probe`.

## Release-Ziel
- 0.8.x Technical Preview, Security-Härtung (kein Release-Gate geändert)

## Issue
- Closes #1103

## Scope
- `backend/app/llm/transport_security.py` (neu), `backend/app/llm/client.py`, `backend/app/services/model_catalog_service.py`, `backend/app/services/provider_connections/adapters.py`, `backend/tests/llm/test_transport_security.py` (neu), `docs/configuration.md`, `CHANGELOG.md`, `docs/STATUS.md` (Testanzahl-Sync)

## Out-of-Scope
- Embedding-Pfade (`embedding_configurations/adapters.py`, `embedding_ollama_pull.py`, `storage/embedding_service.py`) — Folge-Issue #1110
- `providers/ollama.py`-Header-Bau (läuft durch `LLMClient` und ist damit abgedeckt), Registry-Detection, Frontend

## Tests
- `uv run pytest tests/llm/test_transport_security.py -q` — PASS (36 passed)
- Contract-Tests → Schema-Check → Ruff → mypy — PASS
- `scripts/pre-push-gate.sh backend` — PASS (inkl. sync-status --check OK)

## Dokumentationssync
- `docs/STATUS.md`: aktualisiert (Backend-Testanzahl via `sync-status.sh`)
- `ROADMAP.md`: NICHT BETROFFEN — kein Release-Gate, keine strategische Reihenfolge geändert
- `CHANGELOG.md`: aktualisiert (Unreleased, security-Eintrag)
- Folge-Issue: https://github.com/arn0ld87/agora/issues/1110 (Embedding-Pfade)

## Orchestrierung
- Lead, Planung und Verifikation: Fable
- Implementierung: `agora-refactor-worker` auf `sonnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Sicherheitsverbesserungen**
  * API-Key-geschützte LLM- und Provider-Anfragen über unsicheres HTTP werden standardmäßig blockiert.
  * Lokale und private Ziele bleiben zulässig; öffentliche Ziele werden sicher abgelehnt.
  * Eine explizite Ausnahme für unsichere Verbindungen ist verfügbar und wird protokolliert.
  * Zugangsdaten werden aus Fehlermeldungen und Warnungen entfernt.

* **Dokumentation**
  * Die neue Konfigurationsoption und das Verhalten der Transportsicherheit wurden dokumentiert.
  * Die dokumentierte Anzahl der Backend-Tests wurde aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->