### PR TITLE
refactor(runs): RunLifecycle zentralisiert pending→Endzustand-Führung

### DIFF
--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -32,12 +32,12 @@ from ..services.llm_routing_seed import (
     seed_run_stage_routing,
 )
 from ..services.report_agent import ReportAgent, ReportManager, ReportStatus
+from ..services.run_lifecycle import RunLifecycle
 from ..services.run_registry import RunRegistry
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import RunnerStatus, SimulationRunner
 from ..services.stage_model_router import StageModelRouter
 from ..services.sim.cancel_flag import request_cancel as _request_cancel
-from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
 from ..utils.llm_client import LLMClient
 from ..utils.artifact_locator import ArtifactLocator
@@ -547,86 +547,92 @@ def _restart_graph_build(run: dict):
     chunk_size = project.chunk_size or Config.DEFAULT_CHUNK_SIZE
     chunk_overlap = project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP
 
-    new_run = run_registry.create_run(
-        run_type="graph_build",
-        entity_id=project_id,
+    # Issue #1183: Anlage-Fenster hinter RunLifecycle — jeder Abbruch bis zum
+    # Thread-Start markiert den Run als failed statt ihn pending zu verwaisen.
+    with RunLifecycle.begin(
+        run_registry,
+        "graph_build",
+        project_id,
         parent_run_id=run["run_id"],
-        status="pending",
+        failure_message="Graph build restart failed: {exc_type}",
         progress=0,
         message="Graph build restart queued",
         linked_ids={"project_id": project_id},
         artifacts=ArtifactLocator.existing_paths({"project_dir": ProjectManager._get_project_dir(project_id)}),
         resume_capability={"available": True, "action": "restart", "label": "Restart graph build"},
         metadata={"graph_name": graph_name},
-    )
-    task_manager = TaskManager()
-    task_id = task_manager.create_task(
-        f"Build graph: {graph_name}",
-        metadata={"project_id": project_id, "run_id": new_run["run_id"]},
-    )
-    project.status = ProjectStatus.GRAPH_BUILDING
-    project.graph_build_task_id = task_id
-    ProjectManager.save_project(project)
+    ) as lifecycle:
+        new_run = lifecycle.record
+        task_manager = TaskManager()
+        task_id = task_manager.create_task(
+            f"Build graph: {graph_name}",
+            metadata={"project_id": project_id, "run_id": new_run["run_id"]},
+        )
+        lifecycle.attach_task(task_manager, task_id)
+        project.status = ProjectStatus.GRAPH_BUILDING
+        project.graph_build_task_id = task_id
+        ProjectManager.save_project(project)
 
-    def build_task():
-        try:
-            task_manager.update_task(task_id, status=TaskStatus.PROCESSING, message="Initializing graph build service...")
-            builder = container.graph_builder()
-            task_manager.update_task(task_id, message="Chunking text...", progress=5)
-            from ..services.text_processor import TextProcessor
-            chunks = TextProcessor.split_text(text, chunk_size=chunk_size, overlap=chunk_overlap)
-            total_chunks = len(chunks)
-            task_manager.update_task(task_id, message="Creating graph...", progress=10)
-            graph_id = builder.create_graph(name=graph_name)
-            project.graph_id = graph_id
-            ProjectManager.save_project(project)
-            run_registry.update_run(new_run["run_id"], linked_ids={"graph_id": graph_id}, entity_id=graph_id)
-            task_manager.update_task(task_id, message="Setting ontology definition...", progress=15)
-            builder.set_ontology(graph_id, ontology)
+        def build_task():
+            try:
+                task_manager.update_task(task_id, status=TaskStatus.PROCESSING, message="Initializing graph build service...")
+                builder = container.graph_builder()
+                task_manager.update_task(task_id, message="Chunking text...", progress=5)
+                from ..services.text_processor import TextProcessor
+                chunks = TextProcessor.split_text(text, chunk_size=chunk_size, overlap=chunk_overlap)
+                total_chunks = len(chunks)
+                task_manager.update_task(task_id, message="Creating graph...", progress=10)
+                graph_id = builder.create_graph(name=graph_name)
+                project.graph_id = graph_id
+                ProjectManager.save_project(project)
+                run_registry.update_run(new_run["run_id"], linked_ids={"graph_id": graph_id}, entity_id=graph_id)
+                task_manager.update_task(task_id, message="Setting ontology definition...", progress=15)
+                builder.set_ontology(graph_id, ontology)
 
-            def add_progress_callback(msg, progress_ratio):
-                progress = 15 + int(progress_ratio * 40)
-                task_manager.update_task(task_id, message=msg, progress=progress)
+                def add_progress_callback(msg, progress_ratio):
+                    progress = 15 + int(progress_ratio * 40)
+                    task_manager.update_task(task_id, message=msg, progress=progress)
 
-            episodes = builder.add_text_batches(graph_id, chunks, batch_size=3, progress_callback=add_progress_callback)
-            task_manager.update_task(task_id, message="Retrieving graph data...", progress=95)
-            graph_data = builder.get_graph_data(graph_id)
-            project.status = ProjectStatus.GRAPH_COMPLETED
-            ProjectManager.save_project(project)
-            task_manager.update_task(
-                task_id,
-                status=TaskStatus.COMPLETED,
-                message="Graph build completed",
-                progress=100,
-                result={
-                    "project_id": project_id,
-                    "graph_id": graph_id,
-                    "node_count": graph_data.get("node_count", 0),
-                    "edge_count": graph_data.get("edge_count", 0),
-                    "chunk_count": total_chunks,
-                    "episode_count": len(episodes),
-                },
-            )
-            run_registry.update_run(
-                new_run["run_id"],
-                status="completed",
-                progress=100,
-                message="Graph build completed",
-                artifacts=ArtifactLocator.existing_paths({"project_dir": ProjectManager._get_project_dir(project_id)}),
-            )
-        except Exception as exc:  # noqa: BLE001 — exception reported to task/run registry
-            project.status = ProjectStatus.FAILED
-            project.error = str(exc)
-            ProjectManager.save_project(project)
-            task_manager.update_task(
-                task_id,
-                status=TaskStatus.FAILED,
-                message=f"Build failed: {exc}",
-                error=traceback.format_exc(),
-            )
-            run_registry.update_run(new_run["run_id"], status="failed", message=str(exc), error=str(exc))
+                episodes = builder.add_text_batches(graph_id, chunks, batch_size=3, progress_callback=add_progress_callback)
+                task_manager.update_task(task_id, message="Retrieving graph data...", progress=95)
+                graph_data = builder.get_graph_data(graph_id)
+                project.status = ProjectStatus.GRAPH_COMPLETED
+                ProjectManager.save_project(project)
+                task_manager.update_task(
+                    task_id,
+                    status=TaskStatus.COMPLETED,
+                    message="Graph build completed",
+                    progress=100,
+                    result={
+                        "project_id": project_id,
+                        "graph_id": graph_id,
+                        "node_count": graph_data.get("node_count", 0),
+                        "edge_count": graph_data.get("edge_count", 0),
+                        "chunk_count": total_chunks,
+                        "episode_count": len(episodes),
+                    },
+                )
+                run_registry.update_run(
+                    new_run["run_id"],
+                    status="completed",
+                    progress=100,
+                    message="Graph build completed",
+                    artifacts=ArtifactLocator.existing_paths({"project_dir": ProjectManager._get_project_dir(project_id)}),
+                )
+            except Exception as exc:  # noqa: BLE001 — exception reported to task/run registry
+                project.status = ProjectStatus.FAILED
+                project.error = str(exc)
+                ProjectManager.save_project(project)
+                task_manager.update_task(
+                    task_id,
+                    status=TaskStatus.FAILED,
+                    message=f"Build failed: {exc}",
+                    error=traceback.format_exc(),
+                )
+                run_registry.update_run(new_run["run_id"], status="failed", message=str(exc), error=str(exc))
 
-    threading.Thread(target=build_task, daemon=True).start()
+        threading.Thread(target=build_task, daemon=True).start()
+
     return {"run_id": new_run["run_id"], "task_id": task_id, "status": "processing"}
 
 
@@ -648,11 +654,14 @@ def _restart_simulation_prepare(run: dict):
         raise ValueError("GraphStorage not initialized")
 
     config = manager.get_simulation_config(simulation_id) or {}
-    new_run = run_registry.create_run(
-        run_type="simulation_prepare",
-        entity_id=simulation_id,
+    # Issue #841/#844/#1183: Anlage-Fenster hinter RunLifecycle — Markierung,
+    # Task-Reihenfolge und strikte Persistenzsemantik liegen im Kontextmanager.
+    with RunLifecycle.begin(
+        run_registry,
+        "simulation_prepare",
+        simulation_id,
         parent_run_id=run["run_id"],
-        status="pending",
+        failure_message="Simulation preparation restart failed: {exc_type}",
         progress=0,
         message="Simulation preparation restart queued",
         linked_ids={"simulation_id": simulation_id, "project_id": state.project_id},
@@ -660,131 +669,109 @@ def _restart_simulation_prepare(run: dict):
         resume_capability={"available": True, "action": "restart", "label": "Restart preparation"},
         branch_label=state.branch_name,
         metadata={"graph_id": state.graph_id, "branch_name": state.branch_name},
-    )
-    run_id = new_run["run_id"]
+    ) as lifecycle:
+        new_run = lifecycle.record
+        run_id = new_run["run_id"]
 
-    # Restart hat keinen Request-Payload — llm_runtime=None, damit das
-    # Resolving ausschließlich über die persistierte Route bzw. den in der
-    # Settings-DB hinterlegten Store-Key läuft und nicht still auf
-    # Config.LLM_API_KEY/LLM_BASE_URL aus der lokalen .env zurückfällt (#798,
-    # Opus-Review-Folgebefund zu #778). Exakt derselbe Resolver-Pfad wie
-    # simulation_prepare.py::prepare_simulation (Zeilen 401-431).
-    from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
+        # Restart hat keinen Request-Payload — llm_runtime=None, damit das
+        # Resolving ausschließlich über die persistierte Route bzw. den in der
+        # Settings-DB hinterlegten Store-Key läuft und nicht still auf
+        # Config.LLM_API_KEY/LLM_BASE_URL aus der lokalen .env zurückfällt (#798,
+        # Opus-Review-Folgebefund zu #778). Exakt derselbe Resolver-Pfad wie
+        # simulation_prepare.py::prepare_simulation.
+        from ..utils.endpoints import LOCAL_NO_AUTH_API_KEY, is_local_endpoint
 
