### PR TITLE
refactor(report): useReportGeneration kapselt die Report-Statusmaschine (#1206)

### DIFF
--- a/backend/tests/services/test_report_budget_abort_run_status.py
+++ b/backend/tests/services/test_report_budget_abort_run_status.py
@@ -55,8 +55,13 @@ def budget_abort_env(tmp_path, monkeypatch):
     created: dict[str, str] = {}
     _real_create_run = registry.create_run
 
-    def _capture_create_run(**kwargs):
-        record = _real_create_run(**kwargs)
+    # Reicht durch, statt die Signatur nachzubilden: seit PR #1205 ruft
+    # ``RunLifecycle.__enter__`` ``create_run(run_type, entity_id, ...)`` mit
+    # zwei positionalen Argumenten. Ein Fake, der nur ``**kwargs`` annimmt,
+    # bricht bei jeder solchen Verlagerung erneut — obwohl er nichts weiter
+    # tut, als die run_id mitzuschneiden (Issue #1210).
+    def _capture_create_run(*args, **kwargs):
+        record = _real_create_run(*args, **kwargs)
         created["run_id"] = record["run_id"]
         return record
 

--- a/changelog.d/1206-use-report-generation.md
+++ b/changelog.d/1206-use-report-generation.md
@@ -1,0 +1,11 @@
+### Geändert
+
+- Report-Statusmaschine aus `Step4Report.vue` in das Composable
+  `useReportGeneration` gezogen (#1206). Neun offene Status-Refs, die
+  141-zeilige `pollStatus()`-Schleife samt Endzustands-Zweigen, die
+  Transportfehler-Zählung aus #1023 und die Koordination der drei
+  Polling-Instanzen liegen jetzt hinter dem Interface
+  `{ status, progress, report, bootstrap(), start(), stop(), regenerate() }`;
+  `usePolling` ist damit interne Abhängigkeit statt Detail der Komponente.
+  Frontend-Gegenstück zu `RunLifecycle` (#1204). Verhalten unverändert — der
+  Flow ist jetzt zusätzlich ohne `mount()` und ohne Modul-Mocks testbar.

--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -136,6 +136,7 @@ import {
   exportReport,
 } from '../../api/report'
 import { useIncrementalLogPolling } from '../../composables/useIncrementalLogPolling'
+import { REPORT_STATUS_POLL_INTERVAL_MS } from '../../composables/useReportGeneration'
 import Step4Report from '@/components/v4/steps/Step4Report.vue'
 import deMessages from '../../i18n/locales/de.json'
 
@@ -1647,52 +1648,67 @@ describe('Step4Report — Lauf-Modell-Vorbelegung statt Workspace-Default (#1023
 // (`catch { /* swallow */ }`) ohne Retry-Zaehler — der Nutzer wartete auf ein
 // Ergebnis, das laengst nicht mehr zustande kommen konnte. Der Defekt zeigt
 // sich nur ueber eine FOLGE fehlgeschlagener Polls, nicht in einem
-// Einzelzustand (genau die Luecke aus #961/#966/#985) — diese Suite ruft
-// pollStatus() deshalb mehrfach in Folge auf statt nur einmal.
+// Einzelzustand (genau die Luecke aus #961/#966/#985).
+//
+// Issue #1206: die Zaehl-Semantik selbst liegt jetzt in
+// composables/__tests__/useReportGeneration.spec.ts und wird dort direkt
+// ueber das Interface geprueft. Hier bleibt, was nur ein Mount zeigen kann:
+// dass der gezaehlte Zustand tatsaechlich im DOM ankommt. Die Poll-Folge
+// entsteht dafuer ueber den echten Timer-Loop statt ueber einen Aufruf des
+// komponenteninternen pollStatus() — vorher war das eine Kopplung an ein
+// Internum, das es nicht mehr gibt.
 describe('Step4Report — Poll-Transportfehler werden gezaehlt statt verschluckt (#1023, Befund B-17)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.clear()
     resetMockSelection()
+    vi.useFakeTimers()
   })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const transportErrorVisible = (wrapper: ReturnType<typeof mountComponent>) =>
+    wrapper.find('[data-testid="report-poll-transport-error"]').exists()
 
   it('zeigt den Transportfehler-Hinweis erst nach 3 aufeinanderfolgenden Fehlschlaegen, nicht bei einem einzelnen', async () => {
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'))
 
     const wrapper = mountComponent()
-    // onMounted ruft pollStatus() einmal auf — Fehlschlag #1.
-    await flushPromises()
+    // onMounted pollt einmal — Fehlschlag #1.
+    await vi.advanceTimersByTimeAsync(0)
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(false)
+    expect(transportErrorVisible(wrapper)).toBe(false)
 
-    const vm = wrapper.vm as unknown as { pollStatus: () => Promise<void> }
-    await vm.pollStatus() // Fehlschlag #2
+    // Fehlschlag #2 aus dem laufenden Poll-Intervall.
+    await vi.advanceTimersByTimeAsync(REPORT_STATUS_POLL_INTERVAL_MS)
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(false)
+    expect(transportErrorVisible(wrapper)).toBe(false)
 
-    await vm.pollStatus() // Fehlschlag #3 — Schwelle erreicht
+    // Fehlschlag #3 — Schwelle erreicht.
+    await vi.advanceTimersByTimeAsync(REPORT_STATUS_POLL_INTERVAL_MS)
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(true)
+    expect(transportErrorVisible(wrapper)).toBe(true)
   })
 
   it('heilt den Transportfehler-Hinweis aus, sobald ein Poll wieder erfolgreich ist', async () => {
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'))
 
     const wrapper = mountComponent()
-    await flushPromises()
-    const vm = wrapper.vm as unknown as { pollStatus: () => Promise<void> }
-    await vm.pollStatus()
-    await vm.pollStatus()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(REPORT_STATUS_POLL_INTERVAL_MS)
+    await vi.advanceTimersByTimeAsync(REPORT_STATUS_POLL_INTERVAL_MS)
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(true)
+    expect(transportErrorVisible(wrapper)).toBe(true)
 
     ;(getReportStatus as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       success: true,
       data: { status: 'planning', report_id: 'report_test01', simulation_id: 'sim_test01' },
     })
-    await vm.pollStatus()
+    await vi.advanceTimersByTimeAsync(REPORT_STATUS_POLL_INTERVAL_MS)
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('[data-testid="report-poll-transport-error"]').exists()).toBe(false)
+    expect(transportErrorVisible(wrapper)).toBe(false)
   })
 })
 

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -2,11 +2,15 @@
 import { ref, computed, onMounted, onUnmounted, watch, type ComponentPublicInstance } from 'vue'
 import { useIncrementalLogPolling } from '../../../composables/useIncrementalLogPolling'
 import { useStickyScroll } from '../../../composables/useStickyScroll'
-import { usePolling } from '../../../composables/usePolling'
+import {
+  useReportGeneration,
+  REPORT_STATUS_POLL_INTERVAL_MS,
+  type ReportGenerationStatusData,
+} from '../../../composables/useReportGeneration'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { renderMarkdown } from '../../../utils/markdown'
-import { generateReport, getAgentLog, getConsoleLog, getReport, getReportStatus, getReportEvidence } from '../../../api/report'
+import { getAgentLog, getConsoleLog, getReportEvidence } from '../../../api/report'
 import type { GenerateReportData } from '../../../api/report'
 import { createSimulationBranch } from '../../../api/simulation'
 import { getRun } from '../../../api/runs'
@@ -37,11 +41,7 @@ import { parseAgentEntry } from '../../../utils/reportAgentLog'
 import { parseSourceAnchor } from '../../../utils/sourceAnchor'
 import { buildReportRoute, buildInteractionRoute } from '../../../utils/reportRoute'
 import {
-  ReportSchema,
-  ReportOutlineSchema,
   EvidenceMapSchema,
-  type Report,
-  type ReportOutline,
   type EvidenceMap,
   type EvidenceOmission,
 } from '../../../contracts/reportContract'
@@ -51,18 +51,6 @@ import {
   type ReportMode,
 } from '../../../contracts/reportV3Contract'
 
