### PR TITLE
fix(oasis): host-adaptives BERT-Memory-Profil beendet Runde-0-Hang (#1148)

### DIFF
--- a/backend/scripts/_sim_common.py
+++ b/backend/scripts/_sim_common.py
@@ -636,28 +636,63 @@ _TWHIN_BERT_MODEL_NAMES: frozenset[str] = frozenset(
     }
 )
 
-_BERT_PROFILE_DEFAULT = "low"
+_BERT_PROFILE_DEFAULT = "auto"
+
+# Ab dieser verfuegbaren Container-RAM (MB) laden wir TWHIN-BERT in fp32.
+# fp32 besitzt native CPU-Kernel und laeuft 16-threaded (~14 s/Forward);
+# fp16 hat auf CPU keine nativen Kernel und fallt auf eine langsame
+# single-threaded Emulation zurueck (~12 min/Forward — blockiert den
+# asyncio-Event-Loop der OASIS-Plattform). Darunter bleibt fp16 aktiv als
+# OOM-Schutz fuer Kleincontainer der 2.8-GiB-Klasse (Originalanforderung
+# dieses Profils). 4 GB Deckt die ~1.2 GB fp32-Modellgewichte + 250-350 MB
+# torch/transformers-Import-Overhead + Working-Set des Forward sicher ab.
+_BERT_FP32_MIN_AVAIL_MB = 4096
 
 
 def install_bert_memory_profile(profile: str | None = None) -> str:
     """
     Aktiviert ein speicherschonendes Ladeprofil für TWHIN-BERT.
-    
-    Das Profil wird über den Parameter oder `AGORA_BERT_MEMORY_PROFILE` bestimmt
-    und standardmäßig auf `"low"` gesetzt. Für TWHIN-BERT werden geeignete
-    Speicheroptionen gesetzt; andere Modelle bleiben unverändert. Bei deaktiviertem
-    Profil oder fehlender Transformers-Bibliothek erfolgt keine Anpassung.
-    
+
+    Das Profil wird über den Parameter oder ``AGORA_BERT_MEMORY_PROFILE`` bestimmt
+    und standardmäßig auf ``"auto"`` gesetzt. Für TWHIN-BERT werden geeignete
+    Speicheroptionen gesetzt; andere Modelle bleiben unverändert. Bei
+    deaktiviertem Profil oder fehlender Transformers-Bibliothek erfolgt keine
+    Anpassung.
+
+    Profil-Level:
+
+    - ``"off"``  — kein Patch (Bypass).
+    - ``"low"``  — immer ``low_cpu_mem_usage=True`` UND ``torch_dtype=fp16``
+      (OOM-Schutz fuer 2.8-GiB-Kleincontainer; historisches Verhalten).
+    - ``"auto"`` — ``low_cpu_mem_usage=True`` immer; ``fp16`` NUR bei knappem
+      Container-RAM (``< _BERT_FP32_MIN_AVAIL_MB``), sonst fp32 (schnelle
+      native CPU-Kernel). Kann der verfuegbare RAM nicht ermittelt werden,
+      bleibt es konservativ bei fp16. Default seit dem Fix des
+      Round-0-Hangs (fp16-Forward blockierte den Event-Loop ~12 min).
+
     Args:
-        profile: Zu verwendendes Speicherprofil, beispielsweise `"off"` oder
-            `"low"`.
-    
+        profile: Zu verwendendes Speicherprofil (``"off"``, ``"low"`` oder
+            ``"auto"``). Ohne Angabe greift ``AGORA_BERT_MEMORY_PROFILE`` bzw.
+            der Default.
+
     Returns:
         Der effektive Profilname.
     """
     effective = (profile or os.environ.get("AGORA_BERT_MEMORY_PROFILE") or _BERT_PROFILE_DEFAULT).lower()
     if effective == "off":
         return "off"
+
+    # fp16-Injektion entscheiden (einmalig, zur Patch-Zeit):
+    #  - "low":  immer fp16 (OOM-Schutz, historisches Verhalten).
+    #  - "auto": fp16 nur bei knappem Container-RAM (< Schwellenwert),
+    #            sonst fp32 (16-Thread-CPU-Kernel, ~14 s/Forward). Laesst sich
+    #            der RAM nicht ermitteln, konservativ fp16 (OOM-Schutz bleibt).
+    #  - sonst:  fp16 (backward-kompatibel zu unbekannten Profilnamen).
+    if effective == "auto":
+        avail_mb = _read_available_mb_linux()
+        inject_fp16 = not (avail_mb is not None and avail_mb >= _BERT_FP32_MIN_AVAIL_MB)
+    else:
+        inject_fp16 = True
 
     try:
         import transformers  # type: ignore[import-not-found]
