### PR TITLE
docs(copilot): path-spezifische Copilot-Instructions ergänzen

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "backend/**/*.py"
+---
+
+# Backend (Flask + uv)
+
+## Werkzeuge
+
+- Abhängigkeiten und Läufe immer über `uv` (`uv run …`, `uv sync`), nie über `pip` oder ein aktiviertes venv.
+- Arbeitsverzeichnis für alle Backend-Kommandos ist `backend/`.
+
+## Verbindlich
+
+- API-Verträge sind Pydantic-Modelle in `backend/app/contracts/`. Keine Dataclasses, keine handgeschriebenen Inline-Schemas.
+- Verträge zuerst, Consumer danach. Ändert sich ein Contract, wandert der Schema-Dump in denselben Commit.
+- Provider-Detection ausschließlich über die Registry. Keine lokalen Heuristiken daneben.
+- Strukturiertes Logging statt `print()` in Produktivcode.
+- Keine API-Keys oder Secrets in Code, Logs, Fixtures oder Docstrings.
+- Keine neuen Query-Tokens `?token=`; URL-Auth nur über signierte Tickets.
+
+## Evidence-Gating (ADR-0002) — nicht anfassen
+
+Diese fünf Anker dürfen nicht geschwächt, umformuliert oder „aufgeräumt" werden ohne
+`docs/decisions/0002-supersedes.md` und ausdrückliche Freigabe:
+
+1. `<evidence_gating priority="hard">` in `backend/app/services/report_prompts/sections.py`
+2. Hedge-Snapshot `backend/tests/eval/snapshots/evidence-gating-hedge-words.txt`
+3. Enum `EvidenceSourceKind` in `backend/app/contracts/report_contract.py`
+4. Validator `cross_stakeholder_for_high`
+5. Validator `reject_inferred_in_high_confidence`
+
+## Vor dem Commit (sequentiell, Exit 0)
+
+```bash
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+uv run ruff check app/ tests/
+uv run mypy app
+```
+
+Vor dem Push zusätzlich `bash scripts/pre-push-gate.sh backend`. Kein `--no-verify`.

