### PR TITLE
refactor(llm): RequestPlan + ResilientCall — Provider-Quirks aus LLMClient.chat lösen (#1225)

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -43,6 +43,13 @@ from .providers import base as _provider_base
 from .providers import ollama as _provider_ollama
 from .providers import openai as _provider_openai
 from .providers.registry import openai_compat_base_url
+from .request_plan import (
+    TEMPERATURE_QUIRK,
+    TOKEN_KEY_QUIRK,
+    build_request,
+    execute,
+    thinking_extra_body,
+)
 from .tool_calls import _chat_with_tools
 from .transport_security import ensure_credentialed_transport_security
 
@@ -705,37 +712,6 @@ class LLMClient:
             self._log_invocation_event(stage=context, latency_ms=0.0, success=True)
             self._budget_record()
             return e2e_stub_chat_response(messages=messages)
-        kwargs: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-        }
-        # #1096: GPT-5-/o-Reasoning-Familie akzeptiert nur den Default-Wert
-        # (1) und antwortet sonst 400 unsupported_value — kein temperature-
-        # Key im Request statt jedes Mal auf den 400 zu warten.
-        if not self._omits_temperature(self.model or ""):
-            kwargs["temperature"] = temperature
-        kwargs.update(self._completion_token_kwargs(max_tokens))
-
-        if response_format:
-            kwargs["response_format"] = response_format
-
-        # For Ollama: pass num_ctx via extra_body to prevent prompt truncation,
-        # plus think flag to control reasoning output on capable models.
-        # force_no_thinking=True überschreibt self._think hart auf False —
-        # verhindert, dass Reasoning-Profile den Token-Cap mit Thoughts belegen.
-        if self._is_ollama():
-            extra_body: Dict[str, Any] = {}
-            effective_num_ctx = self._ollama_num_ctx_for(max_tokens)
-            if effective_num_ctx:
-                extra_body["options"] = {"num_ctx": effective_num_ctx}
-            extra_body["think"] = False if force_no_thinking else self._think
-            kwargs["extra_body"] = extra_body
-        elif self._is_minimax():
-            # MiniMax-eigenes ``thinking``-Feld (Spec) statt Ollama-``think``.
-            kwargs["extra_body"] = self._minimax_thinking_extra_body(
-                force_no_thinking=force_no_thinking
-            )
-
         # Force streaming for Ollama: the OpenAI-compatible endpoint in Ollama
         # 0.21.0 stalls on non-streaming completions for cloud models (e.g.
         # qwen3-coder-next:cloud, deepseek-v4-flash:cloud) — the call never
@@ -745,15 +721,31 @@ class LLMClient:
             self._is_ollama()
             and os.environ.get("LLM_FORCE_STREAM", "true").lower() in ("1", "true", "yes")
         )
+        # force_no_thinking=True überschreibt self._think hart auf False —
+        # verhindert, dass Reasoning-Profile den Token-Cap mit Thoughts belegen.
+        plan = build_request(
+            model=self.model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format=response_format,
+            extra_body=thinking_extra_body(
+                ollama=self._is_ollama(),
+                minimax=self._is_minimax(),
+                num_ctx=self._ollama_num_ctx_for(max_tokens),
+                think=False if force_no_thinking else self._think,
+            ),
+            stream=force_stream,
+        )
 
         def _create(call_kwargs: Dict[str, Any]) -> Tuple[Any, float]:
-            """Single-Attempt-Wrapper mit transient-retry. Budget-Check,
-            Failure-Telemetrie und -Record laufen INNERHALB des Wrappers —
-            jeder Retried-Attempt erzeugt damit genau eine
+            """Ein physischer Providerattempt mit transient-retry.
+
+            Budget-Check, Failure-Telemetrie und -Record laufen INNERHALB des
+            Wrappers — jeder Retried-Attempt erzeugt damit genau eine
             Check/Event/Record-Triplet.
 
-            KEINE 400-Behandlung — die macht der aeussere Wrapper
-            ``_call_with_token_key_fallback``.
+            KEINE 400-Behandlung: die machen die Quirks in ``execute``.
             """
             return llm_call_with_retry(
                 lambda: self._provider_attempt(call_kwargs, context),
@@ -762,59 +754,17 @@ class LLMClient:
                 max_delay=self._retry_max_delay,
             )
 
-        def _call_with_token_key_fallback(call_kwargs: Dict[str, Any]) -> Tuple[Any, float]:
-            """Fallback-Retry: bei 400 wg. max_tokens/max_completion_tokens-Inkompatibilität
-            einmalig den anderen Schlüssel verwenden. Heuristik in
-            ``_uses_max_completion_tokens`` deckt die bekannten Familien ab; der
-            Fallback schützt vor neuen Modellen/Proxies, die wir noch nicht kennen.
+        def _call() -> Tuple[Any, float]:
+            """Der abgesicherte Call: Token-Key-Quirk innen, Temperature aussen.
 
-            Jeder Aufruf von ``_create`` zaehlt als separater Providerattempt
-            mit eigener Check/Event/Record-Triplet.
+            Beide Quirks greifen unabhaengig voneinander — der aeussere setzt
+            auf dem Originalrequest auf, und der innere steht dem korrigierten
+            Lauf wieder zur Verfuegung. Jeder Neuversuch zaehlt als eigener
+            Providerattempt mit eigener Check/Event/Record-Triplet.
             """
