### PR TITLE
fix(claude): raise maxTurns and mandate final message output for opus reviewer

### DIFF
--- a/.claude/agents/agora-opus-reviewer.md
+++ b/.claude/agents/agora-opus-reviewer.md
@@ -5,7 +5,7 @@ tools: Read, Grep, Glob, Bash
 disallowedTools: Edit, Write, Agent
 model: opus
 effort: high
-maxTurns: 12
+maxTurns: 20
 background: true
 ---
 
@@ -51,6 +51,8 @@ Fehlt eine dieser Angaben und lässt sie sich nicht read-only aus dem Repository
 
 ## Output
 
+Befund und Urteil MÜSSEN zwingend im finalen Antworttext ausgegeben werden (nicht in einem Tool-Aufruf, sondern als deine abschließende Nachricht an den Nutzer).
+
 Antworte ausschließlich in diesem Format:
 
 ```markdown
@@ -92,6 +94,12 @@ REQUEST_CHANGES
 ```
 
 Das letzte Wort ist exakt `APPROVE` oder `REQUEST_CHANGES`.
+
+## Turn-Management und Budget-Sicherung
+
+- Dir stehen maximal `maxTurns` zur Verfügung (siehe Frontmatter).
+- Behalte immer mindestens 3 Turns Reserve für das Schreiben deines finalen Berichts. Beende deine Tool-Aufrufe spätestens bei Turn `(maxTurns - 3)`, um sicherzustellen, dass dein Befund und dein Urteil vollständig ausgegeben werden und nicht aufgrund des Turn-Limits abgeschnitten werden.
+- Führe nur absolut notwendige Tool-Aufrufe aus. Lies gezielt und verschwende keine Turns für redundante Suchen oder unnötige Datei-Queries.
 
 ## Verbote
 

--- a/.claude/agents/agora-reviewer-m3.md
+++ b/.claude/agents/agora-reviewer-m3.md
@@ -5,7 +5,7 @@ tools: Read, Grep, Glob, Bash
 disallowedTools: Edit, Write, Agent
 model: opus
 effort: high
-maxTurns: 12
+maxTurns: 20
 background: true
 ---
 
@@ -51,6 +51,8 @@ Fehlt eine dieser Angaben und lässt sie sich nicht read-only aus dem Repository
 
 ## Output
 
+Befund und Urteil MÜSSEN zwingend im finalen Antworttext ausgegeben werden (nicht in einem Tool-Aufruf, sondern als deine abschließende Nachricht an den Nutzer).
+
 Antworte ausschließlich in diesem Format:
 
 ```markdown
@@ -92,6 +94,12 @@ REQUEST_CHANGES
 ```
 
 Das letzte Wort ist exakt `APPROVE` oder `REQUEST_CHANGES`.
+
+## Turn-Management und Budget-Sicherung
+
+- Dir stehen maximal `maxTurns` zur Verfügung (siehe Frontmatter).
+- Behalte immer mindestens 3 Turns Reserve für das Schreiben deines finalen Berichts. Beende deine Tool-Aufrufe spätestens bei Turn `(maxTurns - 3)`, um sicherzustellen, dass dein Befund und dein Urteil vollständig ausgegeben werden und nicht aufgrund des Turn-Limits abgeschnitten werden.
+- Führe nur absolut notwendige Tool-Aufrufe aus. Lies gezielt und verschwende keine Turns für redundante Suchen oder unnötige Datei-Queries.
 
 ## Verbote
 


### PR DESCRIPTION
This PR resolves the issue where the agora-opus-reviewer agent consistently terminates with a truncated response because of hitting the turn limit (12) or lacks explicit instructions regarding where to output the findings and verdict.

Fixes #802

---
*PR created automatically by Jules for task [12129327090875639261](https://jules.google.com/task/12129327090875639261) started by @arn0ld87*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Prüfungen haben mehr verfügbare Verarbeitungsschritte und können dadurch gründlicher durchgeführt werden.
  * Ergebnisse und abschließende Bewertungen werden nun zuverlässig in der finalen Nachricht ausgegeben.
  * Prüfungen werden effizienter gesteuert und rechtzeitig abgeschlossen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->