-interface StatusData {
-  message?: string
-  outline?: unknown
-  sections?: Record<string, unknown>
-  current_section_index?: number
-  simulation_id?: string
-  report_id?: string
-  /** Issue #764 (Codex P1): Registry-ID des Report-Runs (report_generation). */
-  run_id?: string
-  status?: string
-  error?: string
-}
 interface ApiResult {
   success?: boolean
   data?: Record<string, unknown> & {
@@ -70,10 +58,6 @@ interface ApiResult {
     simulation_id?: string
   }
   error?: string
-}
-interface StatusApiResult {
-  success?: boolean
-  data?: StatusData
 }
 
 const { t } = useI18n()
@@ -93,33 +77,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['add-log', 'update-status', 'stop'])
-
-const phase = ref(0)
-const reportPending = ref(false)
-const statusMsg = ref('')
-// Tatsaechlicher Backend-Status: 'pending' | 'planning' | 'generating' |
-// 'incomplete' | 'completed' | 'failed'. Wird im Status-Poll gesetzt und
-// steuert Badge-Text/Variant (P2.6: vorher fiel 'incomplete' durch den
-// else-Zweig und blieb als 'running' sichtbar).
-const reportStatus = ref<string>('')
-// Issue #1023 (Befund B-17, P2): pollStatus() verschluckte Transportfehler
-// (`catch { /* swallow */ }`) ohne Retry-Zaehler — bei einem toten Backend
-// wartete der Nutzer auf ein Ergebnis, das laengst nicht mehr zustande kommen
-// konnte. STATUS_POLLING_INTERVAL_MS ist 2500ms (siehe unten); 3
-// aufeinanderfolgende Fehlschlaege sind ~7.5s — lang genug, um eine einzelne
-// verlorene Anfrage oder einen kurzen Backend-Restart zu tolerieren, aber
-// kurz genug, dass der Nutzer nicht minutenlang auf einen toten Poll starrt.
-const POLL_FAILURE_THRESHOLD = 3
-const pollFailureCount = ref(0)
-const pollTransportError = ref(false)
-const reportOutline = ref<ReportOutline | null>(null)
-const generatedSections = ref<Record<string, unknown>>({})
-const currentSectionIndex = ref<number | null>(null)
-const isComplete = ref(false)
-const fullReport = ref<Report | null>(null)
-// Issue #764 (Codex P1): letztes Report-Status-Objekt, damit loadReportRunUsage
-// den Report-Run (report_generation) ueber dessen run_id nachladen kann.
-const lastReportStatus = ref<StatusData | null>(null)
 
 // Issue #764: Verbrauchsübersicht zum Sim-Run, einmalig nach Abschluss
 // geladen (die Simulation ist der Run — simulation_id == run_id).
