### PR TITLE
fix(report-ui): Evidence-Export bleibt sichtbar, solange die Evidenzkarte fehlt (#1188)

### DIFF
--- a/changelog.d/1188-evidence-export-sichtbar.md
+++ b/changelog.d/1188-evidence-export-sichtbar.md
@@ -1,0 +1,11 @@
+### Fixed (Evidence-Export bleibt sichtbar — 2026-08-10)
+
+- **Evidence-JSON-Button verschwindet nicht mehr spurlos:** Solange die
+  Evidenzkarte eines Reports noch nicht vorliegt, bleibt der Export-Button in
+  der Report-Ansicht sichtbar, ist aber deaktiviert (`aria-disabled` plus
+  zugängliche Beschreibung). `Step4Report.vue` lädt die Evidenzkarte nach
+  Laufende mit exponentiellem Backoff (3 s bis 30 s gedeckelt) über ein
+  10-Minuten-Budget nach, statt sie nach wenigen Sekunden dauerhaft leer zu
+  belassen — dimensioniert auf die in #1187 gemessene Nachbearbeitungsdauer.
+  Ist das Budget ausgeschöpft, zeigt der Tooltip „nicht verfügbar" statt
+  weiterhin „wird noch erzeugt" zu behaupten. (#1188)

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -6,7 +6,7 @@
  * - Unbekanntes Top-Level-Feld in Report (strict): schemaError gesetzt, Banner sichtbar.
  * - Fehlendes confidence_label im Claim: EvidenceMap-Parse schlaegt fehl → schemaError.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { createI18n } from 'vue-i18n'
@@ -1693,5 +1693,62 @@ describe('Step4Report — Poll-Transportfehler werden gezaehlt statt verschluckt
     await vm.pollStatus()
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(false)
+  })
+})
+
+// Issue #1188 (Nachbesserung): 15s Gesamtbudget (5x alle 3s) verfehlte das
+// reale Zeitfenster aus Issue #1187 (bis zu 1344s Nachbearbeitung) um zwei
+// Groessenordnungen. Belegt: solange der Lauf terminal ist und die
+// Evidenzkarte trotzdem fehlt, retried Step4Report.vue mit Backoff
+// (3s → 30s gedeckelt) ueber ein 10-Minuten-Budget, bevor der Button auf
+// "nicht verfuegbar" statt "wird noch erzeugt" umspringt.
+describe('Step4Report — Evidence-Retry-Budget nach Laufende (#1188, Nachbesserung)', () => {
+  const evidenceI18n = createI18n({ legacy: false, locale: 'de', messages: { de: deMessages } })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMockSelection()
+    ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: { status: 'completed', report_id: 'report_test01', simulation_id: 'sim_test01' },
+    })
+    ;(getReport as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: VALID_REPORT })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('haelt den Button auf "wird noch erzeugt", solange das 10-Minuten-Budget nicht ausgeschoepft ist, und wechselt danach auf "nicht verfuegbar"', async () => {
+    vi.useFakeTimers()
+    ;(getReportEvidence as ReturnType<typeof vi.fn>).mockResolvedValue({ success: false })
+
+    const wrapper = mount(Step4Report, {
+      props: { reportId: 'report_test01' },
+      global: { plugins: [router, evidenceI18n], stubs: globalStubs },
+    })
+    await flushPromises()
+
+    const desc = () => wrapper.find('[data-testid="evidence-export-pending-desc"]')
+    expect(desc().exists()).toBe(true)
+    expect(desc().text()).toBe(deMessages.step4.export.evidencePending)
+
+    // Kurz nach dem ersten Fehlschlag (< 10 Minuten Budget) bleibt der Text
+    // "wird noch erzeugt" — kein vorzeitiges Aufgeben mehr wie beim alten
+    // 15s-Budget.
+    await vi.advanceTimersByTimeAsync(20000)
+    await flushPromises()
+    expect(desc().exists()).toBe(true)
+    expect(desc().text()).toBe(deMessages.step4.export.evidencePending)
+
+    // Budget (10 Minuten) ueberschreiten: der Text muss auf "nicht
+    // verfuegbar" wechseln, sonst behauptet die UI faelschlich, die Karte
+    // sei noch unterwegs.
+    await vi.advanceTimersByTimeAsync(650000)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    expect(desc().exists()).toBe(true)
+    expect(desc().text()).toBe(deMessages.step4.export.evidenceUnavailable)
   })
 })

--- a/frontend/src/components/step4/ReportFinalView.vue
+++ b/frontend/src/components/step4/ReportFinalView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Button from '@/components/v4/forms/Button.vue'
 import Kicker from '@/components/v4/data/Kicker.vue'
