### PR TITLE
refactor(report): Section-Loop hinter process_section (#1212)

### DIFF
--- a/backend/app/services/report_agent/agent.py
+++ b/backend/app/services/report_agent/agent.py
@@ -60,6 +60,7 @@ from .tools import (
     is_valid_tool_call,
     parse_tool_calls,
 )
+from .section_pipeline import SectionEvidenceOutcome
 from .workflow import chat as chat_impl, generate_report as generate_report_impl, generate_section_react as generate_section_react_impl
 from .prompts import (
     CHAT_OBSERVATION_SUFFIX,
@@ -1032,7 +1033,16 @@ class ReportAgent:
                 kept.append(item)
             setattr(self, attribute, kept)
 
-    def _save_evidence_section(self, report_id: str, section_index: int, section_title: str, content: str) -> None:
+    def _save_evidence_section(
+        self, report_id: str, section_index: int, section_title: str, content: str
+    ) -> SectionEvidenceOutcome:
+        """Extrahiert Claims, bindet Evidence und persistiert die Evidenzkarte.
+
+        Issue #1212: Der Rückgabewert ist additiv — die Persistenz und alle
+        Seiteneffekte auf ``self.evidence_map`` sind unverändert. Er macht
+        beobachtbar, was gebunden und was vom Gate verworfen wurde, ohne dass
+        ein Aufrufer dafür die persistierte Karte durchsuchen muss.
+        """
         from .output_contract import is_fallback_content  # noqa: PLC0415
 
         # Issue #1187: macht die bislang unsichtbare Nachbearbeitung
@@ -1277,6 +1287,12 @@ class ReportAgent:
         ReportManager.save_evidence_map(report_id, validated)
         if phase_tracker is not None:
             phase_tracker.end_phase()
+        return SectionEvidenceOutcome.from_persisted_section(
+            validated,
+            section_index,
+            gate_decisions=gate_decisions,
+            generation_failed=generation_failed,
+        )
 
     def _define_tools(self) -> Dict[str, Dict[str, Any]]:
         return define_tools(self)

--- a/backend/app/services/report_agent/section_pipeline.py
+++ b/backend/app/services/report_agent/section_pipeline.py
@@ -1,0 +1,536 @@
+"""Verarbeitung eines einzelnen Report-Abschnitts (Issue #1212).
+
+Der Abschnitts-Durchlauf lag als 188-Zeilen-Schleife in
+:func:`app.services.report_agent.workflow.generate_report`. Er ist damit nur
+über den Weg testbar gewesen, den ``tests/services/test_partial_report.py``
+gegangen ist: 21 ``patch()``-Aufrufe auf Modulnamen in ``workflow``.
+
+Hier steht derselbe Ablauf hinter einem Interface aus drei Teilen:
+
+``SectionContext``
+    Alles, was der Ablauf über seine Umgebung braucht — Daten und Seams. Die
+    Seams sind Felder mit Default-Bindung an die echten Implementierungen,
+    dasselbe Options-Muster wie in ``frontend/src/composables/useReportGeneration.ts``
+    (Issue #1206). Ein Test setzt Fakes in den Kontext, statt Modulnamen zu patchen.
+
+``process_section``
+    Der Ablauf selbst: Wiederherstellung, Generierung, Zitatprüfung,
+    Fließtext-Verifikation, Metadaten, Claim-Extraktion und Evidence-Binding.
+
+``SectionResult``
+    Das Ergebnis, beobachtbar statt als Seiteneffekt verstreut — einschließlich
+    dessen, was das Evidence-Gate gebunden und was es verworfen hat.
+
+Abschnittsübergreifender Zustand bleibt bewusst draußen: Cancel-Prüfung,
+Akkumulation der fertigen Abschnitte und die Statusableitung des Gesamtreports
+gehören zur Orchestrierung in ``generate_report``.
+
+Dieses Modul importiert weder ``workflow`` noch ``agent`` — die Importrichtung
+läuft ``agent`` → ``workflow`` → ``section_pipeline``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from ...contracts.report_v3 import DEFAULT_REPORT_MODE, ReportMode
+from ...utils.logger import get_logger
+from .evidence import validate_quote_anchors
+from .manager import ReportManager
+from .output_contract import is_fallback_content
+from .postprocess_timing import PostprocessPhaseTracker
+from .text_verification import verify_prose
+
+logger = get_logger('agora.report_agent')
+
+# M11.8e — Section-Typen, die Persona-Zitate enthalten können/sollen.
+# Für diese Sections wird validate_quote_anchors mit strict-Repair-Retry ausgeführt.
+# Meta-Sections (Plan, Executive Summary, Datenlücken) sind ausgenommen.
+_QUOTE_REQUIRED_SECTION_KEYWORDS = frozenset({
+    "persona",
+    "personas",
+    "zielgrupp",
+    "segment",
+    "multipli",
+    "multiplier",
+    "friction",
+    "reibung",
+    "trust",
+    "vertrauen",
+    "interview",
+    "reaktion",
+    "reaction",
+})
+
+
+def _section_expects_quotes(section_title: str) -> bool:
+    """Gibt True zurück wenn der Abschnittstyp Persona-Zitate erwarten lässt."""
+    lower = section_title.lower()
+    return any(kw in lower for kw in _QUOTE_REQUIRED_SECTION_KEYWORDS)
+
+
+@dataclass
+class SectionEvidenceOutcome:
+    """Ergebnis von Claim-Extraktion und Evidence-Binding eines Abschnitts.
+
+    Rückgabewert von ``ReportAgent._save_evidence_section``. Die Methode
+    persistiert unverändert in die Evidenzkarte; dieser Wert macht zusätzlich
+    beobachtbar, *was* dabei gebunden und *was* vom Gate verworfen wurde.
+
+    Ohne das ist die Bindung nur über die persistierte Karte prüfbar — genau
+    die Blindstelle, an der die Evidence-Durchreichung viermal nachgebessert
+    wurde (#929, #1006, #1147, #1151) und die Issue #1209 Befund 6 adressiert.
+    """
+
+    claims: List[Dict[str, Any]] = field(default_factory=list)
+    hypotheses: List[Dict[str, Any]] = field(default_factory=list)
+    hypotheses_appendix: List[Dict[str, Any]] = field(default_factory=list)
+    data_gaps: List[Dict[str, Any]] = field(default_factory=list)
+    gate_decisions: List[Dict[str, Any]] = field(default_factory=list)
+    generation_failed: bool = False
+
+    @classmethod
+    def from_persisted_section(
+        cls,
+        evidence_map: Dict[str, Any],
+        section_index: int,
+        *,
+        gate_decisions: List[Dict[str, Any]],
+        generation_failed: bool,
+    ) -> "SectionEvidenceOutcome":
+        """Liest das Ergebnis aus der bereits validierten Evidenzkarte.
+
+        Bewusst aus der persistierten Karte und nicht aus den lokalen Listen
+        des Aufrufers: die Reparaturläufe bei ``ValidationError`` können
+        Einträge herabstufen oder entfernen. Der Rückgabewert zeigt damit, was
+        tatsächlich in der Karte steht — nicht, was vor der Validierung
+        gedacht war.
+        """
+        sections = evidence_map.get("sections") or []
+        entry: Dict[str, Any] = next(
+            (
+                s
+                for s in sections
+                if isinstance(s, dict) and s.get("section_index") == section_index
+            ),
+            {},
+        )
+        return cls(
+            claims=list(entry.get("claims") or []),
+            hypotheses=list(entry.get("hypotheses") or []),
+            hypotheses_appendix=list(entry.get("hypotheses_appendix") or []),
+            data_gaps=list(entry.get("data_gaps") or []),
+            gate_decisions=list(gate_decisions),
+            generation_failed=generation_failed,
+        )
+
+
+@dataclass
+class SectionResult:
+    """Was bei der Verarbeitung eines Abschnitts herausgekommen ist."""
+
+    section_index: int
+    title: str
+    content: str
+    #: Abschnitt lag bereits auf der Platte und wurde übernommen, nicht erzeugt.
+    restored: bool = False
+    #: Generierung lieferte Fallback-Text statt Bericht (P0-7).
+    failed: bool = False
+    #: Zitatprüfung inklusive Repair-Retry blieb erfolglos (M11.8e).
+    quote_validation_failed: bool = False
+    #: Strukturierte Metadaten aus ``generate_section_metadata`` (M11.8d).
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    #: Claim-Extraktion und Evidence-Binding.
+    evidence: SectionEvidenceOutcome = field(default_factory=SectionEvidenceOutcome)
+
+    @property
+    def bound_claims(self) -> List[Dict[str, Any]]:
+        """Claims, die das Evidence-Gate passiert haben."""
+        return self.evidence.claims
+
+    @property
+    def hypotheses(self) -> List[Dict[str, Any]]:
+        """Aussagen, die das Gate zu Hypothesen herabgestuft hat."""
+        return self.evidence.hypotheses
+
+    @property
+    def gate_decisions(self) -> List[Dict[str, Any]]:
+        """Gate-Entscheidungen mit Verstoß, Aktion und Begründung."""
+        return self.evidence.gate_decisions
+
+    @property
+    def markdown(self) -> str:
+        """Abschnitt als Markdown-Block, wie er in den Gesamtreport geht."""
+        return f"## {self.title}\n\n{self.content}"
+
+
+# --- Seam-Signaturen -------------------------------------------------------
+# Der Aufrufer bindet die echten Implementierungen; Tests setzen Fakes.
+
+SectionGenerator = Callable[..., str]
+MetadataGenerator = Callable[..., Dict[str, Any]]
+QuoteValidator = Callable[..., Any]
+ProseVerifier = Callable[..., Any]
+FallbackDetector = Callable[[str], bool]
+
+
+@dataclass
+class SectionContext:
+    """Umgebung eines Abschnitts-Durchlaufs: Daten und Seams.
+
+    Die Seam-Felder haben Defaults auf die echten Implementierungen. Ein
+    Aufrufer, der eigene Namensbindungen patchbar halten muss (``generate_report``
+    tut das für ``workflow``-Globals), überschreibt sie beim Bauen des Kontexts.
+    """
+
+    report_id: str
+    outline: Any
+    total_sections: int
+    #: Wird von ``_safe_generate_section_react`` gebunden — kein Default, weil
+    #: die Implementierung in ``workflow`` liegt und ein Import zyklisch wäre.
+    generate_section: SectionGenerator
+    generate_metadata: MetadataGenerator
+    report_mode: ReportMode = DEFAULT_REPORT_MODE
+    #: Bereits fertige Abschnitte als Markdown — Kontext für die Generierung.
+    #: Der Aufrufer erweitert die Liste; ``process_section`` liest sie nur.
+    previous_sections: List[str] = field(default_factory=list)
+    #: Bereits fertige Abschnittstitel, für Fortschrittsmeldungen.
+    completed_section_titles: List[str] = field(default_factory=list)
+    #: Auf der Platte vorgefundene Abschnitte: ``section_index`` → Inhalt.
+    persisted_section_contents: Dict[int, str] = field(default_factory=dict)
+    progress_callback: Optional[Callable[[str, int, str], None]] = None
+    # Seams mit Default-Bindung
+    validate_quotes: QuoteValidator = validate_quote_anchors
+    verify_prose_fn: ProseVerifier = verify_prose
+    is_fallback: FallbackDetector = is_fallback_content
+    report_manager: Any = ReportManager
+    phase_tracker_factory: Any = PostprocessPhaseTracker
+
+    def base_progress_for(self, section_index: int) -> int:
+        """Fortschritt zu Beginn eines Abschnitts (20 % … 90 %)."""
+        if self.total_sections <= 0:
+            return 20
+        return 20 + int(((section_index - 1) / self.total_sections) * 70)
+
+
+def _restore_persisted_section(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    *,
+    section_index: int,
+) -> SectionResult:
+    """Übernimmt einen bereits persistierten Abschnitt unverändert."""
+    section.content = ctx.report_manager._clean_section_content(
+        ctx.persisted_section_contents[section_index], section.title
+    )
+    persisted_sections = (agent.evidence_map or {}).get("sections") or []
+    has_persisted_evidence = any(
+        s.get("section_index") == section_index for s in persisted_sections
+    )
+    if not has_persisted_evidence:
+        logger.warning(
+            "Section %s already exists on disk without persisted evidence; "
+            "preserving markdown and leaving evidence unchanged",
+            section_index,
+        )
+    return SectionResult(
+        section_index=section_index,
+        title=section.title,
+        content=section.content,
+        restored=True,
+    )
+
+
+def _generate_content(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    *,
+    section_index: int,
+    base_progress: int,
+) -> str:
+    """Meldet den Start und erzeugt den Abschnittsinhalt."""
+    generating_message = (
+        f"Generating section: {section.title} "
+        f"({section_index}/{ctx.total_sections})"
+    )
+    ctx.report_manager.update_progress(
+        ctx.report_id,
+        "generating",
+        base_progress,
+        generating_message,
+        current_section=section.title,
+        completed_sections=ctx.completed_section_titles,
+    )
+    if ctx.progress_callback:
+        ctx.progress_callback("generating", base_progress, generating_message)
+
+    def _section_progress(stage: str, prog: int, msg: str) -> None:
+        if ctx.progress_callback:
+            ctx.progress_callback(
+                stage,
+                base_progress + int(prog * 0.7 / ctx.total_sections),
+                msg,
+            )
+
+    return ctx.generate_section(
+        agent,
+        section=section,
+        outline=ctx.outline,
+        previous_sections=ctx.previous_sections,
+        progress_callback=_section_progress if ctx.progress_callback else None,
+        section_index=section_index,
+        report_id=ctx.report_id,
+    )
+
+
+def _validate_quotes_with_repair(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    content: str,
+    *,
+    section_index: int,
+) -> tuple[str, bool]:
+    """Prüft Persona-Zitate und versucht bei Verstoß genau einen Repair-Retry.
+
+    M11.8e + P4.1 — nur für Abschnittstypen, die Zitate erwarten:
+    ``explorative`` überspringt die Prüfung, ``balanced`` repariert
+    best-effort, ``strict`` protokolliert den gescheiterten Repair prominent.
+    In keinem Modus wird der Abschnitt verworfen.
+
+    Liefert ``(Inhalt, quote_validation_failed)``.
+    """
+    if not _section_expects_quotes(section.title) or ctx.report_mode == "explorative":
+        return content, False
+
+    evidence_map_for_validation = agent.evidence_map or {}
+    persona_ids_for_validation: List[str] = getattr(agent, "persona_ids", []) or []
+    quote_result = ctx.validate_quotes(
+        content,
+        evidence_map_for_validation,
+        persona_ids_for_validation,
+    )
+    if quote_result.valid:
+        return content, False
+
+    logger.warning(
+        "quote_anchor_validation: section=%d title=%r mode=%s — "
+        "invalid quotes detected, attempting repair retry. "
+        "invalid_quotes=%r unbound_refs=%r",
+        section_index,
+        section.title,
+        ctx.report_mode,
+        quote_result.invalid_quotes,
+        quote_result.unbound_evidence_refs,
+    )
+    repair_content = ctx.generate_section(
+        agent,
+        section=section,
+        outline=ctx.outline,
+        previous_sections=ctx.previous_sections,
+        progress_callback=None,
+        section_index=section_index,
+        report_id=ctx.report_id,
+    )
+    repair_result = ctx.validate_quotes(
+        repair_content,
+        evidence_map_for_validation,
+        persona_ids_for_validation,
+    )
+    if repair_result.valid:
+        logger.info(
+            "quote_anchor_validation: section=%d repair successful",
+            section_index,
+        )
+        return repair_content, False
+
+    # Repair fehlgeschlagen — Section trotzdem weiter, Flag setzen
+    log_fn = logger.error if ctx.report_mode == "strict" else logger.warning
+    log_fn(
+        "quote_anchor_validation: section=%d mode=%s repair retry also failed. "
+        "Setting quote_validation_failed=True. "
+        "repair_invalid_quotes=%r repair_unbound=%r",
+        section_index,
+        ctx.report_mode,
+        repair_result.invalid_quotes,
+        repair_result.unbound_evidence_refs,
+    )
+    return repair_content, True
+
+
+def _verify_prose_facts(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    content: str,
+    *,
+    section_index: int,
+) -> str:
+    """Entfernt ungedeckte Faktenaussagen aus dem sichtbaren Fließtext (P0).
+
+    Quantitative Aussagen ohne deckende Quelle werden entfernt und als
+    Hypothese geführt — sonst steht im gelesenen Report weiter, was das
+    Entailment längst verworfen hat.
+    """
+    if ctx.is_fallback(content):
+        return content
+    verified = ctx.verify_prose_fn(content, agent._prose_evidence_pool())
+    if not verified.changed:
+        return content
+    logger.warning(
+        "section %d (%r): %d ungedeckte Faktenaussage(n) aus dem "
+        "Fließtext entfernt und als Hypothese geführt.",
+        section_index,
+        section.title,
+        len(verified.rejected),
+    )
+    agent._record_prose_hypotheses(section_index, verified.rejected)
+    return verified.content
+
+
+def _extract_metadata(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    content: str,
+    *,
+    section_index: int,
+    base_progress: int,
+) -> Dict[str, Any]:
+    """Strukturierte Metadaten-Extraktion via strict-schema chat_json (M11.8d).
+
+    Fehler blockieren nicht die Hauptgenerierung (``generate_section_metadata``
+    gibt bei Exception ``{}`` zurück).
+    """
+    # Issue #1187: macht die bislang unsichtbare Metadaten-Extraktion
+    # sichtbar/messbar — keine Verhaltensaenderung an section_meta selbst.
+    metadata_phase_tracker = ctx.phase_tracker_factory(
+        ctx.report_id,
+        section_index=section_index,
+        section_title=section.title,
+        base_progress=base_progress,
+        completed_sections=ctx.completed_section_titles,
+        report_logger=agent.report_logger,
+        # eigene, in Tests patchbare Namensbindung durchreichen
+        # (siehe postprocess_timing.PostprocessPhaseTracker).
+        report_manager=ctx.report_manager,
+    )
+    with metadata_phase_tracker.phase("section_metadata"):
+        return ctx.generate_metadata(
+            agent,
+            section_title=section.title,
+            section_content=content,
+            section_index=section_index,
+        )
+
+
+def _apply_metadata(
+    agent: Any,
+    section: Any,
+    section_meta: Dict[str, Any],
+    *,
+    section_index: int,
+) -> None:
+    """Schreibt die Metadaten an Section und Agent (P0-6)."""
+    if section_meta and agent.report_logger and hasattr(
+        agent.report_logger, "log_section_metadata"
+    ):
+        agent.report_logger.log_section_metadata(
+            section_title=section.title,
+            section_index=section_index,
+            metadata=section_meta,
+        )
+    if not section_meta:
+        return
+    # P0-6: Die extrahierten Struktur-Daten sind ab hier die kanonische
+    # Quelle für ReportV3 — vorher endeten sie im Logger.
+    if not hasattr(section, "metadata") or section.metadata is None:
+        section.metadata = {}
+    section.metadata["structured_metadata"] = section_meta
+    agent._record_section_metadata(section_index, section_meta)
+
+
+def process_section(
+    agent: Any,
+    section: Any,
+    ctx: SectionContext,
+    *,
+    section_index: int,
+) -> SectionResult:
+    """Verarbeitet genau einen Abschnitt und liefert das Ergebnis.
+
+    Reihenfolge — jeder Schritt hängt vom vorigen ab:
+
+    1. Liegt der Abschnitt schon auf der Platte, wird er übernommen (Resume).
+    2. Generierung des Inhalts.
+    3. Zitatprüfung mit einem Repair-Retry, wenn der Typ Zitate erwartet.
+    4. Fließtext-Verifikation: ungedeckte Faktenaussagen werden Hypothesen.
+    5. Fallback-Erkennung — fehlgeschlagene Abschnitte liefern Fehlertext und
+       dürfen weder Metadaten noch Claims noch Evidence erzeugen (P0-7).
+    6. Metadaten-Extraktion.
+    7. Persistenz des Abschnitts, dann Claim-Extraktion und Evidence-Binding.
+
+    Der Aufrufer bleibt für abschnittsübergreifenden Zustand zuständig:
+    Cancel-Prüfung, Akkumulation und Statusableitung des Gesamtreports.
+    """
+    if section_index in ctx.persisted_section_contents:
+        return _restore_persisted_section(
+            agent, section, ctx, section_index=section_index
+        )
+
+    base_progress = ctx.base_progress_for(section_index)
+    content = _generate_content(
+        agent, section, ctx, section_index=section_index, base_progress=base_progress
+    )
+    content, quote_validation_failed = _validate_quotes_with_repair(
+        agent, section, ctx, content, section_index=section_index
+    )
+    if quote_validation_failed:
+        if not hasattr(section, "metadata") or section.metadata is None:
+            section.metadata = {}
+        section.metadata["quote_validation_failed"] = True
+    content = _verify_prose_facts(
+        agent, section, ctx, content, section_index=section_index
+    )
+
+    # Fehlgeschlagene Sections liefern Fehlertext, keinen Inhalt: keine
+    # Metadaten-Extraktion, keine Claims, keine Evidence daraus.
+    section_failed = ctx.is_fallback(content)
+    if section_failed:
+        logger.warning(
+            "section %d (%r): Fallback-Inhalt erkannt — Metadaten- und "
+            "Claim-Extraktion werden übersprungen.",
+            section_index,
+            section.title,
+        )
+        section_meta: Dict[str, Any] = {}
+    else:
+        section_meta = _extract_metadata(
+            agent,
+            section,
+            ctx,
+            content,
+            section_index=section_index,
+            base_progress=base_progress,
+        )
+    _apply_metadata(agent, section, section_meta, section_index=section_index)
+
+    section.content = content
+    ctx.report_manager.save_section(ctx.report_id, section_index, section)
+    evidence = agent._save_evidence_section(
+        ctx.report_id, section_index, section.title, content
+    )
+
+    return SectionResult(
+        section_index=section_index,
+        title=section.title,
+        content=content,
+        failed=section_failed,
+        quote_validation_failed=quote_validation_failed,
+        metadata=section_meta or {},
+        evidence=evidence if isinstance(evidence, SectionEvidenceOutcome)
+        else SectionEvidenceOutcome(generation_failed=section_failed),
+    )

--- a/backend/app/services/report_agent/workflow.py
+++ b/backend/app/services/report_agent/workflow.py
@@ -27,6 +27,12 @@ from .output_contract import (
 )
 from .planning import plan_outline as plan_outline_impl
 from .postprocess_timing import PostprocessPhaseTracker
+from .section_pipeline import (
+    SectionContext,
+    SectionResult,
+    _section_expects_quotes,
+    process_section,
+)
 from .search_dedup import (
     REPEATED_EMPTY_SEARCH_MSG,
     is_search_tool,
@@ -43,30 +49,10 @@ from ..evidence_migrations import migrate_v1_to_v2, normalize_persisted_evidence
 
 logger = get_logger('agora.report_agent')
 
-# M11.8e — Section-Typen, die Persona-Zitate enthalten können/sollen.
-# Für diese Sections wird validate_quote_anchors mit strict-Repair-Retry ausgeführt.
-# Meta-Sections (Plan, Executive Summary, Datenlücken) sind ausgenommen.
-_QUOTE_REQUIRED_SECTION_KEYWORDS = frozenset({
-    "persona",
-    "personas",
-    "zielgrupp",
-    "segment",
-    "multipli",
-    "multiplier",
-    "friction",
-    "reibung",
-    "trust",
-    "vertrauen",
-    "interview",
-    "reaktion",
-    "reaction",
-})
-
-
-def _section_expects_quotes(section_title: str) -> bool:
-    """Gibt True zurück wenn der Abschnittstyp Persona-Zitate erwarten lässt."""
-    lower = section_title.lower()
-    return any(kw in lower for kw in _QUOTE_REQUIRED_SECTION_KEYWORDS)
+# Die Abschnittsverarbeitung liegt seit Issue #1212 in ``section_pipeline``.
+# ``_section_expects_quotes`` bleibt hier als Name erreichbar, damit bestehende
+# Referenzen auf ``workflow`` nicht brechen.
+__all__ = ["_section_expects_quotes", "chat", "generate_report", "generate_section_react"]
 
 
 def _load_persona_count(agent: Any) -> int:
@@ -1103,6 +1089,28 @@ def generate_report(
             completed_section_titles.append(title)
             generated_sections.append(section_info["content"])
 
+        # Issue #1212: Der Abschnitts-Durchlauf steht in ``section_pipeline``.
+        # Die Seams werden hier aus den Modul-Globals dieses Moduls gebunden —
+        # damit bleibt patchbar, was bisher patchbar war, ohne dass die
+        # Pipeline ``workflow`` kennen muss.
+        section_ctx = SectionContext(
+            report_id=report_id,
+            outline=outline,
+            total_sections=total_sections,
+            generate_section=_safe_generate_section_react,
+            generate_metadata=generate_section_metadata,
+            report_mode=report_mode,
+            previous_sections=generated_sections,
+            completed_section_titles=completed_section_titles,
+            persisted_section_contents=existing_sections,
+            progress_callback=progress_callback,
+            validate_quotes=validate_quote_anchors,
+            verify_prose_fn=verify_prose,
+            is_fallback=is_fallback_content,
+            report_manager=ReportManager,
+            phase_tracker_factory=PostprocessPhaseTracker,
+        )
+
         for i, section in enumerate(outline.sections):
             # Cancel-Check am Anfang jeder Section-Iteration (Stage-Boundary 2+)
             if _is_cancel_requested(cancel_run_id):
@@ -1115,182 +1123,29 @@ def generate_report(
                     progress_callback=progress_callback,
                 )
             section_num = i + 1
-            base_progress = 20 + int((i / total_sections) * 70)
-            if section_num in existing_sections:
-                section.content = ReportManager._clean_section_content(existing_sections[section_num], section.title)
-                persisted_sections = (agent.evidence_map or {}).get("sections") or []
-                has_persisted_evidence = any(s.get("section_index") == section_num for s in persisted_sections)
-                if not has_persisted_evidence:
-                    logger.warning(
-                        "Section %s already exists on disk without persisted evidence; preserving markdown and leaving evidence unchanged",
-                        section_num,
-                    )
-                continue
-            generating_message = f"Generating section: {section.title} ({section_num}/{total_sections})"
-            ReportManager.update_progress(report_id, "generating", base_progress, generating_message, current_section=section.title, completed_sections=completed_section_titles)
-            if progress_callback:
-                progress_callback("generating", base_progress, generating_message)
-            section_content = _safe_generate_section_react(
-                agent,
-                section=section,
-                outline=outline,
-                previous_sections=generated_sections,
-                progress_callback=lambda stage, prog, msg: progress_callback(stage, base_progress + int(prog * 0.7 / total_sections), msg) if progress_callback else None,
-                section_index=section_num,
-                report_id=report_id,
+            result: SectionResult = process_section(
+                agent, section, section_ctx, section_index=section_num
             )
-            # M11.8e + P4.1: Quote-Anchor-Validierung für Persona-/Segment-/Friction-Sections.
-            # Nur bei Section-Typen, die Persona-Zitate erwarten (nicht Plan/Meta-Sections).
-            # explorative: Validierung vollständig überspringen.
-            # balanced: Best-Effort-Repair-Retry (aktuelles Verhalten).
-            # strict: Hart — fehlgeschlagener Repair setzt quota_validation_failed=True
-            #         und wird prominent geloggt; kein weiteres Fallback.
-            if _section_expects_quotes(section.title) and report_mode != "explorative":
-                evidence_map_for_validation = agent.evidence_map or {}
-                persona_ids_for_validation: List[str] = getattr(agent, "persona_ids", []) or []
-                quote_result = validate_quote_anchors(
-                    section_content,
-                    evidence_map_for_validation,
-                    persona_ids_for_validation,
-                )
-                if not quote_result.valid:
-                    repair_hint = (
-                        f"Korrigiere die Persona-Zitate: "
-                        f"invalid_quotes={quote_result.invalid_quotes!r}, "
-                        f"unbound_evidence_refs={quote_result.unbound_evidence_refs!r}. "
-                        f"Jedes Zitat MUSS <simulated_quote persona_id=\"...\" seed_anchor=\"...\">...</simulated_quote> "
-                        f"mit gültigen Attributen verwenden."
-                    )
-                    logger.warning(
-                        "quote_anchor_validation: section=%d title=%r mode=%s — "
-                        "invalid quotes detected, attempting repair retry. "
-                        "invalid_quotes=%r unbound_refs=%r",
-                        section_num,
-                        section.title,
-                        report_mode,
-                        quote_result.invalid_quotes,
-                        quote_result.unbound_evidence_refs,
-                    )
-                    repair_content = _safe_generate_section_react(
-                        agent,
-                        section=section,
-                        outline=outline,
-                        previous_sections=generated_sections,
-                        progress_callback=None,
-                        section_index=section_num,
-                        report_id=report_id,
-                    )
-                    repair_result = validate_quote_anchors(
-                        repair_content,
-                        evidence_map_for_validation,
-                        persona_ids_for_validation,
-                    )
-                    if repair_result.valid:
-                        section_content = repair_content
-                        logger.info(
-                            "quote_anchor_validation: section=%d repair successful",
-                            section_num,
-                        )
-                    else:
-                        # Repair fehlgeschlagen — Section trotzdem weiter, Flag setzen
-                        log_fn = logger.error if report_mode == "strict" else logger.warning
-                        log_fn(
-                            "quote_anchor_validation: section=%d mode=%s repair retry also failed. "
-                            "Setting quote_validation_failed=True. "
-                            "repair_invalid_quotes=%r repair_unbound=%r",
-                            section_num,
-                            report_mode,
-                            repair_result.invalid_quotes,
-                            repair_result.unbound_evidence_refs,
-                        )
-                        if not hasattr(section, "metadata") or section.metadata is None:
-                            section.metadata = {}
-                        section.metadata["quote_validation_failed"] = True
-                        section_content = repair_content
-                        _ = repair_hint  # consumed in log above
-            # M11.8d: Strukturierte Metadaten-Extraktion via strict-schema chat_json.
-            # Fehler blockieren nicht die Hauptgenerierung (generate_section_metadata
-            # gibt bei Exception {} zurück). Metadaten werden im Report-Logger
-            # für Provenance-Tracking gespeichert.
-            # P0: Faktenprüfung des sichtbaren Fließtexts. Quantitative
-            # Aussagen ohne deckende Quelle werden entfernt und als Hypothese
-            # geführt — sonst steht im gelesenen Report weiter, was das
-            # Entailment längst verworfen hat.
-            if not is_fallback_content(section_content):
-                verified = verify_prose(
-                    section_content,
-                    agent._prose_evidence_pool(),
-                )
-                if verified.changed:
-                    logger.warning(
-                        "section %d (%r): %d ungedeckte Faktenaussage(n) aus dem "
-                        "Fließtext entfernt und als Hypothese geführt.",
-                        section_num,
-                        section.title,
-                        len(verified.rejected),
-                    )
-                    agent._record_prose_hypotheses(section_num, verified.rejected)
-                    section_content = verified.content
-
-            # Fehlgeschlagene Sections liefern Fehlertext, keinen Inhalt: keine
-            # Metadaten-Extraktion, keine Claims, keine Evidence daraus.
-            section_failed = is_fallback_content(section_content)
-            if section_failed:
+            if result.restored:
+                continue
+            if result.failed:
                 failed_section_indices.append(section_num)
-                logger.warning(
-                    "section %d (%r): Fallback-Inhalt erkannt — Metadaten- und "
-                    "Claim-Extraktion werden übersprungen.",
-                    section_num,
-                    section.title,
-                )
-                section_meta = {}
-            else:
-                # Issue #1187: macht die bislang unsichtbare
-                # Metadaten-Extraktion sichtbar/messbar — kein
-                # Verhaltensaenderung an section_meta selbst.
-                metadata_phase_tracker = PostprocessPhaseTracker(
-                    report_id,
-                    section_index=section_num,
-                    section_title=section.title,
-                    base_progress=base_progress,
-                    completed_sections=completed_section_titles,
-                    report_logger=agent.report_logger,
-                    # eigene, in Tests patchbare Namensbindung durchreichen
-                    # (siehe postprocess_timing.PostprocessPhaseTracker).
-                    report_manager=ReportManager,
-                )
-                with metadata_phase_tracker.phase("section_metadata"):
-                    section_meta = generate_section_metadata(
-                        agent,
-                        section_title=section.title,
-                        section_content=section_content,
-                        section_index=section_num,
-                    )
-            if section_meta and agent.report_logger and hasattr(agent.report_logger, "log_section_metadata"):
-                agent.report_logger.log_section_metadata(
-                    section_title=section.title,
-                    section_index=section_num,
-                    metadata=section_meta,
-                )
-            if section_meta:
-                # P0-6: Die extrahierten Struktur-Daten sind ab hier die
-                # kanonische Quelle für ReportV3 — vorher endeten sie im Logger.
-                if not hasattr(section, "metadata") or section.metadata is None:
-                    section.metadata = {}
-                section.metadata["structured_metadata"] = section_meta
-                agent._record_section_metadata(section_num, section_meta)
-            section.content = section_content
-            generated_sections.append(f"## {section.title}\n\n{section_content}")
-            ReportManager.save_section(report_id, section_num, section)
-            agent._save_evidence_section(report_id, section_num, section.title, section_content)
-            completed_section_titles.append(section.title)
+            generated_sections.append(result.markdown)
+            completed_section_titles.append(result.title)
             if agent.report_logger:
                 agent.report_logger.log_section_full_complete(
-                    section_title=section.title,
+                    section_title=result.title,
                     section_index=section_num,
-                    full_content=f"## {section.title}\n\n{section_content}".strip(),
+                    full_content=result.markdown.strip(),
                 )
-            ReportManager.update_progress(report_id, "generating", base_progress + int(70 / total_sections), f"Section {section.title} completed", current_section=None, completed_sections=completed_section_titles)
+            ReportManager.update_progress(
+                report_id,
+                "generating",
+                section_ctx.base_progress_for(section_num) + int(70 / total_sections),
+                f"Section {result.title} completed",
+                current_section=None,
+                completed_sections=completed_section_titles,
+            )
 
         assembling_message = "Assembling the complete report..."
         if progress_callback:

--- a/backend/tests/services/test_section_pipeline.py
+++ b/backend/tests/services/test_section_pipeline.py
@@ -1,0 +1,515 @@
+"""Tests für die Abschnitts-Pipeline (Issue #1212).
+
+Diese Datei prüft ``process_section`` direkt am Interface. Kein einziger
+``patch()``-Aufruf: alles, was der Ablauf über seine Umgebung braucht, kommt
+über ``SectionContext`` herein. Das ist der Unterschied zu
+``test_partial_report.py``, das denselben Ablauf über 21 Patches auf
+Modulnamen in ``workflow`` erreicht und damit Namen statt Verhalten festhält.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, List
+
+from app.models.report import ReportOutline, ReportSection
+from app.services.report_agent.section_pipeline import (
+    SectionContext,
+    SectionEvidenceOutcome,
+    process_section,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — bewusst kleine, echte Klassen statt MagicMock: sie zeigen, welches
+# Interface die Pipeline von ihrer Umgebung tatsächlich erwartet.
+# ---------------------------------------------------------------------------
+
+
+class FakeReportLogger:
+    def __init__(self) -> None:
+        self.section_metadata: List[Dict[str, Any]] = []
+
+    def log_section_metadata(self, **kwargs: Any) -> None:
+        self.section_metadata.append(kwargs)
+
+
+class FakeAgent:
+    """Minimaler Agent-Ersatz mit den von der Pipeline genutzten Anschlüssen."""
+
+    def __init__(
+        self,
+        *,
+        evidence_map: Dict[str, Any] | None = None,
+        prose_pool: List[Dict[str, Any]] | None = None,
+        evidence_outcome: SectionEvidenceOutcome | None = None,
+    ) -> None:
+        self.evidence_map = evidence_map if evidence_map is not None else {}
+        self.persona_ids = ["p1", "p2"]
+        self.report_logger = FakeReportLogger()
+        self._pool = prose_pool or []
+        self._evidence_outcome = evidence_outcome or SectionEvidenceOutcome()
+        self.recorded_prose_hypotheses: List[tuple] = []
+        self.recorded_metadata: List[tuple] = []
+        self.saved_evidence_calls: List[tuple] = []
+
+    def _prose_evidence_pool(self) -> List[Dict[str, Any]]:
+        return self._pool
+
+    def _record_prose_hypotheses(self, section_index: int, rejected: Any) -> None:
+        self.recorded_prose_hypotheses.append((section_index, rejected))
+
+    def _record_section_metadata(self, section_index: int, metadata: Dict[str, Any]) -> None:
+        self.recorded_metadata.append((section_index, metadata))
+
+    def _save_evidence_section(
+        self, report_id: str, section_index: int, section_title: str, content: str
+    ) -> SectionEvidenceOutcome:
+        self.saved_evidence_calls.append((report_id, section_index, section_title, content))
+        return self._evidence_outcome
+
+
+class FakeReportManager:
+    def __init__(self) -> None:
+        self.progress_calls: List[Dict[str, Any]] = []
+        self.saved_sections: List[tuple] = []
+
+    def update_progress(self, report_id: str, stage: str, progress: int, message: str, **kw: Any) -> None:
+        self.progress_calls.append({"stage": stage, "progress": progress, "message": message, **kw})
+
+    def save_section(self, report_id: str, section_index: int, section: Any) -> None:
+        self.saved_sections.append((report_id, section_index, section.content))
+
+    def _clean_section_content(self, content: str, section_title: str) -> str:
+        return content.strip()
+
+
+class FakePhaseTracker:
+    """Erfüllt den ``phase(name)``-Kontextmanager-Vertrag."""
+
+    instances: List["FakePhaseTracker"] = []
+
+    def __init__(self, report_id: str, **kwargs: Any) -> None:
+        self.report_id = report_id
+        self.kwargs = kwargs
+        self.phases: List[str] = []
+        FakePhaseTracker.instances.append(self)
+
+    @contextmanager
+    def phase(self, name: str):
+        self.phases.append(name)
+        yield
+
+
+class FakeQuoteResult:
+    def __init__(self, valid: bool) -> None:
+        self.valid = valid
+        self.invalid_quotes: List[str] = [] if valid else ["<simulated_quote persona_id=\"?\">"]
+        self.unbound_evidence_refs: List[str] = [] if valid else ["ev_missing"]
+
+
+class FakeVerifiedProse:
+    def __init__(self, content: str, *, changed: bool = False, rejected: List[str] | None = None) -> None:
+        self.content = content
+        self.changed = changed
+        self.rejected = rejected or []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_outline(n: int = 3) -> ReportOutline:
+    return ReportOutline(
+        title="Test Report",
+        summary="Test summary",
+        sections=[
+            ReportSection(title=f"Section {i + 1}", content="", description="")
+            for i in range(n)
+        ],
+    )
+
+
+def _make_ctx(
+    *,
+    outline: ReportOutline | None = None,
+    generated_content: str = "Erzeugter Abschnittsinhalt.",
+    total_sections: int = 3,
+    **overrides: Any,
+) -> SectionContext:
+    """Baut einen Kontext, in dem jeder Seam auf einen Fake zeigt."""
+    outline = outline or _make_outline(total_sections)
+    generate_calls: List[Dict[str, Any]] = []
+
+    def fake_generate_section(agent: Any, **kwargs: Any) -> str:
+        generate_calls.append(kwargs)
+        return generated_content
+
+    defaults: Dict[str, Any] = {
+        "report_id": "report_test123",
+        "outline": outline,
+        "total_sections": total_sections,
+        "generate_section": fake_generate_section,
+        "generate_metadata": lambda agent, **kw: {},
+        "validate_quotes": lambda *a, **kw: FakeQuoteResult(valid=True),
+        "verify_prose_fn": lambda content, pool: FakeVerifiedProse(content),
+        "is_fallback": lambda content: False,
+        "report_manager": FakeReportManager(),
+        "phase_tracker_factory": FakePhaseTracker,
+    }
+    defaults.update(overrides)
+    ctx = SectionContext(**defaults)
+    # Für Assertions am Testende erreichbar machen.
+    ctx.generate_calls = generate_calls  # type: ignore[attr-defined]
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# 1. Resume-Pfad
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_section_is_restored_without_generating():
+    """Ein Abschnitt, der schon auf der Platte liegt, wird nicht neu erzeugt."""
+    outline = _make_outline(3)
+    ctx = _make_ctx(outline=outline, persisted_section_contents={2: "  Bereits vorhanden.  "})
+    agent = FakeAgent(evidence_map={"sections": [{"section_index": 2}]})
+
+    result = process_section(agent, outline.sections[1], ctx, section_index=2)
+
+    assert result.restored is True
+    assert result.content == "Bereits vorhanden."
+    assert result.failed is False
+    assert ctx.generate_calls == [], "Resume darf keine Generierung auslösen"
+    assert agent.saved_evidence_calls == [], "Resume darf keine Evidence neu binden"
+
+
+def test_restored_section_without_persisted_evidence_still_returns_content():
+    """Fehlende Evidenz zum Abschnitt wird geloggt, der Inhalt bleibt erhalten."""
+    outline = _make_outline(2)
+    ctx = _make_ctx(outline=outline, total_sections=2, persisted_section_contents={1: "Alter Text."})
+    agent = FakeAgent(evidence_map={"sections": []})
+
+    result = process_section(agent, outline.sections[0], ctx, section_index=1)
+
+    assert result.restored is True
+    assert result.content == "Alter Text."
+
+
+# ---------------------------------------------------------------------------
+# 2. Regulärer Durchlauf
+# ---------------------------------------------------------------------------
+
+
+def test_generated_section_reports_content_and_markdown():
+    outline = _make_outline(3)
+    ctx = _make_ctx(outline=outline, generated_content="Der Abschnittstext.")
+    agent = FakeAgent()
+
+    result = process_section(agent, outline.sections[0], ctx, section_index=1)
+
+    assert result.restored is False
+    assert result.failed is False
+    assert result.content == "Der Abschnittstext."
+    assert result.title == "Section 1"
+    assert result.markdown == "## Section 1\n\nDer Abschnittstext."
+    assert ctx.report_manager.saved_sections == [("report_test123", 1, "Der Abschnittstext.")]
+    assert agent.saved_evidence_calls[0][1] == 1
+
+
+def test_generated_section_reports_progress_before_generating():
+    outline = _make_outline(4)
+    seen: List[tuple] = []
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=4,
+        progress_callback=lambda stage, prog, msg: seen.append((stage, prog, msg)),
+    )
+
+    process_section(FakeAgent(), outline.sections[1], ctx, section_index=2)
+
+    assert seen[0][0] == "generating"
+    assert "Generating section: Section 2 (2/4)" in seen[0][2]
+
+
+def test_base_progress_spans_twenty_to_ninety_percent():
+    ctx = _make_ctx(total_sections=4)
+    assert ctx.base_progress_for(1) == 20
+    assert ctx.base_progress_for(4) == 72
+    # Ein leerer Outline darf nicht durch Null teilen.
+    assert _make_ctx(total_sections=0).base_progress_for(1) == 20
+
+
+# ---------------------------------------------------------------------------
+# 3. Fehlgeschlagene Generierung (P0-7)
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_content_marks_failure_and_skips_metadata():
+    """Fallback-Text erzeugt weder Metadaten noch Claims."""
+    outline = _make_outline(2)
+    metadata_calls: List[Any] = []
+
+    def tracking_metadata(agent: Any, **kw: Any) -> Dict[str, Any]:
+        metadata_calls.append(kw)
+        return {"claims": ["darf nicht entstehen"]}
+
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=2,
+        generated_content="[Abschnitt konnte nicht erzeugt werden]",
+        is_fallback=lambda content: content.startswith("[Abschnitt konnte nicht"),
+        generate_metadata=tracking_metadata,
+    )
+    agent = FakeAgent()
+
+    result = process_section(agent, outline.sections[0], ctx, section_index=1)
+
+    assert result.failed is True
+    assert result.metadata == {}
+    assert metadata_calls == [], "Fallback-Abschnitt darf keine Metadaten extrahieren"
+    assert agent.recorded_metadata == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Zitatprüfung (M11.8e / P4.1)
+# ---------------------------------------------------------------------------
+
+
+def _quote_ctx(outline: ReportOutline, results: List[FakeQuoteResult], **overrides: Any) -> SectionContext:
+    """Kontext, dessen Zitatprüfung eine vorgegebene Ergebnisfolge liefert."""
+    calls = {"n": 0}
+
+    def scripted_validate(*a: Any, **kw: Any) -> FakeQuoteResult:
+        result = results[min(calls["n"], len(results) - 1)]
+        calls["n"] += 1
+        return result
+
+    contents = ["Erster Versuch.", "Reparierter Versuch."]
+    gen_calls = {"n": 0}
+
+    def two_shot_generate(agent: Any, **kwargs: Any) -> str:
+        content = contents[min(gen_calls["n"], len(contents) - 1)]
+        gen_calls["n"] += 1
+        return content
+
+    defaults: Dict[str, Any] = {
+        "outline": outline,
+        "total_sections": len(outline.sections),
+        "validate_quotes": scripted_validate,
+        "generate_section": two_shot_generate,
+    }
+    defaults.update(overrides)
+    ctx = _make_ctx(**defaults)
+    ctx.generate_call_count = gen_calls  # type: ignore[attr-defined]
+    return ctx
+
+
+def test_invalid_quotes_trigger_repair_retry_that_succeeds():
+    """Scheitert die Zitatprüfung, ersetzt ein erfolgreicher Repair den Inhalt."""
+    outline = ReportOutline(
+        title="R", summary="s",
+        sections=[ReportSection(title="Persona-Reaktionen", content="", description="")],
+    )
+    ctx = _quote_ctx(outline, [FakeQuoteResult(valid=False), FakeQuoteResult(valid=True)])
+
+    result = process_section(FakeAgent(), outline.sections[0], ctx, section_index=1)
+
+    assert result.content == "Reparierter Versuch."
+    assert result.quote_validation_failed is False
+    assert ctx.generate_call_count["n"] == 2, "genau ein Repair-Retry"
+
+
+def test_failed_repair_sets_flag_and_keeps_section():
+    """Auch ein gescheiterter Repair verwirft den Abschnitt nicht."""
+    outline = ReportOutline(
+        title="R", summary="s",
+        sections=[ReportSection(title="Persona-Reaktionen", content="", description="")],
+    )
+    ctx = _quote_ctx(outline, [FakeQuoteResult(valid=False), FakeQuoteResult(valid=False)])
+    section = outline.sections[0]
+
+    result = process_section(FakeAgent(), section, ctx, section_index=1)
+
+    assert result.quote_validation_failed is True
+    assert result.content == "Reparierter Versuch."
+    assert result.failed is False
+    assert section.metadata["quote_validation_failed"] is True
+
+
+def test_explorative_mode_skips_quote_validation():
+    """Im Modus ``explorative`` findet keine Zitatprüfung statt."""
+    outline = ReportOutline(
+        title="R", summary="s",
+        sections=[ReportSection(title="Persona-Reaktionen", content="", description="")],
+    )
+    validations: List[int] = []
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=1,
+        report_mode="explorative",
+        validate_quotes=lambda *a, **kw: validations.append(1) or FakeQuoteResult(valid=False),
+    )
+
+    result = process_section(FakeAgent(), outline.sections[0], ctx, section_index=1)
+
+    assert validations == [], "explorative darf die Zitatprüfung nicht aufrufen"
+    assert result.quote_validation_failed is False
+
+
+def test_meta_section_titles_skip_quote_validation():
+    """Abschnitte ohne Zitaterwartung werden nicht geprüft."""
+    outline = ReportOutline(
+        title="R", summary="s",
+        sections=[ReportSection(title="Executive Summary", content="", description="")],
+    )
+    validations: List[int] = []
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=1,
+        validate_quotes=lambda *a, **kw: validations.append(1) or FakeQuoteResult(valid=False),
+    )
+
+    process_section(FakeAgent(), outline.sections[0], ctx, section_index=1)
+
+    assert validations == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Fließtext-Verifikation (P0)
+# ---------------------------------------------------------------------------
+
+
+def test_prose_verification_replaces_content_and_records_hypotheses():
+    outline = _make_outline(1)
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=1,
+        generated_content="Roher Text mit 42 % Behauptung.",
+        verify_prose_fn=lambda content, pool: FakeVerifiedProse(
+            "Bereinigter Text.", changed=True, rejected=["42 % Behauptung"]
+        ),
+    )
+    agent = FakeAgent()
+
+    result = process_section(agent, outline.sections[0], ctx, section_index=1)
+
+    assert result.content == "Bereinigter Text."
+    assert agent.recorded_prose_hypotheses == [(1, ["42 % Behauptung"])]
+
+
+def test_prose_verification_is_skipped_for_fallback_content():
+    outline = _make_outline(1)
+    verifications: List[int] = []
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=1,
+        is_fallback=lambda content: True,
+        verify_prose_fn=lambda content, pool: verifications.append(1) or FakeVerifiedProse(content),
+    )
+
+    process_section(FakeAgent(), outline.sections[0], ctx, section_index=1)
+
+    assert verifications == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Metadaten (M11.8d / P0-6)
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_is_attached_to_section_and_agent():
+    outline = _make_outline(1)
+    FakePhaseTracker.instances.clear()
+    ctx = _make_ctx(
+        outline=outline,
+        total_sections=1,
+        generate_metadata=lambda agent, **kw: {"key_findings": ["A"]},
+    )
+    agent = FakeAgent()
+    section = outline.sections[0]
+
+    result = process_section(agent, section, ctx, section_index=1)
+
+    assert result.metadata == {"key_findings": ["A"]}
+    assert section.metadata["structured_metadata"] == {"key_findings": ["A"]}
+    assert agent.recorded_metadata == [(1, {"key_findings": ["A"]})]
+    assert agent.report_logger.section_metadata[0]["section_index"] == 1
+    assert FakePhaseTracker.instances[-1].phases == ["section_metadata"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Evidence-Ergebnis wird beobachtbar durchgereicht (Vorarbeit Issue #1209)
+# ---------------------------------------------------------------------------
+
+
+def test_result_carries_bound_claims_and_gate_decisions():
+    """Was gebunden und was verworfen wurde, steht im SectionResult.
+
+    Vorbedingung für Issue #1209 Befund 6: die Zuordnung von Claims zu
+    Evidence ist am Interface prüfbar, ohne die persistierte Evidenzkarte zu
+    durchsuchen und ohne ``patch()``.
+    """
+    outline = _make_outline(1)
+    outcome = SectionEvidenceOutcome(
+        claims=[{"claim_id": "claim_01", "evidence": ["ev_a"]}],
+        hypotheses=[{"hypothesis_id": "hypothesis_01", "hypothesis_text": "Unbelegt."}],
+        data_gaps=[{"gap_id": "gap_01"}],
+        gate_decisions=[{
+            "claim_id": "claim_02",
+            "violation": "no_supporting_evidence",
+            "action": "moved_to_hypotheses",
+            "detail": "Keine direkte Evidence gebunden.",
+        }],
+    )
+    ctx = _make_ctx(outline=outline, total_sections=1)
+    agent = FakeAgent(evidence_outcome=outcome)
+
+    result = process_section(agent, outline.sections[0], ctx, section_index=1)
+
+    assert result.bound_claims == [{"claim_id": "claim_01", "evidence": ["ev_a"]}]
+    assert result.hypotheses[0]["hypothesis_id"] == "hypothesis_01"
+    assert result.gate_decisions[0]["violation"] == "no_supporting_evidence"
+    assert result.evidence.data_gaps == [{"gap_id": "gap_01"}]
+
+
+def test_outcome_reads_from_the_validated_evidence_map():
+    """``from_persisted_section`` spiegelt die Karte nach der Validierung.
+
+    Die Reparaturläufe bei ``ValidationError`` können Einträge entfernen —
+    maßgeblich ist, was am Ende in der Karte steht.
+    """
+    validated = {
+        "sections": [
+            {"section_index": 1, "claims": [{"claim_id": "claim_x"}]},
+            {
+                "section_index": 2,
+                "claims": [{"claim_id": "claim_y"}],
+                "hypotheses": [{"hypothesis_id": "hypothesis_01"}],
+                "hypotheses_appendix": [{"hypothesis_id": "hypothesis_02"}],
+                "data_gaps": [{"gap_id": "gap_01"}],
+            },
+        ]
+    }
+
+    outcome = SectionEvidenceOutcome.from_persisted_section(
+        validated, 2, gate_decisions=[{"violation": "no_supporting_evidence"}],
+        generation_failed=False,
+    )
+
+    assert outcome.claims == [{"claim_id": "claim_y"}]
+    assert outcome.hypotheses == [{"hypothesis_id": "hypothesis_01"}]
+    assert outcome.hypotheses_appendix == [{"hypothesis_id": "hypothesis_02"}]
+    assert outcome.data_gaps == [{"gap_id": "gap_01"}]
+    assert outcome.gate_decisions == [{"violation": "no_supporting_evidence"}]
+    assert outcome.generation_failed is False
+
+
+def test_outcome_for_unknown_section_is_empty_not_an_error():
+    outcome = SectionEvidenceOutcome.from_persisted_section(
+        {"sections": []}, 7, gate_decisions=[], generation_failed=True
+    )
+
+    assert outcome.claims == []
+    assert outcome.generation_failed is True

--- a/changelog.d/1212-section-pipeline.md
+++ b/changelog.d/1212-section-pipeline.md
@@ -1,0 +1,5 @@
+Der Abschnitts-Durchlauf der Reportgenerierung liegt nicht mehr als Schleife in `generate_report`, sondern hinter `process_section` im neuen Modul `app/services/report_agent/section_pipeline.py`. `generate_report` schrumpft von 455 auf 322 Zeilen und behält nur noch die Orchestrierung: Abbruchprüfung, Akkumulation der fertigen Abschnitte und Statusableitung.
+
+Was ein Abschnitt beim Verarbeiten braucht, kommt über `SectionContext` herein — Daten und Seams, mit Default-Bindung an die echten Implementierungen. Das Ergebnis steht in `SectionResult` und trägt beobachtbar, was gebunden und was vom Evidence-Gate verworfen wurde. `ReportAgent._save_evidence_section` gibt dieses Ergebnis dafür zurück, statt es nur als Seiteneffekt in der Evidenzkarte abzulegen; die Persistenz bleibt unverändert.
+
+Verhalten unverändert — reiner Deepening-Refactor.


### PR DESCRIPTION
Schließt #1212.

## Was sich ändert

Der Abschnitts-Durchlauf lag als 188-Zeilen-Schleife in `generate_report`. Er steht jetzt in `backend/app/services/report_agent/section_pipeline.py` hinter

```python
process_section(agent, section, ctx: SectionContext, *, section_index: int) -> SectionResult
```

`SectionContext` trägt alles, was der Ablauf über seine Umgebung braucht — Daten und Seams mit Default-Bindung an die echten Implementierungen. Dasselbe Options-Muster wie in `useReportGeneration.ts` (#1206). `generate_report` behält die Orchestrierung: Abbruchprüfung an der Stage-Boundary, Akkumulation der fertigen Abschnitte, Statusableitung.

| | vorher | nachher |
|---|---|---|
| `generate_report` | 455 Zeilen, cc 70 | 322 Zeilen, cc 47 |
| `process_section` | — | cc 8 |
| `section_pipeline.py` | — | keine Funktion über Rank B |
| `workflow.py` | 1533 Zeilen | 1388 Zeilen |

## Grenze zu #1209 Befund 6

Claim-Extraktion und Evidence-Binding liegen innerhalb von `process_section` und schlagen sich im `SectionResult` nieder — gebundene Claims, Hypothesen, Datenlücken und Gate-Entscheidungen mit Grund, nicht als Seiteneffekt auf dem Kontextobjekt.

Damit das trägt, gibt `ReportAgent._save_evidence_section` sein Ergebnis zurück statt nur in die Evidenzkarte zu schreiben. Rein additiv: sämtliche Persistenz-Seiteneffekte sind unverändert, und alle sieben aufrufenden Testdateien ignorieren den Rückgabewert bereits heute. Gelesen wird aus der **validierten** Karte — die Reparaturläufe bei `ValidationError` können Einträge entfernen, maßgeblich ist, was am Ende drinsteht.

`test_result_carries_bound_claims_and_gate_decisions` zeigt, dass ein Test „Claim mit passender Evidence wird gebunden" danach ohne Modul-Patches schreibbar ist. Der Fix für Befund 6 selbst ist nicht Teil dieses PRs.

## Tests

16 neue Tests in `backend/tests/services/test_section_pipeline.py` prüfen `SectionResult` direkt am Interface — **kein einziger `patch()`-Aufruf**. Abgedeckt: Resume-Pfad, regulärer Durchlauf, Fallback-Erkennung, Zitat-Repair (erfolgreich/gescheitert/übersprungen), Fließtext-Verifikation, Metadaten und die Durchreichung des Evidence-Ergebnisses.

`test_partial_report.py` läuft **unverändert** durch, inklusive seiner 21 Patches: die Seams werden in `generate_report` aus den Modul-Globals gebunden, damit bleibt patchbar, was patchbar war. Eine Verdrahtungsänderung war nicht nötig.

## Abgrenzung

Reiner Deepening-Refactor, Verhalten unverändert. Die fünf ADR-0002-Hartanker sind unberührt — `git diff origin/main` auf `report_prompts/sections.py`, den Hedge-Snapshot und `report_contract.py` ist leer.

## Gate

```
4970 passed, 10 skipped
ruff · mypy · dump_schemas --check   ohne Befund
pre-push-gate.sh backend             ALL GREEN
```

`contract-gates` ist auf `main` unabhängig von diesem PR rot (Radon-Allowlist-Drift, seit acht Läufen) — analysiert und getrennt in #1213. Die fünf gemeldeten Hotspots liegen sämtlich außerhalb der hier berührten Dateien und sind durch diesen PR unverändert.