-            try:
-                return _create(call_kwargs)
-            except Exception as exc:  # noqa: BLE001 — wir filtern selbst
-                if not self._is_token_key_400(exc):
-                    raise
-                swapped = self._swap_token_kwargs(call_kwargs)
-                if swapped is None:
-                    raise
-                logger.warning(
-                    "LLM 400 on token-limit key — retrying once with swapped key (model=%s, msg=%s)",
-                    self.model,
-                    str(exc)[:200],
-                )
-                return _create(swapped)
-
-        def _call_with_temperature_fallback(call_kwargs: Dict[str, Any]) -> Tuple[Any, float]:
-            """Fallback-Retry (#1096): bei 400 wg. einem nicht unterstuetzten
-            ``temperature``-Wert (GPT-5-/o-Reasoning-Familie akzeptiert nur
-            den Default) einmalig ohne ``temperature`` retryen.
-            ``_omits_temperature`` deckt die bekannten Familien bereits
-            proaktiv ab (kein ``temperature``-Key im Request); dieser
-            Fallback ist das Netz fuer neue Modelle/Proxies, die wir noch
-            nicht kennen — komponiert mit dem Token-Key-Fallback statt ihn
-            zu ersetzen, damit beide Retries unabhaengig voneinander
-            greifen koennen.
-
-            Jeder Aufruf von ``_call_with_token_key_fallback`` zaehlt als
-            separater Providerattempt mit eigener Check/Event/Record-Triplet.
-            """
-            try:
-                return _call_with_token_key_fallback(call_kwargs)
-            except Exception as exc:  # noqa: BLE001 — wir filtern selbst
-                if not self._is_temperature_400(exc):
-                    raise
-                if "temperature" not in call_kwargs:
-                    raise
-                dropped = dict(call_kwargs)
-                dropped.pop("temperature", None)
-                logger.warning(
-                    "LLM 400 on temperature param — retrying once without temperature (model=%s, msg=%s)",
-                    self.model,
-                    str(exc)[:200],
-                )
-                return _call_with_token_key_fallback(dropped)
+            return execute(
+                plan, _create, quirks=(TOKEN_KEY_QUIRK, TEMPERATURE_QUIRK)
+            )
 
         # Provider-Pfad: jeder physische Request (erster Call, jeder Retry,
         # Token-Key-Fallback, Temperature-Fallback) erhaelt GENAU EINE
@@ -830,8 +780,7 @@ class LLMClient:
         completion_tokens: Optional[int] = None
         try:
             if force_stream:
-                kwargs["stream"] = True
-                _response, _latency_ms = _call_with_temperature_fallback(kwargs)
+                _response, _latency_ms = _call()
                 chunks: List[str] = []
                 try:
                     for event in _response:  # type: ignore[union-attr]
@@ -864,7 +813,7 @@ class LLMClient:
                     raise
                 content = "".join(chunks)
             else:
-                _response, _latency_ms = _call_with_temperature_fallback(kwargs)
+                _response, _latency_ms = _call()
                 # Issue #764 (Review): die lokale Verarbeitung einer
                 # HTTP-erfolgreichen Antwort kann fehlschlagen (leeres
                 # ``choices``, ``message`` ohne ``content``, fehlende
@@ -990,28 +939,28 @@ class LLMClient:
                 {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{image_b64}"}},
             ],
         }]
-        kwargs: Dict[str, Any] = {
-            "model": vision_model,
-            "messages": messages,
-        }
-        # #1096: siehe chat() — GPT-5-/o-Reasoning-Familie akzeptiert nur den
-        # Default-``temperature``-Wert (1).
-        if not self._omits_temperature(vision_model or ""):
-            kwargs["temperature"] = temperature
-        kwargs.update(self._completion_token_kwargs(max_tokens, model=vision_model))
-        if self._is_ollama():
-            extra_body: Dict[str, Any] = {
-                "options": {
-                    "num_ctx": max(
-                        self._ollama_num_ctx_for(max_tokens, model=vision_model) or 0,
-                        8192,
-                    )
-                }
-            }
-            extra_body["think"] = False  # never want reasoning noise in vision output
-            kwargs["extra_body"] = extra_body
+        plan = build_request(
+            model=vision_model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            extra_body=thinking_extra_body(
+                ollama=self._is_ollama(),
+                # MiniMax wird auf dem Vision-Pfad bewusst nicht behandelt —
+                # das ist der Ist-Zustand, kein Versehen dieses Refactorings.
+                minimax=False,
+                # Vision-Boden: ein Bild belegt das Kontextfenster spürbar,
+                # deshalb hier mehr als das, was max_tokens allein verlangt.
+                num_ctx=max(
+                    self._ollama_num_ctx_for(max_tokens, model=vision_model) or 0,
+                    8192,
+                ),
+                # never want reasoning noise in vision output
+                think=False,
+            ),
+        )
 
-        def _create_vision(call_kwargs: Dict[str, Any]):
+        def _create_vision(call_kwargs: Dict[str, Any]) -> Any:
             return llm_call_with_retry(
                 self.client.chat.completions.create,
                 max_retries=self._max_retries,
@@ -1020,19 +969,9 @@ class LLMClient:
                 **call_kwargs,
             )
 
-        try:
-            response = _create_vision(kwargs)
-        except Exception as exc:  # noqa: BLE001
-            if not self._is_token_key_400(exc):
-                raise
-            swapped = self._swap_token_kwargs(kwargs)
-            if swapped is None:
-                raise
-            logger.warning(
-                "Vision LLM 400 on token-limit key — retrying once with swapped key (model=%s)",
-                vision_model,
-            )
-            response = _create_vision(swapped)
+        response = execute(
+            plan, _create_vision, quirks=(TOKEN_KEY_QUIRK,), label="vision"
+        )
         content = response.choices[0].message.content or ""
         content = re.sub(r'<think>[\s\S]*?</think>', '', content, flags=re.IGNORECASE).strip()
         return content

