### PR TITLE
chore(crg): Harness-Worktrees und Design-Archive vom Graph-Index ausschließen

### DIFF
--- a/.code-review-graphignore
+++ b/.code-review-graphignore
@@ -21,8 +21,14 @@ backend/venv311/**
 backend/data/**
 backend/instance/**
 
-# Worktrees (lokale Slice-Workspaces)
+# Worktrees (lokale Slice-Workspaces und Harness-Worktrees der Subagenten)
 .worktrees/**
+.claude/worktrees/**
+
+# Design-Archive: statische Referenz-Assets, kein Produktivcode
+design/**
+frontend/public/design/**
+docs/design-reference/**
 
 # OASIS / Runtime
 backend/uploads/**


### PR DESCRIPTION
## Was

Erweitert `.code-review-graphignore` um vier Excludes:

- `.claude/worktrees/**` — Harness-Worktrees der Subagenten (Checkout-Duplikate)
- `design/**`, `frontend/public/design/**`, `docs/design-reference/**` — statische Design-Archive

## Warum

Ein Refactoring-Audit über den code-review-graph lieferte ~40 % Duplikat-Knoten aus `.claude/worktrees/agent-*` und reihenweise Dead-Code-Falschtreffer aus den Design-Archiven. Nach Exclude + Vollrebuild: 0 Worktree-/Design-Knoten im Graphen, FTS und Knotenbestand synchron (13170).

Gate: `pre-push-gate.sh schemas` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFWAqbLeY54DuMVumu5xvh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Die Ignore-Konfiguration wurde erweitert, um zusätzliche Worktree-Verzeichnisse und Design-Referenzdateien auszuschließen.
  * Die Beschreibung des Worktree-Bereichs wurde präzisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->