### PR TITLE
fix(ci): Bash-Syntaxfehler im pip-audit-Hardstop-Check — main-Blocker

### DIFF
--- a/backend/tests/scripts/test_check_pip_audit_hardstop.py
+++ b/backend/tests/scripts/test_check_pip_audit_hardstop.py
@@ -1,0 +1,57 @@
+"""Regressionstests für scripts/check-pip-audit-hardstop.sh.
+
+Hintergrund (main-Rotlauf 2026-08-08): Zeile 32 nutzte ``>=`` innerhalb von
+``[[ ]]`` — den Operator gibt es in Bash nicht, jeder Lauf endete mit
+"syntax error in conditional expression" und Exit 2, unabhängig von Datum
+und Flag-Liste. Diese Tests führen das Skript wirklich aus; ein erneuter
+Syntaxfehler lässt bereits den Vor-Cutoff-Fall fehlschlagen.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check-pip-audit-hardstop.sh"
+
+
+def _run(hardcutoff: str, flags: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env={
+            "PATH": "/usr/bin:/bin",
+            "PIP_AUDIT_HARDCUTOFF": hardcutoff,
+            "PIP_AUDIT_FLAGS": flags,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_before_hardcutoff_allows_ignore_list() -> None:
+    result = _run("2999-01-01", "--ignore-vuln GHSA-xxxx")
+    assert result.returncode == 0, result.stderr
+    assert "vor dem Hardcutoff" in result.stdout
+
+
+def test_after_hardcutoff_with_empty_list_is_ok() -> None:
+    result = _run("2000-01-01", "")
+    assert result.returncode == 0, result.stderr
+    assert "Liste ist leer" in result.stdout
+
+
+def test_after_hardcutoff_with_ignore_list_fails_with_exit_2() -> None:
+    result = _run("2000-01-01", "--ignore-vuln GHSA-xxxx --ignore-vuln GHSA-yyyy")
+    assert result.returncode == 2
+    assert "non-empty" in result.stderr
+
+
+def test_on_hardcutoff_day_list_must_already_be_empty() -> None:
+    # Inklusiv-Semantik: am Cutoff-Tag selbst ist die Liste nicht mehr erlaubt.
+    import datetime
+
+    today = datetime.date.today().isoformat()
+    result = _run(today, "--ignore-vuln GHSA-xxxx")
+    assert result.returncode == 2

--- a/changelog.d/1143-pip-audit-hardstop-syntax.md
+++ b/changelog.d/1143-pip-audit-hardstop-syntax.md
@@ -1,0 +1,3 @@
+### Fixed (Hardstop-Check brach den Backend-Job auf main mit Bash-Syntaxfehler — 2026-08-08)
+
+- **`scripts/check-pip-audit-hardstop.sh` endete bei jedem Lauf mit „syntax error in conditional expression" (Exit 2):** `[[ "$TODAY" >= "$HARDCUTOFF" ]]` — den Operator `>=` gibt es in Bash-`[[ ]]` nicht. Ersetzt durch den äquivalenten lexikografischen `<`-Vergleich; Regressionstests führen das Skript jetzt tatsächlich aus (vor/nach/am Cutoff-Tag). Der Defekt blieb unbemerkt, weil frühere main-Läufe schon am Ruff-Step scheiterten, bevor der Hardstop-Step erreicht wurde.

--- a/scripts/check-pip-audit-hardstop.sh
+++ b/scripts/check-pip-audit-hardstop.sh
@@ -29,8 +29,11 @@ TODAY="$(date -u +%F)"
 # Inklusiv: am Cutoff-Tag selbst muss die Liste bereits leer sein (AGENTS.md L76
 # verbietet CVE-Ausnahmen ohne Hardstop; ein Tag ``< Hardcutoff`` wuerde das
 # aushebeln — das letzte 24-Stunden-Fenster vor dem Hardstop waere unguelltig).
-if [[ ! "$TODAY" >= "$HARDCUTOFF" ]]; then
-  echo "OK: $TODAY ist vor oder am Hardcutoff $HARDCUTOFF — pip-audit --ignore-vuln ist erlaubt."
+# ``>=`` existiert in ``[[ ]]`` nicht (Syntaxfehler, Exit 2 bei jedem Lauf);
+# ``<`` ist der lexikografische String-Vergleich und exakt äquivalent zu
+# ``! (TODAY >= HARDCUTOFF)``.
+if [[ "$TODAY" < "$HARDCUTOFF" ]]; then
+  echo "OK: $TODAY ist vor dem Hardcutoff $HARDCUTOFF — pip-audit --ignore-vuln ist erlaubt."
   exit 0
 fi
 


### PR DESCRIPTION
Der Step „Verify pip-audit --ignore-vuln hardstop" im Backend-Job auf main bricht mit `syntax error in conditional expression` (Exit 2) ab: `[[ "$TODAY" >= "$HARDCUTOFF" ]]` — `>=` existiert in Bash-`[[ ]]` nicht.

- Ersetzt durch den äquivalenten lexikografischen `<`-Vergleich (Semantik unverändert inklusiv: am Cutoff-Tag muss die Liste leer sein).
- Regressionstests `backend/tests/scripts/test_check_pip_audit_hardstop.py` führen das Skript real aus — ein erneuter Syntaxfehler macht schon den Vor-Cutoff-Fall rot.
- Der Defekt war seit #1066 latent und blieb unsichtbar, weil die letzten main-Läufe vorher am Ruff-Step (#1141) scheiterten.

Verifikation: `bash -n` sauber, 4/4 Tests grün, `pre-push-gate.sh backend` ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)