@@ -217,7 +174,7 @@ async function loadRunUsage(): Promise<void> {
 // nach Abschluss zusaetzlich in `reportUsage` — das `runUsage`-Computed
 // uebernimmt die ehrliche Aggregation aus beiden Quellen.
 async function loadReportRunUsage(): Promise<void> {
-  const st = lastReportStatus.value as StatusData | null
+  const st = lastReportStatus.value as ReportGenerationStatusData | null
   const reportRunId = st?.run_id
   if (!reportRunId) return
   try {
@@ -230,15 +187,6 @@ async function loadReportRunUsage(): Promise<void> {
   } catch { /* Report-Run ist optional */ }
 }
 
-// Sobald der Report terminal ist (completed/incomplete/failed), einmalig
-// die Abschluss-Verbrauchsdaten ziehen. Sim-Ladevorgang zuerst, damit
-// der Report-Verbrauch nicht in einen leeren Baseline aggregiert wird
-// (sonst wirken spaetere Regenerationen wie sprunghafte Zahlen).
-watch(isComplete, async (done) => {
-  if (!done) return
-  await loadRunUsage()
-  await loadReportRunUsage()
-})
 const evidenceMap = ref<EvidenceMap | null>(null)
 const selectedEvidenceSection = ref<number | null>(null)
 const branchBusy = ref(false)
@@ -272,7 +220,6 @@ function recordEvidenceOmission(omission: EvidenceOmission | null): void {
   }
 }
 
-const resolvedSimulationId = ref(props.simulationId || null)
 // Phase-1 Konsolidierung: Das Report-Modell wird aus dem Kanon
 // (routing/defaults.global via useEffectiveModelSelection) initialisiert, nicht
 // mehr aus einem eigenen agora.report.aiModelRef-Key. Ein Picker-Pick ist ein
@@ -345,7 +292,6 @@ function onReportRoutePicked(val: AiModelRef | null) {
   reportRoute.value = val
   reportRouteOverride.value = val
 }
-const isRegenerating = ref(false)
 
 const STORAGE_REPORT_MODE = 'agora.reportMode'
 function resolveStoredReportMode(): ReportMode {
@@ -424,65 +370,11 @@ function reportNavigationTarget(reportId: string) {
   return buildReportRoute(reportId, props.runId)
 }
 
-async function regenerateWithModel() {
-  const simId = resolvedSimulationId.value || props.simulationId
-  if (!simId) { addLog('simulationId fehlt — Regenerieren nicht möglich.'); return }
-  isRegenerating.value = true
-  try {
-    const payload: GenerateReportData = {
-      simulation_id: simId,
-      force_regenerate: true,
-      mode: reportMode.value,
-      ...buildModelSelection(),
-    }
-    const m = effectiveReportModel()
-    addLog(`Report neu generieren${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
-    const res = (await generateReport(payload)) as ApiResult
-    if (res?.success && res.data?.report_id) {
-      isComplete.value = false; phase.value = 1; reportOutline.value = null
-      generatedSections.value = {}; currentSectionIndex.value = null
-      resetAgentLogs(); resetConsoleLogs(); fullReport.value = null
-      emit('update-status', 'processing')
-      router.push(reportNavigationTarget(res.data.report_id as string))
-      startPolling()
-    } else { addLog(`Fehler: ${res?.error || 'unbekannt'}`) }
-  } catch (err) { addLog((err as Error).message) }
-  finally { isRegenerating.value = false }
-}
-
-async function startReportConfirmed() {
-  const simId = resolvedSimulationId.value || props.simulationId
-  if (!simId) { addLog('simulationId fehlt — Report-Start nicht möglich.'); return }
-  reportPending.value = false
-  isRegenerating.value = true
-  try {
-    const payload: GenerateReportData = {
-      simulation_id: simId,
-      mode: reportMode.value,
-      ...buildModelSelection(),
-    }
-    const m = effectiveReportModel()
-    addLog(`Report starten${m ? ` mit ${m}` : ''} (Modus: ${reportMode.value})…`)
-    const res = (await generateReport(payload)) as ApiResult
-    if (res?.success && res.data?.report_id) {
-      isComplete.value = false; phase.value = 1; reportOutline.value = null
-      generatedSections.value = {}; currentSectionIndex.value = null
-      resetAgentLogs(); resetConsoleLogs(); fullReport.value = null
-      emit('update-status', 'processing')
-      router.push(reportNavigationTarget(res.data.report_id as string))
-      startPolling()
-    } else { addLog(`Fehler: ${res?.error || 'unbekannt'}`); reportPending.value = true }
-  } catch (err) { addLog((err as Error).message); reportPending.value = true }
-  finally { isRegenerating.value = false }
-}
-
 function addLog(msg: string) { emit('add-log', msg) }
 
-const STATUS_POLLING_INTERVAL_MS = 2500
-const AGENT_LOG_POLLING_INTERVAL_MS = STATUS_POLLING_INTERVAL_MS
+// Die Log-Polls takten im selben Raster wie die Statusabfrage (Sub-Slice J.3).
+const AGENT_LOG_POLLING_INTERVAL_MS = REPORT_STATUS_POLL_INTERVAL_MS
 const CONSOLE_LOG_POLLING_INTERVAL_MS = 2000
-
-const statusPolling = usePolling(pollStatus, STATUS_POLLING_INTERVAL_MS)
 
 const agentLogRef = ref<HTMLElement | null>(null)
 const consoleLogRef = ref<HTMLElement | null>(null)
@@ -517,92 +409,65 @@ const {
   stickyScroll: consoleSticky,
 })
 
-async function pollStatus() {
-  if (!props.reportId && !props.simulationId) return
-  try {
-    const res = (await getReportStatus({
-      simulationId: resolvedSimulationId.value || props.simulationId,
-      reportId: props.reportId,
-    })) as StatusApiResult
-    if (res?.success && res.data) {
-      // Ein erfolgreicher Poll heilt einen zuvor sichtbar gemachten
-      // Transportfehler wieder aus — die Verbindung ist zurueck.
-      pollFailureCount.value = 0
-      pollTransportError.value = false
-      const st = res.data
-      lastReportStatus.value = st
-      statusMsg.value = st.message || ''
-      if (st.outline) { try { reportOutline.value = ReportOutlineSchema.parse(st.outline) } catch (err) { recordSchemaError('outline', err) } }
-      if (st.sections) generatedSections.value = st.sections
-      currentSectionIndex.value = st.current_section_index ?? currentSectionIndex.value
-      if (st.simulation_id && !resolvedSimulationId.value) resolvedSimulationId.value = st.simulation_id
-      // P2.6: Backend-Status separat merken — er treibt das Badge und die
-      // 'incomplete'-Transition. 'completed' und 'incomplete' sind beide
-      // Endzustände mit unterschiedlicher User-Botschaft.
-      reportStatus.value = st.status || ''
-      if (st.status === 'completed') {
-        const resolvedId = (st.report_id || props.reportId) as string
-        isComplete.value = true; phase.value = 2
-        emit('update-status', 'completed')
-        try {
-          const full = (await getReport(resolvedId)) as ApiResult
-          if (full?.success) {
-            try {
-              const parsed = ReportSchema.parse(full.data)
-              fullReport.value = parsed
-              syncOutlineFromReport(parsed)
-            } catch (err) { recordSchemaError('report', err); fullReport.value = null }
-            await loadEvidence()
-          }
-        } catch { /* report not yet flushed */ }
-        stopPolling()
-      } else if (st.status === 'incomplete') {
-        // Backend liefert fehlgeschlagene Pflichtsections → INCOMPLETE.
-        // Rest des Reports ist nutzbar; der Nutzer sieht, was fehlt.
-        const resolvedId = (st.report_id || props.reportId) as string
-        // INCOMPLETE ist terminal: isComplete verhindert, dass onMounted nach
-        // einem Reload erneut in den Polling-Pfad springt.
-        isComplete.value = true; phase.value = 2
-        emit('update-status', 'incomplete')
-        addLog(t('step4.status.incomplete') || 'Report unvollständig — einige Abschnitte fehlen.')
-        try {
-          const full = (await getReport(resolvedId)) as ApiResult
-          if (full?.success) {
-            try {
-              const parsed = ReportSchema.parse(full.data)
-              fullReport.value = parsed
-              syncOutlineFromReport(parsed)
-            } catch (err) { recordSchemaError('report', err); fullReport.value = null }
-            await loadEvidence()
-          }
-        } catch { /* report not yet flushed */ }
-        stopPolling()
-      } else if (st.status === 'failed') {
-        // FAILED ist terminal: isComplete verhindert, dass onMounted nach
-        // einem Reload erneut in den Polling-Pfad springt und den
-        // "Failed"-Zustand durch "Running" ersetzt (analog zu
-        // completed/incomplete).
-        isComplete.value = true; phase.value = 2
-        emit('update-status', 'error')
-        addLog(`${t('errors.reportFailed')}: ${st.error || ''}`)
-        stopPolling()
-      } else { phase.value = 1 }
-    }
-  } catch {
-    // Issue #1023 (Befund B-17): Transportfehler zaehlen statt schweigend
-    // verwerfen. Log nur beim Ueberschreiten der Schwelle (nicht bei jedem
-    // weiteren Fehlschlag danach) — sonst spammt ein anhaltend totes Backend
-    // das Log mit einer Meldung pro Poll-Intervall.
-    pollFailureCount.value++
-    if (pollFailureCount.value === POLL_FAILURE_THRESHOLD) {
-      pollTransportError.value = true
-      addLog(t('step4.status.pollTransportError'))
-    }
-  }
-}
+/**
+ * Issue #1206: die Report-Statusmaschine liegt hinter `useReportGeneration`.
+ * Diese Komponente verdrahtet sie nur noch — sie liefert die Umgebung
+ * (Route-IDs, i18n, Log-Senke, Modell-/Modusauswahl, Navigation) und bekommt
+ * `status` / `progress` / `report` zurueck. Die Refs werden auf ihre bisherigen
+ * Namen aufgeloest, damit Template und Verbraucher unveraendert bleiben.
+ */
+const reportGeneration = useReportGeneration({
+  reportId: () => props.reportId,
+  simulationId: () => props.simulationId,
+  t,
+  addLog,
+  onLifecycleChange: (status) => emit('update-status', status),
+  recordSchemaError,
+  loadEvidence,
+  buildRequestOptions: () => ({ mode: reportMode.value, ...buildModelSelection() }),
+  describeModel: effectiveReportModel,
+  onStarted: (reportId) => { router.push(reportNavigationTarget(reportId)) },
+  logStreams: [
+    { polling: agentLogPolling, reset: resetAgentLogs },
+    { polling: consoleLogPolling, reset: resetConsoleLogs },
+  ],
+})
 
-function startPolling() { void statusPolling.start(); void agentLogPolling.start(); void consoleLogPolling.start() }
-function stopPolling() { statusPolling.stop(); agentLogPolling.stop(); consoleLogPolling.stop() }
+const {
+  phase,
+  pending: reportPending,
+  message: statusMsg,
+  backendStatus: reportStatus,
+  transportError: pollTransportError,
+  isComplete,
+  isBusy: isRegenerating,
+} = reportGeneration.status
+const {
+  outline: reportOutline,
+  sections: generatedSections,
+  currentSectionIndex,
+} = reportGeneration.progress
+const {
+  full: fullReport,
+  resolvedSimulationId,
+  lastStatus: lastReportStatus,
+} = reportGeneration.report
+const {
+  bootstrap: bootstrapReport,
+  start: startReportConfirmed,
+  regenerate: regenerateWithModel,
+  stop: stopPolling,
+} = reportGeneration
+
+// Sobald der Report terminal ist (completed/incomplete/failed), einmalig
+// die Abschluss-Verbrauchsdaten ziehen. Sim-Ladevorgang zuerst, damit
+// der Report-Verbrauch nicht in einen leeren Baseline aggregiert wird
+// (sonst wirken spaetere Regenerationen wie sprunghafte Zahlen).
+watch(isComplete, async (done) => {
+  if (!done) return
+  await loadRunUsage()
+  await loadReportRunUsage()
+})
 
 const reportMarkdown = computed((): string => fullReport.value?.markdown_content ?? '')
 const reportHtml = computed(() => renderMarkdown(reportMarkdown.value))
@@ -738,19 +603,6 @@ async function loadEvidence() {
   } catch (err) { recordSchemaError('evidence', err) }
 }
 
-// Sub-Slice 2 von 5 (Issue #739): synchronisiere reportOutline aus
-// fullReport.outline. Wenn /report/<id> nach completed-Status betreten wird
-// (Direct-Page-Goto, Refresh oder Regenerate-Stream), liefert der
-// Status-Endpoint oft kein `outline`-Feld — das Outline hängt aber am
-// Report-Contract. Setzt reportOutline idempotent, damit ReportOutlinePanel
-// auch ohne vorherige Status-Poll-Outline-Daten rendert.
-function syncOutlineFromReport(report: Report | null) {
-  if (!report?.outline || reportOutline.value) return
-  try {
-    reportOutline.value = ReportOutlineSchema.parse(report.outline)
-  } catch (err) { recordSchemaError('outline', err) }
-}
-
 const {
   copyMarkdown,
   downloadCombinedJson,
@@ -817,23 +669,7 @@ onMounted(async () => {
       reportRoute.value = runModel ?? effectiveModel.effectiveRef.value
     },
   )
-  await pollStatus()
-  if (!isComplete.value) {
-    if (props.reportId) { phase.value = 1; startPolling() }
-    else { phase.value = 0; reportPending.value = true }
-  } else if (!fullReport.value) {
-    try {
-      const full = (await getReport(props.reportId!)) as ApiResult
-      if (full?.success) {
-        try {
-          const parsed = ReportSchema.parse(full.data)
-          fullReport.value = parsed
-          syncOutlineFromReport(parsed)
-        } catch (err) { recordSchemaError('report', err); fullReport.value = null }
-        await loadEvidence()
-      }
-    } catch { /* swallow */ }
-  }
+  await bootstrapReport()
 })
 onUnmounted(() => { stopPolling(); clearEvidenceRetry() })
 </script>

--- a/frontend/src/composables/__tests__/useReportGeneration.spec.ts
+++ b/frontend/src/composables/__tests__/useReportGeneration.spec.ts
@@ -254,6 +254,19 @@ describe('useReportGeneration — Endzustaende', () => {
     expect(h.loadEvidence).toHaveBeenCalled()
   })
 
+  it('laedt keinen Report nach, wenn der Endzustand ohne Report-ID kommt', async () => {
+    // Die Statusabfrage kommt auch mit reiner Simulations-ID durch. Fehlt in
+    // der Antwort dann `report_id`, gibt es nichts nachzuladen — ein
+    // getReport(undefined) landete still im leeren catch (CodeRabbit, PR #1207).
+    const h = setup({ reportId: () => undefined, simulationId: () => 'sim_1' })
+    h.api.getReportStatus.mockResolvedValue({ success: true, data: { status: 'completed' } })
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.isComplete.value).toBe(true)
+    expect(h.api.getReport).not.toHaveBeenCalled()
+  })
+
   it('zieht die Outline aus dem Report nach, wenn der Status keine liefert (#739)', async () => {
     const h = setup()
     h.api.getReportStatus.mockResolvedValue({

--- a/frontend/src/composables/__tests__/useReportGeneration.spec.ts
+++ b/frontend/src/composables/__tests__/useReportGeneration.spec.ts
@@ -1,0 +1,428 @@
+// Issue #1206 — Interface-Tests der Report-Statusmaschine.
+//
+// Bewusst ohne `mount()` und ohne `vi.mock`: das Options-Objekt liefert die
+// gesamte Umgebung (HTTP-Seam, i18n, Log-Senke, Modellauswahl, Navigation,
+// Begleit-Polls), also ist das zurueckgegebene Interface die Testflaeche.
+// Vorbild fuer den Schnitt: contracts/__tests__/runParamsQuery.spec.ts.
+//
+// Vorher war dieser Flow nur ueber einen Mount von Step4Report.vue plus
+// sechzehn Modul-Mocks beobachtbar — entsprechend hat jede Aenderung an der
+// Statusmaschine die 1754-Zeilen-Komponenten-Spec mitgezogen.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  useReportGeneration,
+  REPORT_POLL_FAILURE_THRESHOLD,
+  type UseReportGenerationOptions,
+  type UseReportGenerationReturn,
+} from '../useReportGeneration'
+import type { GenerateReportData } from '../../api/report'
+import type { Report } from '../../contracts/reportContract'
+
+const VALID_REPORT: Report = {
+  schema_version: 2,
+  report_id: 'report_1',
+  simulation_id: 'sim_1',
+  graph_id: 'graph_1',
+  simulation_requirement: 'Testanforderung',
+  status: 'completed',
+  markdown_content: '# Bericht',
+  missing_sections: [],
+  has_evidence: false,
+  red_team_findings: [],
+  evidence_sections: 0,
+}
+
+const VALID_OUTLINE = {
+  title: 'Berichtstitel',
+  summary: 'Zusammenfassung',
+  sections: [{ title: 'Abschnitt A', description: 'Beschreibung A' }],
+}
+
+function makeLogStream() {
+  return {
+    polling: {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(() => {}),
+    },
+    reset: vi.fn(() => {}),
+  }
+}
+
+function makeApi() {
+  return {
+    generateReport: vi
+      .fn<(data: GenerateReportData) => Promise<unknown>>()
+      .mockResolvedValue({ success: true, data: { report_id: 'report_neu' } }),
+    getReport: vi
+      .fn<(reportId: string) => Promise<unknown>>()
+      .mockResolvedValue({ success: true, data: VALID_REPORT }),
+    getReportStatus: vi
+      .fn<(params: { simulationId?: string; reportId?: string }) => Promise<unknown>>()
+      .mockResolvedValue({ success: true, data: { status: 'generating' } }),
+  }
+}
+
+interface Harness {
+  generation: UseReportGenerationReturn
+  api: ReturnType<typeof makeApi>
+  addLog: ReturnType<typeof vi.fn>
+  onLifecycleChange: ReturnType<typeof vi.fn>
+  recordSchemaError: ReturnType<typeof vi.fn>
+  loadEvidence: ReturnType<typeof vi.fn>
+  onStarted: ReturnType<typeof vi.fn>
+  logStream: ReturnType<typeof makeLogStream>
+}
+
+/**
+ * Ohne Komponente feuert das `onUnmounted`-Cleanup von `usePolling` nie — die
+ * laufende Statusabfrage muss deshalb nach jedem Test von Hand gestoppt
+ * werden, sonst pollen Intervalle vergangener Tests in spaetere hinein.
+ * Fake-Timer als zweite Absicherung: so entsteht gar kein echtes Intervall.
+ */
+const activeGenerations: UseReportGenerationReturn[] = []
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  while (activeGenerations.length) activeGenerations.pop()!.stop()
+  vi.useRealTimers()
+})
+
+function setup(overrides: Partial<UseReportGenerationOptions> = {}): Harness {
+  const api = {
+    generateReport: vi.fn().mockResolvedValue({ success: true, data: { report_id: 'report_neu' } }),
+    getReport: vi.fn().mockResolvedValue({ success: true, data: VALID_REPORT }),
+    getReportStatus: vi.fn().mockResolvedValue({ success: true, data: { status: 'generating' } }),
+  }
+  const addLog = vi.fn()
+  const onLifecycleChange = vi.fn()
+  const recordSchemaError = vi.fn()
+  const loadEvidence = vi.fn().mockResolvedValue(undefined)
+  const onStarted = vi.fn()
+  const logStream = makeLogStream()
+
+  const generation = useReportGeneration({
+    reportId: () => 'report_1',
+    simulationId: () => 'sim_1',
+    // Identitaets-Uebersetzer: der Test prueft, DASS ein Schluessel gemeldet
+    // wird, nicht wie de.json ihn gerade formuliert.
+    t: (key) => key,
+    addLog,
+    onLifecycleChange,
+    recordSchemaError,
+    loadEvidence,
+    buildRequestOptions: () => ({ mode: 'balanced' }),
+    onStarted,
+    logStreams: [logStream],
+    api,
+    ...overrides,
+  })
+  activeGenerations.push(generation)
+
+  return { generation, api, addLog, onLifecycleChange, recordSchemaError, loadEvidence, onStarted, logStream }
+}
+
+describe('useReportGeneration — bootstrap()', () => {
+  it('fordert ohne Report-ID die Startbestaetigung an, statt zu pollen', async () => {
+    const h = setup({ reportId: () => undefined, simulationId: () => 'sim_1' })
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.phase.value).toBe(0)
+    expect(h.generation.status.pending.value).toBe(true)
+    expect(h.logStream.polling.start).not.toHaveBeenCalled()
+  })
+
+  it('fragt ohne jede ID gar nicht erst beim Backend nach', async () => {
+    const h = setup({ reportId: () => undefined, simulationId: () => undefined })
+
+    await h.generation.bootstrap()
+
+    expect(h.api.getReportStatus).not.toHaveBeenCalled()
+  })
+
+  it('nimmt bei laufendem Report das Polling inklusive Begleit-Polls auf', async () => {
+    const h = setup()
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.phase.value).toBe(1)
+    expect(h.generation.status.backendStatus.value).toBe('generating')
+    expect(h.logStream.polling.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('laedt den Report nach, wenn die Ansicht auf einem bereits fertigen Lauf betreten wird', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'completed', report_id: 'report_1' },
+    })
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.isComplete.value).toBe(true)
+    expect(h.generation.status.phase.value).toBe(2)
+    expect(h.generation.report.full.value?.report_id).toBe('report_1')
+    // Terminal erreicht: die Begleit-Polls duerfen nicht weiterlaufen.
+    expect(h.logStream.polling.stop).toHaveBeenCalled()
+  })
+})
+
+describe('useReportGeneration — Endzustaende', () => {
+  it('meldet completed, laedt Report und Evidenzkarte und beendet das Polling', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'completed', report_id: 'report_1', simulation_id: 'sim_x' },
+    })
+
+    await h.generation.bootstrap()
+
+    expect(h.onLifecycleChange).toHaveBeenCalledWith('completed')
+    expect(h.api.getReport).toHaveBeenCalledWith('report_1')
+    expect(h.loadEvidence).toHaveBeenCalledTimes(1)
+    expect(h.generation.report.resolvedSimulationId.value).toBe('sim_1')
+  })
+
+  it('meldet incomplete als eigenen Endzustand mit Nutzerhinweis', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'incomplete', report_id: 'report_1' },
+    })
+
+    await h.generation.bootstrap()
+
+    expect(h.onLifecycleChange).toHaveBeenCalledWith('incomplete')
+    expect(h.addLog).toHaveBeenCalledWith('step4.status.incomplete')
+    // Der Rest des Reports bleibt nutzbar — er wird trotzdem geladen.
+    expect(h.api.getReport).toHaveBeenCalledWith('report_1')
+    expect(h.generation.status.isComplete.value).toBe(true)
+  })
+
+  it('meldet failed terminal und beendet das Polling', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'failed', error: 'LLM-Timeout' },
+    })
+
+    await h.generation.bootstrap()
+
+    expect(h.onLifecycleChange).toHaveBeenCalledWith('error')
+    expect(h.addLog).toHaveBeenCalledWith('errors.reportFailed: LLM-Timeout')
+    expect(h.generation.status.phase.value).toBe(2)
+    expect(h.generation.status.isComplete.value).toBe(true)
+    expect(h.logStream.polling.stop).toHaveBeenCalled()
+  })
+
+  it('sperrt nach einem Endzustand den erneuten Einstieg ins Polling', async () => {
+    // isComplete ist zugleich die Reload-Sperre: ein zweites bootstrap() darf
+    // den erreichten Endzustand nicht durch "laeuft gerade" ersetzen.
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'failed', error: 'LLM-Timeout' },
+    })
+    await h.generation.bootstrap()
+    h.logStream.polling.start.mockClear()
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.phase.value).toBe(2)
+    expect(h.logStream.polling.start).not.toHaveBeenCalled()
+  })
+
+  it('meldet einen Schema-Mismatch des Reports, statt kaputte Daten zu halten', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'completed', report_id: 'report_1' },
+    })
+    h.api.getReport.mockResolvedValue({ success: true, data: { schema_version: 99 } })
+
+    await h.generation.bootstrap()
+
+    expect(h.recordSchemaError).toHaveBeenCalledWith('report', expect.anything())
+    expect(h.generation.report.full.value).toBeNull()
+    // Die Evidenzkarte wird trotz Report-Mismatch angefordert.
+    expect(h.loadEvidence).toHaveBeenCalled()
+  })
+
+  it('zieht die Outline aus dem Report nach, wenn der Status keine liefert (#739)', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'completed', report_id: 'report_1' },
+    })
+    h.api.getReport.mockResolvedValue({
+      success: true,
+      data: { ...VALID_REPORT, outline: VALID_OUTLINE },
+    })
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.progress.outline.value?.title).toBe('Berichtstitel')
+  })
+})
+
+// Issue #1023 (Befund B-17): der Defekt zeigt sich nur ueber eine FOLGE
+// fehlgeschlagener Polls, nie in einem Einzelzustand — genau die Luecke, an
+// der #961/#966/#985 nacheinander vorbeigezielt haben.
+describe('useReportGeneration — Transportfehler (#1023, Befund B-17)', () => {
+  it('meldet den Transportfehler erst beim Erreichen der Schwelle', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockRejectedValue(new Error('network down'))
+
+    for (let i = 1; i < REPORT_POLL_FAILURE_THRESHOLD; i++) {
+      await h.generation.bootstrap()
+      expect(h.generation.status.transportError.value).toBe(false)
+    }
+
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.failureCount.value).toBe(REPORT_POLL_FAILURE_THRESHOLD)
+    expect(h.generation.status.transportError.value).toBe(true)
+    expect(h.addLog).toHaveBeenCalledWith('step4.status.pollTransportError')
+  })
+
+  it('loggt nach der Schwelle nicht bei jedem weiteren Fehlschlag erneut', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockRejectedValue(new Error('network down'))
+
+    for (let i = 0; i < REPORT_POLL_FAILURE_THRESHOLD + 3; i++) {
+      await h.generation.bootstrap()
+    }
+
+    const transportLogs = h.addLog.mock.calls.filter(
+      ([message]) => message === 'step4.status.pollTransportError'
+    )
+    expect(transportLogs).toHaveLength(1)
+  })
+
+  it('heilt aus, sobald ein Poll wieder durchkommt', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockRejectedValue(new Error('network down'))
+    for (let i = 0; i < REPORT_POLL_FAILURE_THRESHOLD; i++) await h.generation.bootstrap()
+    expect(h.generation.status.transportError.value).toBe(true)
+
+    h.api.getReportStatus.mockResolvedValue({ success: true, data: { status: 'generating' } })
+    await h.generation.bootstrap()
+
+    expect(h.generation.status.transportError.value).toBe(false)
+    expect(h.generation.status.failureCount.value).toBe(0)
+  })
+})
+
+describe('useReportGeneration — start() und regenerate()', () => {
+  it('startet ohne force_regenerate und uebernimmt Modus und Modellauswahl', async () => {
+    const h = setup({
+      buildRequestOptions: () => ({
+        mode: 'strict',
+        ai_model_ref: { provider_connection_id: 'conn_1', model_id: 'modell-a', source: 'explicit' },
+      }),
+      describeModel: () => 'modell-a',
+    })
+
+    await h.generation.start()
+
+    const payload = h.api.generateReport.mock.calls.at(-1)![0]
+    expect(payload).toEqual({
+      simulation_id: 'sim_1',
+      mode: 'strict',
+      ai_model_ref: { provider_connection_id: 'conn_1', model_id: 'modell-a', source: 'explicit' },
+    })
+    expect(payload).not.toHaveProperty('force_regenerate')
+    expect(h.addLog).toHaveBeenCalledWith('Report starten mit modell-a (Modus: strict)…')
+  })
+
+  it('setzt Fortschritt und Begleit-Polls zurueck und meldet die neue Report-ID', async () => {
+    const h = setup()
+    h.api.getReportStatus.mockResolvedValue({
+      success: true,
+      data: { status: 'generating', sections: { intro: {} }, current_section_index: 2 },
+    })
+    await h.generation.bootstrap()
+    expect(h.generation.progress.currentSectionIndex.value).toBe(2)
+
+    await h.generation.start()
+
+    expect(h.generation.progress.currentSectionIndex.value).toBeNull()
+    expect(h.generation.progress.sections.value).toEqual({})
+    expect(h.generation.report.full.value).toBeNull()
+    expect(h.logStream.reset).toHaveBeenCalledTimes(1)
+    expect(h.onLifecycleChange).toHaveBeenCalledWith('processing')
+    expect(h.onStarted).toHaveBeenCalledWith('report_neu')
+    expect(h.generation.status.phase.value).toBe(1)
+  })
+
+  it('wirft den Nutzer bei einem fehlgeschlagenen Start in die Bestaetigung zurueck', async () => {
+    const h = setup()
+    h.api.generateReport.mockResolvedValue({ success: false, error: 'kein Kontingent' })
+
+    await h.generation.start()
+
+    expect(h.addLog).toHaveBeenCalledWith('Fehler: kein Kontingent')
+    expect(h.generation.status.pending.value).toBe(true)
+    expect(h.generation.status.isBusy.value).toBe(false)
+    expect(h.onStarted).not.toHaveBeenCalled()
+  })
+
+  it('startet ohne Simulations-ID gar nicht erst', async () => {
+    const h = setup({ reportId: () => undefined, simulationId: () => undefined })
+
+    await h.generation.start()
+
+    expect(h.api.generateReport).not.toHaveBeenCalled()
+    expect(h.addLog).toHaveBeenCalledWith('simulationId fehlt — Report-Start nicht möglich.')
+  })
+
+  it('regeneriert mit force_regenerate', async () => {
+    const h = setup()
+
+    await h.generation.regenerate()
+
+    expect(h.api.generateReport.mock.calls.at(-1)![0]).toMatchObject({
+      simulation_id: 'sim_1',
+      force_regenerate: true,
+      mode: 'balanced',
+    })
+    expect(h.addLog).toHaveBeenCalledWith('Report neu generieren (Modus: balanced)…')
+  })
+
+  it('laesst die Startbestaetigung beim Regenerieren unangetastet — es steht bereits ein Report', async () => {
+    const h = setup()
+    h.api.generateReport.mockResolvedValue({ success: false, error: 'kaputt' })
+
+    await h.generation.regenerate()
+
+    expect(h.generation.status.pending.value).toBe(false)
+  })
+
+  it('faengt einen Transportfehler beim Start ab, ohne den Aufrufer zu werfen', async () => {
+    const h = setup()
+    h.api.generateReport.mockRejectedValue(new Error('backend weg'))
+
+    await expect(h.generation.start()).resolves.toBeUndefined()
+
+    expect(h.addLog).toHaveBeenCalledWith('backend weg')
+    expect(h.generation.status.pending.value).toBe(true)
+    expect(h.generation.status.isBusy.value).toBe(false)
+  })
+})
+
+describe('useReportGeneration — stop()', () => {
+  it('haelt die Begleit-Polls mit an', async () => {
+    const h = setup()
+    await h.generation.bootstrap()
+
+    h.generation.stop()
+
+    expect(h.logStream.polling.stop).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useReportGeneration.ts
+++ b/frontend/src/composables/useReportGeneration.ts
@@ -1,0 +1,470 @@
+/**
+ * useReportGeneration — die Report-Statusmaschine als tiefes Modul.
+ *
+ * Issue #1206. Vorher lag der komplette Flow inline in
+ * `components/v4/steps/Step4Report.vue`: neun offene Status-Refs, eine
+ * 141-Zeilen-`pollStatus()`-Statusmaschine, die Transportfehler-Zaehler aus
+ * #1023 und die Koordination dreier Polling-Instanzen. Beobachtbar war das
+ * nur ueber `mount()` plus sechzehn Modul-Mocks — entsprechend hat jede
+ * Aenderung am Flow die 1754-Zeilen-Spec mitgezogen.
+ *
+ * Frontend-Gegenstueck zu `RunLifecycle` im Backend (#1204 / PR #1205):
+ * dieselbe Idee, Statusmaschine hinter einem kleinen Interface, Endzustaende
+ * an genau einer Stelle gefuehrt.
+ *
+ * Das Interface ist die Testflaeche:
+ *
+ *   { status, progress, report, bootstrap(), start(), stop(), regenerate() }
+ *
+ * Alles, was die Statusmaschine ueber ihre Umgebung wissen muss, kommt ueber
+ * das Options-Objekt herein (Vorbild: `useReportExports`). Das Composable
+ * greift selbst weder auf `props`, noch auf den Router, noch auf vue-i18n
+ * oder das DOM zu und laesst sich daher ohne `mount()` und ohne `vi.mock`
+ * betreiben — die HTTP-Aufrufe sind ueber `api` injizierbar.
+ */
+
+import { ref, type Ref } from 'vue'
+import {
+  generateReport as defaultGenerateReport,
+  getReport as defaultGetReport,
+  getReportStatus as defaultGetReportStatus,
+  type GenerateReportData,
+} from '../api/report'
+import {
+  ReportSchema,
+  ReportOutlineSchema,
+  type Report,
+  type ReportOutline,
+} from '../contracts/reportContract'
+import type { ReportMode } from '../contracts/reportV3Contract'
+import { usePolling, type UsePollingReturn } from './usePolling'
+
+/** Poll-Intervall der Report-Statusabfrage. Die Log-Polls des Aufrufers
+ *  takten bewusst im selben Raster (Sub-Slice J.3). */
+export const REPORT_STATUS_POLL_INTERVAL_MS = 2500
+
+/**
+ * Issue #1023 (Befund B-17, P2): `pollStatus()` verschluckte Transportfehler
+ * (`catch { /* swallow *\/ }`) ohne Retry-Zaehler — bei einem toten Backend
+ * wartete der Nutzer auf ein Ergebnis, das laengst nicht mehr zustande kommen
+ * konnte. Bei 2500 ms Poll-Intervall sind 3 aufeinanderfolgende Fehlschlaege
+ * ~7,5 s: lang genug fuer eine einzelne verlorene Anfrage oder einen kurzen
+ * Backend-Restart, kurz genug, dass der Nutzer nicht minutenlang auf einen
+ * toten Poll starrt.
+ */
+export const REPORT_POLL_FAILURE_THRESHOLD = 3
+
+/** 0 = noch nichts angestossen, 1 = laeuft, 2 = terminal. */
+export type ReportPhase = 0 | 1 | 2
+
+/** Nach aussen gemeldeter Lebenszyklus-Zustand des Report-Laufs. */
+export type ReportLifecycleStatus = 'processing' | 'completed' | 'incomplete' | 'error'
+
+/**
+ * Status-Objekt des Backends. Bewusst lokal gehalten und nicht aus
+ * `api/report` importiert: dort fehlt `run_id`, das seit #764 fuer
+ * `/api/runs/<id>` gebraucht wird (`simulation_id` und `run_id` sind seither
+ * nicht mehr identisch).
+ */
+export interface ReportGenerationStatusData {
+  message?: string
+  outline?: unknown
+  sections?: Record<string, unknown>
+  current_section_index?: number
+  simulation_id?: string
+  report_id?: string
+  /** Issue #764 (Codex P1): Registry-ID des Report-Runs (report_generation). */
+  run_id?: string
+  status?: string
+  error?: string
+}
+
+interface ApiResult {
+  success?: boolean
+  data?: Record<string, unknown> & {
+    report_id?: string
+    simulation_id?: string
+  }
+  error?: string
+}
+
+interface StatusApiResult {
+  success?: boolean
+  data?: ReportGenerationStatusData
+}
+
+/** Anteile des Generierungs-Requests, die aus der Modell- und Modusauswahl
+ *  des Aufrufers stammen. */
+export interface ReportRequestOptions extends Pick<GenerateReportData, 'ai_model_ref'> {
+  mode: ReportMode
+}
+
+/**
+ * Ein Begleit-Poll, der dem Lebenszyklus des Reports folgt (Agent- und
+ * Konsolen-Log). Die Instanzen selbst bleiben beim Aufrufer, weil sie an
+ * Sticky-Scroll und damit ans DOM gebunden sind; hier zaehlt nur, dass sie
+ * mit der Statusmaschine zusammen starten, stoppen und zuruecksetzen.
+ */
+export interface ReportLogStream {
+  polling: Pick<UsePollingReturn, 'start' | 'stop'>
+  reset: () => void
+}
+
+/** HTTP-Seam. Default sind die echten Endpunkte; Tests reichen Fakes herein
+ *  und kommen so ohne Modul-Mocks aus. */
+export interface ReportGenerationApi {
+  generateReport: (data: GenerateReportData) => Promise<unknown>
+  getReport: (reportId: string) => Promise<unknown>
+  getReportStatus: (params: { simulationId?: string; reportId?: string }) => Promise<unknown>
+}
+
+export interface UseReportGenerationOptions {
+  /** Aktuelle Report-ID aus der Route; `undefined`, solange kein Lauf existiert. */
+  reportId: () => string | undefined
+  /** Simulations-ID aus den Props — bewusst getrennt von der aus dem Status
+   *  aufgeloesten ID (`report.resolvedSimulationId`). */
+  simulationId: () => string | undefined
+  /** i18n-Uebersetzer des Aufrufers. Injiziert, damit die Statusmaschine
+   *  ohne App-Instanz laeuft. */
+  t: (key: string) => string
+  addLog: (message: string) => void
+  /** Meldet Lebenszyklus-Wechsel nach oben (in Step4Report ein `update-status`-Emit). */
+  onLifecycleChange: (status: ReportLifecycleStatus) => void
+  recordSchemaError: (where: string, error: unknown) => void
+  /** Laedt die Evidenzkarte zum abgeschlossenen Report (inkl. Retry-Budget,
+   *  #1188) — bleibt beim Aufrufer, weil sie dessen Anzeigezustand steuert. */
+  loadEvidence: () => Promise<void>
+  /** Modell- und Modusauswahl fuer Start und Regenerierung. */
+  buildRequestOptions: () => ReportRequestOptions
+  /** Anzeigename des gewaehlten Modells fuer die Start-Logzeile. */
+  describeModel?: () => string | null
+  /** Wird nach erfolgreichem Start/Regenerieren mit der neuen Report-ID
+   *  aufgerufen (in Step4Report die Routen-Navigation). */
+  onStarted: (reportId: string) => void
+  logStreams?: ReportLogStream[]
+  pollIntervalMs?: number
+  api?: Partial<ReportGenerationApi>
+}
+
+export interface ReportGenerationStatus {
+  phase: Ref<ReportPhase>
+  /** Es liegt kein Lauf vor und der Nutzer muss den Start bestaetigen. */
+  pending: Ref<boolean>
+  /** Freitext-Fortschrittsmeldung des Backends. */
+  message: Ref<string>
+  /**
+   * Roher Backend-Status: 'pending' | 'planning' | 'generating' |
+   * 'incomplete' | 'completed' | 'failed'. Getrennt von `phase` gefuehrt, weil
+   * 'completed' und 'incomplete' dieselbe Phase, aber unterschiedliche
+   * Botschaften tragen (P2.6).
+   */
+  backendStatus: Ref<string>
+  /** Statusabfrage schlaegt anhaltend auf Transportebene fehl (#1023). */
+  transportError: Ref<boolean>
+  failureCount: Ref<number>
+  /** Der Lauf ist terminal (completed, incomplete oder failed). */
+  isComplete: Ref<boolean>
+  /** Start oder Regenerierung laeuft gerade. */
+  isBusy: Ref<boolean>
+}
+
+export interface ReportGenerationProgress {
+  outline: Ref<ReportOutline | null>
+  sections: Ref<Record<string, unknown>>
+  currentSectionIndex: Ref<number | null>
+}
+
+export interface ReportGenerationResult {
+  full: Ref<Report | null>
+  /** Aus dem Status aufgeloeste Simulations-ID; faellt beim Aufrufer auf die
+   *  Prop zurueck. */
+  resolvedSimulationId: Ref<string | null>
+  /** Letztes Status-Objekt — traegt u. a. die `run_id` des Report-Laufs (#764). */
+  lastStatus: Ref<ReportGenerationStatusData | null>
+}
+
+export interface UseReportGenerationReturn {
+  status: ReportGenerationStatus
+  progress: ReportGenerationProgress
+  report: ReportGenerationResult
+  /** Einstieg beim Betreten der Ansicht: einmal Status ziehen und je nach
+   *  Ergebnis Polling aufnehmen, Bestaetigung anfordern oder den fertigen
+   *  Report nachladen. */
+  bootstrap: () => Promise<void>
+  /** Startet einen neuen Report-Lauf (bestaetigter Erststart). */
+  start: () => Promise<void>
+  /** Startet den Report mit `force_regenerate` neu. */
+  regenerate: () => Promise<void>
+  /** Beendet Statusabfrage und Begleit-Polls. */
+  stop: () => void
+}
+
+export function useReportGeneration(
+  options: UseReportGenerationOptions
+): UseReportGenerationReturn {
+  const api: ReportGenerationApi = {
+    generateReport: defaultGenerateReport,
+    getReport: defaultGetReport,
+    getReportStatus: defaultGetReportStatus,
+    ...options.api,
+  }
+  const logStreams = options.logStreams ?? []
+
+  const phase = ref<ReportPhase>(0)
+  const pending = ref(false)
+  const message = ref('')
+  const backendStatus = ref<string>('')
+  const failureCount = ref(0)
+  const transportError = ref(false)
+  const isComplete = ref(false)
+  const isBusy = ref(false)
+
+  const outline = ref<ReportOutline | null>(null)
+  const sections = ref<Record<string, unknown>>({})
+  const currentSectionIndex = ref<number | null>(null)
+
+  const full = ref<Report | null>(null)
+  const resolvedSimulationId = ref<string | null>(options.simulationId() || null)
+  const lastStatus = ref<ReportGenerationStatusData | null>(null)
+
+  const statusPolling = usePolling(
+    () => pollStatus(),
+    options.pollIntervalMs ?? REPORT_STATUS_POLL_INTERVAL_MS
+  )
+
+  function startPolling(): void {
+    void statusPolling.start()
+    for (const stream of logStreams) void stream.polling.start()
+  }
+
+  function stopPolling(): void {
+    statusPolling.stop()
+    for (const stream of logStreams) stream.polling.stop()
+  }
+
+  /**
+   * Sub-Slice 2 von 5 (Issue #739): Outline aus dem Report nachziehen. Wird
+   * `/report/<id>` nach dem Abschluss betreten (Direct-Goto, Reload oder
+   * Regenerate-Stream), liefert der Status-Endpunkt oft kein `outline` — das
+   * haengt dann nur noch am Report-Contract. Idempotent, damit eine bereits
+   * gepollte Outline nicht ueberschrieben wird.
+   */
+  function syncOutlineFromReport(report: Report | null): void {
+    if (!report?.outline || outline.value) return
+    try {
+      outline.value = ReportOutlineSchema.parse(report.outline)
+    } catch (err) {
+      options.recordSchemaError('outline', err)
+    }
+  }
+
+  /**
+   * Laedt den fertigen Report und die zugehoerige Evidenzkarte. Ein
+   * fehlgeschlagener Abruf ist hier erwartbar (der Report ist ggf. noch nicht
+   * geflusht) und bleibt folgenlos; ein Zod-Mismatch dagegen wird gemeldet.
+   */
+  async function loadFullReport(reportId: string): Promise<void> {
+    try {
+      const envelope = (await api.getReport(reportId)) as ApiResult
+      if (!envelope?.success) return
+      try {
+        const parsed = ReportSchema.parse(envelope.data)
+        full.value = parsed
+        syncOutlineFromReport(parsed)
+      } catch (err) {
+        options.recordSchemaError('report', err)
+        full.value = null
+      }
+      await options.loadEvidence()
+    } catch {
+      /* Report noch nicht geflusht — der naechste Poll bzw. Reload holt ihn nach. */
+    }
+  }
+
+  /** Terminalen Zustand setzen: Phase, Lebenszyklus-Meldung, Polling-Ende. */
+  function enterTerminal(status: ReportLifecycleStatus): void {
+    // isComplete ist zugleich die Sperre gegen einen erneuten Polling-Einstieg
+    // in `bootstrap()` nach einem Reload — sonst ersetzte "Running" den
+    // erreichten Endzustand.
+    isComplete.value = true
+    phase.value = 2
+    options.onLifecycleChange(status)
+  }
+
+  async function pollStatus(): Promise<void> {
+    if (!options.reportId() && !options.simulationId()) return
+    try {
+      const res = (await api.getReportStatus({
+        simulationId: resolvedSimulationId.value || options.simulationId(),
+        reportId: options.reportId(),
+      })) as StatusApiResult
+      if (!res?.success || !res.data) return
+
+      // Ein erfolgreicher Poll heilt einen zuvor sichtbar gemachten
+      // Transportfehler wieder aus — die Verbindung ist zurueck.
+      failureCount.value = 0
+      transportError.value = false
+
+      const st = res.data
+      lastStatus.value = st
+      message.value = st.message || ''
+      if (st.outline) {
+        try {
+          outline.value = ReportOutlineSchema.parse(st.outline)
+        } catch (err) {
+          options.recordSchemaError('outline', err)
+        }
+      }
+      if (st.sections) sections.value = st.sections
+      currentSectionIndex.value = st.current_section_index ?? currentSectionIndex.value
+      if (st.simulation_id && !resolvedSimulationId.value) {
+        resolvedSimulationId.value = st.simulation_id
+      }
+      backendStatus.value = st.status || ''
+
+      if (st.status === 'completed') {
+        enterTerminal('completed')
+        await loadFullReport((st.report_id || options.reportId()) as string)
+        stopPolling()
+      } else if (st.status === 'incomplete') {
+        // Backend meldet fehlgeschlagene Pflichtsections. Der Rest des Reports
+        // bleibt nutzbar; der Nutzer sieht, was fehlt.
+        enterTerminal('incomplete')
+        options.addLog(
+          options.t('step4.status.incomplete') || 'Report unvollständig — einige Abschnitte fehlen.'
+        )
+        await loadFullReport((st.report_id || options.reportId()) as string)
+        stopPolling()
+      } else if (st.status === 'failed') {
+        enterTerminal('error')
+        options.addLog(`${options.t('errors.reportFailed')}: ${st.error || ''}`)
+        stopPolling()
+      } else {
+        phase.value = 1
+      }
+    } catch {
+      // Issue #1023 (Befund B-17): Transportfehler zaehlen statt schweigend
+      // verwerfen. Log nur beim Ueberschreiten der Schwelle (nicht bei jedem
+      // weiteren Fehlschlag danach) — sonst spammt ein anhaltend totes Backend
+      // das Log mit einer Meldung pro Poll-Intervall.
+      failureCount.value++
+      if (failureCount.value === REPORT_POLL_FAILURE_THRESHOLD) {
+        transportError.value = true
+        options.addLog(options.t('step4.status.pollTransportError'))
+      }
+    }
+  }
+
+  /** Fortschritt auf Anfang zuruecksetzen — vor jedem neuen Lauf. */
+  function resetProgress(): void {
+    isComplete.value = false
+    phase.value = 1
+    outline.value = null
+    sections.value = {}
+    currentSectionIndex.value = null
+    full.value = null
+    for (const stream of logStreams) stream.reset()
+  }
+
+  /**
+   * Gemeinsamer Rumpf von `start()` und `regenerate()`. Einziger Unterschied
+   * ist `force_regenerate` und die Frage, ob ein Fehlschlag den Nutzer wieder
+   * in die Startbestaetigung zurueckwirft — beim Erststart ja, beim
+   * Regenerieren nein (dort steht bereits ein Report auf dem Schirm).
+   */
+  async function launch(opts: {
+    forceRegenerate: boolean
+    logPrefix: string
+    missingIdMessage: string
+    restorePendingOnFailure: boolean
+  }): Promise<void> {
+    const simId = resolvedSimulationId.value || options.simulationId()
+    if (!simId) {
+      options.addLog(opts.missingIdMessage)
+      return
+    }
+    if (opts.restorePendingOnFailure) pending.value = false
+    isBusy.value = true
+    try {
+      const requestOptions = options.buildRequestOptions()
+      const payload: GenerateReportData = {
+        simulation_id: simId,
+        ...(opts.forceRegenerate ? { force_regenerate: true } : {}),
+        ...requestOptions,
+      }
+      const model = options.describeModel?.() ?? null
+      options.addLog(
+        `${opts.logPrefix}${model ? ` mit ${model}` : ''} (Modus: ${requestOptions.mode})…`
+      )
+      const res = (await api.generateReport(payload)) as ApiResult
+      if (res?.success && res.data?.report_id) {
+        resetProgress()
+        options.onLifecycleChange('processing')
+        options.onStarted(res.data.report_id as string)
+        startPolling()
+      } else {
+        options.addLog(`Fehler: ${res?.error || 'unbekannt'}`)
+        if (opts.restorePendingOnFailure) pending.value = true
+      }
+    } catch (err) {
+      options.addLog((err as Error).message)
+      if (opts.restorePendingOnFailure) pending.value = true
+    } finally {
+      isBusy.value = false
+    }
+  }
+
+  async function start(): Promise<void> {
+    await launch({
+      forceRegenerate: false,
+      logPrefix: 'Report starten',
+      missingIdMessage: 'simulationId fehlt — Report-Start nicht möglich.',
+      restorePendingOnFailure: true,
+    })
+  }
+
+  async function regenerate(): Promise<void> {
+    await launch({
+      forceRegenerate: true,
+      logPrefix: 'Report neu generieren',
+      missingIdMessage: 'simulationId fehlt — Regenerieren nicht möglich.',
+      restorePendingOnFailure: false,
+    })
+  }
+
+  async function bootstrap(): Promise<void> {
+    await pollStatus()
+    if (!isComplete.value) {
+      if (options.reportId()) {
+        phase.value = 1
+        startPolling()
+      } else {
+        phase.value = 0
+        pending.value = true
+      }
+      return
+    }
+    if (!full.value) {
+      await loadFullReport(options.reportId() as string)
+    }
+  }
+
+  return {
+    status: {
+      phase,
+      pending,
+      message,
+      backendStatus,
+      transportError,
+      failureCount,
+      isComplete,
+      isBusy,
+    },
+    progress: { outline, sections, currentSectionIndex },
+    report: { full, resolvedSimulationId, lastStatus },
+    bootstrap,
+    start,
+    regenerate,
+    stop: stopPolling,
+  }
+}

--- a/frontend/src/composables/useReportGeneration.ts
+++ b/frontend/src/composables/useReportGeneration.ts
@@ -322,9 +322,16 @@ export function useReportGeneration(
       }
       backendStatus.value = st.status || ''
 
+      // Die Statusabfrage kommt auch mit reiner Simulations-ID durch; liefert
+      // die Antwort dann kein `report_id`, gibt es nichts nachzuladen. Vorher
+      // stand hier ein `as string`-Cast, der `getReport(undefined)` auf die
+      // Reise schickte — der Fehlschlag verschwand im leeren catch und der
+      // Report blieb ohne Meldung leer (CodeRabbit zu PR #1207).
+      const terminalReportId = st.report_id || options.reportId()
+
       if (st.status === 'completed') {
         enterTerminal('completed')
-        await loadFullReport((st.report_id || options.reportId()) as string)
+        if (terminalReportId) await loadFullReport(terminalReportId)
         stopPolling()
       } else if (st.status === 'incomplete') {
         // Backend meldet fehlgeschlagene Pflichtsections. Der Rest des Reports
@@ -333,7 +340,7 @@ export function useReportGeneration(
         options.addLog(
           options.t('step4.status.incomplete') || 'Report unvollständig — einige Abschnitte fehlen.'
         )
-        await loadFullReport((st.report_id || options.reportId()) as string)
+        if (terminalReportId) await loadFullReport(terminalReportId)
         stopPolling()
       } else if (st.status === 'failed') {
         enterTerminal('error')
@@ -444,8 +451,9 @@ export function useReportGeneration(
       }
       return
     }
-    if (!full.value) {
-      await loadFullReport(options.reportId() as string)
+    const reportId = options.reportId()
+    if (!full.value && reportId) {
+      await loadFullReport(reportId)
     }
   }
 


### PR DESCRIPTION
Schließt #1206. Frontend-Gegenstück zu `RunLifecycle` (#1204 / PR #1205) — dasselbe Muster „Statusmaschine hinter kleines Interface".

## Was sich ändert

`Step4Report.vue` hielt den kompletten Report-Flow offen im Setup-Scope: neun Status-Refs, eine 141-zeilige `pollStatus()`-Schleife mit den drei Endzustands-Zweigen, die Transportfehler-Zählung aus #1023 und die Handkoordination dreier Polling-Instanzen. Das liegt jetzt in `frontend/src/composables/useReportGeneration.ts` hinter

```ts
{ status, progress, report, bootstrap(), start(), stop(), regenerate() }
```

`usePolling` ist damit interne Abhängigkeit statt Detail der Komponente. Alles, was die Statusmaschine über ihre Umgebung braucht — Route-IDs, i18n, Log-Senke, Modell- und Modusauswahl, Navigation, Begleit-Polls und der HTTP-Seam — kommt über das Options-Objekt herein (Vorbild `useReportExports`).

`Step4Report.vue`: 1013 → 849 Zeilen, Script 838 → 675. Die Komponente verdrahtet nur noch.

## Verhalten

Unverändert — reiner Deepening-Refactor. Die Endzustands-Zweige, die Reload-Sperre über `isComplete`, die Schwelle von 3 Fehlschlägen samt Einmal-Log, die Outline-Nachsynchronisierung aus #739 und die Asymmetrie zwischen Erststart und Regenerieren (nur der Erststart wirft bei Fehlschlag in die Bestätigung zurück) sind eins zu eins übernommen.

## Tests

- **Neu:** `composables/__tests__/useReportGeneration.spec.ts` — 21 Interface-Tests ohne `mount()` und ohne `vi.mock`. Das Options-Objekt liefert die gesamte Umgebung, also ist das zurückgegebene Interface die Testfläche (Vorbild `contracts/__tests__/runParamsQuery.spec.ts`).
- **Angepasst:** zwei Tests in `Step4Report.spec.ts` riefen `vm.pollStatus()` auf — ein Internum, das es nicht mehr gibt. Sie treiben die Poll-Folge jetzt über den echten Timer-Loop und prüfen weiterhin genau das, was nur ein Mount zeigen kann: dass der gezählte Zustand im DOM ankommt. Die Zähl-Semantik selbst liegt in der Composable-Spec.
- Alle übrigen 52 Tests in `Step4Report.spec.ts` sind unverändert grün.

Volle Suite: **194 Dateien, 1870 Tests, alle grün.** `GATE_FULL=1 GATE_BUILD=1 bash scripts/pre-push-gate.sh frontend` → green.

## Bewusst nicht in diesem Slice

Karte 7 des Reviews (`ReportFinalView` von 10 Emits auf 2) hält der Prüfung in der vorgeschlagenen Form nicht stand: ruft `ReportFinalView` `useReportExports` selbst auf, braucht es dafür `reportId`, `reportMarkdown` und `evidenceMap` als neue Props plus `addLog`, `recordSchemaError` und `recordEvidenceOmission` als Callback-Props. Das sind sechs Emits weg gegen fünf bis sechs Props hin — Emits in Callback-Props umbenannt, keine echte Interface-Verkleinerung. Der Gewinn entstünde erst, wenn auch die Fehler-Senken (`schemaError`- und `evidenceOmission`-Box) mitwandern, und die hängen am Template von `Step4Report`. Als eigenes Issue mit dieser Analyse ausgelagert statt hier drangehängt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Die Anzeige des Report-Fortschritts und -Status läuft konsistenter über den gesamten Generierungsprozess.
  * Statusänderungen werden regelmäßig aktualisiert; abgeschlossene, unvollständige und fehlgeschlagene Reports werden zuverlässig erkannt.
  * Vorübergehende Verbindungsfehler werden kontrolliert behandelt. Nach mehreren aufeinanderfolgenden Fehlern erscheint ein Hinweis, der nach erfolgreicher Verbindung wieder verschwindet.
  * Start, Regenerierung und Beenden der Report-Erstellung funktionieren weiterhin im bestehenden Ablauf.
* **Tests**
  * Umfangreiche Tests decken Statuswechsel, Polling, Fehlerbehandlung sowie Start und Regenerierung ab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->