@@ -688,7 +723,7 @@ def install_bert_memory_profile(profile: str | None = None) -> str:
         # ``pretrained_model_name_or_path`` als kwarg.
         """
         Lädt TWHIN-BERT-Modelle mit speichersparenden Standardeinstellungen.
-        
+
         Returns:
             Das von der ursprünglichen Ladefunktion erzeugte Modell.
         """
@@ -697,7 +732,7 @@ def install_bert_memory_profile(profile: str | None = None) -> str:
             # User-Override hat Vorrang.
             if "low_cpu_mem_usage" not in kwargs:
                 kwargs["low_cpu_mem_usage"] = True
-            if torch_float16 is not None and "torch_dtype" not in kwargs:
+            if torch_float16 is not None and inject_fp16 and "torch_dtype" not in kwargs:
                 kwargs["torch_dtype"] = torch_float16
         return original(*args, **kwargs)
 
@@ -719,6 +754,58 @@ def _read_rss_mb_linux() -> float | None:
                     return int(line.split()[1]) / 1024.0
     except (OSError, ValueError, IndexError):
         return None
+    return None
+
+
+def _read_available_mb_linux() -> float | None:
+    """Verfuegbaren RAM in MB — cgroup-Limit bevorzugt, Fallback /proc/meminfo.
+
+    In einem Docker-Container zeigt ``/proc/meminfo`` (ohne lxcfs) den
+    Host-Speicher, nicht das tatsaechliche Container-Limit. Daher wird
+    zunaechst das cgroup-Speicherlimit (v2, dann v1) minus aktueller
+    Belegung gelesen; erst wenn kein endliches cgroup-Limit ermittelt werden
+    kann, greift der ``MemAvailable``-Fallback (Bare-Metal-/Dev-Host).
+
+    Liefert ``None``, wenn keine Quelle lesbar ist (z.B. macOS-Dev oder
+    nicht-Linux). Fuer ``"auto"``-Profil bedeutet das: konservativ fp16
+    verwenden (OOM-Schutz bleibt erhalten).
+    """
+    # cgroup v2: /sys/fs/cgroup/memory.max + memory.current.
+    try:
+        limit_text = Path("/sys/fs/cgroup/memory.max").read_text(encoding="utf-8").strip()
+        if limit_text != "max":
+            limit_bytes = int(limit_text)
+            usage_bytes = int(
+                Path("/sys/fs/cgroup/memory.current").read_text(encoding="utf-8").strip()
+            )
+            return max(0.0, (limit_bytes - usage_bytes) / 1024.0 / 1024.0)
+    except (OSError, ValueError):
+        pass
+    # cgroup v1: memory.limit_in_bytes / memory.usage_in_bytes.
+    try:
+        limit_bytes = int(
+            Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        # v1 kodiert "kein Limit" als sehr grossen Wert (~2^63-1).
+        if limit_bytes < (1 << 62):
+            usage_bytes = int(
+                Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+                .read_text(encoding="utf-8")
+                .strip()
+            )
+            return max(0.0, (limit_bytes - usage_bytes) / 1024.0 / 1024.0)
+    except (OSError, ValueError):
+        pass
+    # Fallback: /proc/meminfo MemAvailable (kB -> MB).
+    try:
+        with Path("/proc/meminfo").open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return float(line.split()[1]) / 1024.0
+    except (OSError, ValueError, IndexError):
+        pass
     return None
 
 

--- a/backend/tests/scripts/test_bert_memory_profile.py
+++ b/backend/tests/scripts/test_bert_memory_profile.py
@@ -426,3 +426,152 @@ def test_low_profile_no_torch_does_not_inject_torch_dtype(
     # Kein torch → kein torch_dtype-Key (sonst wuerde der echte
     # AutoModel.from_pretrained mit einem ungueltigen dtype fehlschlagen).
     assert "torch_dtype" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# fix/oasis-fp16-round0-hang: host-adaptives "auto"-Profil
+# ---------------------------------------------------------------------------
+# Root cause: ``install_bert_memory_profile`` zwang TWHIN-BERT immer auf fp16.
+# fp16 hat auf CPU keine nativen Kernel -> langsame single-threaded Emulation
+# -> ein ``update_rec_table()``-Forward blockierte den asyncio-Event-Loop der
+# OASIS-Plattform ~12 min (Round 0-Hang). fp32 laeuft 16-threaded in ~14 s.
+# Fix: neuer Default ``"auto"`` — fp16 nur noch bei knappem Container-RAM
+# (< _BERT_FP32_MIN_AVAIL_MB), sonst fp32. ``low``/``off`` bleiben unveraendert.
+# ---------------------------------------------------------------------------
+
+import _sim_common as _sim_common_module  # noqa: E402
+
+
+def test_auto_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default-Profil ist ``"auto"`` (nicht mehr ``"low"``). Sichert, dass
+    der Fix-Default nicht versehentlich zurueckgesetzt wird."""
+    monkeypatch.delenv("AGORA_BERT_MEMORY_PROFILE", raising=False)
+    # _read_available_mb_linux deterministisch stubben, damit der Test nicht
+    # vom echten Host-RAM abhaengt.
+    monkeypatch.setattr(_sim_common_module, "_read_available_mb_linux", lambda: 8192.0)
+
+    def sentinel(*_args: object, **_kwargs: object) -> mock.Mock:
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = sentinel
+    with mock.patch.dict(sys.modules, {"transformers": fake_module}):
+        result = install_bert_memory_profile()
+    assert result == "auto"
+    # Patch wird dennoch installiert (low_cpu_mem_usage immer).
+    assert fake_module.AutoModel.from_pretrained is not sentinel
+
+
+def test_auto_profile_fp32_when_ram_plenty(
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
+) -> None:
+    """``auto`` + reichlich Container-RAM (>= Schwellenwert) -> fp32:
+    ``low_cpu_mem_usage=True``, aber KEIN ``torch_dtype`` (kein fp16)."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "auto")
+    monkeypatch.setattr(
+        _sim_common_module, "_read_available_mb_linux", lambda: 8192.0
+    )
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args, **kwargs):
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with _patch_transformers_and_torch(fake_module, fake_torch):
+        install_bert_memory_profile()
+        patched = fake_module.AutoModel.from_pretrained
+
+    patched("Twitter/twhin-bert-base")
+    assert len(captured_calls) == 1
+    kwargs = captured_calls[0]["kwargs"]
+    assert kwargs.get("low_cpu_mem_usage") is True
+    # Genug RAM -> fp32 -> torch_dtype darf NICHT injiziert werden.
+    assert "torch_dtype" not in kwargs
+
+
+def test_auto_profile_fp16_when_ram_low(
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
+) -> None:
+    """``auto`` + knapper Container-RAM (< Schwellenwert) -> fp16:
+    ``low_cpu_mem_usage=True`` UND ``torch_dtype=fp16`` (OOM-Schutz aktiv)."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "auto")
+    monkeypatch.setattr(
+        _sim_common_module, "_read_available_mb_linux", lambda: 1024.0
+    )
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args, **kwargs):
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with _patch_transformers_and_torch(fake_module, fake_torch):
+        install_bert_memory_profile()
+        patched = fake_module.AutoModel.from_pretrained
+
+    patched("Twitter/twhin-bert-base")
+    assert len(captured_calls) == 1
+    kwargs = captured_calls[0]["kwargs"]
+    assert kwargs.get("low_cpu_mem_usage") is True
+    assert kwargs.get("torch_dtype") == "fp16"  # fake_torch.float16 sentinel
+
+
+def test_auto_profile_fp16_when_ram_unknown(
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
+) -> None:
+    """``auto`` + RAM nicht ermittelbar (``None``, z.B. macOS) ->
+    konservativ fp16 (OOM-Schutz bleibt als Safe-Default erhalten)."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "auto")
+    monkeypatch.setattr(
+        _sim_common_module, "_read_available_mb_linux", lambda: None
+    )
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args, **kwargs):
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with _patch_transformers_and_torch(fake_module, fake_torch):
+        install_bert_memory_profile()
+        patched = fake_module.AutoModel.from_pretrained
+
+    patched("Twitter/twhin-bert-base")
+    kwargs = captured_calls[0]["kwargs"]
+    assert kwargs.get("low_cpu_mem_usage") is True
+    assert kwargs.get("torch_dtype") == "fp16"
+
+
+def test_auto_profile_boundary_exact_threshold(
+    monkeypatch: pytest.MonkeyPatch, fake_torch: mock.Mock
+) -> None:
+    """Genau am Schwellenwert (``_BERT_FP32_MIN_AVAIL_MB``) -> fp32
+    (``>=``-Bedingung). Verriegelt die Grenze gegen Off-by-One-Drift."""
+    monkeypatch.setenv("AGORA_BERT_MEMORY_PROFILE", "auto")
+    threshold = _sim_common_module._BERT_FP32_MIN_AVAIL_MB
+    monkeypatch.setattr(
+        _sim_common_module, "_read_available_mb_linux", lambda: float(threshold)
+    )
+
+    captured_calls: list[dict] = []
+
+    def _fake_from_pretrained(*args, **kwargs):
+        captured_calls.append({"args": args, "kwargs": kwargs})
+        return mock.Mock(name="model")
+
+    fake_module = mock.Mock()
+    fake_module.AutoModel.from_pretrained = _fake_from_pretrained
+    with _patch_transformers_and_torch(fake_module, fake_torch):
+        install_bert_memory_profile()
+        patched = fake_module.AutoModel.from_pretrained
+
+    patched("Twitter/twhin-bert-base")
+    kwargs = captured_calls[0]["kwargs"]
+    assert "torch_dtype" not in kwargs  # >= threshold -> fp32

