### PR TITLE
fix(sim): Tool-Skip-Regel erlaubt DISLIKE_* ohne Tool-Aufruf (#1215)

### DIFF
--- a/backend/scripts/agent_tools.py
+++ b/backend/scripts/agent_tools.py
@@ -585,10 +585,13 @@ You can perform one of these actions: {action_names}
 {tools.tools_description_text}
 
 ## Tool Usage Rules (IMPORTANT)
-1. You SHOULD call a tool FIRST to gather real information before posting.
+1. You SHOULD call a tool FIRST to gather real information before posting (CREATE_POST).
    Especially use `web_search` or `web_fetch` when the topic mentions
    a specific website, blog, company, or person — never invent facts.
-   Only skip tools if the situation is a trivial LIKE_POST or DO_NOTHING.
+   Call a tool only when the action needs facts you do not already have.
+   For trivial reactions where the observation already shows the target
+   (LIKE_POST, DISLIKE_POST, DISLIKE_COMMENT, LIKE_COMMENT, FOLLOW, MUTE,
+   REPOST, QUOTE_POST, DO_NOTHING), skip tools and output the action directly.
 2. To call a tool, use EXACTLY this format (must appear on its own):
 <tool_call>
 {{"name": "tool_name", "parameters": {{"param": "value"}}}}

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -457,3 +457,32 @@ def test_build_agent_prompt_with_tools_binds_conflict_rule_to_available_actions(
     # Aktionen emittiert werden (#1215 / CodeRabbit Finding B).
     assert "Available Actions" in prompt
     assert "not available" in prompt.lower()
+
+
+def test_build_agent_prompt_with_tools_skips_tools_for_dislike_actions():
+    """CodeRabbit Finding 1316 (#1215): Die Tool-Usage-Rule darf keinen
+    Tool-Aufruf fuer DISLIKE_* erzwingen. Vorher erlaubte die Klausel den
+    Tool-Skip nur fuer LIKE_POST/DO_NOTHING — bei Tool-Limit oder Tool-Fehler
+    fiel DISLIKE_* auf DO_NOTHING zurueck, was B2 (Reddit nie Dislike)
+    mit-erklaert. Die Skip-Klausel muss DISLIKE_POST/DISLIKE_COMMENT explizit
+    nennen, damit das Modell sie direkt ausgeben kann, wenn die Observation
+    das Ziel schon zeigt."""
+    module = _load_module(
+        "agent_tools_prompt_toolskip_test", "backend/scripts/agent_tools.py"
+    )
+
+    class DummyTools:
+        def tools_description_text(self):
+            return ""
+
+    prompt = module.build_agent_prompt_with_tools(
+        agent_name="A", agent_role="r", agent_bio="b",
+        observation="o",
+        available_actions=["CREATE_POST", "LIKE_POST", "DISLIKE_POST",
+                           "DISLIKE_COMMENT", "DO_NOTHING"],
+        tools=DummyTools(), language="de",
+    )
+    assert "trivial reactions" in prompt.lower()
+    skip_window = prompt.lower().split("trivial reactions", 1)[1][:300]
+    assert "dislike_post" in skip_window
+    assert "dislike_comment" in skip_window

--- a/changelog.d/1215-tool-skip-dislike.md
+++ b/changelog.d/1215-tool-skip-dislike.md
@@ -1,0 +1,3 @@
+### Fixed (Sim Tool-Skip für DISLIKE — 2026-08-11)
+
+- **DISLIKE_* ohne erzwungenen Tool-Aufruf:** Die Tool-Usage-Rule erlaubte den Tool-Skip nur für `LIKE_POST`/`DO_NOTHING` und zwang für `DISLIKE_POST`/`DISLIKE_COMMENT` einen `web_search`/`web_fetch`-Aufruf, der bei Tool-Limit oder Tool-Fehler auf `DO_NOTHING` zurückfiel — Reddit-Agenten dislike-ten nie (B2 aus #1215). Die Skip-Klausel nennt jetzt die volle Reaktionsmenge (`LIKE_POST`, `DISLIKE_POST`, `DISLIKE_COMMENT`, `LIKE_COMMENT`, `FOLLOW`, `MUTE`, `REPOST`, `QUOTE_POST`, `DO_NOTHING`) und fordert Tools nur, wenn Fakten fehlen, die das Modell nicht schon aus der Observation hat. (#1215)


### PR DESCRIPTION
Folge-PR zu #1220 (gemergt in `97a65508`), behebt das vierte CodeRabbit-Finding (1316), das im alten PR nicht mehr landen konnte.

## Problem

CodeRabbit Finding 1316 auf PR #1220: Die `Tool Usage Rules` im Prompt-Builder erlaubten den Tool-Skip nur für `LIKE_POST`/`DO_NOTHING` und zwangen für `DISLIKE_POST`/`DISLIKE_COMMENT` einen `web_search`/`web_fetch`-Aufruf. Bei Tool-Limit oder Tool-Fehler fiel die Aktion auf `DO_NOTHING` zurück — Reddit-Agenten dislike-ten nie (B2 aus #1215).

## Fix

`build_agent_prompt_with_tools` in `backend/scripts/agent_tools.py`: Skip-Klausel nennt jetzt die volle Reaktionsmenge (`LIKE_POST`, `DISLIKE_POST`, `DISLIKE_COMMENT`, `LIKE_COMMENT`, `FOLLOW`, `MUTE`, `REPOST`, `QUOTE_POST`, `DO_NOTHING`) und fordert Tools nur, wenn Fakten fehlen, die das Modell nicht schon aus der Observation hat.

## Test

`test_build_agent_prompt_with_tools_skips_tools_for_dislike_actions` in `backend/tests/test_simulation_runtime.py` — assertiert, dass die Tool-Skip-Klausel `trivial reactions` heißt und `DISLIKE_POST`/`DISLIKE_COMMENT` im Skip-Fenster nennt. RED gegen den gemergten Stand verifiziert (vor dem Fix fehlt `trivial reactions` im Prompt).

## Gates

- contracts: 600 passed
- schema-check: 58/58 matchen
- ruff: clean
- mypy app: success
- pre-push-gate.sh backend: ALL GREEN

Refs #1215.