### PR TITLE
fix(frontend): Rundenzahl und Budget des Dashboard-Starts über den Query-Vertrag (#1234)

### DIFF
--- a/changelog.d/1234-run-params-query.md
+++ b/changelog.d/1234-run-params-query.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Der Dashboard-Start reicht Rundenzahl und Run-Budget wieder bis zum
+  Simulationsstart durch. Beide reisten über den `pendingUpload`-Store, den
+  Schritt 1 nach dem Ontologie-Upload leert — Schritt 3 las anschließend den
+  Reset-Default 10 statt der eingestellten Runden und fand gar kein Budget
+  mehr vor. Sie laufen jetzt über den Query-Vertrag
+  `contracts/runParamsQuery.ts`, der schon die Übergabe Schritt 2 → Schritt 3
+  trägt, und überleben damit auch einen Reload auf der Simulationsroute
+  ([#1234](https://github.com/arn0ld87/agora/issues/1234)).

--- a/frontend/src/components/__tests__/Step3Simulation.spec.ts
+++ b/frontend/src/components/__tests__/Step3Simulation.spec.ts
@@ -572,16 +572,20 @@ describe('Step3Simulation — ai_model_ref beim Simulationsstart (#819)', () => 
 })
 
 /**
- * Regression: numRounds-Slider aus HeroNewRun hatte keinerlei Effekt.
+ * Regression: Rundenzahl und Budget aus HeroNewRun hatten keinerlei Effekt.
  *
- * Der Dashboard-Flow legt den Slider-Wert im pendingUpload-Store ab; Step2
- * (der ihn als Prop durchgereicht hätte) wird dabei übersprungen. Vor dem Fix
- * landete max_rounds deshalb NIE im Start-Request — die Simulation lief
- * immer auf die LLM-generierten total_simulation_hours (z. B. 96 Runden
- * statt der eingestellten 10). Gegenprobe zum Bug-Report: Slider auf 10,
- * Log zeigte "Runde x/96".
+ * Erster Anlauf (Slider ohne Wirkung): Der Dashboard-Flow legte den Wert im
+ * pendingUpload-Store ab und Step 3 las ihn von dort. Das war nur scheinbar
+ * ein Fix — Schritt 1 leert den Store nach dem Ontologie-Upload
+ * (`useGraphBuildPipeline` → `clearPendingUpload`), sodass Step 3 den
+ * Reset-Default 10 statt der eingestellten Runden las und das Budget aus
+ * #764 gar nicht mehr vorfand (Issue #1234).
+ *
+ * Seitdem kommen beide Werte ausschliesslich ueber die Route-Query herein und
+ * erreichen Step 3 als Props. Der Store bleibt hier bewusst befuellt: Er darf
+ * das Ergebnis nicht mehr beeinflussen.
  */
-describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-Flow)', () => {
+describe('Step3Simulation — Run-Parameter aus der Route-Query (Dashboard-Flow)', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     localStorage.clear()
@@ -604,11 +608,10 @@ describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-
     )
   })
 