-    seed_run_stage_routing(
-        run_id,
-        "persona_generation",
-        llm_model_override=config.get("llm_model"),
-        llm_runtime=None,
-    )
-    route_router = StageModelRouter(run_id)
-    resolved_route = route_router.resolve("persona_generation")
-    route_router.lock_stage("persona_generation", resolved_route)
-    resolved_api_key = resolve_route_api_key(resolved_route, None)
-
-    if resolved_api_key is None and not is_local_endpoint(resolved_route.base_url_sanitized):
-        guard_message = (
-            f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
-            f"für Provider '{resolved_route.provider_id}'. "
-            "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
-            "oder im Sitzungsfeld eingeben."
+        seed_run_stage_routing(
+            run_id,
+            "persona_generation",
+            llm_model_override=config.get("llm_model"),
+            llm_runtime=None,
         )
-        # Issue #841: new_run existiert an dieser Stelle bereits (Zeile 523) —
-        # ein Task wird erst danach erzeugt (Zeile 570), daher hier kein
-        # task_manager.fail_task. Ohne dieses Markieren bleibt der Run-Datensatz
-        # dauerhaft als "pending" in der Registry verwaist.
-        #
-        # Issue #844: update_run() liefert None, wenn das Run-Manifest
-        # zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception
-        # werfen. Beide Fälle dürfen NICHT als erfolgreich persistierte
-        # Ablehnung durchgehen — sonst wirft der Code weiterhin den regulären
-        # ValueError("provider_override...") und täuscht damit eine sauber
-        # gespeicherte Statusänderung vor, die tatsächlich nicht stattfand.
-        persistence_error: Optional[Exception] = None
-        try:
-            updated_run = run_registry.update_run(
-                new_run["run_id"], status="failed", message=guard_message, error=guard_message
+        route_router = StageModelRouter(run_id)
+        resolved_route = route_router.resolve("persona_generation")
+        route_router.lock_stage("persona_generation", resolved_route)
+        resolved_api_key = resolve_route_api_key(resolved_route, None)
+
+        if resolved_api_key is None and not is_local_endpoint(resolved_route.base_url_sanitized):
+            guard_message = (
+                f"provider_override: kein api_key im Payload und kein Key in der Settings-DB "
+                f"für Provider '{resolved_route.provider_id}'. "
+                "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
+                "oder im Sitzungsfeld eingeben."
             )
-        except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
-            updated_run = None
-            persistence_error = exc
+            guard_error = ValueError(guard_message)
+            # RunLifecycle liest die failed-Meldung über dieses Attribut (#841).
+            guard_error.run_failure_message = guard_message  # type: ignore[attr-defined]
+            raise guard_error
 
-        if updated_run is None:
-            logger.error(
-                "Persistenzfehler beim Markieren von run_id=%s als failed im "
-                "Restart-Provider-Key-Guard: %s",
-                new_run["run_id"],
-                persistence_error or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
-            )
-            raise RuntimeError(ApiErrorCode.INTERNAL_ERROR) from persistence_error
-        raise ValueError(guard_message)
+        if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
+            resolved_api_key = LOCAL_NO_AUTH_API_KEY
 
-    if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
-        resolved_api_key = LOCAL_NO_AUTH_API_KEY
+        effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
 
-    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
+        task_manager = TaskManager()
+        task_id = task_manager.create_task(
+            "simulation_prepare",
+            metadata={"simulation_id": simulation_id, "project_id": state.project_id, "run_id": new_run["run_id"]},
+        )
+        lifecycle.attach_task(task_manager, task_id)
+        state.status = SimulationStatus.PREPARING
+        manager._save_simulation_state(state)
 
-    task_manager = TaskManager()
-    task_id = task_manager.create_task(
-        "simulation_prepare",
-        metadata={"simulation_id": simulation_id, "project_id": state.project_id, "run_id": new_run["run_id"]},
-    )
-    state.status = SimulationStatus.PREPARING
-    manager._save_simulation_state(state)
+        def run_prepare():
+            try:
+                task_manager.update_task(task_id, status=TaskStatus.PROCESSING, progress=0, message="Start preparing simulation environment...")
 
-    def run_prepare():
-        try:
-            task_manager.update_task(task_id, status=TaskStatus.PROCESSING, progress=0, message="Start preparing simulation environment...")
+                def progress_callback(stage, progress, message, **kwargs):
+                    stage_weights = {
+                        "reading": (0, 20),
+                        "generating_profiles": (20, 70),
+                        "generating_config": (70, 90),
+                        "copying_scripts": (90, 100),
+                    }
+                    start, end = stage_weights.get(stage, (0, 100))
+                    current_progress = int(start + (end - start) * progress / 100)
+                    task_manager.update_task(task_id, progress=current_progress, message=f"[{stage}] {message}")
 
-            def progress_callback(stage, progress, message, **kwargs):
-                stage_weights = {
-                    "reading": (0, 20),
-                    "generating_profiles": (20, 70),
-                    "generating_config": (70, 90),
-                    "copying_scripts": (90, 100),
-                }
-                start, end = stage_weights.get(stage, (0, 100))
-                current_progress = int(start + (end - start) * progress / 100)
-                task_manager.update_task(task_id, progress=current_progress, message=f"[{stage}] {message}")
+                # Sub-Slice 20a: quota_plan aus persistierter Run-Config wieder
+                # aufnehmen, damit Restart denselben Soll-Plan nutzt wie der
+                # ursprüngliche Prepare-Run. Inkonsistenter Plan im persisted
+                # Config-Snapshot würde im Service-Layer als ValidationError
+                # propagieren und den Restart als FAILED markieren — das ist
+                # gewollt (kein silent-Fallback auf "ohne Plan").
+                from ..api.simulation_prepare import _parse_quota_plan
+                quota_plan = _parse_quota_plan(config or {})
 
-            # Sub-Slice 20a: quota_plan aus persistierter Run-Config wieder
-            # aufnehmen, damit Restart denselben Soll-Plan nutzt wie der
-            # ursprüngliche Prepare-Run. Inkonsistenter Plan im persisted
-            # Config-Snapshot würde im Service-Layer als ValidationError
-            # propagieren und den Restart als FAILED markieren — das ist
-            # gewollt (kein silent-Fallback auf "ohne Plan").
-            from ..api.simulation_prepare import _parse_quota_plan
-            quota_plan = _parse_quota_plan(config or {})
+                result_state = manager.prepare_simulation(
+                    simulation_id=simulation_id,
+                    simulation_requirement=simulation_requirement,
+                    document_text=document_text,
+                    defined_entity_types=None,
+                    use_llm_for_profiles=True,
+                    progress_callback=progress_callback,
+                    parallel_profile_count=None,
+                    storage=storage,
+                    llm_model=config.get("llm_model"),
+                    llm_runtime=effective_llm_runtime,
+                    language=config.get("language"),
+                    max_agents=config.get("max_agents"),
+                    quota_plan=quota_plan,
+                )
+                task_manager.complete_task(task_id, result=result_state.to_simple_dict())
+                run_registry.update_run(
+                    new_run["run_id"],
+                    status="completed",
+                    progress=100,
+                    message="Simulation preparation completed",
+                    artifacts=_simulation_artifacts(simulation_id),
+                    resume_capability={"available": True, "action": "restart", "label": "Restart preparation"},
+                )
+            except Exception as exc:  # noqa: BLE001 — exception reported to task/run registry
+                task_manager.fail_task(task_id, str(exc))
+                run_registry.update_run(new_run["run_id"], status="failed", message=str(exc), error=str(exc))
 
-            result_state = manager.prepare_simulation(
-                simulation_id=simulation_id,
-                simulation_requirement=simulation_requirement,
-                document_text=document_text,
-                defined_entity_types=None,
-                use_llm_for_profiles=True,
-                progress_callback=progress_callback,
-                parallel_profile_count=None,
-                storage=storage,
-                llm_model=config.get("llm_model"),
-                llm_runtime=effective_llm_runtime,
-                language=config.get("language"),
-                max_agents=config.get("max_agents"),
-                quota_plan=quota_plan,
-            )
-            task_manager.complete_task(task_id, result=result_state.to_simple_dict())
-            run_registry.update_run(
-                new_run["run_id"],
-                status="completed",
-                progress=100,
-                message="Simulation preparation completed",
-                artifacts=_simulation_artifacts(simulation_id),
-                resume_capability={"available": True, "action": "restart", "label": "Restart preparation"},
-            )
-        except Exception as exc:  # noqa: BLE001 — exception reported to task/run registry
-            task_manager.fail_task(task_id, str(exc))
-            run_registry.update_run(new_run["run_id"], status="failed", message=str(exc), error=str(exc))
+        threading.Thread(target=run_prepare, daemon=True).start()
 
-    threading.Thread(target=run_prepare, daemon=True).start()
     return {"run_id": new_run["run_id"], "task_id": task_id, "status": "processing"}
 
 
@@ -808,22 +795,28 @@ def _resume_or_restart_simulation_run(run: dict):
         )
         return {"run_id": run["run_id"], "status": "processing", "message": "Simulation resumed"}
 
-    new_run_state = SimulationRunner.start_simulation(simulation_id=simulation_id, platform="parallel")
-    state.status = SimulationStatus.RUNNING
-    manager._save_simulation_state(state)
-    new_run = run_registry.create_run(
-        run_type="simulation_run",
-        entity_id=simulation_id,
+    # Issue #1183: Der Run-Record entsteht VOR dem Prozessstart im
+    # Lifecycle-Fenster — schlägt der Start fehl, existiert ein failed-Record
+    # statt gar keinem (vorher: create_run erst nach start_simulation).
+    with RunLifecycle.begin(
+        run_registry,
+        "simulation_run",
+        simulation_id,
         parent_run_id=run["run_id"],
-        status="processing",
+        failure_message="Simulation restart failed: {exc_type}",
         progress=0,
-        message="Simulation restarted",
+        message="Simulation restart queued",
         linked_ids={"simulation_id": simulation_id, "project_id": state.project_id},
         artifacts=_simulation_artifacts(simulation_id),
         resume_capability={"available": True, "action": "resume", "label": "Resume run"},
         branch_label=state.branch_name,
         metadata={"graph_id": state.graph_id, "branch_name": state.branch_name},
-    )
+    ) as lifecycle:
+        new_run = lifecycle.record
+        new_run_state = SimulationRunner.start_simulation(simulation_id=simulation_id, platform="parallel")
+        state.status = SimulationStatus.RUNNING
+        manager._save_simulation_state(state)
+        lifecycle.succeed(status="processing", message="Simulation restarted")
     return {"run_id": new_run["run_id"], "status": new_run_state.runner_status.value, "message": "Simulation restarted"}
 
 

--- a/backend/app/api/simulation_prepare.py
+++ b/backend/app/api/simulation_prepare.py
@@ -24,6 +24,7 @@ from ..services.llm_runtime import parse_runtime_llm_config
 from ..services.persona_eligibility import filter_eligible_entities
 from ..services.prepare_service import compute_persona_target
 from ..services.report_agent import MIN_SIMULATION_AGENTS
+from ..services.run_lifecycle import RunLifecycle, RunPersistenceError
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.stage_model_router import StageModelRouter
 from ..utils.validation import validate_simulation_id, validate_task_id
@@ -211,9 +212,14 @@ class _PrepareRejected(Exception):
     Handler vorher zurückgegeben hat (#1080).
     """
 
-    def __init__(self, response: Any) -> None:
+    def __init__(self, response: Any, run_failure_message: "str | None" = None) -> None:
         super().__init__("simulation prepare rejected")
         self.response = response
+        if run_failure_message is not None:
+            # Sprechende failed-Meldung für einen bereits registrierten Run —
+            # ausgewertet vom RunLifecycle (#841: die detaillierte Meldung
+            # landet zuletzt auf dem Run, nach fail_task()).
+            self.run_failure_message = run_failure_message
 
 
 @dataclass(frozen=True)
@@ -624,14 +630,15 @@ def _precheck_prepare_ai_model_ref(ai_model_ref: "AiModelRef | None") -> None:
         ) from exc
 
 
-def _register_prepare_run(
-    req: _PrepareRequest, state, routing: _PrepareRouting, task_manager
-) -> "tuple[dict[str, Any], str]":
-    """Phase 6b — Run-Record und Task für den Vorbereitungslauf anlegen."""
-    run_record = run_registry.create_run(
-        run_type="simulation_prepare",
-        entity_id=req.simulation_id,
-        status="pending",
+def _begin_prepare_run(
+    req: _PrepareRequest, state, routing: _PrepareRouting
+) -> RunLifecycle:
+    """Phase 6b — Lifecycle für den Run-Record des Vorbereitungslaufs bauen."""
+    return RunLifecycle.begin(
+        run_registry,
+        "simulation_prepare",
+        req.simulation_id,
+        failure_message="Simulation preparation failed: {exc_type}",
         progress=0,
         message="Simulation preparation queued",
         linked_ids={
@@ -654,88 +661,10 @@ def _register_prepare_run(
             **({"budget": req.budget_config.model_dump(mode="json")} if req.budget_config else {}),
         },
     )
-    task_id = task_manager.create_task(
-        task_type="simulation_prepare",
-        metadata={
-            "simulation_id": req.simulation_id,
-            "project_id": state.project_id,
-            "run_id": run_record["run_id"],
-        },
-    )
-    return run_record, task_id
-
-
-def _reject_and_fail_prepare_run(
-    run_record: "dict[str, Any]",
-    task_id: str,
-    task_manager,
-    message: str,
-    *,
-    status: int,
-    context: str,
-) -> _PrepareRejected:
-    """Run und Task als ``failed`` markieren und die Ablehnung bauen.
-
-    Issue #841: run_record und task_id existieren an den Aufrufstellen bereits —
-    ohne dieses Markieren bliebe der Datensatz dauerhaft als "pending" in der
-    Registry verwaist. Die Reihenfolge ist bewusst: ``fail_task()`` setzt intern
-    per ``sync_task()`` eine generische Task-Message ("Task failed") auf den Run
-    zurück — der detaillierte ``update_run()``-Aufruf muss deshalb zuletzt
-    laufen, sonst überschreibt ``sync_task()`` die Meldung.
-
-    Issue #844: ``update_run()`` liefert ``None``, wenn das Run-Manifest
-    zwischenzeitlich verschwunden ist, oder es kann eine I/O-Exception werfen
-    (``write_json_atomic`` ist ungeschützt). Beide Fälle dürfen NICHT wie eine
-    erfolgreich persistierte Ablehnung behandelt werden — sonst bleibt der Run
-    unbemerkt "pending" (siehe #841), obwohl der Client bereits eine scheinbar
-    abschließende Antwort erhalten hat. ``fail_task()`` selbst hat keine
-    prüfbare Fehlersemantik (siehe ``TaskManager.update_task``) und bleibt
-    daher best-effort.
-    """
-    task_manager.fail_task(task_id, message)
-
-    persistence_error: Optional[Exception] = None
-    try:
-        updated_run = run_registry.update_run(
-            run_record["run_id"], status="failed", message=message, error=message
-        )
-    except Exception as exc:  # noqa: BLE001 — Persistenzfehler, unten geloggt
-        updated_run = None
-        persistence_error = exc
-
-    if updated_run is None:
-        logger.error(
-            "Persistenzfehler beim Markieren von run_id=%s (task_id=%s) als "
-            "failed %s: %s",
-            run_record["run_id"],
-            task_id,
-            context,
-            persistence_error
-            or "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
-        )
-        return _PrepareRejected(
-            json_error(
-                ApiErrorCode.INTERNAL_ERROR,
-                status=500,
-                message=(
-                    "Interner Fehler beim Markieren des Runs als fehlgeschlagen. "
-                    "Bitte erneut versuchen."
-                ),
-            )
-        )
-    return _PrepareRejected(
-        json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            status=status,
-            message=message,
-        )
-    )
 
 
 def _seed_prepare_routing(
     run_record: "dict[str, Any]",
-    task_id: str,
-    task_manager,
     routing: _PrepareRouting,
     ai_model_ref: "AiModelRef | None",
 ) -> None:
@@ -760,19 +689,17 @@ def _seed_prepare_routing(
             ai_model_ref=ai_model_ref,
         )
     except ValueError as exc:
-        raise _reject_and_fail_prepare_run(
-            run_record,
-            task_id,
-            task_manager,
-            str(exc),
-            status=400,
-            context="nach AiModelRef-Routingfehler",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=400,
+                message=str(exc),
+            ),
+            run_failure_message=str(exc),
         ) from exc
 
 
-def _resolve_prepare_route(
-    run_record: "dict[str, Any]", task_id: str, task_manager, llm_runtime
-):
+def _resolve_prepare_route(run_record: "dict[str, Any]", llm_runtime):
     """Phase 8 — Stage-Route auflösen, sperren und den API-Key bestimmen."""
     route_router = StageModelRouter(run_record["run_id"])
     resolved_route = route_router.resolve("persona_generation")
@@ -786,13 +713,13 @@ def _resolve_prepare_route(
             "Bitte in Einstellungen → LLM-Anbieter einen Schlüssel speichern "
             "oder im Sitzungsfeld eingeben."
         )
-        raise _reject_and_fail_prepare_run(
-            run_record,
-            task_id,
-            task_manager,
-            guard_message,
-            status=422,
-            context="im Provider-Key-Guard",
+        raise _PrepareRejected(
+            json_error(
+                ApiErrorCode.VALIDATION_FAILED,
+                status=422,
+                message=guard_message,
+            ),
+            run_failure_message=guard_message,
         )
 
     if resolved_api_key is None and is_local_endpoint(resolved_route.base_url_sanitized):
@@ -1044,34 +971,66 @@ def prepare_simulation():
 
         task_manager = TaskManager()
         _precheck_prepare_ai_model_ref(ai_model_ref)
-        run_record, task_id = _register_prepare_run(req, state, routing, task_manager)
-        _seed_prepare_routing(run_record, task_id, task_manager, routing, ai_model_ref)
-        resolved_route, resolved_api_key = _resolve_prepare_route(
-            run_record, task_id, task_manager, routing.llm_runtime
+    except _PrepareRejected as rejected:
+        # Vor der Run-Registrierung — es gibt noch keinen Record, der
+        # verwaisen könnte.
+        return rejected.response
+
+    # Issue #841/#1183: Ab der Registrierung existiert ein Run-Record mit
+    # status="pending". Task-Kopplung (#841-Reihenfolge), BaseException-Netz
+    # und strikte Persistenzsemantik (#844) liegen im RunLifecycle. Auch
+    # Statuswechsel und Enqueue laufen innerhalb des Fensters — ihr Scheitern
+    # hinterließ vorher einen pending-Phantom.
+    try:
+        with _begin_prepare_run(req, state, routing) as run:
+            run_record = run.record
+            task_id = task_manager.create_task(
+                task_type="simulation_prepare",
+                metadata={
+                    "simulation_id": req.simulation_id,
+                    "project_id": state.project_id,
+                    "run_id": run_record["run_id"],
+                },
+            )
+            run.attach_task(task_manager, task_id)
+            _seed_prepare_routing(run_record, routing, ai_model_ref)
+            resolved_route, resolved_api_key = _resolve_prepare_route(
+                run_record, routing.llm_runtime
+            )
+
+            effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
+
+            manager._set_status(state, SimulationStatus.PREPARING)
+
+            # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
+            from ..jobs import enqueue
+            enqueue(
+                "simulation_prepare",
+                _make_prepare_job(
+                    manager=manager,
+                    task_manager=task_manager,
+                    task_id=task_id,
+                    simulation_id=simulation_id,
+                    inputs=inputs,
+                    storage=storage,
+                    llm_model=resolved_route.model,
+                    effective_llm_runtime=effective_llm_runtime,
+                    run_record=run_record,
+                ),
+            )
+    except RunPersistenceError:
+        # #844: Die failed-Markierung wurde nicht persistiert — das darf nicht
+        # wie eine sauber abgeschlossene Ablehnung aussehen.
+        return json_error(
+            ApiErrorCode.INTERNAL_ERROR,
+            status=500,
+            message=(
+                "Interner Fehler beim Markieren des Runs als fehlgeschlagen. "
+                "Bitte erneut versuchen."
+            ),
         )
     except _PrepareRejected as rejected:
         return rejected.response
-
-    effective_llm_runtime = build_runtime_llm_config(resolved_route, resolved_api_key)
-
-    manager._set_status(state, SimulationStatus.PREPARING)
-
-    # TODO(P0-queue): migrate to Redis-Queue (RQ) in Wave 2 — see app/jobs/__init__.py
-    from ..jobs import enqueue
-    enqueue(
-        "simulation_prepare",
-        _make_prepare_job(
-            manager=manager,
-            task_manager=task_manager,
-            task_id=task_id,
-            simulation_id=simulation_id,
-            inputs=inputs,
-            storage=storage,
-            llm_model=resolved_route.model,
-            effective_llm_runtime=effective_llm_runtime,
-            run_record=run_record,
-        ),
-    )
 
     return json_success(_build_prepare_response(simulation_id, task_id, run_record, state, inputs))
 

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -19,6 +19,7 @@ from ..services.llm_routing_seed import (
 )
 from ..utils.endpoints import is_local_endpoint
 from ..services.llm_runtime import RuntimeLlmConfig, parse_runtime_llm_config
+from ..services.run_lifecycle import RunLifecycle, RunPersistenceError
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
 from ..services.stage_model_router import StageModelRouter
@@ -112,6 +113,9 @@ class _StartRejected(Exception):
     und Meldung wortgleich das bleiben, was der monolithische Handler vorher
     zurückgegeben hat (#1079).
     """
+
+    #: Failed-Meldung für einen bereits registrierten Run (RunLifecycle).
+    run_failure_message = "Simulation start rejected before launch"
 
     def __init__(self, response: Any) -> None:
         super().__init__("simulation start rejected")
@@ -476,27 +480,13 @@ def _precheck_ai_model_ref(ai_model_ref: "AiModelRef | None") -> None:
         ) from exc
 
 
-def _mark_run_failed(run_id: str, message: str) -> None:
-    """Bringt einen registrierten Run auf einen Endzustand (Issue #1176).
-
-    Best effort und bewusst schluckend: diese Funktion laeuft in
-    ``except``-Zweigen. Wuerde sie selbst werfen, ginge der urspruengliche
-    Fehler verloren — und der Aufrufer stuende ohne Diagnose da.
-    """
-    try:
-        run_registry.update_run(run_id, status="failed", message=message)
-    except Exception:  # noqa: BLE001 — der Ursprungsfehler ist wichtiger
-        logger.warning(
-            "Failed to mark run %s as failed after a start error", run_id, exc_info=True
-        )
-
-
-def _register_start_run(req: _StartRequest, state) -> "dict[str, Any]":
-    """Phase 5 — Run-Record anlegen, Routing seeden, Budget verankern."""
-    run_record = run_registry.create_run(
-        run_type="simulation_run",
-        entity_id=req.simulation_id,
-        status="pending",
+def _begin_start_run(req: _StartRequest, state) -> RunLifecycle:
+    """Phase 5 — Lifecycle für den Run-Record des Startlaufs bauen."""
+    return RunLifecycle.begin(
+        run_registry,
+        "simulation_run",
+        req.simulation_id,
+        failure_message="Simulation start failed: {exc_type}",
         progress=0,
         message="Simulation run queued",
         linked_ids={"simulation_id": req.simulation_id, "project_id": state.project_id},
@@ -514,21 +504,6 @@ def _register_start_run(req: _StartRequest, state) -> "dict[str, Any]":
             "llm_provider": req.llm_runtime.redacted_metadata() or None,
         },
     )
-    seed_run_stage_routing(
-        run_record["run_id"],
-        "simulation_rounds",
-        llm_model_override=req.llm_model_override,
-        llm_runtime=req.llm_runtime,
-        ai_model_ref=req.ai_model_ref,
-    )
-    # Budget am Run verankern + Subprozess-Config schreiben (Issue #764).
-    # Alt-Artefakte (budget_abort.json eines früheren Runs) werden entfernt,
-    # damit ein Neustart nicht sofort wieder abbricht.
-    from ..services.run_budget import set_run_budget_config as _set_run_budget_config
-    _apply_budget_to_simulation(
-        req.simulation_id, run_record["run_id"], req.budget_config, _set_run_budget_config
-    )
-    return run_record
 
 
 def _resolve_start_route(run_id: str, llm_runtime: RuntimeLlmConfig):
@@ -579,20 +554,8 @@ def _apply_route_to_simulation_config(
     store = get_artifact_store()
     config = store.read_json(req.simulation_id, "simulation_config", default=None)
     if not config:
-        # Der Run wurde in Phase 5 bereits registriert — ohne diese Markierung
-        # bleibt er als Phantom-Run in der Liste stehen (#1094).
-        try:
-            run_registry.update_run(
-                run_id,
-                status="failed",
-                message="Simulation configuration does not exist. Please call /prepare first",
-            )
-        except Exception:  # noqa: BLE001 — best effort
-            logger.warning(
-                "Failed to mark run %s as failed after missing simulation_config",
-                run_id,
-                exc_info=True,
-            )
+        # Der Run wurde in Phase 5 bereits registriert — die failed-Markierung
+        # übernimmt der RunLifecycle um den Startabschnitt (#1094, #1183).
         raise _StartRejected(
             json_error(
                 ApiErrorCode.SIMULATION_NOT_PREPARED,
@@ -667,62 +630,74 @@ def start_simulation():
         _precheck_ai_model_ref(req.ai_model_ref)
 
     except _StartRejected as rejected:
-        # Vor _register_start_run — es gibt noch keinen Run-Record, der
+        # Vor der Run-Registrierung — es gibt noch keinen Run-Record, der
         # verwaisen koennte.
         return rejected.response
 
-    # Issue #1176: Ab hier existiert ein Run-Record mit status="pending".
-    # Jeder Ausgang, der ihn nicht auf einen Endzustand bringt, hinterlaesst
-    # einen Phantom-Run: er steht dauerhaft in der Liste, das Frontend zeigt
-    # weiter "Bereit", und ``POST /api/runs/<id>/cancel`` greift bei ihm nicht.
-    #
-    # #1094 hat zwei bekannte Abbruchpfade einzeln markiert. Das deckt die
-    # Fehlerklasse nicht ab — ``SimulationRunner.start_simulation`` lag ganz
-    # ausserhalb des try, und jeder kuenftige Abbruchpfad haette dieselbe
-    # Luecke wieder aufgerissen. Statt weiterer Einzelmarkierungen faengt ein
-    # Netz um den gesamten Abschnitt.
-    run_record = _register_start_run(req, state)
-    run_id = run_record["run_id"]
+    # Issue #1176/#1183: Ab der Registrierung existiert ein Run-Record mit
+    # status="pending". Jeder Ausgang, der ihn nicht auf einen Endzustand
+    # bringt, hinterlaesst einen Phantom-Run. Das BaseException-Netz und die
+    # strikte Persistenzsemantik (#844) liegen im RunLifecycle — hier steht
+    # nur noch, was start-spezifisch ist. Routing-Seed und Budget-Anker
+    # laufen bewusst innerhalb des Fensters: auch ihr Scheitern darf keinen
+    # pending-Run hinterlassen.
     try:
-        resolved_route, resolved_api_key = _resolve_start_route(run_id, req.llm_runtime)
-        _apply_route_to_simulation_config(req, resolved_route, run_id)
-
-        run_state = SimulationRunner.start_simulation(
-            simulation_id=req.simulation_id,
-            platform=req.platform,
-            max_rounds=req.max_rounds,
-            enable_graph_memory_update=req.enable_graph_memory_update,
-            graph_id=graph_id,
-            runtime_env=build_route_subprocess_env(
-                resolved_route,
-                resolved_api_key,
+        with _begin_start_run(req, state) as run:
+            run_id = run.run_id
+            seed_run_stage_routing(
                 run_id,
+                "simulation_rounds",
+                llm_model_override=req.llm_model_override,
+                llm_runtime=req.llm_runtime,
+                ai_model_ref=req.ai_model_ref,
+            )
+            # Budget am Run verankern + Subprozess-Config schreiben (#764).
+            # Alt-Artefakte (budget_abort.json eines früheren Runs) werden
+            # entfernt, damit ein Neustart nicht sofort wieder abbricht.
+            from ..services.run_budget import set_run_budget_config as _set_run_budget_config
+            _apply_budget_to_simulation(
+                req.simulation_id, run_id, req.budget_config, _set_run_budget_config
+            )
+
+            resolved_route, resolved_api_key = _resolve_start_route(run_id, req.llm_runtime)
+            _apply_route_to_simulation_config(req, resolved_route, run_id)
+
+            run_state = SimulationRunner.start_simulation(
+                simulation_id=req.simulation_id,
+                platform=req.platform,
+                max_rounds=req.max_rounds,
+                enable_graph_memory_update=req.enable_graph_memory_update,
+                graph_id=graph_id,
+                runtime_env=build_route_subprocess_env(
+                    resolved_route,
+                    resolved_api_key,
+                    run_id,
+                ),
+            )
+
+            manager._set_status(state, SimulationStatus.RUNNING)
+            run.succeed(
+                status="processing",
+                progress=0,
+                message="Simulation run started",
+                resume_capability=_simulation_resume_capability(req.simulation_id, state),
+            )
+    except RunPersistenceError:
+        # #844: Die failed-/processing-Markierung wurde nicht persistiert —
+        # das darf nicht wie ein sauber abgeschlossener Vorgang aussehen.
+        return json_error(
+            ApiErrorCode.INTERNAL_ERROR,
+            status=500,
+            message=(
+                "Interner Fehler beim Persistieren des Run-Status. "
+                "Bitte erneut versuchen."
             ),
         )
     except _StartRejected as rejected:
-        _mark_run_failed(run_id, "Simulation start rejected before launch")
         return rejected.response
-    except BaseException as exc:  # noqa: BLE001 — sofort weitergeworfen
-        # BaseException, nicht Exception: ein Worker-Timeout erreicht den
-        # Handler als Signal-Ableitung (SystemExit), und genau der Fall — der
-        # haengende Request — hat die Phantom-Runs erzeugt. Ein
-        # ``except Exception`` haette ihn durchgelassen.
-        _mark_run_failed(run_id, f"Simulation start failed: {type(exc).__name__}")
-        raise
-
-    manager._set_status(state, SimulationStatus.RUNNING)
-    run_registry.update_run(
-        run_record["run_id"],
-        status="processing",
-        progress=0,
-        message="Simulation run started",
-        resume_capability=_simulation_resume_capability(req.simulation_id, state),
-    )
 
     return json_success(
-        _build_start_response(
-            req, run_state, run_record["run_id"], graph_id, force_restarted
-        )
+        _build_start_response(req, run_state, run_id, graph_id, force_restarted)
     )
 
 

--- a/backend/app/services/report_generation.py
+++ b/backend/app/services/report_generation.py
@@ -7,6 +7,7 @@ from flask import current_app
 
 from ..services.report_agent import ReportAgent, ReportManager, ReportStatus
 from ..services.report_agent.output_contract import is_deliverable_report_status
+from ..services.run_lifecycle import RunLifecycle
 from ..services.run_registry import RunRegistry
 from ..services.simulation_manager import SimulationManager
 from ..models.project import ProjectManager
@@ -95,10 +96,14 @@ class ReportGenerationService:
         report_id = f"report_{uuid.uuid4().hex[:12]}"
 
         task_manager = TaskManager()
-        run_record = run_registry.create_run(
-            run_type="report_generate",
-            entity_id=report_id,
-            status="pending",
+        # Issue #1183: Anlage-Fenster (create_run bis enqueue) hinter
+        # RunLifecycle — jeder Abbruch bis zur Übergabe an den Job-Worker
+        # markiert Run und Task als failed statt sie pending zu verwaisen.
+        with RunLifecycle.begin(
+            run_registry,
+            "report_generate",
+            report_id,
+            failure_message="Report generation start failed: {exc_type}",
             progress=0,
             message="Report generation queued",
             linked_ids={
@@ -121,11 +126,65 @@ class ReportGenerationService:
                 "llm_model": llm_model_override,
                 "llm_provider": llm_runtime.redacted_metadata() or None,
             },
-        )
-        task_id = task_manager.create_task(
-            task_type="report_generate",
-            metadata={"simulation_id": simulation_id, "graph_id": graph_id, "report_id": report_id, "run_id": run_record["run_id"]}
-        )
+        ) as lifecycle:
+            run_record = lifecycle.record
+            task_id = task_manager.create_task(
+                task_type="report_generate",
+                metadata={"simulation_id": simulation_id, "graph_id": graph_id, "report_id": report_id, "run_id": run_record["run_id"]}
+            )
+            lifecycle.attach_task(task_manager, task_id)
+            cls._wire_and_enqueue_generation(
+                simulation_requirement=simulation_requirement,
+                task_manager=task_manager,
+                task_id=task_id,
+                simulation_id=simulation_id,
+                report_id=report_id,
+                report_mode=report_mode,
+                run_record=run_record,
+                graph_id=graph_id,
+                state=state,
+                llm_model_override=llm_model_override,
+                llm_runtime=llm_runtime,
+                llm_profile_id=llm_profile_id,
+                ai_model_ref=ai_model_ref,
+                budget=budget,
+            )
+
+        return {
+            "simulation_id": simulation_id,
+            "report_id": report_id,
+            "task_id": task_id,
+            "run_id": run_record["run_id"],
+            "status": "generating",
+            "message": "Report generation task started. Query progress via /api/report/generate/status",
+            "already_generated": False
+        }
+
+    @classmethod
+    def _wire_and_enqueue_generation(
+        cls,
+        *,
+        simulation_requirement,
+        task_manager,
+        task_id,
+        simulation_id,
+        report_id,
+        report_mode,
+        run_record,
+        graph_id,
+        state,
+        llm_model_override,
+        llm_runtime,
+        llm_profile_id,
+        ai_model_ref,
+        budget,
+    ):
+        """Routing, Budget und Worker-Closure des Reports verdrahten.
+
+        Läuft vollständig innerhalb des RunLifecycle-Fensters von
+        :meth:`start_generation` — jede Exception hier markiert Run und
+        Task als failed (#1183).
+        """
         # Issue #764: Budget des Simulationslaufs auf den Report-Run vererben.
         try:
             from .run_budget import inherit_budget_from_simulation
@@ -287,13 +346,3 @@ class ReportGenerationService:
 
         from ..jobs import enqueue
         enqueue("report_generate", run_generate)
-
-        return {
-            "simulation_id": simulation_id,
-            "report_id": report_id,
-            "task_id": task_id,
-            "run_id": run_record["run_id"],
-            "status": "generating",
-            "message": "Report generation task started. Query progress via /api/report/generate/status",
-            "already_generated": False
-        }

--- a/backend/app/services/run_lifecycle.py
+++ b/backend/app/services/run_lifecycle.py
@@ -1,0 +1,202 @@
+"""Run-Lifecycle — zentrale Zustandsführung für RunRegistry-Runs.
+
+Invariante: ein Run, der als ``pending`` angelegt wurde, verlässt jeden
+Ausgang des Anlage-Fensters auf einem Endzustand. Kein Abbruchpfad darf
+einen Phantom-Run hinterlassen, der dauerhaft ``pending`` in der Liste
+steht (#841, #1094, #1176/#1183 — drei Anläufe am selben Symptom, weil
+das Muster an mehreren Stellen handgeschrieben war).
+
+Gekapselte Semantik:
+
+* **#841 — Task-Reihenfolge:** ist ein Task an den Run gekoppelt, läuft
+  ``fail_task()`` zuerst (setzt per ``sync_task()`` eine generische
+  Meldung auf den Run zurück) und der detaillierte ``update_run()``-Aufruf
+  zuletzt, sonst überschreibt ``sync_task()`` die Meldung.
+* **#844 — Persistenz ist prüfbar:** ``update_run()`` liefert ``None``,
+  wenn das Run-Manifest verschwunden ist, oder wirft eine I/O-Exception.
+  Beide Fälle dürfen nicht wie eine erfolgreich persistierte Markierung
+  aussehen — sie werden als :class:`RunPersistenceError` sichtbar.
+* **#1183 — BaseException-Netz:** ein Worker-Timeout erreicht den Handler
+  als Signal-Ableitung (``SystemExit``); ``except Exception`` ließe genau
+  den Fall durch, der die Phantom-Runs erzeugt hat.
+
+Der Kontextmanager markiert und **re-raist immer** — er schluckt keine
+Exception und baut keine HTTP-Antworten. Antwortbau (``json_error``,
+Rejection-Objekte) bleibt Sache der API-Schicht.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Exceptions können unter diesem Attribut eine sprechende failed-Meldung
+#: für den Run mitführen (z. B. Rejection-Klassen der API-Schicht). Fehlt
+#: es, greift das ``failure_message``-Template von :meth:`RunLifecycle.begin`.
+FAILURE_MESSAGE_ATTR = "run_failure_message"
+
+
+class RunPersistenceError(RuntimeError):
+    """Ein Statusübergang wurde NICHT persistiert (Issue #844).
+
+    Wird geworfen, wenn ``update_run()`` ``None`` liefert (Run-Manifest
+    verschwunden) oder eine Exception wirft. Der Aufrufer darf den Vorgang
+    dann nicht als sauber abgeschlossen behandeln — typischerweise wird
+    daraus eine 500-Antwort statt der regulären Ablehnung.
+    """
+
+    def __init__(self, run_id: str, cause: Optional[BaseException] = None):
+        self.run_id = run_id
+        self.cause = cause
+        # Bewusst ohne Ursachen-Detail: die Meldung kann über generische
+        # API-Fehlerpfade beim Client landen — Pfade/IO-Details gehören ins
+        # Log (siehe Aufrufstellen), nicht in die Response.
+        super().__init__(f"Statusübergang für Run {run_id} wurde nicht persistiert")
+
+
+class RunLifecycle:
+    """Kontextmanager um das Anlage-Fenster eines RunRegistry-Runs.
+
+    ::
+
+        with RunLifecycle.begin(run_registry, "simulation_run", sim_id,
+                                failure_message="Simulation start failed: {exc_type}",
+                                linked_ids={...}, metadata={...}) as run:
+            task_id = task_manager.create_task(...)
+            run.attach_task(task_manager, task_id)
+            ...  # alles, was den Run verwaisen lassen könnte
+            run.succeed(status="processing", message="Simulation run started")
+
+    * Eintritt: legt den Run mit ``status="pending"`` an.
+    * Sauberes Blockende ohne :meth:`succeed`: der Run bleibt ``pending``
+      (Übergabe an einen Worker, der die Terminalzustände besitzt).
+    * Jede ``BaseException`` im Block: Run wird ``failed`` markiert
+      (strikt, #844) und die Exception unverändert re-raist.
+    """
+
+    def __init__(
+        self,
+        registry: Any,
+        run_type: str,
+        entity_id: str,
+        *,
+        failure_message: Optional[str] = None,
+        **create_kwargs: Any,
+    ) -> None:
+        self._registry = registry
+        self._run_type = run_type
+        self._entity_id = entity_id
+        self._failure_message = failure_message
+        self._create_kwargs = create_kwargs
+        self._task_manager: Any = None
+        self._task_id: Optional[str] = None
+        self.record: dict[str, Any] = {}
+        self.run_id: str = ""
+
+    @classmethod
+    def begin(
+        cls,
+        registry: Any,
+        run_type: str,
+        entity_id: str,
+        *,
+        failure_message: Optional[str] = None,
+        **create_kwargs: Any,
+    ) -> "RunLifecycle":
+        """Lifecycle für einen neuen Run bauen (``status`` wird immer ``pending``)."""
+        create_kwargs.pop("status", None)
+        return cls(
+            registry,
+            run_type,
+            entity_id,
+            failure_message=failure_message,
+            **create_kwargs,
+        )
+
+    def __enter__(self) -> "RunLifecycle":
+        self.record = self._registry.create_run(
+            self._run_type,
+            self._entity_id,
+            status="pending",
+            **self._create_kwargs,
+        )
+        self.run_id = self.record["run_id"]
+        return self
+
+    def attach_task(self, task_manager: Any, task_id: str) -> None:
+        """Task an den Run koppeln — bei Fehlern gilt die #841-Reihenfolge."""
+        self._task_manager = task_manager
+        self._task_id = task_id
+
+    def succeed(self, *, status: str = "processing", **updates: Any) -> dict[str, Any]:
+        """Erfolgs-Übergang, strikt persistiert (#844) — wirft :class:`RunPersistenceError`."""
+        return self._strict_update(status=status, **updates)
+
+    def _strict_update(self, **updates: Any) -> dict[str, Any]:
+        try:
+            updated = self._registry.update_run(self.run_id, **updates)
+        except Exception as exc:  # noqa: BLE001 — Persistenzfehler wird typisiert weitergereicht
+            logger.error(
+                "Persistenzfehler beim Statusübergang von run_id=%s: %s", self.run_id, exc
+            )
+            raise RunPersistenceError(self.run_id, exc) from exc
+        if updated is None:
+            logger.error(
+                "Persistenzfehler beim Statusübergang von run_id=%s: %s",
+                self.run_id,
+                "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+            )
+            raise RunPersistenceError(self.run_id)
+        return updated
+
+    def _failure_text(self, exc: BaseException) -> str:
+        attr_message = getattr(exc, FAILURE_MESSAGE_ATTR, None)
+        if attr_message:
+            return str(attr_message)
+        template = self._failure_message or "{run_type} failed: {exc_type}"
+        return template.format(run_type=self._run_type, exc_type=type(exc).__name__)
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc is None:
+            return False
+
+        if isinstance(exc, RunPersistenceError) and exc.run_id == self.run_id:
+            # Bereits ein Persistenzproblem dieses Runs (z. B. aus succeed()) —
+            # ein weiterer Markierungsversuch würde nur denselben Fehler doppeln.
+            return False
+
+        message = self._failure_text(exc)
+
+        if self._task_manager is not None and self._task_id is not None:
+            try:
+                self._task_manager.fail_task(self._task_id, message)
+            except Exception:  # noqa: BLE001 — Task-Markierung ist best-effort (#841)
+                logger.warning(
+                    "fail_task(%s) schlug beim failed-Markieren von Run %s fehl",
+                    self._task_id,
+                    self.run_id,
+                    exc_info=True,
+                )
+
+        try:
+            updated = self._registry.update_run(
+                self.run_id, status="failed", message=message, error=message
+            )
+        except Exception as persist_exc:  # noqa: BLE001 — siehe #844
+            logger.error(
+                "Persistenzfehler beim Markieren von run_id=%s als failed: %s",
+                self.run_id,
+                persist_exc,
+            )
+            raise RunPersistenceError(self.run_id, persist_exc) from exc
+        if updated is None:
+            logger.error(
+                "Persistenzfehler beim Markieren von run_id=%s als failed: %s",
+                self.run_id,
+                "update_run() lieferte None (Run-Manifest existiert nicht mehr)",
+            )
+            raise RunPersistenceError(self.run_id) from exc
+
+        return False

--- a/backend/tests/api/test_runs_resume_stop.py
+++ b/backend/tests/api/test_runs_resume_stop.py
@@ -538,7 +538,7 @@ def test_resume_simulation_prepare_raises_internal_error_when_run_update_returns
     ValueError("provider_override..."). Kein Task wird erzeugt,
     prepare_simulation wird nicht gestartet.
     """
-    from app.utils.api_errors import ApiErrorCode
+    from app.services.run_lifecycle import RunPersistenceError
 
     run = _create_run(
         env["registry"],
@@ -587,10 +587,9 @@ def test_resume_simulation_prepare_raises_internal_error_when_run_update_returns
         env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
 
         with env["app"].app_context():
-            with pytest.raises(RuntimeError) as exc_info:
+            with pytest.raises(RunPersistenceError) as exc_info:
                 _run_restart_prepare_sync(run)
 
-        assert exc_info.value.args and exc_info.value.args[0] == ApiErrorCode.INTERNAL_ERROR
         # Die irreführende 422-Provider-Key-Meldung darf nicht auftauchen.
         assert "provider_override" not in str(exc_info.value)
         assert not MockMgr.return_value.prepare_simulation.called
@@ -602,7 +601,7 @@ def test_resume_simulation_prepare_raises_internal_error_when_run_update_raises(
     interner Persistenzfehler statt Maskierung als normaler Guard-Fall.
     Kein Task wird erzeugt, prepare_simulation wird nicht gestartet.
     """
-    from app.utils.api_errors import ApiErrorCode
+    from app.services.run_lifecycle import RunPersistenceError
 
     run = _create_run(
         env["registry"],
@@ -651,10 +650,9 @@ def test_resume_simulation_prepare_raises_internal_error_when_run_update_raises(
         env["app"].extensions["neo4j_storage"] = MagicMock(name="Neo4jStorage")
 
         with env["app"].app_context():
-            with pytest.raises(RuntimeError) as exc_info:
+            with pytest.raises(RunPersistenceError) as exc_info:
                 _run_restart_prepare_sync(run)
 
-        assert exc_info.value.args and exc_info.value.args[0] == ApiErrorCode.INTERNAL_ERROR
         assert "provider_override" not in str(exc_info.value)
         assert "disk full" not in str(exc_info.value)
         assert not MockMgr.return_value.prepare_simulation.called

--- a/backend/tests/api/test_simulation_prepare_phases.py
+++ b/backend/tests/api/test_simulation_prepare_phases.py
@@ -413,13 +413,17 @@ def test_precheck_prepare_ai_model_ref_maps_value_error_to_400(app_ctx, monkeypa
     assert _body(excinfo)["error"] == "connection disabled"
 
 
-def test_register_prepare_run_creates_run_and_task(app_ctx, monkeypatch):
+def test_begin_prepare_run_creates_pending_run(app_ctx, monkeypatch):
+    """Phase 6b heißt jetzt RunLifecycle: der Eintritt legt den pending-Record an.
+
+    Task-Anlage und -Kopplung laufen im Handler (``run.attach_task``); die
+    Fehlerpfad-Semantik (#841-Reihenfolge, #844-Persistenz) deckt
+    ``tests/services/test_run_lifecycle.py`` durchs Lifecycle-Interface ab.
+    """
     registry = MagicMock()
     registry.create_run.return_value = {"run_id": "run-1"}
     monkeypatch.setattr(mod, "run_registry", registry)
     monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
-    task_manager = MagicMock()
-    task_manager.create_task.return_value = "task-1"
     req = mod._PrepareRequest(
         simulation_id=VALID_SIM_ID,
         ai_model_ref=None,
@@ -427,28 +431,23 @@ def test_register_prepare_run_creates_run_and_task(app_ctx, monkeypatch):
         force_regenerate=False,
     )
 
-    run_record, task_id = mod._register_prepare_run(
-        req, _state(), _routing(llm_model_override="gpt-4o"), task_manager
-    )
+    with mod._begin_prepare_run(req, _state(), _routing(llm_model_override="gpt-4o")) as run:
+        assert run.record == {"run_id": "run-1"}
 
-    assert run_record == {"run_id": "run-1"}
-    assert task_id == "task-1"
-    create_kwargs = registry.create_run.call_args.kwargs
-    assert create_kwargs["run_type"] == "simulation_prepare"
-    assert create_kwargs["metadata"]["llm_model"] == "gpt-4o"
-    assert "budget" not in create_kwargs["metadata"]
-    assert task_manager.create_task.call_args.kwargs["metadata"]["run_id"] == "run-1"
+    create_call = registry.create_run.call_args
+    assert create_call.args == ("simulation_prepare", VALID_SIM_ID)
+    assert create_call.kwargs["status"] == "pending"
+    assert create_call.kwargs["metadata"]["llm_model"] == "gpt-4o"
+    assert "budget" not in create_call.kwargs["metadata"]
 
 
-def test_register_prepare_run_carries_budget_metadata(app_ctx, monkeypatch):
+def test_begin_prepare_run_carries_budget_metadata(app_ctx, monkeypatch):
     from app.contracts.run_budget_contract import RunBudgetConfig
 
     registry = MagicMock()
     registry.create_run.return_value = {"run_id": "run-1"}
     monkeypatch.setattr(mod, "run_registry", registry)
     monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
-    task_manager = MagicMock()
-    task_manager.create_task.return_value = "task-1"
     req = mod._PrepareRequest(
         simulation_id=VALID_SIM_ID,
         ai_model_ref=None,
@@ -456,54 +455,11 @@ def test_register_prepare_run_carries_budget_metadata(app_ctx, monkeypatch):
         force_regenerate=False,
     )
 
-    mod._register_prepare_run(req, _state(), _routing(), task_manager)
+    with mod._begin_prepare_run(req, _state(), _routing()):
+        pass
 
     metadata = registry.create_run.call_args.kwargs["metadata"]
     assert metadata["budget"]["max_tokens"] == 1000
-
-
-# ---------------------------------------------------------------------------
-# Fehlerpfad — Run/Task als failed markieren
-# ---------------------------------------------------------------------------
-
-def test_reject_and_fail_prepare_run_marks_run_failed(app_ctx, monkeypatch):
-    registry = MagicMock()
-    registry.update_run.return_value = {"run_id": "run-1", "status": "failed"}
-    monkeypatch.setattr(mod, "run_registry", registry)
-    task_manager = MagicMock()
-
-    rejected = mod._reject_and_fail_prepare_run(
-        {"run_id": "run-1"}, "task-1", task_manager, "kaputt", status=422, context="im Test"
-    )
-
-    assert rejected.response[1] == 422
-    task_manager.fail_task.assert_called_once_with("task-1", "kaputt")
-    assert registry.update_run.call_args.kwargs["status"] == "failed"
-
-
-def test_reject_and_fail_prepare_run_returns_500_when_run_vanished(app_ctx, monkeypatch):
-    registry = MagicMock()
-    registry.update_run.return_value = None
-    monkeypatch.setattr(mod, "run_registry", registry)
-
-    rejected = mod._reject_and_fail_prepare_run(
-        {"run_id": "run-1"}, "task-1", MagicMock(), "kaputt", status=422, context="im Test"
-    )
-
-    assert rejected.response[1] == 500
-    assert rejected.response[0].get_json()["code"] == "internal_error"
-
-
-def test_reject_and_fail_prepare_run_returns_500_on_persistence_error(app_ctx, monkeypatch):
-    registry = MagicMock()
-    registry.update_run.side_effect = OSError("disk full")
-    monkeypatch.setattr(mod, "run_registry", registry)
-
-    rejected = mod._reject_and_fail_prepare_run(
-        {"run_id": "run-1"}, "task-1", MagicMock(), "kaputt", status=400, context="im Test"
-    )
-
-    assert rejected.response[1] == 500
 
 
 # ---------------------------------------------------------------------------
@@ -514,9 +470,7 @@ def test_seed_prepare_routing_without_ref_passes_profile(app_ctx, monkeypatch):
     seed = MagicMock()
     monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
 
-    mod._seed_prepare_routing(
-        {"run_id": "run-1"}, "task-1", MagicMock(), _routing(routed_profile_id="p1"), None
-    )
+    mod._seed_prepare_routing({"run_id": "run-1"}, _routing(routed_profile_id="p1"), None)
 
     assert seed.call_args.args == ("run-1", "persona_generation")
     assert seed.call_args.kwargs["llm_profile_id"] == "p1"
@@ -528,29 +482,29 @@ def test_seed_prepare_routing_with_ref_forwards_ref(app_ctx, monkeypatch):
     monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
     ref = MagicMock(name="AiModelRef")
 
-    mod._seed_prepare_routing({"run_id": "run-1"}, "task-1", MagicMock(), _routing(), ref)
+    mod._seed_prepare_routing({"run_id": "run-1"}, _routing(), ref)
 
     assert seed.call_args.kwargs["ai_model_ref"] is ref
 
 
-def test_seed_prepare_routing_failure_marks_run_failed(app_ctx, monkeypatch):
+def test_seed_prepare_routing_failure_rejects_with_run_message(app_ctx, monkeypatch):
+    """Die Phase markiert nicht mehr selbst — sie lehnt ab und gibt die
+    failed-Meldung über ``run_failure_message`` an den RunLifecycle weiter
+    (#841: fail_task zuerst, detaillierte Run-Meldung zuletzt)."""
     def _raise(*_args, **_kwargs):
         raise ValueError("model not on connection")
 
     monkeypatch.setattr(mod, "seed_run_stage_routing", _raise)
     registry = MagicMock()
-    registry.update_run.return_value = {"run_id": "run-1"}
     monkeypatch.setattr(mod, "run_registry", registry)
-    task_manager = MagicMock()
 
     with pytest.raises(mod._PrepareRejected) as excinfo:
-        mod._seed_prepare_routing(
-            {"run_id": "run-1"}, "task-1", task_manager, _routing(), MagicMock()
-        )
+        mod._seed_prepare_routing({"run_id": "run-1"}, _routing(), MagicMock())
 
     assert _status(excinfo) == 400
     assert _body(excinfo)["error"] == "model not on connection"
-    task_manager.fail_task.assert_called_once_with("task-1", "model not on connection")
+    assert excinfo.value.run_failure_message == "model not on connection"
+    registry.update_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -581,9 +535,7 @@ def test_resolve_prepare_route_locks_stage_and_returns_key(app_ctx, monkeypatch)
     router = _patch_router(monkeypatch, route)
     monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: "sk-bound")
 
-    resolved, api_key = mod._resolve_prepare_route(
-        {"run_id": "run-1"}, "task-1", MagicMock(), RuntimeLlmConfig()
-    )
+    resolved, api_key = mod._resolve_prepare_route({"run_id": "run-1"}, RuntimeLlmConfig())
 
     assert resolved is route
     assert api_key == "sk-bound"
@@ -591,30 +543,27 @@ def test_resolve_prepare_route_locks_stage_and_returns_key(app_ctx, monkeypatch)
 
 
 def test_resolve_prepare_route_guards_missing_key_with_422(app_ctx, monkeypatch):
+    """Die failed-Markierung liegt im RunLifecycle — die Phase lehnt nur ab
+    und trägt die Run-Meldung als ``run_failure_message``."""
     _patch_router(monkeypatch, _resolved_route())
     monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
     registry = MagicMock()
-    registry.update_run.return_value = {"run_id": "run-1"}
     monkeypatch.setattr(mod, "run_registry", registry)
-    task_manager = MagicMock()
 
     with pytest.raises(mod._PrepareRejected) as excinfo:
-        mod._resolve_prepare_route(
-            {"run_id": "run-1"}, "task-1", task_manager, RuntimeLlmConfig()
-        )
+        mod._resolve_prepare_route({"run_id": "run-1"}, RuntimeLlmConfig())
 
     assert _status(excinfo) == 422
     assert "provider_override" in _body(excinfo)["error"]
-    task_manager.fail_task.assert_called_once()
+    assert "provider_override" in excinfo.value.run_failure_message
+    registry.update_run.assert_not_called()
 
 
 def test_resolve_prepare_route_uses_placeholder_for_local_endpoint(app_ctx, monkeypatch):
     _patch_router(monkeypatch, _resolved_route(base_url="http://localhost:11434/v1"))
     monkeypatch.setattr(mod, "resolve_route_api_key", lambda _route, _runtime: None)
 
-    _resolved, api_key = mod._resolve_prepare_route(
-        {"run_id": "run-1"}, "task-1", MagicMock(), RuntimeLlmConfig()
-    )
+    _resolved, api_key = mod._resolve_prepare_route({"run_id": "run-1"}, RuntimeLlmConfig())
 
     assert api_key == mod.LOCAL_NO_AUTH_API_KEY
 

--- a/backend/tests/api/test_simulation_prepare_profile_routing.py
+++ b/backend/tests/api/test_simulation_prepare_profile_routing.py
@@ -154,6 +154,13 @@ def prepare_env(monkeypatch):
     monkeypatch.setattr(
         f"{prefix}.run_registry.create_run", lambda *a, **k: {"run_id": "run_prepare_1"}
     )
+    monkeypatch.setattr(
+        # Der RunLifecycle markiert seit #1183 jeden Fensterabbruch strikt als
+        # failed (#844) — der gestubbte Run braucht deshalb auch ein
+        # erfolgreiches update_run, sonst würde jeder Fehlerpfad-Test hier
+        # fälschlich im 500-Persistenzfehler enden.
+        f"{prefix}.run_registry.update_run", lambda *a, **k: {"run_id": "run_prepare_1"}
+    )
     monkeypatch.setattr("app.jobs.threading.Thread.start", run_inline)
     monkeypatch.setattr("app.models.task.TaskManager", FakeTaskManager)
 

--- a/backend/tests/api/test_simulation_start_phases.py
+++ b/backend/tests/api/test_simulation_start_phases.py
@@ -379,31 +379,28 @@ def test_precheck_ai_model_ref_maps_value_error_to_422(app_ctx, monkeypatch):
 # Phase 5 — Run-Registrierung
 # ---------------------------------------------------------------------------
 
-def test_register_start_run_creates_run_and_seeds_routing(app_ctx, monkeypatch):
+def test_begin_start_run_creates_pending_run(app_ctx, monkeypatch):
+    """Phase 5 heißt jetzt RunLifecycle: der Eintritt legt den pending-Record an.
+
+    Routing-Seed und Budget-Anker laufen nicht mehr in der Registrierung,
+    sondern im Handler innerhalb des Lifecycle-Fensters — ihr Scheitern deckt
+    ``test_start_run_never_stuck_pending.py`` auf HTTP-Ebene ab.
+    """
     registry = MagicMock()
     registry.create_run.return_value = {"run_id": "run-1"}
     monkeypatch.setattr(mod, "run_registry", registry)
     monkeypatch.setattr(mod, "_simulation_run_artifacts", lambda _sid: [])
     monkeypatch.setattr(mod, "_simulation_resume_capability", lambda _sid, _state: {"resumable": False})
-    seed = MagicMock()
-    monkeypatch.setattr(mod, "seed_run_stage_routing", seed)
-    applied = {}
-    monkeypatch.setattr(
-        mod,
-        "_apply_budget_to_simulation",
-        lambda sid, rid, budget, _fn: applied.update(sid=sid, rid=rid, budget=budget),
-    )
     req = mod._parse_start_request({"simulation_id": VALID_SIM_ID, "platform": "reddit"})
 
-    run_record = mod._register_start_run(req, _state(graph_id="graph-1"))
+    with mod._begin_start_run(req, _state(graph_id="graph-1")) as run:
+        assert run.record == {"run_id": "run-1"}
+        assert run.run_id == "run-1"
 
-    assert run_record == {"run_id": "run-1"}
-    create_kwargs = registry.create_run.call_args.kwargs
-    assert create_kwargs["run_type"] == "simulation_run"
-    assert create_kwargs["entity_id"] == VALID_SIM_ID
-    assert create_kwargs["metadata"]["platform"] == "reddit"
-    assert seed.call_args.args == ("run-1", "simulation_rounds")
-    assert applied == {"sid": VALID_SIM_ID, "rid": "run-1", "budget": None}
+    create_call = registry.create_run.call_args
+    assert create_call.args == ("simulation_run", VALID_SIM_ID)
+    assert create_call.kwargs["status"] == "pending"
+    assert create_call.kwargs["metadata"]["platform"] == "reddit"
 
 
 # ---------------------------------------------------------------------------
@@ -516,10 +513,15 @@ def test_apply_route_to_simulation_config_rejects_missing_config(app_ctx, monkey
     assert _body(excinfo)["code"] == "simulation_not_prepared"
 
 
-def test_apply_route_to_simulation_config_rejects_missing_config_marks_run_failed(
+def test_apply_route_to_simulation_config_rejects_without_marking(
     app_ctx, monkeypatch
 ):
-    """Issue #1094: fehlende simulation_config darf keinen Phantom-Run hinterlassen."""
+    """Issue #1094/#1183: Die Phase lehnt nur noch ab — die failed-Markierung
+    liegt im RunLifecycle um den Startabschnitt, nicht mehr in der Phase.
+
+    Dass der Run dabei nicht pending verwaist, deckt
+    ``test_start_run_never_stuck_pending.py`` auf HTTP-Ebene ab.
+    """
     store = MagicMock()
     store.read_json.return_value = None
     monkeypatch.setattr(mod, "get_artifact_store", lambda: store)
@@ -532,9 +534,7 @@ def test_apply_route_to_simulation_config_rejects_missing_config_marks_run_faile
 
     assert _status(excinfo) == 404
     assert _body(excinfo)["code"] == "simulation_not_prepared"
-    registry.update_run.assert_called_once()
-    assert registry.update_run.call_args.args[0] == "run-1"
-    assert registry.update_run.call_args.kwargs["status"] == "failed"
+    registry.update_run.assert_not_called()
 
 
 def test_apply_route_to_simulation_config_writes_model_for_ai_model_ref(app_ctx, monkeypatch):

--- a/backend/tests/api/test_start_run_never_stuck_pending.py
+++ b/backend/tests/api/test_start_run_never_stuck_pending.py
@@ -233,20 +233,38 @@ class TestFailureAfterRegistrationEndsTheRun:
         assert _final_status(registry) == "failed"
 
 
-class TestMarkRunFailedSwallowsItsOwnErrors:
-    def test_ein_registry_fehler_verdeckt_nicht_den_ursprungsfehler(
-        self, monkeypatch
+class TestPersistenzfehlerBeimMarkierenWirdSichtbar:
+    def test_ein_persistenzfehler_ersetzt_die_ablehnung_durch_500(
+        self, client, monkeypatch
     ) -> None:
-        """``_mark_run_failed`` läuft in ``except``-Zweigen.
+        """Issue #844, vereinheitlicht auf die strenge Semantik.
 
-        Würde sie selbst werfen, ginge der ursprüngliche Fehler verloren — und
-        der Aufrufer stünde ohne Diagnose da. Ein nicht markierter Run ist
-        ärgerlich; eine verschluckte Ursache ist schlimmer.
+        Früher schluckte ``_mark_run_failed`` Registry-Fehler best-effort —
+        der Client bekam die reguläre Ablehnung (hier: 422), obwohl der Run
+        weiter ``pending`` in der Registry stand. Jetzt gilt der Prepare-Weg
+        auch beim Start: eine nicht persistierte failed-Markierung darf nicht
+        wie eine sauber abgeschlossene Ablehnung aussehen — der Handler
+        antwortet 500.
         """
-        import app.api.simulation_run as mod
+        registry = _stub_start_infra(monkeypatch)
+        registry.update_run.side_effect = OSError("Registry nicht schreibbar")
+        remote = ResolvedRoute(
+            stage="simulation_rounds",
+            provider_id="conn-openai",
+            model="gpt-4o",
+            base_url_sanitized="https://api.openai.com/v1",
+            routing_version=1,
+            provider_options={"base_url": "https://api.openai.com/v1"},
+        )
+        router = MagicMock()
+        router.resolve.return_value = remote
+        router.lock_stage.return_value = remote
+        monkeypatch.setattr("app.api.simulation_run.StageModelRouter", lambda _r: router)
+        monkeypatch.setattr(
+            "app.api.simulation_run.resolve_route_api_key", lambda _r, _rt: None
+        )
 
-        broken = MagicMock()
-        broken.update_run.side_effect = RuntimeError("Registry nicht erreichbar")
-        monkeypatch.setattr(mod, "run_registry", broken)
+        response = _start(client)
 
-        mod._mark_run_failed("run_01", "egal")  # darf nicht werfen
+        assert response.status_code == 500, response.data
+        registry.update_run.assert_called()

--- a/backend/tests/contracts/test_evidence_degradation.py
+++ b/backend/tests/contracts/test_evidence_degradation.py
@@ -395,8 +395,11 @@ def test_report_generation_liefert_incomplete_statt_zu_scheitern():
 
     from app.services import report_generation
 
-    source = inspect.getsource(report_generation.ReportGenerationService.start_generation)
+    # Der Worker-Zweig lebt seit dem RunLifecycle-Slice in
+    # ``_wire_and_enqueue_generation`` (von ``start_generation`` aufgerufen) —
+    # geprueft wird die ganze Service-Klasse, nicht eine einzelne Methode.
+    source = inspect.getsource(report_generation.ReportGenerationService)
     assert "is_deliverable_report_status(report.status)" in source, (
-        "start_generation entscheidet nicht mehr ueber is_deliverable_report_status — "
+        "ReportGenerationService entscheidet nicht mehr ueber is_deliverable_report_status — "
         "ein degradierter Report wuerde wieder als Fehlschlag zugestellt."
     )

--- a/backend/tests/services/test_run_lifecycle.py
+++ b/backend/tests/services/test_run_lifecycle.py
@@ -1,0 +1,211 @@
+"""Interface-Tests für den RunLifecycle-Kontextmanager.
+
+Ersetzt die Struktur-Tests der früheren Einzel-Helper
+(``_register_start_run``/``_mark_run_failed`` in ``simulation_run.py``,
+``_register_prepare_run``/``_reject_and_fail_prepare_run`` in
+``simulation_prepare.py``) — getestet wird ausschließlich durchs
+öffentliche Interface: ``begin`` → ``attach_task``/``succeed`` → Exit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.run_lifecycle import (
+    FAILURE_MESSAGE_ATTR,
+    RunLifecycle,
+    RunPersistenceError,
+)
+
+
+class FakeRegistry:
+    """Minimaler RunRegistry-Ersatz mit steuerbarem update_run-Verhalten."""
+
+    def __init__(self):
+        self.runs: dict[str, dict] = {}
+        self.calls: list[tuple[str, dict]] = []
+        self.update_returns_none = False
+        self.update_raises: Exception | None = None
+        self._counter = 0
+
+    def create_run(self, run_type, entity_id, **kwargs):
+        self._counter += 1
+        run_id = f"run_test_{self._counter}"
+        record = {"run_id": run_id, "run_type": run_type, "entity_id": entity_id, **kwargs}
+        self.runs[run_id] = record
+        self.calls.append(("create_run", dict(record)))
+        return record
+
+    def update_run(self, run_id, **updates):
+        self.calls.append(("update_run", {"run_id": run_id, **updates}))
+        if self.update_raises is not None:
+            raise self.update_raises
+        if self.update_returns_none:
+            return None
+        self.runs[run_id].update(updates)
+        return self.runs[run_id]
+
+
+class FakeTaskManager:
+    def __init__(self, fail_raises: Exception | None = None):
+        self.failed: list[tuple[str, str]] = []
+        self.fail_raises = fail_raises
+        self.order_log: list[str] | None = None
+
+    def fail_task(self, task_id, message):
+        if self.order_log is not None:
+            self.order_log.append("fail_task")
+        if self.fail_raises is not None:
+            raise self.fail_raises
+        self.failed.append((task_id, message))
+
+
+class _Boom(Exception):
+    pass
+
+
+class _Rejected(Exception):
+    """Rejection mit sprechender Run-Meldung (wie _StartRejected/_PrepareRejected)."""
+
+    run_failure_message = "start rejected before launch"
+
+
+def test_begin_creates_pending_run():
+    registry = FakeRegistry()
+    with RunLifecycle.begin(registry, "simulation_run", "sim-1", linked_ids={"a": 1}) as run:
+        assert run.record["status"] == "pending"
+        assert run.record["linked_ids"] == {"a": 1}
+        assert run.run_id
+    # Ohne succeed(): Run bleibt pending (Worker-Übergabe).
+    assert registry.runs[run.run_id]["status"] == "pending"
+
+
+def test_begin_forces_pending_even_if_status_passed():
+    registry = FakeRegistry()
+    with RunLifecycle.begin(registry, "simulation_run", "sim-1", status="processing") as run:
+        pass
+    assert registry.runs[run.run_id]["status"] == "pending"
+
+
+def test_exception_marks_failed_and_reraises():
+    registry = FakeRegistry()
+    with pytest.raises(_Boom):
+        with RunLifecycle.begin(registry, "simulation_run", "sim-1") as run:
+            raise _Boom("kaputt")
+    record = registry.runs[run.run_id]
+    assert record["status"] == "failed"
+    assert record["message"] == "simulation_run failed: _Boom"
+    assert record["error"] == record["message"]
+
+
+def test_failure_message_template_is_used():
+    registry = FakeRegistry()
+    with pytest.raises(_Boom):
+        with RunLifecycle.begin(
+            registry,
+            "simulation_run",
+            "sim-1",
+            failure_message="Simulation start failed: {exc_type}",
+        ) as run:
+            raise _Boom()
+    assert registry.runs[run.run_id]["message"] == "Simulation start failed: _Boom"
+
+
+def test_exception_attribute_message_wins():
+    registry = FakeRegistry()
+    with pytest.raises(_Rejected):
+        with RunLifecycle.begin(
+            registry, "simulation_run", "sim-1", failure_message="fallback {exc_type}"
+        ) as run:
+            raise _Rejected()
+    assert registry.runs[run.run_id]["message"] == "start rejected before launch"
+    assert getattr(_Rejected, FAILURE_MESSAGE_ATTR) == "start rejected before launch"
+
+
+def test_base_exception_is_marked_and_reraised():
+    """#1183: SystemExit (Worker-Timeout als Signal-Ableitung) darf keinen
+    pending-Phantom hinterlassen."""
+    registry = FakeRegistry()
+    with pytest.raises(SystemExit):
+        with RunLifecycle.begin(registry, "simulation_run", "sim-1") as run:
+            raise SystemExit(1)
+    assert registry.runs[run.run_id]["status"] == "failed"
+
+
+def test_task_is_failed_before_run_update():
+    """#841: fail_task() zuerst, der detaillierte update_run() zuletzt."""
+    registry = FakeRegistry()
+    task_manager = FakeTaskManager()
+    order: list[str] = []
+    task_manager.order_log = order
+    original_update = registry.update_run
+
+    def logging_update(run_id, **updates):
+        order.append("update_run")
+        return original_update(run_id, **updates)
+
+    registry.update_run = logging_update
+
+    with pytest.raises(_Boom):
+        with RunLifecycle.begin(registry, "simulation_prepare", "sim-1") as run:
+            run.attach_task(task_manager, "task-1")
+            raise _Boom()
+    assert order == ["fail_task", "update_run"]
+
+
+def test_task_failure_is_best_effort():
+    registry = FakeRegistry()
+    task_manager = FakeTaskManager(fail_raises=RuntimeError("task store weg"))
+    with pytest.raises(_Boom):
+        with RunLifecycle.begin(registry, "simulation_prepare", "sim-1") as run:
+            run.attach_task(task_manager, "task-1")
+            raise _Boom()
+    # Run wurde trotz Task-Fehler markiert.
+    assert registry.runs[run.run_id]["status"] == "failed"
+
+
+def test_persistence_none_raises_run_persistence_error():
+    """#844: update_run() → None darf nicht wie eine persistierte Markierung aussehen."""
+    registry = FakeRegistry()
+    registry.update_returns_none = True
+    with pytest.raises(RunPersistenceError) as excinfo:
+        with RunLifecycle.begin(registry, "simulation_run", "sim-1"):
+            raise _Boom()
+    assert isinstance(excinfo.value.__cause__, _Boom)
+
+
+def test_persistence_exception_raises_run_persistence_error():
+    registry = FakeRegistry()
+    registry.update_raises = OSError("disk weg")
+    with pytest.raises(RunPersistenceError):
+        with RunLifecycle.begin(registry, "simulation_run", "sim-1"):
+            raise _Boom()
+
+
+def test_succeed_transitions_and_persists():
+    registry = FakeRegistry()
+    with RunLifecycle.begin(registry, "simulation_run", "sim-1") as run:
+        run.succeed(status="processing", message="Simulation run started")
+    record = registry.runs[run.run_id]
+    assert record["status"] == "processing"
+    assert record["message"] == "Simulation run started"
+
+
+def test_succeed_persistence_failure_raises_and_is_not_remasked():
+    """Ein Persistenzfehler aus succeed() wird nicht durch einen zweiten
+    (ebenfalls scheiternden) failed-Markierungsversuch ersetzt."""
+    registry = FakeRegistry()
+    registry.update_returns_none = True
+    with pytest.raises(RunPersistenceError):
+        with RunLifecycle.begin(registry, "simulation_run", "sim-1") as run:
+            run.succeed(status="processing")
+    # Genau ein update_run-Versuch (aus succeed) — __exit__ hat nicht erneut markiert.
+    update_calls = [c for c in registry.calls if c[0] == "update_run"]
+    assert len(update_calls) == 1
+
+
+def test_clean_exit_without_succeed_keeps_pending():
+    registry = FakeRegistry()
+    with RunLifecycle.begin(registry, "graph_build", "proj-1") as run:
+        pass
+    assert registry.runs[run.run_id]["status"] == "pending"

--- a/changelog.d/1204-run-lifecycle.md
+++ b/changelog.d/1204-run-lifecycle.md
@@ -1,0 +1,9 @@
+### Geändert
+
+- Run-Zustandsführung zentralisiert: das handgeschriebene Muster „Run anlegen
+  (pending) → Arbeit → Endzustand" an sechs Stellen (Simulationsstart und
+  -vorbereitung, Run-Restarts, Report-Start) läuft jetzt über den
+  Kontextmanager `RunLifecycle` (#1204). Kein Abbruchpfad — auch
+  `SystemExit`-artige — hinterlässt mehr einen pending-Phantom-Run; ein nicht
+  persistierter Statusübergang wird als Fehler sichtbar (500) statt still
+  verschluckt.


### PR DESCRIPTION
Closes #1204

## Was

Deepening-Refactor aus dem Architektur-Review: das an sechs Stellen handgeschriebene Muster „Run anlegen (pending) → Arbeit → Endzustand" wandert hinter den Kontextmanager [`services/run_lifecycle.py`](backend/app/services/run_lifecycle.py).

Gekapselte Semantik (bisher pro Stelle einzeln gepflegt):
- **#841** — Task-Reihenfolge: `fail_task()` zuerst, detaillierte Run-Meldung zuletzt (sonst überschreibt `sync_task()` sie)
- **#844** — strikte Persistenzsemantik: `update_run() → None`/Exception wird `RunPersistenceError` (→ 500) statt still verschluckt — jetzt einheitlich auch im Start-Pfad
- **#1183** — `BaseException`-Netz als Modulinvariante (Worker-Timeout als `SystemExit`)

## Migrierte Stellen

| Stelle | Änderung |
|---|---|
| `api/simulation_run.py` | `_mark_run_failed`/`_register_start_run` gelöscht; Routing-Seed + Budget-Anker liegen jetzt im Fangnetz (vorher Lücke) |
| `api/simulation_prepare.py` | `_register_prepare_run`/`_reject_and_fail_prepare_run` gelöscht; Statuswechsel + Enqueue im Fenster (vorher Lücke) |
| `api/runs.py` (×3) | Restart-/Resume-Pfade inkl. Thread-Start im Fenster; Restart-Run entsteht vor dem Prozessstart |
| `services/report_generation.py` | Fenster von `create_run` bis `enqueue`; Worker-Verdrahtung nach `_wire_and_enqueue_generation` extrahiert |

**Bewusst ausgenommen:** `graph_build.py` (eigenes, reicheres Terminalisierungs-Seam `_terminalize_ai_model_ref_sync_failure`), `branching_service.py` (synthetischer completed-Record, kein pending-Fenster), `embedding_migration.py` (eigener ADR-0007-Lifecycle).

## Bewusste Verhaltensänderungen

1. Persistenzfehler beim failed-Markieren im **Start-Pfad** antworten 500 statt best-effort-Schlucken (Angleichung an den Prepare-Weg aus #844).
2. `report_generation`/Restart-Pfade bekommen das `BaseException`-Netz, das sie bisher nicht hatten; Sync-Fehler zwischen `create_run` und Worker-Übergabe hinterlassen keinen pending-Phantom mehr.
3. Restart eines Simulationslaufs legt den Run-Record vor dem Prozessstart an — ein gescheiterter Start hinterlässt einen failed-Record statt gar keinem.

## Tests

- Neu: [`tests/services/test_run_lifecycle.py`](backend/tests/services/test_run_lifecycle.py) — 13 Interface-Tests (Task-Reihenfolge, Persistenzfehler, BaseException, succeed-Semantik)
- `test_start_run_never_stuck_pending.py` (Verhaltensspezifikation #1176/#1183) bleibt bestehen; die frühere Schluck-Erwartung ist durch einen Test der strikten 500-Semantik ersetzt
- Struktur-Tests der gelöschten Helper auf das Lifecycle-Interface umgeschrieben
- Gate: `pre-push-gate.sh backend` grün (Contracts, Schemas, ruff, mypy, Smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFWAqbLeY54DuMVumu5xvh