### PR TITLE
fix(ci): ghcr.io in Smoke-Egress-Allowlist — Release-Publish-Blocker

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -327,9 +327,11 @@ jobs:
             auth.docker.io:443
             docker-images-prod.s3.amazonaws.com:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
+            ghcr.io:443
             github.com:443
             index.docker.io:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
             registry-1.docker.io:443

--- a/changelog.d/1145-smoke-egress-ghcr.md
+++ b/changelog.d/1145-smoke-egress-ghcr.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- CI: `prod-proxy-smoke` blockte via Harden-Runner-Egress jeden Zugriff auf `ghcr.io` und scheiterte damit auf jedem Release-/Tag-Push am Pull des `astral-sh/uv`-Basis-Images — der GHCR-Publish wurde dadurch nie erreicht. `ghcr.io:443` und `pkg-containers.githubusercontent.com:443` in die Smoke-Allowlist aufgenommen ([#1145](https://github.com/arn0ld87/agora/pull/1145)).


### PR DESCRIPTION
## Problem

Seit das Dockerfile `ghcr.io/astral-sh/uv` als Basis-Image nutzt, scheitert der `prod-proxy-smoke`-Job auf **jedem** Release-/Tag-Push deterministisch:

```
#3 ERROR: failed to do request: Head "https://ghcr.io/v2/astral-sh/uv/manifests/sha256:9a23…":
dial tcp 54.185.253.63:443: connect: connection refused
```

Ursache: Die Harden-Runner-Allowlist des Smoke-Jobs enthält kein `ghcr.io:443` — `build-only` und `publish` haben es beide. Der Compose-Build des Proxy-Targets läuft damit ins Egress-Sinkhole, `publish` wird geskippt, und die v0.9.3-Images haben GHCR nie erreicht (Runs 31278567787, 31278849293, 31278997838 — identischer Fehler, inkl. Rerun).

## Fix

`ghcr.io:443` (Manifeste) und `pkg-containers.githubusercontent.com:443` (Blob-Storage) in die `allowed-endpoints` des Smoke-Jobs aufgenommen, analog zur publish-Allowlist.

## Verifikation

Workflow-only-Change; der Beweis ist ein grüner `prod-proxy-smoke` auf einem Dispatch-/Release-Run nach Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)