### PR TITLE
bug(sim): Twitter only CREATE_POST and Reddit no Dislikes fixed in prompt builder

### DIFF
--- a/backend/scripts/agent_tools.py
+++ b/backend/scripts/agent_tools.py
@@ -615,9 +615,10 @@ You can perform one of these actions: {action_names}
 
 ## Interaction and Conflict (IMPORTANT)
 Do not be overly polite, agreeable, or passive. In real-world social media, users frequently express dissent, disagreement, or opposition.
-If any post, comment, or opinion on your timeline contradicts your bio, beliefs, professional role, or political alignment, you should actively:
-- DISLIKE the post or comment, or
-- Write a reply comment with clear dissent, expressing disagreement, criticism, or alternative viewpoints.
+If a post, comment, or opinion on your timeline contradicts your bio, beliefs, professional role, or political alignment, you should actively dissent — but ONLY via an action that is listed in "Available Actions" above. For example:
+- DISLIKE via DISLIKE_POST or DISLIKE_COMMENT, or
+- reply via CREATE_COMMENT with clear disagreement, criticism, or alternative viewpoints.
+If none of these conflict actions are listed in "Available Actions", choose another listed action (e.g. DO_NOTHING) rather than emitting an action that is not available — the parser will drop unavailable actions anyway.
 Ensure your actions and text content realistically reflect conflicts, concerns, or opposition exactly as your persona would in the real world.
 
 ## Response Language
@@ -793,37 +794,94 @@ class ToolAwareActionLoop:
         return LLMAction()
 
     def _create_manual_action(self, action_data: Dict[str, Any], available_actions: List[str]) -> Any:
-        """Convert parsed action JSON to OASIS ManualAction"""
+        """Convert parsed action JSON to an OASIS ManualAction.
+
+        The prompt contract (see ``build_agent_prompt_with_tools``) asks the
+        model to supply target IDs as ``post_id`` / ``comment_id`` / ``agent_id``
+        and free text as ``content``. OASIS' platform functions, however,
+        expect action-specific kwargs (``followee_id`` for FOLLOW,
+        ``mutee_id`` for MUTE, ``quote_content`` for QUOTE_POST — see
+        ``oasis/social_agent/agent_action.py``). This method maps the prompt
+        contract onto those kwarg names and, when ``available_actions`` is
+        non-empty, rejects any action the platform does not offer.
+
+        Any action whose required payload field is missing falls back to
+        ``DO_NOTHING`` — otherwise OASIS would raise a ``TypeError`` at
+        ``env.step`` time, which surfaces as a silent no-op in the simulation
+        log. That mismatch was the root cause of #1215 (B1/B2): pairwise
+        actions were emitted but never executed because their target IDs
+        were discarded here.
+        """
         from oasis import ManualAction, ActionType
 
         action_name = action_data.get("action", "DO_NOTHING").upper()
+        post_id = action_data.get("post_id")
+        comment_id = action_data.get("comment_id")
+        agent_id = action_data.get("agent_id")
         content = action_data.get("content", "")
 
-        # Map action name to ActionType
         action_type_map = {
             "CREATE_POST": ActionType.CREATE_POST,
             "LIKE_POST": ActionType.LIKE_POST,
+            "DISLIKE_POST": ActionType.DISLIKE_POST,
             "REPOST": ActionType.REPOST,
-            "FOLLOW": ActionType.FOLLOW,
-            "DO_NOTHING": ActionType.DO_NOTHING,
             "QUOTE_POST": ActionType.QUOTE_POST,
-            "COMMENT": ActionType.CREATE_POST,  # Reddit uses CREATE_POST for comments
+            "FOLLOW": ActionType.FOLLOW,
+            "MUTE": ActionType.MUTE,
+            "CREATE_COMMENT": ActionType.CREATE_COMMENT,
+            "LIKE_COMMENT": ActionType.LIKE_COMMENT,
+            "DISLIKE_COMMENT": ActionType.DISLIKE_COMMENT,
+            "DO_NOTHING": ActionType.DO_NOTHING,
         }
 
         action_type = action_type_map.get(action_name, ActionType.DO_NOTHING)
 
