### PR TITLE
fix(api): Run bei fehlender simulation_config als failed markieren (#1094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (`/simulation/start` hinterließ einen Phantom-Run bei fehlender `simulation_config` — 2026-08-06)
+
+- **Fehlte die persistierte `simulation_config` (z. B. weil `/prepare` nie lief), lehnte `_apply_route_to_simulation_config` mit 404 `simulation_not_prepared` ab, ohne den in Phase 5 bereits registrierten Run als `failed` zu markieren.** Der Run blieb als nicht ausführbarer Geisterlauf in der Run-Liste stehen. Vor dem `raise` markiert die Funktion den Run jetzt best-effort als `failed` — dieselbe Vorlage (`try`/`except` mit Log-Warnung statt hartem Fehler), die der API-Key-Guard in `_resolve_start_route` bereits für den analogen Fall nutzt. Die HTTP-Antwort (404, `simulation_not_prepared`) bleibt unverändert. (#1094)
+
 ### Security (HTTPS für credential-behaftete LLM-Endpoints erzwingen — 2026-08-05)
 
 - **`LLMClient` und die LLM-Discovery-Pfade (`ModelCatalogService`, Provider-Connection-Adapter) sendeten `Authorization: Bearer <api_key>` auch an `http://`-Endpoints, ohne den Host zu prüfen (CWE-319) — bei einer öffentlich erreichbaren, versehentlich auf `http://` konfigurierten `base_url` ginge der API-Key im Klartext über die Leitung.** Ein neues, zentrales Gate (`ensure_credentialed_transport_security`, `backend/app/llm/transport_security.py`) läuft jetzt vor jedem credential-behafteten Request und lässt `http://` nur für nachweislich lokale/private Hosts zu (`localhost`, Docker-Compose-Servicenamen, Docker-Host-Gateway-Namen, Loopback, RFC1918, CGNAT/Tailscale-Bereich, Link-Local). Gegen alle anderen Hosts bricht ein unverschlüsselter Request mit einem credential-behafteten Key jetzt mit `InsecureTransportError` ab — fail-closed auch bei unparsebaren URLs. Für dokumentierte Ausnahmen (z. B. ein bewusst unverschlüsseltes internes Gateway ohne TLS-Terminierung) steht `AGORA_LLM_ALLOW_INSECURE_HTTP` zur Verfügung; Default bleibt sicher, die Ausnahme loggt eine sanitisierte Warnung statt still durchzulassen. (#1103)

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -561,7 +561,7 @@ def _has_config_overrides(req: _StartRequest) -> bool:
 
 
 def _apply_route_to_simulation_config(
-    req: _StartRequest, resolved_route: "ResolvedRoute"
+    req: _StartRequest, resolved_route: "ResolvedRoute", run_id: str
 ) -> None:
     """Phase 7 — Laufzeit-Overrides in die persistierte Sim-Config schreiben."""
     if not _has_config_overrides(req):
@@ -570,6 +570,16 @@ def _apply_route_to_simulation_config(
     store = get_artifact_store()
     config = store.read_json(req.simulation_id, "simulation_config", default=None)
     if not config:
+        # Der Run wurde in Phase 5 bereits registriert — ohne diese Markierung
+        # bleibt er als Phantom-Run in der Liste stehen (#1094).
+        try:
+            run_registry.update_run(
+                run_id,
+                status="failed",
+                message="Simulation configuration does not exist. Please call /prepare first",
+            )
+        except Exception:  # noqa: BLE001 — best effort
+            logger.warning("Failed to mark orphaned run as failed", exc_info=True)
         raise _StartRejected(
             json_error(
                 ApiErrorCode.SIMULATION_NOT_PREPARED,
@@ -647,7 +657,7 @@ def start_simulation():
         resolved_route, resolved_api_key = _resolve_start_route(
             run_record["run_id"], req.llm_runtime
         )
-        _apply_route_to_simulation_config(req, resolved_route)
+        _apply_route_to_simulation_config(req, resolved_route, run_record["run_id"])
     except _StartRejected as rejected:
         return rejected.response
 

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -579,7 +579,11 @@ def _apply_route_to_simulation_config(
                 message="Simulation configuration does not exist. Please call /prepare first",
             )
         except Exception:  # noqa: BLE001 — best effort
-            logger.warning("Failed to mark orphaned run as failed", exc_info=True)
+            logger.warning(
+                "Failed to mark run %s as failed after missing simulation_config",
+                run_id,
+                exc_info=True,
+            )
         raise _StartRejected(
             json_error(
                 ApiErrorCode.SIMULATION_NOT_PREPARED,

--- a/backend/tests/api/test_simulation_start_phases.py
+++ b/backend/tests/api/test_simulation_start_phases.py
@@ -474,7 +474,7 @@ def test_apply_route_to_simulation_config_skips_without_overrides(app_ctx, monke
     monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
     req = mod._parse_start_request({"simulation_id": VALID_SIM_ID})
 
-    mod._apply_route_to_simulation_config(req, _resolved_route())
+    mod._apply_route_to_simulation_config(req, _resolved_route(), "run-1")
 
     store.read_json.assert_not_called()
     store.write_json.assert_not_called()
@@ -486,7 +486,7 @@ def test_apply_route_to_simulation_config_writes_simulation_hours(app_ctx, monke
     monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
     req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
 
-    mod._apply_route_to_simulation_config(req, _resolved_route())
+    mod._apply_route_to_simulation_config(req, _resolved_route(), "run-1")
 
     written = store.write_json.call_args.args[2]
     assert written["time_config"]["total_simulation_hours"] == 72
@@ -499,10 +499,31 @@ def test_apply_route_to_simulation_config_rejects_missing_config(app_ctx, monkey
     req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
 
     with pytest.raises(mod._StartRejected) as excinfo:
-        mod._apply_route_to_simulation_config(req, _resolved_route())
+        mod._apply_route_to_simulation_config(req, _resolved_route(), "run-1")
 
     assert _status(excinfo) == 404
     assert _body(excinfo)["code"] == "simulation_not_prepared"
+
+
+def test_apply_route_to_simulation_config_rejects_missing_config_marks_run_failed(
+    app_ctx, monkeypatch
+):
+    """Issue #1094: fehlende simulation_config darf keinen Phantom-Run hinterlassen."""
+    store = MagicMock()
+    store.read_json.return_value = None
+    monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    registry = MagicMock()
+    monkeypatch.setattr(mod, "run_registry", registry)
+    req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
+
+    with pytest.raises(mod._StartRejected) as excinfo:
+        mod._apply_route_to_simulation_config(req, _resolved_route(), "run-1")
+
+    assert _status(excinfo) == 404
+    assert _body(excinfo)["code"] == "simulation_not_prepared"
+    registry.update_run.assert_called_once()
+    assert registry.update_run.call_args.args[0] == "run-1"
+    assert registry.update_run.call_args.kwargs["status"] == "failed"
 
 
 def test_apply_route_to_simulation_config_writes_model_for_ai_model_ref(app_ctx, monkeypatch):
@@ -520,7 +541,7 @@ def test_apply_route_to_simulation_config_writes_model_for_ai_model_ref(app_ctx,
         }
     )
 
-    mod._apply_route_to_simulation_config(req, _resolved_route())
+    mod._apply_route_to_simulation_config(req, _resolved_route(), "run-1")
 
     written = store.write_json.call_args.args[2]
     assert written["llm_model"] == "gpt-4o"

--- a/backend/tests/api/test_simulation_start_phases.py
+++ b/backend/tests/api/test_simulation_start_phases.py
@@ -496,6 +496,7 @@ def test_apply_route_to_simulation_config_rejects_missing_config(app_ctx, monkey
     store = MagicMock()
     store.read_json.return_value = None
     monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
+    monkeypatch.setattr(mod, "run_registry", MagicMock())
     req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "simulation_days": 3})
 
     with pytest.raises(mod._StartRejected) as excinfo:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4553 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4554 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 


### PR DESCRIPTION
Closes #1094.

## Was

Der 404-Pfad `simulation_not_prepared` in `_apply_route_to_simulation_config` (`backend/app/api/simulation_run.py`) lehnte ab, ohne den in Phase 5 bereits registrierten Run zu markieren — er blieb als Phantom-Run in der Run-Liste. Jetzt läuft vor dem `raise` ein best-effort `run_registry.update_run(status="failed", …)` nach exakt derselben Vorlage wie der API-Key-Guard in `_resolve_start_route` (try/except mit Log-Warnung). Die HTTP-Antwort (404, `simulation_not_prepared`) bleibt unverändert.

## Tests

Neuer Regressionstest `test_apply_route_to_simulation_config_rejects_missing_config_marks_run_failed` in `backend/tests/api/test_simulation_start_phases.py` — assertet `update_run("run-1", status="failed")` beim 404. Vor dem Fix rot. Gezielte Suiten (44 Tests), ruff und mypy grün.

Umsetzung durch isolierten Worker, Diff und Tests vom Lead verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)