### PR TITLE
fix(release-tooling): README-Badge-Regex im Versions-Drift-Fixer case-insensitiv

### DIFF
--- a/backend/scripts/check_version_drift.py
+++ b/backend/scripts/check_version_drift.py
@@ -131,9 +131,13 @@ def read_readme_badge_version(repo_root: Path) -> str | None:
     readme = repo_root / "README.md"
     text = readme.read_text(encoding="utf-8")
     # Matches: [![Version](https://img.shields.io/badge/Version-1.0.0-blue?...)](...)
+    # sowie das aktuelle README-Format mit kleingeschriebenem Label und
+    # Hex-Farbe: .../badge/version-0.9.3-635BFF?style=flat-square
     # (.+?) fasst auch Bindestrich-Versionen (Pre-Releases wie 0.8.0-rc.1),
     # da bis zum abschliessenden Farb-Suffix vor '?'/')' nicht-gierig gematcht wird.
-    m = re.search(r"img\.shields\.io/badge/Version-(.+?)-\w+(?=[?)])", text)
+    m = re.search(
+        r"img\.shields\.io/badge/version-(.+?)-\w+(?=[?)])", text, re.IGNORECASE
+    )
     return m.group(1) if m else None
 
 
@@ -141,10 +145,11 @@ def write_readme_badge_version(repo_root: Path, version: str) -> None:
     readme = repo_root / "README.md"
     text = readme.read_text(encoding="utf-8")
     new_text, count = re.subn(
-        r"(img\.shields\.io/badge/Version-).+?(-\w+(?=[?)]))",
+        r"(img\.shields\.io/badge/version-).+?(-\w+(?=[?)]))",
         rf"\g<1>{version}\g<2>",
         text,
         count=1,
+        flags=re.IGNORECASE,
     )
     if count == 0:
         # No badge present — nothing to write, not an error.

--- a/backend/tests/scripts/test_check_version_drift.py
+++ b/backend/tests/scripts/test_check_version_drift.py
@@ -166,6 +166,27 @@ class TestReadReadmeBadgeVersion:
         (tmp_path / "README.md").write_text(readme_content)
         assert mod.read_readme_badge_version(tmp_path) == "1.0.0"
 
+    def test_extracts_version_from_lowercase_badge_with_hex_color(self, tmp_path):
+        # Aktuelles README-Format (Release-Cut 0.9.3, 2026-08-08): kleines
+        # Label + Hex-Farbe. Die Groß-Variante oben bleibt abgedeckt.
+        mod = _load_script()
+        readme_content = (
+            "[![Version](https://img.shields.io/badge/version-0.9.3-635BFF"
+            "?style=flat-square)](./VERSION)\n"
+        )
+        (tmp_path / "README.md").write_text(readme_content)
+        assert mod.read_readme_badge_version(tmp_path) == "0.9.3"
+
+    def test_write_updates_lowercase_badge(self, tmp_path):
+        mod = _load_script()
+        (tmp_path / "README.md").write_text(
+            "[![Version](https://img.shields.io/badge/version-0.9.0-635BFF"
+            "?style=flat-square)](./VERSION)\n"
+        )
+        mod.write_readme_badge_version(tmp_path, "0.9.3")
+        assert mod.read_readme_badge_version(tmp_path) == "0.9.3"
+        assert "badge/version-0.9.3-635BFF" in (tmp_path / "README.md").read_text()
+
 
 class TestMain:
     def test_returns_0_when_all_agree(self, tmp_path, monkeypatch):

--- a/changelog.d/1144-version-drift-badge-regex.md
+++ b/changelog.d/1144-version-drift-badge-regex.md
@@ -1,0 +1,3 @@
+### Fixed (Drift-Fixer erkennt den README-Version-Badge wieder — 2026-08-08)
+
+- **`check_version_drift.py` meldete „No version badge found in README.md", obwohl Zeile 11 einen Badge trägt:** Die Regex matchte nur `badge/Version-` (großes V), das README nutzt seit dem Redesign `badge/version-<semver>-<hexfarbe>`. Lese- und Schreib-Regex matchen jetzt case-insensitiv; beim Release-Cut 0.9.3 musste der Badge deshalb manuell nachgezogen werden. Regressionstests decken das aktuelle Kleinschreibungs-Format mit Hex-Farbe für Read- und Write-Pfad ab.


### PR DESCRIPTION
`check_version_drift.py` meldete bei jedem Lauf „INFO: No version badge found in README.md" und ließ den Badge bei `--write` aus — die Regex matchte nur `badge/Version-` (großes V), das README nutzt `badge/version-<semver>-<hexfarbe>` (z. B. `version-0.9.3-635BFF`). Beim Release-Cut 0.9.3 musste der Badge deshalb manuell per sed nachgezogen werden.

- Lese- und Schreib-Regex matchen jetzt case-insensitiv (`re.IGNORECASE`), Capture-Verhalten unverändert.
- Regressionstests für das aktuelle Kleinschreibungs-Format mit Hex-Farbe: Read-Pfad und Write-Pfad (`test_extracts_version_from_lowercase_badge_with_hex_color`, `test_write_updates_lowercase_badge`); Alt-Format bleibt abgedeckt.
- Verifiziert: Live-Lauf liest den Badge jetzt (kein INFO-Skip), 38/38 Drift-Tests grün, `pre-push-gate.sh backend` ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)