### PR TITLE
docs(runbook): e2e-required-check.md auf tatsächlichen Aktivierungsstand bringen (#1089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Ve
 
 ## [Unreleased]
 
+### Changed (E2E-Required-Check-Runbook auf aktiven Branch-Protection-Stand korrigiert — 2026-08-08)
+
+- **Das Runbook beschrieb die Required-Erzwingung noch als offen und zeigte ein destruktives `PUT`-Beispiel mit nur sechs Playwright-Checks.** Der dokumentierte Status entspricht jetzt der aktiven `main`-Branch-Protection mit 17 Required Checks; das CLI-Beispiel liest den aktuellen Satz, ergänzt die sechs Playwright-Smokes idempotent und aktualisiert ausschließlich `required_status_checks`, sodass CodeQL-, Dependency-, Schema-, Contract-, Security-, Version- und PR-Smoke-Gates erhalten bleiben. (#1089)
+
 ### Fixed (Budget-Enforcement griff nicht in Report-Resume und Prepare-Phasen — 2026-08-06)
 
 - **`POST /api/runs/<id>/resume` baute seinen `LLMClient` ohne `run_id` — ein fortgesetzter Report lief ohne jede Budgetdurchsetzung, selbst mit hartem Budget am Run.** Der Resume-Client entsteht jetzt aus der beim Original-Start gelockten Stage-Route via `LLMClient.from_route(..., run_id=...)` (SSoT aus #817, keine zweite Client-Bauweise neben der Route); Routing-/Key-Fehler antworten weiterhin synchron mit 422. Ein `BudgetExceededError` im Resume-Worker endet als `stopped` + `termination_reason` statt `failed` (Reihenfolge `fail_task()` → `mark_budget_abort()`, #978/#841). (#984)

--- a/docs/runbooks/e2e-required-check.md
+++ b/docs/runbooks/e2e-required-check.md
@@ -1,21 +1,21 @@
 # E2E-Smokes als Required Check
 
-Datei: `docs/runbooks/e2e-required-check.md` · Stand: 2026-07-19 (Status: 3 grüne Läufe in Folge auf `32bad751`; Required-Erzwingung noch nicht freigegeben) · Eingeführt mit: Issue #739
+Datei: `docs/runbooks/e2e-required-check.md` · Stand: 2026-08-08 (Status: Required-Erzwingung ist aktiv — `main` hat einen konfigurierten Branch-Protection-Regelsatz mit den sechs Playwright-Smokes und weiteren Checks als Pflicht) · Eingeführt mit: Issue #739, aktualisiert für Issue #1089
 
 ## Zweck
 
-Der `pull_request`-Trigger des E2E-Workflows (`.github/workflows/e2e-smokes.yml`) ist aktiviert. Diese Anleitung beschreibt, wie man die sechs Kern-Smokes als **erforderliche Branch-Protection-Checks** für `main` konfiguriert — das verhindert PRs, wenn E2E rot ist.
+Der `pull_request`-Trigger des E2E-Workflows (`.github/workflows/e2e-smokes.yml`) ist aktiviert. Diese Anleitung beschreibt, wie man die sechs Kern-Smokes als **erforderliche Branch-Protection-Checks** für `main` konfiguriert — das verhindert PRs, wenn E2E rot ist. Der hier beschriebene Zielzustand ist inzwischen umgesetzt (siehe Status).
 
 ## Status
 
 | Datum | Ereignis |
 |---|---|
 | 2026-07-19 | Trigger `on: pull_request` reaktiviert (#739); drei aufeinanderfolgende grüne Läufe auf `32bad751` (`29691168025`, `29691166308`, `29691165639`) — *nicht* repräsentativ für dauerhafte Stabilität |
-| offen | Branch-Protection-Erzwingung durch Owner manuell konfigurieren, sobald weitere Läufe die Stabilität bestätigen |
+| 2026-08-08 | Erhoben via `gh api repos/arn0ld87/agora/branches/main/protection`: Required-Erzwingung ist aktiv. Die sechs Playwright-Smokes sind Required Checks, ebenso `Backend PR smoke gate (ruff + mypy + pytest-contracts)` und `Frontend PR smoke gate (lint + typecheck + test + build)` (laut Issue #979, Punkt E5) sowie weitere Checks — vollständige Liste unten |
 
-## Die sechs Required Checks
+## Die sechs Kern-Smokes (Playwright)
 
-Diese Job-Namen müssen als erforderlich konfiguriert werden:
+Diese Job-Namen sind Teil der konfigurierten Required Checks:
 
 1. `Playwright Health-Smoke`
 2. `Playwright Upload+Graph-Smoke`
@@ -24,6 +24,8 @@ Diese Job-Namen müssen als erforderlich konfiguriert werden:
 5. `Playwright Golden-Gate-Accessibility-Smoke (Slice 7.3.1)`
 6. `Playwright AiModelPicker-Smoke (Slice 5.6 / 7.3.1)`
 
+Der vollständige, per `gh api` erhobene Satz an Required Checks für `main` umfasst darüber hinaus (Stand 2026-08-08): `CodeQL (javascript-typescript)`, `CodeQL (python)`, `Dependency Review`, `Schema-Drift verhindern`, `Pydantic-Contract-Tests`, `Evidence-Quality-Gate`, `Frontend-Zod muss Backend-Schema spiegeln`, `Version-Drift-Check`, `Security scans`, `Backend PR smoke gate (ruff + mypy + pytest-contracts)`, `Frontend PR smoke gate (lint + typecheck + test + build)`. Dieses Runbook fokussiert auf die sechs Playwright-Smokes; die übrigen Checks werden von anderen Workflows definiert und sind hier nicht im Detail beschrieben.
+
 ## Konfiguration via GitHub UI
 
 1. `Settings` → `Branches`
@@ -31,6 +33,8 @@ Diese Job-Namen müssen als erforderlich konfiguriert werden:
 3. Checkbox `Require status checks to pass before merging` aktivieren
 4. Im Suchfeld je einen Job-Namen eingeben und auswählen (mind. die sechs oben)
 5. `Save changes`
+
+Diese Schritte sind bereits umgesetzt und dienen hier als Referenz für spätere Anpassungen (z. B. weitere Checks ergänzen).
 
 ## Konfiguration via `gh api` (Beispiel)
 
@@ -71,7 +75,7 @@ Beachte: `strict: true` bedeutet, dass Checks auch bei neueren Commits erneut er
 
 ## Absicherung gegen Flakes
 
-**Erst nach mehreren grünen Läufen erzwingen.** Der Workflow ist neu reaktiviert; gib dem Team Zeit, um zu verifizieren, dass die Checks stabil grün sind.
+Die Erzwingung ist aktiv. Bei wiederholten Flakes auf einem der sechs Playwright-Smokes gilt weiterhin: erst die Ursache im Workflow beheben, dann ggf. den betroffenen Check kurzzeitig über Option B (siehe Rollback) aus der Required-Liste nehmen — nicht dauerhaft, sondern nur für die Dauer der Fehlersuche.
 
 ## Rollback
 

--- a/docs/runbooks/e2e-required-check.md
+++ b/docs/runbooks/e2e-required-check.md
@@ -36,42 +36,41 @@ Der vollständige, per `gh api` erhobene Satz an Required Checks für `main` umf
 
 Diese Schritte sind bereits umgesetzt und dienen hier als Referenz für spätere Anpassungen (z. B. weitere Checks ergänzen).
 
-## Konfiguration via `gh api` (Beispiel)
+## Konfiguration via `gh api` (sicheres Read/merge/update-Beispiel)
 
 ```bash
-# Voraussetzung: gh CLI installiert, Auth konfiguriert.
-# Wichtig: --method PUT, sonst liefert gh api nur ein GET.
-# Review-Flags MÜSSEN in "required_pull_request_reviews" stehen —
-# außerhalb dieses Blocks werden sie von der GitHub-API verworfen
-# bzw. überschreiben vorhandene Einstellungen.
-gh api --method PUT \
-  repos/arn0ld87/agora/branches/main/protection \
-  --input - <<'EOF'
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": [
-      "Playwright Health-Smoke",
-      "Playwright Upload+Graph-Smoke",
-      "Playwright Minimalreport-Smoke",
-      "Playwright Report-Modes-Smoke (P4.4)",
-      "Playwright Golden-Gate-Accessibility-Smoke (Slice 7.3.1)",
-      "Playwright AiModelPicker-Smoke (Slice 5.6 / 7.3.1)"
-    ]
-  },
-  "required_pull_request_reviews": {
-    "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
-    "require_last_push_approval": false
-  },
-  "enforce_admins": true,
-  "allow_force_pushes": false,
-  "allow_deletions": false
-}
-EOF
+# Voraussetzung: gh CLI und jq installiert, Auth konfiguriert.
+# Vorhandene Required Checks inklusive ihrer App-Bindung lesen, die sechs
+# Playwright-Smokes idempotent ergänzen und nur diesen Schutzbereich aktualisieren.
+gh api repos/arn0ld87/agora/branches/main/protection \
+  | jq '
+      .required_status_checks as $current
+      | [
+          "Playwright Health-Smoke",
+          "Playwright Upload+Graph-Smoke",
+          "Playwright Minimalreport-Smoke",
+          "Playwright Report-Modes-Smoke (P4.4)",
+          "Playwright Golden-Gate-Accessibility-Smoke (Slice 7.3.1)",
+          "Playwright AiModelPicker-Smoke (Slice 5.6 / 7.3.1)"
+        ] as $required_playwright_checks
+      | {
+          strict: ($current.strict // true),
+          checks: (
+            ($current.checks // [])
+            + (
+                $required_playwright_checks
+                - (($current.checks // []) | map(.context))
+                | map({context: ., app_id: -1})
+              )
+          )
+        }
+    ' \
+  | gh api --method PATCH \
+      repos/arn0ld87/agora/branches/main/protection/required_status_checks \
+      --input -
 ```
 
-Beachte: `strict: true` bedeutet, dass Checks auch bei neueren Commits erneut erforderlich sind.
+Das Beispiel verwendet bewusst nicht `PUT` auf dem gesamten Branch-Protection-Objekt: Ein Payload mit nur den sechs Playwright-Namen würde alle anderen Required Checks ersetzen. Bestehende Checks und ihre `app_id` bleiben erhalten; nur fehlende Playwright-Smokes werden mit `app_id: -1` (jede App) ergänzt. `strict: true` bedeutet, dass Checks auch bei neueren Commits erneut erforderlich sind.
 
 ## Absicherung gegen Flakes
 


### PR DESCRIPTION
## Zusammenfassung

Schließt #1089 (E6 aus #979).

- Kopfzeile: Required-Erzwingung ist **aktiv** (Stand 2026-08-08), nicht mehr "noch nicht freigegeben"
- Status-Tabelle: Erhebung via `gh api repos/arn0ld87/agora/branches/main/protection` dokumentiert
- Required-Check-Liste wörtlich gegen die tatsächliche Branch-Protection abgeglichen (17 Checks, `strict: true`)
- Rollback-Abschnitt auf real existierende Check-Namen gebracht
- Keine anderen Runbooks angefasst, Branch-Protection selbst unverändert

## Verifikation

Ist-Zustand unabhängig doppelt erhoben (Worker + Lead, identisches Ergebnis). `pre-push-gate.sh schemas`: ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Das Runbook für erforderliche E2E-Prüfungen wurde aktualisiert.
  * Der aktuelle Status der Branch-Schutzregeln und sechs Playwright-Smoke-Checks ist dokumentiert.
  * Die Anleitung zum sicheren Ergänzen und temporären Zurücksetzen erforderlicher Checks wurde präzisiert.
  * Der Changelog enthält einen neuen Eintrag zur Korrektur des Runbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->