### PR TITLE
fix(frontend): Step4Report-Testfixture an ADR-0002-Evidenzpflicht anpassen

### DIFF
--- a/frontend/src/components/__tests__/Step4Report.spec.ts
+++ b/frontend/src/components/__tests__/Step4Report.spec.ts
@@ -919,17 +919,11 @@ describe('Step4Report — ConfidenceBadge-Integration (Sub-Slice 16a)', () => {
         section_index: 3,
         section_title: 'Abschnitt 3',
         section_summary: 'Zusammenfassung 3 — spekulativer Bereich',
-        // speculative-Claim: kein Evidence nötig (laut ADR-0002 Anker)
-        claims: [
-          {
-            claim_id: 'claim_03',
-            claim_text: 'Spekulativer Claim ohne belastbare Evidence — Frühindikator',
-            confidence_label: 'speculative',
-            confidence_score: 0.1,
-            evidence: [],
-            audit_trail: [],
-          },
-        ],
+        // Seit #1235 (ADR-0002) braucht jeder Claim mindestens ein stützendes
+        // Evidence-Item, unabhängig vom confidence_label. Eine Aussage ohne
+        // stützende Evidence wird backendseitig zur Hypothese/zum Data-Gap
+        // geroutet und erscheint hier folgerichtig nicht als Claim.
+        claims: [],
       },
     ],
   }


### PR DESCRIPTION
## Summary
- `main` (`84ba49ac`/`55f4f8d3`) hat gerade einen roten Required-Check: `Frontend PR smoke gate` schlägt bei `Step4Report — ConfidenceBadge-Integration > rendert 2 ConfidenceBadge-Instanzen für 2 Sections mit Evidence` fehl (0 statt ≥2 Badges)
- Root Cause: PR #1235 hat `ReportClaimSchema` verschärft — jeder Claim braucht jetzt mindestens ein stützendes Evidence-Item, unabhängig vom `confidence_label` (vorher waren `speculative`/`low` ausgenommen)
- Die Testfixture in `Step4Report.spec.ts` hatte weiterhin einen `speculative`-Claim ohne Evidence in Abschnitt 3 → `EvidenceMapSchema.parse()` wirft beim Laden, `evidenceMap` bleibt `null`, alle Badges (auch für Sections 1/2 mit echter Evidence) verschwinden
- Fix: Abschnitt 3 führt jetzt `claims: []` — deckungsgleich mit dem Backend-Verhalten aus #1233 (Aussagen ohne stützende Evidence werden zu Hypothese/Data-Gap, nicht zu Claims)

## Test plan
- [x] `bun run test -- src/components/__tests__/Step4Report.spec.ts` — 54/54 grün (vorher: 1 fail)
- [x] `bash scripts/pre-push-gate.sh frontend` — ALL GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)