### PR TITLE
fix(report): Evidence-Provenance-Pipeline — Interviews/Fakten kanonisch persistieren, Gate-Audit-Trail, Metadata-Vollttext

### DIFF
--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -624,6 +624,13 @@ class EvidenceMapModel(BaseModel):
     # Issue #1006: additiv, Default leer — bestehende persistierte
     # EvidenceMaps ohne dieses Feld validieren unverändert weiter.
     degradation_log: list[EvidenceDegradationModel] = Field(default_factory=list)
+    #: Audit-Trail regulärer Evidence-Gate-Entscheidungen (Reviewer-Floor,
+    #: fehlende Supporting-Evidence, Fließtext-Entfernungen). Bewusst getrennt
+    #: vom ``degradation_log``: der dokumentiert Validator-Reparaturen und
+    #: stuft den Report-Status über ``apply_degradation_downgrade`` auf
+    #: INCOMPLETE ab — ein erwartetes Hypothesen-Routing im Balanced-Modus
+    #: ist dagegen kein Statusmangel (Codex-Review PR #1151, P1).
+    gate_decision_log: list[EvidenceDegradationModel] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_evidence_cross_references(self) -> "EvidenceMapModel":

--- a/backend/app/services/evidence_identity.py
+++ b/backend/app/services/evidence_identity.py
@@ -34,4 +34,27 @@ def build_evidence_id(
     return f"ev_{hashlib.sha256(material).hexdigest()[:32]}"
 
 
-__all__ = ["build_evidence_id"]
+def build_producer_key(prefix: str, *parts: object) -> str:
+    """Baut einen deterministischen ``producer_key`` aus strukturierten Teilen.
+
+    Laengen-Praefix pro Teil verhindert Kollisionen durch Konkatenation
+    (``("ab", "c")`` vs. ``("a", "bc")``). Der Praefix bleibt lesbar, der
+    Hash haelt den Key unter dem 500-Zeichen-Limit von
+    ``EvidenceRecordModel.producer_key``.
+    """
+    normalized = tuple(
+        _identity_part(part, field_name=f"producer_key part {index}")
+        for index, part in enumerate(parts)
+    )
+    if not normalized:
+        raise ValueError("build_producer_key braucht mindestens einen Teil.")
+    material = b"".join(
+        len(part.encode("utf-8")).to_bytes(4, "big") + part.encode("utf-8")
+        for part in normalized
+    )
+    digest = hashlib.sha256(material).hexdigest()[:24]
+    clean_prefix = _identity_part(prefix, field_name="prefix")
+    return f"{clean_prefix}:{digest}"
+
+
+__all__ = ["build_evidence_id", "build_producer_key"]

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -188,9 +188,11 @@ class ReportAgent:
         except ValidationError as exc:
             # Ein einzelnes defektes Tool-Item darf die Section nicht abbrechen;
             # es bleibt als unresolved sichtbar statt still zu verschwinden.
+            # producer_key bewusst nicht loggen: web:-Keys tragen volle URLs,
+            # die Query-Secrets enthalten können (CodeRabbit PR #1151, Major).
             logger.warning(
-                "register_evidence_record: Item verworfen (type=%r, producer_key=%r): %s",
-                enriched.get("type"), enriched.get("producer_key"), exc,
+                "register_evidence_record: Item verworfen (type=%r, %d Validierungsfehler)",
+                enriched.get("type"), len(exc.errors()),
             )
             self._active_section_unresolved_evidence.append(enriched)
             return

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from ...utils.llm_client import LLMClient
 from ..confidence_calculator import compute_confidence
 from ..evidence_binder import bind_evidence_to_claim, detect_contradiction_penalty
+from ..evidence_identity import build_producer_key
 from .evidence import (
     degrade_sections_for_violations,
     init_evidence_map,
@@ -173,11 +174,21 @@ class ReportAgent:
         if self.evidence_map is None:
             self._active_section_unresolved_evidence.append(enriched)
             return
-        record = register_evidence_record(
-            self.evidence_map,
-            enriched,
-            scope_id=self.simulation_id,
-        )
+        try:
+            record = register_evidence_record(
+                self.evidence_map,
+                enriched,
+                scope_id=self.simulation_id,
+            )
+        except ValidationError as exc:
+            # Ein einzelnes defektes Tool-Item darf die Section nicht abbrechen;
+            # es bleibt als unresolved sichtbar statt still zu verschwinden.
+            logger.warning(
+                "register_evidence_record: Item verworfen (type=%r, producer_key=%r): %s",
+                enriched.get("type"), enriched.get("producer_key"), exc,
+            )
+            self._active_section_unresolved_evidence.append(enriched)
+            return
         if record is None:
             self._active_section_unresolved_evidence.append(enriched)
             return
@@ -288,17 +299,32 @@ class ReportAgent:
         rendered_result: str,
         section_index: int,
     ) -> None:
+        # Kanonische Identität für Fakten aus dem Graphen: der Fakt-Text selbst
+        # ist die deterministische Quelle (kein freier LLM-Text), die Query
+        # bleibt außen vor — derselbe Fakt über verschiedene Queries ist
+        # dieselbe Evidence. Ohne producer_key verwirft
+        # register_evidence_record das Item still (report_06f654800817:
+        # 0 von ~40 Interview-/Fakten-Items im evidence_index).
+        def _graph_fact_item(fact: str, item_type: str, query: str, key_prefix: str) -> Optional[Dict[str, Any]]:
+            snippet = self._truncate(fact)
+            if not snippet:
+                return None
+            return {
+                "type": item_type,
+                "tool_name": tool_name,
+                "query": query,
+                "snippet": snippet,
+                "raw": fact,
+                "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
+                "producer_key": build_producer_key(key_prefix, str(fact).strip()),
+            }
+
         items: List[Dict[str, Any]] = []
         if isinstance(structured_result, InsightForgeResult):
             for fact in structured_result.semantic_facts[:10]:
-                items.append({
-                    "type": "graph_fact",
-                    "tool_name": tool_name,
-                    "query": structured_result.query,
-                    "snippet": self._truncate(fact),
-                    "raw": fact,
-                    "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                item = _graph_fact_item(fact, "graph_fact", structured_result.query, "graph-fact")
+                if item:
+                    items.append(item)
             for entity in structured_result.entity_insights[:8]:
                 item = {
                     "type": "entity_summary",
@@ -312,52 +338,58 @@ class ReportAgent:
                     item["producer_key"] = f"graph-node:{entity['uuid']}"
                 items.append(item)
             for chain in structured_result.relationship_chains[:8]:
-                items.append({
-                    "type": "relationship_chain",
-                    "tool_name": tool_name,
-                    "query": structured_result.query,
-                    "snippet": self._truncate(chain),
-                    "raw": chain,
-                    "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                item = _graph_fact_item(chain, "relationship_chain", structured_result.query, "graph-chain")
+                if item:
+                    items.append(item)
         elif isinstance(structured_result, PanoramaResult):
             for fact in structured_result.active_facts[:10]:
-                items.append({
-                    "type": "graph_fact",
-                    "tool_name": tool_name,
-                    "query": structured_result.query,
-                    "snippet": self._truncate(fact),
-                    "raw": fact,
-                    "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                item = _graph_fact_item(fact, "graph_fact", structured_result.query, "graph-fact")
+                if item:
+                    items.append(item)
             for fact in structured_result.historical_facts[:6]:
-                items.append({
-                    "type": "graph_fact",
-                    "tool_name": tool_name,
-                    "query": structured_result.query,
-                    "snippet": self._truncate(fact),
-                    "raw": fact,
-                    "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                item = _graph_fact_item(fact, "graph_fact", structured_result.query, "graph-fact")
+                if item:
+                    items.append(item)
         elif isinstance(structured_result, SearchResult):
             for fact in structured_result.facts[:10]:
-                items.append({
-                    "type": "graph_fact",
-                    "tool_name": tool_name,
-                    "query": structured_result.query,
-                    "snippet": self._truncate(fact),
-                    "raw": fact,
-                    "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
-                })
+                item = _graph_fact_item(fact, "graph_fact", structured_result.query, "graph-fact")
+                if item:
+                    items.append(item)
         elif isinstance(structured_result, InterviewResult):
-            for interview in structured_result.interviews[:6]:
+            # Jede erfolgreiche Interviewantwort wird ein eigenständig
+            # referenzierbares Evidence-Item. Identitätsbasis: Section, Topic,
+            # Agent, Frage UND Antwort-Hash — gleicher Text verschiedener
+            # Agenten kollabiert nicht, zwei Fragen an denselben Agenten
+            # bleiben unterscheidbar. source_kind wird via Typ-Mapping
+            # agent_quote (simulierte Stakeholder-Stimme, ADR-0002) —
+            # deshalb sind quote und persona_stakeholder_group Pflicht.
+            topic = structured_result.interview_topic or ""
+            for interview in structured_result.interviews[:10]:
+                response = (interview.response or "").strip()
+                if not response:
+                    continue
+                quote_source = next(
+                    (q.strip() for q in interview.key_quotes if q and q.strip()),
+                    response,
+                )
                 items.append({
                     "type": "agent_interview",
                     "tool_name": tool_name,
-                    "query": structured_result.interview_topic,
-                    "snippet": self._truncate(interview.response),
+                    "query": topic,
+                    "snippet": self._truncate(response),
                     "raw": interview.to_dict(),
+                    "quote": quote_source[:500],
+                    "persona_stakeholder_group": (
+                        (interview.agent_role or interview.agent_name or "unbekannt").strip()[:200]
+                    ),
                     "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
+                    "producer_key": build_producer_key(
+                        f"interview:s{section_index}",
+                        topic or "no-topic",
+                        interview.agent_name or "unknown-agent",
+                        interview.question or "no-question",
+                        response,
+                    ),
                 })
         elif isinstance(structured_result, dict) and "results" in structured_result:
             for result in (structured_result.get("results") or [])[:8]:

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -601,10 +601,19 @@ class ReportAgent:
     def _finalize_section_claims(
         self,
         claims: List[Dict[str, Any]],
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ) -> tuple[
+        List[Dict[str, Any]],
+        List[Dict[str, Any]],
+        List[Dict[str, Any]],
+        List[Dict[str, Any]],
+    ]:
         finalized_claims: List[Dict[str, Any]] = []
         hypotheses: List[Dict[str, Any]] = []
         data_gaps: List[Dict[str, Any]] = []
+        # Slice 7 (Audit Trail): jede Routing-Entscheidung des Evidence-Gates
+        # wird als EvidenceDegradationModel-Eintrag protokolliert —
+        # section_index ergänzt der Caller (_save_evidence_section).
+        gate_decisions: List[Dict[str, Any]] = []
 
         from app.contracts.report_v3 import CLAIM_MIN_EVIDENCE_FOR_CLAIM  # noqa: PLC0415
 
@@ -670,6 +679,12 @@ class ReportAgent:
                     "rationale": rationale,
                     "suggested_evidence": [],
                 })
+                gate_decisions.append({
+                    "claim_id": str(claim.get("claim_id") or "<no-id>"),
+                    "violation": "reviewer_floor_insufficient_evidence",
+                    "action": "moved_to_hypotheses",
+                    "detail": rationale[:500],
+                })
                 continue
 
             # P0-5: Ohne eine einzige stützende Quelle ist die Aussage eine
@@ -710,6 +725,12 @@ class ReportAgent:
                     ),
                     "suggested_fix": suggestions[0],
                 })
+                gate_decisions.append({
+                    "claim_id": str(claim.get("claim_id") or "<no-id>"),
+                    "violation": "no_supporting_evidence",
+                    "action": "moved_to_hypotheses",
+                    "detail": rationale[:500],
+                })
                 continue
             if not evidence and label in ("medium", "high", "verified"):
                 # P2.1: medium/high/verified ohne Evidence darf nicht in claims[]
@@ -727,10 +748,16 @@ class ReportAgent:
                     "gap_reason": "no_evidence_bound",
                     "suggested_fix": suggestions[0] if suggestions else None,
                 })
+                gate_decisions.append({
+                    "claim_id": str(claim.get("claim_id") or "<no-id>"),
+                    "violation": "confidence_label_without_evidence",
+                    "action": "dropped",
+                    "detail": f"Label '{label}' ohne Evidence — als data_gap geführt."[:500],
+                })
                 continue
             finalized_claims.append(claim)
 
-        return finalized_claims, hypotheses, data_gaps
+        return finalized_claims, hypotheses, data_gaps, gate_decisions
 
     def _section_dedup_check(
         self, new_summary: str, existing: List[Dict[str, Any]]
@@ -819,6 +846,7 @@ class ReportAgent:
             )
             claims: List[Dict[str, Any]] = []
             raw_hypotheses: List[Dict[str, Any]] = []
+            gate_decisions: List[Dict[str, Any]] = []
             data_gaps: List[Dict[str, Any]] = [{
                 # ReportSectionDataGapModel.gap_id erzwingt ^gap_\d{2,}$ —
                 # ein sprechendes Präfix ("gap_section_03") lässt die gesamte
@@ -828,19 +856,42 @@ class ReportAgent:
                 "claim_text": section_title,
             }]
         else:
-            claims, raw_hypotheses, data_gaps = self._finalize_section_claims(
+            claims, raw_hypotheses, data_gaps, gate_decisions = self._finalize_section_claims(
                 self._build_claims_for_section(content)
             )
         # Aus dem Fließtext entfernte Faktenaussagen sind Hypothesen, keine
         # gelöschten Sätze — sie bleiben für den Leser nachvollziehbar.
-        raw_hypotheses = list(raw_hypotheses) + (
+        prose_hypotheses = (
             getattr(self, "_pending_prose_hypotheses", {}) or {}
         ).get(section_index, [])
+        raw_hypotheses = list(raw_hypotheses) + prose_hypotheses
         # IDs zentral neu vergeben: Claim-Routing und Fließtext-Prüfung zählen
         # jeweils ab 1, zusammengeführt kollidieren sie sonst.
         for _position, _hypothesis in enumerate(raw_hypotheses, start=1):
             if isinstance(_hypothesis, dict):
                 _hypothesis["hypothesis_id"] = f"hypothesis_{_position:02d}"
+        # Slice 7 (Audit Trail): Gate-Routing und Fließtext-Entfernungen sind
+        # Degradation-Entscheidungen und werden auditierbar protokolliert —
+        # der leere degradation_log bei 17 entfernten Aussagen
+        # (report_06f654800817) war eine Erfassungslücke, keine Absicht.
+        for _prose_hypothesis in prose_hypotheses:
+            if not isinstance(_prose_hypothesis, dict):
+                continue
+            gate_decisions.append({
+                "claim_id": str(_prose_hypothesis.get("hypothesis_id") or "<no-id>"),
+                "violation": "prose_fact_unsupported",
+                "action": "moved_to_hypotheses",
+                "detail": self._truncate(
+                    str(_prose_hypothesis.get("hypothesis_text") or ""), 500
+                ) or "Fließtext-Aussage ohne deckende Evidence entfernt.",
+            })
+        if gate_decisions:
+            self.evidence_map["degradation_log"] = list(
+                self.evidence_map.get("degradation_log") or []
+            ) + [
+                {**decision, "section_index": section_index}
+                for decision in gate_decisions
+            ]
         # Slice 3 (Issue #495): Dedup + Cap per Section.
         from .hypothesis_cap import dedup_and_cap_hypotheses  # noqa: PLC0415
         hypotheses_visible, hypotheses_appendix = dedup_and_cap_hypotheses(raw_hypotheses)

--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -80,6 +80,11 @@ FORBIDDEN_EVIDENCE_TYPES = frozenset({
     "section_synthesis",
 })
 
+#: Platzhalter, den GraphToolsService für stumme Interview-Plattformen einsetzt
+#: — ein Interview, das nur daraus besteht, ist fehlgeschlagen, keine Evidence.
+_INTERVIEW_NO_RESPONSE = "(No response from this platform)"
+_INTERVIEW_STRUCTURE_RE = re.compile(r"\[(?:Twitter|Reddit) Platform Response\]")
+
 
 class ReportAgent:
     """Simulation report generation agent."""
@@ -363,11 +368,26 @@ class ReportAgent:
             # bleiben unterscheidbar. source_kind wird via Typ-Mapping
             # agent_quote (simulierte Stakeholder-Stimme, ADR-0002) —
             # deshalb sind quote und persona_stakeholder_group Pflicht.
-            topic = structured_result.interview_topic or ""
+            topic = (structured_result.interview_topic or "").strip()
             for interview in structured_result.interviews[:10]:
                 response = (interview.response or "").strip()
-                if not response:
+                # GraphToolsService liefert bei stummen Plattformen einen
+                # strukturierten Platzhalter-Text — der ist kein Interview
+                # und darf nicht als agent_quote-Evidence persistieren
+                # (Codex-Review PR #1151, P2).
+                substance = _INTERVIEW_STRUCTURE_RE.sub("", response)
+                substance = substance.replace(_INTERVIEW_NO_RESPONSE, "").strip()
+                if not substance:
                     continue
+                # Whitespace-only Werte sind truthy — erst normalisieren, dann
+                # Fallback, sonst wirft build_producer_key ValueError.
+                agent_name = (interview.agent_name or "").strip() or "unknown-agent"
+                question = (interview.question or "").strip() or "no-question"
+                stakeholder_group = (
+                    (interview.agent_role or "").strip()
+                    or (interview.agent_name or "").strip()
+                    or "unbekannt"
+                )
                 quote_source = next(
                     (q.strip() for q in interview.key_quotes if q and q.strip()),
                     response,
@@ -379,15 +399,13 @@ class ReportAgent:
                     "snippet": self._truncate(response),
                     "raw": interview.to_dict(),
                     "quote": quote_source[:500],
-                    "persona_stakeholder_group": (
-                        (interview.agent_role or interview.agent_name or "unbekannt").strip()[:200]
-                    ),
+                    "persona_stakeholder_group": stakeholder_group[:200],
                     "agent_log_ref": {"section_index": section_index, "action": "tool_result", "tool_name": tool_name},
                     "producer_key": build_producer_key(
                         f"interview:s{section_index}",
                         topic or "no-topic",
-                        interview.agent_name or "unknown-agent",
-                        interview.question or "no-question",
+                        agent_name,
+                        question,
                         response,
                     ),
                 })
@@ -725,9 +743,17 @@ class ReportAgent:
                     ),
                     "suggested_fix": suggestions[0],
                 })
+                # Copilot-Review PR #1151: dieser Zweig fängt auch den Fall
+                # medium/high/verified ohne jede Evidence ab (der spätere
+                # P2.1-Zweig ist dafür unerreichbar) — das Label macht die
+                # Verletzung im Audit-Trail unterscheidbar.
                 gate_decisions.append({
                     "claim_id": str(claim.get("claim_id") or "<no-id>"),
-                    "violation": "no_supporting_evidence",
+                    "violation": (
+                        "confidence_label_without_evidence"
+                        if not evidence and label in ("medium", "high", "verified")
+                        else "no_supporting_evidence"
+                    ),
                     "action": "moved_to_hypotheses",
                     "detail": rationale[:500],
                 })
@@ -747,12 +773,6 @@ class ReportAgent:
                     "claim_text": claim_text,
                     "gap_reason": "no_evidence_bound",
                     "suggested_fix": suggestions[0] if suggestions else None,
-                })
-                gate_decisions.append({
-                    "claim_id": str(claim.get("claim_id") or "<no-id>"),
-                    "violation": "confidence_label_without_evidence",
-                    "action": "dropped",
-                    "detail": f"Label '{label}' ohne Evidence — als data_gap geführt."[:500],
                 })
                 continue
             finalized_claims.append(claim)
