### PR TITLE
fix(report): Resume löscht die Abbruchbegründung (#1243)

### DIFF
--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -32,7 +32,11 @@ from ..services.llm_routing_seed import (
     seed_run_stage_routing,
 )
 from ..services.report_agent import ReportAgent, ReportManager, ReportStatus
-from ..services.report_generation import finish_cancelled_run, was_run_cancelled
+from ..services.report_generation import (
+    finish_cancelled_run,
+    finish_completed_run,
+    was_run_cancelled,
+)
 from ..services.run_lifecycle import RunLifecycle
 from ..services.run_registry import RunRegistry
 from ..services.simulation_manager import SimulationManager, SimulationStatus
@@ -937,24 +941,8 @@ def _resume_report_generate(run: dict):
                     run["run_id"], report_id=report_id, simulation_id=simulation_id
                 )
             elif report.status == ReportStatus.COMPLETED:
-                run_registry.update_run(
-                    run["run_id"],
-                    status="completed",
-                    progress=100,
-                    message="Report generated",
-                    # Issue #1243 (CodeRabbit PR #1251): Ein zuvor abgebrochener
-                    # und dann fortgesetzter Run behielt sonst
-                    # termination_reason="user_cancel" — update_run laesst das
-                    # Feld stehen, solange es nicht ausdruecklich ueberschrieben
-                    # wird. Der erfolgreich zu Ende gefuehrte Lauf stuende dann
-                    # als "completed" da und waere im Monitor trotzdem als
-                    # nutzerabgebrochen gefuehrt.
-                    termination_reason=None,
-                    artifacts=ArtifactLocator.existing_paths({
-                        "report": ArtifactLocator.report_artifacts(report_id),
-                        "simulation": ArtifactLocator.simulation_artifacts(simulation_id),
-                    }),
-                    resume_capability={"available": False, "action": None, "label": None},
+                finish_completed_run(
+                    run["run_id"], report_id=report_id, simulation_id=simulation_id
                 )
                 task_manager.complete_task(task_id, result={"report_id": report_id, "simulation_id": simulation_id})
             else:

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -942,6 +942,14 @@ def _resume_report_generate(run: dict):
                     status="completed",
                     progress=100,
                     message="Report generated",
+                    # Issue #1243 (CodeRabbit PR #1251): Ein zuvor abgebrochener
+                    # und dann fortgesetzter Run behielt sonst
+                    # termination_reason="user_cancel" — update_run laesst das
+                    # Feld stehen, solange es nicht ausdruecklich ueberschrieben
+                    # wird. Der erfolgreich zu Ende gefuehrte Lauf stuende dann
+                    # als "completed" da und waere im Monitor trotzdem als
+                    # nutzerabgebrochen gefuehrt.
+                    termination_reason=None,
                     artifacts=ArtifactLocator.existing_paths({
                         "report": ArtifactLocator.report_artifacts(report_id),
                         "simulation": ArtifactLocator.simulation_artifacts(simulation_id),

--- a/backend/app/services/report_generation.py
+++ b/backend/app/services/report_generation.py
@@ -39,6 +39,34 @@ def was_run_cancelled(run_id: str) -> bool:
         return False
 
 
+def finish_completed_run(run_id: str, *, report_id: str, simulation_id: str) -> None:
+    """Setzt den Erfolgs-Endzustand eines fertigen Reports (Issue #1243).
+
+    Bewusst eine eigene Funktion statt eines Inline-Blocks: der Resume-Pfad
+    ist die einzige Stelle, an der ein Run von ``stopped`` +
+    ``termination_reason="user_cancel"`` wieder in den Erfolg laufen kann.
+    ``RunRegistry.update_run`` laesst das Feld stehen, solange es nicht
+    ausdruecklich ueberschrieben wird — der erfolgreich zu Ende gefuehrte Lauf
+    stuende sonst als "completed" da und waere im Monitor gleichzeitig als
+    nutzerabgebrochen gefuehrt.
+
+    Als Funktion ist der Endzustand gegen eine echte Registry pruefbar, statt
+    nur als Textmuster im Quelltext (CodeRabbit PR #1262).
+    """
+    RunRegistry().update_run(
+        run_id,
+        status="completed",
+        progress=100,
+        message="Report generated",
+        termination_reason=None,
+        artifacts=ArtifactLocator.existing_paths({
+            "report": ArtifactLocator.report_artifacts(report_id),
+            "simulation": ArtifactLocator.simulation_artifacts(simulation_id),
+        }),
+        resume_capability={"available": False, "action": None, "label": None},
+    )
+
+
 def finish_cancelled_run(run_id: str, *, report_id: str, simulation_id: str) -> None:
     """Setzt den Abbruch-Endzustand eines per ``/cancel`` gestoppten Reports.
 

--- a/backend/tests/services/test_report_cancel_wiring.py
+++ b/backend/tests/services/test_report_cancel_wiring.py
@@ -227,22 +227,61 @@ def test_report_agent_fassade_reicht_cancel_run_id_weiter():
     assert params["cancel_run_id"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
-def test_resume_loescht_die_abbruchbegruendung():
-    """CodeRabbit PR #1251: `termination_reason` überlebte den Resume.
+def test_erfolgreicher_abschluss_loescht_die_abbruchbegruendung(tmp_path, monkeypatch):
+    """CodeRabbit PR #1262: `termination_reason` überlebte den Resume.
 
-    `update_run` lässt das Feld stehen, solange es nicht ausdrücklich
-    überschrieben wird. Ein abgebrochener, dann fortgesetzter und erfolgreich
-    beendeter Run stünde als `completed` da und wäre im Monitor trotzdem als
-    nutzerabgebrochen geführt.
+    Vorher prüfte dieser Test nur, ob der Quelltext den String
+    ``termination_reason=None`` enthält. Das wäre grün geblieben, wenn das
+    Schlüsselwort in den falschen Zweig gewandert oder toter Code geworden
+    wäre. Jetzt läuft der Endzustand gegen eine echte Registry.
+
+    Der Lebenszyklus ist der reale: abgebrochen → fortgesetzt → erfolgreich
+    beendet. Ohne den Fix stünde der Run als ``completed`` da und wäre im
+    Monitor gleichzeitig als nutzerabgebrochen geführt.
+    """
+    from app.services.report_generation import (
+        finish_cancelled_run,
+        finish_completed_run,
+    )
+
+    registry_dir = tmp_path / "reg"
+    registry_dir.mkdir()
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", str(registry_dir))
+    RunRegistry._instance = None
+    registry = RunRegistry()
+
+    record = registry.create_run("report_generate", "report_x")
+    run_id = record["run_id"]
+
+    finish_cancelled_run(run_id, report_id="report_x", simulation_id="sim_x")
+    cancelled = registry.get_run(run_id)
+    assert cancelled["status"] == "stopped"
+    assert cancelled["termination_reason"] == "user_cancel"
+
+    finish_completed_run(run_id, report_id="report_x", simulation_id="sim_x")
+    resumed = registry.get_run(run_id)
+    assert resumed["status"] == "completed"
+    assert resumed["termination_reason"] is None, (
+        "Der erfolgreich fortgesetzte Run trägt weiterhin die Abbruchbegründung"
+    )
+    assert resumed["progress"] == 100
+    assert resumed["resume_capability"]["available"] is False
+
+    RunRegistry._instance = None
+
+
+def test_resume_pfad_nutzt_den_gemeinsamen_endzustand():
+    """Der Resume-Handler darf den Endzustand nicht selbst nachbauen.
+
+    Sonst driftet er wieder von ``finish_completed_run`` ab — genau so ist die
+    Lücke entstanden.
     """
     import inspect
 
     from app.api import runs as runs_api
 
     source = inspect.getsource(runs_api._resume_report_generate)
-    assert "termination_reason=None" in source, (
-        "Der Resume-Erfolgspfad löscht die Abbruchbegründung nicht"
-    )
+    assert "finish_completed_run(" in source
 
 
 def test_registry_kann_die_abbruchbegruendung_ueberhaupt_loeschen(tmp_path, monkeypatch):

--- a/backend/tests/services/test_report_cancel_wiring.py
+++ b/backend/tests/services/test_report_cancel_wiring.py
@@ -225,3 +225,39 @@ def test_report_agent_fassade_reicht_cancel_run_id_weiter():
         "Die Agent-Fassade kennt cancel_run_id nicht — der Parameter endet dort"
     )
     assert params["cancel_run_id"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_resume_loescht_die_abbruchbegruendung():
+    """CodeRabbit PR #1251: `termination_reason` überlebte den Resume.
+
+    `update_run` lässt das Feld stehen, solange es nicht ausdrücklich
+    überschrieben wird. Ein abgebrochener, dann fortgesetzter und erfolgreich
+    beendeter Run stünde als `completed` da und wäre im Monitor trotzdem als
+    nutzerabgebrochen geführt.
+    """
+    import inspect
+
+    from app.api import runs as runs_api
+
+    source = inspect.getsource(runs_api._resume_report_generate)
+    assert "termination_reason=None" in source, (
+        "Der Resume-Erfolgspfad löscht die Abbruchbegründung nicht"
+    )
+
+
+def test_registry_kann_die_abbruchbegruendung_ueberhaupt_loeschen(tmp_path, monkeypatch):
+    """Ohne diese Zusicherung wäre der Fix oben wirkungslos."""
+    registry_dir = tmp_path / "reg"
+    registry_dir.mkdir()
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", str(registry_dir))
+    RunRegistry._instance = None
+    registry = RunRegistry()
+
+    record = registry.create_run("report_generate", "report_x")
+    registry.update_run(record["run_id"], status="stopped", termination_reason="user_cancel")
+    assert registry.get_run(record["run_id"])["termination_reason"] == "user_cancel"
+
+    registry.update_run(record["run_id"], status="completed", termination_reason=None)
+    assert registry.get_run(record["run_id"])["termination_reason"] is None
+
+    RunRegistry._instance = None


### PR DESCRIPTION
Nachtrag zu #1251. Der Fix entstand als Antwort auf ein CodeRabbit-Finding, wurde aber gepusht, nachdem #1251 bereits per Squash gemergt war — er ist dadurch nicht in `main` gelandet. Verifiziert: `grep termination_reason=None` auf `origin/main:backend/app/api/runs.py` → 0 Treffer.

## Problem

`RunRegistry.update_run` lässt `termination_reason` stehen, solange es nicht ausdrücklich überschrieben wird. Ein per `POST /api/runs/<id>/cancel` abgebrochener Run trägt nach #1251 `stopped` + `termination_reason="user_cancel"` und bietet „Continue report generation" an.

Wird er darüber fortgesetzt und läuft erfolgreich durch, setzt der Resume-Pfad `status="completed"` — die Abbruchbegründung bleibt aber im Manifest. Der Run steht dann als abgeschlossen da und wird im Ressourcen-Monitor gleichzeitig als nutzerabgebrochen geführt.

## Änderung

Der Erfolgspfad des Resume setzt `termination_reason=None`.

## Tests

- Statische Prüfung, dass der Resume-Erfolgspfad das Feld zurücksetzt
- Lebenszyklus-Test gegen eine echte `RunRegistry`: `stopped` + `user_cancel` → `completed` + `None`. Ohne diese Zusicherung wäre der Fix wirkungslos, denn er hängt daran, dass die Registry das Löschen überhaupt unterstützt.

Gate: `bash scripts/pre-push-gate.sh backend` — ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBLuMfd5j3T3vB2dGo13y7