-  it('ohne maxRounds-Prop fällt max_rounds auf den Slider-Wert zurück', async () => {
+  it('ohne maxRounds-Prop bleibt max_rounds weg — der Store ist kein Ersatz', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_0123456789ab' } } as never)
 
-    // Dashboard-Flow: KEINE maxRounds-Prop.
     const wrapper = mount(Step3Simulation, {
       props: {
         simulationId: 'sim_0123456789ab',
@@ -624,11 +627,14 @@ describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-
     await startBtn!.trigger('click')
     await flushPromises()
 
+    // Der Store trug hier frueher die 10 bei — ein Wert, der in Wahrheit der
+    // Reset-Default war und die Nutzereingabe still ueberschrieb. Ohne Query
+    // gilt jetzt der Auto-Wert des Backends.
     const payload = vi.mocked(simulationApi.startSimulation).mock.calls[0][0] as unknown as Record<string, unknown>
-    expect(payload.max_rounds).toBe(10)
+    expect('max_rounds' in payload).toBe(false)
   })
 
-  it('Budget aus dem pendingUpload-Store wird als budget durchgereicht (Issue #764)', async () => {
+  it('reicht das Budget aus der Prop an /simulation/start durch (Issue #764, #1234)', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_0123456789ab' } } as never)
 
@@ -638,12 +644,11 @@ describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-
       currency: 'USD',
       max_tokens: 5000,
     }
-    const { setPendingUpload } = await import('../../store/pendingUpload')
-    setPendingUpload([], 'requirement', null, 30, 10, budget)
 
     const wrapper = mount(Step3Simulation, {
       props: {
         simulationId: 'sim_0123456789ab',
+        budget,
         projectData: { name: 'dashboard-flow' },
         graphData: { nodes: [], edges: [] },
         systemLogs: [],
@@ -660,7 +665,7 @@ describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-
     expect(payload.budget).toEqual(budget)
   })
 
-  it('ohne Budget im Store bleibt das budget-Feld weg (kein null-Payload)', async () => {
+  it('ohne Budget-Prop bleibt das budget-Feld weg (kein null-Payload)', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_0123456789ab' } } as never)
 
@@ -683,7 +688,7 @@ describe('Step3Simulation — max_rounds aus dem pendingUpload-Store (Dashboard-
     expect('budget' in payload).toBe(false)
   })
 
-  it('maxRounds-Prop (Stepped-Flow) gewinnt vor dem Slider-Wert', async () => {
+  it('nimmt die maxRounds-Prop des Stepped-Flows unveraendert an', async () => {
     vi.mocked(simulationApi.getRunStatus).mockResolvedValue({ success: true, data: {} } as never)
     vi.mocked(simulationApi.startSimulation).mockResolvedValue({ success: true, data: { simulation_id: 'sim_0123456789ab' } } as never)
 

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -21,6 +21,7 @@ import { fetchLlmProfiles } from '../../../api/llmProfiles'
 import { preflightEstimate } from '../../../api/budget'
 import type { PreflightEstimateParams } from '../../../api/budget'
 import { setPendingUpload } from '../../../store/pendingUpload'
+import { toRunParamsQuery } from '../../../contracts/runParamsQuery'
 import { STORAGE_LANG } from '../../../composables/useEnvForm'
 import { useEffectiveModelSelection } from '@/composables/useEffectiveModelSelection'
 import { setRunModelOverride, clearRunModelOverride } from '@/store/runModelOverride'
@@ -144,8 +145,10 @@ const numAgents = ref<number>(NUM_AGENTS_DEFAULT)
 const numRounds = ref<number>(NUM_ROUNDS_DEFAULT)
 
 // ---- Issue #764: optionale Run-Budgets + Preflight-Schätzung ----
-// Das Budget wandert über den pendingUpload-Store zu Step3Simulation, die es
-// beim Sim-Start als `budget` an /api/simulation/start durchreicht. Die
+// Das Budget wandert über die Route-Query (contracts/runParamsQuery) zu
+// Step3Simulation, die es beim Sim-Start als `budget` an
+// /api/simulation/start durchreicht. Nicht über den pendingUpload-Store: den
+// leert Schritt 1 nach dem Upload, das Budget kam nie an (Issue #1234). Die
 // Preflight-Schätzung ist rein informativ (is_estimate=true) und wird per
 // Button aktualisiert — bewusst kein Debounce auf jeden Slider-Tick.
 const budget = ref<RunBudgetConfig | null>(null)
@@ -338,9 +341,17 @@ async function startSimulation() {
       profileId,
       numAgents.value,
       numRounds.value,
-      budget.value,
     )
-    router.push({ name: 'Process', params: { projectId: 'new' } })
+    // Rundenzahl und Budget gehen in die Query, nicht in den Store: Schritt 1
+    // leert ihn nach dem Upload (`clearPendingUpload`), Schritt 3 las danach
+    // Reset-Defaults — die eingestellte Rundenzahl wurde still zu 10, das
+    // Budget verschwand ganz (Issue #1234). Die Dateien bleiben zwangsläufig
+    // im Store, sie sind nicht serialisierbar.
+    router.push({
+      name: 'Process',
+      params: { projectId: 'new' },
+      query: toRunParamsQuery({ maxRounds: numRounds.value, budget: budget.value }),
+    })
   } catch (e) {
     errorMsg.value = e instanceof Error ? e.message : String(e)
   }

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
@@ -171,7 +171,6 @@ describe('HeroNewRun — LLM-Profile (P5.5)', () => {
       null,
       expect.anything(),
       expect.anything(),
-      null,
     )
   })
 
@@ -205,7 +204,6 @@ describe('HeroNewRun — LLM-Profile (P5.5)', () => {
       null,
       expect.anything(),
       expect.anything(),
-      null,
     )
   })
 
@@ -257,9 +255,12 @@ describe('HeroNewRun — LLM-Profile (P5.5)', () => {
       'abc',
       30,
       10,
-      // Issue #764: sechstes Argument ist das Run-Budget (Default: keines).
-      null,
     )
-    expect(pushSpy).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+    // Issue #1234: Rundenzahl und Budget reisen in der Query, nicht im Store.
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'Process',
+      params: { projectId: 'new' },
+      query: { maxRounds: '10' },
+    })
   })
 })

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -502,13 +502,17 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
       'abc',
       30,
       10,
-      // Issue #764: sechstes Argument ist das Run-Budget (Default: keines).
-      null,
     )
-    expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+    // Issue #1234: Die Rundenzahl reist in der Query, nicht im Store — den
+    // leert Schritt 1 nach dem Upload.
+    expect(routerPushMock).toHaveBeenCalledWith({
+      name: 'Process',
+      params: { projectId: 'new' },
+      query: { maxRounds: '10' },
+    })
   })
 
-  it('startSimulation: gesetztes Run-Budget wird als sechstes Argument durchgereicht (Issue #764)', async () => {
+  it('startSimulation: gesetztes Run-Budget wird in die Query geschrieben (Issue #764, #1234)', async () => {
     const w = await mountHero()
 
     const file = new File(['x'], 'briefing.md', { type: 'text/markdown' })
@@ -532,19 +536,22 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     await w.find('.hero-cta').trigger('click')
     await flushPromises()
 
+    // Das Budget gehoert nicht mehr in den Store: Schritt 1 raeumt ihn nach
+    // dem Upload, Schritt 3 fand dort nie eines vor (Issue #1234).
     expect(setPendingUploadMock).toHaveBeenCalledWith(
       [file],
       'Wie reagiert die DACH-Region?',
       null,
       30,
       10,
-      {
-        schema_version: 1,
-        enforcement: 'soft',
-        currency: 'USD',
-        max_tokens: 50000,
-      },
     )
+    const pushed = routerPushMock.mock.calls.at(-1)?.[0] as { query?: Record<string, string> }
+    expect(JSON.parse(String(pushed.query?.budget))).toEqual({
+      schema_version: 1,
+      enforcement: 'soft',
+      currency: 'USD',
+      max_tokens: 50000,
+    })
   })
 
   it('startSimulation: ohne Profile lässt Legacy-Modell-Keys unangetastet', async () => {
@@ -576,7 +583,11 @@ describe('HeroNewRun (Phase-1, Kanon-First Migration)', () => {
     expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastModel')
     expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('agora.lastCustomModel')
     expect(setPendingUploadMock).toHaveBeenCalled()
-    expect(routerPushMock).toHaveBeenCalledWith({ name: 'Process', params: { projectId: 'new' } })
+    expect(routerPushMock).toHaveBeenCalledWith({
+      name: 'Process',
+      params: { projectId: 'new' },
+      query: { maxRounds: '10' },
+    })
   })
 
   it('startSimulation: ohne Profile setzt die Picker-Wahl den Run-Override (voller AiModelRef)', async () => {

--- a/frontend/src/components/v4/steps/Step3Simulation.vue
+++ b/frontend/src/components/v4/steps/Step3Simulation.vue
@@ -27,7 +27,6 @@ import { tokenizeFeedText } from '../../../utils/feedHighlight'
 import { isErrorLine } from '@/utils/errorLinePattern'
 import { useSimFeed, clearSimFeed } from '../../../composables/useSimFeed'
 import { useSimClock, clearSimClock } from '../../../composables/useSimClock'
-import { getPendingUpload } from '../../../store/pendingUpload'
 import SimulationProgressPanel from '../../step3/SimulationProgressPanel.vue'
 import PersonaActionFeed from '../../step3/PersonaActionFeed.vue'
 import SimulationToolPanel from '../../step3/SimulationToolPanel.vue'
@@ -40,6 +39,10 @@ const props = defineProps({
   simulationId: String,
   maxRounds: Number,
   simulationDays: Number,
+  // Issue #1234: Run-Budget aus der Route-Query. Kommt vom Dashboard-Start
+  // und ueberlebt anders als der pendingUpload-Store sowohl Schritt 1 als
+  // auch einen Reload auf dieser Route.
+  budget: Object,
   minutesPerRound: { type: Number, default: 30 },
   projectData: Object,
   graphData: Object,
@@ -251,19 +254,16 @@ async function doStart() {
       platform: 'parallel',
       enable_graph_memory_update: false
     }
-    // Der Dashboard-Start (HeroNewRun) hat keinen Step2-Durchlauf — dessen
-    // Slider-Wert liegt im pendingUpload-Store. Der Stepped-Flow übergibt
-    // maxRounds als Prop und gewinnt. Vorher wurde der Slider-Wert nur beim
-    // Ontologie-Upload gesendet, wo das Backend ihn still verwirft — die
-    // eingestellte Rundenzahl hatte keinerlei Effekt (Bug: Slider ohne
-    // Wirkung, Simulation lief immer auf total_simulation_hours).
-    const effectiveMaxRounds = props.maxRounds ?? (getPendingUpload().numRounds || null)
-    if (effectiveMaxRounds) params.max_rounds = effectiveMaxRounds
-    // Issue #764: Optionale Run-Budgets aus dem Dashboard-Start (HeroNewRun)
-    // werden unverändert an /api/simulation/start durchgereicht. Ohne Budget
-    // bleibt das Feld weg — das Backend läuft dann ohne Limit.
-    const pendingBudget = getPendingUpload().budget
-    if (pendingBudget) params.budget = pendingBudget
+    // Rundenzahl und Budget kommen ueber die Route-Query herein — vom
+    // Dashboard-Start (HeroNewRun) oder, falls der Nutzer dort ueberstimmt
+    // hat, aus Schritt 2. Frueher lasen wir beides aus dem pendingUpload-
+    // Store; den leert Schritt 1 nach dem Upload, sodass hier stets der
+    // Reset-Default 10 und gar kein Budget ankam (Issue #1234).
+    if (props.maxRounds) params.max_rounds = props.maxRounds
+    // Issue #764: Optionale Run-Budgets werden unveraendert an
+    // /api/simulation/start durchgereicht. Ohne Budget bleibt das Feld weg —
+    // das Backend laeuft dann ohne Limit.
+    if (props.budget) params.budget = props.budget
     if (props.simulationDays) params.simulation_days = props.simulationDays
     // Autoritative (Connection, Modell)-Auswahl: Der transiente Dashboard-
     // Run-Override (HeroNewRun-Pick, store/runModelOverride) gewinnt vor dem
@@ -297,7 +297,7 @@ async function doStart() {
       // im selben Tab den alten Override stillschweigend erbt.
       if (usedRunOverride) clearRunModelOverride()
       phase.value = 1
-      addLog(t('step3.status.running', { current: 0, total: effectiveMaxRounds || '?' }))
+      addLog(t('step3.status.running', { current: 0, total: params.max_rounds || '?' }))
       startPolling()
     } else {
       startError.value = res?.error || 'unknown'
@@ -468,9 +468,9 @@ const statusLabel = computed(() => {
       : t('step3.status.completed', { total: runStatus.value.current_round || '?' })
   }
   if (runStatus.value.paused) {
-    return t('step3.status.paused', { current: runStatus.value.current_round || 0, total: runStatus.value.total_rounds || props.maxRounds || getPendingUpload().numRounds || '?' })
+    return t('step3.status.paused', { current: runStatus.value.current_round || 0, total: runStatus.value.total_rounds || props.maxRounds || '?' })
   }
-  return t('step3.status.running', { current: runStatus.value.current_round || 0, total: runStatus.value.total_rounds || props.maxRounds || getPendingUpload().numRounds || '?' })
+  return t('step3.status.running', { current: runStatus.value.current_round || 0, total: runStatus.value.total_rounds || props.maxRounds || '?' })
 })
 
 const statusKind = computed(() => {

--- a/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
+++ b/frontend/src/composables/__tests__/useGraphBuildPipeline.spec.ts
@@ -139,10 +139,32 @@ describe('useGraphBuildPipeline', () => {
     expect(router.replace).toHaveBeenCalledWith({
       name: 'StepGraphBuild',
       params: { projectId: 'project_42' },
+      query: {},
     })
     expect(graphApi.buildGraph).toHaveBeenCalledTimes(1)
     expect(graphApi.buildGraph).toHaveBeenCalledWith({ project_id: 'project_42' })
     expect(pipeline.currentProjectId.value).toBe('project_42')
+  })
+
+  // Issue #1234: Der Replace auf die konkrete Projekt-ID liegt genau eine
+  // Zeile hinter `clearPendingUpload()`. Verliert er die Query, sind die
+  // Run-Parameter des Dashboard-Starts danach nirgends mehr.
+  it('nimmt die Query der aktuellen Route in den Replace mit', async () => {
+    const router = createRouter()
+    const pipeline = useGraphBuildPipeline({
+      projectId: 'new',
+      router,
+      t,
+      preserveQuery: { maxRounds: '25', budget: '{"schema_version":1,"max_tokens":5000}' },
+    })
+
+    await pipeline.initialize()
+
+    expect(router.replace).toHaveBeenCalledWith({
+      name: 'StepGraphBuild',
+      params: { projectId: 'project_42' },
+      query: { maxRounds: '25', budget: '{"schema_version":1,"max_tokens":5000}' },
+    })
   })
 
   it('pollt Task- und Graph-Status auch im Hintergrund-Tab weiter', () => {

--- a/frontend/src/composables/useGraphBuildPipeline.ts
+++ b/frontend/src/composables/useGraphBuildPipeline.ts
@@ -20,8 +20,16 @@ import { useSystemLog } from './useSystemLog'
 import { getPendingUpload, clearPendingUpload } from '../store/pendingUpload'
 import { useRunModelResolver } from './useRunModelResolver'
 
+/** Strukturaequivalent zu vue-routers ``LocationQueryRaw`` — ohne Import, der Adapter bleibt Router-agnostisch. */
+type RouteQueryValue = string | number | null | undefined
+type RouteQuery = Record<string, RouteQueryValue | RouteQueryValue[]>
+
 type RouterAdapter = {
-  replace: (location: { name: string; params: Record<string, string> }) => Promise<unknown> | void
+  replace: (location: {
+    name: string
+    params: Record<string, string>
+    query?: RouteQuery
+  }) => Promise<unknown> | void
 }
 
 type Translate = (key: string) => string
@@ -30,10 +38,17 @@ export function useGraphBuildPipeline({
   projectId,
   router,
   t,
+  preserveQuery,
 }: {
   projectId: MaybeRef<string>
   router: RouterAdapter
   t: Translate
+  /**
+   * Query der aktuellen Route. Der interne ``replace`` auf die echte
+   * Projekt-ID muss sie mitnehmen, sonst enden die Run-Parameter des
+   * Dashboard-Starts in Schritt 1 (Issue #1234).
+   */
+  preserveQuery?: MaybeRef<RouteQuery>
 }) {
   const currentProjectId = ref(String(unref(projectId)))
   const loading = ref(false)
@@ -160,7 +175,14 @@ export function useGraphBuildPipeline({
       currentProjectId.value = response.data.project_id
       projectData.value = response.data
       ontologyProgress.value = null
-      await router.replace({ name: 'StepGraphBuild', params: { projectId: response.data.project_id } })
+      // Die Query trägt die Run-Parameter des Dashboard-Starts weiter. Ohne
+      // sie endet die Kette hier: `clearPendingUpload()` eine Zeile darüber
+      // hat den Store bereits geräumt (Issue #1234).
+      await router.replace({
+        name: 'StepGraphBuild',
+        params: { projectId: response.data.project_id },
+        query: { ...unref(preserveQuery) },
+      })
       if (isCurrent(generation)) await startBuildGraph(generation, aiModelRef)
     } catch (caughtError) {
       if (!isCurrent(generation)) return

--- a/frontend/src/contracts/__tests__/runParamsQuery.spec.ts
+++ b/frontend/src/contracts/__tests__/runParamsQuery.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
+  coerceBudget,
   coercePositiveInt,
   readRunParamsFromQuery,
   toRunParamsQuery,
+  BUDGET_QUERY_KEY,
   MAX_ROUNDS_QUERY_KEY,
   SIMULATION_DAYS_QUERY_KEY,
   MAX_SIMULATION_DAYS,
@@ -89,13 +91,62 @@ describe('runParamsQuery — Query-Vertrag', () => {
     // Schluessel. Genau dieser implizite Tausch war vorher gebrochen.
     const query = toRunParamsQuery({ maxRounds: 12, simulationDays: 4 })
 
-    expect(readRunParamsFromQuery(query)).toEqual({ maxRounds: 12, simulationDays: 4 })
+    expect(readRunParamsFromQuery(query)).toEqual({
+      maxRounds: 12,
+      simulationDays: 4,
+      budget: null,
+    })
   })
 
   it('meldet fehlende Werte als null statt als 0', () => {
     // null bedeutet "nicht gesetzt" — 0 waere eine gueltige, aber falsche
     // Rundenzahl und wuerde als Wert an das Backend gehen.
-    expect(readRunParamsFromQuery({})).toEqual({ maxRounds: null, simulationDays: null })
-    expect(readRunParamsFromQuery(undefined)).toEqual({ maxRounds: null, simulationDays: null })
+    expect(readRunParamsFromQuery({})).toEqual({
+      maxRounds: null,
+      simulationDays: null,
+      budget: null,
+    })
+    expect(readRunParamsFromQuery(undefined)).toEqual({
+      maxRounds: null,
+      simulationDays: null,
+      budget: null,
+    })
+  })
+})
+
+// Issue #1234: Das Run-Budget des Dashboard-Starts reist im selben Vertrag.
+// Es lag vorher im pendingUpload-Store und erreichte den Simulationsstart nie,
+// weil Schritt 1 den Store nach dem Upload leert.
+describe('runParamsQuery — Run-Budget', () => {
+  const BUDGET = {
+    schema_version: 1 as const,
+    max_tokens: 5000,
+    enforcement: 'hard' as const,
+    currency: 'USD',
+  }
+
+  it('macht den Roundtrip Objekt -> Query -> Objekt, ohne Budget keinen Schluessel', () => {
+    const query = toRunParamsQuery({ budget: BUDGET })
+
+    // Ein bereits serialisierter Wert (Zwischenstationen sehen nur den String)
+    // ueberlebt eine weitere Runde unveraendert.
+    expect(toRunParamsQuery({ budget: query[BUDGET_QUERY_KEY] })).toEqual(query)
+    expect(readRunParamsFromQuery(query).budget).toEqual(BUDGET)
+    expect(toRunParamsQuery({ budget: null })).toEqual({})
+  })
+
+  it('verwirft alles, was RunBudgetConfigSchema nicht annimmt', () => {
+    // Die URL ist Nutzereingabe. Ein Budget, das das Schema ablehnt, darf
+    // nicht als Limit an /api/simulation/start gehen — auch nicht teilweise.
+    expect(coerceBudget('kein json')).toBeNull()
+    expect(coerceBudget('{"max_tokens":0}')).toBeNull()
+    expect(coerceBudget('{"max_tokens":5000,"unbekannt":true}')).toBeNull()
+    // Schema-Defaults gelten auch fuer eine verkuerzte URL.
+    expect(coerceBudget('{"max_tokens":5000}')).toEqual({
+      schema_version: 1,
+      max_tokens: 5000,
+      enforcement: 'soft',
+      currency: 'USD',
+    })
   })
 })

--- a/frontend/src/contracts/runParamsQuery.ts
+++ b/frontend/src/contracts/runParamsQuery.ts
@@ -1,7 +1,10 @@
 /**
- * Run-Parameter-Query — Vertrag zwischen Step 2 (Sender) und Step 3 (Empfänger).
+ * Run-Parameter-Query — Vertrag für alle Sender, die einen Simulationsstart
+ * parametrisieren (Dashboard-Start und Schritt 2), und für Schritt 3 als
+ * einzigen Empfänger.
  *
  * Slice 5 · 2026-08-02 — Fix B-09/B-27 (Runden/Tage überlebten Schritt 2→3 nicht).
+ * Issue #1234 · 2026-08-11 — der Dashboard-Start kommt dazu (Rundenzahl + Budget).
  *
  * Step 2 emittiert ``next-step`` mit den Werten, die der Nutzer gegen den
  * Auto-Vorschlag gesetzt hat. Der Wrapper verwarf sie bisher kommentarlos und
@@ -10,16 +13,22 @@
  *
  * Warum Query und nicht der pendingUpload-Store: Step 3 ist eine eigene Route,
  * auf der eine laufende Simulation beobachtet wird. Ein Reload dort darf die
- * eingestellte Rundenzahl nicht verlieren. Der Store ist bloß ``reactive``,
- * nicht persistiert, und gehört fachlich dem Dashboard-Start (HeroNewRun).
+ * eingestellte Rundenzahl nicht verlieren. Der Store ist bloß ``reactive`` und
+ * nicht persistiert — schlimmer noch, er gehört fachlich Schritt 1 (Dateien,
+ * Requirement) und wird dort nach dem Upload absichtlich geleert
+ * (``useGraphBuildPipeline`` → ``clearPendingUpload``). Schritt 3 las
+ * anschließend Reset-Defaults: die Dashboard-Rundenzahl wurde still zu 10, das
+ * Run-Budget aus #764 erreichte ``/api/simulation/start`` nie (Issue #1234).
  *
  * Diese Datei ist die einzige Stelle, an der die Query-Schlüssel definiert
  * werden — genau der implizite Schlüsseltausch zwischen zwei Seiten war die
  * Ursache des Bugs.
  */
+import { RunBudgetConfigSchema, type RunBudgetConfig } from './runBudgetContract'
 
 export const MAX_ROUNDS_QUERY_KEY = 'maxRounds'
 export const SIMULATION_DAYS_QUERY_KEY = 'simulationDays'
+export const BUDGET_QUERY_KEY = 'budget'
 
 /**
  * Obergrenze für Simulationstage — gespiegelt aus
@@ -36,6 +45,8 @@ export interface RunParams {
   maxRounds: number | null
   /** Vom Nutzer überstimmte Simulationstage; ``null`` = Auto-Wert des Backends gilt. */
   simulationDays: number | null
+  /** Run-Budget aus dem Dashboard-Start; ``null`` = Lauf ohne Limit. */
+  budget: RunBudgetConfig | null
 }
 
 /** Query-Werte sind laut vue-router string, Array oder fehlend. */
@@ -67,6 +78,37 @@ export function coercePositiveInt(value: unknown, max?: number): number | null {
   return Number.isSafeInteger(parsed) && parsed > 0 ? withinBounds(parsed) : null
 }
 
+/**
+ * Normalisiert einen Query-Wert auf ein gültiges Run-Budget.
+ *
+ * Das Budget ist als kompaktes JSON in *einem* Schlüssel unterwegs und nicht in
+ * sechs Einzelschlüsseln: ``RunBudgetConfig`` ist ein versionierter Vertrag mit
+ * eigenem Zod-Schema. Eine flache Query-Darstellung wäre eine zweite,
+ * unabhängig driftende Beschreibung desselben Objekts.
+ *
+ * Die URL ist Nutzereingabe: geparst wird gegen ``RunBudgetConfigSchema``
+ * (``.strict()``), alles andere fällt auf ``null``. Ein manipulierter Wert darf
+ * nicht als Budget an ``/api/simulation/start`` gehen.
+ */
+function coerceBudgetObject(value: unknown): RunBudgetConfig | null {
+  const result = RunBudgetConfigSchema.safeParse(value)
+  return result.success ? result.data : null
+}
+
+export function coerceBudget(value: unknown): RunBudgetConfig | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  return coerceBudgetObject(parsed)
+}
+
 /** Liest die Run-Parameter aus einer Router-Query (Step-3-Seite). */
 export function readRunParamsFromQuery(
   query: Record<string, QueryValue> | undefined | null,
@@ -77,6 +119,7 @@ export function readRunParamsFromQuery(
       query?.[SIMULATION_DAYS_QUERY_KEY],
       MAX_SIMULATION_DAYS,
     ),
+    budget: coerceBudget(query?.[BUDGET_QUERY_KEY]),
   }
 }
 
@@ -89,6 +132,7 @@ export function readRunParamsFromQuery(
 export function toRunParamsQuery(source: {
   maxRounds?: unknown
   simulationDays?: unknown
+  budget?: unknown
 }): Record<string, string> {
   const query: Record<string, string> = {}
 
@@ -102,6 +146,17 @@ export function toRunParamsQuery(source: {
   )
   if (simulationDays !== null) {
     query[SIMULATION_DAYS_QUERY_KEY] = String(simulationDays)
+  }
+  // Sender geben das Budget als Objekt herein (HeroNewRun), Zwischenstationen
+  // als bereits serialisierten Query-Wert. Beide Formen laufen durch dieselbe
+  // Validierung — ein unterwegs manipulierter Wert wird hier verworfen und
+  // nicht bloß weitergereicht.
+  const budget =
+    typeof source?.budget === 'string'
+      ? coerceBudget(source.budget)
+      : coerceBudgetObject(source?.budget)
+  if (budget !== null) {
+    query[BUDGET_QUERY_KEY] = JSON.stringify(budget)
   }
   return query
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -118,7 +118,14 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/process/:projectId',
     name: 'Process',
-    redirect: (to) => ({ name: 'StepGraphBuild', params: { projectId: String(to.params.projectId) } }),
+    // Query explizit mitnehmen: der Dashboard-Start hängt die Run-Parameter
+    // (Rundenzahl, Budget) an diese Route. Ein Redirect, der sie nicht nennt,
+    // verwirft sie — der Start landete dann auf Reset-Defaults (Issue #1234).
+    redirect: (to) => ({
+      name: 'StepGraphBuild',
+      params: { projectId: String(to.params.projectId) },
+      query: to.query,
+    }),
   },
   {
     path: '/simulation/:simulationId',

--- a/frontend/src/store/pendingUpload.ts
+++ b/frontend/src/store/pendingUpload.ts
@@ -1,18 +1,25 @@
 /**
  * Temporarily store files and requirements to be uploaded
  * Used to immediately navigate after clicking Start Engine on home page, API call is made on Process page
+ *
+ * Der Store gehört Schritt 1 und trägt genau das, was der Ontologie-Upload
+ * braucht — allen voran die Dateien, die nicht serialisierbar sind. Er wird
+ * nach dem Upload geleert (``useGraphBuildPipeline`` → ``clearPendingUpload``).
+ *
+ * Was Schritt 3 braucht, gehört deshalb NICHT hierher: Rundenzahl und
+ * Run-Budget reisen über die Route-Query (``contracts/runParamsQuery``). Vor
+ * Issue #1234 lag das Budget hier und erreichte den Simulationsstart nie, weil
+ * Schritt 1 es zwischendurch weggeräumt hatte.
  */
 import { reactive } from 'vue'
-import type { RunBudgetConfig } from '../contracts/runBudgetContract'
 
 interface PendingUploadState {
   files: File[]
   simulationRequirement: string
   llmProfileId: string | null
   numAgents: number
+  /** Nur für den Upload-Payload in Schritt 1. Der Simulationsstart liest ``maxRounds`` aus der Query. */
   numRounds: number
-  /** Issue #764: optionale Run-Budgets, werden in Step3Simulation an /simulation/start durchgereicht. */
-  budget: RunBudgetConfig | null
   isPending: boolean
 }
 
@@ -22,7 +29,6 @@ const state = reactive<PendingUploadState>({
   llmProfileId: null,
   numAgents: 30,
   numRounds: 10,
-  budget: null,
   isPending: false
 })
 
@@ -32,14 +38,12 @@ export function setPendingUpload(
   llmProfileId: string | null = null,
   numAgents = 30,
   numRounds = 10,
-  budget: RunBudgetConfig | null = null,
 ): void {
   state.files = files
   state.simulationRequirement = requirement
   state.llmProfileId = llmProfileId
   state.numAgents = numAgents
   state.numRounds = numRounds
-  state.budget = budget
   state.isPending = true
 }
 
@@ -50,7 +54,6 @@ export function getPendingUpload(): PendingUploadState {
     llmProfileId: state.llmProfileId,
     numAgents: state.numAgents,
     numRounds: state.numRounds,
-    budget: state.budget,
     isPending: state.isPending,
   }
 }
@@ -61,7 +64,6 @@ export function clearPendingUpload(): void {
   state.llmProfileId = null
   state.numAgents = 30
   state.numRounds = 10
-  state.budget = null
   state.isPending = false
 }
 

--- a/frontend/src/views/v4/steps/StepEnvSetupView.vue
+++ b/frontend/src/views/v4/steps/StepEnvSetupView.vue
@@ -22,19 +22,20 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
 import PipelineStepper from '@/components/v4/steps/PipelineStepper.vue'
 import Step2EnvSetup from '@/components/v4/steps/Step2EnvSetup.vue'
 import StepModelOverrideChip from '@/components/v4/forms/StepModelOverrideChip.vue'
 import type { BreadcrumbItem } from '@/components/v4/shell/Breadcrumbs.vue'
-import { toRunParamsQuery } from '@/contracts/runParamsQuery'
+import { readRunParamsFromQuery, toRunParamsQuery } from '@/contracts/runParamsQuery'
 
 const props = defineProps<{
   projectId: string
 }>()
 
+const route = useRoute()
 const router = useRouter()
 
 const crumbs = computed<BreadcrumbItem[]>(() => [
@@ -55,10 +56,22 @@ function handleNextStep(payload: {
   // überstimmt hat. Sie müssen in die Query: die Route hat ``props: true``,
   // das überträgt ausschließlich Route-Params — vorher gingen die Werte hier
   // verloren und Step 3 startete stets mit dem Auto-Wert (B-09/B-27).
+  //
+  // Was schon in der Query steht, kommt vom Dashboard-Start und bleibt, sofern
+  // Schritt 2 nichts Eigenes dazu sagt (Issue #1234). Das Budget kennt Schritt
+  // 2 gar nicht — es reist unverändert durch.
+  const inherited = readRunParamsFromQuery(route.query)
   void router.push({
     name: 'StepSimulation',
     params: { simulationId: payload.simulationId },
-    query: { projectId: props.projectId, ...toRunParamsQuery(payload) },
+    query: {
+      projectId: props.projectId,
+      ...toRunParamsQuery({
+        maxRounds: payload.maxRounds ?? inherited.maxRounds,
+        simulationDays: payload.simulationDays ?? inherited.simulationDays,
+        budget: inherited.budget,
+      }),
+    },
   })
 }
 

--- a/frontend/src/views/v4/steps/StepGraphBuildView.vue
+++ b/frontend/src/views/v4/steps/StepGraphBuildView.vue
@@ -50,7 +50,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import AppShell from '@/components/v4/shell/AppShell.vue'
 import PageHeader from '@/components/v4/shell/PageHeader.vue'
@@ -67,13 +67,18 @@ const props = defineProps<{
   projectId: string
 }>()
 
+const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 
+// Der Dashboard-Start hängt Rundenzahl und Budget an die Route. Schritt 1
+// verbraucht sie nicht, muss sie aber weiterreichen — sonst enden sie hier,
+// weil der pendingUpload-Store nach dem Upload geleert wird (Issue #1234).
 function handleNextStep(): void {
   void router.push({
     name: 'StepEnvSetup',
     params: { projectId: props.projectId },
+    query: { ...route.query },
   })
 }
 const {
@@ -90,7 +95,12 @@ const {
   degradations,
   initialize,
   refreshGraph,
-} = useGraphBuildPipeline({ projectId: props.projectId, router, t })
+} = useGraphBuildPipeline({
+  projectId: props.projectId,
+  router,
+  t,
+  preserveQuery: computed(() => ({ ...route.query })),
+})
 
 // Issue #1023 (Befund B-08): GraphToolbar emittiert toggle-maximize seit
 // jeher, ohne dass irgendein Consumer zuhoert. CSS-Vollbild-Toggle statt

--- a/frontend/src/views/v4/steps/StepSimulationView.vue
+++ b/frontend/src/views/v4/steps/StepSimulationView.vue
@@ -35,6 +35,7 @@
         :simulation-id="simulationId"
         :max-rounds="runParams.maxRounds ?? undefined"
         :simulation-days="runParams.simulationDays ?? undefined"
+        :budget="runParams.budget ?? undefined"
         @go-back="handleGoBack"
       />
     </div>

--- a/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/StepGraphBuildView.spec.ts
@@ -32,9 +32,15 @@ vi.mock('@/composables/useGraphBuildPipeline', async () => {
     }),
   }
 })
+const route = vi.hoisted(() => ({
+  name: 'StepGraphBuild',
+  params: {} as Record<string, unknown>,
+  query: {} as Record<string, unknown>,
+}))
+
 vi.mock('vue-router', () => ({
   useRouter: () => ({ replace: vi.fn(), push: routerPush }),
-  useRoute: () => ({ name: 'StepGraphBuild', params: {} }),
+  useRoute: () => route,
 }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
 
@@ -44,6 +50,7 @@ describe('StepGraphBuildView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     pipeline.degradations = { schema_version: 1, events: [] }
+    route.query = {}
   })
 
   it('bindet den Graph-Build-Pipelinezustand an Step1GraphBuild und macht Fehler zugänglich', () => {
@@ -149,6 +156,43 @@ describe('StepGraphBuildView', () => {
     expect(routerPush).toHaveBeenCalledWith({
       name: 'StepEnvSetup',
       params: { projectId: 'project_42' },
+      query: {},
+    })
+  })
+
+  // Issue #1234: Schritt 1 verbraucht die Run-Parameter des Dashboard-Starts
+  // nicht, ist aber die einzige Station zwischen ihnen und Schritt 3. Ohne
+  // Weitergabe endete die Kette hier — der pendingUpload-Store, der sie
+  // frueher trug, wird genau in diesem Schritt geleert.
+  it('reicht die Run-Parameter aus der Query an Schritt 2 weiter', async () => {
+    routerPush.mockClear()
+    route.query = { maxRounds: '25', budget: '{"schema_version":1,"max_tokens":5000}' }
+    const wrapper = mount(StepGraphBuildView, {
+      props: { projectId: 'project_42' },
+      global: {
+        mocks: { $t: (key: any) => key },
+        stubs: {
+          AppShell: { template: '<main><slot /></main>' },
+          PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
+          PipelineStepper: true,
+          StepModelOverrideChip: true,
+          GraphPanel: true,
+          Step1GraphBuild: {
+            name: 'Step1GraphBuild',
+            props: ['projectData', 'currentPhase', 'ontologyProgress', 'buildProgress', 'graphData', 'systemLogs'],
+            emits: ['next-step'],
+            template: '<section />',
+          },
+        },
+      },
+    })
+
+    await wrapper.getComponent({ name: 'Step1GraphBuild' }).vm.$emit('next-step')
+
+    expect(routerPush).toHaveBeenCalledWith({
+      name: 'StepEnvSetup',
+      params: { projectId: 'project_42' },
+      query: { maxRounds: '25', budget: '{"schema_version":1,"max_tokens":5000}' },
     })
   })
 

--- a/frontend/src/views/v4/steps/__tests__/runParamsHandover.spec.ts
+++ b/frontend/src/views/v4/steps/__tests__/runParamsHandover.spec.ts
@@ -26,6 +26,21 @@ import StepSimulationView from '../StepSimulationView.vue'
 
 const i18nMock = { $t: (key: string) => key }
 
+// Budget, wie HeroNewRun es aufbaut — inkl. der Schema-Defaults, die
+// RunBudgetConfigSchema beim Parsen setzt.
+const DASHBOARD_BUDGET = {
+  schema_version: 1,
+  enforcement: 'hard',
+  currency: 'USD',
+  max_tokens: 5000,
+}
+
+/** Query der letzten Navigation. Das Budget wird als JSON verglichen, nicht als String — die Schluesselreihenfolge gehoert dem Zod-Schema. */
+function pushedQuery(): Record<string, unknown> {
+  const call = routerPush.mock.calls.at(-1)?.[0] as { query?: Record<string, unknown> }
+  return call?.query ?? {}
+}
+
 function mountEnvSetup() {
   return mount(StepEnvSetupView, {
     props: { projectId: 'project_42' },
@@ -61,7 +76,7 @@ function mountSimulation() {
         PageHeader: { template: '<header><slot /><slot name="right" /></header>' },
         Step3Simulation: {
           name: 'Step3Simulation',
-          props: ['simulationId', 'maxRounds', 'simulationDays'],
+          props: ['simulationId', 'maxRounds', 'simulationDays', 'budget'],
           emits: ['go-back'],
           template: '<section />',
         },
@@ -116,6 +131,38 @@ describe('Schritt 2 -> Schritt 3: Uebergabe der Run-Parameter', () => {
   })
 })
 
+// Regressionstest fuer #1234: Rundenzahl und Budget aus dem Dashboard-Start
+// erreichten Schritt 3 nie. Sie reisten ueber den pendingUpload-Store, den
+// Schritt 1 nach dem Ontologie-Upload leert — Schritt 3 las anschliessend den
+// Reset-Default 10 und gar kein Budget. Nicht erst nach einem Reload, sondern
+// im normalen Durchlauf.
+describe('Dashboard -> Schritt 3: Uebergabe ueber Schritt 2 hinweg', () => {
+  it('erbt die Dashboard-Werte, laesst aber eine Eingabe in Schritt 2 gewinnen', async () => {
+    route.query = {
+      projectId: 'project_42',
+      maxRounds: '25',
+      budget: JSON.stringify(DASHBOARD_BUDGET),
+    }
+
+    await mountEnvSetup()
+      .getComponent({ name: 'Step2EnvSetup' })
+      .vm.$emit('next-step', { simulationId: 'sim_x' })
+
+    expect(pushedQuery().maxRounds).toBe('25')
+
+    await mountEnvSetup()
+      .getComponent({ name: 'Step2EnvSetup' })
+      .vm.$emit('next-step', { simulationId: 'sim_x', maxRounds: 7 })
+
+    // Schritt 2 kennt das Budget nicht und darf es deshalb auch nicht
+    // verlieren — nur die Rundenzahl wird ueberschrieben.
+    const query = pushedQuery()
+    expect(query.projectId).toBe('project_42')
+    expect(query.maxRounds).toBe('7')
+    expect(JSON.parse(String(query.budget))).toEqual(DASHBOARD_BUDGET)
+  })
+})
+
 describe('Schritt 3: Uebernahme der Run-Parameter', () => {
   it('reicht Runden/Tage aus der Query als Zahlen an Step3Simulation', () => {
     route.query = { projectId: 'project_42', maxRounds: '7', simulationDays: '2' }
@@ -145,6 +192,14 @@ describe('Schritt 3: Uebernahme der Run-Parameter', () => {
 
     expect(step3.props('maxRounds')).toBeUndefined()
     expect(step3.props('simulationDays')).toBeUndefined()
+  })
+
+  it('reicht das Run-Budget aus der Query als Objekt an Step3Simulation', () => {
+    route.query = { projectId: 'project_42', budget: JSON.stringify(DASHBOARD_BUDGET) }
+
+    const step3 = mountSimulation().getComponent({ name: 'Step3Simulation' })
+
+    expect(step3.props('budget')).toEqual(DASHBOARD_BUDGET)
   })
 
   it('nimmt die Query beim Tab-Wechsel mit', async () => {


### PR DESCRIPTION
Closes #1234

## Problem

Der Dashboard-Start legte Rundenzahl und Run-Budget im `pendingUpload`-Store ab. Schritt 1 leert diesen Store nach dem Ontologie-Upload ([`useGraphBuildPipeline.ts:159`](frontend/src/composables/useGraphBuildPipeline.ts)), Schritt 3 las ihn erst beim Simulationsstart. Dort kam der Reset-Default 10 statt der eingestellten Rundenzahl an, das Budget aus #764 gar nicht. Kein Reload nötig — der normale Durchlauf reichte.

Die bisherigen Tests waren grün, weil sie `setPendingUpload()` direkt vor dem Mount von Schritt 3 aufriefen und damit genau den Schritt übersprangen, der den Store leert.

## Änderung

Beide Werte laufen über [`contracts/runParamsQuery.ts`](frontend/src/contracts/runParamsQuery.ts) — den Vertrag, der die Übergabe Schritt 2 → Schritt 3 seit #1013 schon trägt. Kein zweiter Vertrag daneben: Schritt 3 ist der einzige Empfänger, zwei Module für dieselbe Route-Query wären genau die Fragmentierung, die hier weg soll.

- Das Budget reist als kompaktes JSON in **einem** Schlüssel und wird beim Lesen gegen `RunBudgetConfigSchema` (`.strict()`) geprüft. Sechs flache Query-Keys wären eine zweite, unabhängig driftende Beschreibung eines Objekts, das bereits ein Zod-Schema hat.
- Die Zwischenstationen (`Process`-Redirect, Pipeline-`replace`, Schritt 1, Schritt 2) reichen die Query durch. Eine Eingabe in Schritt 2 gewinnt gegen den Dashboard-Wert; das Budget kennt Schritt 2 nicht und reicht es unverändert weiter.
- `Step3Simulation` liest den Store nicht mehr und nimmt `maxRounds`/`budget` als Props. Der Store verliert sein `budget`-Feld und trägt nur noch, was der Upload in Schritt 1 braucht.

Nebeneffekt: Die Werte überleben einen Reload auf der Simulationsroute — dieselbe Begründung wie bei #1013.

## Tests

Neun Tests waren gegen den unveränderten Code rot, zwei davon direkt auf dem Defekt: `max_rounds` kam als Reset-Default 10 im Start-Request an, `budget` als `undefined`.

## Kontext

Kandidat 8 aus dem Architektur-Review. Die Karte hatte den Reload-Verlust auf `/process/new` als Schaden benannt — der trägt nicht, weil die Dateien dort zwangsläufig im Store liegen und nach einem Reload ohnehin fehlen. Der reale Schaden lag eine Stufe früher. Der zweite Teil der Karte (`utils/reportRoute.ts` nach `contracts/` verschieben) ist bewusst nicht mit drin: das ist eine reine Verschiebung und fällt durch den Deletion-Test.