### PR TITLE
fix(report): kanonische Evidence-Identität einführen

### DIFF
--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -131,7 +131,7 @@ jobs:
             --min-evidence-coverage 0.85 \
             --min-claim-support-ratio 0.75 \
             --orphan-claim-rate 0.10 \
-            --require-schema-version 2
+            --require-schema-version 3
 
   zod-mirror-drift:
     name: Frontend-Zod muss Backend-Schema spiegeln

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -7,11 +7,13 @@ Pflicht-Lesepfad bei Änderungen:
 3. schemas/*.schema.json (auto-generiert via dump_schemas)
 """
 from .report_contract import (
+    ClaimEvidenceBindingModel,
     ConfidenceLabel,
     EvidenceDegradationModel,
     EvidenceItemModel,
     EvidenceMapModel,
     EvidenceOmissionModel,
+    EvidenceRecordModel,
     EvidenceSourceKind,
     EvidenceType,
     ReportClaimModel,
@@ -173,6 +175,7 @@ __all__ = [
     "ClusterChange",
     "ClusterShift",
     "ClusterSummary",
+    "ClaimEvidenceBindingModel",
     "ComparisonDeltas",
     "ConfidenceLabel",
     "DegradationKind",
@@ -185,6 +188,7 @@ __all__ = [
     "EvidenceItemModel",
     "EvidenceMapModel",
     "EvidenceOmissionModel",
+    "EvidenceRecordModel",
     "EvidenceSourceKind",
     "EvidenceType",
     "GraphDiff",

--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -196,6 +196,64 @@ class EvidenceItemModel(BaseModel):
         return self
 
 
+EVIDENCE_ID_PATTERN = r"^ev_[0-9a-f]{32}$"
+
+
+class EvidenceRecordModel(BaseModel):
+    """Claim-unabhaengiger, kanonisch adressierbarer Quellen-Datensatz."""
+
+    model_config = _STRICT
+
+    evidence_id: str = Field(pattern=EVIDENCE_ID_PATTERN)
+    producer_key: str = Field(min_length=1, max_length=500)
+    type: EvidenceType
+    source: str = Field(min_length=1)
+    snippet: str = Field(min_length=1, max_length=2000)
+    value: Optional[str | int | float | bool] = None
+    tool_name: Optional[str] = None
+    query: Optional[str] = None
+    raw: Optional[Any] = None
+    agent_log_ref: Optional[AgentLogRef] = None
+    quote: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    source_id_anchor: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    sentiment_score: Optional[float] = Field(default=None, ge=-1.0, le=1.0)
+    source_kind: EvidenceSourceKind = EvidenceSourceKind.inferred
+    source_model: Optional[str] = Field(default=None, max_length=200)
+    persona_stakeholder_group: Optional[str] = Field(
+        default=None, min_length=1, max_length=200
+    )
+
+    @model_validator(mode="after")
+    def reject_inference_in_evidence(self) -> "EvidenceRecordModel":
+        if self.type.value in FORBIDDEN_EVIDENCE_TYPES:
+            raise ValueError(
+                f"EvidenceType '{self.type.value}' ist nur im audit_trail erlaubt."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def agent_quote_needs_stakeholder_group(self) -> "EvidenceRecordModel":
+        if self.source_kind == EvidenceSourceKind.agent_quote and not self.persona_stakeholder_group:
+            raise ValueError(
+                "source_kind=agent_quote verlangt persona_stakeholder_group."
+            )
+        return self
+
+
+class ClaimEvidenceBindingModel(BaseModel):
+    """Claim-relative Bewertung einer Referenz auf ``EvidenceRecordModel``."""
+
+    model_config = _STRICT
+
+    evidence_id: str = Field(pattern=EVIDENCE_ID_PATTERN)
+    match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    retrieval_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    entailment: Optional[EntailmentVerdict] = None
+    entailment_reason: Optional[str] = Field(default=None, max_length=500)
+    supports_claim: Optional[bool] = None
+    contradicts_claim: Optional[bool] = None
+
+
 class ReportClaimModel(BaseModel):
     model_config = _STRICT
 
@@ -219,6 +277,7 @@ class ReportClaimModel(BaseModel):
                 "eine Evidence mit nachvollziehbarem Anker."
             )
         return self
+
 
     @model_validator(mode="after")
     def verified_needs_strong_match(self) -> "ReportClaimModel":
@@ -309,6 +368,41 @@ class ReportClaimModel(BaseModel):
                 f"Gefunden: agent_quote={has_agent_quote}, "
                 f"seed_corpus={has_seed_corpus}."
             )
+        return self
+
+
+class IndexedReportClaimModel(BaseModel):
+    """Claim-Shape der EvidenceMap v3 mit referenzierten Bindings."""
+
+    model_config = _STRICT
+
+    claim_id: str = Field(pattern=r"^claim_\d{2,}$")
+    claim_text: str = Field(min_length=8)
+    confidence_label: ConfidenceLabel
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    evidence: list[ClaimEvidenceBindingModel] = Field(default_factory=list, max_length=10)
+    audit_trail: list[dict[str, Any]] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+    @model_validator(mode="after")
+    def require_binding_for_non_low_claim(self) -> "IndexedReportClaimModel":
+        if self.confidence_label != ConfidenceLabel.low and not self.evidence:
+            raise ValueError(
+                f"Label '{self.confidence_label.value}' verlangt mindestens ein Evidence-Binding."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def require_strong_supported_binding(self) -> "IndexedReportClaimModel":
+        if self.confidence_label == ConfidenceLabel.verified:
+            top = max((item.match_score or 0.0) for item in self.evidence)
+            if top < 0.85:
+                raise ValueError("Label 'verified' verlangt match_score >= 0.85.")
+        if self.confidence_label in (ConfidenceLabel.high, ConfidenceLabel.verified):
+            if not any(item.supports_claim for item in self.evidence):
+                raise ValueError(
+                    f"Label '{self.confidence_label.value}' verlangt supports_claim=True."
+                )
         return self
 
 
@@ -404,7 +498,7 @@ class ReportSectionModel(BaseModel):
     section_index: int = Field(ge=1)
     section_title: str = Field(min_length=3)
     section_summary: str = Field(min_length=1)
-    claims: list[ReportClaimModel] = Field(default_factory=list)
+    claims: list[IndexedReportClaimModel] = Field(default_factory=list)
     hypotheses: list[ReportSectionHypothesisModel] = Field(default_factory=list)
     # Slice 3 (Issue #495): Hypothesen-Appendix — Überhang nach dem Cap von 5.
     # Frontend kann diesen Slot optional ausklappen. max_length=50 verhindert
@@ -521,14 +615,87 @@ class EvidenceDegradationModel(BaseModel):
 class EvidenceMapModel(BaseModel):
     """Persistierte Evidence-Map. Ablöse für die rohen Dicts in report_agent.py."""
     model_config = _STRICT
-    schema_version: Literal[2] = 2
+    schema_version: Literal[3] = 3
     report_id: str = Field(min_length=1)
     simulation_id: str = Field(min_length=1)
-    global_evidence: list[EvidenceItemModel] = Field(default_factory=list)
+    evidence_index: dict[str, EvidenceRecordModel] = Field(default_factory=dict)
+    global_evidence_refs: list[str] = Field(default_factory=list)
     sections: list[ReportSectionModel] = Field(default_factory=list)
     # Issue #1006: additiv, Default leer — bestehende persistierte
     # EvidenceMaps ohne dieses Feld validieren unverändert weiter.
     degradation_log: list[EvidenceDegradationModel] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_evidence_cross_references(self) -> "EvidenceMapModel":
+        known_ids = set(self.evidence_index)
+        mismatched = [
+            key
+            for key, record in self.evidence_index.items()
+            if key != record.evidence_id
+        ]
+        if mismatched:
+            raise ValueError(
+                "evidence_index-Key stimmt nicht mit evidence_id ueberein: "
+                + ", ".join(sorted(mismatched))
+            )
+
+        unknown_global = sorted(set(self.global_evidence_refs) - known_ids)
+        if unknown_global:
+            raise ValueError(
+                "global_evidence_refs enthalten unbekannte Evidence: "
+                + ", ".join(unknown_global)
+            )
+
+        for section in self.sections:
+            for claim in section.claims:
+                unknown = sorted(
+                    {binding.evidence_id for binding in claim.evidence} - known_ids
+                )
+                if unknown:
+                    raise ValueError(
+                        f"Claim {claim.claim_id} referenziert unbekannte Evidence: "
+                        + ", ".join(unknown)
+                    )
+
+                resolved = [
+                    (binding, self.evidence_index[binding.evidence_id])
+                    for binding in claim.evidence
+                ]
+                if claim.confidence_label in (ConfidenceLabel.high, ConfidenceLabel.verified):
+                    groups = {
+                        record.persona_stakeholder_group
+                        for binding, record in resolved
+                        if binding.supports_claim
+                        and record.source_kind == EvidenceSourceKind.agent_quote
+                        and record.persona_stakeholder_group
+                    }
+                    if len(groups) < 2:
+                        raise ValueError(
+                            f"Claim {claim.claim_id}: high/verified verlangt zwei "
+                            "stuetzende Stakeholder-Gruppen."
+                        )
+                    if any(
+                        record.source_kind == EvidenceSourceKind.inferred
+                        for _, record in resolved
+                    ):
+                        raise ValueError(
+                            f"Claim {claim.claim_id}: inferred Evidence ist fuer "
+                            "high/verified unzulaessig."
+                        )
+                if claim.confidence_label == ConfidenceLabel.medium:
+                    has_agent_quote = any(
+                        record.source_kind == EvidenceSourceKind.agent_quote and record.quote
+                        for _, record in resolved
+                    )
+                    has_seed = any(
+                        record.source_kind == EvidenceSourceKind.seed_corpus
+                        for _, record in resolved
+                    )
+                    if not (has_agent_quote and has_seed):
+                        raise ValueError(
+                            f"Claim {claim.claim_id}: medium verlangt agent_quote und seed_corpus."
+                        )
+        return self
 
 
 class EvidenceOmissionModel(BaseModel):

--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -653,7 +653,8 @@ class EvidenceMapModel(BaseModel):
                 )
                 if unknown:
                     raise ValueError(
-                        f"Claim {claim.claim_id} referenziert unbekannte Evidence: "
+                        f"Section {section.section_index} Claim {claim.claim_id} "
+                        "referenziert unbekannte Evidence: "
                         + ", ".join(unknown)
                     )
 
@@ -671,7 +672,8 @@ class EvidenceMapModel(BaseModel):
                     }
                     if len(groups) < 2:
                         raise ValueError(
-                            f"Claim {claim.claim_id}: high/verified verlangt zwei "
+                            f"Section {section.section_index} Claim {claim.claim_id}: "
+                            "high/verified verlangt zwei "
                             "stuetzende Stakeholder-Gruppen."
                         )
                     if any(
@@ -679,7 +681,8 @@ class EvidenceMapModel(BaseModel):
                         for _, record in resolved
                     ):
                         raise ValueError(
-                            f"Claim {claim.claim_id}: inferred Evidence ist fuer "
+                            f"Section {section.section_index} Claim {claim.claim_id}: "
+                            "inferred Evidence ist fuer "
                             "high/verified unzulaessig."
                         )
                 if claim.confidence_label == ConfidenceLabel.medium:
@@ -693,7 +696,8 @@ class EvidenceMapModel(BaseModel):
                     )
                     if not (has_agent_quote and has_seed):
                         raise ValueError(
-                            f"Claim {claim.claim_id}: medium verlangt agent_quote und seed_corpus."
+                            f"Section {section.section_index} Claim {claim.claim_id}: "
+                            "medium verlangt agent_quote und seed_corpus."
                         )
         return self
 

--- a/backend/app/contracts/report_v3.py
+++ b/backend/app/contracts/report_v3.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .provider_types import ProviderType
+from .report_contract import EvidenceRecordModel
 
 
 _STRICT = ConfigDict(extra="forbid", str_strip_whitespace=True)
@@ -255,15 +256,16 @@ class ReportV3(BaseModel):
     """
     Container für alle 11 Pflichtabschnitte des strukturierten Reports v3.
 
-    schema_version=3 ist als Literal festgelegt — verhindert Versions-Drift
+    schema_version=4 ist als Literal festgelegt — verhindert Versions-Drift
     analog zu ReportContractModel(schema_version=2).
     """
 
     model_config = _STRICT
 
-    schema_version: Literal[3] = 3
+    schema_version: Literal[4] = 4
     report_id: str = Field(min_length=1)
     generated_at: datetime
+    evidence_index: dict[str, EvidenceRecordModel] = Field(default_factory=dict)
     report_mode: ReportMode = Field(
         default=DEFAULT_REPORT_MODE,
         description="Vertrauensmodus (PLAN.md §5.1). Default 'balanced'.",
@@ -293,3 +295,38 @@ class ReportV3(BaseModel):
         max_length=10,
         description="Befunde der Red-Team-Review-Stage (max. 10).",
     )
+
+    @model_validator(mode="after")
+    def validate_evidence_cross_references(self) -> "ReportV3":
+        known_ids = set(self.evidence_index)
+        mismatched = [
+            key
+            for key, record in self.evidence_index.items()
+            if key != record.evidence_id
+        ]
+        if mismatched:
+            raise ValueError(
+                "evidence_index-Key stimmt nicht mit evidence_id ueberein: "
+                + ", ".join(sorted(mismatched))
+            )
+
+        collections = (
+            self.personas,
+            self.claims,
+            self.multipliers,
+            self.friction_points,
+            self.trust_signals,
+            self.change_recommendations,
+            self.project_impacts,
+            self.positioning_variants,
+            self.content_ideas,
+        )
+        for collection in collections:
+            for item in collection:
+                unknown = sorted(set(item.evidence_refs) - known_ids)
+                if unknown:
+                    raise ValueError(
+                        f"evidence_refs von {item.id} enthalten unbekannte Evidence: "
+                        + ", ".join(unknown)
+                    )
+        return self

--- a/backend/app/services/evidence_binder.py
+++ b/backend/app/services/evidence_binder.py
@@ -108,7 +108,11 @@ def bind_evidence_to_claim(
         if score < threshold:
             continue
 
-        bound = dict(item)
+        # Canonical Records werden nicht in jeden Claim kopiert. Der
+        # Legacy-Zweig ohne evidence_id bleibt nur fuer interne Alt-Caller;
+        # persistierte v3-Maps akzeptieren ausschliesslich Bindings.
+        evidence_id = item.get("evidence_id")
+        bound = {"evidence_id": evidence_id} if evidence_id else dict(item)
         rounded = round(float(score), 3)
         bound["retrieval_score"] = rounded
         bound["match_score"] = rounded

--- a/backend/app/services/evidence_identity.py
+++ b/backend/app/services/evidence_identity.py
@@ -1,0 +1,37 @@
+"""Deterministische, run-lokale Identitaet fuer Evidence-Records."""
+
+from __future__ import annotations
+
+import hashlib
+from enum import Enum
+
+
+def _identity_part(value: object, *, field_name: str) -> str:
+    if isinstance(value, Enum):
+        value = value.value
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} darf nicht leer sein.")
+    return normalized
+
+
+def build_evidence_id(
+    scope_id: str,
+    source_kind: str,
+    producer_key: str,
+) -> str:
+    """Baut ``ev_<128-bit-hex>`` ohne Inhaltstext als Identitaetsmaterial."""
+
+    parts = (
+        _identity_part(scope_id, field_name="scope_id"),
+        _identity_part(source_kind, field_name="source_kind"),
+        _identity_part(producer_key, field_name="producer_key"),
+    )
+    material = b"".join(
+        len(part.encode("utf-8")).to_bytes(4, "big") + part.encode("utf-8")
+        for part in parts
+    )
+    return f"ev_{hashlib.sha256(material).hexdigest()[:32]}"
+
+
+__all__ = ["build_evidence_id"]

--- a/backend/app/services/evidence_migrations.py
+++ b/backend/app/services/evidence_migrations.py
@@ -10,9 +10,10 @@ P3.1-Followup — Echte Persona/Segment/FrictionPoint/TrustSignal-Aggregation
 - ``migrate_legacy_claims_to_anchored`` entfernt orphan Claims VOR Validator,
   damit Bestands-evidence-map.json nicht beim Reload an
   ``ReportClaimModel.non_low_claims_need_evidence`` scheitern.
-- ``migrate_v2_to_v3`` baut aus einem v2-Report-Dict ein dict, das
-  ``ReportV3.model_validate()`` besteht. ``CURRENT_SCHEMA_VERSION`` bleibt 2 —
-  es ist die Evidence-Map-Schema-Version, NICHT die Report-Container-Version.
+- ``migrate_evidence_map_v2_to_v3`` trennt kanonische Evidence-Records von
+  Claim-Bindings und hebt persistierte Evidence-Maps auf schema_version=3.
+- ``migrate_v2_to_v3`` baut aus einem Legacy-Report-Dict ein dict, das gegen
+  den selbstenthaltenen ReportV3-Container mit schema_version=4 validiert.
   Neu (P3.1-Followup): Personas aus ``artifact_store`` (``reddit_profiles``),
   Segments per Gruppen-Aggregation, FrictionPoints/TrustSignals aus
   Sections mit Keyword-Matching auf Section-Titel.
@@ -24,10 +25,13 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
+from .evidence_identity import build_evidence_id
+
 if TYPE_CHECKING:
     from .artifact_store import SimulationArtifactStore
 
-CURRENT_SCHEMA_VERSION = 2
+LEGACY_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 # Confidence-Labels, die einen Evidence-Anker erfordern (P2.1).
 _ANCHOR_REQUIRED_LABELS = frozenset({"medium", "high", "verified"})
@@ -71,10 +75,10 @@ def migrate_v1_to_v2(raw: Optional[dict]) -> Optional[dict]:
     for section in sections:
         if isinstance(section, dict):
             section.pop("schema_version", None)
-    if raw.get("schema_version") == CURRENT_SCHEMA_VERSION:
+    if raw.get("schema_version") in {LEGACY_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION}:
         return raw
 
-    raw["schema_version"] = CURRENT_SCHEMA_VERSION
+    raw["schema_version"] = LEGACY_SCHEMA_VERSION
     return raw
 
 
@@ -256,31 +260,192 @@ def normalize_persisted_evidence_map(raw: Optional[dict]) -> Optional[dict]:
     Mutiert das uebergebene Dict wie die Einzelschritte und gibt ``None``
     zurueck, wenn ``raw`` None ist.
     """
-    return migrate_medium_seed_only_claims_to_low(
+    if raw is None:
+        return None
+    if (
+        raw.get("schema_version") == CURRENT_SCHEMA_VERSION
+        and "global_evidence" not in raw
+    ):
+        return raw
+    if raw.get("schema_version") == CURRENT_SCHEMA_VERSION:
+        raw["schema_version"] = LEGACY_SCHEMA_VERSION
+    legacy = migrate_medium_seed_only_claims_to_low(
         migrate_legacy_claims_to_anchored(migrate_v1_to_v2(raw))
     )
+    return migrate_evidence_map_v2_to_v3(legacy)
+
+
+_RECORD_FIELDS = frozenset({
+    "type",
+    "source",
+    "snippet",
+    "value",
+    "tool_name",
+    "query",
+    "raw",
+    "agent_log_ref",
+    "quote",
+    "source_id_anchor",
+    "sentiment_score",
+    "source_kind",
+    "source_model",
+    "persona_stakeholder_group",
+})
+_BINDING_FIELDS = frozenset({
+    "match_score",
+    "retrieval_score",
+    "entailment",
+    "entailment_reason",
+    "supports_claim",
+    "contradicts_claim",
+})
+
+
+def _legacy_item_to_record_and_binding(
+    item: dict[str, Any],
+    *,
+    scope_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Konvertiert nur Legacy-Items mit explizitem Producer-Schluessel."""
+
+    anchor = str(item.get("source_id_anchor") or "").strip()
+    producer_key = str(item.get("producer_key") or "").strip()
+    if not producer_key:
+        # Ein vorhandener, nicht vom LLM-Sonderfall ``seed_doc`` stammender
+        # Hartanker erlaubt eine eindeutige Legacy-Zuordnung. Freie ``source``-
+        # Werte wie ``report_tool`` bleiben bewusst unresolved.
+        if anchor and not anchor.startswith("seed_doc:"):
+            producer_key = f"legacy-anchor:{anchor}"
+    if not producer_key:
+        return None
+    source_kind = str(item.get("source_kind") or "").strip()
+    if not source_kind:
+        source_kind = "graph_relation" if anchor.startswith("kg:") else "inferred"
+    evidence_id = build_evidence_id(scope_id, source_kind, producer_key)
+    record = {key: item[key] for key in _RECORD_FIELDS if key in item}
+    if record.get("type") == "graph_node":
+        record["type"] = "graph_fact"
+    if not str(record.get("source") or "").strip():
+        record["source"] = anchor or producer_key
+    if not str(record.get("snippet") or "").strip():
+        record["snippet"] = str(item.get("source") or anchor or producer_key)[:2000]
+    record.update({
+        "evidence_id": evidence_id,
+        "producer_key": producer_key,
+        "source_kind": source_kind,
+    })
+    binding = {key: item[key] for key in _BINDING_FIELDS if key in item}
+    binding["evidence_id"] = evidence_id
+    return record, binding
+
+
+def _next_legacy_hypothesis_id(section: dict[str, Any]) -> str:
+    used = {
+        str(item.get("hypothesis_id"))
+        for slot in ("hypotheses", "hypotheses_appendix")
+        for item in section.get(slot) or []
+        if isinstance(item, dict) and item.get("hypothesis_id")
+    }
+    index = 1
+    while f"hypothesis_{index:02d}" in used:
+        index += 1
+    return f"hypothesis_{index:02d}"
+
+
+def migrate_evidence_map_v2_to_v3(raw: Optional[dict]) -> Optional[dict]:
+    """Hebt eine normalisierte Legacy-EvidenceMap auf den ID-Vertrag v3."""
+
+    if raw is None:
+        return None
+    if raw.get("schema_version") == CURRENT_SCHEMA_VERSION:
+        return raw
+
+    scope_id = str(raw.get("simulation_id") or raw.get("report_id") or "").strip()
+    evidence_index: dict[str, dict[str, Any]] = {}
+    global_refs: list[str] = []
+    for item in raw.get("global_evidence") or []:
+        if not isinstance(item, dict):
+            continue
+        converted = _legacy_item_to_record_and_binding(item, scope_id=scope_id)
+        if converted is None:
+            continue
+        record, _ = converted
+        evidence_index[record["evidence_id"]] = record
+        global_refs.append(record["evidence_id"])
+
+    for section in raw.get("sections") or []:
+        if not isinstance(section, dict):
+            continue
+        section.setdefault("hypotheses", [])
+        surviving_claims: list[Any] = []
+        for claim in section.get("claims") or []:
+            if not isinstance(claim, dict):
+                continue
+            bindings: list[dict[str, Any]] = []
+            unresolved = False
+            for item in claim.get("evidence") or []:
+                if not isinstance(item, dict):
+                    unresolved = True
+                    continue
+                converted = _legacy_item_to_record_and_binding(item, scope_id=scope_id)
+                if converted is None:
+                    unresolved = True
+                    continue
+                record, binding = converted
+                evidence_index[record["evidence_id"]] = record
+                bindings.append(binding)
+            if bindings:
+                migrated_claim = dict(claim)
+                migrated_claim["evidence"] = bindings
+                surviving_claims.append(migrated_claim)
+                continue
+            if unresolved or claim.get("evidence"):
+                claim_text = str(
+                    claim.get("claim_text") or claim.get("claim") or ""
+                ).strip()
+                if claim_text:
+                    section["hypotheses"].append({
+                        "hypothesis_id": _next_legacy_hypothesis_id(section),
+                        "hypothesis_text": claim_text[:1000],
+                        "rationale": (
+                            "legacy_unresolved: Legacy-Evidence besitzt keinen "
+                            "verifizierbaren producer_key."
+                        ),
+                        "suggested_evidence": [],
+                    })
+            else:
+                surviving_claims.append(claim)
+        section["claims"] = surviving_claims
+
+    raw.pop("global_evidence", None)
+    raw["schema_version"] = CURRENT_SCHEMA_VERSION
+    raw["evidence_index"] = evidence_index
+    raw["global_evidence_refs"] = list(dict.fromkeys(global_refs))
+    return raw
 
 
 def _resolve_evidence_refs(
     claim: dict[str, Any],
-    section_index: int,
-    claim_id: str,
-) -> list[str]:
-    """Extrahiert Evidence-Refs aus einem Claim-dict."""
-    evidence_items = [
-        item for item in (claim.get("evidence") or [])
-        if isinstance(item, dict)
-    ]
+    *,
+    scope_id: str,
+    evidence_index: dict[str, dict[str, Any]],
+) -> tuple[list[str], bool]:
+    """Indiziert explizit identifizierbare Legacy-Evidence ohne Fallback-Refs."""
+
     refs: list[str] = []
-    for idx, item in enumerate(evidence_items, 1):
-        ref = str(
-            item.get("source_id_anchor")
-            or item.get("anchor")
-            or item.get("source")
-            or f"section_{section_index}:{claim_id}:evidence_{idx:02d}"
-        ).strip()
-        refs.append(ref or f"section_{section_index}:{claim_id}:evidence_{idx:02d}")
-    return refs
+    unresolved = False
+    for item in claim.get("evidence") or []:
+        if not isinstance(item, dict):
+            unresolved = True
+            continue
+        converted = _legacy_item_to_record_and_binding(item, scope_id=scope_id)
+        if converted is None:
+            unresolved = True
+            continue
+        record, _ = converted
+        evidence_index[record["evidence_id"]] = record
+        refs.append(record["evidence_id"])
+    return list(dict.fromkeys(refs)), unresolved
 
 
 def _label_to_confidence(label: str) -> str:
@@ -421,8 +586,11 @@ def migrate_v2_to_v3(
 
     claims: list[dict] = []
     data_gaps: list[dict] = []
+    hypotheses: list[dict] = []
     friction_points: list[dict] = []
     trust_signals: list[dict] = []
+    evidence_index: dict[str, dict[str, Any]] = {}
+    scope_id = str(raw.get("simulation_id") or simulation_id or report_id)
 
     sections = raw.get("sections") or []
     for section in sections:
@@ -440,9 +608,29 @@ def migrate_v2_to_v3(
             claim_id = str(
                 claim.get("claim_id") or f"claim_{len(claims) + 1:02d}"
             )
-            evidence_refs = _resolve_evidence_refs(claim, section_index, claim_id)
+            evidence_refs, unresolved = _resolve_evidence_refs(
+                claim,
+                scope_id=scope_id,
+                evidence_index=evidence_index,
+            )
 
             if not evidence_refs:
+                if unresolved or claim.get("evidence"):
+                    statement = str(
+                        claim.get("claim_text") or claim.get("claim") or ""
+                    ).strip()
+                    if statement:
+                        hypotheses.append({
+                            "id": f"legacy_unresolved_{len(hypotheses) + 1:02d}",
+                            "hypothesis_text": statement,
+                            "rationale": (
+                                "legacy_unresolved: Legacy-Evidence besitzt keinen "
+                                "verifizierbaren producer_key."
+                            ),
+                            "suggested_evidence": [],
+                            "origin_section_index": section_index or None,
+                            "confidence_score": 0.0,
+                        })
                 continue
 
             statement = str(
@@ -530,6 +718,7 @@ def migrate_v2_to_v3(
     # --- Persona-Aggregation (P3.1-Followup) ---
     personas: list[dict] = []
     segments: list[dict] = []
+    profiles: list[dict] = []
 
     # Zuerst v2-interne Personas prüfen (falls schon im dict vorhanden)
     raw_personas = raw.get("personas") or []
@@ -545,6 +734,40 @@ def migrate_v2_to_v3(
                 for idx, profile in enumerate(profiles, 1)
             ]
             segments = _aggregate_segments(personas, profiles)
+
+    # Persona-Provenance darf nicht als freier ``entity:<uuid>``-String im
+    # ReportV3 stehen. Der Artifact-Store kennt die stabile Entity-ID und kann
+    # deshalb einen echten Record samt run-lokaler ID erzeugen.
+    if profiles:
+        for persona, profile in zip(personas, profiles):
+            source_uuid = str(profile.get("source_entity_uuid") or "").strip()
+            if not source_uuid:
+                persona["evidence_refs"] = []
+                continue
+            producer_key = f"entity:{source_uuid}"
+            evidence_id = build_evidence_id(scope_id, "graph_relation", producer_key)
+            evidence_index[evidence_id] = {
+                "evidence_id": evidence_id,
+                "producer_key": producer_key,
+                "type": "entity_summary",
+                "source": "persona_artifact",
+                "snippet": str(
+                    profile.get("bio")
+                    or profile.get("persona")
+                    or profile.get("name")
+                    or producer_key
+                )[:2000],
+                "raw": profile,
+                "source_id_anchor": producer_key,
+                "source_kind": "graph_relation",
+            }
+            persona["evidence_refs"] = [evidence_id]
+    else:
+        known_ids = set(evidence_index)
+        for persona in personas:
+            persona["evidence_refs"] = [
+                ref for ref in persona.get("evidence_refs") or [] if ref in known_ids
+            ]
 
     # DataGap-Marker wenn keine Personas gefunden
     if not personas:
@@ -564,9 +787,10 @@ def migrate_v2_to_v3(
         )
 
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "report_id": report_id,
         "generated_at": generated_at,
+        "evidence_index": evidence_index,
         "personas": personas,
         "segments": segments,
         "claims": claims,
@@ -578,4 +802,5 @@ def migrate_v2_to_v3(
         "positioning_variants": [],
         "content_ideas": [],
         "data_gaps": data_gaps,
+        "hypotheses": hypotheses,
     }

--- a/backend/app/services/evidence_migrations.py
+++ b/backend/app/services/evidence_migrations.py
@@ -229,7 +229,7 @@ def normalize_persisted_evidence_map(raw: Optional[dict]) -> Optional[dict]:
     HTTP 200 blieb. Zwei Pfade, zwei Reihenfolgen, ein stiller Datenverlust.
     Deshalb liegt die Reihenfolge jetzt an genau einer Stelle.
 
-    Die Reihenfolge ist bindend (Issue #968):
+    Fuer Legacy-Maps ist die Reihenfolge bindend (Issue #968):
 
     1. ``migrate_v1_to_v2``
     2. ``migrate_legacy_claims_to_anchored``
@@ -262,13 +262,27 @@ def normalize_persisted_evidence_map(raw: Optional[dict]) -> Optional[dict]:
     """
     if raw is None:
         return None
-    if (
-        raw.get("schema_version") == CURRENT_SCHEMA_VERSION
-        and "global_evidence" not in raw
-    ):
-        return raw
     if raw.get("schema_version") == CURRENT_SCHEMA_VERSION:
-        raw["schema_version"] = LEGACY_SCHEMA_VERSION
+        if "global_evidence" in raw:
+            scope_id = str(
+                raw.get("simulation_id") or raw.get("report_id") or "legacy"
+            )
+            evidence_index = raw.setdefault("evidence_index", {})
+            global_refs = list(raw.get("global_evidence_refs") or [])
+            for item in raw.pop("global_evidence") or []:
+                if not isinstance(item, dict):
+                    continue
+                resolved = _legacy_item_to_record_and_binding(
+                    item, scope_id=scope_id
+                )
+                if resolved is None:
+                    continue
+                record, _ = resolved
+                evidence_id = record["evidence_id"]
+                evidence_index.setdefault(evidence_id, record)
+                global_refs.append(evidence_id)
+            raw["global_evidence_refs"] = list(dict.fromkeys(global_refs))
+        return raw
     legacy = migrate_medium_seed_only_claims_to_low(
         migrate_legacy_claims_to_anchored(migrate_v1_to_v2(raw))
     )
@@ -328,7 +342,7 @@ def _legacy_item_to_record_and_binding(
     if not str(record.get("source") or "").strip():
         record["source"] = anchor or producer_key
     if not str(record.get("snippet") or "").strip():
-        record["snippet"] = str(item.get("source") or anchor or producer_key)[:2000]
+        record["snippet"] = "[legacy evidence snippet missing]"
     record.update({
         "evidence_id": evidence_id,
         "producer_key": producer_key,
@@ -403,7 +417,7 @@ def migrate_evidence_map_v2_to_v3(raw: Optional[dict]) -> Optional[dict]:
                 claim_text = str(
                     claim.get("claim_text") or claim.get("claim") or ""
                 ).strip()
-                if claim_text:
+                if len(claim_text) >= 8:
                     section["hypotheses"].append({
                         "hypothesis_id": _next_legacy_hypothesis_id(section),
                         "hypothesis_text": claim_text[:1000],
@@ -757,7 +771,10 @@ def migrate_v2_to_v3(
                     or profile.get("name")
                     or producer_key
                 )[:2000],
-                "raw": profile,
+                "raw": {
+                    "source_entity_uuid": source_uuid,
+                    "source_entity_type": profile.get("source_entity_type"),
+                },
                 "source_id_anchor": producer_key,
                 "source_kind": "graph_relation",
             }

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -13,11 +13,12 @@ from .evidence import (
     normalize_claims_for_contract,
     normalize_sections_for_contract,
     record_evidence_item,
+    register_evidence_record,
     resolve_embedder,
 )
 from .manager import ReportManager
 from .planning import plan_outline as plan_outline_impl
-from .schemas import CURRENT_SCHEMA_VERSION, EvidenceMapModel
+from .schemas import CURRENT_SCHEMA_VERSION, EvidenceMapModel, normalize_persisted_evidence_map
 from .sections import (
     attach_provenance,
     atomize_claim_chunk,
@@ -152,6 +153,7 @@ class ReportAgent:
         self.console_logger: Optional[ReportConsoleLogger] = None
         self.evidence_map: Optional[Dict[str, Any]] = None
         self._active_section_evidence: List[Dict[str, Any]] = []
+        self._active_section_unresolved_evidence: List[Dict[str, Any]] = []
         self._current_section_index: Optional[int] = None
 
         logger.info(f"ReportAgent initialization complete: graph_id={graph_id}, simulation_id={simulation_id}")
@@ -167,9 +169,21 @@ class ReportAgent:
         return truncate_text(text, limit)
 
     def _record_evidence_item(self, item: Dict[str, Any]) -> None:
+        enriched = attach_provenance(dict(item))
+        if self.evidence_map is None:
+            self._active_section_unresolved_evidence.append(enriched)
+            return
+        record = register_evidence_record(
+            self.evidence_map,
+            enriched,
+            scope_id=self.simulation_id,
+        )
+        if record is None:
+            self._active_section_unresolved_evidence.append(enriched)
+            return
         self._active_section_evidence = record_evidence_item(
             self._active_section_evidence,
-            item,
+            record,
         )
 
     def _try_get_embedder(self) -> Optional[Callable[[str], List[float]]]:
@@ -216,6 +230,7 @@ class ReportAgent:
                     ),
                     raw={"metrics": metrics},
                 ).to_dict())
+                items[-1]["producer_key"] = "simulation-metric:status"
             else:
                 metric_fields = (
                     "echo_chamber_index",
@@ -234,6 +249,7 @@ class ReportAgent:
                         snippet=f"{field}: {value}",
                         raw={"metric": field, "value": value, "metrics": metrics},
                     ).to_dict())
+                    items[-1]["producer_key"] = f"simulation-metric:{field}"
 
             sampled_actions = self._sample_actions_timeseries(action_dicts, k=8)
             for action in sampled_actions:
@@ -248,6 +264,17 @@ class ReportAgent:
                     snippet=f"{agent} {action_type} on {platform} in round {round_num}",
                     raw=action,
                 ).to_dict())
+                action_identity = (
+                    action.get("platform"),
+                    action.get("round_num"),
+                    action.get("agent_id"),
+                    action.get("action_type"),
+                    action.get("timestamp"),
+                )
+                if all(value is not None and str(value).strip() for value in action_identity):
+                    items[-1]["producer_key"] = "simulation-action:" + ":".join(
+                        str(value) for value in action_identity
+                    )
             return items
         except Exception as exc:  # noqa: BLE001 — exception is logged; swallowed intentionally
             logger.warning(f"Failed to collect simulation evidence: {exc}")
@@ -273,14 +300,17 @@ class ReportAgent:
                     "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
                 })
             for entity in structured_result.entity_insights[:8]:
-                items.append({
+                item = {
                     "type": "entity_summary",
                     "tool_name": tool_name,
                     "query": structured_result.query,
                     "snippet": self._truncate(entity.get("summary") or entity.get("name")),
                     "raw": entity,
                     "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                }
+                if entity.get("uuid"):
+                    item["producer_key"] = f"graph-node:{entity['uuid']}"
+                items.append(item)
             for chain in structured_result.relationship_chains[:8]:
                 items.append({
                     "type": "relationship_chain",
@@ -331,14 +361,18 @@ class ReportAgent:
                 })
         elif isinstance(structured_result, dict) and "results" in structured_result:
             for result in (structured_result.get("results") or [])[:8]:
-                items.append({
+                item = {
                     "type": "web_search_result",
                     "tool_name": tool_name,
                     "query": structured_result.get("query") or parameters.get("query"),
                     "snippet": self._truncate(result.get("content") or result.get("title")),
                     "raw": result,
                     "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                }
+                result_url = result.get("url") or result.get("source_url")
+                if result_url:
+                    item["producer_key"] = f"web:{result_url}"
+                items.append(item)
         elif isinstance(structured_result, dict) and "url" in structured_result:
             items.append({
                 "type": "web_fetch",
@@ -347,6 +381,7 @@ class ReportAgent:
                 "snippet": self._truncate(structured_result.get("content") or structured_result.get("title")),
                 "raw": structured_result,
                 "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
+                "producer_key": f"web:{structured_result['url']}",
             })
 
         if not items and rendered_result:
@@ -398,7 +433,12 @@ class ReportAgent:
             atomic_chunks.extend(atoms or [chunk])
         chunks = atomic_chunks
         claims = []
-        global_items = deepcopy((self.evidence_map or {}).get("global_evidence", [])[:6])
+        evidence_index = (self.evidence_map or {}).get("evidence_index") or {}
+        global_items = [
+            deepcopy(evidence_index[evidence_id])
+            for evidence_id in (self.evidence_map or {}).get("global_evidence_refs", [])[:6]
+            if evidence_id in evidence_index
+        ]
         # S4b: claim-spezifisches Binding wenn ein Embedder verfügbar ist.
         # S5: model_generated_inference und section_synthesis sind keine
         # Evidence — sie sind Modell-Output. Sie wandern in das separate
@@ -418,6 +458,13 @@ class ReportAgent:
                     raw={"content": chunk},
                 ).to_dict()
             ]
+            for unresolved in getattr(self, "_active_section_unresolved_evidence", [])[:10]:
+                audit_trail.append({
+                    "type": "unresolved_evidence",
+                    "source": str(unresolved.get("source") or "report_tool"),
+                    "snippet": self._truncate(str(unresolved.get("snippet") or "")),
+                    "raw": {"reason": "missing_producer_key"},
+                })
 
             bound: List[Dict[str, Any]] = []
             embedder_ok = False
@@ -441,20 +488,28 @@ class ReportAgent:
                 evidence_items = bound
                 direct_count = len(bound)
             else:
-                evidence_items = direct_items
+                evidence_items = [
+                    {"evidence_id": item["evidence_id"]}
+                    for item in direct_items
+                    if item.get("evidence_id")
+                ]
                 direct_count = len(direct_items)
 
-            # Layer 3 (Task 12): Provenance-Anker an jedes Evidence-Item heften.
-            evidence_items = [self._attach_provenance(it) for it in evidence_items]
+            resolved_evidence = []
+            current_index = (self.evidence_map or {}).get("evidence_index") or {}
+            for binding in evidence_items:
+                record = current_index.get(binding.get("evidence_id"))
+                if record:
+                    resolved_evidence.append(dict(record) | dict(binding))
 
             # S6: formelbasierte Confidence statt linear-in-N. Berechnet
             # aus relevance (mean match_score), source_quality (Typ-
             # Gewichtung), specificity (top match_score), consistency
             # (Anzahl unique Quellen). Verified-Label nur bei Top-
             # Match-Score >= 0.85.
-            penalty = detect_contradiction_penalty(evidence_items)
+            penalty = detect_contradiction_penalty(resolved_evidence)
             confidence_score, confidence_label = compute_confidence(
-                evidence_items,
+                resolved_evidence,
                 contradiction_penalty=penalty,
             )
             if penalty > 0.0:
@@ -465,7 +520,7 @@ class ReportAgent:
                 })
             # Anti-Dekorations-Guard: kein Evidence → ehrliches speculative-Label
             # und Audit-Eintrag statt dekorativem global_items-Fallback.
-            if not evidence_items:
+            if not resolved_evidence:
                 confidence_score, confidence_label = 0.15, "speculative"
                 audit_trail.append({
                     "type": "model_generated_inference",
@@ -483,7 +538,7 @@ class ReportAgent:
                 evidence=evidence_items,
                 confidence_score=confidence_score,
                 confidence_label=confidence_label,
-                notes="Section-chunk level evidence mapping (schema_version 2).",
+                notes="Section-chunk level evidence mapping (schema_version 3).",
             ).to_dict()
             claim_dict["audit_trail"] = audit_trail
             claims.append(claim_dict)
@@ -534,14 +589,32 @@ class ReportAgent:
             # Vorher zählte jedes thematisch ähnliche Item mit — dadurch
             # erreichten Interpretationen den Claim-Floor, obwohl kein
             # einziges Item sie belegte.
-            supporting = [
-                item for item in evidence
-                if isinstance(item, dict) and item.get("supports_claim") is True
-            ]
-            evidence_count = len(supporting) or (
-                len(claim.get("evidence_refs") or []) if not evidence else 0
+            evidence_ids = {
+                str(item["evidence_id"])
+                for item in evidence
+                if isinstance(item, dict) and item.get("evidence_id")
+            }
+            supporting_ids = {
+                str(item["evidence_id"])
+                for item in evidence
+                if isinstance(item, dict)
+                and item.get("evidence_id")
+                and item.get("supports_claim") is True
+            }
+            legacy_ref_ids = {
+                str(evidence_ref)
+                for evidence_ref in claim.get("evidence_refs") or []
+                if evidence_ref
+            }
+            evidence_count = len(supporting_ids) or (
+                len(legacy_ref_ids) if not evidence else 0
             )
-            related_only = len(evidence) - len(supporting)
+            unkeyed_related = sum(
+                1
+                for item in evidence
+                if not isinstance(item, dict) or not item.get("evidence_id")
+            )
+            related_only = len(evidence_ids - supporting_ids) + unkeyed_related
             if 0 < evidence_count < CLAIM_MIN_EVIDENCE_FOR_CLAIM:
                 index = len(hypotheses) + 1
                 claim_text = (
@@ -572,7 +645,7 @@ class ReportAgent:
             # anhängt. Vorher griff dieser Zweig nur bei komplett leerer
             # Evidence-Liste und niedrigem Score; Interpretationen mit
             # dekorativer Evidence liefen als Claims durch.
-            if not supporting:
+            if not supporting_ids:
                 index = len(hypotheses) + 1
                 claim_text = (
                     str(claim.get("claim_text") or claim.get("claim") or "").strip()
@@ -647,7 +720,12 @@ class ReportAgent:
         """
         pool: List[Dict[str, Any]] = list(self._active_section_evidence or [])
         if self.evidence_map:
-            pool.extend(self.evidence_map.get("global_evidence") or [])
+            evidence_index = self.evidence_map.get("evidence_index") or {}
+            pool.extend(
+                evidence_index[evidence_id]
+                for evidence_id in self.evidence_map.get("global_evidence_refs") or []
+                if evidence_id in evidence_index
+            )
         return pool
 
     def _record_prose_hypotheses(
@@ -686,8 +764,14 @@ class ReportAgent:
 
         if self.evidence_map is None:
             self._init_evidence_map(report_id)
+        else:
+            self.evidence_map = (
+                normalize_persisted_evidence_map(self.evidence_map)
+                or self.evidence_map
+            )
         self.evidence_map.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
-        self.evidence_map.setdefault("global_evidence", self._collect_simulation_evidence_items())
+        self.evidence_map.setdefault("evidence_index", {})
+        self.evidence_map.setdefault("global_evidence_refs", [])
         # schema_version gehört nur auf Map-Ebene, nicht auf Section-Ebene
         # (ReportSectionModel hat das Feld nicht).
         #

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -132,7 +132,11 @@ def register_evidence_record(
         "source_kind": source_kind,
     })
     record = EvidenceRecordModel.model_validate(payload).model_dump(mode="json")
-    evidence_map.setdefault("evidence_index", {})[record["evidence_id"]] = record
+    evidence_index = evidence_map.setdefault("evidence_index", {})
+    existing = evidence_index.get(record["evidence_id"])
+    if existing is not None:
+        return existing
+    evidence_index[record["evidence_id"]] = record
     return record
 
 
@@ -543,10 +547,27 @@ def degrade_sections_for_violations(
             # Cross-Record-Validatoren hängen ihre Fehler an die EvidenceMap
             # selbst. Den betroffenen Claim transportieren sie deshalb stabil
             # im Fehlertext (``Claim <id>: ...``), nicht im ``loc``-Pfad.
+            section_claim_match = re.search(
+                r"\bSection ([^ ]+) Claim ([^:]+):", detail
+            )
             claim_match = re.search(r"\bClaim ([^:]+):", detail)
-            if claim_match:
+            target_section = (
+                section_claim_match.group(1) if section_claim_match else None
+            )
+            if section_claim_match:
+                target_id = section_claim_match.group(2)
+            elif claim_match:
                 target_id = claim_match.group(1)
+            else:
+                target_id = None
+            if target_id:
+                targeted = False
                 for fallback_si, fallback_section in enumerate(repaired):
+                    if (
+                        target_section is not None
+                        and str(fallback_section.get("section_index")) != target_section
+                    ):
+                        continue
                     for fallback_ci, claim in enumerate(fallback_section.get("claims") or []):
                         if not isinstance(claim, dict) or claim.get("claim_id") != target_id:
                             continue
@@ -562,6 +583,9 @@ def degrade_sections_for_violations(
                                 "action": "downgraded_to_low",
                                 "detail": detail,
                             })
+                        targeted = True
+                        break
+                    if targeted:
                         break
             continue
 

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -7,6 +7,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pydantic import ValidationError
 
+from ...contracts import EvidenceRecordModel
+from ..evidence_identity import build_evidence_id
+from ..evidence_migrations import normalize_persisted_evidence_map
 from .schemas import CURRENT_SCHEMA_VERSION, EvidenceMapModel
 
 
@@ -20,9 +23,14 @@ def init_evidence_map(
         "schema_version": CURRENT_SCHEMA_VERSION,
         "report_id": report_id,
         "simulation_id": simulation_id,
-        "global_evidence": global_evidence,
+        "evidence_index": {},
+        "global_evidence_refs": [],
         "sections": [],
     }
+    for item in global_evidence:
+        record = register_evidence_record(payload, item, scope_id=simulation_id)
+        if record is not None:
+            payload["global_evidence_refs"].append(record["evidence_id"])
     return EvidenceMapModel.model_validate(payload).model_dump(mode="json")
 
 
@@ -89,6 +97,43 @@ def record_evidence_item(
     enriched.setdefault("source_kind", normalize_source_kind(item))
     target.append(enriched)
     return target
+
+
+_CLAIM_RELATIVE_FIELDS = frozenset({
+    "match_score",
+    "retrieval_score",
+    "entailment",
+    "entailment_reason",
+    "supports_claim",
+    "contradicts_claim",
+})
+
+
+def register_evidence_record(
+    evidence_map: Dict[str, Any],
+    item: Dict[str, Any],
+    *,
+    scope_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Validiert und registriert ein Producer-Item mit explizitem Schluessel."""
+
+    producer_key = str(item.get("producer_key") or "").strip()
+    if not producer_key:
+        return None
+    source_kind = normalize_source_kind(item)
+    payload = {
+        key: value
+        for key, value in item.items()
+        if key not in _CLAIM_RELATIVE_FIELDS
+    }
+    payload.update({
+        "evidence_id": build_evidence_id(scope_id, source_kind, producer_key),
+        "producer_key": producer_key,
+        "source_kind": source_kind,
+    })
+    record = EvidenceRecordModel.model_validate(payload).model_dump(mode="json")
+    evidence_map.setdefault("evidence_index", {})[record["evidence_id"]] = record
+    return record
 
 
 def resolve_embedder(
@@ -239,14 +284,17 @@ def _extract_known_anchors(evidence_map: Union[Dict[str, Any], Any]) -> set:
     EvidenceMapModel-Instanzen.
     """
     known: set = set()
-    if hasattr(evidence_map, "global_evidence"):
+    if hasattr(evidence_map, "evidence_index"):
         # EvidenceMapModel-Instanz
-        for item in evidence_map.global_evidence:
+        for evidence_id, item in evidence_map.evidence_index.items():
+            known.add(evidence_id)
             anchor = getattr(item, "source_id_anchor", None)
             if anchor:
                 known.add(anchor)
     elif isinstance(evidence_map, dict):
-        for item in evidence_map.get("global_evidence", []):
+        evidence_map = normalize_persisted_evidence_map(evidence_map) or evidence_map
+        for evidence_id, item in (evidence_map.get("evidence_index") or {}).items():
+            known.add(evidence_id)
             anchor = item.get("source_id_anchor")
             if anchor:
                 known.add(anchor)
@@ -489,7 +537,32 @@ def degrade_sections_for_violations(
 
     for err in error.errors():
         loc = err.get("loc") or ()
+        violation_type = str(err.get("type") or "unknown")
+        detail = str(err.get("msg") or "")[:500]
         if len(loc) < 4 or loc[0] != "sections":
+            # Cross-Record-Validatoren hängen ihre Fehler an die EvidenceMap
+            # selbst. Den betroffenen Claim transportieren sie deshalb stabil
+            # im Fehlertext (``Claim <id>: ...``), nicht im ``loc``-Pfad.
+            claim_match = re.search(r"\bClaim ([^:]+):", detail)
+            if claim_match:
+                target_id = claim_match.group(1)
+                for fallback_si, fallback_section in enumerate(repaired):
+                    for fallback_ci, claim in enumerate(fallback_section.get("claims") or []):
+                        if not isinstance(claim, dict) or claim.get("claim_id") != target_id:
+                            continue
+                        if (fallback_si, fallback_ci) in processed_claims:
+                            break
+                        processed_claims.add((fallback_si, fallback_ci))
+                        if claim.get("evidence"):
+                            claim["confidence_label"] = "low"
+                            _log_violation({
+                                "section_index": fallback_section.get("section_index", 0),
+                                "claim_id": target_id,
+                                "violation": violation_type,
+                                "action": "downgraded_to_low",
+                                "detail": detail,
+                            })
+                        break
             continue
 
         si = loc[1]
@@ -498,9 +571,6 @@ def degrade_sections_for_violations(
             continue
         section = repaired[si]
         section_index_value = section.get("section_index", 0)
-        violation_type = str(err.get("type") or "unknown")
-        detail = str(err.get("msg") or "")[:500]
-
         if kind == "claims":
             ci = loc[3]
             claims_list = section.get("claims") or []
@@ -603,6 +673,7 @@ __all__ = [
     "normalize_claims_for_contract",
     "normalize_sections_for_contract",
     "record_evidence_item",
+    "register_evidence_record",
     "resolve_embedder",
     # M11.8e
     "QuoteValidationResult",

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -263,7 +263,9 @@ class ReportManager:
                 evidence_refs = list(dict.fromkeys(
                     str(item.get("evidence_id"))
                     for item in claim.get("evidence") or []
-                    if isinstance(item, dict) and item.get("evidence_id")
+                    if isinstance(item, dict)
+                    and item.get("evidence_id")
+                    and item.get("supports_claim") is True
                 ))
                 # balanced/explorative: Claims ohne Evidence → überspringen (kein Evidence-Anker)
                 # strict: Claims ohne Evidence → gedroppt (gleiche Logik, aber auch low-conf)

--- a/backend/app/services/report_agent/manager.py
+++ b/backend/app/services/report_agent/manager.py
@@ -15,6 +15,7 @@ from .metadata_merge import merge_section_metadata
 from ...config import Config
 from ...models.report import Report, ReportOutline, ReportSection, ReportStatus
 from ...utils.logger import get_logger
+from ..evidence_migrations import normalize_persisted_evidence_map
 from .storage import (
     ensure_report_folder,
     ensure_reports_dir,
@@ -240,23 +241,6 @@ class ReportManager:
             return None
 
     @classmethod
-    def _evidence_ref_for_item(
-        cls,
-        item: Dict[str, Any],
-        *,
-        section_index: int,
-        claim_id: str,
-        item_index: int,
-    ) -> str:
-        ref = str(
-            item.get("source_id_anchor")
-            or item.get("anchor")
-            or item.get("source")
-            or f"section_{section_index}:{claim_id}:evidence_{item_index:02d}"
-        )
-        return ref.strip() or f"section_{section_index}:{claim_id}:evidence_{item_index:02d}"
-
-    @classmethod
     def build_report_v3(
         cls,
         report: Report,
@@ -264,6 +248,7 @@ class ReportManager:
         *,
         report_mode: ReportMode = DEFAULT_REPORT_MODE,
     ) -> ReportV3:
+        evidence_map = normalize_persisted_evidence_map(evidence_map) or evidence_map
         claims: List[ReportV3Claim] = []
         data_gaps: List[ReportV3DataGap] = []
         hypotheses: List[ReportV3Hypothesis] = []
@@ -275,16 +260,11 @@ class ReportManager:
                 if not isinstance(claim, dict):
                     continue
                 claim_id = str(claim.get("claim_id") or f"claim_{len(claims) + 1:02d}")
-                evidence_refs = [
-                    cls._evidence_ref_for_item(
-                        item,
-                        section_index=section_index,
-                        claim_id=claim_id,
-                        item_index=index,
-                    )
-                    for index, item in enumerate(claim.get("evidence") or [], 1)
-                    if isinstance(item, dict)
-                ]
+                evidence_refs = list(dict.fromkeys(
+                    str(item.get("evidence_id"))
+                    for item in claim.get("evidence") or []
+                    if isinstance(item, dict) and item.get("evidence_id")
+                ))
                 # balanced/explorative: Claims ohne Evidence → überspringen (kein Evidence-Anker)
                 # strict: Claims ohne Evidence → gedroppt (gleiche Logik, aber auch low-conf)
                 if not evidence_refs:
@@ -401,14 +381,28 @@ class ReportManager:
                 len(merged.rejected),
                 "; ".join(merged.rejected[:5]),
             )
+        evidence_index = dict(evidence_map.get("evidence_index") or {})
+        metadata_kwargs = merged.as_report_v3_kwargs()
+        for slot, items in list(metadata_kwargs.items()):
+            metadata_kwargs[slot] = [
+                item.model_copy(update={
+                    "evidence_refs": [
+                        ref for ref in item.evidence_refs if ref in evidence_index
+                    ]
+                })
+                if hasattr(item, "evidence_refs")
+                else item
+                for item in items
+            ]
         return ReportV3(
             report_id=report.report_id,
             generated_at=datetime.now(timezone.utc),
+            evidence_index=evidence_index,
             report_mode=report_mode,
             claims=claims,
             data_gaps=data_gaps,
             hypotheses=hypotheses,
-            **merged.as_report_v3_kwargs(),
+            **metadata_kwargs,
         )
     
     @classmethod

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -5,7 +5,9 @@ from functools import cache
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from ...contracts import (
+    ClaimEvidenceBindingModel,
     EvidenceMapModel,
+    EvidenceRecordModel,
     ReportV3,
     Persona,
     Segment,
@@ -19,7 +21,11 @@ from ...contracts import (
     ContentIdea,
     DataGap,
 )
-from ..evidence_migrations import CURRENT_SCHEMA_VERSION, migrate_v1_to_v2
+from ..evidence_migrations import (
+    CURRENT_SCHEMA_VERSION,
+    migrate_v1_to_v2,
+    normalize_persisted_evidence_map,
+)
 
 _STRICT = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
@@ -153,8 +159,11 @@ def _section_schema_for(section_title: str) -> type[BaseModel]:
 __all__ = [
     # Evidence / migration helpers
     "EvidenceMapModel",
+    "EvidenceRecordModel",
+    "ClaimEvidenceBindingModel",
     "CURRENT_SCHEMA_VERSION",
     "migrate_v1_to_v2",
+    "normalize_persisted_evidence_map",
     # ReportV3 container + 11 Pflichtabschnitt-DTOs
     "ReportV3",
     "Persona",

--- a/backend/app/services/report_agent/storage.py
+++ b/backend/app/services/report_agent/storage.py
@@ -207,6 +207,82 @@ def write_report_v3(
     return path
 
 
+_REPORT_V3_REF_COLLECTIONS = (
+    "personas",
+    "claims",
+    "multipliers",
+    "friction_points",
+    "trust_signals",
+    "change_recommendations",
+    "project_impacts",
+    "positioning_variants",
+    "content_ideas",
+)
+
+
+def _upgrade_report_v3_payload(
+    raw: Dict[str, Any],
+    *,
+    report_id: str,
+    reports_dir: str,
+) -> Dict[str, Any]:
+    """Hebt persistierte ReportV3-v3-Daten verlustarm auf Schema 4."""
+
+    if raw.get("schema_version") != 3:
+        return raw
+
+    from ..evidence_migrations import normalize_persisted_evidence_map
+
+    evidence_index: Dict[str, Any] = {}
+    evidence_path = get_evidence_map_path(reports_dir, report_id)
+    if os.path.exists(evidence_path):
+        try:
+            with open(evidence_path, "r", encoding="utf-8") as handle:
+                evidence_raw = json.load(handle)
+            normalized = normalize_persisted_evidence_map(evidence_raw)
+            if isinstance(normalized, dict):
+                evidence_index = dict(normalized.get("evidence_index") or {})
+        except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+            _storage_logger.warning(
+                "Evidence-Index fuer ReportV3-Upgrade nicht lesbar (%s): %s",
+                report_id,
+                exc,
+            )
+
+    aliases: Dict[str, set[str]] = {}
+    for evidence_id, record in evidence_index.items():
+        if not isinstance(record, dict):
+            continue
+        for value in (
+            evidence_id,
+            record.get("evidence_id"),
+            record.get("producer_key"),
+            record.get("source_id_anchor"),
+        ):
+            alias = str(value or "").strip()
+            if alias:
+                aliases.setdefault(alias, set()).add(evidence_id)
+    unique_aliases = {
+        alias: next(iter(candidates))
+        for alias, candidates in aliases.items()
+        if len(candidates) == 1
+    }
+
+    upgraded = dict(raw)
+    upgraded["schema_version"] = 4
+    upgraded["evidence_index"] = evidence_index
+    for collection_name in _REPORT_V3_REF_COLLECTIONS:
+        for entry in upgraded.get(collection_name) or []:
+            if not isinstance(entry, dict):
+                continue
+            entry["evidence_refs"] = list(dict.fromkeys(
+                unique_aliases[ref]
+                for value in entry.get("evidence_refs") or []
+                if (ref := str(value or "").strip()) in unique_aliases
+            ))
+    return upgraded
+
+
 def read_report_v3(
     report_id: str,
     reports_dir: Optional[str] = None,
@@ -231,6 +307,11 @@ def read_report_v3(
     try:
         with open(path, "r", encoding="utf-8") as handle:
             raw = json.load(handle)
+        raw = _upgrade_report_v3_payload(
+            raw,
+            report_id=report_id,
+            reports_dir=base_dir,
+        )
         return ReportV3.model_validate(raw)
     except (json.JSONDecodeError, OSError, ValidationError) as exc:
         _storage_logger.warning(

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -27,11 +27,10 @@ from .output_contract import (
 from .planning import plan_outline as plan_outline_impl
 from .text_verification import verify_prose
 from .schemas import (
-    CURRENT_SCHEMA_VERSION,
     EvidenceMapModel,
     _section_schema_for,
-    migrate_v1_to_v2,
 )
+from ..evidence_migrations import migrate_v1_to_v2, normalize_persisted_evidence_map
 
 logger = get_logger('agora.report_agent')
 
@@ -391,6 +390,7 @@ def generate_section_react(
     logger.info(f"ReACT generating section: {section.title}")
     agent._current_section_index = section_index
     agent._active_section_evidence = []
+    agent._active_section_unresolved_evidence = []
 
     if agent.report_logger:
         agent.report_logger.log_section_start(section.title, section_index)
@@ -896,15 +896,15 @@ def generate_report(
 
     try:
         ReportManager._ensure_report_folder(report_id)
-        agent.evidence_map = migrate_v1_to_v2(ReportManager.get_evidence_map(report_id)) or (
-            EvidenceMapModel.model_validate({
-                "schema_version": CURRENT_SCHEMA_VERSION,
-                "report_id": report_id,
-                "simulation_id": agent.simulation_id,
-                "global_evidence": agent._collect_simulation_evidence_items(),
-                "sections": [],
-            }).model_dump(mode="json")
+        legacy_evidence_map = migrate_v1_to_v2(
+            ReportManager.get_evidence_map(report_id)
         )
+        agent.evidence_map = normalize_persisted_evidence_map(legacy_evidence_map)
+        if agent.evidence_map is None:
+            agent._init_evidence_map(report_id)
+            agent.evidence_map = EvidenceMapModel.model_validate(
+                agent.evidence_map
+            ).model_dump(mode="json")
 
         agent.report_logger = agent.ReportLogger(report_id)
         agent.report_logger.log_start(

--- a/backend/app/services/report_export.py
+++ b/backend/app/services/report_export.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import zipfile
 from datetime import datetime, timezone
-from typing import Any, Iterator, Literal, Optional, cast
+from typing import Any, Iterator, Optional
 
 from pydantic import ValidationError
 
@@ -19,7 +19,6 @@ from ..contracts import (
 )
 from ..contracts.report_contract import EvidenceOmissionModel
 from ..services.evidence_migrations import (
-    CURRENT_SCHEMA_VERSION,
     normalize_persisted_evidence_map,
 )
 from ..services.report_agent import ReportManager, ReportStatus
@@ -27,6 +26,7 @@ from ..services.report_agent.csv_export import claims_to_csv, personas_to_csv, s
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
+EXPORT_CONTRACT_SCHEMA_VERSION = 2
 
 # ZIP-Bundle-Schwellwerte
 ZIP_STREAM_THRESHOLD_BYTES: int = 50 * 1024 * 1024   # 50 MB
@@ -57,7 +57,7 @@ class ReportExportService:
     @classmethod
     def build_report_contract_model(cls, report_obj) -> ReportModel:
         report_dict = report_obj.to_dict()
-        report_dict["schema_version"] = CURRENT_SCHEMA_VERSION
+        report_dict["schema_version"] = EXPORT_CONTRACT_SCHEMA_VERSION
         report_dict["missing_sections"] = list(report_dict.get("missing_sections") or [])
         if report_dict.get("status") == ReportStatus.INCOMPLETE.value:
             report_dict["outline"] = None
@@ -124,7 +124,7 @@ class ReportExportService:
                 )
 
         return ReportContractModel(
-            schema_version=cast(Literal[2], CURRENT_SCHEMA_VERSION),
+            schema_version=EXPORT_CONTRACT_SCHEMA_VERSION,
             exported_at=datetime.now(timezone.utc),
             report=report,
             evidence=evidence,

--- a/backend/app/utils/llm_e2e_stub.py
+++ b/backend/app/utils/llm_e2e_stub.py
@@ -180,9 +180,19 @@ def _stub_report_v3() -> dict[str, Any]:
     Verwende minimale, aber valide Objekte je Feldtyp.
     """
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "report_id": "e2e-stub-report-001",
         "generated_at": _STUB_TIMESTAMP,
+        "evidence_index": {
+            "ev_00000000000000000000000000000000": {
+                "evidence_id": "ev_00000000000000000000000000000000",
+                "producer_key": "e2e-stub:evidence-01",
+                "type": "graph_fact",
+                "source": "e2e_stub",
+                "snippet": "Deterministische Evidence fuer E2E-Smoke-Tests.",
+                "source_kind": "graph_relation",
+            }
+        },
         "personas": [
             {
                 "id": "p-stub-01",
@@ -194,7 +204,7 @@ def _stub_report_v3() -> dict[str, Any]:
                 "haushaltseinkommen": None,
                 "needs": ["Sicherheit", "Verlässlichkeit"],
                 "values": ["Qualität", "Transparenz"],
-                "evidence_refs": ["ev-stub-01"],
+                "evidence_refs": ["ev_00000000000000000000000000000000"],
             }
         ],
         "segments": [
@@ -210,7 +220,7 @@ def _stub_report_v3() -> dict[str, Any]:
             {
                 "id": "claim-stub-01",
                 "statement": "Das Produkt wird von der Zielgruppe als vertrauenswürdig eingeschätzt.",
-                "evidence_refs": ["ev-stub-01"],
+                "evidence_refs": ["ev_00000000000000000000000000000000"],
                 "confidence": "medium",
                 "persona_ids": ["p-stub-01"],
                 "aggregation_basis": "aggregat",

--- a/backend/scripts/check_evidence_quality.py
+++ b/backend/scripts/check_evidence_quality.py
@@ -10,7 +10,7 @@ Aufruf:
         --min-evidence-coverage 0.85 \
         --min-claim-support-ratio 0.75 \
         --orphan-claim-rate 0.10 \
-        --require-schema-version 2
+        --require-schema-version 3
 
 Verwendete Metriken (aus ChatGPT-Audit):
 - evidence_coverage:    Claims mit evidence != [] / alle Claims              >= 0.90
@@ -30,7 +30,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from pydantic import ValidationError
 
-from app.contracts.report_contract import EvidenceMapModel, ReportContractModel  # noqa: E402
+from app.contracts.report_contract import EvidenceMapModel  # noqa: E402
+from app.services.evidence_migrations import normalize_persisted_evidence_map  # noqa: E402
 
 
 def evaluate(evidence_map: EvidenceMapModel) -> dict[str, float]:
@@ -71,9 +72,10 @@ def evaluate(evidence_map: EvidenceMapModel) -> dict[str, float]:
     dedup_rate = (dedup_count / total_sections) if total_sections else 0.0
 
     # concentration_index: max(count_pro_source) / total_evidence im
-    # global_evidence-Pool (kleiner Pool oder Single-Source -> hoher Index).
+    # globalen Evidence-Pool (kleiner Pool oder Single-Source -> hoher Index).
     sources_count: dict[str, int] = {}
-    for item in evidence_map.global_evidence:
+    for evidence_id in evidence_map.global_evidence_refs:
+        item = evidence_map.evidence_index[evidence_id]
         src = str(item.source)
         sources_count[src] = sources_count.get(src, 0) + 1
     total_global = sum(sources_count.values())
@@ -92,12 +94,17 @@ def evaluate(evidence_map: EvidenceMapModel) -> dict[str, float]:
 def load_one(path: Path, require_schema_version: int) -> EvidenceMapModel | None:
     raw = json.loads(path.read_text(encoding="utf-8"))
     # Akzeptiere sowohl ReportContract als auch nackte EvidenceMap als Fixture
+    evidence_raw = raw.get("evidence") if isinstance(raw.get("evidence"), dict) else raw
+    if evidence_raw.get("schema_version") != require_schema_version:
+        print(
+            f"Fixture {path.name}: schema_version={evidence_raw.get('schema_version')} "
+            f"!= required {require_schema_version}",
+            file=sys.stderr,
+        )
+        return None
     try:
-        if "evidence" in raw and isinstance(raw.get("evidence"), dict):
-            contract = ReportContractModel.model_validate(raw)
-            ev = contract.evidence
-        else:
-            ev = EvidenceMapModel.model_validate(raw)
+        normalized = normalize_persisted_evidence_map(evidence_raw)
+        ev = EvidenceMapModel.model_validate(normalized)
     except ValidationError as e:
         print(f"  \u2717 {path.name}: {e}", file=sys.stderr)
         return None
@@ -120,7 +127,7 @@ def main() -> int:
     ap.add_argument("--min-evidence-coverage", type=float, default=0.85)
     ap.add_argument("--min-claim-support-ratio", type=float, default=0.75)
     ap.add_argument("--orphan-claim-rate", type=float, default=0.10)
-    ap.add_argument("--require-schema-version", type=int, default=2)
+    ap.add_argument("--require-schema-version", type=int, default=3)
     ap.add_argument(
         "--soft",
         action="store_true",

--- a/backend/scripts/migrate_reports_v1_to_v2.py
+++ b/backend/scripts/migrate_reports_v1_to_v2.py
@@ -1,4 +1,4 @@
-"""Migrations-Skript: persistierte v1-Evidence-Maps auf schema_version=2 heben.
+"""Migrations-Skript: persistierte v1-Evidence-Maps auf das aktuelle Schema heben.
 
 Aufruf (aus backend/):
     python -m scripts.migrate_reports_v1_to_v2 <pfad> [--dry-run] [--glob "*.json"]
@@ -9,7 +9,7 @@ Bei Verzeichnis: rekursiv mit dem angegebenen Glob-Pattern (Standard: ``*.json``
 Pro Datei:
 - JSON laden (robust gegen kaputte Dateien).
 - schema_version prüfen; falls bereits CURRENT_SCHEMA_VERSION: no-op.
-- Falls v1 (oder kein Feld + v1-Heuristik): migrate_v1_to_v2() aufrufen.
+- Falls v1 (oder kein Feld + v1-Heuristik): kanonische Normalisierung aufrufen.
 - Migriertes Dict gegen EvidenceMapModel revalidieren.
 - Backup <datei>.v1.bak.json anlegen (nur wenn noch nicht vorhanden, idempotent).
 - Atomic write via <datei>.tmp + os.replace.
@@ -30,7 +30,10 @@ from typing import Optional
 from pydantic import ValidationError
 
 from app.contracts import EvidenceMapModel
-from app.services.evidence_migrations import CURRENT_SCHEMA_VERSION, migrate_v1_to_v2
+from app.services.evidence_migrations import (
+    CURRENT_SCHEMA_VERSION,
+    normalize_persisted_evidence_map,
+)
 
 logger = logging.getLogger("migrate_reports_v1_to_v2")
 
@@ -130,9 +133,9 @@ def _process_file(
     )
 
     # Migration
-    migrated = migrate_v1_to_v2(copy.deepcopy(payload))
+    migrated = normalize_persisted_evidence_map(copy.deepcopy(payload))
     if migrated is None:
-        return _STATUS_ERROR, "migrate_v1_to_v2 hat None zurückgegeben"
+        return _STATUS_ERROR, "normalize_persisted_evidence_map hat None zurückgegeben"
 
     _strip_section_schema_version(migrated)
 

--- a/backend/tests/api/test_report_evidence_route.py
+++ b/backend/tests/api/test_report_evidence_route.py
@@ -67,9 +67,8 @@ def _legacy_medium_seed_only_map():
 
 
 class TestReportEvidenceRoute:
-    def test_legacy_medium_seed_only_map_returns_200_and_low_label(self, client):
-        """Persistierte medium-seed-only-Map bricht nicht mit 422 — die
-        Migration stuft den Claim vor dem Validator auf ``low``."""
+    def test_legacy_medium_seed_only_map_returns_unresolved_hypothesis(self, client):
+        """Unverifizierbare Legacy-Seed-Evidence wird nicht zum Claim erhoben."""
         with (
             patch("app.api.report.validate_report_id", return_value=True),
             patch(
@@ -81,13 +80,18 @@ class TestReportEvidenceRoute:
 
         assert resp.status_code == 200
         body = resp.get_json()
-        claim = body["data"]["sections"][0]["claims"][0]
-        assert claim["confidence_label"] == "low"
+        section = body["data"]["sections"][0]
+        assert section["claims"] == []
+        assert "legacy_unresolved" in section["hypotheses"][0]["rationale"]
 
     def test_agent_grounded_medium_claim_stays_medium(self, client):
         evidence_map = _legacy_medium_seed_only_map()
+        evidence_map["sections"][0]["claims"][0]["evidence"][0][
+            "producer_key"
+        ] = "fixture-seed:doc_1"
         evidence_map["sections"][0]["claims"][0]["evidence"].append(
             {
+                "producer_key": "agent:persona_1:quote:1",
                 "type": "agent_interview",
                 "source_kind": "agent_quote",
                 "source": "agent:persona_1",
@@ -254,12 +258,14 @@ class TestReportEvidenceRouteOrphanClaims:
         assert first == second, "Pipeline ist nicht idempotent"
 
         section = first["data"]["sections"][0]
-        # orphan -> data_gaps, seed-only -> bleibt Claim, aber auf low abgestuft
+        # orphan -> data_gaps, unverifizierbare Seed-Evidence -> Hypothese
         assert len(section["data_gaps"]) == 1
         assert section["data_gaps"][0]["gap_reason"] == "no_evidence_bound"
-        assert len(section["claims"]) == 1
-        assert section["claims"][0]["claim_id"] == "claim_91"
-        assert section["claims"][0]["confidence_label"] == "low"
+        assert section["claims"] == []
+        assert any(
+            "legacy_unresolved" in item["rationale"]
+            for item in section["hypotheses"]
+        )
 
 
 class TestReportEvidenceRouteV1Migration:
@@ -302,7 +308,7 @@ class TestReportEvidenceRouteV1Migration:
 
         assert resp.status_code == 200, resp.get_data(as_text=True)
         data = resp.get_json()["data"]
-        assert data["schema_version"] == 2
+        assert data["schema_version"] == 3
         assert "schema_version" not in data["sections"][0]
 
     def test_poisoned_v2_map_is_healed(self, client):

--- a/backend/tests/api/test_report_export_evidence_parity.py
+++ b/backend/tests/api/test_report_export_evidence_parity.py
@@ -154,6 +154,7 @@ class TestExportRunsFullMigrationPipeline:
                 "type": "graph_fact",
                 "source_kind": "seed_corpus",
                 "source": "briefing.md",
+                "producer_key": "briefing.md#verified-q3-fixture",
                 "snippet": "Das Vorhaben startet im Q3.",
                 "match_score": 0.75,
                 "supports_claim": True,

--- a/backend/tests/api/test_report_export_zip.py
+++ b/backend/tests/api/test_report_export_zip.py
@@ -13,6 +13,7 @@ Abgedeckt:
 from __future__ import annotations
 
 import io
+import json
 import zipfile
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,9 @@ from app.api import report_bp
 VALID_REPORT_ID = "report_abcdef123456"
 
 _REPORT_V3_MD_CONTENT = "# Report V3\n\nInhalt des Berichts."
-_REPORT_V3_JSON_CONTENT = '{"schema_version": 3, "report_id": "report_abcdef123456"}'
+_REPORT_V3_JSON_CONTENT = (
+    '{"schema_version": 4, "report_id": "report_abcdef123456", "evidence_index": {}}'
+)
 
 
 @pytest.fixture
@@ -134,6 +137,11 @@ class TestZipExportEndpoint:
             f"{prefix}/claims.csv",
         }
         assert set(names) == expected
+        report_v3_json = json.loads(
+            zf.read(f"{prefix}/report-v3.json").decode("utf-8")
+        )
+        assert report_v3_json["schema_version"] == 4
+        assert report_v3_json["evidence_index"] == {}
 
     def test_export_zip_personas_csv_header(self, client):
         """personas.csv im ZIP beginnt mit 'id,voice_register'."""

--- a/backend/tests/api/test_report_export_zip.py
+++ b/backend/tests/api/test_report_export_zip.py
@@ -74,9 +74,10 @@ def _make_evidence_map():
 
 def _make_report_v3():
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "report_id": VALID_REPORT_ID,
         "generated_at": "2026-05-10T12:00:00",
+        "evidence_index": {},
         "personas": [
             {
                 "id": "P1",

--- a/backend/tests/contracts/test_evidence_degradation.py
+++ b/backend/tests/contracts/test_evidence_degradation.py
@@ -164,6 +164,42 @@ def test_medium_violation_haelt_uebrige_sections():
         assert entry["action"] == "moved_to_hypotheses"
 
 
+def test_root_validator_targets_section_when_claim_ids_repeat():
+    first_section = _valid_existing_section()
+    first_section["claims"] = [_seed_only_medium_claim()]
+    second_section = _valid_existing_section()
+    second_section["section_index"] = 2
+    second_section["section_title"] = "Zweite Sektion"
+    second_section["claims"] = [_seed_only_medium_claim()]
+    payload = {
+        "schema_version": 3,
+        "report_id": "r-duplicate-claims",
+        "simulation_id": "sim-duplicate-claims",
+        "evidence_index": {
+            _SEED_EVIDENCE_ID: {
+                "evidence_id": _SEED_EVIDENCE_ID,
+                "producer_key": "seed:duplicate-claim-fixture",
+                "type": "graph_fact",
+                "source": "seed",
+                "snippet": "Seed-only Evidence.",
+                "source_kind": "seed_corpus",
+            }
+        },
+        "global_evidence_refs": [],
+        "sections": [first_section, second_section],
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        EvidenceMapModel.model_validate(payload)
+
+    repaired, _ = degrade_sections_for_violations(
+        payload["sections"], exc_info.value
+    )
+
+    assert repaired[0]["claims"][0]["confidence_label"] == "low"
+    assert repaired[1]["claims"][0]["confidence_label"] == "medium"
+
+
 # ---------------------------------------------------------------------------
 # 2. normalize_sections_for_contract filtert hypotheses_appendix-Platzhalter
 # ---------------------------------------------------------------------------

--- a/backend/tests/contracts/test_evidence_degradation.py
+++ b/backend/tests/contracts/test_evidence_degradation.py
@@ -32,6 +32,8 @@ from app.services.report_agent.output_contract import (
     is_deliverable_report_status,
 )
 
+_SEED_EVIDENCE_ID = "ev_00000000000000000000000000000001"
+
 
 class _FakeAgentForDegradation:
     """Leichtgewichtiges Fake-Objekt für den ungebundenen Aufruf von
@@ -91,10 +93,8 @@ def _seed_only_medium_claim() -> dict:
         "confidence_score": 0.5,
         "evidence": [
             {
-                "type": "graph_fact",
-                "source": "seed_dokument_01",
-                "snippet": "Beleg-Snippet aus dem Seed-Korpus.",
-                "source_kind": "seed_corpus",
+                "evidence_id": _SEED_EVIDENCE_ID,
+                "supports_claim": True,
             },
         ],
         "audit_trail": [],
@@ -109,10 +109,20 @@ def _seed_only_medium_claim() -> dict:
 def test_medium_violation_haelt_uebrige_sections():
     fake_agent = _FakeAgentForDegradation(
         evidence_map={
-            "schema_version": 2,
+            "schema_version": 3,
             "report_id": "r1",
             "simulation_id": "sim1",
-            "global_evidence": [],
+            "evidence_index": {
+                _SEED_EVIDENCE_ID: {
+                    "evidence_id": _SEED_EVIDENCE_ID,
+                    "producer_key": "seed_dokument_01#degradation-fixture",
+                    "type": "graph_fact",
+                    "source": "seed_dokument_01",
+                    "snippet": "Beleg-Snippet aus dem Seed-Korpus.",
+                    "source_kind": "seed_corpus",
+                }
+            },
+            "global_evidence_refs": [],
             "sections": [_valid_existing_section()],
             "degradation_log": [],
         },
@@ -186,10 +196,11 @@ def test_hypotheses_appendix_placeholder_wird_gefiltert():
     assert normalized[0]["hypotheses_appendix"] == []
 
     payload = {
-        "schema_version": 2,
+        "schema_version": 3,
         "report_id": "r1",
         "simulation_id": "sim1",
-        "global_evidence": [],
+        "evidence_index": {},
+        "global_evidence_refs": [],
         "sections": normalized,
     }
     validated = EvidenceMapModel.model_validate(payload)

--- a/backend/tests/contracts/test_evidence_identity_contract.py
+++ b/backend/tests/contracts/test_evidence_identity_contract.py
@@ -1,0 +1,92 @@
+"""Vertragstests für kanonische Evidence-Identität und Claim-Bindings."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from pydantic import ValidationError
+
+
+EVIDENCE_ID = "ev_0123456789abcdef0123456789abcdef"
+
+
+def _contract(name: str):
+    contracts = importlib.import_module("app.contracts")
+    return getattr(contracts, name)
+
+
+def _record_payload() -> dict[str, object]:
+    return {
+        "evidence_id": EVIDENCE_ID,
+        "producer_key": "graph-node:node-17",
+        "type": "graph_fact",
+        "source": "report_tool",
+        "snippet": "Der Graph enthält einen belastbaren Fakt.",
+        "source_kind": "graph_relation",
+    }
+
+
+def test_build_evidence_id_is_deterministic_run_local_and_content_independent() -> None:
+    module = importlib.import_module("app.services.evidence_identity")
+    build_evidence_id = module.build_evidence_id
+
+    first = build_evidence_id("run-17", "graph_relation", "report-tool:result-1")
+
+    assert first == build_evidence_id(
+        "run-17", "graph_relation", "report-tool:result-1"
+    )
+    assert first != build_evidence_id(
+        "run-18", "graph_relation", "report-tool:result-1"
+    )
+    assert first != build_evidence_id(
+        "run-17", "graph_relation", "report-tool:result-2"
+    )
+    assert len(first) == 35
+    assert first.startswith("ev_")
+    assert first[3:] == first[3:].lower()
+    assert all(character in "0123456789abcdef" for character in first[3:])
+    with pytest.raises(TypeError):
+        build_evidence_id(
+            "run-17",
+            "graph_relation",
+            "report-tool:result-1",
+            snippet="LLM-Text darf keine Identität bilden",
+        )
+
+
+def test_evidence_record_requires_evidence_id_and_producer_key() -> None:
+    EvidenceRecordModel = _contract("EvidenceRecordModel")
+
+    for missing_field in ("evidence_id", "producer_key"):
+        payload = _record_payload()
+        payload.pop(missing_field)
+        with pytest.raises(ValidationError, match=missing_field):
+            EvidenceRecordModel.model_validate(payload)
+
+
+def test_claim_binding_owns_claim_relative_fields_and_validates_scores() -> None:
+    EvidenceRecordModel = _contract("EvidenceRecordModel")
+    ClaimEvidenceBindingModel = _contract("ClaimEvidenceBindingModel")
+
+    with pytest.raises(ValidationError, match="retrieval_score"):
+        EvidenceRecordModel.model_validate(_record_payload() | {"retrieval_score": 0.74})
+
+    binding = ClaimEvidenceBindingModel.model_validate(
+        {
+            "evidence_id": EVIDENCE_ID,
+            "match_score": 0.81,
+            "retrieval_score": 0.74,
+            "entailment": "SUPPORTED",
+            "entailment_reason": "Der Quellenfakt stützt den Claim.",
+            "supports_claim": True,
+            "contradicts_claim": False,
+        }
+    )
+    assert binding.entailment.value == "SUPPORTED"
+    assert binding.supports_claim is True
+
+    with pytest.raises(ValidationError, match="retrieval_score"):
+        ClaimEvidenceBindingModel.model_validate(
+            {"evidence_id": EVIDENCE_ID, "retrieval_score": 1.01}
+        )

--- a/backend/tests/contracts/test_evidence_identity_contract.py
+++ b/backend/tests/contracts/test_evidence_identity_contract.py
@@ -42,6 +42,9 @@ def test_build_evidence_id_is_deterministic_run_local_and_content_independent() 
     assert first != build_evidence_id(
         "run-17", "graph_relation", "report-tool:result-2"
     )
+    assert first != build_evidence_id(
+        "run-17", "web_source", "report-tool:result-1"
+    )
     assert len(first) == 35
     assert first.startswith("ev_")
     assert first[3:] == first[3:].lower()

--- a/backend/tests/contracts/test_evidence_map_v3_contract.py
+++ b/backend/tests/contracts/test_evidence_map_v3_contract.py
@@ -1,0 +1,85 @@
+"""Referenzielle Integrität der EvidenceMap v3."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts import EvidenceMapModel
+
+
+EVIDENCE_ID = "ev_0123456789abcdef0123456789abcdef"
+UNKNOWN_ID = "ev_ffffffffffffffffffffffffffffffff"
+
+
+def _evidence_map_payload() -> dict:
+    return {
+        "schema_version": 3,
+        "report_id": "report-17",
+        "simulation_id": "run-17",
+        "evidence_index": {
+            EVIDENCE_ID: {
+                "evidence_id": EVIDENCE_ID,
+                "producer_key": "graph-node:node-17",
+                "type": "graph_fact",
+                "source": "report_tool",
+                "snippet": "Der Graph enthält einen belastbaren Fakt.",
+                "source_kind": "graph_relation",
+            }
+        },
+        "global_evidence_refs": [EVIDENCE_ID],
+        "sections": [
+            {
+                "section_index": 1,
+                "section_title": "Wirkungsanalyse",
+                "section_summary": "Zusammenfassung der beobachteten Wirkung.",
+                "claims": [
+                    {
+                        "claim_id": "claim_01",
+                        "claim_text": "Die Zielgruppe reagiert positiv auf den Ansatz.",
+                        "confidence_label": "low",
+                        "confidence_score": 0.4,
+                        "evidence": [
+                            {
+                                "evidence_id": EVIDENCE_ID,
+                                "match_score": 0.7,
+                                "retrieval_score": 0.6,
+                                "entailment": "RELATED_ONLY",
+                                "supports_claim": False,
+                                "contradicts_claim": False,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_evidence_map_v3_resolves_global_and_claim_bindings() -> None:
+    evidence_map = EvidenceMapModel.model_validate(_evidence_map_payload())
+
+    assert evidence_map.schema_version == 3
+    assert evidence_map.global_evidence_refs == [EVIDENCE_ID]
+    assert evidence_map.sections[0].claims[0].evidence[0].evidence_id == EVIDENCE_ID
+
+
+def test_evidence_map_v3_rejects_mismatched_or_unknown_ids() -> None:
+    mismatched_key = _evidence_map_payload()
+    mismatched_key["evidence_index"] = {
+        UNKNOWN_ID: deepcopy(mismatched_key["evidence_index"])[EVIDENCE_ID]
+    }
+    with pytest.raises(ValidationError, match="evidence_id"):
+        EvidenceMapModel.model_validate(mismatched_key)
+
+    unknown_global = _evidence_map_payload()
+    unknown_global["global_evidence_refs"] = [UNKNOWN_ID]
+    with pytest.raises(ValidationError, match="unbekannt|auflös|evidence"):
+        EvidenceMapModel.model_validate(unknown_global)
+
+    unknown_claim = _evidence_map_payload()
+    unknown_claim["sections"][0]["claims"][0]["evidence"][0]["evidence_id"] = UNKNOWN_ID
+    with pytest.raises(ValidationError, match="unbekannt|auflös|evidence"):
+        EvidenceMapModel.model_validate(unknown_claim)

--- a/backend/tests/contracts/test_report_contract.py
+++ b/backend/tests/contracts/test_report_contract.py
@@ -390,10 +390,30 @@ def test_full_contract_round_trip():
             "evidence_sections": 1,
         },
         "evidence": {
-            "schema_version": 2,
+            "schema_version": 3,
             "report_id": "report_abc",
             "simulation_id": "sim_abc",
-            "global_evidence": [],
+            "evidence_index": {
+                "ev_00000000000000000000000000000001": {
+                    "evidence_id": "ev_00000000000000000000000000000001",
+                    "producer_key": "agent:kmu_ceo:interview:1",
+                    "type": "agent_interview",
+                    "source": "agent_log",
+                    "snippet": "Persona kmu_ceo äußerte Bedenken.",
+                    "source_kind": "agent_quote",
+                    "persona_stakeholder_group": "Geschaeftsfuehrung",
+                },
+                "ev_00000000000000000000000000000002": {
+                    "evidence_id": "ev_00000000000000000000000000000002",
+                    "producer_key": "agent:it_lead:interview:1",
+                    "type": "agent_interview",
+                    "source": "agent_log",
+                    "snippet": "Persona it_lead bestaetigte das Problem.",
+                    "source_kind": "agent_quote",
+                    "persona_stakeholder_group": "IT-Abteilung",
+                },
+            },
+            "global_evidence_refs": [],
             "sections": [{
                 "section_index": 1,
                 "section_title": "Erster Eindruck",
@@ -413,22 +433,14 @@ def test_full_contract_round_trip():
                     # agent_quote-Evidence aus mindestens 2 Stakeholder-Gruppen.
                     "evidence": [
                         {
-                            "type": "agent_interview",
-                            "source": "agent_log",
-                            "snippet": "Persona kmu_ceo äußerte Bedenken.",
+                            "evidence_id": "ev_00000000000000000000000000000001",
                             "match_score": 0.7,
                             "supports_claim": True,
-                            "source_kind": "agent_quote",
-                            "persona_stakeholder_group": "Geschaeftsfuehrung",
                         },
                         {
-                            "type": "agent_interview",
-                            "source": "agent_log",
-                            "snippet": "Persona it_lead bestaetigte das Problem.",
+                            "evidence_id": "ev_00000000000000000000000000000002",
                             "match_score": 0.72,
                             "supports_claim": True,
-                            "source_kind": "agent_quote",
-                            "persona_stakeholder_group": "IT-Abteilung",
                         },
                     ],
                     "audit_trail": [],

--- a/backend/tests/contracts/test_report_section_hypotheses.py
+++ b/backend/tests/contracts/test_report_section_hypotheses.py
@@ -7,14 +7,14 @@ from pydantic import ValidationError
 from app.contracts import ReportSectionHypothesisModel
 from app.contracts.report_contract import (
     ConfidenceLabel,
-    ReportClaimModel,
+    IndexedReportClaimModel,
     ReportSectionDataGapModel,
     ReportSectionModel,
 )
 
 
-def _claim() -> ReportClaimModel:
-    return ReportClaimModel(
+def _claim() -> IndexedReportClaimModel:
+    return IndexedReportClaimModel(
         claim_id="claim_01",
         claim_text="Ein belegter Claim mit ausreichend langem Text.",
         confidence_label=ConfidenceLabel.low,

--- a/backend/tests/contracts/test_report_v3_contract.py
+++ b/backend/tests/contracts/test_report_v3_contract.py
@@ -316,6 +316,62 @@ def test_persisted_v3_validates(tmp_path, monkeypatch):
     assert "Preisbereitschaft ist im Seed-Korpus nicht belegt." in report_v3_markdown
 
 
+def test_build_report_v3_floor_ignores_non_supporting_bindings():
+    from app.models.report import Report, ReportStatus  # noqa: PLC0415
+    from app.services.report_agent.manager import ReportManager  # noqa: PLC0415
+
+    first_id = "ev_11111111111111111111111111111111"
+    second_id = "ev_22222222222222222222222222222222"
+    evidence_index = {
+        evidence_id: {
+            "evidence_id": evidence_id,
+            "producer_key": f"graph-node:{index}",
+            "type": "graph_fact",
+            "source": "graph",
+            "snippet": f"Nicht stützende Quelle {index}.",
+            "source_kind": "graph_relation",
+        }
+        for index, evidence_id in enumerate((first_id, second_id), 1)
+    }
+    evidence_map = {
+        "schema_version": 3,
+        "report_id": "report_non_supporting_floor",
+        "simulation_id": "sim_non_supporting_floor",
+        "evidence_index": evidence_index,
+        "global_evidence_refs": [],
+        "sections": [
+            {
+                "section_index": 1,
+                "section_title": "Floor",
+                "section_summary": "Nicht stützende Bindings zählen nicht.",
+                "claims": [
+                    {
+                        "claim_id": "claim_01",
+                        "claim_text": "Zwei verwandte Quellen belegen die Aussage nicht.",
+                        "confidence_label": "low",
+                        "confidence_score": 0.3,
+                        "evidence": [
+                            {"evidence_id": first_id, "supports_claim": False},
+                            {"evidence_id": second_id, "supports_claim": False},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    report = Report(
+        report_id="report_non_supporting_floor",
+        simulation_id="sim_non_supporting_floor",
+        graph_id="graph_non_supporting_floor",
+        simulation_requirement="Test",
+        status=ReportStatus.COMPLETED,
+    )
+
+    migrated = ReportManager.build_report_v3(report, evidence_map)
+
+    assert migrated.claims == []
+
+
 # ---- migrate_v2_to_v3 Unit-Tests ----
 
 def test_migrate_v2_to_v3_minimal():
@@ -458,6 +514,39 @@ def test_write_and_read_report_v3_roundtrip(tmp_path):
     assert restored.report_id == report_id
     assert restored.claims[0].evidence_refs == [EVIDENCE_ID]
     assert restored.data_gaps[0].id == "dg1"
+
+
+def test_read_report_v3_upgrades_persisted_schema_three(tmp_path):
+    from app.services.report_agent.storage import read_report_v3  # noqa: PLC0415
+
+    report_id = "report_legacy_schema_three"
+    reports_dir = tmp_path / "reports"
+    report_dir = reports_dir / report_id
+    report_dir.mkdir(parents=True)
+    (report_dir / "report-v3.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "report_id": report_id,
+                "generated_at": "2026-08-09T00:00:00Z",
+                "hypotheses": [
+                    {
+                        "id": "hypothesis_01",
+                        "hypothesis_text": "Persistierter Inhalt bleibt beim Upgrade erhalten.",
+                        "rationale": "Legacy-ReportV3 ohne Evidence-Index.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    restored = read_report_v3(report_id, reports_dir=str(reports_dir))
+
+    assert restored is not None
+    assert restored.schema_version == 4
+    assert restored.evidence_index == {}
+    assert restored.hypotheses[0].hypothesis_text.startswith("Persistierter Inhalt")
 
 
 def test_read_report_v3_returns_none_when_missing(tmp_path):

--- a/backend/tests/contracts/test_report_v3_contract.py
+++ b/backend/tests/contracts/test_report_v3_contract.py
@@ -28,6 +28,21 @@ from app.contracts.report_v3 import (
     TrustSignal,
 )
 
+EVIDENCE_ID = "ev_00000000000000000000000000000001"
+
+
+def _evidence_index() -> dict[str, dict]:
+    return {
+        EVIDENCE_ID: {
+            "evidence_id": EVIDENCE_ID,
+            "producer_key": "report-v4-contract-fixture",
+            "type": "graph_fact",
+            "source": "contract-fixture",
+            "snippet": "Vertraglich gebundene Evidence.",
+            "source_kind": "graph_relation",
+        }
+    }
+
 
 # ---- Importierbarkeit aller 13 Klassen ----
 
@@ -140,7 +155,7 @@ def test_persona_invalid_voice_register_rejected():
         )
 
 
-# ---- schema_version == 3 (Literal) ----
+# ---- schema_version == 4 (Literal) ----
 
 def test_schema_version_must_be_3():
     """Literal[3] verhindert schema_version=2."""
@@ -152,13 +167,13 @@ def test_schema_version_must_be_3():
         })
 
 
-def test_schema_version_defaults_to_3():
-    """Ohne explizite schema_version wird 3 gesetzt."""
+def test_schema_version_defaults_to_4():
+    """Ohne explizite schema_version wird 4 gesetzt."""
     r = ReportV3(
         report_id="r1",
         generated_at=datetime(2026, 5, 9, tzinfo=timezone.utc),
     )
-    assert r.schema_version == 3
+    assert r.schema_version == 4
 
 
 # ---- Roundtrip: model_dump_json → model_validate_json ----
@@ -168,6 +183,7 @@ def test_minimal_report_v3_roundtrip():
     original = ReportV3(
         report_id="rep-001",
         generated_at=datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc),
+        evidence_index=_evidence_index(),
         personas=[
             Persona(
                 id="p1",
@@ -177,14 +193,14 @@ def test_minimal_report_v3_roundtrip():
                 region="Schweiz",
                 needs=["Zuverlässigkeit", "Sicherheit"],
                 values=["Qualität"],
-                evidence_refs=["ev-001"],
+                evidence_refs=[EVIDENCE_ID],
             )
         ],
         claims=[
             Claim(
                 id="c1",
                 statement="Sicherheitsbedenken sind der primäre Hemmfaktor.",
-                evidence_refs=["ev-001"],
+                evidence_refs=[EVIDENCE_ID],
                 confidence="high",
                 persona_ids=["p1"],
                 aggregation_basis="persona",
@@ -213,11 +229,11 @@ def test_minimal_report_v3_roundtrip():
     restored = ReportV3.model_validate_json(json_str)
 
     assert restored.report_id == original.report_id
-    assert restored.schema_version == 3
+    assert restored.schema_version == 4
     assert len(restored.personas) == 1
     assert restored.personas[0].voice_register == "formal-de"
     assert len(restored.claims) == 1
-    assert restored.claims[0].evidence_refs == ["ev-001"]
+    assert restored.claims[0].evidence_refs == [EVIDENCE_ID]
     assert len(restored.data_gaps) == 1
     assert len(restored.hypotheses) == 1
     assert restored.hypotheses[0].suggested_evidence == ["Preisinterviews"]
@@ -287,7 +303,7 @@ def test_persisted_v3_validates(tmp_path, monkeypatch):
     report_v3_markdown = ReportManager.build_report_v3_markdown(report_id)
     assert report_v3_markdown is not None, "build_report_v3_markdown() lieferte None — report-v3.json fehlt oder ungültig"
 
-    assert restored.schema_version == 3
+    assert restored.schema_version == 4
     assert restored.report_id == report_id
     # Reviewer-Floor S1: Claim mit 1 Evidence-Item wird zur Hypothesis geroutet.
     assert len(restored.claims) == 0, (
@@ -338,11 +354,13 @@ def test_migrate_v2_to_v3_minimal():
     result = migrate_v2_to_v3(v2)
     report_v3 = ReportV3.model_validate(result)
 
-    assert report_v3.schema_version == 3
+    assert report_v3.schema_version == 4
     assert report_v3.report_id == "rep-migration-001"
     assert len(report_v3.claims) == 1
     assert report_v3.claims[0].confidence == "medium"
-    assert report_v3.claims[0].evidence_refs == ["kg:node:mobility-001"]
+    evidence_ref = report_v3.claims[0].evidence_refs[0]
+    assert evidence_ref in report_v3.evidence_index
+    assert report_v3.evidence_index[evidence_ref].source_id_anchor == "kg:node:mobility-001"
     # DataGap aus Claim + DataGap aus Migration-Hinweis (keine Personas)
     gap_ids = {dg.id for dg in report_v3.data_gaps}
     assert "g01" in gap_ids
@@ -413,11 +431,12 @@ def test_write_and_read_report_v3_roundtrip(tmp_path):
     original = ReportV3(
         report_id=report_id,
         generated_at=datetime(2026, 5, 10, 10, 0, 0, tzinfo=timezone.utc),
+        evidence_index=_evidence_index(),
         claims=[
             Claim(
                 id="c1",
                 statement="Sicherheitsbedenken hemmen die Adoption sichtbar.",
-                evidence_refs=["ev-001"],
+                evidence_refs=[EVIDENCE_ID],
                 confidence="high",
                 aggregation_basis="persona",
             )
@@ -435,9 +454,9 @@ def test_write_and_read_report_v3_roundtrip(tmp_path):
 
     restored = read_report_v3(report_id, reports_dir=reports_dir)
     assert restored is not None
-    assert restored.schema_version == 3
+    assert restored.schema_version == 4
     assert restored.report_id == report_id
-    assert restored.claims[0].evidence_refs == ["ev-001"]
+    assert restored.claims[0].evidence_refs == [EVIDENCE_ID]
     assert restored.data_gaps[0].id == "dg1"
 
 

--- a/backend/tests/contracts/test_report_v4_evidence_contract.py
+++ b/backend/tests/contracts/test_report_v4_evidence_contract.py
@@ -1,0 +1,145 @@
+"""ReportV3-v4-Vertrag für eingebettete, auflösbare Evidence-Referenzen."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.report_v3 import ReportV3
+
+
+EVIDENCE_ID = "ev_0123456789abcdef0123456789abcdef"
+UNKNOWN_ID = "ev_ffffffffffffffffffffffffffffffff"
+
+
+def _base_report() -> dict[str, object]:
+    return {
+        "schema_version": 4,
+        "report_id": "report-17",
+        "generated_at": "2026-08-09T10:00:00Z",
+        "evidence_index": {
+            EVIDENCE_ID: {
+                "evidence_id": EVIDENCE_ID,
+                "producer_key": "graph-node:node-17",
+                "type": "graph_fact",
+                "source": "report_tool",
+                "snippet": "Der Graph enthält einen belastbaren Fakt.",
+                "source_kind": "graph_relation",
+            }
+        },
+    }
+
+
+REF_DTO_PAYLOADS: tuple[tuple[str, dict[str, object]], ...] = (
+    (
+        "personas",
+        {
+            "id": "persona-1",
+            "voice_register": "neutral-de",
+            "alter_range": "35–50",
+            "beruf": "Projektleitung",
+            "region": "DACH",
+        },
+    ),
+    (
+        "claims",
+        {
+            "id": "claim-1",
+            "statement": "Die Zielgruppe reagiert positiv auf den Ansatz.",
+            "confidence": "low",
+            "aggregation_basis": "persona",
+        },
+    ),
+    (
+        "multipliers",
+        {
+            "id": "multiplier-1",
+            "name": "Empfehlungen",
+            "kategorie": "awareness",
+            "reichweite_score": 6,
+        },
+    ),
+    (
+        "friction_points",
+        {
+            "id": "friction-1",
+            "beschreibung": "Unklare Zuständigkeiten erschweren die Einführung.",
+            "severity": "medium",
+        },
+    ),
+    (
+        "trust_signals",
+        {
+            "id": "trust-1",
+            "beschreibung": "Ein unabhängiges Prüfsiegel erhöht das Vertrauen.",
+            "signal_type": "authority",
+        },
+    ),
+    (
+        "change_recommendations",
+        {
+            "id": "change-1",
+            "titel": "Zuständigkeiten klären",
+            "beschreibung": "Verantwortlichkeiten werden sichtbar dokumentiert.",
+            "priority": "high",
+            "aufwand": "S",
+        },
+    ),
+    (
+        "project_impacts",
+        {
+            "id": "impact-1",
+            "beschreibung": "Der Ansatz verkürzt die Abstimmungswege.",
+            "confidence": "low",
+        },
+    ),
+    (
+        "positioning_variants",
+        {
+            "id": "positioning-1",
+            "titel": "Sicher entscheiden",
+            "claim_text": "Nachvollziehbare Evidenz für jede Entscheidung.",
+        },
+    ),
+    (
+        "content_ideas",
+        {
+            "id": "content-1",
+            "titel": "Evidence Walkthrough",
+            "format": "video",
+        },
+    ),
+)
+
+
+def _report_with_all_reference_dtos(evidence_id: str) -> dict[str, object]:
+    payload = _base_report()
+    for collection, dto in REF_DTO_PAYLOADS:
+        payload[collection] = [deepcopy(dto) | {"evidence_refs": [evidence_id]}]
+    return payload
+
+
+def test_report_v3_uses_schema_version_four_and_embeds_evidence_index() -> None:
+    report = ReportV3.model_validate(_report_with_all_reference_dtos(EVIDENCE_ID))
+
+    assert report.schema_version == 4
+    assert report.evidence_index[EVIDENCE_ID].evidence_id == EVIDENCE_ID
+
+
+    previous_version = _base_report()
+    previous_version["schema_version"] = 3
+    with pytest.raises(ValidationError, match="schema_version"):
+        ReportV3.model_validate(previous_version)
+
+
+def test_report_v3_rejects_unknown_evidence_refs_for_every_ref_dto() -> None:
+    for collection, dto in REF_DTO_PAYLOADS:
+        payload = _base_report()
+        payload[collection] = [deepcopy(dto) | {"evidence_refs": [UNKNOWN_ID]}]
+        with pytest.raises(
+            ValidationError,
+            match="unbekannt|auflös|evidence_refs",
+        ):
+            ReportV3.model_validate(payload)

--- a/backend/tests/contracts/test_report_v4_evidence_contract.py
+++ b/backend/tests/contracts/test_report_v4_evidence_contract.py
@@ -134,6 +134,15 @@ def test_report_v3_uses_schema_version_four_and_embeds_evidence_index() -> None:
         ReportV3.model_validate(previous_version)
 
 
+def test_report_v3_rejects_mismatched_evidence_index_key() -> None:
+    payload = _base_report()
+    record = payload["evidence_index"].pop(EVIDENCE_ID)
+    payload["evidence_index"][UNKNOWN_ID] = record
+
+    with pytest.raises(ValidationError, match="evidence_index-Key"):
+        ReportV3.model_validate(payload)
+
+
 def test_report_v3_rejects_unknown_evidence_refs_for_every_ref_dto() -> None:
     for collection, dto in REF_DTO_PAYLOADS:
         payload = _base_report()

--- a/backend/tests/eval/fixtures/bad/orphan_heavy.json
+++ b/backend/tests/eval/fixtures/bad/orphan_heavy.json
@@ -1,43 +1,177 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "report_id": "report_orphan_heavy",
   "simulation_id": "sim_orphan_heavy_001",
-  "global_evidence": [
-    {
+  "evidence_index": {
+    "ev_3b9f18904d6425d37c5999e3b8321aa8": {
+      "evidence_id": "ev_3b9f18904d6425d37c5999e3b8321aa8",
+      "producer_key": "fixture:bad-orphan_heavy:global:0",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Netzwerkdichte: 0.34 im Kernsegment.",
-      "match_score": 0.7,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_c6653ac3e8818e4a74ee33df4fdec7ae": {
+      "evidence_id": "ev_c6653ac3e8818e4a74ee33df4fdec7ae",
+      "producer_key": "fixture:bad-orphan_heavy:global:1",
       "type": "graph_metric",
       "source": "neo4j-graph",
       "snippet": "Durchschnittlicher Degree: 4.2 Knoten.",
-      "match_score": 0.68,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_4d82443a827f38dd5e901433042577aa": {
+      "evidence_id": "ev_4d82443a827f38dd5e901433042577aa",
+      "producer_key": "fixture:bad-orphan_heavy:global:2",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Cluster-Koeffizient: 0.61 im Community-Graph.",
-      "match_score": 0.72,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_f577b5711ad60e509492f9bb21302d6e": {
+      "evidence_id": "ev_f577b5711ad60e509492f9bb21302d6e",
+      "producer_key": "fixture:bad-orphan_heavy:global:3",
       "type": "agent_interview",
       "source": "agent-log",
       "snippet": "Persona Hoffmann: Die Vernetzung in meiner Branche ist gering.",
-      "match_score": 0.58,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_quote",
+      "source_model": null,
+      "persona_stakeholder_group": "fixture:agent-log"
     },
-    {
+    "ev_6e177d1da2e303ebc37f7f00def38ed5": {
+      "evidence_id": "ev_6e177d1da2e303ebc37f7f00def38ed5",
+      "producer_key": "fixture:bad-orphan_heavy:global:4",
       "type": "graph_metric",
       "source": "neo4j-graph",
       "snippet": "Isolierte Knoten: 12 % des Gesamtgraphen.",
-      "match_score": 0.65,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_d63b5346c3cc4878f42da250e6023555": {
+      "evidence_id": "ev_d63b5346c3cc4878f42da250e6023555",
+      "producer_key": "fixture:bad-orphan_heavy:section:0:claim:0:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Netzwerkdichte: 0.34 im Kernsegment.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_58af5b8cafa01389ddc9b22011c4494f": {
+      "evidence_id": "ev_58af5b8cafa01389ddc9b22011c4494f",
+      "producer_key": "fixture:bad-orphan_heavy:section:0:claim:3:evidence:0",
+      "type": "graph_metric",
+      "source": "neo4j-graph",
+      "snippet": "Durchschnittlicher Degree: 4.2 Knoten.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_ae6c22374f68da1b4914e7a146c107e2": {
+      "evidence_id": "ev_ae6c22374f68da1b4914e7a146c107e2",
+      "producer_key": "fixture:bad-orphan_heavy:section:1:claim:1:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Cluster-Koeffizient: 0.61 im Community-Graph.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_b5d07eaa383b02336ab4cf5bd93b030c": {
+      "evidence_id": "ev_b5d07eaa383b02336ab4cf5bd93b030c",
+      "producer_key": "fixture:bad-orphan_heavy:section:1:claim:3:evidence:0",
+      "type": "graph_metric",
+      "source": "neo4j-graph",
+      "snippet": "Isolierte Knoten: 12 % des Gesamtgraphen.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     }
+  },
+  "global_evidence_refs": [
+    "ev_3b9f18904d6425d37c5999e3b8321aa8",
+    "ev_c6653ac3e8818e4a74ee33df4fdec7ae",
+    "ev_4d82443a827f38dd5e901433042577aa",
+    "ev_f577b5711ad60e509492f9bb21302d6e",
+    "ev_6e177d1da2e303ebc37f7f00def38ed5"
   ],
   "sections": [
     {
@@ -52,14 +186,17 @@
           "confidence_score": 0.7,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Netzwerkdichte: 0.34 im Kernsegment.",
+              "evidence_id": "ev_d63b5346c3cc4878f42da250e6023555",
               "match_score": 0.7,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_02",
@@ -67,7 +204,8 @@
           "confidence_label": "low",
           "confidence_score": 0.15,
           "evidence": [],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_03",
@@ -75,7 +213,8 @@
           "confidence_label": "low",
           "confidence_score": 0.15,
           "evidence": [],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_04",
@@ -84,16 +223,24 @@
           "confidence_score": 0.65,
           "evidence": [
             {
-              "type": "graph_metric",
-              "source": "neo4j-graph",
-              "snippet": "Durchschnittlicher Degree: 4.2 Knoten.",
+              "evidence_id": "ev_58af5b8cafa01389ddc9b22011c4494f",
               "match_score": 0.68,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 2,
@@ -106,7 +253,8 @@
           "confidence_label": "low",
           "confidence_score": 0.15,
           "evidence": [],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_06",
@@ -115,14 +263,17 @@
           "confidence_score": 0.68,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Cluster-Koeffizient: 0.61 im Community-Graph.",
+              "evidence_id": "ev_ae6c22374f68da1b4914e7a146c107e2",
               "match_score": 0.72,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_07",
@@ -130,7 +281,8 @@
           "confidence_label": "low",
           "confidence_score": 0.15,
           "evidence": [],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_08",
@@ -139,16 +291,25 @@
           "confidence_score": 0.62,
           "evidence": [
             {
-              "type": "graph_metric",
-              "source": "neo4j-graph",
-              "snippet": "Isolierte Knoten: 12 % des Gesamtgraphen.",
+              "evidence_id": "ev_b5d07eaa383b02336ab4cf5bd93b030c",
               "match_score": 0.65,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     }
-  ]
+  ],
+  "degradation_log": []
 }

--- a/backend/tests/eval/fixtures/good/clean_small.json
+++ b/backend/tests/eval/fixtures/good/clean_small.json
@@ -1,50 +1,232 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "report_id": "report_clean_small",
   "simulation_id": "sim_clean_small_001",
-  "global_evidence": [
-    {
+  "evidence_index": {
+    "ev_bd3707619202541f01c8170e053b5d90": {
+      "evidence_id": "ev_bd3707619202541f01c8170e053b5d90",
+      "producer_key": "fixture:clean_small:global:0",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Unternehmen A hat 500 Mitarbeiter im DACH-Raum.",
-      "match_score": 0.88,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_92ea6ee0341643f295fd6e96ad9fa2bb": {
+      "evidence_id": "ev_92ea6ee0341643f295fd6e96ad9fa2bb",
+      "producer_key": "fixture:clean_small:global:1",
       "type": "graph_metric",
       "source": "neo4j-graph",
       "snippet": "Umsatz 2024: 12,4 Mio EUR.",
-      "match_score": 0.91,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_83b2a89856235c9e4f53a512808b4f90": {
+      "evidence_id": "ev_83b2a89856235c9e4f53a512808b4f90",
+      "producer_key": "fixture:clean_small:global:2",
       "type": "agent_interview",
       "source": "agent-log",
       "snippet": "Persona Maier: Ich sehe das Produkt positiv, aber der Preis ist zu hoch.",
-      "match_score": 0.82,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_quote",
+      "source_model": null,
+      "persona_stakeholder_group": "fixture:agent-log"
     },
-    {
+    "ev_29abbcc24cb9e876cad2e62a3b86fa79": {
+      "evidence_id": "ev_29abbcc24cb9e876cad2e62a3b86fa79",
+      "producer_key": "fixture:clean_small:global:3",
       "type": "web_search_result",
       "source": "web",
       "snippet": "Marktanteil im DACH-Segment steigt laut Branchenreport 2024.",
-      "match_score": 0.79,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_dddba0ecd6d647c2bdfbd63ae38a385b": {
+      "evidence_id": "ev_dddba0ecd6d647c2bdfbd63ae38a385b",
+      "producer_key": "fixture:clean_small:global:4",
       "type": "entity_summary",
       "source": "knowledge-base",
       "snippet": "Branche: SaaS B2B, Zielgruppe: KMU Deutschland.",
-      "match_score": 0.85,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_a000f27c68394b76a12a2ef6e6a21662": {
+      "evidence_id": "ev_a000f27c68394b76a12a2ef6e6a21662",
+      "producer_key": "fixture:clean_small:global:5",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Wettbewerber B hat 30 % geringere Kundenzufriedenheit.",
-      "match_score": 0.77,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_8ebdf61fc39b551e88b0770fe2d95999": {
+      "evidence_id": "ev_8ebdf61fc39b551e88b0770fe2d95999",
+      "producer_key": "fixture:clean_small:section:0:claim:0:evidence:0",
+      "type": "graph_metric",
+      "source": "neo4j-graph",
+      "snippet": "Umsatz 2024: 12,4 Mio EUR.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_c8c050651a44af9a3073db9a7a1b1bcd": {
+      "evidence_id": "ev_c8c050651a44af9a3073db9a7a1b1bcd",
+      "producer_key": "fixture:clean_small:section:0:claim:1:evidence:0",
+      "type": "web_search_result",
+      "source": "web",
+      "snippet": "Marktanteil im DACH-Segment steigt laut Branchenreport 2024.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_625aef51faaa012fd48a0bb5b6ff7f1b": {
+      "evidence_id": "ev_625aef51faaa012fd48a0bb5b6ff7f1b",
+      "producer_key": "fixture:clean_small:section:1:claim:0:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Wettbewerber B hat 30 % geringere Kundenzufriedenheit.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_452a0f436806a880161dde58a897929a": {
+      "evidence_id": "ev_452a0f436806a880161dde58a897929a",
+      "producer_key": "fixture:clean_small:section:1:claim:1:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Unternehmen A hat 500 Mitarbeiter im DACH-Raum.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_d56bd75f65bba7cf0b3ebaf8251ce403": {
+      "evidence_id": "ev_d56bd75f65bba7cf0b3ebaf8251ce403",
+      "producer_key": "fixture:clean_small:section:2:claim:0:evidence:0",
+      "type": "agent_interview",
+      "source": "agent-log",
+      "snippet": "Persona Maier: Ich sehe das Produkt positiv, aber der Preis ist zu hoch.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_quote",
+      "source_model": null,
+      "persona_stakeholder_group": "fixture:agent-log"
+    },
+    "ev_0e678cdf1bf5616c4e70ce35fecf9e81": {
+      "evidence_id": "ev_0e678cdf1bf5616c4e70ce35fecf9e81",
+      "producer_key": "fixture:clean_small:section:2:claim:1:evidence:0",
+      "type": "entity_summary",
+      "source": "knowledge-base",
+      "snippet": "Branche: SaaS B2B, Zielgruppe: KMU Deutschland.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     }
+  },
+  "global_evidence_refs": [
+    "ev_bd3707619202541f01c8170e053b5d90",
+    "ev_92ea6ee0341643f295fd6e96ad9fa2bb",
+    "ev_83b2a89856235c9e4f53a512808b4f90",
+    "ev_29abbcc24cb9e876cad2e62a3b86fa79",
+    "ev_dddba0ecd6d647c2bdfbd63ae38a385b",
+    "ev_a000f27c68394b76a12a2ef6e6a21662"
   ],
   "sections": [
     {
@@ -59,14 +241,17 @@
           "confidence_score": 0.87,
           "evidence": [
             {
-              "type": "graph_metric",
-              "source": "neo4j-graph",
-              "snippet": "Umsatz 2024: 12,4 Mio EUR.",
+              "evidence_id": "ev_8ebdf61fc39b551e88b0770fe2d95999",
               "match_score": 0.91,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_02",
@@ -75,16 +260,24 @@
           "confidence_score": 0.8,
           "evidence": [
             {
-              "type": "web_search_result",
-              "source": "web",
-              "snippet": "Marktanteil im DACH-Segment steigt laut Branchenreport 2024.",
+              "evidence_id": "ev_c8c050651a44af9a3073db9a7a1b1bcd",
               "match_score": 0.79,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 2,
@@ -98,14 +291,17 @@
           "confidence_score": 0.78,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Wettbewerber B hat 30 % geringere Kundenzufriedenheit.",
+              "evidence_id": "ev_625aef51faaa012fd48a0bb5b6ff7f1b",
               "match_score": 0.77,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_04",
@@ -114,16 +310,24 @@
           "confidence_score": 0.88,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Unternehmen A hat 500 Mitarbeiter im DACH-Raum.",
+              "evidence_id": "ev_452a0f436806a880161dde58a897929a",
               "match_score": 0.88,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 3,
@@ -137,14 +341,17 @@
           "confidence_score": 0.82,
           "evidence": [
             {
-              "type": "agent_interview",
-              "source": "agent-log",
-              "snippet": "Persona Maier: Ich sehe das Produkt positiv, aber der Preis ist zu hoch.",
+              "evidence_id": "ev_d56bd75f65bba7cf0b3ebaf8251ce403",
               "match_score": 0.82,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_06",
@@ -153,16 +360,25 @@
           "confidence_score": 0.85,
           "evidence": [
             {
-              "type": "entity_summary",
-              "source": "knowledge-base",
-              "snippet": "Branche: SaaS B2B, Zielgruppe: KMU Deutschland.",
+              "evidence_id": "ev_0e678cdf1bf5616c4e70ce35fecf9e81",
               "match_score": 0.85,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     }
-  ]
+  ],
+  "degradation_log": []
 }

--- a/backend/tests/eval/fixtures/good/medium_with_dedup.json
+++ b/backend/tests/eval/fixtures/good/medium_with_dedup.json
@@ -1,64 +1,306 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "report_id": "report_medium_dedup",
   "simulation_id": "sim_medium_dedup_001",
-  "global_evidence": [
-    {
+  "evidence_index": {
+    "ev_7064a2513ebdd1a45ccd8d9e6b365b68": {
+      "evidence_id": "ev_7064a2513ebdd1a45ccd8d9e6b365b68",
+      "producer_key": "fixture:medium_with_dedup:global:0",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Segment Einzelhandel: 42 % der Befragten bevorzugen Online-Kauf.",
-      "match_score": 0.8,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_0efd1b789393fd3843c4687cd58dee84": {
+      "evidence_id": "ev_0efd1b789393fd3843c4687cd58dee84",
+      "producer_key": "fixture:medium_with_dedup:global:1",
       "type": "agent_interview",
       "source": "agent-log",
       "snippet": "Persona Schmidt: Ich kaufe lieber im Geschaeft, weil ich das Produkt anfassen will.",
-      "match_score": 0.65,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_quote",
+      "source_model": null,
+      "persona_stakeholder_group": "fixture:agent-log"
     },
-    {
+    "ev_aec4f56cc6866b4d30d5093c1b15cdf2": {
+      "evidence_id": "ev_aec4f56cc6866b4d30d5093c1b15cdf2",
+      "producer_key": "fixture:medium_with_dedup:global:2",
       "type": "web_search_result",
       "source": "web",
       "snippet": "E-Commerce-Wachstum 2024 in Deutschland: +8,3 %.",
-      "match_score": 0.72,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_d999e142db038350ae020558258731dc": {
+      "evidence_id": "ev_d999e142db038350ae020558258731dc",
+      "producer_key": "fixture:medium_with_dedup:global:3",
       "type": "graph_metric",
       "source": "neo4j-graph",
       "snippet": "Retourenquote Online-Kanal: 18 %.",
-      "match_score": 0.58,
-      "supports_claim": false
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_96700fd0992141ac4089b41335a340db": {
+      "evidence_id": "ev_96700fd0992141ac4089b41335a340db",
+      "producer_key": "fixture:medium_with_dedup:global:4",
       "type": "entity_summary",
       "source": "knowledge-base",
       "snippet": "Stationaerer Handel verliert Marktanteile seit 2020.",
-      "match_score": 0.7,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_6feeea6a37e66b102208bdaa26726f70": {
+      "evidence_id": "ev_6feeea6a37e66b102208bdaa26726f70",
+      "producer_key": "fixture:medium_with_dedup:global:5",
       "type": "agent_action",
       "source": "agent-log",
       "snippet": "Agent analysiert Kaufverhalten in der Altersgruppe 35-55.",
-      "match_score": 0.55,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_action",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_224c0d0e8e2b44adaa6651480fe7beb7": {
+      "evidence_id": "ev_224c0d0e8e2b44adaa6651480fe7beb7",
+      "producer_key": "fixture:medium_with_dedup:global:6",
       "type": "graph_fact",
       "source": "neo4j-graph",
       "snippet": "Preisakzeptanz im Premium-Segment gestiegen um 12 %.",
-      "match_score": 0.76,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
     },
-    {
+    "ev_c8a709e60494ef87954c7710b9e06624": {
+      "evidence_id": "ev_c8a709e60494ef87954c7710b9e06624",
+      "producer_key": "fixture:medium_with_dedup:global:7",
       "type": "web_search_result",
       "source": "web",
       "snippet": "Omnichannel-Strategien gewinnen laut Handelsstudie an Bedeutung.",
-      "match_score": 0.68,
-      "supports_claim": true
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_175b56fb874890c4c69790400dca3053": {
+      "evidence_id": "ev_175b56fb874890c4c69790400dca3053",
+      "producer_key": "fixture:medium_with_dedup:section:0:claim:0:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Segment Einzelhandel: 42 % der Befragten bevorzugen Online-Kauf.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_566e14f03c43fe493586d531f70ee5ea": {
+      "evidence_id": "ev_566e14f03c43fe493586d531f70ee5ea",
+      "producer_key": "fixture:medium_with_dedup:section:0:claim:1:evidence:0",
+      "type": "entity_summary",
+      "source": "knowledge-base",
+      "snippet": "Stationaerer Handel verliert Marktanteile seit 2020.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_40eb5a021abcc66cbec7a457e31cb54f": {
+      "evidence_id": "ev_40eb5a021abcc66cbec7a457e31cb54f",
+      "producer_key": "fixture:medium_with_dedup:section:1:claim:0:evidence:0",
+      "type": "agent_interview",
+      "source": "agent-log",
+      "snippet": "Persona Schmidt: Ich kaufe lieber im Geschaeft, weil ich das Produkt anfassen will.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_quote",
+      "source_model": null,
+      "persona_stakeholder_group": "fixture:agent-log"
+    },
+    "ev_62d2b7b1374ad449277673747369a66d": {
+      "evidence_id": "ev_62d2b7b1374ad449277673747369a66d",
+      "producer_key": "fixture:medium_with_dedup:section:1:claim:1:evidence:0",
+      "type": "graph_metric",
+      "source": "neo4j-graph",
+      "snippet": "Retourenquote Online-Kanal: 18 %.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_a57cf888cde88b01c324a9e6735b18d2": {
+      "evidence_id": "ev_a57cf888cde88b01c324a9e6735b18d2",
+      "producer_key": "fixture:medium_with_dedup:section:2:claim:0:evidence:0",
+      "type": "web_search_result",
+      "source": "web",
+      "snippet": "E-Commerce-Wachstum 2024 in Deutschland: +8,3 %.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_f2185617ead2aa782a89e0c9702e0a86": {
+      "evidence_id": "ev_f2185617ead2aa782a89e0c9702e0a86",
+      "producer_key": "fixture:medium_with_dedup:section:2:claim:1:evidence:0",
+      "type": "web_search_result",
+      "source": "web",
+      "snippet": "Omnichannel-Strategien gewinnen laut Handelsstudie an Bedeutung.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "web_source",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_577c5c3bbb193a0c064fc0cfdaa7f7a5": {
+      "evidence_id": "ev_577c5c3bbb193a0c064fc0cfdaa7f7a5",
+      "producer_key": "fixture:medium_with_dedup:section:3:claim:0:evidence:0",
+      "type": "graph_fact",
+      "source": "neo4j-graph",
+      "snippet": "Preisakzeptanz im Premium-Segment gestiegen um 12 %.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "graph_relation",
+      "source_model": null,
+      "persona_stakeholder_group": null
+    },
+    "ev_7a3eb3556a9fffb536f5d45ab6923f9a": {
+      "evidence_id": "ev_7a3eb3556a9fffb536f5d45ab6923f9a",
+      "producer_key": "fixture:medium_with_dedup:section:3:claim:1:evidence:0",
+      "type": "agent_action",
+      "source": "agent-log",
+      "snippet": "Agent analysiert Kaufverhalten in der Altersgruppe 35-55.",
+      "value": null,
+      "tool_name": null,
+      "query": null,
+      "raw": null,
+      "agent_log_ref": null,
+      "quote": null,
+      "source_id_anchor": null,
+      "sentiment_score": null,
+      "source_kind": "agent_action",
+      "source_model": null,
+      "persona_stakeholder_group": null
     }
+  },
+  "global_evidence_refs": [
+    "ev_7064a2513ebdd1a45ccd8d9e6b365b68",
+    "ev_0efd1b789393fd3843c4687cd58dee84",
+    "ev_aec4f56cc6866b4d30d5093c1b15cdf2",
+    "ev_d999e142db038350ae020558258731dc",
+    "ev_96700fd0992141ac4089b41335a340db",
+    "ev_6feeea6a37e66b102208bdaa26726f70",
+    "ev_224c0d0e8e2b44adaa6651480fe7beb7",
+    "ev_c8a709e60494ef87954c7710b9e06624"
   ],
   "sections": [
     {
@@ -73,14 +315,17 @@
           "confidence_score": 0.8,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Segment Einzelhandel: 42 % der Befragten bevorzugen Online-Kauf.",
+              "evidence_id": "ev_175b56fb874890c4c69790400dca3053",
               "match_score": 0.8,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_02",
@@ -89,16 +334,24 @@
           "confidence_score": 0.65,
           "evidence": [
             {
-              "type": "entity_summary",
-              "source": "knowledge-base",
-              "snippet": "Stationaerer Handel verliert Marktanteile seit 2020.",
+              "evidence_id": "ev_566e14f03c43fe493586d531f70ee5ea",
               "match_score": 0.7,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 2,
@@ -112,11 +365,13 @@
           "confidence_score": 0.6,
           "evidence": [
             {
-              "type": "agent_interview",
-              "source": "agent-log",
-              "snippet": "Persona Schmidt: Ich kaufe lieber im Geschaeft, weil ich das Produkt anfassen will.",
+              "evidence_id": "ev_40eb5a021abcc66cbec7a457e31cb54f",
               "match_score": 0.65,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
           "audit_trail": [
@@ -131,7 +386,8 @@
                 "matched_section_index": 1
               }
             }
-          ]
+          ],
+          "notes": null
         },
         {
           "claim_id": "claim_04",
@@ -140,16 +396,24 @@
           "confidence_score": 0.45,
           "evidence": [
             {
-              "type": "graph_metric",
-              "source": "neo4j-graph",
-              "snippet": "Retourenquote Online-Kanal: 18 %.",
+              "evidence_id": "ev_62d2b7b1374ad449277673747369a66d",
               "match_score": 0.58,
-              "supports_claim": false
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": false,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 3,
@@ -163,14 +427,17 @@
           "confidence_score": 0.72,
           "evidence": [
             {
-              "type": "web_search_result",
-              "source": "web",
-              "snippet": "E-Commerce-Wachstum 2024 in Deutschland: +8,3 %.",
+              "evidence_id": "ev_a57cf888cde88b01c324a9e6735b18d2",
               "match_score": 0.72,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_06",
@@ -179,16 +446,24 @@
           "confidence_score": 0.65,
           "evidence": [
             {
-              "type": "web_search_result",
-              "source": "web",
-              "snippet": "Omnichannel-Strategien gewinnen laut Handelsstudie an Bedeutung.",
+              "evidence_id": "ev_f2185617ead2aa782a89e0c9702e0a86",
               "match_score": 0.68,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     },
     {
       "section_index": 4,
@@ -202,14 +477,17 @@
           "confidence_score": 0.76,
           "evidence": [
             {
-              "type": "graph_fact",
-              "source": "neo4j-graph",
-              "snippet": "Preisakzeptanz im Premium-Segment gestiegen um 12 %.",
+              "evidence_id": "ev_577c5c3bbb193a0c064fc0cfdaa7f7a5",
               "match_score": 0.76,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         },
         {
           "claim_id": "claim_08",
@@ -218,16 +496,25 @@
           "confidence_score": 0.55,
           "evidence": [
             {
-              "type": "agent_action",
-              "source": "agent-log",
-              "snippet": "Agent analysiert Kaufverhalten in der Altersgruppe 35-55.",
+              "evidence_id": "ev_7a3eb3556a9fffb536f5d45ab6923f9a",
               "match_score": 0.55,
-              "supports_claim": true
+              "retrieval_score": null,
+              "entailment": null,
+              "entailment_reason": null,
+              "supports_claim": true,
+              "contradicts_claim": null
             }
           ],
-          "audit_trail": []
+          "audit_trail": [],
+          "notes": null
         }
-      ]
+      ],
+      "hypotheses": [],
+      "hypotheses_appendix": [],
+      "data_gaps": [],
+      "structured_metadata": {},
+      "generation_failed": false
     }
-  ]
+  ],
+  "degradation_log": []
 }

--- a/backend/tests/eval/test_eval_baselines.py
+++ b/backend/tests/eval/test_eval_baselines.py
@@ -28,7 +28,7 @@ FIXTURE_NAMES = sorted(EXPECTED.keys())
 def metrics() -> dict[str, dict[str, float]]:
     out: dict[str, dict[str, float]] = {}
     for name in FIXTURE_NAMES:
-        ev = load_one(FIXTURES_DIR / name, 2)
+        ev = load_one(FIXTURES_DIR / name, 3)
         assert ev is not None, f"Fixture {name} ist nicht ladbar"
         out[name] = evaluate(ev)
     return out
@@ -54,7 +54,7 @@ def test_metrics_match_snapshot(name: str, metrics: dict[str, dict[str, float]])
 
 def test_evaluate_output_keys() -> None:
     """check_evidence_quality.evaluate() muss alle Layer-5-Metriken liefern."""
-    ev = load_one(FIXTURES_DIR / FIXTURE_NAMES[0], 2)
+    ev = load_one(FIXTURES_DIR / FIXTURE_NAMES[0], 3)
     assert ev is not None
     m = evaluate(ev)
     required = {

--- a/backend/tests/services/test_evidence_migrations_aggregation.py
+++ b/backend/tests/services/test_evidence_migrations_aggregation.py
@@ -164,6 +164,29 @@ class TestVollAggregation:
         assert anna.voice_register == "technical-de"
         assert anna.alter_range == "38"
 
+    def test_persona_evidence_exports_only_minimal_provenance(self):
+        store = InMemoryArtifactStore()
+        sim_id = "sim_profile_provenance"
+        profiles = _make_reddit_profiles()
+        profiles[0]["private_profile_field"] = "darf nicht exportiert werden"
+        store.write_json(sim_id, "reddit_profiles", profiles)
+
+        result = migrate_v2_to_v3(
+            _make_v2_with_sections(),
+            simulation_id=sim_id,
+            artifact_store=store,
+        )
+        record = next(
+            item
+            for item in result["evidence_index"].values()
+            if item["producer_key"] == "entity:ent-001"
+        )
+
+        assert record["raw"] == {
+            "source_entity_uuid": "ent-001",
+            "source_entity_type": "individual",
+        }
+
     def test_no_datengap_personas_marker_wenn_personas_vorhanden(self):
         """Mit Personas kein dg-migration-personas DataGap-Eintrag."""
         store = InMemoryArtifactStore()

--- a/backend/tests/services/test_legacy_evidence_identity_migration.py
+++ b/backend/tests/services/test_legacy_evidence_identity_migration.py
@@ -1,0 +1,47 @@
+"""Legacy-Evidence ohne rekonstruierbare Identität bleibt unbelegt."""
+
+from app.services.evidence_migrations import migrate_v2_to_v3
+
+
+def _legacy_report_tool_payload() -> dict:
+    return {
+        "schema_version": 2,
+        "report_id": "legacy-report-17",
+        "simulation_id": "run-17",
+        "sections": [
+            {
+                "section_index": 1,
+                "section_title": "Wirkungsanalyse",
+                "section_summary": "Legacy-Abschnitt.",
+                "claims": [
+                    {
+                        "claim_id": "claim_01",
+                        "claim_text": "Die Zielgruppe reagiert positiv auf den Ansatz.",
+                        "confidence_label": "low",
+                        "confidence_score": 0.4,
+                        "evidence": [
+                            {
+                                "type": "graph_fact",
+                                "source": "report_tool",
+                                "snippet": "LLM-generierter Auszug ohne stabilen Quellschlüssel.",
+                                "source_kind": "graph_relation",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_legacy_report_tool_becomes_unresolved_hypothesis_not_claim() -> None:
+    migrated = migrate_v2_to_v3(_legacy_report_tool_payload())
+
+    assert migrated["claims"] == []
+    assert migrated["evidence_index"] == {}
+    assert any(
+        hypothesis["hypothesis_text"]
+        == "Die Zielgruppe reagiert positiv auf den Ansatz."
+        and "legacy_unresolved" in hypothesis["rationale"]
+        for hypothesis in migrated["hypotheses"]
+    )

--- a/backend/tests/services/test_legacy_evidence_identity_migration.py
+++ b/backend/tests/services/test_legacy_evidence_identity_migration.py
@@ -1,6 +1,11 @@
 """Legacy-Evidence ohne rekonstruierbare Identität bleibt unbelegt."""
 
-from app.services.evidence_migrations import migrate_v2_to_v3
+from app.services.evidence_identity import build_evidence_id
+from app.services.evidence_migrations import (
+    migrate_evidence_map_v2_to_v3,
+    migrate_v2_to_v3,
+    normalize_persisted_evidence_map,
+)
 
 
 def _legacy_report_tool_payload() -> dict:
@@ -45,3 +50,84 @@ def test_legacy_report_tool_becomes_unresolved_hypothesis_not_claim() -> None:
         and "legacy_unresolved" in hypothesis["rationale"]
         for hypothesis in migrated["hypotheses"]
     )
+
+
+def test_short_legacy_claim_is_not_promoted_to_hypothesis() -> None:
+    payload = _legacy_report_tool_payload()
+    payload["sections"][0]["claims"][0]["claim_text"] = "kurz"
+
+    migrated = migrate_evidence_map_v2_to_v3(payload)
+    section = migrated["sections"][0]
+
+    assert section["claims"] == []
+    assert section["hypotheses"] == []
+
+
+def test_missing_legacy_snippet_gets_explicit_placeholder() -> None:
+    payload = _legacy_report_tool_payload()
+    item = payload["sections"][0]["claims"][0]["evidence"][0]
+    item.pop("snippet")
+    item["producer_key"] = "graph-node:legacy-17"
+
+    migrated = migrate_evidence_map_v2_to_v3(payload)
+    record = next(iter(migrated["evidence_index"].values()))
+
+    assert record["snippet"] == "[legacy evidence snippet missing]"
+
+
+def test_current_map_resolves_global_evidence_additively() -> None:
+    scope_id = "sim-current-17"
+    existing_id = build_evidence_id(scope_id, "graph_relation", "graph-node:existing")
+    global_id = build_evidence_id(scope_id, "graph_relation", "graph-node:global")
+    payload = {
+        "schema_version": 3,
+        "report_id": "report-current-17",
+        "simulation_id": scope_id,
+        "evidence_index": {
+            existing_id: {
+                "evidence_id": existing_id,
+                "producer_key": "graph-node:existing",
+                "type": "graph_fact",
+                "source": "graph",
+                "snippet": "Bestehender Record.",
+                "source_kind": "graph_relation",
+            }
+        },
+        "global_evidence_refs": [],
+        "global_evidence": [
+            {
+                "producer_key": "graph-node:global",
+                "type": "graph_fact",
+                "source": "graph",
+                "snippet": "Globaler Record.",
+                "source_kind": "graph_relation",
+            }
+        ],
+        "sections": [
+            {
+                "section_index": 1,
+                "section_title": "Bestehend",
+                "section_summary": "Bestehende Section bleibt unverändert.",
+                "claims": [
+                    {
+                        "claim_id": "claim_01",
+                        "claim_text": "Bestehende Bindung bleibt vollständig erhalten.",
+                        "confidence_label": "low",
+                        "confidence_score": 0.4,
+                        "evidence": [
+                            {"evidence_id": existing_id, "supports_claim": True}
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    normalized = normalize_persisted_evidence_map(payload)
+
+    assert normalized["schema_version"] == 3
+    assert normalized["sections"][0]["claims"][0]["evidence"][0]["evidence_id"] == existing_id
+    assert normalized["evidence_index"][existing_id]["snippet"] == "Bestehender Record."
+    assert normalized["evidence_index"][global_id]["snippet"] == "Globaler Record."
+    assert normalized["global_evidence_refs"] == [global_id]
+    assert "global_evidence" not in normalized

--- a/backend/tests/services/test_report_agent_quote_anchors.py
+++ b/backend/tests/services/test_report_agent_quote_anchors.py
@@ -242,9 +242,12 @@ class TestEmptySection:
 class TestEvidenceMapModelInstance:
     def test_accepts_evidence_map_model_instance(self):
         """validate_quote_anchors() akzeptiert auch EvidenceMapModel-Objekte."""
-        from app.contracts.report_contract import EvidenceMapModel, EvidenceItemModel, EvidenceType
+        from app.contracts.report_contract import EvidenceMapModel, EvidenceRecordModel, EvidenceType
 
-        item = EvidenceItemModel(
+        evidence_id = "ev_00000000000000000000000000000001"
+        item = EvidenceRecordModel(
+            evidence_id=evidence_id,
+            producer_key="quote-anchor-fixture",
             type=EvidenceType.graph_fact,
             source="test-src",
             snippet="Test-Snippet",
@@ -253,7 +256,8 @@ class TestEvidenceMapModelInstance:
         em = EvidenceMapModel(
             report_id="r1",
             simulation_id="s1",
-            global_evidence=[item],
+            evidence_index={evidence_id: item},
+            global_evidence_refs=[evidence_id],
             sections=[],
         )
 

--- a/backend/tests/services/test_report_v3_markdown_renderer.py
+++ b/backend/tests/services/test_report_v3_markdown_renderer.py
@@ -13,9 +13,20 @@ from app.services.report_agent.markdown_renderer import (
 
 
 def test_report_v3_renderer_outputs_tables_and_data_gaps() -> None:
+    evidence_id = "ev_00000000000000000000000000000001"
     report = ReportV3(
         report_id="report_abcdef123456",
         generated_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        evidence_index={
+            evidence_id: {
+                "evidence_id": evidence_id,
+                "producer_key": "metric:echo_chamber_index",
+                "type": "graph_metric",
+                "source": "simulation_metrics",
+                "snippet": "echo_chamber_index: 0.42",
+                "source_kind": "graph_relation",
+            }
+        },
         personas=[
             Persona(
                 id="P01",
@@ -37,7 +48,7 @@ def test_report_v3_renderer_outputs_tables_and_data_gaps() -> None:
             Claim(
                 id="claim_01",
                 statement="Sicherheitsbedenken sind ein sichtbarer Hemmfaktor.",
-                evidence_refs=["kg:metric:echo_chamber_index"],
+                evidence_refs=[evidence_id],
                 confidence="medium",
                 aggregation_basis="persona",
             )

--- a/backend/tests/test_evidence_migration.py
+++ b/backend/tests/test_evidence_migration.py
@@ -12,8 +12,8 @@ from app.services.evidence_migrations import (
 )
 
 
-def test_current_schema_version_is_2():
-    assert CURRENT_SCHEMA_VERSION == 2
+def test_current_schema_version_is_3():
+    assert CURRENT_SCHEMA_VERSION == 3
 
 
 def test_migrate_none_returns_none():

--- a/backend/tests/test_llm_e2e_stub.py
+++ b/backend/tests/test_llm_e2e_stub.py
@@ -84,7 +84,7 @@ class TestStubValidatesAgainstReportV3DTO:
         resp = e2e_stub_response(schema=schema, messages=_minimal_messages())
         # Darf keine ValidationError / Exception werfen
         validated = ReportV3.model_validate(resp)
-        assert validated.schema_version == 3
+        assert validated.schema_version == 4
         assert validated.report_id == "e2e-stub-report-001"
 
     def test_stub_passes_pydantic_class_as_schema(self) -> None:
@@ -165,7 +165,7 @@ class TestStubActiveWithEnv:
 
             # Ergebnis ist valides ReportV3
             validated = ReportV3.model_validate(result)
-            assert validated.schema_version == 3
+        assert validated.schema_version == 4
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_report_agent_contracts.py
+++ b/backend/tests/test_report_agent_contracts.py
@@ -231,3 +231,31 @@ def test_reviewer_floor_counts_unique_evidence_ids(tmp_path):
     assert finalized == []
     assert len(hypotheses) == 1
     assert "nur 1 von 2" in hypotheses[0]["rationale"]
+
+
+def test_duplicate_producer_key_preserves_first_record() -> None:
+    from app.services.report_agent.evidence import register_evidence_record
+
+    evidence_map = {"evidence_index": {}}
+    first = {
+        "producer_key": "graph-node:17",
+        "type": "graph_fact",
+        "source": "graph",
+        "snippet": "Erster unveränderlicher Payload.",
+        "source_kind": "graph_relation",
+    }
+    conflicting = {
+        **first,
+        "snippet": "Abweichender späterer Payload.",
+    }
+
+    registered_first = register_evidence_record(
+        evidence_map, first, scope_id="sim-17"
+    )
+    registered_conflict = register_evidence_record(
+        evidence_map, conflicting, scope_id="sim-17"
+    )
+
+    evidence_id = registered_first["evidence_id"]
+    assert registered_conflict == registered_first
+    assert evidence_map["evidence_index"][evidence_id]["snippet"] == first["snippet"]

--- a/backend/tests/test_report_agent_contracts.py
+++ b/backend/tests/test_report_agent_contracts.py
@@ -54,11 +54,11 @@ def _make_valid_evidence_item() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Test 1: _init_evidence_map — schema_version == 2 und EvidenceMapModel-konform
+# Test 1: _init_evidence_map — schema_version == 3 und EvidenceMapModel-konform
 # ---------------------------------------------------------------------------
 
-def test_init_evidence_map_sets_schema_version_2(tmp_path):
-    """_init_evidence_map muss schema_version=2 setzen und EvidenceMapModel-konform sein."""
+def test_init_evidence_map_sets_schema_version_3(tmp_path):
+    """_init_evidence_map muss schema_version=3 setzen und EvidenceMapModel-konform sein."""
     agent = _make_agent(tmp_path)
 
     # _collect_simulation_evidence_items liefert leere Liste (keine echte Simulation)
@@ -68,14 +68,14 @@ def test_init_evidence_map_sets_schema_version_2(tmp_path):
 
     assert agent.evidence_map is not None
     assert agent.evidence_map["schema_version"] == CURRENT_SCHEMA_VERSION
-    assert agent.evidence_map["schema_version"] == 2
+    assert agent.evidence_map["schema_version"] == 3
     assert agent.evidence_map["report_id"] == "report_abc123"
     assert agent.evidence_map["simulation_id"] == "sim_test"
     assert isinstance(agent.evidence_map["sections"], list)
 
     # Nochmals gegen das Modell validieren — darf keine Exception werfen
     validated = EvidenceMapModel.model_validate(agent.evidence_map)
-    assert validated.schema_version == 2
+    assert validated.schema_version == 3
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ def test_save_evidence_section_round_trip(tmp_path):
     """
     Vollständiger Round-Trip: _save_evidence_section mit valider Section,
     dann erneutes EvidenceMapModel.model_validate → keine Exception,
-    schema_version bleibt 2.
+    schema_version bleibt 3.
     """
     agent = _make_agent(tmp_path)
     agent._collect_simulation_evidence_items = MagicMock(return_value=[])
@@ -165,7 +165,7 @@ def test_save_evidence_section_round_trip(tmp_path):
 
     # Erneute Validierung des persistierten Dicts
     re_validated = EvidenceMapModel.model_validate(persisted_payload)
-    assert re_validated.schema_version == 2
+    assert re_validated.schema_version == 3
     assert len(re_validated.sections) == 1
     assert re_validated.sections[0].section_index == 1
 
@@ -209,3 +209,25 @@ def test_save_evidence_section_routes_orphans_to_gaps(tmp_path):
     assert len(section.hypotheses) == 1
     assert len(section.data_gaps) == 1
     assert section.data_gaps[0].gap_reason == "no_evidence_bound"
+
+
+def test_reviewer_floor_counts_unique_evidence_ids(tmp_path):
+    """Zwei Bindings auf denselben Record sind nur eine unabhängige Quelle."""
+    agent = _make_agent(tmp_path)
+    evidence_id = "ev_0123456789abcdef0123456789abcdef"
+    claim = {
+        "claim_id": "claim_01",
+        "claim_text": "Eine doppelt gebundene Quelle bleibt nur eine Quelle.",
+        "confidence_label": "low",
+        "confidence_score": 0.4,
+        "evidence": [
+            {"evidence_id": evidence_id, "supports_claim": True},
+            {"evidence_id": evidence_id, "supports_claim": True},
+        ],
+    }
+
+    finalized, hypotheses, _ = agent._finalize_section_claims([claim])
+
+    assert finalized == []
+    assert len(hypotheses) == 1
+    assert "nur 1 von 2" in hypotheses[0]["rationale"]

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -102,6 +102,7 @@ def _persist_report(*, with_evidence: bool = False) -> None:
                                 {
                                     "type": "agent_interview",
                                     "source_kind": "agent_quote",
+                                    "producer_key": "agent_07:interview:1",
                                     "source": "agent_07",
                                     "snippet": "Ich warte lieber ab.",
                                     "quote": "Ich warte lieber ab.",
@@ -112,6 +113,7 @@ def _persist_report(*, with_evidence: bool = False) -> None:
                                 {
                                     "type": "graph_fact",
                                     "source_kind": "seed_corpus",
+                                    "producer_key": "briefing.md#q3",
                                     "source": "briefing.md",
                                     "snippet": "Das Vorhaben startet im Q3.",
                                     "match_score": 0.75,
@@ -290,7 +292,7 @@ def test_export_json_returns_combined_envelope(env):
     # Sub-Slice 02b: Export-Envelope ist ein ReportContractModel — schema_version
     # ist auf v2 fix-getypt (Literal[2]) und kann nicht mehr driften.
     assert payload["schema_version"] == 2
-    assert payload["evidence"]["schema_version"] == 2
+    assert payload["evidence"]["schema_version"] == 3
     assert payload["exported_at"]
     assert payload["report"]["report_id"] == REPORT_ID
     assert payload["report"]["status"] == "completed"

--- a/backend/tests/test_report_manager.py
+++ b/backend/tests/test_report_manager.py
@@ -162,8 +162,8 @@ def test_build_claims_uses_embedder_and_emits_match_score():
     assert not any("Bayern" in (e.get("snippet") or "") for e in matches)
 
 
-def test_init_evidence_map_sets_schema_version_2(monkeypatch):
-    """S4b: neue Evidence-Maps tragen schema_version=2."""
+def test_init_evidence_map_sets_schema_version_3(monkeypatch):
+    """Kanonische Evidence-Maps tragen den ID-Vertrag schema_version=3."""
     agent = ReportAgent.__new__(ReportAgent)
     agent.simulation_id = "sim_xyz"
 
@@ -173,7 +173,7 @@ def test_init_evidence_map_sets_schema_version_2(monkeypatch):
         lambda self: [],
     )
     agent._init_evidence_map("rep_001")
-    assert agent.evidence_map["schema_version"] == 2
+    assert agent.evidence_map["schema_version"] == 3
 
 
 def test_report_claim_model_keeps_legacy_fields_and_numeric_score():
@@ -218,14 +218,16 @@ def test_report_claim_model_keeps_legacy_fields_and_numeric_score():
     # (len==2, Bedingung len<2 ist False). consistency: 1 unique (type,source)-Paar → 0.6.
     # relevance(0.5) + source_quality(1.0) + specificity(0.5) + consistency(0.6)
     # = 0.40*0.5 + 0.25*1.0 + 0.20*0.5 + 0.15*0.6 = 0.64, Label "low" (Slice-2: < 0.65).
-    assert claims[0]["confidence"] == "low"
-    assert claims[0]["confidence_score"] == 0.64
+    # Freie ``report_tool``-Strings besitzen keinen Producer-Key und dürfen
+    # deshalb weder Confidence noch Claim-Status dekorativ erhöhen.
+    assert claims[0]["confidence"] == "speculative"
+    assert claims[0]["confidence_score"] == 0.15
     assert claims[0]["evidence"] == claims[0]["evidence_items"]
     # S5: model_generated_inference darf nicht mehr im Evidence-Array sein.
     evidence_types = {item["type"] for item in claims[0]["evidence"]}
     assert "model_generated_inference" not in evidence_types
-    # Nach Sub-Slice 07: nur noch graph_fact (kein global graph_metric-Leak)
-    assert evidence_types == {"graph_fact"}
+    # Ohne stabilen Producer-Key bleibt auch graph_fact reine Audit-Evidence.
+    assert evidence_types == set()
     # Statt dessen lebt die Synthese im audit_trail.
     audit_types = {item["type"] for item in claims[0].get("audit_trail", [])}
     assert "model_generated_inference" in audit_types

--- a/changelog.d/1147-evidence-identity.md
+++ b/changelog.d/1147-evidence-identity.md
@@ -1,0 +1,3 @@
+### Fixed (Kanonische Evidence-Identität — 2026-08-09)
+
+- **Report-Claims referenzieren Evidence jetzt über deterministische IDs:** EvidenceMap v3 und ReportV3 v4 trennen unveränderliche Source-Records von Claim-relativen Bindings, validieren alle Cross-References und stufen nicht auflösbare Legacy-Refs ehrlich zu Hypothesen ab.

--- a/changelog.d/1147-evidence-identity.md
+++ b/changelog.d/1147-evidence-identity.md
@@ -1,3 +1,4 @@
 ### Fixed (Kanonische Evidence-Identität — 2026-08-09)
 
 - **Report-Claims referenzieren Evidence jetzt über deterministische IDs:** EvidenceMap v3 und ReportV3 v4 trennen unveränderliche Source-Records von Claim-relativen Bindings, validieren alle Cross-References und stufen nicht auflösbare Legacy-Refs ehrlich zu Hypothesen ab.
+- **Legacy- und CI-Pfade verwenden denselben aktuellen Evidence-Vertrag:** Persistierte ReportV3-v3-Daten werden vor der Validierung kompatibel hochgestuft, EvidenceMap-v3-Ergänzungen bleiben verlustfrei und der Quality-Gate prüft kanonische v3-Fixtures.

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -222,10 +222,11 @@ const VALID_REPORT: Report = {
 
 // Valides EvidenceMap-Payload
 const VALID_EVIDENCE: EvidenceMap = {
-  schema_version: 2,
+  schema_version: 3,
   report_id: 'report_test01',
   simulation_id: 'sim_test01',
-  global_evidence: [],
+  evidence_index: {},
+  global_evidence_refs: [],
   sections: [],
   // Issue #1006: additives Feld mit Default. Wie global_evidence und sections
   // ist es im z.infer-Output-Typ required, obwohl es beim Parsen optional ist.
@@ -384,10 +385,11 @@ describe('Step4Report — strict-Zod-Parse (Sub-Slice 15)', () => {
     ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
       data: {
-        schema_version: 2,
+        schema_version: 3,
         report_id: 'report_test01',
         // simulation_id fehlt — Pflichtfeld
-        global_evidence: [],
+        evidence_index: {},
+        global_evidence_refs: [],
         sections: [],
       },
     })
@@ -518,12 +520,35 @@ describe('Step4Report — INCOMPLETE-Status und generation_failed (P2.6)', () =>
 
 // Sub-Slice 16b: klickbare Quotes + source_id_anchor-Scroll (Refs #173)
 describe('Quote + Anchor (Sub-Slice 16b)', () => {
+  const QUOTE_EVIDENCE_ID = 'ev_00000000000000000000000000000011'
+  const SEED_EVIDENCE_ID = 'ev_00000000000000000000000000000012'
   // EvidenceMap mit einem Item, das quote + source_id_anchor hat
   const EVIDENCE_WITH_QUOTE = {
-    schema_version: 2,
+    schema_version: 3,
     report_id: 'report_test01',
     simulation_id: 'sim_test01',
-    global_evidence: [],
+    evidence_index: {
+      [QUOTE_EVIDENCE_ID]: {
+        evidence_id: QUOTE_EVIDENCE_ID,
+        producer_key: 'agent:test:quote:1',
+        type: 'agent_interview',
+        source: 'agent_log',
+        snippet: 'Snippet-Text ohne Quote',
+        quote: 'Dies ist ein wörtliches Zitat aus der Quelle.',
+        source_id_anchor: 'agent-log-1#entry-testentry',
+        source_kind: 'agent_quote',
+        persona_stakeholder_group: 'Testgruppe',
+      },
+      [SEED_EVIDENCE_ID]: {
+        evidence_id: SEED_EVIDENCE_ID,
+        producer_key: 'seed:test:quote:1',
+        type: 'graph_fact',
+        source: 'briefing.md',
+        snippet: 'Seed-Beleg für den Quote-Test.',
+        source_kind: 'seed_corpus',
+      },
+    },
+    global_evidence_refs: [],
     sections: [
       {
         section_index: 1,
@@ -547,13 +572,14 @@ describe('Quote + Anchor (Sub-Slice 16b)', () => {
             confidence_score: 0.85,
             evidence: [
               {
-                type: 'graph_fact',
-                source: 'neo4j',
-                snippet: 'Snippet-Text ohne Quote',
+                evidence_id: QUOTE_EVIDENCE_ID,
                 supports_claim: true,
                 match_score: 0.9,
-                quote: 'Dies ist ein wörtliches Zitat aus der Quelle.',
-                source_id_anchor: 'agent-log-1#entry-testentry',
+              },
+              {
+                evidence_id: SEED_EVIDENCE_ID,
+                supports_claim: true,
+                match_score: 0.8,
               },
             ],
             audit_trail: [],
@@ -564,10 +590,29 @@ describe('Quote + Anchor (Sub-Slice 16b)', () => {
   }
 
   const EVIDENCE_WITHOUT_QUOTE = {
-    schema_version: 2,
+    schema_version: 3,
     report_id: 'report_test01',
     simulation_id: 'sim_test01',
-    global_evidence: [],
+    evidence_index: {
+      [QUOTE_EVIDENCE_ID]: {
+        evidence_id: QUOTE_EVIDENCE_ID,
+        producer_key: 'agent:test:quote:1',
+        type: 'agent_interview',
+        source: 'agent_log',
+        snippet: 'Nur Snippet, kein Quote',
+        source_kind: 'agent_quote',
+        persona_stakeholder_group: 'Testgruppe',
+      },
+      [SEED_EVIDENCE_ID]: {
+        evidence_id: SEED_EVIDENCE_ID,
+        producer_key: 'seed:test:quote:1',
+        type: 'graph_fact',
+        source: 'briefing.md',
+        snippet: 'Seed-Beleg für den Quote-Test.',
+        source_kind: 'seed_corpus',
+      },
+    },
+    global_evidence_refs: [],
     sections: [
       {
         section_index: 1,
@@ -582,11 +627,14 @@ describe('Quote + Anchor (Sub-Slice 16b)', () => {
             confidence_score: 0.85,
             evidence: [
               {
-                type: 'graph_fact',
-                source: 'neo4j',
-                snippet: 'Nur Snippet, kein Quote',
+                evidence_id: QUOTE_EVIDENCE_ID,
                 supports_claim: true,
                 match_score: 0.9,
+              },
+              {
+                evidence_id: SEED_EVIDENCE_ID,
+                supports_claim: true,
+                match_score: 0.8,
               },
             ],
             audit_trail: [],
@@ -665,22 +713,13 @@ describe('Quote + Anchor (Sub-Slice 16b)', () => {
   it('click auf web-anchor ruft window.open auf', async () => {
     const EVIDENCE_WEB = {
       ...EVIDENCE_WITH_QUOTE,
-      sections: [
-        {
-          ...EVIDENCE_WITH_QUOTE.sections[0],
-          claims: [
-            {
-              ...EVIDENCE_WITH_QUOTE.sections[0].claims[0],
-              evidence: [
-                {
-                  ...EVIDENCE_WITH_QUOTE.sections[0].claims[0].evidence[0],
-                  source_id_anchor: 'web:https://example.com/artikel',
-                },
-              ],
-            },
-          ],
+      evidence_index: {
+        ...EVIDENCE_WITH_QUOTE.evidence_index,
+        [QUOTE_EVIDENCE_ID]: {
+          ...EVIDENCE_WITH_QUOTE.evidence_index[QUOTE_EVIDENCE_ID],
+          source_id_anchor: 'web:https://example.com/artikel',
         },
-      ],
+      },
     }
 
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
@@ -803,11 +842,29 @@ describe('Step4Report — agentLog-Polling-Intervall (Sub-Slice J.3)', () => {
 })
 
 describe('Step4Report — ConfidenceBadge-Integration (Sub-Slice 16a)', () => {
+  const C1_QUOTE_ID = 'ev_00000000000000000000000000000021'
+  const C1_SEED_ID = 'ev_00000000000000000000000000000022'
+  const C2_QUOTE_ID = 'ev_00000000000000000000000000000023'
+  const C2_SEED_ID = 'ev_00000000000000000000000000000024'
   const VALID_EVIDENCE_WITH_SECTIONS = {
-    schema_version: 2,
+    schema_version: 3,
     report_id: 'report_test01',
     simulation_id: 'sim_test01',
-    global_evidence: [],
+    evidence_index: Object.fromEntries([
+      [C1_QUOTE_ID, 'Claim 1 Quote', 'agent_quote', 'Gruppe A'],
+      [C1_SEED_ID, 'Claim 1 Seed', 'seed_corpus', null],
+      [C2_QUOTE_ID, 'Claim 2 Quote', 'agent_quote', 'Gruppe B'],
+      [C2_SEED_ID, 'Claim 2 Seed', 'seed_corpus', null],
+    ].map(([evidenceId, snippet, sourceKind, stakeholderGroup]) => [evidenceId, {
+      evidence_id: evidenceId,
+      producer_key: `confidence:${evidenceId}`,
+      type: sourceKind === 'agent_quote' ? 'agent_interview' : 'graph_fact',
+      source: sourceKind === 'agent_quote' ? 'agent_log' : 'briefing.md',
+      snippet,
+      source_kind: sourceKind,
+      ...(stakeholderGroup ? { persona_stakeholder_group: stakeholderGroup } : {}),
+    }])),
+    global_evidence_refs: [],
     sections: [
       {
         section_index: 1,
@@ -823,12 +880,11 @@ describe('Step4Report — ConfidenceBadge-Integration (Sub-Slice 16a)', () => {
             confidence_score: 0.8,
             evidence: [
               {
-                type: 'graph_fact',
-                source: 'neo4j',
-                snippet: 'Graph-Fakt A',
+                evidence_id: C1_QUOTE_ID,
                 supports_claim: true,
                 match_score: 0.9,
               },
+              { evidence_id: C1_SEED_ID, supports_claim: true, match_score: 0.8 },
             ],
             audit_trail: [{ source: 'graph_tool', snippet: 'Audit A' }],
           },
@@ -846,12 +902,11 @@ describe('Step4Report — ConfidenceBadge-Integration (Sub-Slice 16a)', () => {
             confidence_score: 0.5,
             evidence: [
               {
-                type: 'graph_fact',
-                source: 'neo4j',
-                snippet: 'Graph-Fakt B',
+                evidence_id: C2_QUOTE_ID,
                 supports_claim: true,
                 match_score: 0.6,
               },
+              { evidence_id: C2_SEED_ID, supports_claim: true, match_score: 0.7 },
             ],
             audit_trail: [{ source: 'agent_log', snippet: 'Audit B' }],
           },

--- a/frontend/src/components/step4/ReportEvidencePanel.vue
+++ b/frontend/src/components/step4/ReportEvidencePanel.vue
@@ -2,14 +2,17 @@
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Badge from '../ui/Badge.vue'
-import type { EvidenceItem, ReportClaim, ReportSection } from '../../contracts/reportContract'
+import type { EvidenceIndex, EvidenceRecord, ReportClaim, ReportSection } from '../../contracts/reportContract'
 
 interface Props {
   sections: ReportSection[]
+  evidenceIndex?: EvidenceIndex
   selectedSection: number | null
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  evidenceIndex: () => ({}),
+})
 
 const emit = defineEmits<{
   'update:selectedSection': [sectionIndex: number]
@@ -51,11 +54,14 @@ function claimConfidenceText(claim: ReportClaim | null | undefined): string {
   return score === null ? label : `${Math.round(score * 100)}% · ${label}`
 }
 
-function claimEvidenceItems(claim: ReportClaim | null | undefined): EvidenceItem[] {
-  return Array.isArray(claim?.evidence) ? claim.evidence : []
+function claimEvidenceItems(claim: ReportClaim | null | undefined): EvidenceRecord[] {
+  if (!Array.isArray(claim?.evidence)) return []
+  return claim.evidence
+    .map((binding) => props.evidenceIndex[binding.evidence_id])
+    .filter((record): record is EvidenceRecord => record !== undefined)
 }
 
-function evidenceSnippet(item: EvidenceItem | null | undefined): string {
+function evidenceSnippet(item: EvidenceRecord | null | undefined): string {
   return item?.snippet ?? ''
 }
 

--- a/frontend/src/components/step4/ReportFinalView.vue
+++ b/frontend/src/components/step4/ReportFinalView.vue
@@ -5,7 +5,7 @@ import Kicker from '@/components/v4/data/Kicker.vue'
 import ReportEvidencePanel from './ReportEvidencePanel.vue'
 import ReportBranchControls from './ReportBranchControls.vue'
 import ReportRedTeamSection from '../report/ReportRedTeamSection.vue'
-import type { ReportSection } from '../../contracts/reportContract'
+import type { EvidenceIndex, ReportSection } from '../../contracts/reportContract'
 
 const { t } = useI18n()
 
@@ -13,6 +13,7 @@ withDefaults(defineProps<{
   reportHtml: string
   redTeamFindings?: string[]
   evidenceSections?: ReportSection[]
+  evidenceIndex?: EvidenceIndex
   selectedEvidenceSection?: number | null
   resolvedSimulationId?: string | null
   simulationId?: string
@@ -20,6 +21,7 @@ withDefaults(defineProps<{
 }>(), {
   redTeamFindings: () => [],
   evidenceSections: () => [],
+  evidenceIndex: () => ({}),
   selectedEvidenceSection: null,
   resolvedSimulationId: null,
   simulationId: '',
@@ -62,6 +64,7 @@ const emit = defineEmits([
           v-if="evidenceSections.length"
           :selected-section="selectedEvidenceSection"
           :sections="evidenceSections"
+          :evidence-index="evidenceIndex"
           @update:selected-section="emit('update:selectedEvidenceSection', $event)"
           @navigate="emit('navigate', $event)"
         />

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -650,6 +650,7 @@ const sectionHtml = computed((): Record<string, string> => {
 })
 
 const evidenceSections = computed(() => evidenceMap.value?.sections || [])
+const evidenceIndex = computed(() => evidenceMap.value?.evidence_index || {})
 
 function navigateToAnchor(anchor: string | null | undefined) {
   const parsed = parseSourceAnchor(anchor)
@@ -877,6 +878,7 @@ onUnmounted(stopPolling)
         :report-html="reportHtml"
         :red-team-findings="redTeamFindings"
         :evidence-sections="evidenceSections"
+        :evidence-index="evidenceIndex"
         :selected-evidence-section="selectedEvidenceSection"
         :resolved-simulation-id="resolvedSimulationId"
         :simulation-id="simulationId"

--- a/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
+++ b/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import * as reportContract from '../reportContract';
+import { ReportV3Schema } from '../reportV3Contract';
+
+function exportedSchema(moduleValue: object, exportName: string): z.ZodType {
+  const candidate: unknown = Reflect.get(moduleValue, exportName);
+  if (!(candidate instanceof z.ZodType)) {
+    throw new Error(`reportContract muss ${exportName} exportieren`);
+  }
+  return candidate;
+}
+
+const EVIDENCE_ID = 'ev_47f9a1c2d4e5689a01bc23de45fa678b';
+const UNKNOWN_EVIDENCE_ID = 'ev_00000000000000000000000000000000';
+const MISMATCHED_EVIDENCE_ID = 'ev_ffffffffffffffffffffffffffffffff';
+
+const EVIDENCE_RECORD = {
+  evidence_id: EVIDENCE_ID,
+  producer_key: 'agent-log:42#post:1234',
+  type: 'agent_interview',
+  source: 'agent_log',
+  snippet: 'Persona kmu_ceo äußerte konkrete Sicherheitsbedenken.',
+  quote: 'Die Freigabe ohne Sicherheitsprüfung kommt für uns nicht infrage.',
+  source_id_anchor: 'agent-log-42#post-1234',
+  source_kind: 'agent_quote',
+  persona_stakeholder_group: 'Geschaeftsfuehrung',
+};
+
+const CLAIM_EVIDENCE_BINDING = {
+  evidence_id: EVIDENCE_ID,
+  match_score: 0.91,
+  retrieval_score: 0.91,
+  entailment: 'SUPPORTED',
+  entailment_reason: 'Das Originalzitat stützt die Aussage direkt.',
+  supports_claim: true,
+  contradicts_claim: false,
+};
+
+const EVIDENCE_INDEX = {
+  [EVIDENCE_ID]: EVIDENCE_RECORD,
+};
+
+const EVIDENCE_MAP_V3 = {
+  schema_version: 3,
+  report_id: 'report_abc',
+  simulation_id: 'sim_abc',
+  evidence_index: EVIDENCE_INDEX,
+  global_evidence_refs: [EVIDENCE_ID],
+  sections: [
+    {
+      section_index: 1,
+      section_title: 'Erster Eindruck',
+      section_summary: 'Die Zielgruppe verlangt belastbare Sicherheitsnachweise.',
+      claims: [
+        {
+          claim_id: 'claim_01',
+          claim_text: 'Sicherheitsbedenken prägen die erste Reaktion.',
+          confidence_label: 'low',
+          confidence_score: 0.42,
+          evidence: [CLAIM_EVIDENCE_BINDING],
+          audit_trail: [],
+        },
+      ],
+    },
+  ],
+};
+
+const REPORT_V4 = {
+  schema_version: 4,
+  report_id: 'report_abc',
+  generated_at: '2026-08-09T12:00:00Z',
+  evidence_index: EVIDENCE_INDEX,
+  claims: [
+    {
+      id: 'claim_01',
+      statement: 'Sicherheitsbedenken prägen die erste Reaktion.',
+      evidence_refs: [EVIDENCE_ID],
+      confidence: 'low',
+      persona_ids: [],
+      aggregation_basis: 'persona',
+    },
+  ],
+};
+
+describe('kanonische Evidence-Identität', () => {
+  it('trennt verpflichtende Quellenidentität von claim-relativen Binding-Werten', () => {
+    const EvidenceRecordSchema = exportedSchema(reportContract, 'EvidenceRecordSchema');
+
+    expect(EvidenceRecordSchema.safeParse(EVIDENCE_RECORD).success).toBe(true);
+    expect(
+      EvidenceRecordSchema.safeParse({
+        ...EVIDENCE_RECORD,
+        evidence_id: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      EvidenceRecordSchema.safeParse({
+        ...EVIDENCE_RECORD,
+        producer_key: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      EvidenceRecordSchema.safeParse({
+        ...EVIDENCE_RECORD,
+        evidence_id: 'ev_47f9a1c2',
+      }).success,
+    ).toBe(false);
+    expect(
+      EvidenceRecordSchema.safeParse({
+        ...EVIDENCE_RECORD,
+        retrieval_score: 0.91,
+        entailment: 'SUPPORTED',
+        supports_claim: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('modelliert Evidence-Bindings ausschließlich mit evidence_id und claim-relativen Werten', () => {
+    const ClaimEvidenceBindingSchema = exportedSchema(
+      reportContract,
+      'ClaimEvidenceBindingSchema',
+    );
+
+    const result = ClaimEvidenceBindingSchema.safeParse(CLAIM_EVIDENCE_BINDING);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        evidence_id: EVIDENCE_ID,
+        match_score: 0.91,
+        retrieval_score: 0.91,
+        entailment: 'SUPPORTED',
+        supports_claim: true,
+        contradicts_claim: false,
+      });
+    }
+    expect(
+      ClaimEvidenceBindingSchema.safeParse({
+        ...CLAIM_EVIDENCE_BINDING,
+        evidence_id: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      ClaimEvidenceBindingSchema.safeParse({
+        ...CLAIM_EVIDENCE_BINDING,
+        evidence_id: 'ev_47F9A1C2D4E5689A01BC23DE45FA678B',
+      }).success,
+    ).toBe(false);
+    expect(
+      ClaimEvidenceBindingSchema.safeParse({
+        ...CLAIM_EVIDENCE_BINDING,
+        source: 'agent_log',
+        snippet: 'Quellenfelder gehören in den EvidenceRecord.',
+        quote: 'Kein Binding-Feld.',
+        persona_stakeholder_group: 'Geschaeftsfuehrung',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('parst EvidenceMap v3 nur mit auflösbaren Referenzen und konsistentem Indexschlüssel', () => {
+    const valid = reportContract.EvidenceMapSchema.safeParse(EVIDENCE_MAP_V3);
+    expect(valid.success).toBe(true);
+
+    const unknownGlobalRef = {
+      ...EVIDENCE_MAP_V3,
+      global_evidence_refs: [UNKNOWN_EVIDENCE_ID],
+    };
+    expect(reportContract.EvidenceMapSchema.safeParse(unknownGlobalRef).success).toBe(false);
+
+    const mismatchedIndexKey = {
+      ...EVIDENCE_MAP_V3,
+      evidence_index: {
+        [MISMATCHED_EVIDENCE_ID]: EVIDENCE_RECORD,
+      },
+    };
+    expect(reportContract.EvidenceMapSchema.safeParse(mismatchedIndexKey).success).toBe(false);
+  });
+
+  it('lehnt EvidenceMap schema_version 2 nach dem echten Versionssprung ab', () => {
+    const legacyVersion = {
+      ...EVIDENCE_MAP_V3,
+      schema_version: 2,
+    };
+    expect(reportContract.EvidenceMapSchema.safeParse(legacyVersion).success).toBe(false);
+  });
+
+  it('lehnt high-Claims mit beliebiger gebundener inferred-Evidence ab', () => {
+    const secondQuoteId = 'ev_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const inferredId = 'ev_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const highClaimWithNonSupportingInference = {
+      ...EVIDENCE_MAP_V3,
+      evidence_index: {
+        ...EVIDENCE_INDEX,
+        [secondQuoteId]: {
+          ...EVIDENCE_RECORD,
+          evidence_id: secondQuoteId,
+          producer_key: 'agent-log:43#post:5678',
+          persona_stakeholder_group: 'IT-Abteilung',
+        },
+        [inferredId]: {
+          evidence_id: inferredId,
+          producer_key: 'audit-trail:inference-1',
+          type: 'entity_summary',
+          source: 'report_tool',
+          snippet: 'Abgeleitete Interpretation ohne verifizierbare Quelle.',
+          source_kind: 'inferred',
+        },
+      },
+      sections: [
+        {
+          ...EVIDENCE_MAP_V3.sections[0],
+          claims: [
+            {
+              ...EVIDENCE_MAP_V3.sections[0].claims[0],
+              confidence_label: 'high',
+              confidence_score: 0.82,
+              evidence: [
+                CLAIM_EVIDENCE_BINDING,
+                {
+                  ...CLAIM_EVIDENCE_BINDING,
+                  evidence_id: secondQuoteId,
+                },
+                {
+                  evidence_id: inferredId,
+                  match_score: 0.4,
+                  retrieval_score: 0.4,
+                  entailment: 'RELATED_ONLY',
+                  supports_claim: false,
+                  contradicts_claim: false,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      reportContract.EvidenceMapSchema.safeParse(highClaimWithNonSupportingInference).success,
+    ).toBe(false);
+  });
+
+  it('parst ReportV3 nur als Version 4 mit eingebettetem, auflösbarem evidence_index', () => {
+    const valid = ReportV3Schema.safeParse(REPORT_V4);
+    expect(valid.success).toBe(true);
+
+    const unknownClaimRef = {
+      ...REPORT_V4,
+      claims: [
+        {
+          ...REPORT_V4.claims[0],
+          evidence_refs: [UNKNOWN_EVIDENCE_ID],
+        },
+      ],
+    };
+    expect(ReportV3Schema.safeParse(unknownClaimRef).success).toBe(false);
+
+    const mismatchedIndexKey = {
+      ...REPORT_V4,
+      evidence_index: {
+        [MISMATCHED_EVIDENCE_ID]: EVIDENCE_RECORD,
+      },
+    };
+    expect(ReportV3Schema.safeParse(mismatchedIndexKey).success).toBe(false);
+  });
+
+  it('lehnt ReportV3 schema_version 3 nach dem echten Versionssprung ab', () => {
+    const legacyVersion = {
+      schema_version: 3,
+      report_id: 'report_abc',
+      generated_at: '2026-08-09T12:00:00Z',
+    };
+    expect(ReportV3Schema.safeParse(legacyVersion).success).toBe(false);
+  });
+});

--- a/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
+++ b/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
@@ -235,9 +235,18 @@ describe('kanonische Evidence-Identität', () => {
       ],
     };
 
-    expect(
-      reportContract.EvidenceMapSchema.safeParse(highClaimWithNonSupportingInference).success,
-    ).toBe(false);
+    const result = reportContract.EvidenceMapSchema.safeParse(highClaimWithNonSupportingInference);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ['sections', 0, 'claims', 0, 'evidence'],
+            message: expect.stringContaining('source_kind=inferred'),
+          }),
+        ]),
+      );
+    }
   });
 
   it('parst ReportV3 nur als Version 4 mit eingebettetem, auflösbarem evidence_index', () => {

--- a/frontend/src/contracts/__tests__/reportContract.spec.ts
+++ b/frontend/src/contracts/__tests__/reportContract.spec.ts
@@ -43,10 +43,30 @@ const VALID_PAYLOAD = {
     evidence_sections: 1,
   },
   evidence: {
-    schema_version: 2,
+    schema_version: 3,
     report_id: 'report_abc',
     simulation_id: 'sim_abc',
-    global_evidence: [],
+    evidence_index: {
+      ev_00000000000000000000000000000001: {
+        evidence_id: 'ev_00000000000000000000000000000001',
+        producer_key: 'agent:kmu_ceo:interview:1',
+        type: 'agent_interview',
+        source: 'agent_log',
+        snippet: 'Persona kmu_ceo äußerte Bedenken.',
+        source_kind: 'agent_quote',
+        persona_stakeholder_group: 'Geschaeftsfuehrung',
+      },
+      ev_00000000000000000000000000000002: {
+        evidence_id: 'ev_00000000000000000000000000000002',
+        producer_key: 'agent:it_lead:interview:1',
+        type: 'agent_interview',
+        source: 'agent_log',
+        snippet: 'Persona it_lead bestaetigte das Problem.',
+        source_kind: 'agent_quote',
+        persona_stakeholder_group: 'IT-Abteilung',
+      },
+    },
+    global_evidence_refs: [],
     sections: [
       {
         section_index: 1,
@@ -71,22 +91,14 @@ const VALID_PAYLOAD = {
             // Evidence aus mindestens 2 Stakeholder-Gruppen.
             evidence: [
               {
-                type: 'agent_interview',
-                source: 'agent_log',
-                snippet: 'Persona kmu_ceo äußerte Bedenken.',
+                evidence_id: 'ev_00000000000000000000000000000001',
                 match_score: 0.7,
                 supports_claim: true,
-                source_kind: 'agent_quote',
-                persona_stakeholder_group: 'Geschaeftsfuehrung',
               },
               {
-                type: 'agent_interview',
-                source: 'agent_log',
-                snippet: 'Persona it_lead bestaetigte das Problem.',
+                evidence_id: 'ev_00000000000000000000000000000002',
                 match_score: 0.72,
                 supports_claim: true,
-                source_kind: 'agent_quote',
-                persona_stakeholder_group: 'IT-Abteilung',
               },
             ],
             audit_trail: [],

--- a/frontend/src/contracts/__tests__/reportV3Contract.spec.ts
+++ b/frontend/src/contracts/__tests__/reportV3Contract.spec.ts
@@ -25,11 +25,23 @@ function shapeKeys(schema: { shape: Record<string, unknown> }) {
   return Object.keys(schema.shape).sort();
 }
 
+const EVIDENCE_ID = "ev_00000000000000000000000000000001";
+
 const MINIMAL_REPORT_V3 = {
-  schema_version: 3,
+  schema_version: 4,
   report_id: "rep-001",
   generated_at: "2026-05-09T12:00:00Z",
   report_mode: "balanced",
+  evidence_index: {
+    [EVIDENCE_ID]: {
+      evidence_id: EVIDENCE_ID,
+      producer_key: "report-v4-contract-fixture",
+      type: "graph_fact",
+      source: "contract-fixture",
+      snippet: "Vertraglich gebundene Evidence.",
+      source_kind: "graph_relation",
+    },
+  },
   personas: [
     {
       id: "p1",
@@ -39,14 +51,14 @@ const MINIMAL_REPORT_V3 = {
       region: "Schweiz",
       needs: ["Zuverlässigkeit", "Sicherheit"],
       values: ["Qualität"],
-      evidence_refs: ["ev-001"],
+      evidence_refs: [EVIDENCE_ID],
     },
   ],
   claims: [
     {
       id: "c1",
       statement: "Sicherheitsbedenken sind der primäre Hemmfaktor.",
-      evidence_refs: ["ev-001"],
+      evidence_refs: [EVIDENCE_ID],
       confidence: "high",
       persona_ids: ["p1"],
       aggregation_basis: "persona",
@@ -76,9 +88,9 @@ describe("ReportV3Schema (Zod-Spiegel)", () => {
     const result = parseReportV3(MINIMAL_REPORT_V3);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data.schema_version).toBe(3);
+      expect(result.data.schema_version).toBe(4);
       expect(result.data.personas[0].voice_register).toBe("formal-de");
-      expect(result.data.claims[0].evidence_refs).toEqual(["ev-001"]);
+      expect(result.data.claims[0].evidence_refs).toEqual([EVIDENCE_ID]);
       expect(result.data.data_gaps[0].severity).toBe("medium");
       expect(result.data.hypotheses[0].suggested_evidence).toEqual([
         "Preisinterviews",
@@ -86,8 +98,8 @@ describe("ReportV3Schema (Zod-Spiegel)", () => {
     }
   });
 
-  it("rejects schema_version=2 (Literal[3] enforced)", () => {
-    const bad = { ...MINIMAL_REPORT_V3, schema_version: 2 };
+  it("rejects schema_version=3 (Literal[4] enforced)", () => {
+    const bad = { ...MINIMAL_REPORT_V3, schema_version: 3 };
     expect(ReportV3Schema.safeParse(bad).success).toBe(false);
   });
 
@@ -172,7 +184,7 @@ describe("ReportV3Schema (Zod-Spiegel)", () => {
 
   it("report_mode defaults to 'balanced' when absent", () => {
     const withoutMode = {
-      schema_version: 3,
+      schema_version: 4,
       report_id: "r-no-mode",
       generated_at: "2026-05-11T00:00:00Z",
     };
@@ -197,7 +209,7 @@ describe("ReportV3Schema (Zod-Spiegel)", () => {
 
   it("parses minimal report with empty section lists", () => {
     const minimal = {
-      schema_version: 3,
+      schema_version: 4,
       report_id: "r-empty",
       generated_at: "2026-05-09T00:00:00Z",
     };

--- a/frontend/src/contracts/reportContract.ts
+++ b/frontend/src/contracts/reportContract.ts
@@ -66,6 +66,9 @@ export const EntailmentVerdictSchema = z.enum([
 ]);
 export type EntailmentVerdict = z.infer<typeof EntailmentVerdictSchema>;
 
+export const EvidenceIdSchema = z.string().regex(/^ev_[0-9a-f]{32}$/);
+export type EvidenceId = z.infer<typeof EvidenceIdSchema>;
+
 export const ReportStatusSchema = z.enum([
   "pending", "planning", "generating", "incomplete", "completed", "failed",
 ]);
@@ -79,7 +82,7 @@ export const AgentLogRefSchema = z.object({
   tool_name: z.string().optional().nullable(),
 }).strict();
 
-export const EvidenceItemSchema = z.object({
+const EvidenceSourceSchema = z.object({
   type: EvidenceTypeSchema,
   source: z.string().min(1),
   snippet: z.string().min(1).max(2000),
@@ -88,15 +91,6 @@ export const EvidenceItemSchema = z.object({
   query: z.string().optional().nullable(),
   raw: z.unknown().optional().nullable(),
   agent_log_ref: AgentLogRefSchema.optional().nullable(),
-  match_score: z.number().min(0).max(1).optional().nullable(),
-  // Retrieval-Score der ersten Binding-Stufe (Cosine-Similarity). Alias von
-  // match_score — beantwortet "gleiches Thema?", nicht "belegt?".
-  retrieval_score: z.number().min(0).max(1).optional().nullable(),
-  // Urteil der zweiten Stufe. supports_claim ist nur bei "SUPPORTED" true.
-  entailment: EntailmentVerdictSchema.optional().nullable(),
-  entailment_reason: z.string().max(500).optional().nullable(),
-  supports_claim: z.boolean().optional().nullable(),
-  contradicts_claim: z.boolean().optional().nullable(),
   // MAI-14 (backend) + Sub-Slice 05.8 (Zod-Spiegel):
   // Sentiment des Quellen-Snippets (-1 negativ, 0 neutral, +1 positiv).
   // confidence_calculator._has_contradiction nutzt es, um widersprüchliche
@@ -113,7 +107,16 @@ export const EvidenceItemSchema = z.object({
   // "<provider>/<model_id>" (z. B. "ollama/qwen2.5:32b"). None bei
   // Pre-Slice-8-Daten — daher .nullable().optional().
   source_model: z.string().max(200).nullable().optional(),
-}).strict().superRefine((value, ctx) => {
+}).strict();
+
+const validateEvidenceSource = (
+  value: {
+    type: string;
+    source_kind: string;
+    persona_stakeholder_group?: string | null;
+  },
+  ctx: z.RefinementCtx,
+) => {
   // Spiegelt EvidenceItemModel.reject_inference_in_evidence
   if (FORBIDDEN_EVIDENCE_TYPES.has(value.type)) {
     ctx.addIssue({
@@ -128,15 +131,51 @@ export const EvidenceItemSchema = z.object({
       message: "source_kind=agent_quote verlangt persona_stakeholder_group.",
     });
   }
-});
+};
+
+export const EvidenceItemSchema = EvidenceSourceSchema.superRefine(validateEvidenceSource);
 export type EvidenceItem = z.infer<typeof EvidenceItemSchema>;
+
+export const EvidenceRecordSchema = EvidenceSourceSchema.extend({
+  evidence_id: EvidenceIdSchema,
+  producer_key: z.string().min(1),
+}).superRefine(validateEvidenceSource);
+export type EvidenceRecord = z.infer<typeof EvidenceRecordSchema>;
+
+export const ClaimEvidenceBindingSchema = z.object({
+  evidence_id: EvidenceIdSchema,
+  // Compatibility-Alias für bestehende Persistenz; beide Scores bleiben
+  // claim-relativ und gehören deshalb nicht in den EvidenceRecord.
+  match_score: z.number().min(0).max(1).optional().nullable(),
+  retrieval_score: z.number().min(0).max(1).optional().nullable(),
+  entailment: EntailmentVerdictSchema.optional().nullable(),
+  entailment_reason: z.string().max(500).optional().nullable(),
+  supports_claim: z.boolean().optional().nullable(),
+  contradicts_claim: z.boolean().optional().nullable(),
+}).strict();
+export type ClaimEvidenceBinding = z.infer<typeof ClaimEvidenceBindingSchema>;
+
+export const EvidenceIndexSchema = z
+  .record(EvidenceIdSchema, EvidenceRecordSchema)
+  .superRefine((index, ctx) => {
+    for (const [key, record] of Object.entries(index)) {
+      if (key !== record.evidence_id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key, 'evidence_id'],
+          message: `Evidence-Index-Key '${key}' stimmt nicht mit evidence_id '${record.evidence_id}' überein.`,
+        });
+      }
+    }
+  });
+export type EvidenceIndex = z.infer<typeof EvidenceIndexSchema>;
 
 export const ReportClaimSchema = z.object({
   claim_id: z.string().regex(/^claim_\d{2,}$/),
   claim_text: z.string().min(8),
   confidence_label: ConfidenceLabelSchema,
   confidence_score: z.number().min(0).max(1),
-  evidence: z.array(EvidenceItemSchema).max(10).default([]),
+  evidence: z.array(ClaimEvidenceBindingSchema).max(10).default([]),
   audit_trail: z.array(z.record(z.string(), z.unknown())).default([]),
   notes: z.string().optional().nullable(),
 }).strict().superRefine((value, ctx) => {
@@ -164,37 +203,6 @@ export const ReportClaimSchema = z.object({
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `Label '${value.confidence_label}' verlangt mindestens eine Evidence mit supports_claim=true`,
-      });
-    }
-  }
-  // ADR-0002 Anker 4 (Sub-Slice M11.7b): high/verified verlangt agent_quote-
-  // Evidence aus mindestens 2 unterschiedlichen Stakeholder-Gruppen.
-  // Nur supports_claim=true zählt — widersprechende Quotes dürfen ein
-  // high-Label nicht rechtfertigen (Gemini-Followup PR #343).
-  if (value.confidence_label === "high" || value.confidence_label === "verified") {
-    const groups = new Set(
-      value.evidence
-        .filter(
-          (e) =>
-            e.source_kind === "agent_quote"
-            && e.supports_claim === true
-            && e.persona_stakeholder_group,
-        )
-        .map((e) => e.persona_stakeholder_group as string),
-    );
-    if (groups.size < 2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Label '${value.confidence_label}' verlangt unterstützende agent_quote-Evidence (supports_claim=true) aus mindestens 2 unterschiedlichen Stakeholder-Gruppen. Gefunden: ${groups.size === 0 ? "∅" : Array.from(groups).sort().join(", ")}.`,
-      });
-    }
-  }
-  // ADR-0002 Anker 5 (Sub-Slice M11.7b): high/verified duldet keine inferred-Evidence.
-  if (value.confidence_label === "high" || value.confidence_label === "verified") {
-    if (value.evidence.some((e) => e.source_kind === "inferred")) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Label '${value.confidence_label}' duldet keine source_kind=inferred-Evidence.`,
       });
     }
   }
@@ -291,15 +299,77 @@ export const EvidenceDegradationSchema = z.object({
 export type EvidenceDegradation = z.infer<typeof EvidenceDegradationSchema>;
 
 export const EvidenceMapSchema = z.object({
-  schema_version: z.literal(2),
+  schema_version: z.literal(3),
   report_id: z.string().min(1),
   simulation_id: z.string().min(1),
-  global_evidence: z.array(EvidenceItemSchema).default([]),
+  evidence_index: EvidenceIndexSchema,
+  global_evidence_refs: z.array(EvidenceIdSchema).default([]),
   sections: z.array(ReportSectionSchema).default([]),
   // Additiv mit Default: persistierte Evidence-Maps von vor #1006 tragen das
   // Feld nicht und müssen weiterhin parsen.
   degradation_log: z.array(EvidenceDegradationSchema).default([]),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  const knownIds = new Set(Object.keys(value.evidence_index));
+  const checkRef = (evidenceId: string, path: PropertyKey[]) => {
+    if (!knownIds.has(evidenceId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path,
+        message: `Unbekannte evidence_id '${evidenceId}'.`,
+      });
+    }
+  };
+
+  value.global_evidence_refs.forEach((evidenceId, index) => {
+    checkRef(evidenceId, ['global_evidence_refs', index]);
+  });
+
+  value.sections.forEach((section, sectionIndex) => {
+    section.claims.forEach((claim, claimIndex) => {
+      claim.evidence.forEach((binding, bindingIndex) => {
+        checkRef(binding.evidence_id, [
+          'sections',
+          sectionIndex,
+          'claims',
+          claimIndex,
+          'evidence',
+          bindingIndex,
+          'evidence_id',
+        ]);
+      });
+
+      if (claim.confidence_label === 'high' || claim.confidence_label === 'verified') {
+        const boundRecords = claim.evidence
+          .map((binding) => value.evidence_index[binding.evidence_id])
+          .filter((record): record is EvidenceRecord => record !== undefined);
+        const supportingRecords = claim.evidence
+          .filter((binding) => binding.supports_claim === true)
+          .map((binding) => value.evidence_index[binding.evidence_id])
+          .filter((record): record is EvidenceRecord => record !== undefined);
+        const stakeholderGroups = new Set(
+          supportingRecords
+            .filter((record) => record.source_kind === 'agent_quote')
+            .map((record) => record.persona_stakeholder_group)
+            .filter((group): group is string => group !== undefined && group !== null),
+        );
+        if (stakeholderGroups.size < 2) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['sections', sectionIndex, 'claims', claimIndex, 'evidence'],
+            message: `Label '${claim.confidence_label}' verlangt unterstützende agent_quote-Evidence aus mindestens 2 unterschiedlichen Stakeholder-Gruppen.`,
+          });
+        }
+        if (boundRecords.some((record) => record.source_kind === 'inferred')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['sections', sectionIndex, 'claims', claimIndex, 'evidence'],
+            message: `Label '${claim.confidence_label}' duldet keine source_kind=inferred-Evidence.`,
+          });
+        }
+      }
+    });
+  });
+});
 export type EvidenceMap = z.infer<typeof EvidenceMapSchema>;
 
 /**

--- a/frontend/src/contracts/reportV3Contract.ts
+++ b/frontend/src/contracts/reportV3Contract.ts
@@ -12,6 +12,20 @@
  * M11.8c Vorbereitung für M11.8d (Strict-Schema-Forced-Output).
  */
 import { z } from "zod";