--- a/backend/app/llm/request_plan.py
+++ b/backend/app/llm/request_plan.py
@@ -1,0 +1,275 @@
+"""Bauen und Durchbringen eines Provider-Requests (Issue #1225).
+
+``LLMClient.chat`` hat beides in einer 315-Zeilen-Methode gemacht: den Request
+zusammensetzen und ihn gegen bekannte Provider-400er durchbringen. Beides lag
+dort nicht allein — dasselbe Shaping stand nochmal in ``describe_image`` und in
+``tool_calls._chat_with_tools``, dieselbe Fallback-Kaskade nochmal in beiden.
+Jede Kopie hatte eine andere Lücke: der Tools-Pfad kennt den
+``temperature``-Quirk aus #1096 nicht, der Vision-Pfad kennt MiniMax nicht.
+Lücken dieser Art entstehen nicht durch Absicht, sondern dadurch, dass beim
+Nachziehen eines Quirks eine der Kopien übersehen wird.
+
+Hier stehen die beiden Hälften getrennt und je genau einmal:
+
+``build_request``
+    Rein, ohne I/O. Setzt ``temperature`` nur, wenn das Modell einen
+    abweichenden Wert überhaupt akzeptiert, und wählt zwischen ``max_tokens``
+    und ``max_completion_tokens``. Was der Aufruf über seine Umgebung braucht,
+    kommt über ``RequestOptions`` herein — Seams mit Default-Bindung an die
+    echten Implementierungen, dasselbe Options-Muster wie ``SectionContext``
+    in ``app/services/report_agent/section_pipeline.py`` (#1212). Ein Test
+    setzt Fakes in die Options, statt Modulnamen zu patchen.
+
+``thinking_extra_body``
+    Der provider-spezifische ``extra_body``: Ollamas ``options.num_ctx`` +
+    ``think``, MiniMax' ``thinking.type``. Ebenfalls rein — welcher Provider
+    vorliegt, entscheidet der Aufrufer und reicht es herein.
+
+``execute``
+    Die Fehlerbehandlung, ohne Shaping. Wickelt den Attempt von innen nach
+    außen in je einen ``Quirk``; jeder versucht genau einmal neu, mit dem
+    kwargs-Stand, den er selbst gesehen hat.
+
+Dieses Modul trifft **keine** Provider-Detection. ``providers/registry.py::
+detect_provider`` bleibt dafür Single Source of Truth; hier kommt das Ergebnis
+als Parameter herein.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from ..utils.logger import get_logger
+from .providers import openai as _provider_openai
+
+logger = get_logger("agora.llm_client")
+
+
+# ---------------------------------------------------------------------------
+# Bauen
+# ---------------------------------------------------------------------------
+
+
+def _default_completion_token_key(model: str) -> str:
+    """``max_completion_tokens`` oder ``max_tokens``, je nach Modellfamilie."""
+    return (
+        "max_completion_tokens"
+        if _provider_openai.uses_max_completion_tokens(model)
+        else "max_tokens"
+    )
+
+
+@dataclass(frozen=True)
+class RequestOptions:
+    """Was ``build_request`` über die Umgebung braucht.
+
+    Die Felder sind Seams: im Betrieb zeigen sie auf die echten
+    Provider-Heuristiken, im Test auf Fakes. Damit ist ``build_request`` ohne
+    ``patch()`` auf Modulnamen prüfbar.
+    """
+
+    omits_temperature: Callable[[str], bool] = _provider_openai.omits_temperature
+    completion_token_key: Callable[[str], str] = _default_completion_token_key
+
+
+DEFAULT_REQUEST_OPTIONS = RequestOptions()
+
+
+@dataclass(frozen=True)
+class RequestPlan:
+    """Der fertige Request — genau das, was an ``completions.create`` geht."""
+
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+def build_request(
+    *,
+    model: Optional[str],
+    messages: List[Dict[str, Any]],
+    temperature: float,
+    max_tokens: int,
+    response_format: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    stream: bool = False,
+    extra: Optional[Dict[str, Any]] = None,
+    options: RequestOptions = DEFAULT_REQUEST_OPTIONS,
+) -> RequestPlan:
+    """Baut die ``create()``-kwargs und wendet dabei die Shaping-Quirks an.
+
+    Parameters:
+        model: Zielmodell. Bestimmt auch, welche Quirks greifen.
+        messages: Nachrichten in OpenAI-Form.
+        temperature: Gewünschte Temperatur. Landet **nicht** im Request, wenn
+            das Modell laut ``options.omits_temperature`` nur den Default
+            akzeptiert (#1096) — sonst antwortet die GPT-5-/o-Reasoning-Familie
+            400 ``unsupported_value``.
+        max_tokens: Ausgabelimit. Der Schlüsselname kommt aus
+            ``options.completion_token_key``.
+        response_format: Optionales ``response_format``, unverändert übernommen.
+        extra_body: Optionaler Provider-``extra_body``, üblicherweise aus
+            :func:`thinking_extra_body`.
+        stream: Wenn ``True``, wird ``stream=True`` gesetzt. Bei ``False``
+            bleibt der Schlüssel weg statt auf ``False`` zu stehen — der
+            Request soll aussehen wie vorher.
+        extra: Weitere kwargs, die dieser Aufrufpfad braucht (``tools``,
+            ``tool_choice``).
+        options: Provider-Seams.
+
+    Returns:
+        RequestPlan: Der fertige Request.
+    """
+    target_model = model or ""
+    kwargs: Dict[str, Any] = {"model": model, "messages": messages}
+    if not options.omits_temperature(target_model):
+        kwargs["temperature"] = temperature
+    kwargs[options.completion_token_key(target_model)] = max_tokens
+    if response_format:
+        kwargs["response_format"] = response_format
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+    if extra:
+        kwargs.update(extra)
+    if stream:
+        kwargs["stream"] = True
+    return RequestPlan(kwargs=kwargs)
+
+
+def thinking_extra_body(
+    *,
+    ollama: bool,
+    minimax: bool,
+    num_ctx: Optional[int] = None,
+    think: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Der provider-spezifische ``extra_body`` für Reasoning und Kontextfenster.
+
+    Ollama bekommt ``options.num_ctx`` (nur wenn gesetzt — sonst gilt der
+    Serverdefault) und immer ein ``think``-Flag. MiniMax bekommt sein eigenes
+    ``thinking``-Feld laut Spec. Alles andere bekommt keinen ``extra_body``.
+
+    Welcher Provider vorliegt, entscheidet der Aufrufer: die Detection ist
+    ``providers/registry.py``-Sache, nicht Sache dieses Moduls.
+    """
+    if ollama:
+        body: Dict[str, Any] = {}
+        if num_ctx:
+            body["options"] = {"num_ctx": num_ctx}
+        body["think"] = think
+        return body
+    if minimax:
+        return {"thinking": {"type": "adaptive" if think else "disabled"}}
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Durchbringen
+# ---------------------------------------------------------------------------
+
+
+def _drop_temperature(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Kopie ohne ``temperature``, oder ``None`` wenn keins gesetzt war."""
+    if "temperature" not in kwargs:
+        return None
+    dropped = dict(kwargs)
+    dropped.pop("temperature", None)
+    return dropped
+
+
+@dataclass(frozen=True)
+class Quirk:
+    """Ein Provider-400 und die eine Umschreibung, die ihn behebt.
+
+    ``matches`` entscheidet, ob dieser Quirk die Ursache ist; ``rewrite``
+    liefert den korrigierten Request oder ``None``, wenn an diesem Request
+    nichts zu korrigieren ist (dann propagiert der Fehler unverändert).
+    """
+
+    name: str
+    remedy: str
+    matches: Callable[[Exception], bool]
+    rewrite: Callable[[Dict[str, Any]], Optional[Dict[str, Any]]]
+
+
+TOKEN_KEY_QUIRK = Quirk(
+    name="token-limit key",
+    remedy="swapped key",
+    matches=_provider_openai.is_token_key_400,
+    rewrite=_provider_openai.swap_token_kwargs,
+)
+"""400 wegen ``max_tokens`` / ``max_completion_tokens``-Inkompatibilität.
+
+``uses_max_completion_tokens`` deckt die bekannten Familien proaktiv ab; dieser
+Fallback ist das Netz für neue Modelle und Proxies, die wir noch nicht kennen.
+"""
+
+TEMPERATURE_QUIRK = Quirk(
+    name="temperature param",
+    remedy="temperature dropped",
+    matches=_provider_openai.is_temperature_400,
+    rewrite=_drop_temperature,
+)
+"""400 wegen eines nicht unterstützten ``temperature``-Werts (#1096).
+
+``omits_temperature`` fängt die bekannten Reasoning-Familien schon beim Bauen
+ab; hier bleibt das Netz für die, die noch nicht in der Heuristik stehen.
+"""
+
+
+def _with_quirk[T](
+    inner: Callable[[Dict[str, Any]], T],
+    quirk: Quirk,
+    label: Optional[str],
+) -> Callable[[Dict[str, Any]], T]:
+    """Legt *quirk* um *inner*: bei Treffer genau ein Neuversuch."""
+
+    def wrapped(kwargs: Dict[str, Any]) -> T:
+        try:
+            return inner(kwargs)
+        except Exception as exc:  # noqa: BLE001 — wir filtern selbst
+            if not quirk.matches(exc):
+                raise
+            rewritten = quirk.rewrite(kwargs)
+            if rewritten is None:
+                raise
+            logger.warning(
+                "LLM 400 on %s%s — retrying once with %s (model=%s, msg=%s)",
+                quirk.name,
+                f" ({label})" if label else "",
+                quirk.remedy,
+                kwargs.get("model"),
+                str(exc)[:200],
+            )
+            return inner(rewritten)
+
+    return wrapped
+
+
+def execute[T](
+    plan: RequestPlan,
+    attempt: Callable[[Dict[str, Any]], T],
+    *,
+    quirks: Sequence[Quirk] = (),
+    label: Optional[str] = None,
+) -> T:
+    """Führt *attempt* mit dem Request aus *plan* aus, abgesichert durch *quirks*.
+
+    ``attempt`` bekommt die kwargs und macht damit genau einen physischen
+    Versuch — inklusive dessen, was dieser Aufrufpfad an Transient-Retry,
+    Budget-Gate und Telemetrie um den Call legt. Dieses Modul kennt davon
+    nichts; es entscheidet nur, ob ein 400 einen korrigierten zweiten Versuch
+    wert ist.
+
+    *quirks* steht von innen nach außen: ``quirks[0]`` sieht den Fehler zuerst,
+    ``quirks[-1]`` zuletzt. Jeder Quirk versucht genau einmal neu, und zwar mit
+    dem kwargs-Stand, den er selbst übergeben bekommen hat — ein äußerer Quirk
+    setzt also auf dem Originalrequest auf, nicht auf der Korrektur eines
+    inneren, und der innere steht dem korrigierten Lauf wieder zur Verfügung.
+
+    *label* landet im Warn-Log und benennt den Aufrufpfad (``"vision"``,
+    ``"tools"``), damit die Retries in den Logs unterscheidbar bleiben.
+    """
+    call = attempt
+    for quirk in quirks:
+        call = _with_quirk(call, quirk, label)
+    return call(plan.kwargs)

--- a/backend/app/llm/tool_calls.py
+++ b/backend/app/llm/tool_calls.py
@@ -15,8 +15,29 @@ from typing import Any, Dict, List, Literal, TypedDict
 
 from ..utils.logger import get_logger
 from ..utils.retry import llm_call_with_retry
+from .request_plan import (
+    TOKEN_KEY_QUIRK,
+    RequestOptions,
+    build_request,
+    execute,
+    thinking_extra_body,
+)
 
 logger = get_logger("agora.llm_client")
+
+
+def _never_omits_temperature(model: str) -> bool:
+    """Der Tools-Pfad setzt ``temperature`` bedingungslos.
+
+    Der ``temperature``-Quirk aus #1096 (GPT-5-/o-Reasoning-Familie akzeptiert
+    nur den Default) ist hier nie nachgezogen worden. Ihn jetzt zu aktivieren
+    wäre ein Verhaltensfix, kein Refactor — deshalb steht die Abweichung als
+    sichtbarer Seam da statt als eigene Kopie des Request-Shapings.
+    """
+    return False
+
+
+_TOOLS_REQUEST_OPTIONS = RequestOptions(omits_temperature=_never_omits_temperature)
 
 
 class ToolCallItem(TypedDict):
@@ -201,28 +222,24 @@ def _chat_with_tools(
     import time as _time
     _t0 = _time.monotonic()
 
-    kwargs: Dict[str, Any] = {
-        "model": self.model,
-        "messages": messages,
-        "temperature": temperature,
-        "tools": tools,
-        "tool_choice": tool_choice,
-    }
-    kwargs.update(self._completion_token_kwargs(max_tokens))
-
-    if self._is_ollama():
-        extra_body: Dict[str, Any] = {}
-        effective_num_ctx = self._ollama_num_ctx_for(max_tokens)
-        if effective_num_ctx:
-            extra_body["options"] = {"num_ctx": effective_num_ctx}
-        extra_body["think"] = self._think
-        kwargs["extra_body"] = extra_body
-    elif self._is_minimax():
-        kwargs["extra_body"] = self._minimax_thinking_extra_body()
-
     force_stream = (
         self._is_ollama()
         and os.environ.get("LLM_FORCE_STREAM", "true").lower() in ("1", "true", "yes")
+    )
+    plan = build_request(
+        model=self.model,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        extra_body=thinking_extra_body(
+            ollama=self._is_ollama(),
+            minimax=self._is_minimax(),
+            num_ctx=self._ollama_num_ctx_for(max_tokens),
+            think=self._think,
+        ),
+        stream=force_stream,
+        extra={"tools": tools, "tool_choice": tool_choice},
+        options=_TOOLS_REQUEST_OPTIONS,
     )
 
     def _create(call_kwargs: Dict[str, Any]) -> Any:
@@ -234,22 +251,8 @@ def _chat_with_tools(
             **call_kwargs,
         )
 
-    def _create_with_fallback(call_kwargs: Dict[str, Any]) -> Any:
-        try:
-            return _create(call_kwargs)
-        except Exception as exc:  # noqa: BLE001
-            if not self._is_token_key_400(exc):
-                raise
-            swapped = self._swap_token_kwargs(call_kwargs)
-            if swapped is None:
-                raise
-            logger.warning(
-                "LLM 400 on token-limit key (tools path) — retrying once with swapped key "
-                "(model=%s, msg=%s)",
-                self.model,
-                str(exc)[:200],
-            )
-            return _create(swapped)
+    def _create_with_fallback() -> Any:
+        return execute(plan, _create, quirks=(TOKEN_KEY_QUIRK,), label="tools")
 
     content: str = ""
     tool_calls: List[ToolCallItem] = []
@@ -258,11 +261,10 @@ def _chat_with_tools(
 
     try:
         if force_stream:
-            kwargs["stream"] = True
-            stream = _create_with_fallback(kwargs)
+            stream = _create_with_fallback()
             content, tool_calls, finish_reason = _accumulate_streaming_tool_calls(stream)
         else:
-            raw_response = _create_with_fallback(kwargs)
+            raw_response = _create_with_fallback()
             choice = raw_response.choices[0]
             finish_reason = getattr(choice, "finish_reason", "stop") or "stop"
             message = choice.message

--- a/backend/tests/llm/test_request_plan.py
+++ b/backend/tests/llm/test_request_plan.py
@@ -1,0 +1,345 @@
+"""Tests für ``app.llm.request_plan`` (Issue #1225).
+
+Alles hier prüft das Interface direkt: ``build_request`` bekommt seine
+Provider-Heuristiken über ``RequestOptions`` herein, ``execute`` bekommt seinen
+Attempt als Callable. Kein ``patch()`` auf Modulnamen — was ein Test einsetzt,
+setzt er als Argument ein.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from app.llm.request_plan import (
+    DEFAULT_REQUEST_OPTIONS,
+    TEMPERATURE_QUIRK,
+    TOKEN_KEY_QUIRK,
+    Quirk,
+    RequestOptions,
+    RequestPlan,
+    build_request,
+    execute,
+    thinking_extra_body,
+)
+
+MESSAGES: List[Dict[str, Any]] = [{"role": "user", "content": "hi"}]
+
+
+def _options(*, omits: bool = False, key: str = "max_tokens") -> RequestOptions:
+    """Options mit festen Antworten — die Seams als Testeingabe."""
+    return RequestOptions(
+        omits_temperature=lambda _model: omits,
+        completion_token_key=lambda _model: key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_request
+# ---------------------------------------------------------------------------
+
+
+def test_build_request_keeps_temperature_when_model_accepts_it() -> None:
+    plan = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=4096,
+        options=_options(omits=False),
+    )
+    assert plan.kwargs["temperature"] == 0.7
+
+
+def test_build_request_omits_temperature_when_model_rejects_it() -> None:
+    """#1096: der Key darf gar nicht erst im Request stehen, nicht nur leer sein."""
+    plan = build_request(
+        model="gpt-5-mini",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=4096,
+        options=_options(omits=True),
+    )
+    assert "temperature" not in plan.kwargs
+
+
+@pytest.mark.parametrize("key", ["max_tokens", "max_completion_tokens"])
+def test_build_request_uses_the_token_key_the_options_name(key: str) -> None:
+    plan = build_request(
+        model="whatever",
+        messages=MESSAGES,
+        temperature=0.3,
+        max_tokens=2048,
+        options=_options(key=key),
+    )
+    assert plan.kwargs[key] == 2048
+    other = "max_completion_tokens" if key == "max_tokens" else "max_tokens"
+    assert other not in plan.kwargs
+
+
+def test_build_request_omits_optional_keys_when_unset() -> None:
+    """Ohne response_format, extra_body, stream oder extra bleibt der Request nackt."""
+    plan = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+        options=_options(),
+    )
+    assert set(plan.kwargs) == {"model", "messages", "temperature", "max_tokens"}
+
+
+def test_build_request_omits_stream_key_when_false() -> None:
+    """``stream=False`` heißt: kein ``stream`` im Request, nicht ``stream=False``."""
+    plan = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+        stream=False,
+        options=_options(),
+    )
+    assert "stream" not in plan.kwargs
+
+    streaming = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+        stream=True,
+        options=_options(),
+    )
+    assert streaming.kwargs["stream"] is True
+
+
+def test_build_request_passes_through_response_format_extra_body_and_extra() -> None:
+    plan = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+        response_format={"type": "json_object"},
+        extra_body={"think": False},
+        extra={"tools": [{"name": "t"}], "tool_choice": "auto"},
+        options=_options(),
+    )
+    assert plan.kwargs["response_format"] == {"type": "json_object"}
+    assert plan.kwargs["extra_body"] == {"think": False}
+    assert plan.kwargs["tools"] == [{"name": "t"}]
+    assert plan.kwargs["tool_choice"] == "auto"
+
+
+def test_build_request_defaults_bind_to_the_real_heuristics() -> None:
+    """Ohne Options greifen die echten Provider-Heuristiken, nicht Platzhalter."""
+    reasoning = build_request(
+        model="gpt-5-mini",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+        options=DEFAULT_REQUEST_OPTIONS,
+    )
+    assert "temperature" not in reasoning.kwargs
+    assert reasoning.kwargs["max_completion_tokens"] == 1024
+
+    classic = build_request(
+        model="gpt-4o",
+        messages=MESSAGES,
+        temperature=0.7,
+        max_tokens=1024,
+    )
+    assert classic.kwargs["temperature"] == 0.7
+    assert classic.kwargs["max_tokens"] == 1024
+
+
+# ---------------------------------------------------------------------------
+# thinking_extra_body
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_extra_body_ollama_carries_num_ctx_and_think() -> None:
+    assert thinking_extra_body(ollama=True, minimax=False, num_ctx=8192, think=True) == {
+        "options": {"num_ctx": 8192},
+        "think": True,
+    }
+
+
+def test_thinking_extra_body_ollama_without_num_ctx_leaves_server_default() -> None:
+    """Ohne num_ctx darf kein ``options``-Block entstehen — sonst überschreibt
+    ein leerer Block still den Serverdefault."""
+    assert thinking_extra_body(ollama=True, minimax=False, num_ctx=None, think=False) == {
+        "think": False
+    }
+
+
+@pytest.mark.parametrize(
+    ("think", "expected"), [(True, "adaptive"), (False, "disabled")]
+)
+def test_thinking_extra_body_minimax_uses_its_own_field(think: bool, expected: str) -> None:
+    assert thinking_extra_body(ollama=False, minimax=True, think=think) == {
+        "thinking": {"type": expected}
+    }
+
+
+def test_thinking_extra_body_returns_none_for_other_providers() -> None:
+    assert thinking_extra_body(ollama=False, minimax=False, num_ctx=8192, think=True) is None
+
+
+def test_thinking_extra_body_prefers_ollama_when_both_flags_set() -> None:
+    body = thinking_extra_body(ollama=True, minimax=True, num_ctx=4096, think=False)
+    assert body is not None
+    assert "think" in body and "thinking" not in body
+
+
+# ---------------------------------------------------------------------------
+# execute
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Attempt-Callable, das jeden Request mitschreibt und nach Skript scheitert.
+
+    *failures* ist die Liste der Exceptions für die ersten Versuche; ist sie
+    aufgebraucht, liefert der Attempt ``"ok"``.
+    """
+
+    def __init__(self, failures: Optional[List[Exception]] = None) -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self._failures = list(failures or [])
+
+    def __call__(self, kwargs: Dict[str, Any]) -> str:
+        self.calls.append(dict(kwargs))
+        if self._failures:
+            raise self._failures.pop(0)
+        return "ok"
+
+
+class _Boom(Exception):
+    """Fehler, den kein Quirk erkennt."""
+
+
+def _plan(**overrides: Any) -> RequestPlan:
+    kwargs: Dict[str, Any] = {"model": "gpt-4o", "max_tokens": 4096, "temperature": 0.7}
+    kwargs.update(overrides)
+    return RequestPlan(kwargs=kwargs)
+
+
+def _token_key_400() -> Exception:
+    return _Boom(
+        "Error code: 400 - Unsupported parameter: 'max_tokens' is not supported "
+        "with this model. Use 'max_completion_tokens' instead."
+    )
+
+
+def _temperature_400() -> Exception:
+    return _Boom(
+        "Unsupported value: 'temperature' does not support 0.7 with this model. "
+        "Only the default (1) value is supported."
+    )
+
+
+def test_execute_without_quirks_runs_the_attempt_once() -> None:
+    attempt = _Recorder()
+    assert execute(_plan(), attempt) == "ok"
+    assert len(attempt.calls) == 1
+
+
+def test_execute_passes_the_plan_kwargs_through_unchanged() -> None:
+    attempt = _Recorder()
+    execute(_plan(messages=MESSAGES), attempt, quirks=(TOKEN_KEY_QUIRK,))
+    assert attempt.calls[0]["messages"] == MESSAGES
+
+
+def test_execute_retries_once_with_the_rewritten_request() -> None:
+    attempt = _Recorder(failures=[_token_key_400()])
+    assert execute(_plan(), attempt, quirks=(TOKEN_KEY_QUIRK,)) == "ok"
+    assert len(attempt.calls) == 2
+    assert attempt.calls[0]["max_tokens"] == 4096
+    assert attempt.calls[1]["max_completion_tokens"] == 4096
+    assert "max_tokens" not in attempt.calls[1]
+
+
+def test_execute_propagates_errors_no_quirk_recognises() -> None:
+    attempt = _Recorder(failures=[_Boom("Invalid API key")])
+    with pytest.raises(_Boom):
+        execute(_plan(), attempt, quirks=(TOKEN_KEY_QUIRK, TEMPERATURE_QUIRK))
+    assert len(attempt.calls) == 1, "ein unbekannter Fehler darf keinen Retry auslösen"
+
+
+def test_execute_propagates_when_the_rewrite_has_nothing_to_change() -> None:
+    """Matchender Quirk ohne anwendbare Korrektur retried nicht."""
+    attempt = _Recorder(failures=[_temperature_400()])
+    with pytest.raises(_Boom):
+        execute(
+            RequestPlan(kwargs={"model": "gpt-4o", "max_tokens": 1}),  # kein temperature
+            attempt,
+            quirks=(TEMPERATURE_QUIRK,),
+        )
+    assert len(attempt.calls) == 1
+
+
+def test_execute_does_not_loop_when_the_same_error_repeats() -> None:
+    attempt = _Recorder(failures=[_token_key_400(), _token_key_400()])
+    with pytest.raises(_Boom):
+        execute(_plan(), attempt, quirks=(TOKEN_KEY_QUIRK,))
+    assert len(attempt.calls) == 2, "genau ein Neuversuch je Quirk, kein dritter"
+
+
+def test_execute_lets_the_outer_quirk_take_over_after_the_inner_one_gave_up() -> None:
+    """Der äußere Quirk setzt auf dem ORIGINALrequest auf.
+
+    Erst scheitert der Token-Key-Retry, dann greift der Temperature-Quirk — und
+    zwar auf den kwargs, die er selbst gesehen hat: mit dem ursprünglichen
+    ``max_tokens``, nicht mit der Korrektur des inneren Quirks.
+    """
+    attempt = _Recorder(failures=[_token_key_400(), _temperature_400()])
+    assert (
+        execute(_plan(), attempt, quirks=(TOKEN_KEY_QUIRK, TEMPERATURE_QUIRK)) == "ok"
+    )
+    assert len(attempt.calls) == 3
+    assert attempt.calls[0]["max_tokens"] == 4096
+    assert attempt.calls[1]["max_completion_tokens"] == 4096  # innerer Quirk
+    # Dritter Versuch: temperature weg, Token-Key wieder wie im Original.
+    assert "temperature" not in attempt.calls[2]
+    assert attempt.calls[2]["max_tokens"] == 4096
+
+
+def test_execute_offers_the_inner_quirk_again_inside_the_outer_retry() -> None:
+    """Nach der äußeren Korrektur steht der innere Quirk erneut zur Verfügung."""
+    attempt = _Recorder(failures=[_temperature_400(), _token_key_400()])
+    assert (
+        execute(_plan(), attempt, quirks=(TOKEN_KEY_QUIRK, TEMPERATURE_QUIRK)) == "ok"
+    )
+    assert len(attempt.calls) == 3
+    assert attempt.calls[1] == {  # äußere Korrektur, Token-Key noch original
+        "model": "gpt-4o",
+        "max_tokens": 4096,
+    }
+    assert attempt.calls[2]["max_completion_tokens"] == 4096
+    assert "temperature" not in attempt.calls[2]
+
+
+def test_execute_applies_quirks_in_the_given_order() -> None:
+    """``quirks[0]`` sieht den Fehler zuerst — auch wenn ein späterer auch passt."""
+    seen: List[str] = []
+
+    def _tag(name: str) -> Quirk:
+        def _rewrite(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+            seen.append(name)
+            return {**kwargs, "touched_by": name}
+
+        return Quirk(
+            name=name, remedy=name, matches=lambda _exc: True, rewrite=_rewrite
+        )
+
+    attempt = _Recorder(failures=[_Boom("anything")])
+    execute(_plan(), attempt, quirks=(_tag("inner"), _tag("outer")))
+    assert seen == ["inner"], "der äußere Quirk kommt erst dran, wenn der innere aufgibt"
+    assert attempt.calls[1]["touched_by"] == "inner"
+
+
+def test_execute_does_not_mutate_the_plan() -> None:
+    plan = _plan()
+    before = dict(plan.kwargs)
+    attempt = _Recorder(failures=[_token_key_400()])
+    execute(plan, attempt, quirks=(TOKEN_KEY_QUIRK,))
+    assert plan.kwargs == before

--- a/changelog.d/1225-request-plan.md
+++ b/changelog.d/1225-request-plan.md
@@ -1,0 +1,9 @@
+Das Zusammensetzen eines Provider-Requests und das Durchbringen dieses Requests gegen bekannte Provider-400er liegen nicht mehr in `LLMClient.chat`, sondern hinter `build_request` und `execute` im neuen Modul `app/llm/request_plan.py`. `chat` schrumpft von 315 auf 257 Zeilen und behält nur noch, was wirklich dazugehört: Stub-Pfad, Streaming-Reassembly, Budget- und Telemetrie-Buchführung.
+
+Die Quirks stehen damit genau einmal im Code. Bisher standen sie viermal: `chat`, `describe_image` und `tool_calls` hatten je eine eigene Kopie des Request-Shapings, drei davon je eine eigene Fallback-Kaskade. Jede Kopie hatte eine andere Lücke — der Tools-Pfad kennt den `temperature`-Quirk aus #1096 nicht, der Vision-Pfad kennt MiniMax nicht. Diese Lücken bleiben unverändert bestehen, stehen jetzt aber als benannter Seam sichtbar da statt als stiller Unterschied zwischen drei Textstellen.
+
+Was ein Request über seine Umgebung braucht, kommt über `RequestOptions` herein — Provider-Seams mit Default-Bindung an die echten Heuristiken. Ein Test setzt Fakes in die Options und prüft `build_request` und `execute` direkt am Interface, ohne `patch()` auf Modulnamen.
+
+`detect_provider` bleibt Single Source of Truth für die Provider-Erkennung; `request_plan` erkennt nichts selbst, sondern bekommt das Ergebnis übergeben.
+
+Verhalten unverändert — reiner Deepening-Refactor.


### PR DESCRIPTION
Closes #1225

Vierter Deepening-Kandidat aus dem Architektur-Review vom 11.08.2026, nach #1204 (RunLifecycle), #1206 (useReportGeneration) und #1212 (SectionPipeline). Reiner Refactor, Verhalten unverändert.

## Was sich ändert

`LLMClient.chat` hat zwei Dinge gemacht, die nichts miteinander zu tun haben: den Provider-Request **zusammensetzen** und ihn gegen bekannte Provider-400er **durchbringen**. Beide stehen jetzt in `backend/app/llm/request_plan.py` und je genau einmal.

| | vorher | nachher |
|---|---|---|
| `LLMClient.chat` | 315 Zeilen, cc D(30) | 257 Zeilen, cc D(24) |
| `LLMClient.describe_image` | cc C(11) | cc A(5) |
| `tool_calls._chat_with_tools` | cc C(12) | cc B(9) |

`build_request` ist rein und ohne I/O: es setzt `temperature` nur, wenn das Modell einen abweichenden Wert überhaupt akzeptiert (#1096), und wählt zwischen `max_tokens` und `max_completion_tokens`. Die Provider-Heuristiken kommen über `RequestOptions` herein — Seams mit Default-Bindung an die echten Implementierungen, dasselbe Options-Muster wie `SectionContext` in `section_pipeline.py`.

`execute` macht die Fehlerbehandlung und kein Shaping. Es wickelt den Attempt von innen nach außen in je einen `Quirk`; jeder versucht genau einmal neu, mit dem kwargs-Stand, den er selbst gesehen hat. Das ist exakt die bisherige Closure-Verschachtelung, nur nicht mehr dreimal ausgeschrieben.

## Ein vierter Pfad, den das Review nicht hatte

Der Befund im Issue nannte drei Kopien. Es waren vier: `tool_calls._chat_with_tools` hat dieselbe Shaping- und Fallback-Duplikation. Er ist mit aufgenommen — ihn auszulassen hätte die Aussage „die Quirks stehen genau einmal im Code" falsch gemacht.

## Was bewusst nicht gefixt ist

Jede der vier Kopien hatte eine andere Lücke. Die bleiben unverändert, weil sie zu schließen ein Verhaltensfix wäre, kein Refactor:

- **`tool_calls` setzt `temperature` bedingungslos.** Der Quirk aus #1096 ist dort nie nachgezogen worden. Steht jetzt als benannter Seam `_never_omits_temperature` sichtbar da, mit Begründung im Docstring, statt als stiller Unterschied zwischen drei Textstellen.
- **`describe_image` behandelt MiniMax nicht.** Gleiche Klasse, gleiche Begründung — jetzt als `minimax=False` mit Kommentar am Aufrufort.

Folge-Issues dafür lege ich nach dem Merge an.

Ebenfalls draußen geblieben: der temperature-Fallback in `chat_json` (Z. 1339–1361 auf `main`). Der liegt eine Ebene höher, um `chat()` statt um den Provider-Call, und schreibt den Request nicht um, sondern wiederholt ihn identisch. Ihn in `execute` zu ziehen hätte das Interface überdehnt.

## Verträge

- `providers/registry.py::detect_provider` bleibt Single Source of Truth. `request_plan` erkennt nichts selbst, sondern bekommt das Ergebnis als Parameter.
- `chat_json` bleibt der Pflichtweg für strukturierte JSON-Calls; der rohe OpenAI-Client wird dafür nicht verwendet.
- `LLM_DISABLE_JSON_MODE` ist nicht neu verdrahtet.
- Die fünf ADR-0002-Hartanker sind nicht berührt.

## Tests

`backend/tests/llm/test_request_plan.py` (26 Tests) prüft `build_request`, `thinking_extra_body` und `execute` direkt am Interface — Fakes kommen als Argument herein, kein `patch()` auf Modulnamen. Abgedeckt ist auch die Quirk-Komposition, die vorher nur implizit in der Closure-Verschachtelung stand: der äußere Quirk setzt auf dem Originalrequest auf, und der innere steht dem korrigierten Lauf wieder zur Verfügung.

Bestehende Specs sind unverändert — sie testen über `LLMClient` mit gefälschtem `client` und haben den Umbau ohne Anpassung mitgemacht, was hier der eigentliche Regressionsnachweis ist.

```
1274 passed   (tests/llm, tests/utils, tests/contracts, test_llm_client*, test_retry, test_native_toolcalls)
bash scripts/pre-push-gate.sh backend   → ALL GREEN
```

Radon: `LLMClient.chat` bleibt bei Rang D und damit über der Gate-Schwelle — der Allowlist-Eintrag bleibt gerechtfertigt, kein Drift in `backend/radon-allowlist.txt`.

Der `contract-gates`-Workflow steht im PR auf „skipping" (läuft nur auf `push:main`). Dass er auf `main` seit dem 10.08.2026 rot ist, ist der geerbte Defekt aus #1213 und hat mit diesem PR nichts zu tun.

## Merge-Strategie

**Squash.** Ein atomarer Refactor in einem Commit; falls beim Review noch Fixups dazukommen, soll davon nichts in der Historie von `main` landen.
