### PR TITLE
fix(sim): Kollisionsbehandlung in die Runner-Basis statt in den Reddit-Override (#1245)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -239,7 +239,7 @@ Diese Beobachtungen sind dokumentiert und erklärt. Wer sie als Neufund meldet, 
 | Viele identische Posts, manche mit leerem `content` | Reposts und Quotes, siehe Auswertungsfalle oben. |
 | `pooler.dense.weight MISSING` beim Laden von `twhin-bert-base` | Bekannt, Issue #1236 — der Twitter-Recommender rankt über zufällig initialisierte Gewichte. |
 | Rohes Persona-Log zeigt Namens- und Gender-Kollaps | Der Dedup-Schritt repariert das. Maßgeblich ist `reddit_profiles.json`, nicht das Log. |
-| `Published 1 initial posts` bei mehr konfigurierten Posts | Der Zähler zählt **distinkte Poster-Agenten**, nicht Posts. |
+| `Published N initial posts from M distinct agents` | Seit #1245 weist die Zeile beide Größen getrennt aus. `N` sind Posts, `M` distinkte Poster-Agenten. Ist `M` deutlich kleiner als `N`, liegen viele Seed-Posts auf wenigen Stimmen — das ist ein Befund, kein Rauschen (vgl. #1226). Die alte Form `Published 1 initial posts` zählte Agenten und nannte sie Posts; Logs aus Läufen vor #1245 sind entsprechend zu lesen. |
 
 ---
 

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -168,9 +168,12 @@ setup_signal_handlers = _platform_runner.setup_signal_handlers
 class RedditSimulationRunner(SinglePlatformRunner):
     """Reddit simulation runner — dünne Subklasse der SinglePlatformRunner-Basis.
 
-    Einzige Verhaltensdifferenz zu Twitter: ``_assign_initial_action`` appended
-    an eine bestehende Action-Liste pro Agent statt sie zu überschreiben
-    (Reddit erlaubt mehrere Initial-Posts desselben Agents).
+    Issue #1245: Die Kollisionsbehandlung für mehrere Initial-Posts desselben
+    Agenten stand bis hierher als Reddit-Override. Sie ist keine
+    Plattformeigenheit, sondern die einzig richtige Behandlung — Twitter
+    verwarf über die überschreibende Basisimplementierung still Seed-Posts.
+    Sie liegt jetzt in ``SinglePlatformRunner``, diese Klasse unterscheidet
+    sich nur noch in Aktionsliste, Dateinamen und Graph-Generator.
     """
 
     # Reddit available actions (INTERVIEW not included, INTERVIEW can only be triggered manually via ManualAction)
@@ -202,21 +205,6 @@ class RedditSimulationRunner(SinglePlatformRunner):
     DB_FILENAME = "reddit_simulation.db"
     PLATFORM_TYPE = oasis.DefaultPlatformType.REDDIT
     GRAPH_GENERATOR = staticmethod(generate_reddit_agent_graph)
-
-    def _assign_initial_action(self, initial_actions, agent, content: str) -> None:
-        """Reddit: mehrere Initial-Posts pro Agent → append an Liste statt überschreiben."""
-        if agent in initial_actions:
-            if not isinstance(initial_actions[agent], list):
-                initial_actions[agent] = [initial_actions[agent]]
-            initial_actions[agent].append(ManualAction(
-                action_type=ActionType.CREATE_POST,
-                action_args={"content": content}
-            ))
-        else:
-            initial_actions[agent] = ManualAction(
-                action_type=ActionType.CREATE_POST,
-                action_args={"content": content}
-            )
 
 
 async def main():

--- a/backend/scripts/sim_runtime/platform_runner.py
+++ b/backend/scripts/sim_runtime/platform_runner.py
@@ -3,12 +3,16 @@
 Verhaltensneutral aus ``run_twitter_simulation.py`` und
 ``run_reddit_simulation.py`` extrahiert: beide Runner-Klassen waren bis auf
 Plattform-Konfiguration (verfügbare Actions, Profile-Dateiname, DB-Dateiname,
-``oasis.DefaultPlatformType``, Graph-Generator) und das Handling von
-``initial_actions`` (Reddit appended an bestehende Listen, Twitter
-überschreibt) identisch.
+``oasis.DefaultPlatformType``, Graph-Generator) identisch.
 
