### PR TITLE
fix(export): ZIP/CSV/Streaming-ZIP lesen die normalisierte Evidence-Sicht (#1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Fixed (Export-Parität: ZIP/CSV lasen eine andere Evidence-Wahrheit als der JSON-Export — 2026-08-06)
+
+- **Derselbe Report lieferte je nach Exportformat verschiedene Evidence-Wahrheiten:** Der JSON-Export normalisierte über `normalize_persisted_evidence_map` (#987), `build_zip_bundle`, `stream_zip_bundle` und `build_csv_export` (`table=claims`) lasen die Roh-Map — ein orphan medium-Claim stand im JSON in `data_gaps`, in `claims.csv` und `evidence-map.json` (ZIP) unverändert als `medium`. Alle Export-Formate lesen jetzt eine normalisierte Sicht über genau eine Stelle (`ReportExportService._normalized_evidence_map`); `evidence-map.json` im ZIP ist damit bewusst kein Rohabzug mehr. Regressionstests vergleichen ZIP, CSV und Streaming-ZIP (Threshold klein gepatcht) gegen den JSON-Export als Referenzwahrheit. (#1036)
+
 ## [0.9.0] — 2026-08-06
 
 ### Changed (Version-Cut `0.8.0` → `0.9.0` Stability Beta — 2026-08-06)

--- a/backend/app/services/evidence_migrations.py
+++ b/backend/app/services/evidence_migrations.py
@@ -209,12 +209,15 @@ def migrate_medium_seed_only_claims_to_low(raw: Optional[dict]) -> Optional[dict
 def normalize_persisted_evidence_map(raw: Optional[dict]) -> Optional[dict]:
     """Die kanonische Normalisierung einer persistierten ``evidence-map.json``.
 
-    Jeder produktive Pfad, der eine Evidence-Map von der Platte liest und
-    anschliessend gegen ``EvidenceMapModel`` validiert, ruft **diese** Funktion
-    — nicht die Einzelschritte. Aufrufer sind der Lese-Pfad
-    ``GET /api/report/<id>/evidence`` (``api/report.py``) und der JSON-Export
+    Jeder produktive Pfad, der eine Evidence-Map von der Platte liest, ruft
+    **diese** Funktion — nicht die Einzelschritte. Aufrufer sind der Lese-Pfad
+    ``GET /api/report/<id>/evidence`` (``api/report.py``), der JSON-Export
     ``GET /api/report/<id>/export?format=json``
-    (``report_export.py::build_export_envelope``).
+    (``report_export.py::build_export_envelope``, validiert zusaetzlich gegen
+    ``EvidenceMapModel``) sowie ZIP- und CSV-Export
+    (``report_export.py::ReportExportService._normalized_evidence_map``,
+    Issue #1036), ueber die ``build_zip_bundle``, ``stream_zip_bundle`` und
+    ``build_csv_export`` laufen.
 
     Der Export rief bis Issue #987 nur ``migrate_v1_to_v2`` und fing die
     anschliessende ``ValidationError`` mit einer ``logger.warning`` ab — die

--- a/backend/app/services/report_export.py
+++ b/backend/app/services/report_export.py
@@ -132,6 +132,26 @@ class ReportExportService:
         )
 
     @staticmethod
+    def _normalized_evidence_map(report_id: str) -> dict[str, Any]:
+        """Liest die persistierte Evidence-Map und normalisiert sie kanonisch.
+
+        Issue #1036: JSON-, ZIP- und CSV-Export lasen bislang dieselbe
+        persistierte ``evidence-map.json`` mit unterschiedlicher Wahrheit —
+        nur ``build_export_envelope`` (``?format=json``) migrierte ueber
+        ``normalize_persisted_evidence_map`` (siehe Issue #987), waehrend
+        ``build_zip_bundle``, ``stream_zip_bundle`` und ``build_csv_export``
+        (``table=claims``) die Roh-Map ungeprueft weiterreichten. Ein orphan
+        medium-Claim ohne Evidence blieb im ZIP/CSV unveraendert in
+        ``claims[]`` stehen, statt — wie im JSON-Export — nach
+        ``data_gaps`` migriert zu werden. Alle Export-Formate lesen die
+        Evidence-Map jetzt ueber genau diese eine Stelle.
+        """
+        raw = ReportManager.get_evidence_map(report_id)
+        if raw is None:
+            return {}
+        return normalize_persisted_evidence_map(raw) or {}
+
+    @staticmethod
     def build_csv_export(report_id: str, table: str) -> str:
         """Lädt die passende Datenquelle und gibt RFC-4180-CSV zurück."""
         if table in ("personas", "segments"):
@@ -141,7 +161,7 @@ class ReportExportService:
             return segments_to_csv(report_v3.get("segments") or [])
 
         # table == "claims"
-        evidence_map = ReportManager.get_evidence_map(report_id) or {}
+        evidence_map = ReportExportService._normalized_evidence_map(report_id)
         return claims_to_csv(evidence_map.get("sections") or [])
 
     @staticmethod
@@ -190,7 +210,11 @@ class ReportExportService:
                 with open(v3_path, encoding="utf-8") as fh:
                     zf.writestr(f"{prefix}/report-v3.json", fh.read())
 
-            evidence_map = ReportManager.get_evidence_map(report_id) or {}
+            # Issue #1036: normalisierte Sicht, nicht die Roh-Map — dieselbe
+            # Migrationskette wie der JSON-Export (siehe
+            # ``_normalized_evidence_map``), damit ``evidence-map.json`` im
+            # ZIP nicht mehr von den anderen Export-Formaten abweicht.
+            evidence_map = ReportExportService._normalized_evidence_map(report_id)
             zf.writestr(
                 f"{prefix}/evidence-map.json",
                 json.dumps(evidence_map, ensure_ascii=False, indent=2),
@@ -262,7 +286,9 @@ class ReportExportService:
                 if os.path.exists(v3_path):
                     zf.write(v3_path, arcname=f"{prefix}/report-v3.json")
 
-                evidence_map = ReportManager.get_evidence_map(report_id) or {}
+                # Issue #1036: normalisierte Sicht, analog zu
+                # ``build_zip_bundle`` — siehe ``_normalized_evidence_map``.
+                evidence_map = ReportExportService._normalized_evidence_map(report_id)
                 zf.writestr(
                     f"{prefix}/evidence-map.json",
                     json.dumps(evidence_map, ensure_ascii=False, indent=2),

--- a/backend/tests/api/test_report_export_evidence_parity.py
+++ b/backend/tests/api/test_report_export_evidence_parity.py
@@ -20,7 +20,10 @@ nicht aufrief — genau die Luecke, die dieser Slice schliesst.
 
 from __future__ import annotations
 
+import csv
+import io
 import json
+import zipfile
 
 import pytest
 from flask import Flask
@@ -297,3 +300,102 @@ class TestResidualContractViolationIsVisible:
 
         assert payload["evidence"] is None
         assert payload["evidence_omitted"] is None
+
+
+def _zip_json_member(response_data: bytes, name: str) -> dict:
+    with zipfile.ZipFile(io.BytesIO(response_data)) as zf:
+        return json.loads(zf.read(name))
+
+
+def _zip_text_member(response_data: bytes, name: str) -> str:
+    with zipfile.ZipFile(io.BytesIO(response_data)) as zf:
+        return zf.read(name).decode("utf-8")
+
+
+def _csv_rows(text: str) -> list[list[str]]:
+    return list(csv.reader(io.StringIO(text)))
+
+
+class TestZipAndCsvExportMatchJsonExport:
+    """Issue #1036 — ZIP und CSV lesen dieselbe normalisierte Evidence-Map wie JSON.
+
+    Vor dem Fix lasen ``build_zip_bundle``, ``stream_zip_bundle`` und
+    ``build_csv_export`` die Roh-Map ueber ``ReportManager.get_evidence_map``
+    direkt, ohne ``normalize_persisted_evidence_map`` zu durchlaufen. Ein
+    orphan medium-Claim (keine Evidence) blieb in ``evidence-map.json`` im
+    ZIP und in ``claims.csv`` unveraendert als Claim stehen, statt — wie im
+    JSON-Export — nach ``data_gaps`` migriert zu werden.
+    """
+
+    _bundle_prefix = f"agora-report-{REPORT_ID}"
+
+    def test_zip_evidence_map_matches_json_export(self, client):
+        _persist(_orphan_claim_map())
+
+        json_evidence = _export_json(client)["evidence"]
+
+        zip_response = client.get(f"/api/report/{REPORT_ID}/export?format=zip")
+        assert zip_response.status_code == 200, zip_response.data
+        zip_evidence = _zip_json_member(
+            zip_response.data, f"{self._bundle_prefix}/evidence-map.json"
+        )
+
+        assert zip_evidence["sections"][0]["claims"] == [], (
+            "orphan Claim ist im ZIP-evidence-map.json nicht nach data_gaps "
+            "migriert worden — ZIP liest noch die Roh-Map"
+        )
+        assert len(zip_evidence["sections"][0]["data_gaps"]) == 1
+        # ZIP validiert nicht gegen EvidenceMapModel, daher Feld-fuer-Feld statt
+        # Objektgleichheit mit dem JSON-Envelope.
+        assert zip_evidence["sections"][0]["data_gaps"][0]["gap_reason"] == (
+            json_evidence["sections"][0]["data_gaps"][0]["gap_reason"]
+        )
+
+    def test_zip_claims_csv_matches_json_export(self, client):
+        _persist(_orphan_claim_map())
+
+        zip_response = client.get(f"/api/report/{REPORT_ID}/export?format=zip")
+        assert zip_response.status_code == 200, zip_response.data
+        claims_csv = _zip_text_member(zip_response.data, f"{self._bundle_prefix}/claims.csv")
+
+        rows = _csv_rows(claims_csv)
+        assert rows[0][0] == "claim_id"
+        assert len(rows) == 1, (
+            "orphan Claim taucht in claims.csv im ZIP noch als Claim auf, "
+            "statt als data_gap zu verschwinden"
+        )
+
+    def test_csv_claims_export_matches_json_export(self, client):
+        _persist(_orphan_claim_map())
+
+        csv_response = client.get(f"/api/report/{REPORT_ID}/export?format=csv&table=claims")
+        assert csv_response.status_code == 200, csv_response.data
+        rows = _csv_rows(csv_response.data.decode("utf-8"))
+
+        assert rows[0][0] == "claim_id"
+        assert len(rows) == 1, (
+            "orphan Claim taucht in ?format=csv&table=claims noch als Claim "
+            "auf, statt als data_gap zu verschwinden"
+        )
+
+    def test_stream_zip_bundle_matches_build_zip_bundle(self, client, monkeypatch):
+        """Streaming-Pfad (grosse Bundles) normalisiert identisch zum In-Memory-Pfad."""
+        _persist(_orphan_claim_map())
+
+        # ZIP_STREAM_THRESHOLD_BYTES klein patchen, damit der Streaming-Pfad
+        # (app.api.report._stream_zip_bundle statt _build_zip_bundle) greift.
+        import app.api.report as report_route
+
+        monkeypatch.setattr(report_route, "_ZIP_STREAM_THRESHOLD_BYTES", 1)
+
+        zip_response = client.get(f"/api/report/{REPORT_ID}/export?format=zip")
+        assert zip_response.status_code == 200, zip_response.data
+        zip_evidence = _zip_json_member(
+            zip_response.data, f"{self._bundle_prefix}/evidence-map.json"
+        )
+
+        assert zip_evidence["sections"][0]["claims"] == [], (
+            "orphan Claim ist im gestreamten ZIP nicht nach data_gaps "
+            "migriert worden — stream_zip_bundle liest noch die Roh-Map"
+        )
+        assert len(zip_evidence["sections"][0]["data_gaps"]) == 1

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ Die Produktreife wird ab diesem Dokumentationsumbau über [`VERSION`](../VERSION
 <!-- BEGIN_AUTOGEN_TESTS -->
 | Kategorie | Anzahl | Methode |
 |---|---|---|
-| Backend Tests (collected) | 4567 | `cd backend && uv run pytest --collect-only -q` |
+| Backend Tests (collected) | 4571 | `cd backend && uv run pytest --collect-only -q` |
 | Frontend Test-Files | 185 | `find frontend/src \( -name '*.spec.ts' -o -name '*.spec.js' -o -name '*.test.ts' -o -name '*.test.js' \)` |
 <!-- END_AUTOGEN_TESTS -->
 
@@ -47,7 +47,7 @@ Agora besitzt eine vollständige fachliche Grundpipeline:
 - Dokument-/Webseitenaufnahme und Knowledge-Graph-Build
 - Persona-Erzeugung, Review und Simulation
 - Run-Dashboard, Status, Stop/Pause/Resume und Live-Ereignisse
-- Evidence-orientierte Reports und Exporte; ein einzelner ADR-0002-Verstoß beendet den Report nicht mehr als `failed`, sondern wird lokal abgestuft und maschinenlesbar protokolliert ([#1006](https://github.com/arn0ld87/agora/issues/1006)). Der JSON-Export normalisiert Evidence über dieselbe kanonische Kette wie der Lese-Pfad und weist eine nicht auslieferbare Evidence-Map im Envelope aus, statt sie stumm zu verwerfen ([#987](https://github.com/arn0ld87/agora/issues/987)); ZIP-/CSV-Export und die Evidence-Sub-Routen normalisieren noch nicht ([#1036](https://github.com/arn0ld87/agora/issues/1036), [#967](https://github.com/arn0ld87/agora/issues/967))
+- Evidence-orientierte Reports und Exporte; ein einzelner ADR-0002-Verstoß beendet den Report nicht mehr als `failed`, sondern wird lokal abgestuft und maschinenlesbar protokolliert ([#1006](https://github.com/arn0ld87/agora/issues/1006)). Der JSON-Export normalisiert Evidence über dieselbe kanonische Kette wie der Lese-Pfad und weist eine nicht auslieferbare Evidence-Map im Envelope aus, statt sie stumm zu verwerfen ([#987](https://github.com/arn0ld87/agora/issues/987)); ZIP-, CSV- und Streaming-ZIP-Export lesen dieselbe normalisierte Sicht ([#1036](https://github.com/arn0ld87/agora/issues/1036)); die Evidence-Sub-Routen normalisieren noch nicht ([#967](https://github.com/arn0ld87/agora/issues/967))
 - Compare-, Graph-Diff- und Observability-Grundlagen
 - fortsetzbare Embedding-Migration für Entity- und Fact-Vektoren
 - Kosten-, Token- und Zeitbudgets für Runs ([#764](https://github.com/arn0ld87/agora/issues/764), ADR-0012): Preflight-Schätzung mit ehrlichen Bereichen, weiche/harte Limits pro Run, Live-Verbrauchsmonitor, Abschlussanalyse nach Stage/Provider/Modell, Budgetabbruch über `termination_reason` von Fehler/Nutzerabbruch unterscheidbar, Verbrauch im Report-Export


### PR DESCRIPTION
## Was

Fixes #1036 — eine normalisierte Evidence-Sicht pro Export-Request, an alle Renderer übergeben.

- **`report_export.py`:** neue zentrale Stelle `ReportExportService._normalized_evidence_map` (liest die persistierte Map und ruft die kanonische `normalize_persisted_evidence_map` aus `evidence_migrations.py`). `build_zip_bundle`, `stream_zip_bundle` und `build_csv_export` (`table=claims`) lesen jetzt diese Sicht statt der Roh-Map.
- **Entscheidung `evidence-map.json` im ZIP (Akzeptanzkriterium):** normalisiert, kein Rohabzug mehr — im Docstring/Kommentar dokumentiert. Damit widersprechen sich JSON-, ZIP- und CSV-Export desselben Reports nicht mehr.
- **`evidence_migrations.py`:** Docstring der kanonischen Funktion listet die neuen Aufrufer.
- Out of scope (wie im Issue): Evidence-Sub-Routen (#967).

## Tests

Vier neue Tests in `backend/tests/api/test_report_export_evidence_parity.py`, alle über den echten Endpunkt mit einer persistierten Map inkl. orphan medium-Claim, JSON-Export als Referenzwahrheit:

- `test_zip_evidence_map_matches_json_export`
- `test_zip_claims_csv_matches_json_export`
- `test_csv_claims_export_matches_json_export`
- `test_stream_zip_bundle_matches_build_zip_bundle` (Streaming-Pfad via klein gepatchtem `ZIP_STREAM_THRESHOLD_BYTES`)

RED-Lauf verifiziert: Mit dem Export-Fix zurückgestasht sind genau diese 4 Tests rot (`4 failed, 8 passed`), mit Fix grün.

## Verifikation

- `pytest tests/api/test_report_export_evidence_parity.py tests/contracts/` — 535 passed
- `ruff check app/ tests/` sauber, `mypy app` sauber
- STATUS (Testzahl 4571, Produktreife-Absatz) und CHANGELOG im selben Commit

Hinweis: Implementierung durch Worker-Subagent, Diff/Tests/RED-GREEN vom Lead selbst verifiziert; aufgesetzt auf `main` nach dem 0.9.0-Version-Cut (#1120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * ZIP-, Streaming-ZIP- und CSV-Exporte verwenden nun dieselbe normalisierte Evidenzdarstellung wie JSON-Exporte.
  * ZIP-Dateien enthalten in `evidence-map.json` keine Rohdaten mehr.
  * Nicht zugeordnete Claims werden korrekt als Datenlücken ausgewiesen.

* **Dokumentation**
  * Changelog und Statusdokumentation wurden entsprechend aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->