### PR TITLE
refactor(api): Interview-Envelope als Pydantic-Contract (#1005)

### DIFF
--- a/backend/app/api/simulation_interviews.py
+++ b/backend/app/api/simulation_interviews.py
@@ -5,6 +5,7 @@ Interview-related simulation API routes split from the main module.
 from flask import jsonify, request
 
 from . import simulation_bp
+from ..contracts.interview_envelope_contract import InterviewEnvelope
 from ..services.simulation_runner import SimulationRunner
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
@@ -101,17 +102,21 @@ def _echo_result(result: dict):
     additively so the frontend's response interceptor — which only reads
     top-level fields — can surface the real cause instead of falling back to
     a generic "Unbekannter Fehler".
+
+    The envelope is built via the ``InterviewEnvelope`` Pydantic contract
+    (#1005) instead of a handwritten dict — ``exclude_none=True`` keeps the
+    wire form byte-identical to the previous conditional-key-assignment,
+    since ``error``/``code`` are only ever populated when a cause could
+    actually be determined.
     """
     success = result.get("success", False)
-    envelope: dict = {"success": success, "data": result}
+    error: str | None = None
+    code: str | None = None
     if not success:
-        error = result.get("error") or _aggregate_batch_error(result)
-        if error:
-            envelope["error"] = error
-        code = result.get("code")
-        if code:
-            envelope["code"] = code
-    return jsonify(envelope)
+        error = result.get("error") or _aggregate_batch_error(result) or None
+        code = result.get("code") or None
+    envelope = InterviewEnvelope(success=success, data=result, error=error, code=code)
+    return jsonify(envelope.model_dump(exclude_none=True))
 
 
 @simulation_bp.route('/interview', methods=['POST'])

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -80,6 +80,7 @@ from app.contracts.embedding_contract import (
     EmbeddingMigrationJobResponse,
     EmbeddingModelMetadata,
 )
+from app.contracts.interview_envelope_contract import InterviewEnvelope
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -143,6 +144,8 @@ CONTRACTS: dict[str, type] = {
     "embedding-migration-job-response.schema.json": EmbeddingMigrationJobResponse,
     "embedding-index-version.schema.json": EmbeddingIndexVersion,
     "embedding-model-metadata.schema.json": EmbeddingModelMetadata,
+    # Interview-Envelope (Issue #1005)
+    "interview-envelope.schema.json": InterviewEnvelope,
 }
 
 

--- a/backend/app/contracts/interview_envelope_contract.py
+++ b/backend/app/contracts/interview_envelope_contract.py
@@ -1,0 +1,52 @@
+"""InterviewEnvelope — Pydantic-Vertrag für die Interview-Endpunkt-Antwort.
+
+Issue #1005 (Review-Kommentar aus PR #1004, Codex P1): ``_echo_result`` in
+``app/api/simulation_interviews.py`` baute die Antwortstruktur bisher als
+handgebautes ``dict`` zusammen. Das verstößt gegen die Regel „Dataclasses
+oder handgeschriebene Inline-Schemas für API-Verträge" aus ``AGENTS.md``.
+
+Legacy-Form (bewusst, nicht versehentlich): die vier Interview-Endpunkte
+(``/interview``, ``/interview/batch``, ``/interview/all``) antworten immer
+mit HTTP 200 — auch wenn der interne Interview-Lauf fehlgeschlagen ist.
+Der Fehlerzustand wird ausschließlich über ``success: false`` sowie die
+additiv gespiegelten Top-Level-Felder ``error``/``code`` transportiert,
+nicht über den HTTP-Status. Das weicht vom regulären ``json_success``/
+``json_error``-Pfad (``app/utils/api_responses.py``) ab, der 4xx/5xx nutzt.
+Dieser Vertrag modelliert die Abweichung explizit, statt sie stillschweigend
+zu vereinheitlichen — eine Statuscode-Angleichung wäre eine Verhaltensänderung
+für bestehende Consumer und ist hier nicht im Scope (vgl. #1000, #1004).
+
+``data`` trägt immer den vollständigen, unveränderten internen Result-Dict
+der jeweiligen ``SimulationRunner``-Methode — dessen innere Form ist nicht
+Teil dieses Vertrags (sie variiert je nach IPC- vs. Direct-Pfad, siehe
+``_aggregate_batch_error``), deshalb bleibt ``data`` bewusst ein offenes
+``dict[str, Any]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InterviewEnvelope(BaseModel):
+    """Antwort-Envelope der Interview-Endpunkte (Legacy-Form, HTTP 200 immer).
+
+    ``error``/``code`` sind nur bei ``success=False`` gesetzt und auch dann nur,
+    wenn eine Fehlerursache tatsächlich ermittelt werden konnte (additiv
+    gespiegelt aus ``data`` bzw. aus der Direct-Pfad-Aggregation) — analog zum
+    bisherigen ``if error: envelope["error"] = error``-Verhalten. Bei
+    ``model_dump(exclude_none=True)`` verschwinden nicht gesetzte Felder aus
+    der Antwort, statt als ``null`` zu erscheinen.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool
+    data: dict[str, Any]
+    error: str | None = None
+    code: str | None = None
+
+
+__all__ = ["InterviewEnvelope"]

--- a/backend/tests/api/test_simulation_endpoints.py
+++ b/backend/tests/api/test_simulation_endpoints.py
@@ -441,3 +441,86 @@ def test_interview_batch_direct_path_per_agent_error_surfaces_top_level(
     assert payload["error"] == provider_error
     assert "code" not in payload
     assert payload["data"] == fake_result
+
+
+def test_interview_batch_code_field_is_mirrored_when_present(client, monkeypatch):
+    """``code`` ist Teil des Vertrags (``InterviewEnvelope``), auch wenn kein
+    aktueller ``SimulationRunner``-Pfad ihn setzt — die Mirroring-Logik selbst
+    muss trotzdem am Endpunkt strukturgleich zum Ist-Verhalten bleiben."""
+    _mock_interview_backend_available(monkeypatch)
+    fake_result = {
+        "success": False,
+        "error": "Rate limit exceeded",
+        "code": "rate_limited",
+        "timestamp": "2026-08-01T12:00:00",
+    }
+    monkeypatch.setattr(
+        "app.api.simulation_interviews.SimulationRunner.interview_agents_batch",
+        staticmethod(lambda **_kwargs: fake_result),
+    )
+    response = client.post(
+        "/api/simulation/interview/batch",
+        json={
+            "simulation_id": VALID_SIM_ID,
+            "interviews": [{"agent_id": 1, "prompt": "Hallo?"}],
+        },
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"] == "Rate limit exceeded"
+    assert payload["code"] == "rate_limited"
+    assert payload["data"] == fake_result
+
+
+def test_interview_single_success_envelope_preserves_data(client, monkeypatch):
+    """Der ``/interview``-Einzelendpunkt teilt sich ``_echo_result`` mit
+    ``/interview/batch`` — dieselbe Envelope-Form muss auch hier gelten."""
+    _mock_interview_backend_available(monkeypatch)
+    fake_result = {
+        "success": True,
+        "agent_id": 1,
+        "mode": "direct",
+        "result": {"agent_id": 1, "platform": "reddit", "response": "Passt."},
+        "timestamp": "2026-08-01T12:00:00",
+    }
+    monkeypatch.setattr(
+        "app.api.simulation_interviews.SimulationRunner.interview_agent",
+        staticmethod(lambda **_kwargs: fake_result),
+    )
+    response = client.post(
+        "/api/simulation/interview",
+        json={"simulation_id": VALID_SIM_ID, "agent_id": 1, "prompt": "Hallo?"},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert "error" not in payload
+    assert "code" not in payload
+    assert payload["data"] == fake_result
+
+
+def test_interview_all_success_envelope_preserves_data(client, monkeypatch):
+    """``/interview/all`` teilt sich ebenfalls ``_echo_result`` — vierter der
+    vier betroffenen Endpunkte aus #1005."""
+    _mock_interview_backend_available(monkeypatch)
+    fake_result = {
+        "success": True,
+        "mode": "direct",
+        "result": {"results": {"reddit_1": {"agent_id": 1, "response": "Klar."}}},
+        "timestamp": "2026-08-01T12:00:00",
+    }
+    monkeypatch.setattr(
+        "app.api.simulation_interviews.SimulationRunner.interview_all_agents",
+        staticmethod(lambda **_kwargs: fake_result),
+    )
+    response = client.post(
+        "/api/simulation/interview/all",
+        json={"simulation_id": VALID_SIM_ID, "prompt": "Wie geht's?"},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert "error" not in payload
+    assert "code" not in payload
+    assert payload["data"] == fake_result

--- a/schemas/interview-envelope.schema.json
+++ b/schemas/interview-envelope.schema.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://alexle135.de/schemas/interview-envelope.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Antwort-Envelope der Interview-Endpunkte (Legacy-Form, HTTP 200 immer).\n\n``error``/``code`` sind nur bei ``success=False`` gesetzt und auch dann nur,\nwenn eine Fehlerursache tats\u00e4chlich ermittelt werden konnte (additiv\ngespiegelt aus ``data`` bzw. aus der Direct-Pfad-Aggregation) \u2014 analog zum\nbisherigen ``if error: envelope[\"error\"] = error``-Verhalten. Bei\n``model_dump(exclude_none=True)`` verschwinden nicht gesetzte Felder aus\nder Antwort, statt als ``null`` zu erscheinen.",
+  "properties": {
+    "code": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Code"
+    },
+    "data": {
+      "additionalProperties": true,
+      "title": "Data",
+      "type": "object"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Error"
+    },
+    "success": {
+      "title": "Success",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "data"
+  ],
+  "title": "InterviewEnvelope",
+  "type": "object"
+}


### PR DESCRIPTION
## Zusammenfassung

Schließt #1005.

- Neuer Contract `backend/app/contracts/interview_envelope_contract.py` (`InterviewEnvelope`) ersetzt das handgebaute `dict` in `_echo_result` (`simulation_interviews.py`), alle vier Endpunkte umgestellt
- **Keine stille Verhaltensänderung:** Die bewusste Legacy-Form (HTTP 200 mit `success: false` im Rumpf) ist im Contract explizit modelliert; Golden-Form-Tests schreiben das Ist-Verhalten fest (Statuscode + JSON-Struktur für Erfolgs- und Fehlerfall)
- Schema `schemas/interview-envelope.schema.json` via `dump_schemas` registriert; Frontend unangetastet (Spiegel-Smoke unauffällig)

## Verifikation

- `tests/api/test_simulation_endpoints.py` + `tests/contracts/`: 553 passed
- `dump_schemas --check`: 56/56 Schemas match
- ruff + `mypy app` (254 Dateien): grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1005