-        # For actions that need content
-        if action_type in (ActionType.CREATE_POST, ActionType.QUOTE_POST) and content:
+        def _noop() -> ManualAction:
+            return ManualAction(action_type=ActionType.DO_NOTHING, action_args={})
+
+        # Reject actions the platform does not offer — the prompt lists them
+        # as "Available Actions", and emitting a non-listed action would no-op
+        # at the OASIS level anyway (e.g. DISLIKE_* on Twitter).
+        if available_actions and action_name not in available_actions:
+            return _noop()
+
+        if action_type == ActionType.CREATE_POST:
+            if not content:
+                return _noop()
+            return ManualAction(
+                action_type=action_type, action_args={"content": content}
+            )
+        if action_type == ActionType.QUOTE_POST:
+            if post_id is None:
+                return _noop()
             return ManualAction(
                 action_type=action_type,
-                action_args={"content": content}
+                action_args={"post_id": post_id, "quote_content": content},
             )
-        elif action_type == ActionType.LIKE_POST:
-            return ManualAction(action_type=action_type, action_args={})
-        elif action_type == ActionType.REPOST:
-            return ManualAction(action_type=action_type, action_args={"content": content or ""})
-        else:
-            return ManualAction(action_type=ActionType.DO_NOTHING, action_args={})
+        if action_type == ActionType.CREATE_COMMENT:
+            if post_id is None or not content:
+                return _noop()
+            return ManualAction(
+                action_type=action_type,
+                action_args={"post_id": post_id, "content": content},
+            )
+        if action_type in (ActionType.LIKE_POST, ActionType.DISLIKE_POST, ActionType.REPOST):
+            if post_id is None:
+                return _noop()
+            return ManualAction(action_type=action_type, action_args={"post_id": post_id})
+        if action_type in (ActionType.LIKE_COMMENT, ActionType.DISLIKE_COMMENT):
+            if comment_id is None:
+                return _noop()
+            return ManualAction(action_type=action_type, action_args={"comment_id": comment_id})
+        if action_type == ActionType.FOLLOW:
+            if agent_id is None:
+                return _noop()
+            return ManualAction(action_type=action_type, action_args={"followee_id": agent_id})
+        if action_type == ActionType.MUTE:
+            if agent_id is None:
+                return _noop()
+            return ManualAction(action_type=action_type, action_args={"mutee_id": agent_id})
+        return _noop()
 
 
 # ── Convenience: wrap for sync use ──

