### PR TITLE
Activate camel-oasis Replacement Evaluation in Dependency Risk Register

### DIFF
--- a/backend/tests/api/test_simulation_uses_request_model.py
+++ b/backend/tests/api/test_simulation_uses_request_model.py
@@ -97,14 +97,24 @@ def test_generate_profiles_endpoint_passes_llm_model_to_generator(
         FakeProfileGenerator,
     )
 
-    response = client.post(
-        "/api/simulation/generate-profiles",
-        json={
-            "graph_id": VALID_GRAPH_ID,
-            "llm_model": "qwen3:14b",
-            "platform": "reddit",
-        },
-    )
+    with (
+        patch("app.api.simulation_history.build_preview_stage_route") as mock_route,
+        patch("app.api.simulation_history.resolve_route_api_key") as mock_key,
+    ):
+        mock_route.return_value = MagicMock(
+            base_url_sanitized="http://localhost:11434",
+            provider_id="ollama",
+        )
+        mock_key.return_value = "fake-key"
+
+        response = client.post(
+            "/api/simulation/generate-profiles",
+            json={
+                "graph_id": VALID_GRAPH_ID,
+                "llm_model": "qwen3:14b",
+                "platform": "reddit",
+            },
+        )
 
     assert response.status_code == 200, response.get_data(as_text=True)
     assert captured_model_name.get("model_name") == "qwen3:14b", (
@@ -156,10 +166,20 @@ def test_generate_profiles_endpoint_falls_back_when_no_llm_model(
         FakeProfileGenerator,
     )
 
-    response = client.post(
-        "/api/simulation/generate-profiles",
-        json={"graph_id": VALID_GRAPH_ID},
-    )
+    with (
+        patch("app.api.simulation_history.build_preview_stage_route") as mock_route,
+        patch("app.api.simulation_history.resolve_route_api_key") as mock_key,
+    ):
+        mock_route.return_value = MagicMock(
+            base_url_sanitized="http://localhost:11434",
+            provider_id="ollama",
+        )
+        mock_key.return_value = "fake-key"
+
+        response = client.post(
+            "/api/simulation/generate-profiles",
+            json={"graph_id": VALID_GRAPH_ID},
+        )
 
     assert response.status_code == 200, response.get_data(as_text=True)
     # model_name=None → OasisProfileGenerator nutzt Config.LLM_MODEL_NAME als Fallback

--- a/docs/dependency-risk-register.md
+++ b/docs/dependency-risk-register.md
@@ -184,6 +184,23 @@ Fließtext. Künftig gehört **jede** `.trivyignore`-Zeile auch in die JSON.
 |---|---|---|---|
 | `transformers` | `>=5.3.0` | — | Upgrade auf v5 via `tool.uv.override-dependencies` unblocked durch `sentence-transformers>=5.3.0`. Behebt CVE-2026-4372, CVE-2026-1839 und PYSEC-2025-217. |
 | `nltk` | `3.10.1` | — (kein Upstream-Pin) | Override-Pin `nltk==3.10.1` (2026-08-02, #995) löst GHSA-p4gq-832x-fm9v (echter Fix in 3.10.0) real auf. PYSEC-2026-597 bleibt ohne echten Upstream-Fix (kein `fixed`-Event in OSV), fällt aber ab 3.10.0 aus dem affected-Set (`last_affected: 3.9.4`) und wird deshalb nicht mehr geflaggt — Tracking bleibt offen in #661. Agora nutzt nltk weiterhin nur transitiv (via `unstructured`/`camel-oasis`). |
+| `camel-oasis` / `camel-ai` | `camel-oasis==0.2.5` / `camel-ai==0.2.78` | `camel-ai==0.2.78` (Upstream-Pin in `camel-oasis`) | `camel-oasis` pinnt exakt `camel-ai==0.2.78`. Alle bisherigen PyPI-Releases (0.2.0 bis 0.2.5) erzwingen diese Version. Dies blockiert das Upgrade auf `camel-ai>=0.2.90` und verhindert automatische Dependabot-Bumps (z. B. PR #793). Die Replacement-Evaluation für `camel-oasis` wurde im August 2026 aktiviert. |
+
+---
+
+### Replacement-Evaluation für camel-oasis
+
+**Status:** Aktiviert am 2026-08-03 (keine neue Version auf PyPI, die `camel-ai>=0.2.90` erlaubt)
+**Grund:** Die feste Kopplung von `camel-oasis` an `camel-ai==0.2.78` blockiert sämtliche `camel-ai`-Sicherheits- und Feature-Updates. Solange kein Upstream-Release diese Einschränkung aufhebt, sind Dependabot-PRs (z. B. #793) nicht mergbar.
+**Letzter PyPI-Poll (2026-08-03):** Version `0.2.5` ist weiterhin die neueste Version auf PyPI und schränkt `camel-ai` auf `==0.2.78` ein.
+
+#### Evaluierte Optionen:
+1. **Upstream-Release-Watch:** PyPI periodisch pollen (unter `https://pypi.org/pypi/camel-oasis/json`). Sobald `camel-oasis>=0.2.6` verfügbar ist, das `camel-ai>=0.2.90` erlaubt, wird das Upgrade durchgeführt und der Dependabot-Filter aufgehoben.
+2. **Replacement durch andere Multi-Agenten-Frameworks (z. B. LangGraph):**
+   - **Nutzen:** Vollständige Entkopplung von der veralteten `camel-ai`-Kette. Erleichtert die Integration neuerer LLMs und flexiblerer Agenten-Zustandsmaschinen.
+   - **Risiko:** Hoher Refactoring-Aufwand im Kern des Simulators (Layer 5/OASIS-Integration). Erfordert gründliche Verifikation des Agenten-Verhaltens.
+3. **Eigene Multi-Agenten-Zustandsmaschine (Custom Orchestration):**
+   - **Nutzen:** Minimale Abhängigkeiten, maximale Performance, vollständige Kontrolle über Prompts und Zustandsübergänge, passend zur Local-First-Philosophie von Agora.
 
 ---
 


### PR DESCRIPTION
Polled the PyPI JSON API for camel-oasis. Confirmed that 0.2.5 is the latest version, which strictly depends on camel-ai==0.2.78. No newer release is available, meaning we are blocked from upgrading camel-ai. Therefore, we activated the Replacement-Evaluation for camel-oasis and documented it in docs/dependency-risk-register.md. Also resolved a test failure in simulation request model verification by properly mocking the AI route resolution.

Fixes #806

---
*PR created automatically by Jules for task [13699754077759869255](https://jules.google.com/task/13699754077759869255) started by @arn0ld87*