### PR TITLE
fix(evidence): cross_stakeholder_for_high zählt Rollenfamilien statt Jobtitel (#1248)

### DIFF
--- a/backend/app/contracts/report_contract.py
+++ b/backend/app/contracts/report_contract.py
@@ -293,6 +293,23 @@ def _stakeholder_group_key(value: Optional[str]) -> str:
     return " ".join(value.split()).casefold()
 
 
+#: Auffangtypen, die keine Rollenfamilie bezeichnen (Issue #1248, CodeRabbit
+#: PR #1260). Die Ontologie fuehrt ``Person`` und ``Organization`` bewusst als
+#: breite Fallback-Typen. Sie als Rollenfamilie zu zaehlen wuerde zwei
+#: voellig verschiedene Stakeholder — etwa einen Bildungstraeger und eine
+#: Aufsichtsbehoerde, beide als ``Organization`` klassifiziert — zu einer
+#: Stimme verschmelzen und damit die Cross-Stakeholder-Stuetzung unmoeglich
+#: machen. Genau die Verwechslung von Auffangtopf und Label ist der Grund,
+#: warum die Typbindung in #1247 nicht getragen hat.
+#:
+#: Fuer diese Typen bleibt der Berufstitel die Vergleichsgroesse — das
+#: bisherige Verhalten. Das Label wirkt nur dort, wo es tatsaechlich eine
+#: Rolle bezeichnet.
+_GENERIC_ENTITY_TYPES: frozenset[str] = frozenset({
+    "person", "organization", "entity", "node", "unknown", "other",
+})
+
+
 def _role_family_key(item: Any) -> str:
     """Zaehlschluessel fuer ``cross_stakeholder_for_high`` (Issue #1248).
 
@@ -320,7 +337,7 @@ def _role_family_key(item: Any) -> str:
     unterscheidbarer Gruppen kann dadurch nur sinken.
     """
     family = getattr(item, "persona_role_family", None)
-    if family:
+    if family and _stakeholder_group_key(family) not in _GENERIC_ENTITY_TYPES:
         return f"family:{_stakeholder_group_key(family)}"
     return f"title:{_stakeholder_group_key(getattr(item, 'persona_stakeholder_group', None))}"
 

--- a/backend/app/services/confidence_calculator.py
+++ b/backend/app/services/confidence_calculator.py
@@ -53,6 +53,13 @@ _CONTRADICTION_STD_THRESHOLD: float = 0.6
 _CONTRADICTION_RANGE_LOW: float = -0.3
 _CONTRADICTION_RANGE_HIGH: float = 0.3
 
+#: Auffangtypen zaehlen nicht als Rollenfamilie (Issue #1248). Spiegelt
+#: ``report_contract._GENERIC_ENTITY_TYPES`` — der Konsenswert muss dieselbe
+#: Vorstellung von "Gruppe" haben wie der Validator, der darueber entscheidet.
+_GENERIC_ENTITY_TYPES: frozenset[str] = frozenset(
+    {"person", "organization", "entity", "node", "unknown", "other"}
+)
+
 
 def _has_contradiction(sentiment_scores: List[float]) -> bool:
     """Erkennt widersprüchliche Sentiment-Vektoren in einem Evidence-Set.
@@ -337,16 +344,15 @@ def compute_confidence_breakdown(evidence: List[Dict]) -> Dict[str, float]:
     # Rollenfamilien-Label, ersatzweise der Berufstitel. Sonst haette der
     # Konsenswert eine andere Vorstellung von "Gruppe" als der Validator, der
     # ueber dasselbe Label entscheidet.
-    groups = {
-        (
-            f"family:{' '.join(str(e.get('persona_role_family')).split()).casefold()}"
-            if e.get("persona_role_family")
-            else f"title:{' '.join(str(e.get('persona_stakeholder_group')).split()).casefold()}"
-        )
-        for e in quote_items
-        if e.get("persona_role_family")
-        or str(e.get("persona_stakeholder_group") or "").strip()
-    }
+    groups: set[str] = set()
+    for e in quote_items:
+        family = " ".join(str(e.get("persona_role_family") or "").split()).casefold()
+        if family and family not in _GENERIC_ENTITY_TYPES:
+            groups.add(f"family:{family}")
+            continue
+        title = " ".join(str(e.get("persona_stakeholder_group") or "").split()).casefold()
+        if title:
+            groups.add(f"title:{title}")
     if len(groups) >= 3:
         consensus = 1.0
     elif len(groups) == 2:

--- a/backend/app/services/report_agent/evidence.py
+++ b/backend/app/services/report_agent/evidence.py
@@ -230,8 +230,13 @@ def _count_supporting_stakeholder_groups(evidence: List[Dict[str, Any]]) -> int:
         # eine Familie "Lecturer" nicht von einem gleichnamigen Jobtitel zu
         # unterscheiden. Spiegelt ``report_contract._role_family_key``.
         family = entry.get("persona_role_family")
-        if family:
-            groups.add(f"family:{' '.join(str(family).split()).casefold()}")
+        family_key = " ".join(str(family or "").split()).casefold()
+        # Issue #1248 (CodeRabbit PR #1260): Auffangtypen bezeichnen keine
+        # Rollenfamilie. Spiegelt ``report_contract._GENERIC_ENTITY_TYPES``.
+        if family_key and family_key not in {
+            "person", "organization", "entity", "node", "unknown", "other",
+        }:
+            groups.add(f"family:{family_key}")
             continue
         group = entry.get("persona_stakeholder_group")
         if group:

--- a/backend/tests/contracts/test_role_family_counting.py
+++ b/backend/tests/contracts/test_role_family_counting.py
@@ -291,3 +291,80 @@ class TestVertragUndSchema:
         from app.services.evidence_migrations import _RECORD_FIELDS
 
         assert "persona_role_family" in _RECORD_FIELDS
+
+
+class TestAuffangtypenSindKeineRollenfamilie:
+    """CodeRabbit PR #1260: `Person` und `Organization` sind Fallback-Töpfe.
+
+    Die Ontologie führt sie bewusst als breite Auffangtypen. Sie als
+    Rollenfamilie zu zählen würde zwei völlig verschiedene Stakeholder — etwa
+    einen Bildungsträger und eine Aufsichtsbehörde, beide `Organization` —
+    zu einer Stimme verschmelzen und Cross-Stakeholder-Stützung unmöglich
+    machen. Für sie bleibt der Berufstitel die Vergleichsgröße.
+    """
+
+    def test_zwei_organisationen_bleiben_zwei_gruppen(self):
+        evidence = [
+            _quote(1, job_title="Nordharz Bildungswerk gGmbH", role_family="Organization"),
+            _quote(2, job_title="Agentur für Arbeit", role_family="Organization"),
+        ]
+
+        claim = ReportClaimModel.model_validate(_claim(evidence))
+        assert claim.confidence_label == ConfidenceLabel.high
+
+    def test_zwei_personen_bleiben_zwei_gruppen(self):
+        evidence = [
+            _quote(1, job_title="Dozentin", role_family="Person"),
+            _quote(2, job_title="Betriebsrätin", role_family="Person"),
+        ]
+
+        claim = ReportClaimModel.model_validate(_claim(evidence))
+        assert claim.confidence_label == ConfidenceLabel.high
+
+    def test_gleicher_jobtitel_unter_auffangtyp_bleibt_eine_gruppe(self):
+        """Die Whitespace-Normalisierung aus #1160 C greift weiterhin."""
+        evidence = [
+            _quote(1, job_title="Umschüler", role_family="Organization"),
+            _quote(2, job_title="  umschüler ", role_family="Organization"),
+        ]
+
+        with pytest.raises(ValidationError):
+            ReportClaimModel.model_validate(_claim(evidence))
+
+    def test_spezifische_familie_wirkt_weiterhin(self):
+        """Gegenprobe: ein echtes Rollenlabel kollabiert wie vorgesehen."""
+        evidence = [
+            _quote(1, job_title="Umschüler im IT-Bereich", role_family="Retrainee"),
+            _quote(2, job_title="Teilnehmer einer Umschulung", role_family="Retrainee"),
+        ]
+
+        with pytest.raises(ValidationError):
+            ReportClaimModel.model_validate(_claim(evidence))
+
+    def test_beide_zaehler_teilen_die_ausnahme(self):
+        from app.services.confidence_calculator import compute_confidence_breakdown
+        from app.services.report_agent.evidence import (
+            _count_supporting_stakeholder_groups as count_groups,
+        )
+
+        items = [
+            {
+                "type": "agent_interview",
+                "source_kind": "agent_quote",
+                "supports_claim": True,
+                "quote": "A",
+                "persona_stakeholder_group": "Bildungsträger",
+                "persona_role_family": "Organization",
+            },
+            {
+                "type": "agent_interview",
+                "source_kind": "agent_quote",
+                "supports_claim": True,
+                "quote": "B",
+                "persona_stakeholder_group": "Aufsichtsbehörde",
+                "persona_role_family": "Organization",
+            },
+        ]
+
+        assert count_groups(items) == 2
+        assert compute_confidence_breakdown(items)["stakeholder_group_count"] == 2.0


### PR DESCRIPTION
Behebt #1248 bis auf die Fremdrollen-Detektion — Begründung unten.

**Basiert auf #1247** (PR #1258), das auf #1246 (PR #1257) basiert. Bitte in dieser Reihenfolge mergen.

## Problem

`persona_stakeholder_group` wird aus dem Berufstitel gefüllt und ist damit Freitext. Normalisiert wurde nur Schreibweise und Whitespace — Wortwahl- und Genusvarianten derselben Rolle zählten als verschiedene Gruppen:

```
40 agent_quotes, 16 "distinkte" Gruppen:
   4x  Umschüler im IT-Bereich (Teilnehmer)
   2x  Teilnehmer einer IT-Umschulung (Retrainee)      ← identische Rolle

33 agent_quotes, 15 "distinkte" Gruppen:
   2x  Umschüler & Sprecher der Teilnehmenden
   1x  Umschüler zur Fachkraft für Lagerlogistik
   1x  Umschüler:in (Logistik & Lagerwesen)            ← vier Gruppen, eine Rolle
   1x  Umschülerin zur Kauffrau für E-Commerce
```

In einem weiteren Lauf genügte ein Genusunterschied: `Festangestellte Dozentin für IT-Umschulungen und Betriebsratsmitglied` gegen `Festangestellter Fachdozent für IT-Umschulungen und Betriebsratsmitglied`.

Der Anker verlangt zwei distinkte Gruppen für `high`. Es genügte also eine andere Formulierung desselben Berufs, um eine Aussage als breit gestützt einzustufen, obwohl nur eine Perspektive gesprochen hat.

## Änderung

- Neues Feld `persona_role_family` auf `EvidenceItemModel` und `EvidenceRecordModel`, gefüllt aus dem Entitätstyp der Quellentität (`source_entity_type` des Persona-Profils). Pro Lauf stabil, im Gegensatz zum Freitext — und weil der Vergleich immer innerhalb eines Reports stattfindet, ist die bekannte Vokabular-Instabilität zwischen Läufen hier irrelevant.
- `cross_stakeholder_for_high` zählt dieses Label. **Der Jobtitel bleibt vollständig erhalten** und wird weiterhin gespeichert und angezeigt.
- Der Konsenswert in `compute_confidence_breakdown` folgt derselben Zählgröße — sonst hätte er eine andere Vorstellung von „Gruppe" als der Validator, der über dasselbe Label entscheidet.
- Der Zähler im Agent-Pfad (`_count_supporting_stakeholder_groups`) ebenfalls.
- `evidence_migrations`: Feld in der Record-Feldliste, sonst fiele es beim Migrieren älterer Artefakte still weg.
- Schema-Dumps im selben Commit nachgezogen.

**Kollektiv und Individuum derselben Organisation** tragen denselben Entitätstyp und sind damit automatisch eine Familie — ohne eine zweite Identitätsquelle.

**Rückwärtskompatibel:** Fehlt das Label, bleibt der Jobtitel die Vergleichsgröße. Das ist das bisherige Verhalten, nie strenger und nie lockerer. Die beiden Namensräume trennt ein Präfix (`family:` / `title:`), damit eine Familie `Lecturer` nicht mit einem gleichlautenden Freitext verschmilzt.

## ADR-0002

Verschärfung von Hartanker 4, keine Schwächung — die Zahl unterscheidbarer Gruppen kann durch das Label nur sinken. Der `<evidence_gating priority="hard">`-Block und der Hedge-Snapshot sind byte-identisch (`git diff` auf beide: leer).

Zwei bestehende Tests matchten auf den Wortlaut der Fehlermeldung, die sich bewusst geändert hat — die Erwartung ist nachgezogen, nicht die Assertion abgeschwächt. Die Meldung erklärt weiterhin, dass normalisiert verglichen wird, und nennt jetzt zusätzlich Rollenfamilien und Berufstitel getrennt.

## Nicht in diesem PR: Fremdrollen-Detektion

Punkt 4 des Issues verlangt, dass eine Antwort mit expliziter Fremdrollen-Zuschreibung ihre `agent_quote`-Eignung verliert, und schreibt ausdrücklich vor, gegen das **Rollenfamilien-Label** zu prüfen und nicht gegen den Freitext.

Genau das ist der Haken: Das Label ist ein Entitätstyp (`WorksCouncilMember`), die Selbstzuschreibung im Text ist deutsch (`„Als Betriebsrat hätte ich…"`). Zwischen beiden liegt eine Sprach- und Vokabulargrenze. Ein Matcher darüber rät — entweder über eine Alias-Tabelle, die gepflegt werden muss und pro Domäne neu falsch ist, oder über einen zusätzlichen Modellaufruf.

Ein Fehltreffer entzieht echter Stakeholder-Evidence die Eignung, still. Das ist teurer als der Defekt, den er schließen soll. Die Entscheidung zwischen Alias-Tabelle und Modellprüfung gehört in ein eigenes Issue mit Sign-off; ich lege sie nicht nebenbei fest.

Die übrigen acht Akzeptanzkriterien sind erfüllt.

## Tests

`backend/tests/contracts/test_role_family_counting.py`, 14 Fälle: Wortwahlvarianten, Genusunterschied, der Vierer-Fall aus dem Referenzlauf, echte Rollenvielfalt trägt `high` weiterhin, Jobtitel bleibt Anzeigetext, Kollektiv+Individuum, Rückwärtskompatibilität ohne Label, Namensraum-Kollision, niedrige Labels unberührt, beide Zähler-Pfade, Vertrags- und Migrationsfelder.

Regressionsbreite: `-k "evidence or confidence or contract or stakeholder or gating or role_family"` → 896 passed.

Gate: `bash scripts/pre-push-gate.sh backend` — ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBLuMfd5j3T3vB2dGo13y7