@@ -886,8 +906,10 @@ class ReportAgent:
                 ) or "Fließtext-Aussage ohne deckende Evidence entfernt.",
             })
         if gate_decisions:
-            self.evidence_map["degradation_log"] = list(
-                self.evidence_map.get("degradation_log") or []
+            # Getrennt vom degradation_log: reguläres Gate-Routing ist kein
+            # Statusmangel und darf apply_degradation_downgrade nicht auslösen.
+            self.evidence_map["gate_decision_log"] = list(
+                self.evidence_map.get("gate_decision_log") or []
             ) + [
                 {**decision, "section_index": section_index}
                 for decision in gate_decisions

--- a/backend/app/services/report_agent/markdown_renderer.py
+++ b/backend/app/services/report_agent/markdown_renderer.py
@@ -145,6 +145,44 @@ _MODE_BANNER: dict[str, str] = {
 }
 
 
+def render_evidence_status(report: ReportV3) -> str:
+    """Kompakte Statusübersicht: was ist belegt, was Hypothese, was fehlt.
+
+    Macht den Balanced-Modus sichtbar (validierte Claims + markierte
+    Hypothesen) und stellt klar, dass Simulationsaussagen keine empirische
+    Nutzerforschung sind — der Leser sieht den Evidenzstand, bevor er den
+    narrativen Text liest.
+    """
+    table = _table(
+        ["Status", "Anzahl", "Bedeutung"],
+        [
+            [
+                "Validierte Claims",
+                len(report.claims),
+                "Durch kanonische Evidence-Referenzen belegt",
+            ],
+            [
+                "Hypothesen",
+                len(report.hypotheses),
+                "Plausibel, aber ohne bindende Evidence — nicht als Fakt lesen",
+            ],
+            [
+                "Data Gaps",
+                len(report.data_gaps),
+                "Fehlende Informationen, die eine belastbare Aussage verhindern",
+            ],
+        ],
+        "Kein Evidenzstatus verfügbar.",
+    )
+    return (
+        "## Evidenzstatus\n\n"
+        + table
+        + "\n\n> Persona-Zitate und Interviewaussagen in diesem Report stammen "
+        "aus **simulierten Agenten**. Sie sind Simulationsevidenz und keine "
+        "empirische Nutzerforschung."
+    )
+
+
 def render_report_v3(report: ReportV3) -> str:
     mode = getattr(report, "report_mode", "balanced") or "balanced"
     banner = _MODE_BANNER.get(mode, _MODE_BANNER["balanced"])
@@ -153,6 +191,7 @@ def render_report_v3(report: ReportV3) -> str:
         f"Report-ID: `{_cell(report.report_id)}`",
         f"Generiert: `{report.generated_at.isoformat()}`",
         banner,
+        render_evidence_status(report),
         "## Persona-Tabelle",
         render_persona_table(report.personas),
         "## Segment-Tabelle",
@@ -209,6 +248,7 @@ def render_report_v3(report: ReportV3) -> str:
 __all__ = [
     "render_claim_table",
     "render_data_gaps",
+    "render_evidence_status",
     "render_hypotheses_table",
     "render_persona_table",
     "render_report_v3",

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -96,6 +96,18 @@ class SectionKeyTakeaway(BaseModel):
         default="medium",
         description="Einschätzungsqualität: low | medium | high",
     )
+    confidence_scope: str = Field(
+        default="simulation_consensus",
+        description=(
+            "Geltungsbereich der Confidence: simulation_consensus "
+            "(Übereinstimmung simulierter Agenten) | evidence (durch "
+            "kanonische Evidence-Referenzen belegt) | empirical (reale "
+            "empirische Daten). Aussagen aus Interviews/Simulation ohne "
+            "Evidence-Bindung sind IMMER simulation_consensus — niemals "
+            "evidence oder empirical angeben, wenn die Aussage nur auf "
+            "simulierten Agenten beruht."
+        ),
+    )
 
 
 class SectionMetadata(BaseModel):

--- a/backend/app/services/report_agent/schemas.py
+++ b/backend/app/services/report_agent/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import cache
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -96,7 +97,9 @@ class SectionKeyTakeaway(BaseModel):
         default="medium",
         description="Einschätzungsqualität: low | medium | high",
     )
-    confidence_scope: str = Field(
+    confidence_scope: Literal[
+        "simulation_consensus", "evidence", "empirical"
+    ] = Field(
         default="simulation_consensus",
         description=(
             "Geltungsbereich der Confidence: simulation_consensus "

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -700,6 +700,12 @@ def generate_section_react(
     return final_answer
 
 
+#: Notbremse für die Metadata-Extraktion: reale Sections liegen bei 5-12k
+#: Zeichen; erst weit darüber wird gekürzt (und geloggt), damit keine
+#: falschen "Abschnitt bricht ab"-Data-Gaps aus einem Preview entstehen.
+METADATA_MAX_CONTENT_CHARS = 24000
+
+
 def generate_section_metadata(
     agent: Any,
     section_title: str,
@@ -745,9 +751,22 @@ def generate_section_metadata(
         "4. Bei fehlenden Informationen: leere Liste oder Default-Wert. "
         "Nicht halluzinieren, nicht auffüllen."
     )
+    # Der frühere 6000-Zeichen-Cap schnitt reale Sections mittendrin ab —
+    # die Metadata-Extraktion meldete daraufhin erfundene Data-Gaps wie
+    # "Abschnitt bricht ab", obwohl der persistierte Text vollständig war
+    # (report_06f654800817, Sections 3-6). Der Guard bleibt nur als
+    # Notbremse gegen entartete Inhalte weit oberhalb realer Sectionlängen.
+    if len(section_content) > METADATA_MAX_CONTENT_CHARS:
+        logger.warning(
+            "generate_section_metadata: section=%d Inhalt %d Zeichen > %d — "
+            "Metadaten sehen einen gekürzten Text.",
+            section_index,
+            len(section_content),
+            METADATA_MAX_CONTENT_CHARS,
+        )
     user_msg = (
         f"## Abschnittstitel\n{section_title}\n\n"
-        f"## Inhalt\n{section_content[:6000]}"
+        f"## Inhalt\n{section_content[:METADATA_MAX_CONTENT_CHARS]}"
     )
 
     try:

--- a/backend/tests/contracts/test_evidence_degradation.py
+++ b/backend/tests/contracts/test_evidence_degradation.py
@@ -61,6 +61,7 @@ class _FakeAgentForDegradation:
             claims,
             hypotheses or [],
             data_gaps or [],
+            [],
         )
         self._truncate = lambda text, length: (
             text[:length] if isinstance(text, str) else text

--- a/backend/tests/eval/test_evidence_routing.py
+++ b/backend/tests/eval/test_evidence_routing.py
@@ -41,7 +41,7 @@ def test_orphan_claims_route_to_hypotheses_and_data_gaps() -> None:
     raw = json.loads(FIXTURE_MIXED.read_text(encoding="utf-8"))
 
     agent = ReportAgent.__new__(ReportAgent)
-    claims, hypotheses, data_gaps = agent._finalize_section_claims(raw["claims"])
+    claims, hypotheses, data_gaps, _decisions = agent._finalize_section_claims(raw["claims"])
 
     assert claims == [], f"Erwartet keine finalisierten Claims, erhalten: {claims}"
     # claim_01 (medium), claim_02 (high), claim_03 (low) — alle ohne Evidence.
@@ -61,7 +61,7 @@ def test_medium_high_orphan_section_validates() -> None:
     raw = json.loads(FIXTURE_MIXED.read_text(encoding="utf-8"))
 
     agent = ReportAgent.__new__(ReportAgent)
-    claims, hypotheses, data_gaps = agent._finalize_section_claims(raw["claims"])
+    claims, hypotheses, data_gaps, _decisions = agent._finalize_section_claims(raw["claims"])
 
     section = ReportSectionModel.model_validate({
         "section_index": 1,

--- a/backend/tests/eval/test_orphan_claim_routing.py
+++ b/backend/tests/eval/test_orphan_claim_routing.py
@@ -15,7 +15,7 @@ def test_all_orphan_claims_route_to_hypotheses_and_data_gaps() -> None:
     raw = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
     agent = ReportAgent.__new__(ReportAgent)
-    claims, hypotheses, data_gaps = agent._finalize_section_claims(raw["claims"])
+    claims, hypotheses, data_gaps, _decisions = agent._finalize_section_claims(raw["claims"])
 
     assert claims == []
     assert len(hypotheses) == len(raw["claims"])

--- a/backend/tests/services/test_evidence_gate_audit.py
+++ b/backend/tests/services/test_evidence_gate_audit.py
@@ -1,0 +1,113 @@
+"""Regressionstests für den auditierbaren Evidence-Gate-Trail (Slice 7).
+
+Der Referenzlauf report_06f654800817 entfernte 17 Fließtext-Aussagen und
+routete sämtliche Claims in Hypothesen — der ``degradation_log`` blieb
+trotzdem leer. Diese Tests fixieren, dass jede Gate-Entscheidung
+(Reviewer-Floor, fehlende Supporting-Evidence, Fließtext-Entfernung)
+als ``EvidenceDegradationModel``-Eintrag protokolliert wird, ohne das
+Gate selbst zu verändern.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.contracts.report_v3 import CLAIM_MIN_EVIDENCE_FOR_CLAIM
+from app.services.report_agent import ReportAgent
+from app.services.report_agent.markdown_renderer import render_evidence_status
+from app.services.report_agent.schemas import SectionKeyTakeaway
+
+_EV_ID = "ev_" + "1" * 32
+
+
+def test_unsupported_claim_routing_writes_gate_decision():
+    agent = ReportAgent.__new__(ReportAgent)
+    claims = [{
+        "claim_id": "claim_01",
+        "claim_text": "Alle acht Agenten lehnen den Hard Cutover ab.",
+        "evidence": [],
+        "confidence_score": 0.2,
+        "confidence_label": "low",
+    }]
+
+    finalized, hypotheses, _gaps, decisions = agent._finalize_section_claims(claims)
+
+    assert finalized == []
+    assert len(hypotheses) == 1
+    assert len(decisions) == 1
+    assert decisions[0]["claim_id"] == "claim_01"
+    assert decisions[0]["violation"] == "no_supporting_evidence"
+    assert decisions[0]["action"] == "moved_to_hypotheses"
+
+
+def test_reviewer_floor_routing_writes_gate_decision():
+    assert CLAIM_MIN_EVIDENCE_FOR_CLAIM >= 2, "Test setzt Reviewer-Floor >= 2 voraus."
+    agent = ReportAgent.__new__(ReportAgent)
+    claims = [{
+        "claim_id": "claim_07",
+        "claim_text": "Die Migration braucht eine kontrollierte Übergangsphase.",
+        "evidence": [{"evidence_id": _EV_ID, "supports_claim": True}],
+        "confidence_score": 0.6,
+        "confidence_label": "low",
+    }]
+
+    finalized, hypotheses, _gaps, decisions = agent._finalize_section_claims(claims)
+
+    assert finalized == []
+    assert len(hypotheses) == 1
+    assert decisions[0]["claim_id"] == "claim_07"
+    assert decisions[0]["violation"] == "reviewer_floor_insufficient_evidence"
+    assert decisions[0]["action"] == "moved_to_hypotheses"
+
+
+def test_prose_removal_logged_in_degradation_log():
+    stub = ReportAgent.__new__(ReportAgent)
+    stub.evidence_map = {
+        "schema_version": 3,
+        "report_id": "r1",
+        "simulation_id": "sim1",
+        "evidence_index": {},
+        "global_evidence_refs": [],
+        "sections": [],
+    }
+    stub._pending_prose_hypotheses = {2: [{
+        "hypothesis_id": "hypothesis_99",
+        "hypothesis_text": "Der Traffic wächst derzeit um rund 20 Prozent pro Monat.",
+        "rationale": "Aus dem Fließtext entfernt: keine deckende Quelle gefunden.",
+        "suggested_evidence": [],
+    }]}
+    stub._pending_section_metadata = {}
+    stub._build_claims_for_section = lambda content: []
+    stub._finalize_section_claims = lambda raw: ([], [], [], [])
+    stub._section_dedup_check = lambda **kwargs: None
+
+    with patch("app.services.report_agent.ReportManager.save_evidence_map"):
+        stub._save_evidence_section(
+            "r1", 2, "Unsicherheiten",
+            "Ein ausreichend langer Abschnittstext ohne Fallback-Marker.",
+        )
+
+    log = stub.evidence_map.get("degradation_log") or []
+    prose_entries = [e for e in log if e["violation"] == "prose_fact_unsupported"]
+    assert len(prose_entries) == 1
+    assert prose_entries[0]["section_index"] == 2
+    assert prose_entries[0]["action"] == "moved_to_hypotheses"
+    # IDs werden vor dem Protokollieren zentral neu vergeben — der Eintrag
+    # referenziert die finale Hypothesen-ID, nicht die vorläufige.
+    assert prose_entries[0]["claim_id"] == "hypothesis_01"
+    section = stub.evidence_map["sections"][0]
+    assert section["hypotheses"][0]["hypothesis_id"] == "hypothesis_01"
+
+
+def test_key_takeaway_confidence_scope_defaults_to_simulation():
+    takeaway = SectionKeyTakeaway(statement="Acht Agenten benennen dieselben Risiken.")
+    assert takeaway.confidence_scope == "simulation_consensus"
+
+
+def test_render_evidence_status_shows_counts_and_simulation_notice():
+    report = SimpleNamespace(claims=[], hypotheses=[object(), object()], data_gaps=[object()])
+    rendered = render_evidence_status(report)
+    assert "Validierte Claims" in rendered
+    assert "Hypothesen" in rendered
+    assert "simulierten Agenten" in rendered
+    assert "keine" in rendered and "empirische Nutzerforschung" in rendered

--- a/backend/tests/services/test_evidence_gate_audit.py
+++ b/backend/tests/services/test_evidence_gate_audit.py
@@ -116,3 +116,20 @@ def test_render_evidence_status_shows_counts_and_simulation_notice():
     assert "Hypothesen" in rendered
     assert "simulierten Agenten" in rendered
     assert "keine" in rendered and "empirische Nutzerforschung" in rendered
+
+
+def test_render_report_v3_includes_evidence_status():
+    from datetime import datetime, timezone
+
+    from app.contracts.report_v3 import ReportV3
+    from app.services.report_agent.markdown_renderer import render_report_v3
+
+    report = ReportV3(
+        report_id="report_test01",
+        generated_at=datetime(2026, 8, 9, tzinfo=timezone.utc),
+    )
+    rendered = render_report_v3(report)
+    assert "## Evidenzstatus" in rendered
+    assert "empirische Nutzerforschung" in rendered
+    # Der Status-Block steht vor den Detail-Tabellen.
+    assert rendered.index("## Evidenzstatus") < rendered.index("## Claims")

--- a/backend/tests/services/test_evidence_gate_audit.py
+++ b/backend/tests/services/test_evidence_gate_audit.py
@@ -1,11 +1,13 @@
 """Regressionstests für den auditierbaren Evidence-Gate-Trail (Slice 7).
 
 Der Referenzlauf report_06f654800817 entfernte 17 Fließtext-Aussagen und
-routete sämtliche Claims in Hypothesen — der ``degradation_log`` blieb
-trotzdem leer. Diese Tests fixieren, dass jede Gate-Entscheidung
-(Reviewer-Floor, fehlende Supporting-Evidence, Fließtext-Entfernung)
-als ``EvidenceDegradationModel``-Eintrag protokolliert wird, ohne das
-Gate selbst zu verändern.
+routete sämtliche Claims in Hypothesen — auditierbar war davon nichts.
+Diese Tests fixieren, dass jede Gate-Entscheidung (Reviewer-Floor,
+fehlende Supporting-Evidence, Fließtext-Entfernung) als
+``EvidenceDegradationModel``-Eintrag im ``gate_decision_log`` landet —
+getrennt vom ``degradation_log``, der über ``apply_degradation_downgrade``
+den Report-Status abstuft und deshalb regulärem Gate-Routing vorbehalten
+bleiben darf (Codex-Review PR #1151, P1).
 """
 from __future__ import annotations
 
@@ -87,7 +89,7 @@ def test_prose_removal_logged_in_degradation_log():
             "Ein ausreichend langer Abschnittstext ohne Fallback-Marker.",
         )
 
-    log = stub.evidence_map.get("degradation_log") or []
+    log = stub.evidence_map.get("gate_decision_log") or []
     prose_entries = [e for e in log if e["violation"] == "prose_fact_unsupported"]
     assert len(prose_entries) == 1
     assert prose_entries[0]["section_index"] == 2
@@ -97,6 +99,9 @@ def test_prose_removal_logged_in_degradation_log():
     assert prose_entries[0]["claim_id"] == "hypothesis_01"
     section = stub.evidence_map["sections"][0]
     assert section["hypotheses"][0]["hypothesis_id"] == "hypothesis_01"
+    # Reguläres Gate-Routing darf den Report-Status NICHT abstufen — der
+    # degradation_log (Trigger für apply_degradation_downgrade) bleibt leer.
+    assert not stub.evidence_map.get("degradation_log")
 
 
 def test_key_takeaway_confidence_scope_defaults_to_simulation():

--- a/backend/tests/services/test_report_tool_evidence.py
+++ b/backend/tests/services/test_report_tool_evidence.py
@@ -60,6 +60,53 @@ def _interview(
     )
 
 
+def test_placeholder_only_interview_is_skipped() -> None:
+    """GraphToolsService-Platzhalter für stumme Plattformen sind keine Evidence."""
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[_interview(response=(
+            "[Twitter Platform Response]\n(No response from this platform)\n\n"
+            "[Reddit Platform Response]\n(No response from this platform)"
+        ))],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    records = list((agent.evidence_map or {})["evidence_index"].values())
+    assert [r for r in records if r["type"] == "agent_interview"] == []
+
+
+def test_interview_cap_registers_at_most_ten() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[
+            _interview(agent_name=f"Agent {i:02d}", response=f"Eigenständige Antwort Nummer {i}.")
+            for i in range(11)
+        ],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    records = list((agent.evidence_map or {})["evidence_index"].values())
+    assert len([r for r in records if r["type"] == "agent_interview"]) == 10
+
+
 def test_interview_response_gets_canonical_evidence_id() -> None:
     agent = _make_agent()
     result = InterviewResult(

--- a/backend/tests/services/test_report_tool_evidence.py
+++ b/backend/tests/services/test_report_tool_evidence.py
@@ -1,0 +1,284 @@
+"""Regressionstests für Commit 7bac1291.
+
+Deckt zwei Fixes ab:
+
+1. ``ReportAgent._record_tool_evidence`` vergibt deterministische
+   ``producer_key``s für ``agent_interview``- und ``graph_fact``-Items, sodass
+   ``register_evidence_record`` sie in ``evidence_map["evidence_index"]`` mit
+   kanonischen ``ev_<32hex>``-IDs registriert (vorher: still verworfen).
+2. ``generate_section_metadata`` kappt den Section-Text erst bei
+   ``METADATA_MAX_CONTENT_CHARS`` (24000), nicht mehr bei 6000 Zeichen.
+"""
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+from app.services.graph.graph_dtos import AgentInterview, InterviewResult, SearchResult
+from app.services.report_agent import ReportAgent
+from app.services.report_agent.evidence import init_evidence_map
+
+EVIDENCE_ID_RE = re.compile(r"^ev_[0-9a-f]{32}$")
+
+
+def _make_agent(simulation_id: str = "sim_test") -> ReportAgent:
+    """Minimaler ReportAgent-Stub ohne echten LLM-/Graph-Call.
+
+    ``_record_tool_evidence`` braucht nur ``evidence_map`` und die beiden
+    ``_active_section_*``-Puffer — kein LLM.
+    """
+    agent = ReportAgent.__new__(ReportAgent)
+    agent.graph_id = "graph_test"
+    agent.simulation_id = simulation_id
+    agent.simulation_requirement = "Test-Requirement"
+    agent.llm = MagicMock()
+    agent.web_tools = MagicMock()
+    agent.graph_tools = MagicMock()
+    agent.evidence_map = init_evidence_map(
+        report_id="report_test",
+        simulation_id=simulation_id,
+        global_evidence=[],
+    )
+    agent._active_section_evidence = []
+    agent._active_section_unresolved_evidence = []
+    return agent
+
+
+def _interview(
+    agent_name: str = "Agent A",
+    agent_role: str = "Kundin",
+    question: str = "Was halten Sie davon?",
+    response: str = "Ich finde das Produkt überzeugend.",
+) -> AgentInterview:
+    return AgentInterview(
+        agent_name=agent_name,
+        agent_role=agent_role,
+        agent_bio="Bio-Text",
+        question=question,
+        response=response,
+        key_quotes=[],
+    )
+
+
+def test_interview_response_gets_canonical_evidence_id() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[
+            _interview(agent_name="Agent A", response="Antwort von Agent A."),
+            _interview(agent_name="Agent B", response="Antwort von Agent B."),
+        ],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    records = list((agent.evidence_map or {})["evidence_index"].values())
+    interview_records = [r for r in records if r["type"] == "agent_interview"]
+    assert len(interview_records) == 2
+    for record in interview_records:
+        assert record["source_kind"] == "agent_quote"
+        assert EVIDENCE_ID_RE.match(record["evidence_id"]), record["evidence_id"]
+        assert record["quote"]
+        assert record["persona_stakeholder_group"]
+
+
+def test_two_questions_same_agent_get_distinct_evidence_ids() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Frage 1", "Frage 2"],
+        interviews=[
+            _interview(agent_name="Agent A", question="Frage 1", response="Antwort 1."),
+            _interview(agent_name="Agent A", question="Frage 2", response="Antwort 2."),
+        ],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    ids = {r["evidence_id"] for r in agent._active_section_evidence}
+    assert len(ids) == 2
+
+
+def test_same_text_different_agents_not_collapsed() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[
+            _interview(agent_name="Agent A", response="Identischer Antworttext."),
+            _interview(agent_name="Agent B", response="Identischer Antworttext."),
+        ],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    ids = {r["evidence_id"] for r in agent._active_section_evidence}
+    assert len(ids) == 2
+
+
+def test_empty_interview_response_is_skipped() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[
+            _interview(agent_name="Agent A", response="   "),
+        ],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    assert agent._active_section_evidence == []
+    assert (agent.evidence_map or {})["evidence_index"] == {}
+
+
+def test_graph_fact_gets_canonical_evidence_id() -> None:
+    agent = _make_agent()
+    result = SearchResult(
+        facts=["Fakt eins über den Markt.", "Fakt zwei über die Zielgruppe."],
+        edges=[],
+        nodes=[],
+        query="marktanalyse",
+        total_count=2,
+    )
+
+    agent._record_tool_evidence(
+        tool_name="quick_search",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=2,
+    )
+
+    records = [
+        r for r in (agent.evidence_map or {})["evidence_index"].values()
+        if r["type"] == "graph_fact"
+    ]
+    assert len(records) == 2
+    for record in records:
+        assert EVIDENCE_ID_RE.match(record["evidence_id"]), record["evidence_id"]
+
+    # Derselbe Fakt erneut registriert -> Deduplizierung auf 1 Record.
+    agent._record_tool_evidence(
+        tool_name="quick_search",
+        parameters={},
+        structured_result=SearchResult(
+            facts=["Fakt eins über den Markt."],
+            edges=[],
+            nodes=[],
+            query="andere-query",
+            total_count=1,
+        ),
+        rendered_result="",
+        section_index=3,
+    )
+    records_after = [
+        r for r in (agent.evidence_map or {})["evidence_index"].values()
+        if r["type"] == "graph_fact"
+    ]
+    assert len(records_after) == 2
+
+
+def test_interview_evidence_keeps_simulation_provenance() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[_interview(agent_name="Agent A", response="Simulierte Stimme.")],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    record = agent._active_section_evidence[0]
+    assert record["source_kind"] == "agent_quote"
+    assert record["source_kind"] not in ("seed_corpus", "web_source")
+    assert isinstance(record["raw"], dict)
+    assert record["raw"]["agent_name"] == "Agent A"
+
+
+def test_claim_can_reference_interview_evidence() -> None:
+    agent = _make_agent()
+    result = InterviewResult(
+        interview_topic="Produktakzeptanz",
+        interview_questions=["Was halten Sie davon?"],
+        interviews=[_interview(agent_name="Agent A", response="Referenzierbare Antwort.")],
+    )
+
+    agent._record_tool_evidence(
+        tool_name="conduct_agent_interview",
+        parameters={},
+        structured_result=result,
+        rendered_result="",
+        section_index=1,
+    )
+
+    assert len(agent._active_section_evidence) == 1
+    binding = {"evidence_id": agent._active_section_evidence[0]["evidence_id"]}
+
+    # Exakter Lookup-Pfad aus _build_claims_for_section.
+    current_index = (agent.evidence_map or {}).get("evidence_index") or {}
+    resolved = current_index.get(binding["evidence_id"])
+
+    assert resolved is not None
+    assert resolved["type"] == "agent_interview"
+
+
+def test_metadata_sees_full_section_text() -> None:
+    from app.services.report_agent.workflow import generate_section_metadata
+
+    agent = ReportAgent.__new__(ReportAgent)
+    agent.llm = MagicMock()
+    agent.llm.chat_json.return_value = {
+        "section_title": "Allgemeine Einleitung",
+        "key_takeaways": [],
+        "data_gaps": [],
+    }
+
+    body = "Wichtiger Datenpunkt. " * 400  # > 8000 Zeichen
+    tail_marker = "ENDE-DES-ABSCHNITTS-MARKER-XYZ"
+    section_content = body + tail_marker
+    assert len(section_content) > 8000
+
+    generate_section_metadata(
+        agent,
+        section_title="Allgemeine Einleitung",
+        section_content=section_content,
+        section_index=1,
+    )
+
+    assert agent.llm.chat_json.called
+    messages = agent.llm.chat_json.call_args.kwargs["messages"]
+    user_msg = next(m["content"] for m in messages if m["role"] == "user")
+    assert tail_marker in user_msg
+    assert section_content[-200:] in user_msg

--- a/backend/tests/test_report_agent_contracts.py
+++ b/backend/tests/test_report_agent_contracts.py
@@ -226,7 +226,7 @@ def test_reviewer_floor_counts_unique_evidence_ids(tmp_path):
         ],
     }
 
-    finalized, hypotheses, _ = agent._finalize_section_claims([claim])
+    finalized, hypotheses, _, _decisions = agent._finalize_section_claims([claim])
 
     assert finalized == []
     assert len(hypotheses) == 1

--- a/changelog.d/1151-evidence-provenance-pipeline.md
+++ b/changelog.d/1151-evidence-provenance-pipeline.md
@@ -1,0 +1,10 @@
+Interview-Antworten und Graph-Fakten werden jetzt als kanonische Evidence
+persistiert und sind von Claims referenzierbar — vorher verwarf der
+Evidence-Index sie still, und Reports endeten trotz durchgeführter
+Interviews mit null validierten Claims. Zusätzlich: der `degradation_log`
+protokolliert jede Gate-Entscheidung (Reviewer-Floor, fehlende Evidence,
+Fließtext-Entfernungen), Key-Takeaways tragen einen `confidence_scope`
+(Simulations-Konsens vs. Evidenz), der ReportV3-Export beginnt mit einem
+Evidenzstatus-Block, und die Structured-Metadata-Extraktion sieht den
+vollständigen Section-Text statt eines 6000-Zeichen-Ausschnitts (beendet
+erfundene „Abschnitt bricht ab"-Data-Gaps).

--- a/changelog.d/1151-evidence-provenance-pipeline.md
+++ b/changelog.d/1151-evidence-provenance-pipeline.md
@@ -1,9 +1,10 @@
 Interview-Antworten und Graph-Fakten werden jetzt als kanonische Evidence
 persistiert und sind von Claims referenzierbar — vorher verwarf der
 Evidence-Index sie still, und Reports endeten trotz durchgeführter
-Interviews mit null validierten Claims. Zusätzlich: der `degradation_log`
-protokolliert jede Gate-Entscheidung (Reviewer-Floor, fehlende Evidence,
-Fließtext-Entfernungen), Key-Takeaways tragen einen `confidence_scope`
+Interviews mit null validierten Claims. Zusätzlich: das neue
+`gate_decision_log` protokolliert jede Gate-Entscheidung (Reviewer-Floor,
+fehlende Evidence, Fließtext-Entfernungen) getrennt vom statusrelevanten
+`degradation_log`, Key-Takeaways tragen einen `confidence_scope`
 (Simulations-Konsens vs. Evidenz), der ReportV3-Export beginnt mit einem
 Evidenzstatus-Block, und die Structured-Metadata-Extraktion sieht den
 vollständigen Section-Text statt eines 6000-Zeichen-Ausschnitts (beendet

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -231,6 +231,8 @@ const VALID_EVIDENCE: EvidenceMap = {
   // Issue #1006: additives Feld mit Default. Wie global_evidence und sections
   // ist es im z.infer-Output-Typ required, obwohl es beim Parsen optional ist.
   degradation_log: [],
+  // PR #1151: Audit-Trail regulärer Gate-Entscheidungen, gleiche Default-Logik.
+  gate_decision_log: [],
 }
 
 // Hilfsfunktion zum Mounten

--- a/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
+++ b/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
@@ -176,6 +176,31 @@ describe('kanonische Evidence-Identität', () => {
     expect(reportContract.EvidenceMapSchema.safeParse(mismatchedIndexKey).success).toBe(false);
   });
 
+  it('defaultet gate_decision_log auf [] und übernimmt Einträge unverändert (PR #1151)', () => {
+    // Persistierte Maps von vor PR #1151 tragen das Feld nicht.
+    const withoutLog = reportContract.EvidenceMapSchema.safeParse(EVIDENCE_MAP_V3);
+    expect(withoutLog.success).toBe(true);
+    if (withoutLog.success) {
+      expect(withoutLog.data.gate_decision_log).toEqual([]);
+    }
+
+    const gateDecision = {
+      section_index: 2,
+      claim_id: 'claim_01',
+      violation: 'no_supporting_evidence',
+      action: 'moved_to_hypotheses',
+      detail: 'Keine direkte Evidence gebunden.',
+    };
+    const withLog = reportContract.EvidenceMapSchema.safeParse({
+      ...EVIDENCE_MAP_V3,
+      gate_decision_log: [gateDecision],
+    });
+    expect(withLog.success).toBe(true);
+    if (withLog.success) {
+      expect(withLog.data.gate_decision_log).toEqual([gateDecision]);
+    }
+  });
+
   it('lehnt EvidenceMap schema_version 2 nach dem echten Versionssprung ab', () => {
     const legacyVersion = {
       ...EVIDENCE_MAP_V3,

--- a/frontend/src/contracts/reportContract.ts
+++ b/frontend/src/contracts/reportContract.ts
@@ -308,6 +308,10 @@ export const EvidenceMapSchema = z.object({
   // Additiv mit Default: persistierte Evidence-Maps von vor #1006 tragen das
   // Feld nicht und müssen weiterhin parsen.
   degradation_log: z.array(EvidenceDegradationSchema).default([]),
+  // PR #1151: Audit-Trail regulärer Gate-Entscheidungen (Reviewer-Floor,
+  // fehlende Supporting-Evidence, Fließtext-Entfernungen). Getrennt vom
+  // degradation_log, weil nur Letzterer den Report-Status abstuft.
+  gate_decision_log: z.array(EvidenceDegradationSchema).default([]),
 }).strict().superRefine((value, ctx) => {
   const knownIds = new Set(Object.keys(value.evidence_index));
   const checkRef = (evidenceId: string, path: PropertyKey[]) => {

--- a/schemas/evidence-map.schema.json
+++ b/schemas/evidence-map.schema.json
@@ -618,6 +618,13 @@
       "title": "Evidence Index",
       "type": "object"
     },
+    "gate_decision_log": {
+      "items": {
+        "$ref": "#/$defs/EvidenceDegradationModel"
+      },
+      "title": "Gate Decision Log",
+      "type": "array"
+    },
     "global_evidence_refs": {
       "items": {
         "type": "string"

--- a/schemas/report-contract.schema.json
+++ b/schemas/report-contract.schema.json
@@ -198,6 +198,13 @@
           "title": "Evidence Index",
           "type": "object"
         },
+        "gate_decision_log": {
+          "items": {
+            "$ref": "#/$defs/EvidenceDegradationModel"
+          },
+          "title": "Gate Decision Log",
+          "type": "array"
+        },
         "global_evidence_refs": {
           "items": {
             "type": "string"


### PR DESCRIPTION
## Zusammenfassung

Behebt die Integrationsfehler aus dem Referenzlauf `report_06f654800817` (armserver, 2026-08-09): Der Report nutzte 8 Interviews pro Section, aber **kein einziges** Interview-/Fakten-Item erreichte den kanonischen `evidence_index` — alle 6 Sections endeten mit `claims: []`, der `degradation_log` blieb trotz 17 entfernter Fließtext-Aussagen leer, und die Structured Metadata meldete erfundene 'Abschnitt bricht ab'-Data-Gaps.

## Root Causes und Fixes

1. **Evidence-Persistenz (P0):** `_record_tool_evidence` erzeugte Interview- und Graph-Fakten-Items ohne `producer_key` → `register_evidence_record` verwarf sie still. Jetzt: deterministische Keys via `build_producer_key` (length-prefixed SHA-256, wiederverwendet die #1147-Identitätsmaschinerie). Interview-Items tragen `quote` + `persona_stakeholder_group` (Pflicht für `source_kind=agent_quote`), Cap 6→10, leere Responses übersprungen.
2. **Metadata-Truncation (P1):** `generate_section_metadata` kappte den Section-Text hart bei 6000 Zeichen — Sections 3–6 des Referenzlaufs waren länger, die LLM-Extraktion sah abgeschnittenen Text. Jetzt `METADATA_MAX_CONTENT_CHARS = 24000` als Notbremse mit Warnung.
3. **Audit-Trail (P1):** `degradation_log` erfasst jetzt jede Gate-Entscheidung (Reviewer-Floor, fehlende Supporting-Evidence, Fließtext-Entfernungen) als `EvidenceDegradationModel`-Eintrag — bestehendes Schema, kein Contract-Touch.
4. **Confidence-Scope (P1):** `SectionKeyTakeaway.confidence_scope` (`simulation_consensus` | `evidence` | `empirical`, Default simulation_consensus) — 'confidence: high' neben 'claims: []' ist damit als Simulations-Konsens ausgewiesen.
5. **Sichtbarkeit (P0):** `render_report_v3` stellt einen Evidenzstatus-Block voran (Claims/Hypothesen/Data-Gaps-Zählung + expliziter Simulationshinweis).

## Nicht enthalten (bewusst)

- **Kein Hartanker berührt** (ADR-0002 Anker 1–5 unverändert, Validators bleiben strikt).
- **Seed-Chunk-Evidence** (`seed_doc:<id>#chunk:<id>`-Anker): braucht Provenance-Durchreichung aus den Graph-Tools — Follow-up-Issue folgt, keine erfundene Provenance in diesem PR.
- Social-Dynamics-Auswertung und Language-Pass (P2): separate Issues.

## Tests

13 neue Regressionstests (`test_report_tool_evidence.py`, `test_evidence_gate_audit.py`); `pre-push-gate.sh backend` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Neue Funktionen**
  - Reports zeigen eine Evidenzübersicht mit Claims, Hypothesen und Datenlücken.
  - Interviewantworten und Fakten sind nachvollziehbar mit Claims verknüpft.
  - Gate-Entscheidungen werden separat und prüfbar protokolliert.
  - Vertrauensbewertungen kennzeichnen nun ihren Geltungsbereich.
  - Die Metadatenauswertung verarbeitet längere Abschnittsinhalte.

- **Verbesserungen**
  - Leere oder unbrauchbare Interviewantworten werden ausgefiltert.
  - Evidenz wird robuster dedupliziert und eindeutig zugeordnet.
  - Der Report weist auf simulierte Aussagen hin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->