-Plattform-spezifische Werte werden über Klassen-Attribute und die
-Template-Method ``_assign_initial_action`` injiziert; die Entry-Points
+Das Handling von ``initial_actions`` war ursprünglich ebenfalls verschieden —
+Reddit appendete an bestehende Listen, Twitter überschrieb. Das war kein
+Plattformunterschied, sondern ein Defekt: Twitter verwarf dadurch still
+Seed-Posts desselben Agenten (Issue #1245). ``_assign_initial_action`` liegt
+seitdem als gemeinsame Implementierung in dieser Basisklasse und ist **kein**
+Erweiterungspunkt mehr.
+
+Plattform-spezifische Werte werden über Klassen-Attribute injiziert; die Entry-Points
 (``run_twitter_simulation.py`` / ``run_reddit_simulation.py``) definieren
 dünne Subklassen plus Modul-Setup (Profiling, Parser, ``main``).
 
@@ -106,9 +110,10 @@ def setup_signal_handlers():
 class SinglePlatformRunner:
     """Single-platform OASIS simulation runner (Twitter/Reddit).
 
-    Subclasses setzen die Plattform-Konfiguration via Klassen-Attribute und
-    überschreiben ggf. ``_assign_initial_action`` für plattform-spezifisches
-    Initial-Posts-Handling.
+    Subclasses setzen die Plattform-Konfiguration via Klassen-Attribute.
+    ``_assign_initial_action`` ist bewusst nicht zu überschreiben: die
+    Kollisionsbehandlung für mehrere Seed-Posts desselben Agenten gilt für
+    beide Plattformen gleich (Issue #1245).
     """
 
     # --- Plattform-Konfiguration (von Subklasse zu setzen) ---

--- a/backend/scripts/sim_runtime/platform_runner.py
+++ b/backend/scripts/sim_runtime/platform_runner.py
@@ -323,14 +323,28 @@ class SinglePlatformRunner:
     def _assign_initial_action(self, initial_actions: Dict, agent: Any, content: str) -> None:
         """Assign an initial CREATE_POST action for ``agent``.
 
-        Default (Twitter-Verhalten): überschreibt eine bestehende Zuweisung.
-        Reddit überschreibt diese Methode, um an eine bestehende Liste zu
-        appenden statt zu überschreiben.
+        Issue #1245 (CodeRabbit PR #1256): Die Standardimplementierung
+        ueberschrieb eine bestehende Zuweisung — mehrere Seed-Posts desselben
+        Agenten kollabierten auf den letzten, still und ohne Warnung. Das galt
+        fuer jeden Lauf mit ``platform="twitter"``, der ueber
+        ``run_twitter_simulation.py`` und diesen Runner geht; der Fix im
+        Parallel-Skript erreichte diesen Pfad nicht.
+
+        Kollisionsbehandlung gehoert nicht auf eine Plattform, sondern in die
+        Basis: ``env.step`` akzeptiert je Agent einen Einzelwert oder eine
+        Liste. Ohne Kollision entsteht weiterhin kein zusaetzliches Wrapping.
         """
-        initial_actions[agent] = ManualAction(
+        action = ManualAction(
             action_type=ActionType.CREATE_POST,
             action_args={"content": content}
         )
+        existing = initial_actions.get(agent)
+        if existing is None:
+            initial_actions[agent] = action
+        elif isinstance(existing, list):
+            existing.append(action)
+        else:
+            initial_actions[agent] = [existing, action]
 
     async def run(self, max_rounds: int = None):
         """Run single-platform simulation
@@ -485,7 +499,19 @@ class SinglePlatformRunner:
 
             if initial_actions:
                 await self.env.step(initial_actions)
-                print(f"  Published {len(initial_actions)} initial posts")
+                # Issue #1245: Posts und distinkte Agenten getrennt ausweisen.
+                # len(initial_actions) zaehlt Dict-Eintraege, also Agenten —
+                # bei kollabierten Seed-Posts meldete die Zeile einen Erfolg,
+                # der den Defekt verdeckte.
+                published = sum(
+                    len(value) if isinstance(value, list) else 1
+                    for value in initial_actions.values()
+                )
+                print(
+                    f"  Published {published} initial post"
+                    f"{'' if published == 1 else 's'} from {len(initial_actions)} "
+                    f"distinct agent{'' if len(initial_actions) == 1 else 's'}"
+                )
 
         print("\nStart simulation loop...")
         start_time = datetime.now()

--- a/backend/tests/scripts/test_initial_post_publish_collision.py
+++ b/backend/tests/scripts/test_initial_post_publish_collision.py
@@ -165,3 +165,61 @@ def test_callback_meldet_jeden_veroeffentlichten_post():
 def test_logzeile_nennt_posts_und_distinkte_agenten(posts_count, agents_count, expected):
     """`Published 1 initial posts` bei neun Posts war der Kern der Irreführung."""
     assert rps.format_initial_posts_log(posts_count, agents_count) == expected
+
+
+# --------------------------------------- Review-Finding (CodeRabbit PR #1256)
+
+
+def test_standalone_runner_verwirft_keine_posts():
+    """Der Einzelplattform-Pfad hatte dieselbe Überschreib-Logik.
+
+    ``platform="twitter"`` startet ``run_twitter_simulation.py``, dessen Runner
+    von ``SinglePlatformRunner`` erbt. Die Basisimplementierung von
+    ``_assign_initial_action`` überschrieb — mehrere Seed-Posts desselben
+    Agenten verschwanden also weiterhin still, obwohl der Parallel-Pfad
+    korrigiert war. Der erste Test dieser Datei ruft nur den Parallel-Helfer
+    zweimal auf und konnte die Divergenz nicht sehen.
+    """
+    import importlib.util
+    from pathlib import Path as _Path
+
+    runtime_dir = _Path(__file__).resolve().parents[2] / "scripts" / "sim_runtime"
+    spec = importlib.util.spec_from_file_location(
+        "_platform_runner_under_test", runtime_dir / "platform_runner.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    runner = module.SinglePlatformRunner.__new__(module.SinglePlatformRunner)
+    agent = _FakeAgent(1)
+    actions: dict = {}
+
+    runner._assign_initial_action(actions, agent, "Betriebsrat")
+    runner._assign_initial_action(actions, agent, "Kostenträger")
+    runner._assign_initial_action(actions, agent, "Honorarkraft")
+
+    assert len(actions) == 1
+    assert sorted(_flatten(actions)) == ["Betriebsrat", "Honorarkraft", "Kostenträger"]
+
+
+def test_standalone_runner_ohne_kollision_unveraendert():
+    """Gegenprobe: ein Post pro Agent bleibt ein Einzelwert, keine Liste."""
+    import importlib.util
+    from pathlib import Path as _Path
+
+    runtime_dir = _Path(__file__).resolve().parents[2] / "scripts" / "sim_runtime"
+    spec = importlib.util.spec_from_file_location(
+        "_platform_runner_under_test2", runtime_dir / "platform_runner.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    runner = module.SinglePlatformRunner.__new__(module.SinglePlatformRunner)
+    actions: dict = {}
+    runner._assign_initial_action(actions, _FakeAgent(1), "A")
+    runner._assign_initial_action(actions, _FakeAgent(2), "B")
+
+    assert len(actions) == 2
+    assert all(not isinstance(v, list) for v in actions.values())


### PR DESCRIPTION
Nachtrag zu #1256. Der Fix entstand als Antwort auf ein CodeRabbit-Finding, wurde aber gepusht, nachdem #1256 bereits per Squash gemergt war — er ist dadurch nicht in `main` gelandet. Verifiziert: `grep "isinstance(existing, list)"` auf `origin/main:backend/scripts/sim_runtime/platform_runner.py` → 0 Treffer.

## Problem

#1256 hat die Kollisionsbehandlung nur im Parallel-Skript `run_parallel_simulation.py` korrigiert. Der **Einzelplattform-Pfad** blieb unberührt:

`platform="twitter"` startet über `sim/process_manager.py` das Skript `run_twitter_simulation.py`, dessen `TwitterSimulationRunner` von `SinglePlatformRunner` erbt. Deren `_assign_initial_action` war die überschreibende Implementierung — mehrere Seed-Posts desselben Agenten kollabierten dort weiterhin still auf den letzten, in einem regulär unterstützten Betriebsmodus.

Der Test aus #1256 konnte das nicht sehen: Er rief den neuen Parallel-Helfer zweimal auf und nannte die Ergebnisse Twitter und Reddit. Damit prüfte er, dass ein Helfer sich zweimal gleich verhält — nicht, dass die echten Plattformpfade übereinstimmen.

## Änderung

Die Kollisionsbehandlung ist keine Plattformeigenheit, sondern die einzig richtige Behandlung: `env.step` akzeptiert je Agent einen Einzelwert oder eine Liste. Sie liegt jetzt in `SinglePlatformRunner`.

Der Reddit-Override wird damit redundant und entfällt — `RedditSimulationRunner` unterscheidet sich nur noch in Aktionsliste, Dateinamen, Plattformtyp und Graph-Generator. Ohne Kollision entsteht weiterhin kein zusätzliches Wrapping.

Die Log-Zeile weist auch im Einzelplattform-Pfad Posts und distinkte Agenten getrennt aus, statt Dict-Einträge als „initial posts" zu melden.

## Tests

Zwei Tests fahren den Basis-Runner selbst statt den Parallel-Helfer:

- drei Posts auf einem Agenten überleben vollständig
- ohne Kollision bleibt jeder Eintrag ein Einzelwert, keine Liste

Gate: `bash scripts/pre-push-gate.sh backend` — ALL GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBLuMfd5j3T3vB2dGo13y7