--- a/backend/scripts/agent_tools.py
+++ b/backend/scripts/agent_tools.py
@@ -577,7 +577,7 @@ def build_agent_prompt_with_tools(
 Bio: {agent_bio[:300]}
 
 ## Current Situation
-{observation[:800]}
+{observation[:1500]}
 
 ## Available Actions
 You can perform one of these actions: {action_names}
@@ -595,10 +595,30 @@ You can perform one of these actions: {action_names}
 </tool_call>
 3. You can call up to the configured tool-call limit in sequence. After each
    tool result, you will see the output and can call another tool or decide.
-4. Only AFTER you have gathered information, output your FINAL ACTION:
+4. Only AFTER you have gathered information, output your FINAL ACTION in <action> tags with the appropriate parameters.
+   If the action is a pairwise action, you MUST provide the target ID in your JSON payload:
+   - For LIKE_POST, DISLIKE_POST, REPOST, CREATE_COMMENT, QUOTE_POST, you MUST specify "post_id" (integer) of the post you are targeting.
+   - For CREATE_COMMENT, also specify "content" (string) for the comment's content.
+   - For QUOTE_POST, also specify "content" (string) for the quote's content.
+   - For LIKE_COMMENT, DISLIKE_COMMENT, you MUST specify "comment_id" (integer) of the comment you are targeting.
+   - For FOLLOW, MUTE, you MUST specify "agent_id" (integer) of the user you want to follow or mute.
+
 <action>
-{{"action": "ACTION_NAME", "content": "Your post content or action details"}}
+{{
+  "action": "ACTION_NAME",
+  "content": "Your post or comment content (if applicable)",
+  "post_id": 123,
+  "comment_id": 456,
+  "agent_id": 789
+}}
 </action>
+
+## Interaction and Conflict (IMPORTANT)
+Do not be overly polite, agreeable, or passive. In real-world social media, users frequently express dissent, disagreement, or opposition.
+If any post, comment, or opinion on your timeline contradicts your bio, beliefs, professional role, or political alignment, you should actively:
+- DISLIKE the post or comment, or
+- Write a reply comment with clear dissent, expressing disagreement, criticism, or alternative viewpoints.
+Ensure your actions and text content realistically reflect conflicts, concerns, or opposition exactly as your persona would in the real world.
 
 ## Response Language
 ALWAYS respond in {lang_instruction}.
@@ -611,7 +631,10 @@ ALWAYS respond in {lang_instruction}.
 [Tool results appear here...]
 
 <action>
-{{"action": "CREATE_POST", "content": "Based on the latest data, I think..."}}
+{{
+  "action": "CREATE_POST",
+  "content": "Based on the latest data, I think..."
+}}
 </action>
 
 Now decide your action."""

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -328,3 +328,132 @@ def test_resolve_memory_token_limit_uses_substring_heuristic_for_unknown_models(
     assert module._resolve_memory_token_limit("qwen3-coder-next:cloud") >= 262_144
     assert module._resolve_memory_token_limit("gpt-oss:120b-cloud") >= 131_072
     assert module._resolve_memory_token_limit("some-unknown-model") == 262_144
+
+
+# ── _create_manual_action: OASIS-Vertrag (#1215 / CodeRabbit Finding A) ──
+#
+# Der Prompt-Builder verlangt Ziel-IDs als post_id/comment_id/agent_id und
+# Content als "content". OASIS' Plattform-Funktionen erwarten aber teils andere
+# kwarg-Namen (followee_id, mutee_id, quote_content). _create_manual_action
+# muss mappen; zuvor wurden Dislike/Comment/Mute gar nicht gemappt und
+# Ziel-IDs verworfen — jede paarerweise Aktion schlug bei env.step fehl und
+# hinterließ nur CREATE_POST (B1) bzw. keinen Dislike (B2).
+
+_ALL_ACTIONS = [
+    "CREATE_POST", "LIKE_POST", "DISLIKE_POST", "REPOST", "QUOTE_POST",
+    "FOLLOW", "MUTE", "CREATE_COMMENT", "LIKE_COMMENT", "DISLIKE_COMMENT",
+    "DO_NOTHING",
+]
+
+
+def _action_loop():
+    module = _load_module(
+        "agent_tools_action_map_test", "backend/scripts/agent_tools.py"
+    )
+    return module.ToolAwareActionLoop(model=None, tools=None), module
+
+
+def test_create_manual_action_maps_all_pairwise_actions_with_oasis_kwargs():
+    from oasis import ActionType
+
+    loop, _ = _action_loop()
+
+    cases = [
+        ({"action": "CREATE_POST", "content": "hi"}, ActionType.CREATE_POST, {"content": "hi"}),
+        ({"action": "LIKE_POST", "post_id": 7}, ActionType.LIKE_POST, {"post_id": 7}),
+        ({"action": "DISLIKE_POST", "post_id": 7}, ActionType.DISLIKE_POST, {"post_id": 7}),
+        ({"action": "REPOST", "post_id": 9}, ActionType.REPOST, {"post_id": 9}),
+        ({"action": "QUOTE_POST", "post_id": 3, "content": "q"},
+         ActionType.QUOTE_POST, {"post_id": 3, "quote_content": "q"}),
+        ({"action": "FOLLOW", "agent_id": 42}, ActionType.FOLLOW, {"followee_id": 42}),
+        ({"action": "MUTE", "agent_id": 42}, ActionType.MUTE, {"mutee_id": 42}),
+        ({"action": "CREATE_COMMENT", "post_id": 5, "content": "c"},
+         ActionType.CREATE_COMMENT, {"post_id": 5, "content": "c"}),
+        ({"action": "LIKE_COMMENT", "comment_id": 11},
+         ActionType.LIKE_COMMENT, {"comment_id": 11}),
+        ({"action": "DISLIKE_COMMENT", "comment_id": 11},
+         ActionType.DISLIKE_COMMENT, {"comment_id": 11}),
+        ({"action": "DO_NOTHING"}, ActionType.DO_NOTHING, {}),
+    ]
+
+    for action_data, exp_type, exp_args in cases:
+        action = loop._create_manual_action(action_data, _ALL_ACTIONS)
+        assert action.action_type == exp_type, (
+            f"{action_data}: action_type {action.action_type} != {exp_type}"
+        )
+        assert action.action_args == exp_args, (
+            f"{action_data}: action_args {action.action_args} != {exp_args}"
+        )
+
+
+def test_create_manual_action_falls_back_to_do_nothing_on_missing_required_payload():
+    from oasis import ActionType
+
+    loop, _ = _action_loop()
+
+    missing_cases = [
+        {"action": "CREATE_POST"},                       # kein content
+        {"action": "LIKE_POST"},                        # kein post_id
+        {"action": "DISLIKE_POST"},                     # kein post_id
+        {"action": "REPOST"},                           # kein post_id
+        {"action": "QUOTE_POST", "content": "q"},        # kein post_id
+        {"action": "FOLLOW"},                           # kein agent_id
+        {"action": "MUTE"},                             # kein agent_id
+        {"action": "CREATE_COMMENT", "post_id": 5},      # kein content
+        {"action": "CREATE_COMMENT", "content": "c"},    # kein post_id
+        {"action": "LIKE_COMMENT"},                     # kein comment_id
+        {"action": "DISLIKE_COMMENT"},                  # kein comment_id
+    ]
+
+    for action_data in missing_cases:
+        action = loop._create_manual_action(action_data, _ALL_ACTIONS)
+        assert action.action_type == ActionType.DO_NOTHING, (
+            f"{action_data}: sollte auf DO_NOTHING fallen, got {action.action_type}"
+        )
+        assert action.action_args == {}
+
+
+def test_create_manual_action_rejects_actions_not_in_available_actions():
+    from oasis import ActionType
+
+    loop, _ = _action_loop()
+    # Twitter-Action-Space: weder DISLIKE_* noch CREATE_COMMENT verfügbar.
+    twitter_actions = [
+        "CREATE_POST", "LIKE_POST", "REPOST", "FOLLOW", "DO_NOTHING", "QUOTE_POST",
+    ]
+
+    assert loop._create_manual_action(
+        {"action": "DISLIKE_POST", "post_id": 1}, twitter_actions
+    ).action_type == ActionType.DO_NOTHING
+    assert loop._create_manual_action(
+        {"action": "CREATE_COMMENT", "post_id": 1, "content": "x"}, twitter_actions
+    ).action_type == ActionType.DO_NOTHING
+    # Erlaubte Aktion wird ausgeführt.
+    assert loop._create_manual_action(
+        {"action": "LIKE_POST", "post_id": 1}, twitter_actions
+    ).action_type == ActionType.LIKE_POST
+    # Leere available_actions = kein Filter (Fallback-Pfad).
+    assert loop._create_manual_action(
+        {"action": "DISLIKE_POST", "post_id": 1}, []
+    ).action_type == ActionType.DISLIKE_POST
+
+
+def test_build_agent_prompt_with_tools_binds_conflict_rule_to_available_actions():
+    module = _load_module(
+        "agent_tools_prompt_conflict_test", "backend/scripts/agent_tools.py"
+    )
+
+    class DummyTools:
+        def tools_description_text(self):
+            return ""
+
+    prompt = module.build_agent_prompt_with_tools(
+        agent_name="A", agent_role="r", agent_bio="b",
+        observation="o", available_actions=["CREATE_POST", "LIKE_POST"],
+        tools=DummyTools(), language="de",
+    )
+    # Die Konflikt-Regel muss die Modell-Auswahl an "Available Actions" binden,
+    # damit auf Plattformen ohne DISLIKE_*/CREATE_COMMENT keine nicht verfügbaren
+    # Aktionen emittiert werden (#1215 / CodeRabbit Finding B).
+    assert "Available Actions" in prompt
+    assert "not available" in prompt.lower()


### PR DESCRIPTION
Diagnosed and resolved simulation action space under-utilization bugs. Updated the prompt builder in agent_tools.py to guide models to utilize target IDs for pairwise actions (like/dislike/follow/mute) and break politeness bias by encouraging realistic conflict and dissent.

Fixes #1215

---
*PR created automatically by Jules for task [6973206345142407414](https://jules.google.com/task/6973206345142407414) started by @arn0ld87*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Agenten können nun einen größeren Beobachtungskontext von bis zu 1.500 Zeichen berücksichtigen.
  * Nach der Nutzung von Werkzeugen werden abschließende Aktionen mit strukturierten Parametern erwartet.
  * Paarweise Aktionen enthalten dabei die erforderlichen Ziel-IDs.
  * Die Vorgaben unterstützen realistischere Meinungsverschiedenheiten in Agenteninteraktionen.
  * Das Aktionsbeispiel verwendet nun ein übersichtlicheres, mehrzeiliges JSON-Format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->