--- a/.github/instructions/contracts.instructions.md
+++ b/.github/instructions/contracts.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: "backend/app/contracts/**/*.py,schemas/**,frontend/src/contracts/**"
+---
+
+# Verträge und Schemas
+
+Der Vertrag ist die Wahrheit. Backend-Pydantic-Modell, gerenderte JSON-Schemas unter
+`schemas/` und die `zod`-Spiegel im Frontend beschreiben dasselbe — sie dürfen nicht
+auseinanderlaufen.
+
+## Reihenfolge
+
+1. Pydantic-Modell in `backend/app/contracts/` ändern.
+2. Contract-Tests anpassen oder ergänzen: `uv run pytest tests/contracts/ -x -q`.
+3. Schemas neu rendern: `uv run python -m app.contracts.dump_schemas` (ohne `--check`).
+4. Consumer nachziehen — Frontend-`zod`-Schema, Services, Fixtures.
+5. Alles in **einen** Commit. Ein gerenderter Schema-Stand ohne das zugehörige Modell ist Drift.
+
+## Verbindlich
+
+- Keine Dataclasses und keine handgeschriebenen Inline-Schemas für API-Verträge.
+- Breaking Changes am Vertrag brauchen einen Eintrag in `CHANGELOG.md` und, bei Release-Wirkung, in `ROADMAP.md`.
+- Feldnamen und Enums nicht stillschweigend umbenennen; Consumer zuerst suchen.
+- `EvidenceSourceKind` und die Evidence-Validatoren stehen unter ADR-0002 und sind gesperrt.
+
+## Gate für diesen Scope
+
+Nur Contract-Tests und Schema-Check — kein Ruff, kein mypy:
+
+```bash
+cd backend
+uv run pytest tests/contracts/ -x -q
+uv run python -m app.contracts.dump_schemas --check
+```
+
+Vor dem Push `bash scripts/pre-push-gate.sh schemas`.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,29 @@
+---
+applyTo: "frontend/**/*.vue,frontend/**/*.ts,frontend/**/*.js"
+---
+
+# Frontend (Vue 3 + Vite + Pinia)
+
+## Werkzeuge
+
+- Paketmanager ist `bun`, nicht `npm` oder `yarn`.
+- Arbeitsverzeichnis für alle Frontend-Kommandos ist `frontend/`.
+
+## Verbindlich
+
+- Keine hartkodierten UI-Texte. Jeder sichtbare String läuft über `vue-i18n`.
+- Kein React-/Lovable-Rewrite und kein zweites paralleles Frontend.
+- Keine neuen produktiven Legacy-Modell-Picker. Der Workflow `check-legacy-model-picker.yml` bricht sonst.
+- API-Antworten gegen die `zod`-Schemas in `src/contracts/` validieren, nicht blind durchreichen.
+- Fremdes HTML nur über `dompurify` rendern.
+- State gehört in Pinia-Stores, nicht in globale Singletons neben dem Store.
+
+## Vor dem Commit
+
+```bash
+cd frontend
+bun run test
+bun run check   # lint + typecheck + coverage + build
+```
+
+Vor dem Push zusätzlich `bash scripts/pre-push-gate.sh frontend`. Kein `--no-verify`.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,29 @@
+---
+applyTo: "backend/tests/**/*.py,frontend/src/__tests__/**,frontend/tests/**"
+---
+
+# Tests
+
+Tests sind die Spezifikation, nicht die Nachdokumentation.
+
+## Verbindlich
+
+- Ein Verhaltensfix bringt einen Regressionstest mit, der genau den Defekt trifft.
+  Dass der Test vorher rot war, prüfst du einmal beim Schreiben — dokumentiert wird das nirgends,
+  weder im PR-Text noch im Commit.
+- Keine abgeschwächten Assertions, keine globalen Skips, keine pauschalen Retries, um rote Tests
+  kosmetisch grün zu machen. Ein instabiler Test bekommt ein Issue, keinen `xfail`.
+- Keine echten Netzwerkzugriffe und keine echten LLM-Provider in Unit- oder Contract-Tests.
+- Keine API-Keys oder Secrets in Fixtures.
+- Contract-Tests liegen unter `backend/tests/contracts/` und laufen als eigener, schneller Scope.
+
+## Kommandos
+
+```bash
+cd backend  && uv run pytest tests/contracts/ -x -q   # Contract-Scope
+cd backend  && uv run pytest                          # Backend vollständig
+cd frontend && bun run test                           # Vitest
+cd frontend && bun run test:coverage
+```
+
+E2E läuft nicht nebenbei mit — siehe `docs/runbooks/e2e-local.md`.


### PR DESCRIPTION
## Was

Vier neue Dateien unter `.github/instructions/`, jede mit einem `applyTo`-Glob:

| Datei | `applyTo` |
|---|---|
| `backend.instructions.md` | `backend/**/*.py` |
| `frontend.instructions.md` | `frontend/**/*.vue,.ts,.js` |
| `contracts.instructions.md` | `backend/app/contracts/**`, `schemas/**`, `frontend/src/contracts/**` |
| `tests.instructions.md` | `backend/tests/**`, `frontend/**/__tests__/**` |

## Warum

Codex und Claude Code lesen `AGENTS.md` bzw. `CLAUDE.md`. GitHub Copilot tut das nicht — es zieht `.github/instructions/*.instructions.md` und wählt sie über den `applyTo`-Glob nach der gerade editierten Datei aus. Bisher arbeitete Copilot im Repo ohne jede Projektregel.

## Inhalt

Destillat aus `AGENTS.md` und `CLAUDE.md`, **keine neuen Regeln**:

- `uv` statt `pip`, `bun` statt `npm`
- Pydantic-Contracts statt Dataclasses oder Inline-Schemas; Verträge zuerst, Consumer danach
- strukturiertes Logging statt `print()`, Provider-Detection nur über die Registry
- `vue-i18n` statt hartkodierter UI-Texte, keine neuen Legacy-Modell-Picker
- die fünf ADR-0002-Hartanker als Sperrzone
- die scope-abhängigen Pre-Commit-Gates und `scripts/pre-push-gate.sh`
- Test-Disziplin: Regressionstest trifft den Defekt, keine abgeschwächten Assertions oder globalen Skips

## Scope

Reine Dokumentation, kein Produktivcode, kein Vertrag, kein Schema berührt. Backend-, Frontend- und Schemas-Gate sind für diesen Diff nicht einschlägig.

## Offen

Ein repo-weites `.github/copilot-instructions.md` fehlt weiterhin — die path-spezifischen Dateien wirken nur ergänzend dazu. Separates Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)