+import {
+  EvidenceIdSchema,
+  EvidenceIndexSchema,
+} from "./reportContract";
+export {
+  EvidenceIdSchema,
+  EvidenceIndexSchema,
+  EvidenceRecordSchema,
+} from "./reportContract";
+export type {
+  EvidenceId,
+  EvidenceIndex,
+  EvidenceRecord,
+} from "./reportContract";
 
 // === Persona ===
 export const PersonaV3Schema = z
@@ -30,7 +44,7 @@ export const PersonaV3Schema = z
     haushaltseinkommen: z.string().nullable().optional(),
     needs: z.array(z.string()).default([]),
     values: z.array(z.string()).default([]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type PersonaV3 = z.infer<typeof PersonaV3Schema>;
@@ -57,7 +71,7 @@ export const ClaimSchema = z
   .object({
     id: z.string().min(1),
     statement: z.string().min(8),
-    evidence_refs: z.array(z.string()).min(1),
+    evidence_refs: z.array(EvidenceIdSchema).min(1),
     confidence: z.enum(["speculative", "low", "medium", "high", "verified"]),
     persona_ids: z.array(z.string()).default([]),
     aggregation_basis: z.enum([
@@ -82,7 +96,7 @@ export const MultiplierSchema = z
       "retention",
     ]),
     reichweite_score: z.number().int().min(1).max(10),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type Multiplier = z.infer<typeof MultiplierSchema>;
@@ -94,7 +108,7 @@ export const FrictionPointSchema = z
     beschreibung: z.string().min(1),
     severity: z.enum(["low", "medium", "high"]),
     affected_persona_ids: z.array(z.string()).default([]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type FrictionPoint = z.infer<typeof FrictionPointSchema>;
@@ -112,7 +126,7 @@ export const TrustSignalSchema = z
       "scarcity",
       "liking",
     ]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type TrustSignal = z.infer<typeof TrustSignalSchema>;
@@ -125,7 +139,7 @@ export const ChangeRecommendationSchema = z
     beschreibung: z.string().min(1),
     priority: z.enum(["low", "medium", "high"]),
     aufwand: z.enum(["S", "M", "L"]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type ChangeRecommendation = z.infer<typeof ChangeRecommendationSchema>;
@@ -137,7 +151,7 @@ export const ProjectImpactSchema = z
     beschreibung: z.string().min(1),
     affected_segments: z.array(z.string()).default([]),
     confidence: z.enum(["speculative", "low", "medium", "high", "verified"]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type ProjectImpact = z.infer<typeof ProjectImpactSchema>;
@@ -149,7 +163,7 @@ export const PositioningVariantSchema = z
     titel: z.string().min(1),
     claim_text: z.string().min(1),
     ziel_persona_ids: z.array(z.string()).default([]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type PositioningVariant = z.infer<typeof PositioningVariantSchema>;
@@ -169,7 +183,7 @@ export const ContentIdeaSchema = z
       "other",
     ]),
     persona_ids: z.array(z.string()).default([]),
-    evidence_refs: z.array(z.string()).default([]),
+    evidence_refs: z.array(EvidenceIdSchema).default([]),
   })
   .strict();
 export type ContentIdea = z.infer<typeof ContentIdeaSchema>;
@@ -239,9 +253,10 @@ export type ModelAttribution = z.infer<typeof ModelAttributionSchema>;
 // === ReportV3 Container ===
 export const ReportV3Schema = z
   .object({
-    schema_version: z.literal(3),
+    schema_version: z.literal(4),
     report_id: z.string().min(1),
     generated_at: z.string().datetime(),
+    evidence_index: EvidenceIndexSchema.default({}),
     report_mode: ReportModeSchema.default("balanced"),
     personas: z.array(PersonaV3Schema).default([]),
     segments: z.array(SegmentSchema).default([]),
@@ -259,7 +274,38 @@ export const ReportV3Schema = z
     red_team_findings: z.array(z.string()).max(10).default([]),
     model_attribution: z.array(ModelAttributionSchema).default([]),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    const knownIds = new Set(Object.keys(value.evidence_index));
+    const refCollections: Array<{
+      path: string;
+      entries: Array<{ evidence_refs: string[] }>;
+    }> = [
+      { path: "personas", entries: value.personas },
+      { path: "claims", entries: value.claims },
+      { path: "multipliers", entries: value.multipliers },
+      { path: "friction_points", entries: value.friction_points },
+      { path: "trust_signals", entries: value.trust_signals },
+      { path: "change_recommendations", entries: value.change_recommendations },
+      { path: "project_impacts", entries: value.project_impacts },
+      { path: "positioning_variants", entries: value.positioning_variants },
+      { path: "content_ideas", entries: value.content_ideas },
+    ];
+
+    for (const collection of refCollections) {
+      collection.entries.forEach((entry, entryIndex) => {
+        entry.evidence_refs.forEach((evidenceId, refIndex) => {
+          if (!knownIds.has(evidenceId)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [collection.path, entryIndex, "evidence_refs", refIndex],
+              message: `Unbekannte evidence_id '${evidenceId}'.`,
+            });
+          }
+        });
+      });
+    }
+  });
 export type ReportV3 = z.infer<typeof ReportV3Schema>;
 
 /**

--- a/frontend/src/contracts/reportV3Contract.ts
+++ b/frontend/src/contracts/reportV3Contract.ts
@@ -297,7 +297,7 @@ export const ReportV3Schema = z
         entry.evidence_refs.forEach((evidenceId, refIndex) => {
           if (!knownIds.has(evidenceId)) {
             ctx.addIssue({
-              code: z.ZodIssueCode.custom,
+              code: "custom",
               path: [collection.path, entryIndex, "evidence_refs", refIndex],
               message: `Unbekannte evidence_id '${evidenceId}'.`,
             });

--- a/schemas/evidence-map.schema.json
+++ b/schemas/evidence-map.schema.json
@@ -32,6 +32,98 @@
       "title": "AgentLogRef",
       "type": "object"
     },
+    "ClaimEvidenceBindingModel": {
+      "additionalProperties": false,
+      "description": "Claim-relative Bewertung einer Referenz auf ``EvidenceRecordModel``.",
+      "properties": {
+        "contradicts_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contradicts Claim"
+        },
+        "entailment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntailmentVerdict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entailment_reason": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entailment Reason"
+        },
+        "evidence_id": {
+          "pattern": "^ev_[0-9a-f]{32}$",
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "match_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Match Score"
+        },
+        "retrieval_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Score"
+        },
+        "supports_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Supports Claim"
+        }
+      },
+      "required": [
+        "evidence_id"
+      ],
+      "title": "ClaimEvidenceBindingModel",
+      "type": "object"
+    },
     "ConfidenceLabel": {
       "enum": [
         "low",
@@ -88,9 +180,9 @@
       "title": "EvidenceDegradationModel",
       "type": "object"
     },
-    "EvidenceItemModel": {
+    "EvidenceRecordModel": {
       "additionalProperties": false,
-      "description": "Bestehende EvidenceItem-Felder aus report_agent.py, jetzt typsicher.",
+      "description": "Claim-unabhaengiger, kanonisch adressierbarer Quellen-Datensatz.",
       "properties": {
         "agent_log_ref": {
           "anyOf": [
@@ -103,55 +195,10 @@
           ],
           "default": null
         },
-        "contradicts_claim": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Contradicts Claim"
-        },
-        "entailment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EntailmentVerdict"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "entailment_reason": {
-          "anyOf": [
-            {
-              "maxLength": 500,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Entailment Reason"
-        },
-        "match_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Match Score"
+        "evidence_id": {
+          "pattern": "^ev_[0-9a-f]{32}$",
+          "title": "Evidence Id",
+          "type": "string"
         },
         "persona_stakeholder_group": {
           "anyOf": [
@@ -166,6 +213,12 @@
           ],
           "default": null,
           "title": "Persona Stakeholder Group"
+        },
+        "producer_key": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Producer Key",
+          "type": "string"
         },
         "query": {
           "anyOf": [
@@ -203,20 +256,6 @@
           "default": null,
           "title": "Raw"
         },
-        "retrieval_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Retrieval Score"
-        },
         "sentiment_score": {
           "anyOf": [
             {
@@ -229,7 +268,6 @@
             }
           ],
           "default": null,
-          "description": "Sentiment des Quellen-Snippets (-1 negativ, 0 neutral, +1 positiv).",
           "title": "Sentiment Score"
         },
         "snippet": {
@@ -272,20 +310,7 @@
             }
           ],
           "default": null,
-          "description": "Provider+Modell, das diese Evidence-Zeile extrahiert hat (Slice 8).",
           "title": "Source Model"
-        },
-        "supports_claim": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Supports Claim"
         },
         "tool_name": {
           "anyOf": [
@@ -325,11 +350,13 @@
         }
       },
       "required": [
+        "evidence_id",
+        "producer_key",
         "type",
         "source",
         "snippet"
       ],
-      "title": "EvidenceItemModel",
+      "title": "EvidenceRecordModel",
       "type": "object"
     },
     "EvidenceSourceKind": {
@@ -362,8 +389,9 @@
       "title": "EvidenceType",
       "type": "string"
     },
-    "ReportClaimModel": {
+    "IndexedReportClaimModel": {
       "additionalProperties": false,
+      "description": "Claim-Shape der EvidenceMap v3 mit referenzierten Bindings.",
       "properties": {
         "audit_trail": {
           "items": {
@@ -394,7 +422,7 @@
         },
         "evidence": {
           "items": {
-            "$ref": "#/$defs/EvidenceItemModel"
+            "$ref": "#/$defs/ClaimEvidenceBindingModel"
           },
           "maxItems": 10,
           "title": "Evidence",
@@ -419,7 +447,7 @@
         "confidence_label",
         "confidence_score"
       ],
-      "title": "ReportClaimModel",
+      "title": "IndexedReportClaimModel",
       "type": "object"
     },
     "ReportSectionDataGapModel": {
@@ -509,7 +537,7 @@
       "properties": {
         "claims": {
           "items": {
-            "$ref": "#/$defs/ReportClaimModel"
+            "$ref": "#/$defs/IndexedReportClaimModel"
           },
           "title": "Claims",
           "type": "array"
@@ -583,11 +611,18 @@
       "title": "Degradation Log",
       "type": "array"
     },
-    "global_evidence": {
-      "items": {
-        "$ref": "#/$defs/EvidenceItemModel"
+    "evidence_index": {
+      "additionalProperties": {
+        "$ref": "#/$defs/EvidenceRecordModel"
       },
-      "title": "Global Evidence",
+      "title": "Evidence Index",
+      "type": "object"
+    },
+    "global_evidence_refs": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Global Evidence Refs",
       "type": "array"
     },
     "report_id": {
@@ -596,8 +631,8 @@
       "type": "string"
     },
     "schema_version": {
-      "const": 2,
-      "default": 2,
+      "const": 3,
+      "default": 3,
       "title": "Schema Version",
       "type": "integer"
     },

--- a/schemas/report-contract.schema.json
+++ b/schemas/report-contract.schema.json
@@ -32,6 +32,98 @@
       "title": "AgentLogRef",
       "type": "object"
     },
+    "ClaimEvidenceBindingModel": {
+      "additionalProperties": false,
+      "description": "Claim-relative Bewertung einer Referenz auf ``EvidenceRecordModel``.",
+      "properties": {
+        "contradicts_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contradicts Claim"
+        },
+        "entailment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntailmentVerdict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entailment_reason": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entailment Reason"
+        },
+        "evidence_id": {
+          "pattern": "^ev_[0-9a-f]{32}$",
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "match_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Match Score"
+        },
+        "retrieval_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Score"
+        },
+        "supports_claim": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Supports Claim"
+        }
+      },
+      "required": [
+        "evidence_id"
+      ],
+      "title": "ClaimEvidenceBindingModel",
+      "type": "object"
+    },
     "ConfidenceLabel": {
       "enum": [
         "low",
@@ -88,250 +180,6 @@
       "title": "EvidenceDegradationModel",
       "type": "object"
     },
-    "EvidenceItemModel": {
-      "additionalProperties": false,
-      "description": "Bestehende EvidenceItem-Felder aus report_agent.py, jetzt typsicher.",
-      "properties": {
-        "agent_log_ref": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AgentLogRef"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contradicts_claim": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Contradicts Claim"
-        },
-        "entailment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EntailmentVerdict"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "entailment_reason": {
-          "anyOf": [
-            {
-              "maxLength": 500,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Entailment Reason"
-        },
-        "match_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Match Score"
-        },
-        "persona_stakeholder_group": {
-          "anyOf": [
-            {
-              "maxLength": 200,
-              "minLength": 1,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Persona Stakeholder Group"
-        },
-        "query": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Query"
-        },
-        "quote": {
-          "anyOf": [
-            {
-              "maxLength": 500,
-              "minLength": 1,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Quote"
-        },
-        "raw": {
-          "anyOf": [
-            {},
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Raw"
-        },
-        "retrieval_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Retrieval Score"
-        },
-        "sentiment_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": -1.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Sentiment des Quellen-Snippets (-1 negativ, 0 neutral, +1 positiv).",
-          "title": "Sentiment Score"
-        },
-        "snippet": {
-          "maxLength": 2000,
-          "minLength": 1,
-          "title": "Snippet",
-          "type": "string"
-        },
-        "source": {
-          "minLength": 1,
-          "title": "Source",
-          "type": "string"
-        },
-        "source_id_anchor": {
-          "anyOf": [
-            {
-              "maxLength": 200,
-              "minLength": 1,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Source Id Anchor"
-        },
-        "source_kind": {
-          "$ref": "#/$defs/EvidenceSourceKind",
-          "default": "inferred"
-        },
-        "source_model": {
-          "anyOf": [
-            {
-              "maxLength": 200,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Provider+Modell, das diese Evidence-Zeile extrahiert hat (Slice 8).",
-          "title": "Source Model"
-        },
-        "supports_claim": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Supports Claim"
-        },
-        "tool_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Tool Name"
-        },
-        "type": {
-          "$ref": "#/$defs/EvidenceType"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Value"
-        }
-      },
-      "required": [
-        "type",
-        "source",
-        "snippet"
-      ],
-      "title": "EvidenceItemModel",
-      "type": "object"
-    },
     "EvidenceMapModel": {
       "additionalProperties": false,
       "description": "Persistierte Evidence-Map. Abl\u00f6se f\u00fcr die rohen Dicts in report_agent.py.",
@@ -343,11 +191,18 @@
           "title": "Degradation Log",
           "type": "array"
         },
-        "global_evidence": {
-          "items": {
-            "$ref": "#/$defs/EvidenceItemModel"
+        "evidence_index": {
+          "additionalProperties": {
+            "$ref": "#/$defs/EvidenceRecordModel"
           },
-          "title": "Global Evidence",
+          "title": "Evidence Index",
+          "type": "object"
+        },
+        "global_evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Global Evidence Refs",
           "type": "array"
         },
         "report_id": {
@@ -356,8 +211,8 @@
           "type": "string"
         },
         "schema_version": {
-          "const": 2,
-          "default": 2,
+          "const": 3,
+          "default": 3,
           "title": "Schema Version",
           "type": "integer"
         },
@@ -414,6 +269,185 @@
       "title": "EvidenceOmissionModel",
       "type": "object"
     },
+    "EvidenceRecordModel": {
+      "additionalProperties": false,
+      "description": "Claim-unabhaengiger, kanonisch adressierbarer Quellen-Datensatz.",
+      "properties": {
+        "agent_log_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentLogRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_id": {
+          "pattern": "^ev_[0-9a-f]{32}$",
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "persona_stakeholder_group": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Persona Stakeholder Group"
+        },
+        "producer_key": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Producer Key",
+          "type": "string"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Query"
+        },
+        "quote": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Quote"
+        },
+        "raw": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw"
+        },
+        "sentiment_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": -1.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sentiment Score"
+        },
+        "snippet": {
+          "maxLength": 2000,
+          "minLength": 1,
+          "title": "Snippet",
+          "type": "string"
+        },
+        "source": {
+          "minLength": 1,
+          "title": "Source",
+          "type": "string"
+        },
+        "source_id_anchor": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Id Anchor"
+        },
+        "source_kind": {
+          "$ref": "#/$defs/EvidenceSourceKind",
+          "default": "inferred"
+        },
+        "source_model": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Model"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        },
+        "type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "required": [
+        "evidence_id",
+        "producer_key",
+        "type",
+        "source",
+        "snippet"
+      ],
+      "title": "EvidenceRecordModel",
+      "type": "object"
+    },
     "EvidenceSourceKind": {
       "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Diese Werte sind im Prompt-Block\n``backend/app/services/report_prompts/sections.py`` referenziert (Anker 1).\n\nErweiterung (Report-Trust-Slice): ``agent_action`` und ``web_source``\nerg\u00e4nzen die urspr\u00fcnglichen vier Werte. Das ist additiv und versch\u00e4rft\nADR-0002, statt es zu schw\u00e4chen \u2014 vorher liefen Agentenaktionen und\nWeb-Treffer \u00fcber den Default ``seed_corpus`` und verschmolzen damit\nSeed-Dokument, Simulation und Recherche zu einer einzigen Quellengattung.\nF\u00fcr die Confidence-Anker gilt weiterhin: nur ``agent_quote`` z\u00e4hlt als\nStakeholder-Stimme, nur ``seed_corpus`` als Dokumentfakt.",
       "enum": [
@@ -444,8 +478,9 @@
       "title": "EvidenceType",
       "type": "string"
     },
-    "ReportClaimModel": {
+    "IndexedReportClaimModel": {
       "additionalProperties": false,
+      "description": "Claim-Shape der EvidenceMap v3 mit referenzierten Bindings.",
       "properties": {
         "audit_trail": {
           "items": {
@@ -476,7 +511,7 @@
         },
         "evidence": {
           "items": {
-            "$ref": "#/$defs/EvidenceItemModel"
+            "$ref": "#/$defs/ClaimEvidenceBindingModel"
           },
           "maxItems": 10,
           "title": "Evidence",
@@ -501,7 +536,7 @@
         "confidence_label",
         "confidence_score"
       ],
-      "title": "ReportClaimModel",
+      "title": "IndexedReportClaimModel",
       "type": "object"
     },
     "ReportModel": {
@@ -766,7 +801,7 @@
       "properties": {
         "claims": {
           "items": {
-            "$ref": "#/$defs/ReportClaimModel"
+            "$ref": "#/$defs/IndexedReportClaimModel"
           },
           "title": "Claims",
           "type": "array"

--- a/schemas/report-v3.schema.json
+++ b/schemas/report-v3.schema.json
@@ -1,5 +1,37 @@
 {
   "$defs": {
+    "AgentLogRef": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "title": "Action",
+          "type": "string"
+        },
+        "section_index": {
+          "minimum": 0,
+          "title": "Section Index",
+          "type": "integer"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "section_index",
+        "action"
+      ],
+      "title": "AgentLogRef",
+      "type": "object"
+    },
     "ChangeRecommendation": {
       "additionalProperties": false,
       "description": "Konkrete Handlungsempfehlung mit Priorit\u00e4t und Umsetzungsaufwand.",
@@ -205,6 +237,215 @@
       ],
       "title": "DataGap",
       "type": "object"
+    },
+    "EvidenceRecordModel": {
+      "additionalProperties": false,
+      "description": "Claim-unabhaengiger, kanonisch adressierbarer Quellen-Datensatz.",
+      "properties": {
+        "agent_log_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentLogRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_id": {
+          "pattern": "^ev_[0-9a-f]{32}$",
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "persona_stakeholder_group": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Persona Stakeholder Group"
+        },
+        "producer_key": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Producer Key",
+          "type": "string"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Query"
+        },
+        "quote": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Quote"
+        },
+        "raw": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw"
+        },
+        "sentiment_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": -1.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sentiment Score"
+        },
+        "snippet": {
+          "maxLength": 2000,
+          "minLength": 1,
+          "title": "Snippet",
+          "type": "string"
+        },
+        "source": {
+          "minLength": 1,
+          "title": "Source",
+          "type": "string"
+        },
+        "source_id_anchor": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Id Anchor"
+        },
+        "source_kind": {
+          "$ref": "#/$defs/EvidenceSourceKind",
+          "default": "inferred"
+        },
+        "source_model": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Model"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        },
+        "type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "required": [
+        "evidence_id",
+        "producer_key",
+        "type",
+        "source",
+        "snippet"
+      ],
+      "title": "EvidenceRecordModel",
+      "type": "object"
+    },
+    "EvidenceSourceKind": {
+      "description": "ADR-0002 Anker 3 \u2014 Quellengattung pro Evidence-Item.\n\nWird von den Cross-Stakeholder-/Inferred-Validators auf\n``ReportClaimModel`` ausgewertet (Sub-Slice M11.7b, Anker 4 + 5).\nDrift-Guard: Diese Werte sind im Prompt-Block\n``backend/app/services/report_prompts/sections.py`` referenziert (Anker 1).\n\nErweiterung (Report-Trust-Slice): ``agent_action`` und ``web_source``\nerg\u00e4nzen die urspr\u00fcnglichen vier Werte. Das ist additiv und versch\u00e4rft\nADR-0002, statt es zu schw\u00e4chen \u2014 vorher liefen Agentenaktionen und\nWeb-Treffer \u00fcber den Default ``seed_corpus`` und verschmolzen damit\nSeed-Dokument, Simulation und Recherche zu einer einzigen Quellengattung.\nF\u00fcr die Confidence-Anker gilt weiterhin: nur ``agent_quote`` z\u00e4hlt als\nStakeholder-Stimme, nur ``seed_corpus`` als Dokumentfakt.",
+      "enum": [
+        "seed_corpus",
+        "agent_quote",
+        "agent_action",
+        "graph_relation",
+        "web_source",
+        "inferred"
+      ],
+      "title": "EvidenceSourceKind",
+      "type": "string"
+    },
+    "EvidenceType": {
+      "description": "\u00dcbernommen aus report_agent.py \u2014 bestehende Typen plus model_generated_inference.",
+      "enum": [
+        "graph_fact",
+        "graph_metric",
+        "graph_metric_status",
+        "relationship_chain",
+        "entity_summary",
+        "agent_action",
+        "agent_interview",
+        "web_search_result",
+        "web_fetch",
+        "model_generated_inference"
+      ],
+      "title": "EvidenceType",
+      "type": "string"
     },
     "FrictionPoint": {
       "additionalProperties": false,
@@ -749,7 +990,7 @@
   "$id": "https://alexle135.de/schemas/report-v3.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "Container f\u00fcr alle 11 Pflichtabschnitte des strukturierten Reports v3.\n\nschema_version=3 ist als Literal festgelegt \u2014 verhindert Versions-Drift\nanalog zu ReportContractModel(schema_version=2).",
+  "description": "Container f\u00fcr alle 11 Pflichtabschnitte des strukturierten Reports v3.\n\nschema_version=4 ist als Literal festgelegt \u2014 verhindert Versions-Drift\nanalog zu ReportContractModel(schema_version=2).",
   "properties": {
     "change_recommendations": {
       "items": {
@@ -778,6 +1019,13 @@
       },
       "title": "Data Gaps",
       "type": "array"
+    },
+    "evidence_index": {
+      "additionalProperties": {
+        "$ref": "#/$defs/EvidenceRecordModel"
+      },
+      "title": "Evidence Index",
+      "type": "object"
     },
     "friction_points": {
       "items": {
@@ -860,8 +1108,8 @@
       "type": "string"
     },
     "schema_version": {
-      "const": 3,
-      "default": 3,
+      "const": 4,
+      "default": 4,
       "title": "Schema Version",
       "type": "integer"
     },


### PR DESCRIPTION
## Zusammenfassung

- führt deterministische, run-lokale `evidence_id`-Werte aus stabilen Producer-Keys ein und trennt Evidence-Records von Claim-Bindings
- hebt EvidenceMap auf Schema v3 und ReportV3 auf Schema v4; Backend und Frontend validieren Index- und Cross-Reference-Konsistenz
- migriert auflösbare Legacy-Evidence und stuft nicht auflösbare `report_tool`-Claims ehrlich zu `legacy_unresolved`-Hypothesen ab
- dedupliziert Reviewer-Floor-Zählung nach `evidence_id`; serverseitig verifizierte `seed_doc`-Producer bleiben bewusst Slice 2C / #1086

## Testplan

- [x] `106 passed` – gezielte Evidence-/Migration-/Manager-/Export-Suites
- [x] `8 passed` – neue Evidence-Identity-/v3-/v4-/Legacy-Tests
- [x] `103 passed` – fokussierte Frontend-Contract-/Step4-Suites
- [x] `bash scripts/pre-push-gate.sh backend` (`531 passed`, 56 Schemas)
- [x] `bash scripts/pre-push-gate.sh frontend`
- [x] `bash scripts/pre-push-gate.sh schemas`

## Folgearbeit

- #1086: serverseitig verifizierte `seed_doc:<document>#chunk:<chunk>`-Producer in Slice 2C
- F4/#765: Claim-Funnel und Kalibrierung bleiben außerhalb dieses Slices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Evidenz wird zentral über stabile IDs gespeichert und von Claims referenziert.
  * Neue Evidence-Records und Bindings ermöglichen nachvollziehbare Quellenzuordnung.
  * Die Report-Ansicht löst Evidenzreferenzen nun aus dem zentralen Index auf.

* **Verbesserungen**
  * Report- und Evidence-Schemas wurden aktualisiert (Evidence Map v3, Report v4).
  * Inkonsistente oder unbekannte Referenzen werden zuverlässig erkannt.
  * Nicht auflösbare Legacy-Evidenz wird als Hypothese gekennzeichnet und bleibt nachvollziehbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->