--- a/changelog.d/1148-oasis-fp16-round0-hang.md
+++ b/changelog.d/1148-oasis-fp16-round0-hang.md
@@ -1,0 +1,3 @@
+### Fixed (OASIS-Simulation hängt auf Runde 0 — 2026-08-09)
+
+- **Host-adaptives BERT-Memory-Profil (`auto`-Default):** `install_bert_memory_profile` erzwang TWHIN-BERT bedingungslos auf `torch_dtype=fp16`. fp16 hat auf CPU keine nativen Kernel und fällt auf eine single-threaded Emulation zurück, deren Forward ~12 min dauert — `update_rec_table` ist `async`, ruft den Forward aber synchron (ohne `run_in_executor`) auf und blockiert so den gemeinsamen asyncio-Event-Loop von Twitter- und Reddit-Plattform (Runde-0-Hang). Neuer Default `"auto"` injiziert fp16 nur noch bei knappem Container-RAM (< 4 GB verfügbar, OOM-Schutz für 2.8-GiB-Kleincontainer) und lädt sonst fp32 (native CPU-Kernel, 16-Thread, ~14 s/Forward). `"low"`/`"off"` behalten ihre Semantik. (#1148)


### PR DESCRIPTION
## Was

Behebt den Runde-0-Hang bei OASIS-Parallel-Simulationen. Closes #1148.

## Root Cause

`backend/scripts/_sim_common.py::install_bert_memory_profile` erzwang TWHIN-BERT (`Twitter/twhin-bert-base`) **bedingungslos auf `torch_dtype=fp16`** (Default-Profil `"low"`).

- fp16 hat auf CPU **keine nativen Kernel** → langsamer single-threaded Fallback.
- Ein `update_rec_table()`-Forward dauert **~12 min** (gemessen: 1 R-Thread, freiwillige Kontext-Switches 0 für 12 min).
- `update_rec_table` ist `async def`, ruft den synchronen torch-Forward aber **ohne `run_in_executor`** auf → blockiert den gesamten Event-Loop (Twitter+Reddit teilen sich einen Loop).
- fp32 zum Vergleich: **16-threaded in ~14 s** (isolierter Forward, gleicher Host).

## Fix

Neuer Default-Profil-Level `"auto"` (host-adaptiv):
- `low_cpu_mem_usage=True` bleibt immer (harmlos, hilft Load-Peak).
- `torch_dtype=fp16` **nur noch bei knappem Container-RAM** (`< 4 GB` verfügbar) — OOM-Schutz für 2.8-GiB-Kleincontainer (Originalanforderung dieses Profils).
- Sonst **fp32** (native CPU-Kernel, 16-Thread, ~14 s/Forward).

Neuer Helper `_read_available_mb_linux()`: cgroup-Limit (v2→v1) minus Belegung, Fallback `/proc/meminfo MemAvailable`. `None` → konservativ fp16 (OOM-Schutz bleibt).

`"low"` und `"off"` behalten ihre bisherige Semantik → kein Breaking Change, bestehende Tests unverändert grün.

## Verifikation auf diesem Host

Container `agora`: `memory.max = max` (kein cgroup-Limit), Host `MemAvailable ≈ 32 GB` → `"auto"` wählt fp32 → Forward ~14 s statt ~12 min. **Keine Container-Vergrößerung nötig.**

## Tests

Regressionstest, der den Defekt trifft (vorher rot, nachher grün): `test_auto_is_default` + 4 weitere `auto`-Profil-Tests (`fp32_when_ram_plenty`, `fp16_when_ram_low`, `fp16_when_ram_unknown`, `boundary_exact_threshold`).

- Alle 16 BERT-Profile-Tests grün.
- Backend-Pre-Commit-Gate grün: 524 Contracts, 56 Schemas (`dump_schemas --check`), Ruff, Mypy (`Success: no issues found in 254 source files`).
- Pre-Push-Gate `backend` grün.

## Risiko / Backward-Compat

- Wer bewusst `AGORA_BERT_MEMORY_PROFILE=low` setzt, bekommt weiterhin fp16 (unverändert).
- Auf fähigen Hosts (≥4 GB frei) wechselt der Default von fp16 → fp32 → höherer RAM-Bedarf des Recommender-Modells (~1.2 GB statt ~600 MB), aber das ist auf solchen Hosts unkritisch und durch die ~50× schnellere Forward-Loop mehr als gerechtfertigt.
- Auf Kleincontainern (<4 GB frei) bleibt fp16 automatisch aktiv — der OOM-Schutz geht nicht verloren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)