@@ -9,7 +10,7 @@ import type { EvidenceIndex, ReportSection } from '../../contracts/reportContrac
 
 const { t } = useI18n()
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   reportHtml: string
   redTeamFindings?: string[]
   evidenceSections?: ReportSection[]
@@ -18,6 +19,12 @@ withDefaults(defineProps<{
   resolvedSimulationId?: string | null
   simulationId?: string
   branchBusy?: boolean
+  /** Issue #1188 (Nachbesserung): true, sobald Step4Report.vue das
+   *  Retry-Budget fuer die Evidenzkarte ausgeschoepft hat (Lauf terminal,
+   *  Karte bleibt weg). Steuert, ob der Tooltip "wird noch erzeugt" oder
+   *  "nicht verfuegbar" zeigt — Ersteres waere nach Budget-Ende eine
+   *  Falschaussage an den Nutzer. */
+  evidenceUnavailable?: boolean
 }>(), {
   redTeamFindings: () => [],
   evidenceSections: () => [],
@@ -26,6 +33,7 @@ withDefaults(defineProps<{
   resolvedSimulationId: null,
   simulationId: '',
   branchBusy: false,
+  evidenceUnavailable: false,
 })
 
 const emit = defineEmits([
@@ -40,6 +48,24 @@ const emit = defineEmits([
   'print-report',
   'download-evidence',
 ])
+
+// Issue #1188: der Evidence-Export darf nicht ersatzlos verschwinden, nur
+// weil die Evidenzkarte (noch) nicht vorliegt — fuer den Nutzer ist das nicht
+// von einem entfernten Feature unterscheidbar. Der Button bleibt sichtbar
+// und wird stattdessen deaktiviert (aria-disabled + zugaengliche Beschreibung
+// via aria-describedby, nicht nur ein title-Attribut), solange keine
+// Evidence-Sections vorliegen. Step4Report.vue laedt die Evidenzkarte nach
+// Abschluss des Laufs erneut (mit Retry), sodass der Button aktiv wird,
+// sobald die Karte eintrifft — siehe loadEvidence()/scheduleEvidenceRetry().
+const evidenceReady = computed(() => (props.evidenceSections?.length ?? 0) > 0)
+const evidencePendingDescKey = computed(() =>
+  props.evidenceUnavailable ? 'step4.export.evidenceUnavailable' : 'step4.export.evidencePending',
+)
+
+function handleDownloadEvidence() {
+  if (!evidenceReady.value) return
+  emit('download-evidence')
+}
 </script>
 
 <template>
@@ -54,7 +80,26 @@ const emit = defineEmits([
           <Button variant="ghost" @click="emit('download-json')">.json</Button>
           <Button variant="ghost" @click="emit('download-html')">.html</Button>
           <Button variant="ghost" @click="emit('print-report')">{{ t('step4.view.printPdf') }}</Button>
-          <Button v-if="evidenceSections.length" variant="ghost" @click="emit('download-evidence')">Evidence JSON</Button>
+          <span class="evidence-export-wrap">
+            <Button
+              variant="ghost"
+              :aria-disabled="!evidenceReady"
+              :aria-describedby="!evidenceReady ? 'evidence-export-pending-desc' : undefined"
+              :class="{ 'is-pending': !evidenceReady }"
+              data-testid="download-evidence-btn"
+              @click="handleDownloadEvidence"
+            >
+              {{ t('step4.view.evidenceJson') }}
+            </Button>
+            <span
+              v-if="!evidenceReady"
+              id="evidence-export-pending-desc"
+              class="sr-only"
+              data-testid="evidence-export-pending-desc"
+            >
+              {{ t(evidencePendingDescKey) }}
+            </span>
+          </span>
         </div>
       </header>
       <ReportRedTeamSection :findings="redTeamFindings ?? []" />
@@ -93,6 +138,19 @@ const emit = defineEmits([
 .card { background: var(--bg); border: 1px solid var(--rule); border-radius: var(--r-1); padding: var(--s-5); display: flex; flex-direction: column; gap: var(--s-4); }
 .card-head { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--rule); padding-bottom: var(--s-3); }
 .log-meta { display: flex; gap: var(--s-2); flex-wrap: wrap; }
+.evidence-export-wrap { display: inline-flex; }
+.evidence-export-wrap :deep(.is-pending) { opacity: 0.55; cursor: not-allowed; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .actions { display: flex; gap: var(--s-3); justify-content: flex-end; }
 .report-body {
   max-width: 72ch;

--- a/frontend/src/components/step4/__tests__/ReportFinalView.spec.ts
+++ b/frontend/src/components/step4/__tests__/ReportFinalView.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * ReportFinalView — Evidence-Export bleibt sichtbar (Issue #1188).
+ *
+ * Vorher: `v-if="evidenceSections.length"` liess den Button spurlos
+ * verschwinden, solange die Evidenzkarte (noch) nicht vorliegt — fuer den
+ * Nutzer nicht von einem entfernten Feature unterscheidbar. Dieser Test
+ * belegt den Regressionsfall: bei leerer evidenceSections-Liste bleibt der
+ * Button sichtbar, ist aber deaktiviert (aria-disabled + zugaengliche
+ * Beschreibung ueber aria-describedby) und loest keinen Download aus.
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import ReportFinalView from '../ReportFinalView.vue'
+import type { ReportSection } from '../../../contracts/reportContract'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'de',
+  messages: {
+    de: {
+      step4: {
+        next: 'Weiter',
+        view: { printPdf: 'Als PDF drucken (Browser)', evidenceJson: 'Evidence JSON' },
+        export: {
+          evidencePending: 'Evidenzkarte wird noch erzeugt.',
+          evidenceUnavailable: 'Evidenzkarte nicht verfügbar.',
+        },
+      },
+    },
+  },
+})
+
+const STUBS = {
+  ReportEvidencePanel: true,
+  ReportBranchControls: true,
+  ReportRedTeamSection: true,
+}
+
+function mountView(evidenceSections: ReportSection[], evidenceUnavailable = false) {
+  return mount(ReportFinalView, {
+    props: {
+      reportHtml: '<p>Testbericht</p>',
+      evidenceSections,
+      evidenceUnavailable,
+    },
+    global: { plugins: [i18n], stubs: STUBS },
+  })
+}
+
+describe('ReportFinalView — Evidence-Export-Button (Issue #1188)', () => {
+  it('bleibt sichtbar und deaktiviert, solange keine Evidence-Sections vorliegen', async () => {
+    const wrapper = mountView([])
+
+    const btn = wrapper.find('[data-testid="download-evidence-btn"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.attributes('aria-disabled')).toBe('true')
+    expect(btn.attributes('aria-describedby')).toBe('evidence-export-pending-desc')
+
+    const desc = wrapper.find('[data-testid="evidence-export-pending-desc"]')
+    expect(desc.exists()).toBe(true)
+    expect(desc.text()).toContain('Evidenzkarte wird noch erzeugt.')
+
+    await btn.trigger('click')
+    expect(wrapper.emitted('download-evidence')).toBeUndefined()
+  })
+
+  it('ist aktiv und loest den Download aus, sobald Evidence-Sections vorliegen', async () => {
+    const wrapper = mountView([
+      { section_index: 0, section_summary: 'x', data_gaps: [], claims: [] } as unknown as ReportSection,
+    ])
+
+    const btn = wrapper.find('[data-testid="download-evidence-btn"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.find('[data-testid="evidence-export-pending-desc"]').exists()).toBe(false)
+
+    await btn.trigger('click')
+    expect(wrapper.emitted('download-evidence')).toHaveLength(1)
+  })
+
+  // Nachbesserung zum urspruenglichen Fix: nach Ausschoepfen des
+  // Retry-Budgets (Step4Report.vue) ist "wird noch erzeugt" eine
+  // Falschaussage — der terminale Zustand braucht einen eigenen Text.
+  it('zeigt "nicht verfuegbar" statt "wird noch erzeugt", wenn das Retry-Budget ausgeschoepft ist', () => {
+    const wrapper = mountView([], true)
+
+    const btn = wrapper.find('[data-testid="download-evidence-btn"]')
+    expect(btn.attributes('aria-disabled')).toBe('true')
+
+    const desc = wrapper.find('[data-testid="evidence-export-pending-desc"]')
+    expect(desc.exists()).toBe(true)
+    expect(desc.text()).toContain('Evidenzkarte nicht verfügbar.')
+    expect(desc.text()).not.toContain('wird noch erzeugt')
+  })
+})

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -664,13 +664,76 @@ function navigateToAnchor(anchor: string | null | undefined) {
   if (parsed.kind === 'kg') console.info('[Step4Report] KG-Anchor noch nicht aufrufbar:', parsed.payload)
 }
 
+// Issue #1188 (Befund 3, Nachbesserung): loadEvidence() wurde bislang genau
+// einmal je Abschluss-Handler aufgerufen. Schlug der Abruf fehl — z. B. weil
+// die Evidenzkarte serverseitig noch in der Nachbearbeitungsphase liegt und
+// die Datei zum Zeitpunkt des ersten GET noch nicht geschrieben ist — blieb
+// evidenceMap fuer immer null und der Export-Button (ReportFinalView) damit
+// dauerhaft im "wird erzeugt"-Zustand, ohne dass je ein zweiter Versuch
+// folgte.
+//
+// Dimensionierung: Issue #1187 misst 178-347s Nachbearbeitung PRO Abschnitt,
+// in Summe bis zu 1344s von 2285s Gesamtlaufzeit. Ein 15s-Gesamtbudget (5x
+// alle 3s) verfehlt dieses Zeitfenster um zwei Groessenordnungen. Backoff
+// startet bei 3s, verdoppelt sich je Fehlschlag und deckelt bei 30s, das
+// Gesamtbudget betraegt 10 Minuten.
+//
+// Das Budget zaehlt nur, sobald der Lauf laut reportStatus terminal ist
+// (completed/incomplete/failed) und die Karte trotzdem fehlt — das ist der
+// fachlich echte "Karte fehlt dauerhaft"-Fall. Waehrend eines laufenden
+// Laufs ist ein fehlender GET erwartbar und wird nicht gegen das Budget
+// verrechnet (in der Praxis ruft nur der terminale Zweig von pollStatus()
+// bzw. onMounted() loadEvidence() ueberhaupt auf).
+//
+// Ein Zod-Parse-Fehler ist dagegen kein transienter Zustand
+// (Schema-Mismatch statt "noch nicht fertig") und wird weiterhin nicht
+// retried, sondern wie zuvor als schemaError gemeldet.
+const EVIDENCE_RETRY_INITIAL_DELAY_MS = 3000
+const EVIDENCE_RETRY_MAX_DELAY_MS = 30000
+const EVIDENCE_RETRY_BACKOFF_FACTOR = 2
+const EVIDENCE_RETRY_TOTAL_BUDGET_MS = 10 * 60 * 1000
+const TERMINAL_REPORT_STATUSES = new Set(['completed', 'incomplete', 'failed'])
+
+const evidenceRetryDelayMs = ref(EVIDENCE_RETRY_INITIAL_DELAY_MS)
+const evidenceRetryElapsedMs = ref(0)
+// Terminaler Endzustand: Lauf abgeschlossen, Karte bleibt trotz
+// ausgeschoepftem Retry-Budget dauerhaft weg. Steuert den Tooltip-Text in
+// ReportFinalView — "wird noch erzeugt" waere ab hier eine Falschaussage.
+const evidenceUnavailable = ref(false)
+let evidenceRetryTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearEvidenceRetry(): void {
+  if (evidenceRetryTimer !== null) { clearTimeout(evidenceRetryTimer); evidenceRetryTimer = null }
+}
+
+function resetEvidenceRetryState(): void {
+  clearEvidenceRetry()
+  evidenceRetryDelayMs.value = EVIDENCE_RETRY_INITIAL_DELAY_MS
+  evidenceRetryElapsedMs.value = 0
+  evidenceUnavailable.value = false
+}
+
+function scheduleEvidenceRetry(): void {
+  const isTerminal = TERMINAL_REPORT_STATUSES.has(reportStatus.value)
+  if (isTerminal && evidenceRetryElapsedMs.value >= EVIDENCE_RETRY_TOTAL_BUDGET_MS) {
+    evidenceUnavailable.value = true
+    return
+  }
+  clearEvidenceRetry()
+  const delay = evidenceRetryDelayMs.value
+  if (isTerminal) evidenceRetryElapsedMs.value += delay
+  evidenceRetryDelayMs.value = Math.min(delay * EVIDENCE_RETRY_BACKOFF_FACTOR, EVIDENCE_RETRY_MAX_DELAY_MS)
+  evidenceRetryTimer = setTimeout(() => { void loadEvidence() }, delay)
+}
+
 async function loadEvidence() {
   if (!props.reportId) return
   try {
     const res = (await getReportEvidence(props.reportId)) as ApiResult
-    if (!res?.success) return
+    if (!res?.success) { scheduleEvidenceRetry(); return }
     const parsed = EvidenceMapSchema.parse(res.data)
     evidenceMap.value = parsed
+    resetEvidenceRetryState()
     if (!selectedEvidenceSection.value && parsed.sections.length) selectedEvidenceSection.value = parsed.sections[0].section_index
   } catch (err) { recordSchemaError('evidence', err) }
 }
@@ -772,7 +835,7 @@ onMounted(async () => {
     } catch { /* swallow */ }
   }
 })
-onUnmounted(stopPolling)
+onUnmounted(() => { stopPolling(); clearEvidenceRetry() })
 </script>
 
 <template>
@@ -879,6 +942,7 @@ onUnmounted(stopPolling)
         :red-team-findings="redTeamFindings"
         :evidence-sections="evidenceSections"
         :evidence-index="evidenceIndex"
+        :evidence-unavailable="evidenceUnavailable"
         :selected-evidence-section="selectedEvidenceSection"
         :resolved-simulation-id="resolvedSimulationId"
         :simulation-id="simulationId"

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -563,7 +563,8 @@
       "raw": "Rohausgabe",
       "exportMd": "Als Markdown exportieren",
       "exportPdf": "Als PDF exportieren",
-      "printPdf": "Als PDF drucken (Browser)"
+      "printPdf": "Als PDF drucken (Browser)",
+      "evidenceJson": "Evidence JSON"
     },
     "model": {
       "reportLabel": "Modell für Report",
@@ -596,7 +597,9 @@
     "export": {
       "evidenceOmitted": {
         "contract_violation": "JSON-Export ausgeliefert, aber ohne Evidence-Map: die persistierte Evidence verletzt den Evidence-Vertrag. Der Report-Rumpf in der Datei ist vollständig."
-      }
+      },
+      "evidencePending": "Evidenzkarte wird noch erzeugt — der Export steht zur Verfügung, sobald sie fertig ist.",
+      "evidenceUnavailable": "Evidenzkarte für diesen Report nicht verfügbar."
     }
   },
   "report": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -563,7 +563,8 @@
       "raw": "Raw output",
       "exportMd": "Export as Markdown",
       "exportPdf": "Export as PDF",
-      "printPdf": "Print as PDF (browser)"
+      "printPdf": "Print as PDF (browser)",
+      "evidenceJson": "Evidence JSON"
     },
     "model": {
       "reportLabel": "Model for report",
@@ -596,7 +597,9 @@
     "export": {
       "evidenceOmitted": {
         "contract_violation": "JSON export delivered without its evidence map: the persisted evidence violates the evidence contract. The report body in the file is complete."
-      }
+      },
+      "evidencePending": "Evidence map is still being generated — the export will be available once it is ready.",
+      "evidenceUnavailable": "Evidence map is not available for this report."
     }
   },
   "report": {


### PR DESCRIPTION
Closes #1188

## Befund

Der Button „Evidence JSON" hing an `evidenceSections.length`. Solange die Evidenzkarte serverseitig noch in der Nachbearbeitung lag, war die Liste leer und der Button **verschwand ersatzlos** — für den Nutzer nicht von einem entfernten Feature unterscheidbar.

Zweiter, eigentlicher Defekt: `loadEvidence()` lief **nur einmalig**. Schlug der GET fehl, weil die Karte noch nicht existierte, blieb `evidenceMap` dauerhaft `null` — ohne jeden weiteren Versuch.

Das Zeitfenster ist kein Randfall: die Nachbearbeitung dauert laut #1187 **178–347 s pro Abschnitt**.

## Änderung

1. **Der Button verschwindet nicht mehr.** Er bleibt sichtbar und wird deaktiviert, mit `aria-disabled` und `aria-describedby` auf eine zugängliche Begründung — kein reines `title`-Attribut.
2. **Nachladen statt Blockieren.** Der Reporttext wird weiter angezeigt, sobald er da ist; die Evidenzkarte wird mit exponentiellem Backoff nachgeladen: 3 s Start, Verdopplung, Deckel bei 30 s, Gesamtbudget 10 Minuten.
3. **Terminaler Zustand wird unterschieden.** Das Budget zählt erst, wenn der Lauf `completed`/`incomplete`/`failed` ist und die Karte trotzdem fehlt — also nur dann, wenn ein dauerhaftes Fehlen fachlich plausibel ist. Danach zeigt die UI „nicht verfügbar" statt weiter „wird noch erzeugt" zu behaupten.

Alle sichtbaren Texte über `vue-i18n`, Keys in `de.json` und `en.json`.

## Tests

Regressionstest in `ReportFinalView.spec.ts`: bei fehlender Evidenzkarte ist der Export **sichtbar und deaktiviert**, nicht abwesend. Plus Test für den terminalen Zustand. Integrationstest in `Step4Report.spec.ts` mit Fake-Timern prüft den Übergang (20 s → weiterhin „pending", +650 s → „unavailable").

## Gate

`bash scripts/pre-push-gate.sh frontend` → ALL GREEN
- 190 Testdateien, 1830 Tests
- lint, typecheck, coverage, build grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)