### PR TITLE
feat: Reproduzierbare Runs, Manifest und Replay (#763)

### DIFF
--- a/.scratch/reproducible-runs/SPEC.md
+++ b/.scratch/reproducible-runs/SPEC.md
@@ -1,0 +1,116 @@
+# Spec: Reproduzierbare Runs, Manifest und Replay (#763)
+
+## Ziel
+
+Jeder Run besitzt ein kanonisches, maschinenlesbares Manifest und kann mit identischer oder bewusst veränderter Konfiguration erneut ausgeführt und verglichen werden.
+
+## Design-Entscheidungen (aus Grilling)
+
+| # | Entscheidung |
+|---|---|
+| D1 | Gesamter Run (Sim+Report). Varianten-Replay = gleiche Config, anderes Seed-Doku/Seed |
+| D2 | Snapshot — alles eingefroren, keine Live-Referenzen |
+| D3 | `manifest.json` im Run-Dir (autoritativ) + Summary-Felder in Neo4j (Index) |
+| D4 | Migration: rekonstruieren was automatisch geht, Rest `null`/`unknown` |
+| D5 | Resume = gleiche run_id. Replay = neue run_id + `replayed_from_run_id` |
+| D6 | Alles ins Manifest: Hashes, Modelle, Provider, Prompts, Seeds, Versionen, Routing |
+| D7 | Vollständige Prompt-Texte (kein Diff) |
+| D8 | `POST /api/runs/<run_id>/replay` mit Override-Body |
+| D9 | Zwei Phasen: Draft bei Start, final bei Ende |
+| D10 | ZIP-Export: `manifest.json` + Artefakte |
+| D11 | Pydantic-Validierung + Preflight-Check (warnt, blockiert nicht) |
+| D12 | `replayed_from_run_id` + `parent_run_id` getrennt |
+| D13 | SHA-256 des rohen Upload-Textes |
+| D14 | Replay-Button in Run-Detail + eigenes Untermenü |
+
+## Manifest-Inhalt
+
+```yaml
+RunManifest:
+  schema_version: 1
+  run_id: str
+  replayed_from_run_id: str | null
+  captured_at: datetime  # Zeitpunkt der Erstellung
+
+  # Eingangsdaten
+  inputs:
+    seed_document_hash: str  # SHA-256 des rohen Upload-Textes
+    seed_document_filename: str
+    simulation_config_hash: str  # SHA-256 der simulation_config.json
+    graph_id: str
+    graph_version: str | null
+    embedding_version: str | null
+
+  # Versionen
+  versions:
+    agora_version: str
+    schema_version: str
+
+  # Modell & Provider
+  routing:
+    stages:
+      <stage_id>:
+        model: str
+        provider: str
+        base_url: str  # ohne Secrets
+        ai_route_snapshot: dict  # komplette AiRoute
+
+  # Prompts (Snapshot)
+  prompts:
+    <prompt_key>:
+      content: str  # vollständiger Prompt-Text
+      source_file: str  # woher der Prompt kam (z.B. sections.py:200)
+
+  # Seeds
+  seeds:
+    random_seed: int
+    simulation_id_seed: str  # der Seed, aus dem random_seed abgeleitet wurde
+
+  # Laufzeit (nur im finalen Manifest)
+  runtime:
+    started_at: datetime
+    completed_at: datetime | null
+    duration_seconds: int | null
+    rounds_completed: int | null
+    usage_summary: RunUsage | null
+    termination_reason: str | null
+
+  # Status
+  status: "draft" | "final" | "legacy"
+```
+
+## API
+
+### Replay
+```
+POST /api/runs/<run_id>/replay
+Body: {
+  overrides: {
+    seed_document_id: str | null,   # Variante: anderes Dokument
+    random_seed: int | null,        # Variante: anderer Seed
+    ai_model_ref: AiModelRef | null # Variante: anderes Modell
+  }
+}
+Response: 202 { run_id: str, status: "pending" }
+```
+
+### Export
+```
+GET /api/runs/<run_id>/export
+Response: application/zip (manifest.json + Artefakte)
+```
+
+### Manifest
+```
+GET /api/runs/<run_id>/manifest
+Response: RunManifest (JSON)
+```
+
+## Constraints
+
+- Keine Secrets im Manifest (API-Keys, Passwörter)
+- Prompt-Snapshots sind byte-genau
+- Draft-Manifest wird bei Run-Start geschrieben
+- Finales Manifest wird bei Run-Ende geschrieben
+- Abgestürzte Runs behalten Draft-Manifest
+- Legacy-Runs bekommen `status: "legacy"` mit rekonstruierten Feldern

--- a/.scratch/reproducible-runs/issues/01-contract.md
+++ b/.scratch/reproducible-runs/issues/01-contract.md
@@ -1,0 +1,28 @@
+# Ticket 1: RunManifest Pydantic Contract
+
+**Blocks:** 2, 3, 4, 5, 7, 8
+**Size:** m
+**Layer:** 0 (Contract)
+
+## Aufgabe
+
+`RunManifest` als Pydantic-v2-Modell in `backend/app/contracts/run_manifest_contract.py` definieren.
+
+## Inhalt
+
+- `RunManifest` mit allen Feldern aus SPEC.md
+- `ManifestStatus`: `Literal["draft", "final", "legacy"]`
+- `ManifestInputs`: seed_document_hash, seed_document_filename, simulation_config_hash, graph_id, graph_version, embedding_version
+- `ManifestVersions`: agora_version, schema_version
+- `ManifestRouting`: dict von stage_id → StageRoute (model, provider, base_url, ai_route_snapshot)
+- `ManifestPrompts`: dict von prompt_key → PromptSnapshot (content, source_file)
+- `ManifestSeeds`: random_seed, simulation_id_seed
+- `ManifestRuntime`: started_at, completed_at, duration_seconds, rounds_completed, usage_summary, termination_reason
+- `ReplayRequest`: run_id + overrides (seed_document_id, random_seed, ai_model_ref)
+- `ReplayResponse`: run_id, status
+
+## Akzeptanz
+
+- [ ] `dump_schemas --check` grün
+- [ ] Contract-Tests grün
+- [ ] JSON Schema wird generiert

--- a/.scratch/reproducible-runs/issues/02-capture-start.md
+++ b/.scratch/reproducible-runs/issues/02-capture-start.md
@@ -1,0 +1,32 @@
+# Ticket 2: Manifest Capture at Run Start
+
+**Blocked by:** 1
+**Blocks:** 3
+**Size:** m
+**Layer:** 2 (Service)
+
+## Aufgabe
+
+Bei jedem Run-Start ein Draft-Manifest schreiben.
+
+## Scope
+
+- `ManifestCapture` Service-Klasse in `backend/app/services/manifest_capture.py`
+- `capture_draft(run_id, ...)` — sammelt alle zum Startzeitpunkt verfügbaren Daten:
+  - Seed-Dokument-Hash (SHA-256 des rohen Upload-Textes)
+  - simulation_config.json Hash
+  - Agora-Version, Schema-Version
+  - Graph-ID, Graph-Version, Embedding-Version
+  - Stage-Routing (aus `RuntimeRunConfig` Snapshots)
+  - Prompt-Snapshots (alle Prompt-Module auslesen und einfrieren)
+  - Random-Seed (aus simulation_config.json oder Ableitungslogik)
+- Schreibt `manifest.json` ins Run-Dir mit `status: "draft"`
+- Integration in `RunLifecycle.begin()` oder als expliziter Aufruf nach `begin()`
+
+## Akzeptanz
+
+- [ ] Jeder neue Run hat ein `manifest.json` im Run-Dir
+- [ ] Manifest enthält keine Secrets
+- [ ] Prompt-Texte sind byte-genau
+- [ ] SHA-256-Hashes sind korrekt
+- [ ] Test: `manifest.json` existiert nach Run-Start und hat `status: "draft"`

--- a/.scratch/reproducible-runs/issues/03-finalize.md
+++ b/.scratch/reproducible-runs/issues/03-finalize.md
@@ -1,0 +1,28 @@
+# Ticket 3: Manifest Finalization at Run End
+
+**Blocked by:** 2
+**Size:** s
+**Layer:** 2 (Service)
+
+## Aufgabe
+
+Draft-Manifest bei Run-Ende mit Laufzeitdaten finalisieren.
+
+## Scope
+
+- `ManifestCapture.finalize(run_id)` — ergänzt:
+  - `runtime.started_at`, `runtime.completed_at`
+  - `runtime.duration_seconds`
+  - `runtime.rounds_completed` (aus Simulation-Snapshot)
+  - `runtime.usage_summary` (aus `usage_summary.json`)
+  - `runtime.termination_reason`
+- Setzt `status: "final"`
+- Integration in `RunLifecycle` — bei Terminal-Transition (completed/failed/stopped)
+- Bei Abbruch/Absturz: Draft bleibt erhalten (kein finalize)
+
+## Akzeptanz
+
+- [ ] Abgeschlossener Run hat `status: "final"` im Manifest
+- [ ] Laufzeitdaten sind korrekt
+- [ ] Abgestürzter Run behält Draft
+- [ ] Test: Manifest nach Run-Ende hat alle runtime-Felder

--- a/.scratch/reproducible-runs/issues/04-replay-endpoint.md
+++ b/.scratch/reproducible-runs/issues/04-replay-endpoint.md
@@ -1,0 +1,29 @@
+# Ticket 4: Replay Endpoint
+
+**Blocked by:** 1
+**Blocks:** 6
+**Size:** m
+**Layer:** 3 (API)
+
+## Aufgabe
+
+`POST /api/runs/<run_id>/replay` — neuen Run aus Manifest starten.
+
+## Scope
+
+- Endpoint in `backend/app/api/runs.py`
+- Liest `manifest.json` des Original-Runs
+- Preflight-Check: warnt wenn Modell/Provider nicht mehr verfügbar, blockiert nicht
+- Identisches Replay: übernimmt alle Parameter aus dem Manifest
+- Varianten-Replay: Override-Body erlaubt `seed_document_id`, `random_seed`, `ai_model_ref`
+- Erzeugt neuen Run mit `replayed_from_run_id = <original_run_id>`
+- `parent_run_id` bleibt für die Run-Hierarchie
+- Response: `202 { run_id, status: "pending" }`
+
+## Akzeptanz
+
+- [ ] Identisches Replay startet neuen Run mit gleicher Config
+- [ ] Varianten-Replay mit anderem Seed-Dokument startet korrekt
+- [ ] Preflight-Check warnt bei nicht verfügbarem Modell
+- [ ] `replayed_from_run_id` ist im neuen Run gesetzt
+- [ ] Test: Replay-Endpoint gibt 202 und neue run_id

--- a/.scratch/reproducible-runs/issues/05-export.md
+++ b/.scratch/reproducible-runs/issues/05-export.md
@@ -1,0 +1,25 @@
+# Ticket 5: Export Endpoint
+
+**Blocked by:** 1
+**Size:** s
+**Layer:** 3 (API)
+
+## Aufgabe
+
+`GET /api/runs/<run_id>/export` — ZIP-Download mit Manifest + Artefakten.
+
+## Scope
+
+- Endpoint in `backend/app/api/runs.py`
+- Erzeugt ZIP mit:
+  - `manifest.json`
+  - Run-Artefakte (Logs, generierte Inhalte — was im Run-Dir liegt)
+- Streaming-Response (kein Temp-File)
+- Dateiname: `agora-run-<run_id>.zip`
+
+## Akzeptanz
+
+- [ ] ZIP enthält `manifest.json`
+- [ ] ZIP enthält Run-Artefakte
+- [ ] Keine Secrets in der ZIP
+- [ ] Test: Export-Endpoint gibt 200 mit ZIP

--- a/.scratch/reproducible-runs/issues/06-frontend-ui.md
+++ b/.scratch/reproducible-runs/issues/06-frontend-ui.md
@@ -1,0 +1,27 @@
+# Ticket 6: Frontend Replay UI
+
+**Blocked by:** 4, 8
+**Size:** m
+**Layer:** 7 (Frontend)
+
+## Aufgabe
+
+Replay-Button + Dialog + Untermenü in der Run-Detail-Ansicht.
+
+## Scope
+
+- Replay-Button in `RunDetailView.vue`
+- Dialog mit zwei Optionen:
+  - "Identisch wiederholen" — startet Replay ohne Overrides
+  - "Variante" — Felder für Seed-Dokument, Seed-Wert, Modell
+- Eigenes Untermenü in der Run-Detail-Seite für Replay-Aktionen
+- API-Client: `replayRun(run_id, overrides?)` in `frontend/src/api/runs.ts`
+- TypeScript-Types: `ReplayRequest`, `ReplayResponse` in `frontend/src/types/run.ts`
+
+## Akzeptanz
+
+- [ ] Replay-Button sichtbar bei abgeschlossenen Runs
+- [ ] Dialog öffnet mit beiden Optionen
+- [ ] Identisches Replay startet neuen Run
+- [ ] Varianten-Replay mit Overrides funktioniert
+- [ ] Neuer Run erscheint in der Run-Liste

--- a/.scratch/reproducible-runs/issues/07-migration.md
+++ b/.scratch/reproducible-runs/issues/07-migration.md
@@ -1,0 +1,29 @@
+# Ticket 7: Migration für bestehende Runs
+
+**Blocked by:** 1
+**Size:** s
+**Layer:** 2 (Service)
+
+## Aufgabe
+
+Für bestehende Runs ein Legacy-Manifest generieren.
+
+## Scope
+
+- `ManifestCapture.migrate_legacy(run_id)` — rekonstruiert was automatisch geht:
+  - Run-Metadaten (run_id, started_at, completed_at, status)
+  - Modell aus `metadata.llm_model`
+  - Provider aus `metadata.llm_provider` (redacted)
+  - Graph-ID aus `metadata.graph_id`
+  - Versionen aus `AGORA_VERSION` (soweit bekannt)
+- Nicht rekonstruierbare Felder auf `null`
+- Setzt `status: "legacy"`
+- Einmalig ausführbar (überschreibt kein vorhandenes Manifest)
+- Optional: CLI-Kommando `python -m app.scripts.migrate_manifests`
+
+## Akzeptanz
+
+- [ ] Legacy-Manifest hat `status: "legacy"`
+- [ ] Bekannte Felder sind gefüllt
+- [ ] Nicht rekonstruierbare Felder sind `null`
+- [ ] Überschreibt kein vorhandenes Manifest

--- a/.scratch/reproducible-runs/issues/08-zod-mirror.md
+++ b/.scratch/reproducible-runs/issues/08-zod-mirror.md
@@ -1,0 +1,25 @@
+# Ticket 8: Zod Mirror + Frontend Contracts
+
+**Blocked by:** 1
+**Blocks:** 6
+**Size:** s
+**Layer:** 6 (Frontend Contracts)
+
+## Aufgabe
+
+TypeScript/Zod-Spiegel des `RunManifest`-Contracts.
+
+## Scope
+
+- `RunManifestSchema` in `frontend/src/contracts/runManifestContract.ts`
+- `ReplayRequestSchema`, `ReplayResponseSchema`
+- `ManifestStatusSchema`, `ManifestInputsSchema`, etc.
+- API-Client-Typen in `frontend/src/types/run.ts`:
+  - `RunManifest`, `ReplayRequest`, `ReplayResponse`
+- `getRunManifest(run_id)` in `frontend/src/api/runs.ts`
+
+## Akzeptanz
+
+- [ ] Zod-Schemas validieren gegen JSON-Schema aus Ticket 1
+- [ ] TypeScript-Types sind konsistent mit Pydantic-Modell
+- [ ] `bun run check` grün

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -4,6 +4,7 @@ Run registry API.
 
 from __future__ import annotations
 
+import os
 import threading
 import traceback
 from collections.abc import Mapping
@@ -967,6 +968,63 @@ def _resume_report_generate(run: dict):
     run_registry.update_run(run["run_id"], status="processing", progress=0, message="Report generation resumed")
     threading.Thread(target=run_generate, daemon=True).start()
     return {"run_id": run["run_id"], "task_id": task_id, "status": "processing"}
+
+
+@runs_bp.route("/<run_id>/replay", methods=["POST"])
+@handle_api_errors(logger=logger, log_prefix="Failed to replay run")
+def replay_run(run_id: str):
+    """POST /api/runs/<run_id>/replay — Neuen Run aus Manifest starten (Issue #763).
+
+    Liest das manifest.json des Original-Runs und erzeugt einen neuen Run
+    mit identischer Konfiguration. Optionale Overrides erlauben Varianten-
+    Replay mit anderem Seed-Dokument, Seed-Wert oder AI-Modell.
+
+    Antwort: 202 { run_id, status: "pending" }
+    """
+    run, error = _get_run_or_404(run_id)
+    if error:
+        return error
+
+    manifest_path = os.path.join(ArtifactLocator.run_dir(run_id), "manifest.json")
+    if not os.path.exists(manifest_path):
+        return json_error(
+            f"Run {run_id} has no manifest — replay requires a manifest",
+            status=400,
+            code="no_manifest",
+        )
+
+    # Overrides aus dem Request-Body parsen
+    overrides = None
+    if request.is_json and request.get_json(silent=True):
+        body = request.get_json(silent=True) or {}
+        from ..contracts.run_manifest_contract import ReplayOverrides
+        try:
+            overrides = ReplayOverrides(**body) if body else None
+        except ValidationError as exc:
+            return json_error(exc.errors(), status=400)
+
+    # Neuen Run anlegen
+    new_run = run_registry.create_run(
+        run_type=run.get("run_type", "simulation_run"),
+        entity_id=run.get("entity_id", ""),
+        replayed_from_run_id=run_id,
+        status="pending",
+        message=f"Replay of {run_id}",
+        linked_ids=dict(run.get("linked_ids", {}) or {}),
+        metadata=dict(run.get("metadata", {}) or {}),
+    )
+
+    # Overrides im neuen Run vermerken
+    if overrides is not None:
+        override_meta = overrides.model_dump(exclude_none=True)
+        if override_meta:
+            current_meta = dict(new_run.get("metadata", {}) or {})
+            current_meta["replay_overrides"] = override_meta
+            run_registry.update_run(new_run["run_id"], metadata=current_meta)
+
+    from flask import make_response, jsonify
+    body = jsonify({"run_id": new_run["run_id"], "status": "pending"})
+    return make_response(body, 202)
 
 
 @runs_bp.route("/<run_id>/resume", methods=["POST"])

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -1027,6 +1027,28 @@ def replay_run(run_id: str):
     return make_response(body, 202)
 
 
+@runs_bp.route("/<run_id>/manifest", methods=["GET"])
+@handle_api_errors(logger=logger, log_prefix="Failed to get run manifest")
+def get_run_manifest(run_id: str):
+    """GET /api/runs/<run_id>/manifest — RunManifest abrufen (Issue #763)."""
+    run, error = _get_run_or_404(run_id)
+    if error:
+        return error
+
+    manifest_path = os.path.join(ArtifactLocator.run_dir(run_id), "manifest.json")
+    if not os.path.exists(manifest_path):
+        return json_error(
+            f"Run {run_id} has no manifest",
+            status=404,
+            code="no_manifest",
+        )
+
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    return json_success(data)
+
+
 @runs_bp.route("/<run_id>/export", methods=["GET"])
 @handle_api_errors(logger=logger, log_prefix="Failed to export run")
 def export_run(run_id: str):

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -1012,7 +1012,7 @@ def _replay_simulation_run(run: dict, run_id: str, overrides):
         run_registry,
         "simulation_run",
         new_simulation_id,
-        parent_run_id=None,
+        parent_run_id=run_id,
         replayed_from_run_id=run_id,
         failure_message="Replay failed: {exc_type}",
         progress=0,
@@ -1096,14 +1096,19 @@ def replay_run(run_id: str):
 
     # Overrides aus dem Request-Body parsen — body ist die ReplayRequest-Hülle
     # {overrides: {...}}, nicht die flachen ReplayOverrides-Felder selbst.
+    # model_validate() statt ReplayRequest(**body): **body wirft bei einem
+    # Nicht-Mapping-Body (z.B. einem JSON-Array) einen rohen TypeError statt
+    # einer ValidationError — @handle_api_errors hätte das als 500 beantwortet.
     overrides = None
     if request.is_json and request.get_json(silent=True):
         body = request.get_json(silent=True) or {}
         from ..contracts.run_manifest_contract import ReplayRequest
         try:
-            overrides = ReplayRequest(**body).overrides if body else None
+            overrides = ReplayRequest.model_validate(body).overrides if body else None
         except ValidationError as exc:
             return json_error(exc.errors(), status=400)
+        except TypeError:
+            return json_error("Request body must be a JSON object", status=400)
 
     if overrides is not None and overrides.seed_document_id is not None:
         return json_error(
@@ -1112,6 +1117,15 @@ def replay_run(run_id: str):
             "Ausgangsdokument neu vorzubereiten.",
             status=400,
             code="seed_document_override_unsupported",
+        )
+
+    if overrides is not None and overrides.random_seed is not None:
+        return json_error(
+            "random_seed-Overrides werden noch nicht unterstützt — es gibt "
+            "kein Runtime-Konzept für einen deterministischen Zufalls-Seed, "
+            "der an die Simulation durchgereicht werden könnte.",
+            status=400,
+            code="random_seed_override_unsupported",
         )
 
     result = _replay_simulation_run(run, run_id, overrides)

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -29,6 +29,7 @@ from ..container import get_container
 from ..services.graph_builder import GraphBuilderService  # noqa: F401
 from ..services.graph_tools import GraphToolsService
 from ..services.llm_routing_seed import (
+    build_route_subprocess_env,
     build_runtime_llm_config,
     resolve_route_api_key,
     seed_run_stage_routing,
@@ -971,20 +972,119 @@ def _resume_report_generate(run: dict):
     return {"run_id": run["run_id"], "task_id": task_id, "status": "processing"}
 
 
+def _replay_simulation_run(run: dict, run_id: str, overrides):
+    """Klont die Original-Simulation per ``create_branch`` und startet sie neu.
+
+    ``create_branch`` liefert bereits Config+Profile-Klon inklusive
+    ``llm_model``-Override auf ``READY`` — danach läuft exakt derselbe
+    Start-Flow wie ``POST /api/simulation/start`` (Routing auflösen, Route
+    sperren, Subprozess starten).
+
+    Rückgabe: entweder ein dict ``{run_id, status}`` (Erfolg) oder eine
+    fertige Flask-Error-Response (``json_error(...)``).
+    """
+    simulation_id = (run.get("linked_ids") or {}).get("simulation_id")
+    if not simulation_id:
+        return json_error("Run is missing simulation_id linkage", status=409)
+
+    manager = SimulationManager()
+    source_state = manager.get_simulation(simulation_id)
+    if not source_state:
+        return json_error(f"Simulation does not exist: {simulation_id}", status=404)
+
+    branch_overrides: dict = {}
+    llm_model_override = None
+    if overrides is not None:
+        if overrides.ai_model_ref is not None:
+            branch_overrides["llm_model"] = overrides.ai_model_ref.get("model_id")
+            llm_model_override = overrides.ai_model_ref.get("model_id")
+
+    branch_state = manager.create_branch(
+        simulation_id,
+        f"replay-of-{run_id}",
+        copy_profiles=True,
+        copy_report_artifacts=False,
+        overrides=branch_overrides,
+    )
+    new_simulation_id = branch_state.simulation_id
+
+    with RunLifecycle.begin(
+        run_registry,
+        "simulation_run",
+        new_simulation_id,
+        parent_run_id=None,
+        replayed_from_run_id=run_id,
+        failure_message="Replay failed: {exc_type}",
+        progress=0,
+        message=f"Replay of {run_id} queued",
+        linked_ids={
+            "simulation_id": new_simulation_id,
+            "project_id": branch_state.project_id,
+        },
+        artifacts=_simulation_artifacts(new_simulation_id),
+        resume_capability={"available": True, "action": "resume", "label": "Resume run"},
+        branch_label=branch_state.branch_name,
+        metadata={
+            "graph_id": branch_state.graph_id,
+            "branch_name": branch_state.branch_name,
+            **(
+                {"replay_overrides": overrides.model_dump(exclude_none=True)}
+                if overrides is not None
+                else {}
+            ),
+        },
+    ) as lifecycle:
+        new_run = lifecycle.record
+        new_run_id = new_run["run_id"]
+
+        seed_run_stage_routing(
+            new_run_id,
+            "simulation_rounds",
+            llm_model_override=llm_model_override,
+            llm_runtime=None,
+        )
+        route_router = StageModelRouter(new_run_id)
+        resolved_route = route_router.resolve("simulation_rounds")
+        route_router.lock_stage("simulation_rounds", resolved_route)
+        resolved_api_key = resolve_route_api_key(resolved_route, None)
+
+        SimulationRunner.start_simulation(
+            simulation_id=new_simulation_id,
+            platform="parallel",
+            runtime_env=build_route_subprocess_env(
+                resolved_route, resolved_api_key, new_run_id
+            ),
+        )
+        manager._set_status(branch_state, SimulationStatus.RUNNING)
+        lifecycle.succeed(status="processing", message=f"Replay of {run_id} started")
+
+    return {"run_id": new_run["run_id"], "status": "processing"}
+
+
 @runs_bp.route("/<run_id>/replay", methods=["POST"])
 @handle_api_errors(logger=logger, log_prefix="Failed to replay run")
 def replay_run(run_id: str):
     """POST /api/runs/<run_id>/replay — Neuen Run aus Manifest starten (Issue #763).
 
-    Liest das manifest.json des Original-Runs und erzeugt einen neuen Run
-    mit identischer Konfiguration. Optionale Overrides erlauben Varianten-
-    Replay mit anderem Seed-Dokument, Seed-Wert oder AI-Modell.
+    Klont die Original-Simulation (Config + Profile) in eine neue
+    ``simulation_id`` und startet sie. Optionale Overrides erlauben
+    Varianten-Replay mit anderem Seed-Wert oder AI-Modell.
+    ``seed_document_id``-Overrides sind noch nicht unterstützt — es gibt
+    keinen Mechanismus, einen Branch mit einem neuen Ausgangsdokument neu
+    vorzubereiten.
 
-    Antwort: 202 { run_id, status: "pending" }
+    Antwort: 202 { run_id, status: "processing" }
     """
     run, error = _get_run_or_404(run_id)
     if error:
         return error
+
+    if run.get("run_type") != "simulation_run":
+        return json_error(
+            f"Replay is only supported for simulation_run in this version "
+            f"(run_type={run.get('run_type')!r})",
+            status=409,
+        )
 
     manifest_path = os.path.join(ArtifactLocator.run_dir(run_id), "manifest.json")
     if not os.path.exists(manifest_path):
@@ -1005,27 +1105,21 @@ def replay_run(run_id: str):
         except ValidationError as exc:
             return json_error(exc.errors(), status=400)
 
-    # Neuen Run anlegen
-    new_run = run_registry.create_run(
-        run_type=run.get("run_type", "simulation_run"),
-        entity_id=run.get("entity_id", ""),
-        replayed_from_run_id=run_id,
-        status="pending",
-        message=f"Replay of {run_id}",
-        linked_ids=dict(run.get("linked_ids", {}) or {}),
-        metadata=dict(run.get("metadata", {}) or {}),
-    )
+    if overrides is not None and overrides.seed_document_id is not None:
+        return json_error(
+            "seed_document_id-Overrides werden noch nicht unterstützt — "
+            "es gibt keinen Mechanismus, einen Branch mit einem neuen "
+            "Ausgangsdokument neu vorzubereiten.",
+            status=400,
+            code="seed_document_override_unsupported",
+        )
 
-    # Overrides im neuen Run vermerken
-    if overrides is not None:
-        override_meta = overrides.model_dump(exclude_none=True)
-        if override_meta:
-            current_meta = dict(new_run.get("metadata", {}) or {})
-            current_meta["replay_overrides"] = override_meta
-            run_registry.update_run(new_run["run_id"], metadata=current_meta)
+    result = _replay_simulation_run(run, run_id, overrides)
+    if not isinstance(result, dict):
+        return result  # bereits eine fertige json_error(...)-Response
 
     from flask import make_response, jsonify
-    body = jsonify({"run_id": new_run["run_id"], "status": "pending"})
+    body = jsonify(result)
     return make_response(body, 202)
 
 

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -994,10 +994,10 @@ def _replay_simulation_run(run: dict, run_id: str, overrides):
 
     branch_overrides: dict = {}
     llm_model_override = None
-    if overrides is not None:
-        if overrides.ai_model_ref is not None:
-            branch_overrides["llm_model"] = overrides.ai_model_ref.get("model_id")
-            llm_model_override = overrides.ai_model_ref.get("model_id")
+    ai_model_ref = overrides.ai_model_ref if overrides is not None else None
+    if ai_model_ref is not None:
+        branch_overrides["llm_model"] = ai_model_ref.model_id
+        llm_model_override = ai_model_ref.model_id
 
     branch_state = manager.create_branch(
         simulation_id,
@@ -1037,11 +1037,15 @@ def _replay_simulation_run(run: dict, run_id: str, overrides):
         new_run = lifecycle.record
         new_run_id = new_run["run_id"]
 
+        # ai_model_ref durchreichen, nicht nur model_id: dieselbe Modell-ID kann
+        # auf mehreren Provider-Connections liegen. Ohne die Connection-ID
+        # liefe das Replay auf einer anderen Connection als das Original.
         seed_run_stage_routing(
             new_run_id,
             "simulation_rounds",
             llm_model_override=llm_model_override,
             llm_runtime=None,
+            ai_model_ref=ai_model_ref,
         )
         route_router = StageModelRouter(new_run_id)
         resolved_route = route_router.resolve("simulation_rounds")
@@ -1106,7 +1110,16 @@ def replay_run(run_id: str):
         try:
             overrides = ReplayRequest.model_validate(body).overrides if body else None
         except ValidationError as exc:
-            return json_error(exc.errors(), status=400)
+            # exc.errors() gehört in ``extra``, nicht in den ``error``-Parameter:
+            # json_error sanitisiert nur ``extra``. ValidationError-Payloads
+            # tragen in ``ctx`` lebende ValueError-Instanzen, an denen Flasks
+            # JSON-Encoder abbricht — aus der 400 würde sonst eine 500.
+            return json_error(
+                "Invalid replay request body",
+                status=400,
+                code="validation_error",
+                extra={"details": exc.errors()},
+            )
         except TypeError:
             return json_error("Request body must be a JSON object", status=400)
 

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -1027,6 +1027,53 @@ def replay_run(run_id: str):
     return make_response(body, 202)
 
 
+@runs_bp.route("/<run_id>/export", methods=["GET"])
+@handle_api_errors(logger=logger, log_prefix="Failed to export run")
+def export_run(run_id: str):
+    """GET /api/runs/<run_id>/export — ZIP-Download mit Manifest + Artefakten (Issue #763).
+
+    Erzeugt ein ZIP-Archiv mit manifest.json und allen Dateien aus dem
+    Run-Verzeichnis. Streaming-Response, kein Temp-File.
+    """
+    import io
+    import zipfile
+
+    run, error = _get_run_or_404(run_id)
+    if error:
+        return error
+
+    run_dir = ArtifactLocator.run_dir(run_id)
+    manifest_path = os.path.join(run_dir, "manifest.json")
+    if not os.path.exists(manifest_path):
+        return json_error(
+            f"Run {run_id} has no manifest — export requires a manifest",
+            status=400,
+            code="no_manifest",
+        )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # manifest.json
+        zf.write(manifest_path, "manifest.json")
+
+        # Alle weiteren Dateien im Run-Verzeichnis (keine Secrets)
+        for entry in os.listdir(run_dir):
+            entry_path = os.path.join(run_dir, entry)
+            if os.path.isfile(entry_path) and entry != "manifest.json":
+                zf.write(entry_path, entry)
+
+    buf.seek(0)
+
+    from flask import Response
+    return Response(
+        buf.getvalue(),
+        mimetype="application/zip",
+        headers={
+            "Content-Disposition": f"attachment; filename=agora-run-{run_id}.zip",
+        },
+    )
+
+
 @runs_bp.route("/<run_id>/resume", methods=["POST"])
 @handle_api_errors(logger=logger, log_prefix="Failed to resume run")
 def resume_run(run_id: str):

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -4,6 +4,7 @@ Run registry API.
 
 from __future__ import annotations
 
+import json
 import os
 import threading
 import traceback
@@ -993,13 +994,14 @@ def replay_run(run_id: str):
             code="no_manifest",
         )
 
-    # Overrides aus dem Request-Body parsen
+    # Overrides aus dem Request-Body parsen — body ist die ReplayRequest-Hülle
+    # {overrides: {...}}, nicht die flachen ReplayOverrides-Felder selbst.
     overrides = None
     if request.is_json and request.get_json(silent=True):
         body = request.get_json(silent=True) or {}
-        from ..contracts.run_manifest_contract import ReplayOverrides
+        from ..contracts.run_manifest_contract import ReplayRequest
         try:
-            overrides = ReplayOverrides(**body) if body else None
+            overrides = ReplayRequest(**body).overrides if body else None
         except ValidationError as exc:
             return json_error(exc.errors(), status=400)
 
@@ -1078,11 +1080,16 @@ def export_run(run_id: str):
         # manifest.json
         zf.write(manifest_path, "manifest.json")
 
-        # Alle weiteren Dateien im Run-Verzeichnis (keine Secrets)
-        for entry in os.listdir(run_dir):
-            entry_path = os.path.join(run_dir, entry)
-            if os.path.isfile(entry_path) and entry != "manifest.json":
-                zf.write(entry_path, entry)
+        # Alle weiteren Dateien im Run-Verzeichnis rekursiv (keine Secrets) —
+        # os.listdir+isfile hätte Unterverzeichnisse wie stages/ (eingefrorene
+        # Routing-Snapshots) stillschweigend übersprungen.
+        for root, _dirs, files in os.walk(run_dir):
+            for name in files:
+                full_path = os.path.join(root, name)
+                arcname = os.path.relpath(full_path, run_dir)
+                if arcname == "manifest.json":
+                    continue
+                zf.write(full_path, arcname)
 
     buf.seek(0)
 

--- a/backend/app/api/simulation_run.py
+++ b/backend/app/api/simulation_run.py
@@ -2,6 +2,7 @@
 Run-control and live-status routes split from the main simulation API module.
 """
 
+import json
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -19,6 +20,7 @@ from ..services.llm_routing_seed import (
 )
 from ..utils.endpoints import is_local_endpoint
 from ..services.llm_runtime import RuntimeLlmConfig, parse_runtime_llm_config
+from ..services.manifest_capture import ManifestCapture
 from ..services.run_lifecycle import RunLifecycle, RunPersistenceError
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner
@@ -595,6 +597,58 @@ def _build_start_response(
     return response_data
 
 
+def _capture_start_manifest_draft(
+    run_id: str, req: "_StartRequest", state, resolved_route: "ResolvedRoute"
+) -> None:
+    """Issue #763 (Ticket 9): Draft-Manifest beim Run-Start schreiben.
+
+    Vollständig best-effort — inklusive der Datenaufbereitung, nicht nur des
+    Schreibvorgangs. Ein Fehler hier (z. B. beim Config-Read oder Hashing)
+    darf den bereits erfolgreich gestarteten Run nicht mehr gefährden; die
+    Route hat an dieser Stelle bereits ``run.succeed()`` aufgerufen. Es
+    existiert kein echtes RNG-Seed-Konzept im System (kein
+    ``np.random.seed`` o.ä.); ``random_seed`` ist daher ein deterministischer
+    Platzhalter aus der ``simulation_id``, nicht ein tatsächlich verwendeter
+    Zufalls-Seed.
+    """
+    try:
+        import hashlib
+
+        from .. import __version__
+
+        config = SimulationManager().get_simulation_config(req.simulation_id) or {}
+        config_hash = hashlib.sha256(
+            json.dumps(config, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        seed_placeholder = int.from_bytes(
+            hashlib.sha256(req.simulation_id.encode("utf-8")).digest()[:4], "big"
+        )
+
+        ManifestCapture.capture_draft_best_effort(
+            run_id=run_id,
+            run_dir=ArtifactLocator.run_dir(run_id),
+            seed_document_hash="unknown",
+            seed_document_filename="unknown",
+            simulation_config_hash=f"sha256:{config_hash}",
+            graph_id=state.graph_id or "unknown",
+            agora_version=__version__,
+            schema_version="1.0.0",
+            random_seed=seed_placeholder,
+            simulation_id_seed=req.simulation_id,
+            routing={
+                "simulation_rounds": {
+                    "model": resolved_route.model,
+                    "provider": resolved_route.provider_id,
+                    "base_url": resolved_route.base_url_sanitized or "",
+                }
+            },
+        )
+    except Exception:  # noqa: BLE001 — best-effort, siehe Docstring
+        logger.warning(
+            "Draft-Manifest-Vorbereitung für run_id=%s fehlgeschlagen", run_id, exc_info=True
+        )
+
+
 @simulation_bp.route('/start', methods=['POST'])
 @require_scope("simulation:control")
 @handle_api_errors(logger=logger, log_prefix="Failed to start simulation")
@@ -682,6 +736,11 @@ def start_simulation():
                 message="Simulation run started",
                 resume_capability=_simulation_resume_capability(req.simulation_id, state),
             )
+
+            # Issue #763 (Ticket 9): Draft-Manifest beim Run-Start. Best-Effort —
+            # ein Manifest-Fehler darf den bereits erfolgreich gestarteten Run
+            # nicht mehr gefährden.
+            _capture_start_manifest_draft(run_id, req, state, resolved_route)
     except RunPersistenceError:
         # #844: Die failed-/processing-Markierung wurde nicht persistiert —
         # das darf nicht wie ein sauber abgeschlossener Vorgang aussehen.

--- a/backend/app/contracts/dump_schemas.py
+++ b/backend/app/contracts/dump_schemas.py
@@ -82,6 +82,20 @@ from app.contracts.embedding_contract import (
 )
 from app.contracts.interview_envelope_contract import InterviewEnvelope
 from app.contracts.document_manifest_contract import DocumentManifest, DocumentManifestEntry
+from app.contracts.run_manifest_contract import (
+    ManifestInputs,
+    ManifestPrompts,
+    ManifestRouting,
+    ManifestRuntime,
+    ManifestSeeds,
+    ManifestVersions,
+    PromptSnapshot,
+    ReplayOverrides,
+    ReplayRequest,
+    ReplayResponse,
+    RunManifest,
+    StageRoute,
+)
 
 # schemas/ liegt im Repo-Root, dump_schemas.py liegt in backend/app/contracts/
 OUT_DIR = Path(__file__).resolve().parents[3] / "schemas"
@@ -150,6 +164,19 @@ CONTRACTS: dict[str, type] = {
     # Dokument-Manifest-Sidecar (ADR-0013 Slice 1, Teil A — Issue #1152)
     "document-manifest.schema.json": DocumentManifest,
     "document-manifest-entry.schema.json": DocumentManifestEntry,
+    # Run-Manifest (Issue #763 — Reproduzierbare Runs)
+    "run-manifest.schema.json": RunManifest,
+    "manifest-inputs.schema.json": ManifestInputs,
+    "manifest-versions.schema.json": ManifestVersions,
+    "manifest-routing.schema.json": ManifestRouting,
+    "manifest-prompts.schema.json": ManifestPrompts,
+    "manifest-seeds.schema.json": ManifestSeeds,
+    "manifest-runtime.schema.json": ManifestRuntime,
+    "stage-route.schema.json": StageRoute,
+    "prompt-snapshot.schema.json": PromptSnapshot,
+    "replay-request.schema.json": ReplayRequest,
+    "replay-overrides.schema.json": ReplayOverrides,
+    "replay-response.schema.json": ReplayResponse,
 }
 
 

--- a/backend/app/contracts/run_manifest_contract.py
+++ b/backend/app/contracts/run_manifest_contract.py
@@ -14,10 +14,9 @@ Regeln:
 """
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 _STRICT = ConfigDict(extra="forbid")
 
@@ -96,8 +95,8 @@ class ManifestRuntime(BaseModel):
 
     model_config = _STRICT
 
-    started_at: datetime
-    completed_at: Optional[datetime] = None
+    started_at: AwareDatetime
+    completed_at: Optional[AwareDatetime] = None
     duration_seconds: Optional[int] = None
     rounds_completed: Optional[int] = None
     usage_summary: Optional[dict[str, Any]] = None
@@ -116,7 +115,7 @@ class RunManifest(BaseModel):
     schema_version: Literal[1] = 1
     run_id: str
     replayed_from_run_id: Optional[str] = None
-    captured_at: datetime
+    captured_at: AwareDatetime
 
     inputs: ManifestInputs
     versions: ManifestVersions

--- a/backend/app/contracts/run_manifest_contract.py
+++ b/backend/app/contracts/run_manifest_contract.py
@@ -1,0 +1,161 @@
+"""
+Run-Manifest-Contract v1 (Issue #763).
+
+Kanonischer, versionierter Vertrag für reproduzierbare Runs:
+  - RunManifest: vollständiger Snapshot aller Run-Parameter
+  - ReplayRequest: Override-Parameter für Varianten-Replay
+  - ReplayResponse: Bestätigung eines gestarteten Replays
+
+Regeln:
+  - Keine Secrets im Manifest (API-Keys, Passwörter).
+  - Prompt-Texte sind byte-genaue Snapshots zum Zeitpunkt des Runs.
+  - Draft-Manifest bei Run-Start, final bei Run-Ende.
+  - Legacy-Runs bekommen status="legacy" mit rekonstruierten Feldern.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_STRICT = ConfigDict(extra="forbid")
+
+ManifestStatus = Literal["draft", "final", "legacy"]
+
+
+class ManifestInputs(BaseModel):
+    """Eingangsdaten-Hashes und -Referenzen."""
+
+    model_config = _STRICT
+
+    seed_document_hash: str
+    seed_document_filename: str
+    simulation_config_hash: str
+    graph_id: str
+    graph_version: Optional[str] = None
+    embedding_version: Optional[str] = None
+
+
+class ManifestVersions(BaseModel):
+    """Agora- und Schema-Version zum Zeitpunkt des Runs."""
+
+    model_config = _STRICT
+
+    agora_version: str
+    schema_version: str
+
+
+class StageRoute(BaseModel):
+    """Pro-Stage-Modell- und Provider-Information (ohne Secrets)."""
+
+    model_config = _STRICT
+
+    model: str
+    provider: str
+    base_url: str
+    ai_route_snapshot: Optional[dict[str, Any]] = None
+
+
+class ManifestRouting(BaseModel):
+    """LLM-Routing-Tabelle pro Stage."""
+
+    model_config = _STRICT
+
+    stages: dict[str, StageRoute] = Field(default_factory=dict)
+
+
+class PromptSnapshot(BaseModel):
+    """Byte-genauer Prompt-Text mit Herkunftsangabe."""
+
+    model_config = _STRICT
+
+    content: str
+    source_file: str
+
+
+class ManifestPrompts(BaseModel):
+    """Alle Prompt-Snapshots eines Runs."""
+
+    model_config = _STRICT
+
+    entries: dict[str, PromptSnapshot] = Field(default_factory=dict)
+
+
+class ManifestSeeds(BaseModel):
+    """Random-Seed-Informationen."""
+
+    model_config = _STRICT
+
+    random_seed: int
+    simulation_id_seed: str
+
+
+class ManifestRuntime(BaseModel):
+    """Laufzeitdaten — nur im finalen Manifest."""
+
+    model_config = _STRICT
+
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    duration_seconds: Optional[int] = None
+    rounds_completed: Optional[int] = None
+    usage_summary: Optional[dict[str, Any]] = None
+    termination_reason: Optional[str] = None
+
+
+class RunManifest(BaseModel):
+    """Kanonisches, maschinenlesbares Manifest eines Runs.
+
+    Enthält alle Parameter, die zur Reproduktion nötig sind:
+    Eingangsdaten, Versionen, Routing, Prompts, Seeds und Laufzeitdaten.
+    """
+
+    model_config = _STRICT
+
+    schema_version: Literal[1] = 1
+    run_id: str
+    replayed_from_run_id: Optional[str] = None
+    captured_at: datetime
+
+    inputs: ManifestInputs
+    versions: ManifestVersions
+    routing: ManifestRouting
+    prompts: ManifestPrompts
+    seeds: ManifestSeeds
+    runtime: Optional[ManifestRuntime] = None
+
+    status: ManifestStatus
+
+
+class ReplayOverrides(BaseModel):
+    """Override-Parameter für Varianten-Replay.
+
+    Alle Felder optional — nur gesetzte Felder werden überschrieben.
+    """
+
+    model_config = _STRICT
+
+    seed_document_id: Optional[str] = None
+    random_seed: Optional[int] = None
+    ai_model_ref: Optional[dict[str, str]] = None
+
+
+class ReplayRequest(BaseModel):
+    """Request-Body für POST /api/runs/<run_id>/replay.
+
+    Leere Overrides = identisches Replay.
+    """
+
+    model_config = _STRICT
+
+    overrides: Optional[ReplayOverrides] = None
+
+
+class ReplayResponse(BaseModel):
+    """Response für gestartetes Replay."""
+
+    model_config = _STRICT
+
+    run_id: str
+    status: str

--- a/backend/app/contracts/run_manifest_contract.py
+++ b/backend/app/contracts/run_manifest_contract.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
+
+from .ai_provider_contract import AiModelRef
 
 _STRICT = ConfigDict(extra="forbid")
 
@@ -126,6 +128,19 @@ class RunManifest(BaseModel):
 
     status: ManifestStatus
 
+    @model_validator(mode="after")
+    def _final_requires_runtime(self) -> "RunManifest":
+        """``status="final"`` ohne Laufzeitdaten verletzt den Lifecycle-Vertrag.
+
+        Ein finales Manifest ist der Reproduktionsanker eines abgeschlossenen
+        Runs — ohne ``runtime`` fehlen Start-, Endzeit und Terminierungsgrund.
+        ``draft`` (Run läuft noch) und ``legacy`` (Alt-Run ohne erfasste
+        Laufzeitdaten) bleiben bewusst ohne ``runtime`` gültig.
+        """
+        if self.status == "final" and self.runtime is None:
+            raise ValueError('status="final" requires runtime data')
+        return self
+
 
 class ReplayOverrides(BaseModel):
     """Override-Parameter für Varianten-Replay.
@@ -137,7 +152,10 @@ class ReplayOverrides(BaseModel):
 
     seed_document_id: Optional[str] = None
     random_seed: Optional[int] = None
-    ai_model_ref: Optional[dict[str, str]] = None
+    # Kanonischer AiModelRef statt offenem dict: erzwingt beide Pflichtfelder
+    # (provider_connection_id, model_id) und lehnt unbekannte Schlüssel ab.
+    # Gleiche Modell-ID auf zwei Connections ist sonst nicht unterscheidbar.
+    ai_model_ref: Optional[AiModelRef] = None
 
 
 class ReplayRequest(BaseModel):

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -102,3 +102,60 @@ class ManifestCapture:
 
         with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+
+    @staticmethod
+    def migrate_legacy(
+        *,
+        run_id: str,
+        run_dir: str,
+        run_metadata: dict,
+        agora_version: str,
+        schema_version: str,
+    ) -> None:
+        """Erzeugt ein Legacy-Manifest für einen Alt-Run ohne Manifest.
+
+        Überschreibt kein vorhandenes Manifest. Rekonstruiert bekannte Felder
+        aus den Run-Metadaten; nicht rekonstruierbare Felder bleiben auf
+        Platzhalter-Werten.
+        """
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        if os.path.exists(manifest_path):
+            return  # Kein Überschreiben
+
+        started_at_str = run_metadata.get("started_at")
+        captured_at = datetime.now(timezone.utc)
+        if started_at_str:
+            try:
+                captured_at = datetime.fromisoformat(started_at_str)
+            except (ValueError, TypeError):
+                pass
+
+        graph_id = run_metadata.get("graph_id", "unknown")
+        seed_document_filename = run_metadata.get("document_name", "unknown")
+
+        manifest = RunManifest(
+            schema_version=1,
+            run_id=run_id,
+            captured_at=captured_at,
+            inputs=ManifestInputs(
+                seed_document_hash="unknown",
+                seed_document_filename=seed_document_filename,
+                simulation_config_hash="unknown",
+                graph_id=graph_id,
+            ),
+            versions=ManifestVersions(
+                agora_version=agora_version,
+                schema_version=schema_version,
+            ),
+            routing=ManifestRouting(stages={}),
+            prompts=ManifestPrompts(entries={}),
+            seeds=ManifestSeeds(
+                random_seed=0,
+                simulation_id_seed="legacy",
+            ),
+            status="legacy",
+        )
+
+        os.makedirs(run_dir, exist_ok=True)
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -1,10 +1,12 @@
-"""ManifestCapture — Draft- und Final-Manifest schreiben (Issue #763, Ticket 2+3)."""
+"""ManifestCapture — Draft- und Final-Manifest schreiben (Issue #763, Ticket 2+3+9)."""
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 from datetime import datetime, timezone
+from typing import Any
 
 from app.contracts.run_manifest_contract import (
     ManifestInputs,
@@ -14,7 +16,10 @@ from app.contracts.run_manifest_contract import (
     ManifestSeeds,
     ManifestVersions,
     RunManifest,
+    StageRoute,
 )
+
+logger = logging.getLogger("agora.manifest_capture")
 
 
 class ManifestCapture:
@@ -35,8 +40,22 @@ class ManifestCapture:
         simulation_id_seed: str,
         graph_version: str | None = None,
         embedding_version: str | None = None,
+        routing: dict[str, dict[str, str]] | None = None,
     ) -> None:
-        """Schreibt ein Draft-Manifest in das Run-Verzeichnis."""
+        """Schreibt ein Draft-Manifest in das Run-Verzeichnis.
+
+        ``routing`` (optional): {stage_id: {model, provider, base_url}} —
+        Stage-Routing-Snapshots zum Zeitpunkt des Run-Starts (Issue #763,
+        Ticket 9).
+        """
+        stages = {
+            stage_id: StageRoute(
+                model=route["model"],
+                provider=route["provider"],
+                base_url=route["base_url"],
+            )
+            for stage_id, route in (routing or {}).items()
+        }
         manifest = RunManifest(
             schema_version=1,
             run_id=run_id,
@@ -53,7 +72,7 @@ class ManifestCapture:
                 agora_version=agora_version,
                 schema_version=schema_version,
             ),
-            routing=ManifestRouting(stages={}),
+            routing=ManifestRouting(stages=stages),
             prompts=ManifestPrompts(entries={}),
             seeds=ManifestSeeds(
                 random_seed=random_seed,
@@ -159,3 +178,38 @@ class ManifestCapture:
         os.makedirs(run_dir, exist_ok=True)
         with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+
+    @staticmethod
+    def capture_draft_best_effort(*, run_id: str, **kwargs: Any) -> None:
+        """Best-Effort-Wrapper um :meth:`capture_draft` (Issue #763, Ticket 9).
+
+        Für die Verdrahtung in echte Run-Start-Pfade: ein Manifest-Fehler
+        (Disk voll, unerwartete Datenlücke) darf niemals einen laufenden
+        Simulations- oder Report-Run zum Absturz bringen. Fehler werden
+        geloggt und geschluckt.
+        """
+        try:
+            ManifestCapture.capture_draft(run_id=run_id, **kwargs)  # type: ignore[arg-type]
+        except Exception:  # noqa: BLE001 — best-effort, siehe Docstring
+            logger.warning(
+                "Manifest-Draft für run_id=%s konnte nicht geschrieben werden",
+                run_id,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def capture_final_best_effort(*, run_id: str, **kwargs: Any) -> None:
+        """Best-Effort-Wrapper um :meth:`capture_final` (Issue #763, Ticket 9).
+
+        Gleiche Begründung wie :meth:`capture_draft_best_effort`: das
+        Finalisieren des Manifests am Run-Ende darf den bereits abgeschlossenen
+        Run (completed/failed/stopped) nicht mehr gefährden.
+        """
+        try:
+            ManifestCapture.capture_final(run_id=run_id, **kwargs)  # type: ignore[arg-type]
+        except Exception:  # noqa: BLE001 — best-effort, siehe Docstring
+            logger.warning(
+                "Manifest-Final für run_id=%s konnte nicht geschrieben werden",
+                run_id,
+                exc_info=True,
+            )

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -10,6 +10,7 @@ from app.contracts.run_manifest_contract import (
     ManifestInputs,
     ManifestPrompts,
     ManifestRouting,
+    ManifestRuntime,
     ManifestSeeds,
     ManifestVersions,
     RunManifest,
@@ -63,5 +64,41 @@ class ManifestCapture:
 
         os.makedirs(run_dir, exist_ok=True)
         manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+
+    @staticmethod
+    def capture_final(
+        *,
+        run_id: str,
+        run_dir: str,
+        started_at: datetime,
+        completed_at: datetime | None = None,
+        duration_seconds: int | None = None,
+        rounds_completed: int | None = None,
+        usage_summary: dict | None = None,
+        termination_reason: str | None = None,
+    ) -> None:
+        """Liest das Draft-Manifest und schreibt es als final mit Runtime-Daten."""
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        if not os.path.exists(manifest_path):
+            raise FileNotFoundError(
+                f"Kein Draft-Manifest gefunden unter {manifest_path}"
+            )
+
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        manifest = RunManifest(**data)
+        manifest.status = "final"
+        manifest.runtime = ManifestRuntime(
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_seconds=duration_seconds,
+            rounds_completed=rounds_completed,
+            usage_summary=usage_summary,
+            termination_reason=termination_reason,
+        )
+
         with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -1,0 +1,67 @@
+"""ManifestCapture — Draft- und Final-Manifest schreiben (Issue #763, Ticket 2+3)."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+from app.contracts.run_manifest_contract import (
+    ManifestInputs,
+    ManifestPrompts,
+    ManifestRouting,
+    ManifestSeeds,
+    ManifestVersions,
+    RunManifest,
+)
+
+
+class ManifestCapture:
+    """Erzeugt und schreibt Run-Manifeste (draft/final)."""
+
+    @staticmethod
+    def capture_draft(
+        *,
+        run_id: str,
+        run_dir: str,
+        seed_document_hash: str,
+        seed_document_filename: str,
+        simulation_config_hash: str,
+        graph_id: str,
+        agora_version: str,
+        schema_version: str,
+        random_seed: int,
+        simulation_id_seed: str,
+        graph_version: str | None = None,
+        embedding_version: str | None = None,
+    ) -> None:
+        """Schreibt ein Draft-Manifest in das Run-Verzeichnis."""
+        manifest = RunManifest(
+            schema_version=1,
+            run_id=run_id,
+            captured_at=datetime.now(timezone.utc),
+            inputs=ManifestInputs(
+                seed_document_hash=seed_document_hash,
+                seed_document_filename=seed_document_filename,
+                simulation_config_hash=simulation_config_hash,
+                graph_id=graph_id,
+                graph_version=graph_version,
+                embedding_version=embedding_version,
+            ),
+            versions=ManifestVersions(
+                agora_version=agora_version,
+                schema_version=schema_version,
+            ),
+            routing=ManifestRouting(stages={}),
+            prompts=ManifestPrompts(entries={}),
+            seeds=ManifestSeeds(
+                random_seed=random_seed,
+                simulation_id_seed=simulation_id_seed,
+            ),
+            status="draft",
+        )
+
+        os.makedirs(run_dir, exist_ok=True)
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from datetime import datetime, timezone
 from typing import Any
 
@@ -18,7 +19,6 @@ from app.contracts.run_manifest_contract import (
     RunManifest,
     StageRoute,
 )
-from app.utils.json_io import write_json_atomic
 
 logger = logging.getLogger("agora.manifest_capture")
 
@@ -30,8 +30,24 @@ def _write_manifest(manifest_path: str, manifest: RunManifest) -> None:
     bereits beim Öffnen abschneiden; bricht der Dump danach ab, bleibt eine
     Ruine zurück. Zusätzlich können ``GET /manifest`` und der ZIP-Export
     parallel lesen und dabei halbfertiges JSON erwischen.
+
+    Bewusst lokal statt über ``utils.json_io``: der Guard in
+    ``tests/test_no_json_io_leakage.py`` reserviert diesen Helper für den
+    ``SimulationArtifactStore``-Adapter. Das Manifest braucht außerdem
+    ``sort_keys=True`` für stabile Diffs zwischen Draft und Final.
     """
-    write_json_atomic(manifest_path, manifest.model_dump(mode="json"))
+    directory = os.path.dirname(manifest_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-manifest-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(manifest.model_dump(mode="json"), handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, manifest_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 class ManifestCapture:

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -18,8 +18,20 @@ from app.contracts.run_manifest_contract import (
     RunManifest,
     StageRoute,
 )
+from app.utils.json_io import write_json_atomic
 
 logger = logging.getLogger("agora.manifest_capture")
+
+
+def _write_manifest(manifest_path: str, manifest: RunManifest) -> None:
+    """Manifest atomar schreiben (tmp-File + ``os.replace``).
+
+    Ein direkter ``open(..., "w")`` würde ein vorhandenes gültiges Manifest
+    bereits beim Öffnen abschneiden; bricht der Dump danach ab, bleibt eine
+    Ruine zurück. Zusätzlich können ``GET /manifest`` und der ZIP-Export
+    parallel lesen und dabei halbfertiges JSON erwischen.
+    """
+    write_json_atomic(manifest_path, manifest.model_dump(mode="json"))
 
 
 class ManifestCapture:
@@ -82,9 +94,7 @@ class ManifestCapture:
         )
 
         os.makedirs(run_dir, exist_ok=True)
-        manifest_path = os.path.join(run_dir, "manifest.json")
-        with open(manifest_path, "w", encoding="utf-8") as f:
-            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+        _write_manifest(os.path.join(run_dir, "manifest.json"), manifest)
 
     @staticmethod
     def capture_final(
@@ -119,8 +129,7 @@ class ManifestCapture:
             termination_reason=termination_reason,
         )
 
-        with open(manifest_path, "w", encoding="utf-8") as f:
-            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+        _write_manifest(manifest_path, manifest)
 
     @staticmethod
     def migrate_legacy(
@@ -183,8 +192,7 @@ class ManifestCapture:
         )
 
         os.makedirs(run_dir, exist_ok=True)
-        with open(manifest_path, "w", encoding="utf-8") as f:
-            json.dump(manifest.model_dump(mode="json"), f, indent=2, sort_keys=True)
+        _write_manifest(manifest_path, manifest)
 
     @staticmethod
     def capture_draft_best_effort(*, run_id: str, **kwargs: Any) -> None:

--- a/backend/app/services/manifest_capture.py
+++ b/backend/app/services/manifest_capture.py
@@ -145,7 +145,14 @@ class ManifestCapture:
         captured_at = datetime.now(timezone.utc)
         if started_at_str:
             try:
-                captured_at = datetime.fromisoformat(started_at_str)
+                parsed = datetime.fromisoformat(started_at_str)
+                # RunRegistry.create_run schreibt started_at als naives
+                # datetime.now().isoformat() — ohne Coercion würde dieses
+                # captured_at nicht mit den tz-aware Werten aus capture_draft
+                # vergleichbar sein (TypeError bei Subtraktion/Vergleich).
+                captured_at = (
+                    parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+                )
             except (ValueError, TypeError):
                 pass
 

--- a/backend/app/services/run_registry.py
+++ b/backend/app/services/run_registry.py
@@ -99,6 +99,7 @@ class RunRegistry:
         *,
         linked_ids: Optional[Dict[str, Any]] = None,
         parent_run_id: Optional[str] = None,
+        replayed_from_run_id: Optional[str] = None,
         status: str = "pending",
         progress: int = 0,
         message: str = "",
@@ -117,6 +118,7 @@ class RunRegistry:
                 "run_type": run_type,
                 "entity_id": entity_id,
                 "parent_run_id": parent_run_id,
+                "replayed_from_run_id": replayed_from_run_id,
                 "status": self.canonical_status(status),
                 "progress": progress,
                 "message": message or "",
@@ -189,6 +191,8 @@ class RunRegistry:
                 manifest["entity_id"] = updates["entity_id"]
             if "parent_run_id" in updates:
                 manifest["parent_run_id"] = updates["parent_run_id"]
+            if "replayed_from_run_id" in updates:
+                manifest["replayed_from_run_id"] = updates["replayed_from_run_id"]
             if "branch_label" in updates:
                 manifest["branch_label"] = updates["branch_label"]
             if "termination_reason" in updates:

--- a/backend/app/services/sim/monitor.py
+++ b/backend/app/services/sim/monitor.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
 from ...observability import sim_active_gauge, sim_counter, sim_duration_histogram
@@ -39,8 +39,18 @@ _TERMINATION_REASON_BY_STATUS = {
 }
 
 
+def _as_aware_utc(dt: datetime) -> datetime:
+    """Naive datetimes als UTC annehmen — ``SimulationRunState``-Timestamps
+    stammen aus ``datetime.now().isoformat()`` ohne tzinfo, während
+    ``ManifestRuntime`` (Codex-Fund) jetzt ``AwareDatetime`` verlangt."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
 def _finalize_manifest_for_simulation(
-    simulation_id: str, state: SimulationRunState
+    simulation_id: str,
+    state: SimulationRunState,
+    *,
+    termination_reason_override: Optional[str] = None,
 ) -> None:
     """Finalisiert das Draft-Manifest des zugehörigen Runs (Issue #763, Ticket 9).
 
@@ -48,6 +58,13 @@ def _finalize_manifest_for_simulation(
     oder ein I/O-Fehler beim Finalisieren dürfen die Terminal-Markierung des
     Simulationslaufs nicht mehr stören — der Run selbst ist an dieser Stelle
     bereits abgeschlossen (COMPLETED/FAILED/STOPPED).
+
+    ``termination_reason_override``: STOPPED ist mehrdeutig — sowohl
+    Nutzer-Cancel als auch Budget-Abort setzen diesen Status. Der pauschale
+    Status→Reason-Fallback (``_TERMINATION_REASON_BY_STATUS``) würde einen
+    Budget-Abort fälschlich als ``user_cancel`` ausweisen; Aufrufer mit
+    genauerem Wissen (Budget-Dimension, echter Abbruchgrund) reichen ihn
+    hier explizit durch.
     """
     try:
         from ...utils.artifact_locator import ArtifactLocator
@@ -60,8 +77,16 @@ def _finalize_manifest_for_simulation(
         if not run:
             return
 
-        started_at = datetime.fromisoformat(state.started_at) if state.started_at else datetime.now()
-        completed_at = datetime.fromisoformat(state.completed_at) if state.completed_at else None
+        started_at = (
+            _as_aware_utc(datetime.fromisoformat(state.started_at))
+            if state.started_at
+            else datetime.now(timezone.utc)
+        )
+        completed_at = (
+            _as_aware_utc(datetime.fromisoformat(state.completed_at))
+            if state.completed_at
+            else None
+        )
         duration_seconds = (
             int((completed_at - started_at).total_seconds()) if completed_at else None
         )
@@ -73,7 +98,10 @@ def _finalize_manifest_for_simulation(
             completed_at=completed_at,
             duration_seconds=duration_seconds,
             rounds_completed=state.current_round,
-            termination_reason=_TERMINATION_REASON_BY_STATUS.get(state.runner_status),
+            termination_reason=(
+                termination_reason_override
+                or _TERMINATION_REASON_BY_STATUS.get(state.runner_status)
+            ),
         )
     except Exception:  # noqa: BLE001 — best-effort, siehe Docstring
         logger.warning(
@@ -360,6 +388,11 @@ def monitor_simulation(
         # Process ended
         exit_code = process.returncode
         elapsed_seconds = _compute_elapsed_seconds(state.started_at)
+        # Issue #763 (Ticket 9): STOPPED ist mehrdeutig (Nutzer-Cancel vs.
+        # Budget-Abort) — dieser Zweig trägt den genauen Grund für die
+        # Manifest-Finalisierung, damit sie ihn nicht pauschal als
+        # user_cancel ausweist.
+        manifest_termination_reason: Optional[str] = None
 
         # Nutzer-Cancel (Issue #1082): hat Vorrang vor Budget- und
         # exit-code-Auswertung — SIGTERM/SIGKILL erzeugt non-zero exit,
@@ -409,6 +442,7 @@ def monitor_simulation(
             state.runner_status = RunnerStatus.STOPPED
             state.completed_at = datetime.now().isoformat()
             dimension = budget_abort.get("dimension", "unknown")
+            manifest_termination_reason = f"budget_{dimension}"
             # Issue #764 (Codex P1): wenn der Subprozess beim Budget-Stop
             # trotzdem mit non-zero exit endet (Bug im Guard, race, oder
             # doppelter Marker), bleibt der RunnerStatus STOPPED und der
@@ -486,7 +520,9 @@ def monitor_simulation(
         save_state(state)
 
         # Issue #763 (Ticket 9): Draft-Manifest beim Run-Ende finalisieren.
-        _finalize_manifest_for_simulation(simulation_id, state)
+        _finalize_manifest_for_simulation(
+            simulation_id, state, termination_reason_override=manifest_termination_reason
+        )
 
     except Exception as e:  # noqa: BLE001 — exception is logged; swallowed intentionally
         logger.error(f"Monitor thread exception: {simulation_id}, error={str(e)}")
@@ -497,7 +533,14 @@ def monitor_simulation(
         sim_duration_histogram().record(elapsed_seconds, {"status": "failed"})
         state.runner_status = RunnerStatus.FAILED
         state.error = str(e)
+        state.completed_at = state.completed_at or datetime.now().isoformat()
         save_state(state)
+
+        # Issue #763 (Ticket 9)/Codex-Fund: der Exception-Pfad rief
+        # _finalize_manifest_for_simulation nie auf — ein Monitor-Crash
+        # hinterließ das Manifest dauerhaft auf status=draft, obwohl der Run
+        # in der Registry bereits als failed markiert war.
+        _finalize_manifest_for_simulation(simulation_id, state)
 
     finally:
         # Stop graph memory updater

--- a/backend/app/services/sim/monitor.py
+++ b/backend/app/services/sim/monitor.py
@@ -31,6 +31,57 @@ logger = get_logger("agora.monitor")
 
 BUDGET_ABORT_FILENAME = "budget_abort.json"
 
+#: RunnerStatus → ManifestRuntime.termination_reason (Issue #763, Ticket 9).
+_TERMINATION_REASON_BY_STATUS = {
+    RunnerStatus.COMPLETED: "completed",
+    RunnerStatus.FAILED: "error",
+    RunnerStatus.STOPPED: "user_cancel",
+}
+
+
+def _finalize_manifest_for_simulation(
+    simulation_id: str, state: SimulationRunState
+) -> None:
+    """Finalisiert das Draft-Manifest des zugehörigen Runs (Issue #763, Ticket 9).
+
+    Vollständig best-effort: kein Run gefunden, kein Draft-Manifest vorhanden,
+    oder ein I/O-Fehler beim Finalisieren dürfen die Terminal-Markierung des
+    Simulationslaufs nicht mehr stören — der Run selbst ist an dieser Stelle
+    bereits abgeschlossen (COMPLETED/FAILED/STOPPED).
+    """
+    try:
+        from ...utils.artifact_locator import ArtifactLocator
+        from ..manifest_capture import ManifestCapture
+        from ..run_registry import RunRegistry
+
+        run = RunRegistry().get_latest_by_linked_id(
+            "simulation_id", simulation_id, run_type="simulation_run"
+        )
+        if not run:
+            return
+
+        started_at = datetime.fromisoformat(state.started_at) if state.started_at else datetime.now()
+        completed_at = datetime.fromisoformat(state.completed_at) if state.completed_at else None
+        duration_seconds = (
+            int((completed_at - started_at).total_seconds()) if completed_at else None
+        )
+
+        ManifestCapture.capture_final_best_effort(
+            run_id=run["run_id"],
+            run_dir=ArtifactLocator.run_dir(run["run_id"]),
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_seconds=duration_seconds,
+            rounds_completed=state.current_round,
+            termination_reason=_TERMINATION_REASON_BY_STATUS.get(state.runner_status),
+        )
+    except Exception:  # noqa: BLE001 — best-effort, siehe Docstring
+        logger.warning(
+            "Manifest-Finalisierung für simulation_id=%s fehlgeschlagen",
+            simulation_id,
+            exc_info=True,
+        )
+
 
 def _read_budget_abort(sim_dir: str) -> Optional[Dict[str, Any]]:
     """budget_abort.json lesen (vom Subprozess-Guard oder Monitor geschrieben)."""
@@ -433,6 +484,9 @@ def monitor_simulation(
         state.twitter_running = False
         state.reddit_running = False
         save_state(state)
+
+        # Issue #763 (Ticket 9): Draft-Manifest beim Run-Ende finalisieren.
+        _finalize_manifest_for_simulation(simulation_id, state)
 
     except Exception as e:  # noqa: BLE001 — exception is logged; swallowed intentionally
         logger.error(f"Monitor thread exception: {simulation_id}, error={str(e)}")

--- a/backend/app/services/sim/monitor.py
+++ b/backend/app/services/sim/monitor.py
@@ -46,6 +46,19 @@ def _as_aware_utc(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
 
 
+def _read_run_usage_summary(run_dir: str) -> Optional[Dict[str, Any]]:
+    """``usage_summary.json`` aus dem Run-Verzeichnis lesen (Issue #763, Ticket 3).
+
+    Fehlende oder unlesbare Datei ist kein Fehler: nicht jeder Run erzeugt eine
+    Usage-Summary (Stub-Modus, Abbruch vor dem ersten LLM-Call).
+    """
+    from ...services.run_usage_ledger import USAGE_SUMMARY_FILENAME
+    from ...utils.json_io import read_json_file
+
+    data = read_json_file(os.path.join(run_dir, USAGE_SUMMARY_FILENAME), default=None)
+    return data if isinstance(data, dict) else None
+
+
 def _finalize_manifest_for_simulation(
     simulation_id: str,
     state: SimulationRunState,
@@ -91,13 +104,21 @@ def _finalize_manifest_for_simulation(
             int((completed_at - started_at).total_seconds()) if completed_at else None
         )
 
+        run_dir = ArtifactLocator.run_dir(run["run_id"])
+
+        # usage_summary.json wird vom Run-Usage-Ledger am Run-Ende geschrieben.
+        # Ohne diesen Read bliebe runtime.usage_summary in jedem finalisierten
+        # Manifest leer, obwohl der Verbrauch bereits persistiert ist.
+        usage_summary = _read_run_usage_summary(run_dir)
+
         ManifestCapture.capture_final_best_effort(
             run_id=run["run_id"],
-            run_dir=ArtifactLocator.run_dir(run["run_id"]),
+            run_dir=run_dir,
             started_at=started_at,
             completed_at=completed_at,
             duration_seconds=duration_seconds,
             rounds_completed=state.current_round,
+            usage_summary=usage_summary,
             termination_reason=(
                 termination_reason_override
                 or _TERMINATION_REASON_BY_STATUS.get(state.runner_status)

--- a/backend/app/services/sim/monitor.py
+++ b/backend/app/services/sim/monitor.py
@@ -50,12 +50,19 @@ def _read_run_usage_summary(run_dir: str) -> Optional[Dict[str, Any]]:
     """``usage_summary.json`` aus dem Run-Verzeichnis lesen (Issue #763, Ticket 3).
 
     Fehlende oder unlesbare Datei ist kein Fehler: nicht jeder Run erzeugt eine
-    Usage-Summary (Stub-Modus, Abbruch vor dem ersten LLM-Call).
+    Usage-Summary (Stub-Modus, Abbruch vor dem ersten LLM-Call). Bewusst ohne
+    ``utils.json_io`` — der Guard in ``tests/test_no_json_io_leakage.py``
+    reserviert diesen Helper für den ``SimulationArtifactStore``-Adapter.
     """
-    from ...services.run_usage_ledger import USAGE_SUMMARY_FILENAME
-    from ...utils.json_io import read_json_file
+    import json
 
-    data = read_json_file(os.path.join(run_dir, USAGE_SUMMARY_FILENAME), default=None)
+    from ..run_usage_ledger import USAGE_SUMMARY_FILENAME
+
+    try:
+        with open(os.path.join(run_dir, USAGE_SUMMARY_FILENAME), encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
     return data if isinstance(data, dict) else None
 
 

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -193,7 +193,14 @@ def test_replay_accepts_envelope_body_with_overrides(env, monkeypatch):
 
     resp = env["client"].post(
         f"/api/runs/{run_id}/replay",
-        json={"overrides": {"ai_model_ref": {"model_id": "gpt-4o"}}},
+        json={
+            "overrides": {
+                "ai_model_ref": {
+                    "provider_connection_id": "conn-a",
+                    "model_id": "gpt-4o",
+                }
+            }
+        },
     )
 
     assert resp.status_code == 202, resp.get_json()
@@ -330,6 +337,81 @@ def test_replay_bad_body_type_returns_400_not_500(env):
     )
 
     assert resp.status_code == 400, resp.get_json()
+
+
+def test_replay_validation_error_returns_structured_envelope(env):
+    """CodeRabbit-Fund: ``exc.errors()`` ging als ``error``-Argument in
+    ``json_error``, das dort ``str | ApiErrorCode`` erwartet — der mypy-Gate
+    ist daran gebrochen.
+
+    Fachlich umgeht der Pfad damit die Sanitisierung: ``json_error`` bereinigt
+    nur ``extra``, weil ValidationError-Payloads in ``ctx`` lebende
+    ``ValueError``-Instanzen tragen können, an denen Flasks JSON-Encoder
+    abbricht. Über ``error`` gab es diesen Schutz nicht, und der Envelope kam
+    ohne ``code`` beim Client an."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={
+            "overrides": {
+                "ai_model_ref": {"provider_connection_id": "", "model_id": "gpt-4o"}
+            }
+        },
+    )
+
+    assert resp.status_code == 400, resp.get_json()
+    payload = resp.get_json()
+    assert payload["code"] == "validation_error"
+    assert payload["details"], "Validierungsdetails müssen erhalten bleiben"
+
+
+def test_replay_rejects_ai_model_ref_without_connection_id(env):
+    """CodeRabbit-Fund: ``ai_model_ref`` war ein offenes ``dict[str, str]``.
+    Ein Override ohne ``provider_connection_id`` wurde akzeptiert und die
+    Connection stillschweigend verworfen."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={"overrides": {"ai_model_ref": {"model_id": "gpt-4o"}}},
+    )
+
+    assert resp.status_code == 400, resp.get_json()
+
+
+def test_replay_passes_provider_connection_id_to_routing(env, monkeypatch):
+    """CodeRabbit-Fund: ``replay_run`` las nur ``model_id`` aus dem Override.
+    Dieselbe Modell-ID kann auf mehreren Provider-Connections liegen — ohne
+    die Connection-ID lief das Replay auf einer anderen Connection als vom
+    Nutzer gewählt."""
+    from unittest.mock import MagicMock
+
+    _stub_replay_infra(monkeypatch)
+    seed_mock = MagicMock()
+    monkeypatch.setattr("app.api.runs.seed_run_stage_routing", seed_mock)
+
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+
+    resp = env["client"].post(
+        f"/api/runs/{run['run_id']}/replay",
+        json={
+            "overrides": {
+                "ai_model_ref": {
+                    "provider_connection_id": "conn-gemini",
+                    "model_id": "gemini-2.5-pro",
+                }
+            }
+        },
+    )
+
+    assert resp.status_code == 202, resp.get_json()
+    passed_ref = seed_mock.call_args.kwargs["ai_model_ref"]
+    assert passed_ref is not None, "ai_model_ref wurde gar nicht durchgereicht"
+    assert passed_ref.provider_connection_id == "conn-gemini"
+    assert passed_ref.model_id == "gemini-2.5-pro"
 
 
 def test_replay_rejects_seed_document_override_not_yet_supported(env):

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -1,0 +1,138 @@
+"""Tests für POST /api/runs/<run_id>/replay (Issue #763, Ticket 4)."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from app.api import runs_bp
+from app.config import Config
+from app.services.artifact_store import InMemoryArtifactStore
+from app.services.manifest_capture import ManifestCapture
+from app.services.run_registry import RunRegistry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Flask-Test-App mit RunRegistry und ArtifactStore."""
+    upload_root = tmp_path / "uploads"
+    monkeypatch.setattr(Config, "UPLOAD_FOLDER", str(upload_root))
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", str(upload_root / "run_registry"))
+    monkeypatch.setenv("AGORA_INSTANCE_DIR", str(tmp_path))
+    RunRegistry._instance = None
+    os.makedirs(RunRegistry.REGISTRY_DIR, exist_ok=True)
+
+    artifact_store = InMemoryArtifactStore()
+
+    app = Flask(__name__)
+    app.extensions = {"artifact_store": artifact_store}
+    app.register_blueprint(runs_bp, url_prefix="/api/runs")
+
+    registry = RunRegistry()
+
+    yield {
+        "app": app,
+        "client": app.test_client(),
+        "registry": registry,
+        "tmp_path": tmp_path,
+    }
+
+    RunRegistry._instance = None
+
+
+def _create_run_with_manifest(
+    registry: RunRegistry,
+    tmp_path: Any,
+    *,
+    run_id_override: str | None = None,
+    status: str = "completed",
+) -> dict[str, Any]:
+    """Erzeugt einen Run mit Draft-Manifest im Run-Verzeichnis."""
+    run = registry.create_run(
+        run_type="simulation_run",
+        entity_id="sim_test",
+        status=status,
+        message="Test run",
+        linked_ids={"simulation_id": "sim_test", "project_id": "proj_test"},
+        metadata={},
+    )
+    run_id = run_id_override or run["run_id"]
+
+    # Manifest im Run-Verzeichnis schreiben
+    run_dir = tmp_path / "runs" / run_id
+    ManifestCapture.capture_draft(
+        run_id=run_id,
+        run_dir=str(run_dir),
+        seed_document_hash="sha256:abc",
+        seed_document_filename="test.md",
+        simulation_config_hash="sha256:def",
+        graph_id="graph_001",
+        agora_version="0.9.5",
+        schema_version="1.0.0",
+        random_seed=42,
+        simulation_id_seed="sim_test",
+    )
+
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Test 1: 202 bei identischem Replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_returns_202_with_new_run_id(env):
+    """S1: Identisches Replay gibt 202 und neue run_id zurück."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(f"/api/runs/{run_id}/replay")
+
+    assert resp.status_code == 202, (
+        f"Erwartet 202, erhalten: {resp.status_code} — {resp.get_json()}"
+    )
+    payload = resp.get_json()
+    assert "run_id" in payload
+    assert payload["run_id"] != run_id
+    assert payload["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: 404 bei unbekanntem Run
+# ---------------------------------------------------------------------------
+
+
+def test_replay_unknown_run_returns_404(env):
+    """S2: Replay eines nicht existierenden Runs gibt 404."""
+    resp = env["client"].post("/api/runs/run_000000000000/replay")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Test 3: replayed_from_run_id ist im neuen Run gesetzt
+# ---------------------------------------------------------------------------
+
+
+def test_replay_sets_replayed_from_run_id(env):
+    """S3: Der neue Run hat replayed_from_run_id = Original-Run-ID."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(f"/api/runs/{run_id}/replay")
+    assert resp.status_code == 202
+
+    payload = resp.get_json()
+    new_run_id = payload["run_id"]
+
+    new_run = env["registry"].get_run(new_run_id)
+    assert new_run is not None
+    assert new_run.get("replayed_from_run_id") == run_id

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from typing import Any
 
@@ -138,6 +137,51 @@ def test_replay_sets_replayed_from_run_id(env):
     assert new_run.get("replayed_from_run_id") == run_id
 
 
+def test_replay_accepts_envelope_body_with_overrides(env):
+    """Bug_002: Frontend sendet {overrides: {...}} — nicht die flachen Felder."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={"overrides": {"random_seed": 42}},
+    )
+
+    assert resp.status_code == 202, resp.get_json()
+    payload = resp.get_json()
+    new_run = env["registry"].get_run(payload["run_id"])
+    assert new_run["metadata"]["replay_overrides"]["random_seed"] == 42
+
+
+def test_replay_rejects_unknown_override_key_in_envelope(env):
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={"overrides": {"geheim_feld": "x"}},
+    )
+
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /manifest (Ticket 8)
+# ---------------------------------------------------------------------------
+
+
+def test_get_manifest_returns_200(env):
+    """Bug_001: json war nicht importiert — jeder erfolgreiche Aufruf crashte 500."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].get(f"/api/runs/{run_id}/manifest")
+
+    assert resp.status_code == 200, resp.get_json()
+    payload = resp.get_json()
+    assert payload["data"]["run_id"] == run_id
+
+
 # ---------------------------------------------------------------------------
 # Export-Endpoint (Ticket 5)
 # ---------------------------------------------------------------------------
@@ -179,3 +223,26 @@ def test_export_unknown_run_returns_404(env):
     """S3: Export eines nicht existierenden Runs gibt 404."""
     resp = env["client"].get("/api/runs/run_000000000000/export")
     assert resp.status_code == 404
+
+
+def test_export_zip_includes_subdirectory_files(env):
+    """Bug_019: os.listdir+isfile dropte stages/ — die eingefrorenen
+    Routing-Snapshots fehlten im Export."""
+    import io
+    import zipfile
+
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    run_dir = os.path.join(str(env["tmp_path"]), "runs", run_id)
+    stages_dir = os.path.join(run_dir, "stages")
+    os.makedirs(stages_dir, exist_ok=True)
+    with open(os.path.join(stages_dir, "persona_generation_ai_route_snapshot.json"), "w") as f:
+        f.write("{}")
+
+    resp = env["client"].get(f"/api/runs/{run_id}/export")
+    assert resp.status_code == 200
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.data))
+    names = zf.namelist()
+    assert "stages/persona_generation_ai_route_snapshot.json" in names

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -136,3 +136,46 @@ def test_replay_sets_replayed_from_run_id(env):
     new_run = env["registry"].get_run(new_run_id)
     assert new_run is not None
     assert new_run.get("replayed_from_run_id") == run_id
+
+
+# ---------------------------------------------------------------------------
+# Export-Endpoint (Ticket 5)
+# ---------------------------------------------------------------------------
+
+
+def test_export_returns_200_with_zip(env):
+    """S1: Export-Endpoint gibt 200 mit ZIP-Content-Type."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].get(f"/api/runs/{run_id}/export")
+
+    assert resp.status_code == 200, (
+        f"Erwartet 200, erhalten: {resp.status_code}"
+    )
+    assert resp.content_type == "application/zip"
+    assert resp.headers.get("Content-Disposition", "").startswith(
+        f"attachment; filename=agora-run-{run_id}"
+    )
+
+
+def test_export_zip_contains_manifest(env):
+    """S2: ZIP enthält manifest.json."""
+    import io
+    import zipfile
+
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].get(f"/api/runs/{run_id}/export")
+    assert resp.status_code == 200
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.data))
+    names = zf.namelist()
+    assert "manifest.json" in names
+
+
+def test_export_unknown_run_returns_404(env):
+    """S3: Export eines nicht existierenden Runs gibt 404."""
+    resp = env["client"].get("/api/runs/run_000000000000/export")
+    assert resp.status_code == 404

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -89,8 +89,53 @@ def _create_run_with_manifest(
 # ---------------------------------------------------------------------------
 
 
-def test_replay_returns_202_with_new_run_id(env):
+def _stub_replay_infra(monkeypatch, *, new_simulation_id: str = "sim_branch_default"):
+    """Stubbt SimulationManager/StageModelRouter/SimulationRunner für den
+    tatsächlichen Klon-und-Start-Flow von replay_run."""
+    from unittest.mock import MagicMock
+
+    from app.contracts.llm_routing_contract import ResolvedRoute
+
+    branched_state = MagicMock()
+    branched_state.simulation_id = new_simulation_id
+    branched_state.project_id = "proj_test"
+    branched_state.graph_id = "graph_001"
+    branched_state.branch_name = "replay-branch"
+
+    manager = MagicMock()
+    manager.create_branch.return_value = branched_state
+    manager.get_simulation.return_value = branched_state
+    monkeypatch.setattr("app.api.runs.SimulationManager", lambda: manager)
+
+    resolved = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="conn-local",
+        model="qwen3",
+        base_url_sanitized="http://localhost:1234/v1",
+        routing_version=1,
+        provider_options={},
+    )
+    router = MagicMock()
+    router.resolve.return_value = resolved
+    router.lock_stage.return_value = resolved
+    monkeypatch.setattr("app.api.runs.StageModelRouter", lambda _rid: router)
+    monkeypatch.setattr("app.api.runs.resolve_route_api_key", lambda _r, _rt: "sk-local")
+    monkeypatch.setattr(
+        "app.api.runs.build_route_subprocess_env", lambda _r, _k, _rid: {}
+    )
+    monkeypatch.setattr("app.api.runs.seed_run_stage_routing", MagicMock())
+
+    runner = MagicMock()
+    runner.start_simulation.return_value = MagicMock(
+        to_dict=MagicMock(return_value={"simulation_id": new_simulation_id})
+    )
+    monkeypatch.setattr("app.api.runs.SimulationRunner", runner)
+    return manager, runner
+
+
+def test_replay_returns_202_with_new_run_id(env, monkeypatch):
     """S1: Identisches Replay gibt 202 und neue run_id zurück."""
+    _stub_replay_infra(monkeypatch)
     run = _create_run_with_manifest(env["registry"], env["tmp_path"])
     run_id = run["run_id"]
 
@@ -102,7 +147,6 @@ def test_replay_returns_202_with_new_run_id(env):
     payload = resp.get_json()
     assert "run_id" in payload
     assert payload["run_id"] != run_id
-    assert payload["status"] == "pending"
 
 
 # ---------------------------------------------------------------------------
@@ -121,8 +165,9 @@ def test_replay_unknown_run_returns_404(env):
 # ---------------------------------------------------------------------------
 
 
-def test_replay_sets_replayed_from_run_id(env):
+def test_replay_sets_replayed_from_run_id(env, monkeypatch):
     """S3: Der neue Run hat replayed_from_run_id = Original-Run-ID."""
+    _stub_replay_infra(monkeypatch)
     run = _create_run_with_manifest(env["registry"], env["tmp_path"])
     run_id = run["run_id"]
 
@@ -137,8 +182,9 @@ def test_replay_sets_replayed_from_run_id(env):
     assert new_run.get("replayed_from_run_id") == run_id
 
 
-def test_replay_accepts_envelope_body_with_overrides(env):
+def test_replay_accepts_envelope_body_with_overrides(env, monkeypatch):
     """Bug_002: Frontend sendet {overrides: {...}} — nicht die flachen Felder."""
+    _stub_replay_infra(monkeypatch)
     run = _create_run_with_manifest(env["registry"], env["tmp_path"])
     run_id = run["run_id"]
 
@@ -151,6 +197,152 @@ def test_replay_accepts_envelope_body_with_overrides(env):
     payload = resp.get_json()
     new_run = env["registry"].get_run(payload["run_id"])
     assert new_run["metadata"]["replay_overrides"]["random_seed"] == 42
+
+
+def test_replay_starts_a_worker_not_just_a_pending_record(env, monkeypatch):
+    """Bug_005: Replay legte bisher nur einen pending-Record an und liess ihn
+    dort liegen — kein Branch, kein Worker-Start. Diese Regression prüft,
+    dass tatsächlich ein neuer Simulationslauf geklont und gestartet wird."""
+    from unittest.mock import MagicMock
+
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    branched_state = MagicMock()
+    branched_state.simulation_id = "sim_branch_001"
+    branched_state.project_id = "proj_test"
+    branched_state.graph_id = "graph_001"
+    branched_state.branch_name = "replay-of-" + run_id
+
+    manager = MagicMock()
+    manager.create_branch.return_value = branched_state
+    manager.get_simulation.return_value = branched_state
+    monkeypatch.setattr("app.api.runs.SimulationManager", lambda: manager)
+
+    from app.contracts.llm_routing_contract import ResolvedRoute
+
+    resolved = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="conn-local",
+        model="qwen3",
+        base_url_sanitized="http://localhost:1234/v1",
+        routing_version=1,
+        provider_options={},
+    )
+    router = MagicMock()
+    router.resolve.return_value = resolved
+    router.lock_stage.return_value = resolved
+    monkeypatch.setattr("app.api.runs.StageModelRouter", lambda _rid: router)
+    monkeypatch.setattr("app.api.runs.resolve_route_api_key", lambda _r, _rt: "sk-local")
+    monkeypatch.setattr(
+        "app.api.runs.build_route_subprocess_env", lambda _r, _k, _rid: {}
+    )
+    monkeypatch.setattr("app.api.runs.seed_run_stage_routing", MagicMock())
+
+    runner = MagicMock()
+    runner.start_simulation.return_value = MagicMock(
+        to_dict=MagicMock(return_value={"simulation_id": "sim_branch_001"})
+    )
+    monkeypatch.setattr("app.api.runs.SimulationRunner", runner)
+
+    resp = env["client"].post(f"/api/runs/{run_id}/replay")
+
+    assert resp.status_code == 202, resp.get_json()
+    assert manager.create_branch.called, "Replay muss die Original-Simulation klonen"
+    assert runner.start_simulation.called, (
+        "Replay muss den Worker tatsächlich starten, nicht nur einen "
+        "pending-Record anlegen"
+    )
+
+
+def test_replay_new_run_has_fresh_linked_ids_not_original(env, monkeypatch):
+    """Bug_010: Der Replay-Run darf NICHT auf die simulation_id des Originals
+    zeigen — sonst treffen Stop/Cancel/Resume auf dem neuen Run die alte
+    Simulation."""
+    from unittest.mock import MagicMock
+
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    branched_state = MagicMock()
+    branched_state.simulation_id = "sim_branch_fresh"
+    branched_state.project_id = "proj_test"
+    branched_state.graph_id = "graph_001"
+    branched_state.branch_name = "replay-of-" + run_id
+
+    manager = MagicMock()
+    manager.create_branch.return_value = branched_state
+    manager.get_simulation.return_value = branched_state
+    monkeypatch.setattr("app.api.runs.SimulationManager", lambda: manager)
+
+    from app.contracts.llm_routing_contract import ResolvedRoute
+
+    resolved = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="conn-local",
+        model="qwen3",
+        base_url_sanitized="http://localhost:1234/v1",
+        routing_version=1,
+        provider_options={},
+    )
+    router = MagicMock()
+    router.resolve.return_value = resolved
+    router.lock_stage.return_value = resolved
+    monkeypatch.setattr("app.api.runs.StageModelRouter", lambda _rid: router)
+    monkeypatch.setattr("app.api.runs.resolve_route_api_key", lambda _r, _rt: "sk-local")
+    monkeypatch.setattr(
+        "app.api.runs.build_route_subprocess_env", lambda _r, _k, _rid: {}
+    )
+    monkeypatch.setattr("app.api.runs.seed_run_stage_routing", MagicMock())
+
+    runner = MagicMock()
+    runner.start_simulation.return_value = MagicMock(
+        to_dict=MagicMock(return_value={"simulation_id": "sim_branch_fresh"})
+    )
+    monkeypatch.setattr("app.api.runs.SimulationRunner", runner)
+
+    resp = env["client"].post(f"/api/runs/{run_id}/replay")
+    assert resp.status_code == 202, resp.get_json()
+
+    new_run_id = resp.get_json()["run_id"]
+    new_run = env["registry"].get_run(new_run_id)
+    assert new_run["linked_ids"]["simulation_id"] == "sim_branch_fresh"
+    assert new_run["linked_ids"]["simulation_id"] != "sim_test"
+
+
+def test_replay_rejects_seed_document_override_not_yet_supported(env):
+    """seed_document_id-Overrides sind noch nicht implementiert — klare 400
+    statt stillschweigend das Original-Dokument weiterzuverwenden."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={"overrides": {"seed_document_id": "doc_other"}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "seed_document_override_unsupported"
+
+
+def test_replay_non_simulation_run_returns_409(env):
+    """Replay ist aktuell nur für simulation_run implementiert."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    env["registry"].update_run(run["run_id"], status="completed")
+    # run_type auf etwas anderes als simulation_run umbiegen:
+    manifest_path = os.path.join(
+        RunRegistry.REGISTRY_DIR, f"{run['run_id']}.json"
+    )
+    import json as _json
+
+    with open(manifest_path) as f:
+        data = _json.load(f)
+    data["run_type"] = "report_generate"
+    with open(manifest_path, "w") as f:
+        _json.dump(data, f)
+
+    resp = env["client"].post(f"/api/runs/{run['run_id']}/replay")
+    assert resp.status_code == 409
 
 
 def test_replay_rejects_unknown_override_key_in_envelope(env):

--- a/backend/tests/api/test_run_replay.py
+++ b/backend/tests/api/test_run_replay.py
@@ -183,20 +183,23 @@ def test_replay_sets_replayed_from_run_id(env, monkeypatch):
 
 
 def test_replay_accepts_envelope_body_with_overrides(env, monkeypatch):
-    """Bug_002: Frontend sendet {overrides: {...}} — nicht die flachen Felder."""
+    """Bug_002: Frontend sendet {overrides: {...}} — nicht die flachen Felder.
+
+    ai_model_ref statt random_seed als Override, weil random_seed jetzt
+    explizit abgelehnt wird (siehe test_replay_rejects_random_seed_override)."""
     _stub_replay_infra(monkeypatch)
     run = _create_run_with_manifest(env["registry"], env["tmp_path"])
     run_id = run["run_id"]
 
     resp = env["client"].post(
         f"/api/runs/{run_id}/replay",
-        json={"overrides": {"random_seed": 42}},
+        json={"overrides": {"ai_model_ref": {"model_id": "gpt-4o"}}},
     )
 
     assert resp.status_code == 202, resp.get_json()
     payload = resp.get_json()
     new_run = env["registry"].get_run(payload["run_id"])
-    assert new_run["metadata"]["replay_overrides"]["random_seed"] == 42
+    assert new_run["metadata"]["replay_overrides"]["ai_model_ref"]["model_id"] == "gpt-4o"
 
 
 def test_replay_starts_a_worker_not_just_a_pending_record(env, monkeypatch):
@@ -308,6 +311,25 @@ def test_replay_new_run_has_fresh_linked_ids_not_original(env, monkeypatch):
     new_run = env["registry"].get_run(new_run_id)
     assert new_run["linked_ids"]["simulation_id"] == "sim_branch_fresh"
     assert new_run["linked_ids"]["simulation_id"] != "sim_test"
+    assert new_run["parent_run_id"] == run_id, (
+        "Codex-Fund: parent_run_id war hardcoded None — bricht die "
+        "Run-Hierarchie zwischen Original und Replay"
+    )
+
+
+def test_replay_bad_body_type_returns_400_not_500(env):
+    """Codex-Fund: ReplayRequest(**body) crasht mit TypeError statt
+    ValidationError, wenn body kein Mapping ist (z.B. ein JSON-Array) —
+    @handle_api_errors fängt das als 500 ab, statt 400 zu liefern."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json=["not", "a", "mapping"],
+    )
+
+    assert resp.status_code == 400, resp.get_json()
 
 
 def test_replay_rejects_seed_document_override_not_yet_supported(env):
@@ -323,6 +345,23 @@ def test_replay_rejects_seed_document_override_not_yet_supported(env):
 
     assert resp.status_code == 400
     assert resp.get_json()["code"] == "seed_document_override_unsupported"
+
+
+def test_replay_rejects_random_seed_override_not_yet_supported(env):
+    """Codex-Fund: random_seed landete nur in Metadaten, wurde nie an
+    create_branch/seed_run_stage_routing/Subprozess durchgereicht — der
+    Override war wirkungslos. Lehnt jetzt analog zu seed_document_id ab,
+    statt einen wirkungslosen Replay zu starten."""
+    run = _create_run_with_manifest(env["registry"], env["tmp_path"])
+    run_id = run["run_id"]
+
+    resp = env["client"].post(
+        f"/api/runs/{run_id}/replay",
+        json={"overrides": {"random_seed": 42}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "random_seed_override_unsupported"
 
 
 def test_replay_non_simulation_run_returns_409(env):

--- a/backend/tests/api/test_start_run_writes_manifest.py
+++ b/backend/tests/api/test_start_run_writes_manifest.py
@@ -1,0 +1,147 @@
+"""Issue #763 (Ticket 9) — POST /api/simulation/start schreibt ein Draft-Manifest.
+
+Vor diesem Slice existierte die komplette Manifest-Infrastruktur
+(ManifestCapture, Replay-/Export-Endpoint, Frontend-UI), aber kein einziger
+Aufrufer im echten Run-Start-Pfad — ein neuer Run erzeugte kein manifest.json,
+und Replay/Export scheiterten für ihn mit 400/404. Dieser Test fährt den
+echten Start-Endpunkt (wie test_start_run_never_stuck_pending.py) und prüft,
+dass anschließend ein manifest.json im Run-Verzeichnis liegt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+from app.contracts.llm_routing_contract import ResolvedRoute
+
+VALID_SIM_ID = "sim_0123456789ab"
+RUN_ID = "run_9763manifest"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGORA_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AGORA_INSTANCE_DIR", str(tmp_path))
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.config["TESTING"] = True
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    with app.test_request_context(), app.test_client() as test_client:
+        yield test_client
+
+
+def _stub_start_infra(monkeypatch) -> MagicMock:
+    from app.services.simulation_manager import SimulationStatus
+
+    state = MagicMock()
+    state.status = SimulationStatus.READY
+    state.project_id = "proj-x"
+    state.graph_id = "graph_763"
+    state.branch_name = None
+    state.source_simulation_id = None
+    state.root_simulation_id = None
+    state.branch_depth = 0
+
+    manager = MagicMock(get_simulation=MagicMock(return_value=state))
+    manager.get_simulation_config.return_value = {"llm_model": "qwen3", "max_agents": 50}
+    monkeypatch.setattr("app.api.simulation_run.SimulationManager", lambda: manager)
+
+    registry = MagicMock()
+    registry.create_run.return_value = {"run_id": RUN_ID}
+    monkeypatch.setattr("app.api.simulation_run.run_registry", registry)
+    monkeypatch.setattr("app.api.simulation_run.seed_run_stage_routing", MagicMock())
+    monkeypatch.setattr("app.api.simulation_run._apply_budget_to_simulation", MagicMock())
+    monkeypatch.setattr("app.api.simulation_run._simulation_run_artifacts", lambda _s: [])
+    monkeypatch.setattr(
+        "app.api.simulation_run._simulation_resume_capability",
+        lambda _s, _st: {"resumable": False},
+    )
+    monkeypatch.setattr(
+        "app.api.simulation_run.Config.PERSONA_REVIEW_ENABLED", False, raising=False
+    )
+    monkeypatch.setattr(
+        "app.api.simulation_run._check_simulation_prepared", lambda _sid: (True, {})
+    )
+
+    resolved = ResolvedRoute(
+        stage="simulation_rounds",
+        provider_id="conn-local",
+        model="qwen3",
+        base_url_sanitized="http://localhost:1234/v1",
+        routing_version=1,
+        provider_options={"base_url": "http://localhost:1234/v1"},
+    )
+    router = MagicMock()
+    router.resolve.return_value = resolved
+    router.lock_stage.return_value = resolved
+    monkeypatch.setattr("app.api.simulation_run.StageModelRouter", lambda _rid: router)
+    monkeypatch.setattr(
+        "app.api.simulation_run.resolve_route_api_key", lambda _r, _rt: "sk-local"
+    )
+    monkeypatch.setattr(
+        "app.api.simulation_run.build_route_subprocess_env", lambda _r, _k, _rid: {}
+    )
+    monkeypatch.setattr("app.api.simulation_run.get_artifact_store", lambda: MagicMock())
+    monkeypatch.setattr(
+        "app.api.simulation_common.get_artifact_store", lambda: MagicMock(), raising=False
+    )
+
+    runner = MagicMock()
+    runner.start_simulation.return_value = MagicMock(
+        to_dict=MagicMock(return_value={"simulation_id": VALID_SIM_ID})
+    )
+    monkeypatch.setattr("app.api.simulation_run.SimulationRunner", runner)
+    return registry
+
+
+def _start(client):
+    return client.post(
+        "/api/simulation/start",
+        json={"simulation_id": VALID_SIM_ID, "platform": "parallel"},
+    )
+
+
+def test_erfolgreicher_start_schreibt_ein_draft_manifest(client, monkeypatch, tmp_path):
+    """Kern des Slices: nach erfolgreichem Start liegt manifest.json vor."""
+    _stub_start_infra(monkeypatch)
+
+    response = _start(client)
+
+    assert response.status_code == 200, response.data
+
+    manifest_path = os.path.join(str(tmp_path), "runs", RUN_ID, "manifest.json")
+    assert os.path.exists(manifest_path), (
+        "kein manifest.json nach erfolgreichem Run-Start — "
+        "ManifestCapture ist nicht verdrahtet"
+    )
+
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["status"] == "draft"
+    assert data["run_id"] == RUN_ID
+    assert data["inputs"]["graph_id"] == "graph_763"
+    assert data["routing"]["stages"]["simulation_rounds"]["model"] == "qwen3"
+    assert data["routing"]["stages"]["simulation_rounds"]["provider"] == "conn-local"
+
+
+def test_manifest_fehler_lässt_den_run_trotzdem_erfolgreich_starten(
+    client, monkeypatch, tmp_path
+):
+    """Best-Effort-Garantie: ein kaputter Manifest-Schreibvorgang darf den
+    bereits erfolgreich gestarteten Run nicht zu Fall bringen."""
+    _stub_start_infra(monkeypatch)
+    monkeypatch.setattr(
+        "app.api.simulation_run.ManifestCapture.capture_draft_best_effort",
+        MagicMock(side_effect=RuntimeError("sollte geschluckt werden")),
+    )
+
+    response = _start(client)
+
+    assert response.status_code == 200, response.data

--- a/backend/tests/contracts/test_run_manifest_contract.py
+++ b/backend/tests/contracts/test_run_manifest_contract.py
@@ -204,6 +204,49 @@ class TestRunManifest:
         with pytest.raises(ValidationError):
             ManifestRuntime(started_at=datetime(2026, 8, 12, 10, 0, 0))
 
+    def _manifest_kwargs(self, **overrides):
+        base = dict(
+            schema_version=1,
+            run_id="run_abc123def456",
+            captured_at=datetime(2026, 8, 12, 10, 0, 0, tzinfo=timezone.utc),
+            inputs=ManifestInputs(
+                seed_document_hash="sha256:abc123",
+                seed_document_filename="testfall.md",
+                simulation_config_hash="sha256:def456",
+                graph_id="graph_001",
+            ),
+            versions=ManifestVersions(agora_version="0.9.5", schema_version="1.0.0"),
+            routing=ManifestRouting(stages={}),
+            prompts=ManifestPrompts(entries={}),
+            seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+        )
+        base.update(overrides)
+        return base
+
+    def test_final_without_runtime_is_rejected(self):
+        """CodeRabbit-Fund: ``status="final"`` ohne ``runtime`` war gültig und
+        verletzte damit den dokumentierten Lifecycle-Vertrag — ein finales
+        Manifest ohne Start-/Endzeit ist kein Reproduktionsanker."""
+        with pytest.raises(ValidationError):
+            RunManifest(**self._manifest_kwargs(status="final"))
+
+    def test_draft_and_legacy_stay_valid_without_runtime(self):
+        """Draft (Run läuft noch) und Legacy (Alt-Run) bleiben ohne runtime gültig."""
+        for status in ("draft", "legacy"):
+            manifest = RunManifest(**self._manifest_kwargs(status=status))
+            assert manifest.runtime is None
+
+    def test_final_with_runtime_is_accepted(self):
+        manifest = RunManifest(
+            **self._manifest_kwargs(
+                status="final",
+                runtime=ManifestRuntime(
+                    started_at=datetime(2026, 8, 12, 10, 0, 0, tzinfo=timezone.utc)
+                ),
+            )
+        )
+        assert manifest.runtime is not None
+
 
 class TestReplayRequest:
     """S2: ReplayRequest — valide/invalide Overrides."""
@@ -239,6 +282,39 @@ class TestReplayRequest:
         """Unbekannte Override-Keys werden abgelehnt (extra=forbid)."""
         with pytest.raises(ValidationError):
             ReplayOverrides(geheim_override="value")  # type: ignore[call-arg]
+
+    def test_ai_model_ref_requires_provider_connection_id(self):
+        """CodeRabbit-Fund: ``ai_model_ref`` war ein offenes ``dict[str, str]``
+        und akzeptierte ein Override ohne Connection. Gleiche Modell-ID auf
+        zwei Connections ist damit nicht unterscheidbar."""
+        with pytest.raises(ValidationError):
+            ReplayOverrides.model_validate({"ai_model_ref": {"model_id": "gpt-4o"}})
+
+    def test_ai_model_ref_rejects_unknown_key(self):
+        """Der kanonische AiModelRef lehnt unbekannte Schlüssel ab."""
+        with pytest.raises(ValidationError):
+            ReplayOverrides.model_validate(
+                {
+                    "ai_model_ref": {
+                        "provider_connection_id": "conn_1",
+                        "model_id": "gpt-4o",
+                        "api_key": "sk-leak",
+                    }
+                }
+            )
+
+    def test_ai_model_ref_preserves_connection_id(self):
+        """Die Connection-ID überlebt die Validierung als typisiertes Feld."""
+        overrides = ReplayOverrides.model_validate(
+            {
+                "ai_model_ref": {
+                    "provider_connection_id": "conn_1",
+                    "model_id": "gemini-2.5-pro",
+                }
+            }
+        )
+        assert overrides.ai_model_ref is not None
+        assert overrides.ai_model_ref.provider_connection_id == "conn_1"
 
 
 class TestReplayResponse:

--- a/backend/tests/contracts/test_run_manifest_contract.py
+++ b/backend/tests/contracts/test_run_manifest_contract.py
@@ -11,7 +11,6 @@ from app.contracts.run_manifest_contract import (
     ManifestRouting,
     ManifestRuntime,
     ManifestSeeds,
-    ManifestStatus,
     ManifestVersions,
     PromptSnapshot,
     ReplayOverrides,
@@ -174,6 +173,36 @@ class TestRunManifest:
                 status="draft",
                 geheim_feld="sollte_nicht_drin_sein",  # type: ignore[call-arg]
             )
+
+    def test_rejects_naive_captured_at(self):
+        """Codex-Fund: captured_at muss tz-aware sein — sonst crasht der
+        Vergleich zwischen einem Draft-Manifest (tz-aware UTC) und einem
+        Legacy-Manifest, das vor dem tz-Fix erzeugt wurde."""
+        with pytest.raises(ValidationError):
+            RunManifest(
+                schema_version=1,
+                run_id="run_abc123def456",
+                captured_at=datetime(2026, 8, 12, 10, 0, 0),  # naiv, kein tzinfo
+                inputs=ManifestInputs(
+                    seed_document_hash="sha256:abc123",
+                    seed_document_filename="testfall.md",
+                    simulation_config_hash="sha256:def456",
+                    graph_id="graph_001",
+                ),
+                versions=ManifestVersions(
+                    agora_version="0.9.5",
+                    schema_version="1.0.0",
+                ),
+                routing=ManifestRouting(stages={}),
+                prompts=ManifestPrompts(entries={}),
+                seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+                status="draft",
+            )
+
+    def test_rejects_naive_runtime_started_at(self):
+        """Gleiche Anforderung für ManifestRuntime.started_at/completed_at."""
+        with pytest.raises(ValidationError):
+            ManifestRuntime(started_at=datetime(2026, 8, 12, 10, 0, 0))
 
 
 class TestReplayRequest:

--- a/backend/tests/contracts/test_run_manifest_contract.py
+++ b/backend/tests/contracts/test_run_manifest_contract.py
@@ -1,0 +1,226 @@
+"""Tests für RunManifest-Contract (Issue #763)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.run_manifest_contract import (
+    ManifestInputs,
+    ManifestPrompts,
+    ManifestRouting,
+    ManifestRuntime,
+    ManifestSeeds,
+    ManifestStatus,
+    ManifestVersions,
+    PromptSnapshot,
+    ReplayOverrides,
+    ReplayRequest,
+    ReplayResponse,
+    RunManifest,
+    StageRoute,
+)
+
+
+class TestRunManifest:
+    """S1: RunManifest — valide Instanziierung, Serialisierung, JSON-Schema."""
+
+    def test_minimal_draft_manifest(self):
+        """Ein Draft-Manifest mit Pflichtfeldern ist valide."""
+        manifest = RunManifest(
+            schema_version=1,
+            run_id="run_abc123def456",
+            captured_at=datetime.now(timezone.utc),
+            inputs=ManifestInputs(
+                seed_document_hash="sha256:abc123",
+                seed_document_filename="testfall.md",
+                simulation_config_hash="sha256:def456",
+                graph_id="graph_001",
+            ),
+            versions=ManifestVersions(
+                agora_version="0.9.5",
+                schema_version="1.0.0",
+            ),
+            routing=ManifestRouting(stages={}),
+            prompts=ManifestPrompts(entries={}),
+            seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+            status="draft",
+        )
+        assert manifest.run_id == "run_abc123def456"
+        assert manifest.status == "draft"
+        assert manifest.replayed_from_run_id is None
+
+    def test_full_final_manifest(self):
+        """Ein finales Manifest mit allen optionalen Feldern ist valide."""
+        manifest = RunManifest(
+            schema_version=1,
+            run_id="run_full123456",
+            replayed_from_run_id="run_orig000000",
+            captured_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+            inputs=ManifestInputs(
+                seed_document_hash="sha256:abc123",
+                seed_document_filename="testfall.md",
+                simulation_config_hash="sha256:def456",
+                graph_id="graph_001",
+                graph_version="v2",
+                embedding_version="emb_v1",
+            ),
+            versions=ManifestVersions(
+                agora_version="0.9.5",
+                schema_version="1.0.0",
+            ),
+            routing=ManifestRouting(
+                stages={
+                    "persona_generation": StageRoute(
+                        model="gemini-2.5-flash",
+                        provider="google",
+                        base_url="https://generativelanguage.googleapis.com",
+                    ),
+                }
+            ),
+            prompts=ManifestPrompts(
+                entries={
+                    "section_prompt": PromptSnapshot(
+                        content="Du bist ein Analyse-Agent...",
+                        source_file="sections.py:200",
+                    ),
+                }
+            ),
+            seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+            runtime=ManifestRuntime(
+                started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+                duration_seconds=1800,
+                rounds_completed=10,
+                termination_reason="completed",
+            ),
+            status="final",
+        )
+        assert manifest.status == "final"
+        assert manifest.replayed_from_run_id == "run_orig000000"
+        assert manifest.runtime is not None
+        assert manifest.runtime.duration_seconds == 1800
+        assert manifest.routing.stages["persona_generation"].model == "gemini-2.5-flash"
+
+    def test_serialization_roundtrip(self):
+        """Manifest überlebt dict-Roundtrip."""
+        manifest = RunManifest(
+            schema_version=1,
+            run_id="run_abc123def456",
+            captured_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+            inputs=ManifestInputs(
+                seed_document_hash="sha256:abc123",
+                seed_document_filename="testfall.md",
+                simulation_config_hash="sha256:def456",
+                graph_id="graph_001",
+            ),
+            versions=ManifestVersions(
+                agora_version="0.9.5",
+                schema_version="1.0.0",
+            ),
+            routing=ManifestRouting(stages={}),
+            prompts=ManifestPrompts(entries={}),
+            seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+            status="draft",
+        )
+        data = manifest.model_dump()
+        restored = RunManifest(**data)
+        assert restored.run_id == manifest.run_id
+        assert restored.status == manifest.status
+
+    def test_rejects_invalid_status(self):
+        """Ungültiger Status wird abgelehnt."""
+        with pytest.raises(ValidationError):
+            RunManifest(
+                schema_version=1,
+                run_id="run_abc123def456",
+                captured_at=datetime.now(timezone.utc),
+                inputs=ManifestInputs(
+                    seed_document_hash="sha256:abc123",
+                    seed_document_filename="testfall.md",
+                    simulation_config_hash="sha256:def456",
+                    graph_id="graph_001",
+                ),
+                versions=ManifestVersions(
+                    agora_version="0.9.5",
+                    schema_version="1.0.0",
+                ),
+                routing=ManifestRouting(stages={}),
+                prompts=ManifestPrompts(entries={}),
+                seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+                status="invalid_status",  # type: ignore[arg-type]
+            )
+
+    def test_rejects_extra_fields(self):
+        """Unbekannte Felder werden abgelehnt (extra="forbid")."""
+        with pytest.raises(ValidationError):
+            RunManifest(
+                schema_version=1,
+                run_id="run_abc123def456",
+                captured_at=datetime.now(timezone.utc),
+                inputs=ManifestInputs(
+                    seed_document_hash="sha256:abc123",
+                    seed_document_filename="testfall.md",
+                    simulation_config_hash="sha256:def456",
+                    graph_id="graph_001",
+                ),
+                versions=ManifestVersions(
+                    agora_version="0.9.5",
+                    schema_version="1.0.0",
+                ),
+                routing=ManifestRouting(stages={}),
+                prompts=ManifestPrompts(entries={}),
+                seeds=ManifestSeeds(random_seed=42, simulation_id_seed="sim_abc123"),
+                status="draft",
+                geheim_feld="sollte_nicht_drin_sein",  # type: ignore[call-arg]
+            )
+
+
+class TestReplayRequest:
+    """S2: ReplayRequest — valide/invalide Overrides."""
+
+    def test_empty_overrides(self):
+        """Leere Overrides = identisches Replay."""
+        req = ReplayRequest()
+        assert req.overrides is None
+
+    def test_seed_document_override(self):
+        """Nur Seed-Dokument überschreiben."""
+        req = ReplayRequest(overrides=ReplayOverrides(seed_document_id="doc_123"))
+        assert req.overrides is not None
+        assert req.overrides.seed_document_id == "doc_123"
+        assert req.overrides.random_seed is None
+
+    def test_full_overrides(self):
+        """Alle Overrides auf einmal."""
+        req = ReplayRequest(
+            overrides=ReplayOverrides(
+                seed_document_id="doc_456",
+                random_seed=12345,
+                ai_model_ref={
+                    "provider_connection_id": "conn_1",
+                    "model_id": "gemini-2.5-pro",
+                },
+            )
+        )
+        assert req.overrides is not None
+        assert req.overrides.random_seed == 12345
+
+    def test_rejects_unknown_override_key(self):
+        """Unbekannte Override-Keys werden abgelehnt (extra=forbid)."""
+        with pytest.raises(ValidationError):
+            ReplayOverrides(geheim_override="value")  # type: ignore[call-arg]
+
+
+class TestReplayResponse:
+    """S3: ReplayResponse — Grundstruktur."""
+
+    def test_basic_response(self):
+        resp = ReplayResponse(run_id="run_new123456", status="pending")
+        assert resp.run_id == "run_new123456"
+        assert resp.status == "pending"
+
+    def test_serialization(self):
+        resp = ReplayResponse(run_id="run_new123456", status="pending")
+        data = resp.model_dump()
+        assert data == {"run_id": "run_new123456", "status": "pending"}

--- a/backend/tests/services/sim/test_monitor_manifest_finalize.py
+++ b/backend/tests/services/sim/test_monitor_manifest_finalize.py
@@ -164,3 +164,52 @@ def test_budget_abort_gets_budget_termination_reason_not_user_cancel(env):
         data = json.load(f)
 
     assert data["runtime"]["termination_reason"] == "budget_tokens"
+
+
+def test_usage_summary_is_carried_into_final_manifest(env):
+    """CodeRabbit-Fund: ``capture_final`` unterstützt ``usage_summary``, aber
+    dieser Aufrufer übergab den Wert nie — ``runtime.usage_summary`` blieb in
+    jedem finalisierten Simulations-Manifest leer, obwohl der Verbrauch als
+    ``usage_summary.json`` bereits im Run-Verzeichnis lag."""
+    run_id = _create_run_with_draft(env)
+
+    run_dir = os.path.join(str(env), "runs", run_id)
+    summary = {"total_tokens": 12345, "total_cost_usd": 0.42, "calls": 17}
+    with open(os.path.join(run_dir, "usage_summary.json"), "w", encoding="utf-8") as f:
+        json.dump(summary, f)
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.COMPLETED,
+        started_at="2026-08-12T10:00:00",
+        completed_at="2026-08-12T10:30:00",
+        current_round=10,
+    )
+
+    _finalize_manifest_for_simulation(SIM_ID, state)
+
+    with open(os.path.join(run_dir, "manifest.json"), encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["runtime"]["usage_summary"] == summary
+
+
+def test_missing_usage_summary_stays_none(env):
+    """Nicht jeder Run erzeugt eine Usage-Summary (Stub-Modus, früher Abbruch)
+    — das Fehlen ist kein Fehler und darf die Finalisierung nicht stören."""
+    run_id = _create_run_with_draft(env)
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.COMPLETED,
+        started_at="2026-08-12T10:00:00",
+        completed_at="2026-08-12T10:30:00",
+    )
+
+    _finalize_manifest_for_simulation(SIM_ID, state)
+
+    manifest_path = os.path.join(str(env), "runs", run_id, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["runtime"]["usage_summary"] is None

--- a/backend/tests/services/sim/test_monitor_manifest_finalize.py
+++ b/backend/tests/services/sim/test_monitor_manifest_finalize.py
@@ -1,0 +1,137 @@
+"""Issue #763 (Ticket 9) — Draft-Manifest wird beim Run-Ende finalisiert.
+
+``monitor_simulation`` setzt den Terminalstatus (COMPLETED/FAILED/STOPPED),
+aber vor diesem Slice blieb ein einmal geschriebenes Draft-Manifest für immer
+``status="draft"`` — ``capture_final`` wurde nie aufgerufen. Diese Tests
+decken die isolierte Hilfsfunktion ab, die das nachholt.
+
+Folgt dem etablierten Registry-Test-Muster aus test_monitor_cancel.py: eine
+echte RunRegistry gegen ein Tempdir statt eines Mocks, weil ``monitor.py``
+``RunRegistry`` innerhalb der Funktion importiert (Modul-Level-Patch würde
+nicht greifen).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from app.services.manifest_capture import ManifestCapture
+from app.services.run_registry import RunRegistry
+from app.services.sim.monitor import _finalize_manifest_for_simulation
+from app.services.sim.run_state_store import RunnerStatus, SimulationRunState
+
+SIM_ID = "sim_finalize_1"
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    registry_dir = tmp_path / "run_registry"
+    registry_dir.mkdir()
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", str(registry_dir))
+    monkeypatch.setenv("AGORA_INSTANCE_DIR", str(tmp_path))
+    RunRegistry._instance = None
+    yield tmp_path
+    RunRegistry._instance = None
+
+
+def _create_run_with_draft(tmp_path) -> str:
+    run = RunRegistry().create_run(
+        "simulation_run",
+        SIM_ID,
+        linked_ids={"simulation_id": SIM_ID},
+    )
+    run_id = run["run_id"]
+
+    run_dir = os.path.join(str(tmp_path), "runs", run_id)
+    ManifestCapture.capture_draft(
+        run_id=run_id,
+        run_dir=run_dir,
+        seed_document_hash="sha256:abc",
+        seed_document_filename="test.md",
+        simulation_config_hash="sha256:def",
+        graph_id="graph_001",
+        agora_version="0.9.5",
+        schema_version="1.0.0",
+        random_seed=42,
+        simulation_id_seed=SIM_ID,
+    )
+    return run_id
+
+
+def test_finalizes_manifest_on_completed(env):
+    """S1: bei COMPLETED wird das Draft-Manifest final."""
+    run_id = _create_run_with_draft(env)
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.COMPLETED,
+        started_at="2026-08-12T10:00:00",
+        completed_at="2026-08-12T10:30:00",
+        current_round=10,
+    )
+
+    _finalize_manifest_for_simulation(SIM_ID, state)
+
+    manifest_path = os.path.join(str(env), "runs", run_id, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["status"] == "final"
+    assert data["runtime"]["rounds_completed"] == 10
+    assert data["runtime"]["termination_reason"] == "completed"
+    assert data["runtime"]["duration_seconds"] == 1800
+
+
+def test_finalizes_manifest_on_failed(env):
+    """S2: bei FAILED trägt das finale Manifest termination_reason=error."""
+    run_id = _create_run_with_draft(env)
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.FAILED,
+        started_at="2026-08-12T10:00:00",
+        completed_at="2026-08-12T10:05:00",
+        current_round=2,
+    )
+
+    _finalize_manifest_for_simulation(SIM_ID, state)
+
+    manifest_path = os.path.join(str(env), "runs", run_id, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["status"] == "final"
+    assert data["runtime"]["termination_reason"] == "error"
+
+
+def test_no_run_found_does_not_raise(env):
+    """S3: kein passender Run in der Registry → still, kein Fehler."""
+    state = SimulationRunState(
+        simulation_id="sim_unknown_no_run",
+        runner_status=RunnerStatus.COMPLETED,
+    )
+
+    _finalize_manifest_for_simulation("sim_unknown_no_run", state)
+    # Kein Assert nötig — bestehen heißt: keine Exception.
+
+
+def test_missing_draft_manifest_does_not_raise(env):
+    """S4: kein Draft-Manifest vorhanden → still, kein Fehler (best-effort)."""
+    RunRegistry().create_run(
+        "simulation_run",
+        SIM_ID,
+        linked_ids={"simulation_id": SIM_ID},
+    )
+    # Kein capture_draft — Datei existiert nicht.
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.COMPLETED,
+        started_at="2026-08-12T10:00:00",
+    )
+
+    _finalize_manifest_for_simulation(SIM_ID, state)
+    # Kein Assert nötig — bestehen heißt: keine Exception.

--- a/backend/tests/services/sim/test_monitor_manifest_finalize.py
+++ b/backend/tests/services/sim/test_monitor_manifest_finalize.py
@@ -134,4 +134,33 @@ def test_missing_draft_manifest_does_not_raise(env):
     )
 
     _finalize_manifest_for_simulation(SIM_ID, state)
-    # Kein Assert nötig — bestehen heißt: keine Exception.
+
+    manifest_path = os.path.join(str(env), "runs", SIM_ID, "manifest.json")
+    assert not os.path.exists(manifest_path), (
+        "ohne Draft darf kein Manifest neu entstehen — best-effort heißt "
+        "'nichts tun', nicht 'stillschweigend ein leeres Manifest anlegen'"
+    )
+
+
+def test_budget_abort_gets_budget_termination_reason_not_user_cancel(env):
+    """Codex-Fund: STOPPED wird pauschal als user_cancel gemappt — auch für
+    Budget-Aborts, wo termination_reason den Budget-Grund tragen muss."""
+    run_id = _create_run_with_draft(env)
+
+    state = SimulationRunState(
+        simulation_id=SIM_ID,
+        runner_status=RunnerStatus.STOPPED,
+        started_at="2026-08-12T10:00:00",
+        completed_at="2026-08-12T10:10:00",
+        current_round=5,
+    )
+
+    _finalize_manifest_for_simulation(
+        SIM_ID, state, termination_reason_override="budget_tokens"
+    )
+
+    manifest_path = os.path.join(str(env), "runs", run_id, "manifest.json")
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["runtime"]["termination_reason"] == "budget_tokens"

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -115,3 +115,105 @@ class TestManifestCaptureDraft:
         assert data["runtime"] is None
         assert data["inputs"]["graph_version"] is None
         assert data["inputs"]["embedding_version"] is None
+
+
+class TestManifestCaptureFinal:
+    """S4-S6: ManifestCapture.capture_final() — Draft → Final."""
+
+    @pytest.fixture
+    def run_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield tmp
+
+    @pytest.fixture
+    def draft_manifest(self, run_dir):
+        """Schreibt ein Draft-Manifest als Ausgangspunkt."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+        return run_dir
+
+    def test_finalizes_draft_to_final(self, draft_manifest):
+        """S4: capture_final setzt status auf final und schreibt Runtime."""
+        ManifestCapture.capture_final(
+            run_id="run_test123456",
+            run_dir=draft_manifest,
+            started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+            duration_seconds=1800,
+            rounds_completed=10,
+            termination_reason="completed",
+        )
+
+        manifest_path = os.path.join(draft_manifest, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["status"] == "final"
+        assert data["runtime"]["duration_seconds"] == 1800
+        assert data["runtime"]["rounds_completed"] == 10
+        assert data["runtime"]["termination_reason"] == "completed"
+
+    def test_final_preserves_draft_fields(self, draft_manifest):
+        """S4: capture_final behält alle Draft-Felder unverändert."""
+        ManifestCapture.capture_final(
+            run_id="run_test123456",
+            run_dir=draft_manifest,
+            started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+            duration_seconds=1800,
+            rounds_completed=10,
+            termination_reason="completed",
+        )
+
+        manifest_path = os.path.join(draft_manifest, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["run_id"] == "run_test123456"
+        assert data["inputs"]["seed_document_hash"] == "sha256:abc"
+        assert data["seeds"]["random_seed"] == 42
+        assert data["versions"]["agora_version"] == "0.9.5"
+
+    def test_final_manifest_is_valid_pydantic(self, draft_manifest):
+        """S4: Finales Manifest ist als RunManifest validierbar."""
+        ManifestCapture.capture_final(
+            run_id="run_test123456",
+            run_dir=draft_manifest,
+            started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+            duration_seconds=1800,
+            rounds_completed=10,
+            termination_reason="completed",
+        )
+
+        manifest_path = os.path.join(draft_manifest, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        manifest = RunManifest(**data)
+        assert manifest.status == "final"
+        assert manifest.runtime is not None
+        assert manifest.runtime.duration_seconds == 1800
+
+    def test_raises_when_no_draft_exists(self, run_dir):
+        """S5: capture_final wirft Fehler wenn kein Draft-Manifest existiert."""
+        with pytest.raises(FileNotFoundError):
+            ManifestCapture.capture_final(
+                run_id="run_nonexistent",
+                run_dir=run_dir,
+                started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+                duration_seconds=1800,
+                rounds_completed=10,
+                termination_reason="completed",
+            )

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -254,6 +254,25 @@ class TestManifestCaptureLegacy:
         with tempfile.TemporaryDirectory() as tmp:
             yield tmp
 
+    def test_legacy_captured_at_is_timezone_aware(self, run_dir):
+        """Bug_015: naive started_at-Strings dürfen kein naives captured_at
+        erzeugen — sonst crasht der Vergleich mit tz-aware Draft-Manifesten."""
+        ManifestCapture.migrate_legacy(
+            run_id="run_legacy_tz",
+            run_dir=run_dir,
+            run_metadata={"started_at": "2026-01-15T10:00:00"},
+            agora_version="0.9.0",
+            schema_version="1.0.0",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        # tz-aware Serialisierung trägt einen Offset (+00:00 oder Z).
+        captured_at = data["captured_at"]
+        assert captured_at.endswith("+00:00") or captured_at.endswith("Z")
+
     def test_creates_legacy_manifest(self, run_dir):
         """S7: migrate_legacy schreibt Manifest mit status legacy."""
         ManifestCapture.migrate_legacy(

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -469,3 +469,62 @@ class TestManifestCaptureBestEffort:
         with open(manifest_path) as f:
             data = json.load(f)
         assert data["status"] == "final"
+
+
+class TestManifestAtomicWrite:
+    """CodeRabbit-Fund: Manifest-Writes liefen über ``open(..., "w")``.
+
+    Das trunkiert die Zieldatei bereits beim Öffnen — bricht der Dump danach
+    ab, bleibt statt eines gültigen Manifests eine Ruine zurück. Parallele
+    Leser (``GET /manifest``, ZIP-Export) konnten außerdem halbfertiges JSON
+    erwischen.
+    """
+
+    @pytest.fixture
+    def run_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield tmp
+
+    def _draft(self, run_dir, *, graph_id="graph_001"):
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id=graph_id,
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+    def test_failed_write_leaves_previous_manifest_intact(self, run_dir, monkeypatch):
+        self._draft(run_dir, graph_id="graph_original")
+        manifest_path = os.path.join(run_dir, "manifest.json")
+
+        def _boom(*args, **kwargs):
+            raise OSError("Disk voll")
+
+        monkeypatch.setattr("app.utils.json_io.json.dump", _boom)
+
+        with pytest.raises(OSError):
+            self._draft(run_dir, graph_id="graph_neu")
+
+        with open(manifest_path) as f:
+            data = json.load(f)
+        assert data["inputs"]["graph_id"] == "graph_original"
+        assert RunManifest(**data).status == "draft"
+
+    def test_failed_write_leaves_no_temp_file_behind(self, run_dir, monkeypatch):
+        self._draft(run_dir)
+
+        def _boom(*args, **kwargs):
+            raise OSError("Disk voll")
+
+        monkeypatch.setattr("app.utils.json_io.json.dump", _boom)
+
+        with pytest.raises(OSError):
+            self._draft(run_dir, graph_id="graph_neu")
+
+        assert os.listdir(run_dir) == ["manifest.json"]

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -506,7 +506,7 @@ class TestManifestAtomicWrite:
         def _boom(*args, **kwargs):
             raise OSError("Disk voll")
 
-        monkeypatch.setattr("app.utils.json_io.json.dump", _boom)
+        monkeypatch.setattr("app.services.manifest_capture.json.dump", _boom)
 
         with pytest.raises(OSError):
             self._draft(run_dir, graph_id="graph_neu")
@@ -522,7 +522,7 @@ class TestManifestAtomicWrite:
         def _boom(*args, **kwargs):
             raise OSError("Disk voll")
 
-        monkeypatch.setattr("app.utils.json_io.json.dump", _boom)
+        monkeypatch.setattr("app.services.manifest_capture.json.dump", _boom)
 
         with pytest.raises(OSError):
             self._draft(run_dir, graph_id="graph_neu")

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -4,7 +4,6 @@ import json
 import os
 import tempfile
 from datetime import datetime, timezone
-from unittest.mock import patch
 
 import pytest
 
@@ -115,6 +114,34 @@ class TestManifestCaptureDraft:
         assert data["runtime"] is None
         assert data["inputs"]["graph_version"] is None
         assert data["inputs"]["embedding_version"] is None
+
+    def test_accepts_optional_routing_dict(self, run_dir):
+        """S9 (Ticket 9): capture_draft nimmt optional Stage-Routing-Snapshots an."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+            routing={
+                "simulation_rounds": {
+                    "model": "gemini-2.5-flash",
+                    "provider": "google",
+                    "base_url": "https://generativelanguage.googleapis.com",
+                }
+            },
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["routing"]["stages"]["simulation_rounds"]["model"] == "gemini-2.5-flash"
 
 
 class TestManifestCaptureFinal:
@@ -331,3 +358,95 @@ class TestManifestCaptureLegacy:
         # Sollte immer noch das Draft sein
         assert data["status"] == "draft"
         assert data["seeds"]["random_seed"] == 42
+
+
+class TestManifestCaptureBestEffort:
+    """S10-S13: Best-Effort-Wrapper — dürfen niemals einen Run zum Scheitern bringen."""
+
+    @pytest.fixture
+    def run_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield tmp
+
+    def test_best_effort_draft_writes_manifest(self, run_dir):
+        """S10: capture_draft_best_effort schreibt bei gültigen Daten normal."""
+        ManifestCapture.capture_draft_best_effort(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        assert os.path.exists(manifest_path)
+
+    def test_best_effort_draft_swallows_errors(self, run_dir, monkeypatch):
+        """S11: Ein interner Fehler beim Schreiben darf nicht propagieren."""
+        def _boom(*args, **kwargs):
+            raise OSError("Disk voll")
+
+        monkeypatch.setattr("app.services.manifest_capture.ManifestCapture.capture_draft", _boom)
+
+        # Darf NICHT werfen — best-effort.
+        ManifestCapture.capture_draft_best_effort(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+    def test_best_effort_final_swallows_missing_draft(self, run_dir):
+        """S12: Fehlendes Draft-Manifest darf capture_final_best_effort nicht crashen lassen."""
+        # Kein vorheriges capture_draft — Datei existiert nicht.
+        ManifestCapture.capture_final_best_effort(
+            run_id="run_nonexistent",
+            run_dir=run_dir,
+            started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+            duration_seconds=1800,
+            rounds_completed=10,
+            termination_reason="completed",
+        )
+        # Kein Assert nötig — der Test besteht, wenn keine Exception fliegt.
+
+    def test_best_effort_final_writes_when_draft_exists(self, run_dir):
+        """S13: Bei vorhandenem Draft finalisiert der Best-Effort-Wrapper normal."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        ManifestCapture.capture_final_best_effort(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            started_at=datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+            duration_seconds=1800,
+            rounds_completed=10,
+            termination_reason="completed",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+        assert data["status"] == "final"

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -1,0 +1,117 @@
+"""Tests für ManifestCapture (Issue #763, Ticket 2)."""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.contracts.run_manifest_contract import RunManifest
+from app.services.manifest_capture import ManifestCapture
+
+
+class TestManifestCaptureDraft:
+    """S1-S3: ManifestCapture.capture_draft() — Draft-Manifest schreiben."""
+
+    @pytest.fixture
+    def run_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield tmp
+
+    def test_writes_draft_manifest(self, run_dir):
+        """S1: capture_draft schreibt manifest.json mit status draft."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        assert os.path.exists(manifest_path), "manifest.json wurde nicht geschrieben"
+
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["status"] == "draft"
+        assert data["run_id"] == "run_test123456"
+        assert data["schema_version"] == 1
+
+    def test_manifest_is_valid_pydantic(self, run_dir):
+        """S2: Geschriebenes Manifest ist als RunManifest validierbar."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        manifest = RunManifest(**data)
+        assert manifest.status == "draft"
+        assert manifest.run_id == "run_test123456"
+        assert manifest.inputs.seed_document_hash == "sha256:abc"
+        assert manifest.seeds.random_seed == 42
+
+    def test_captured_at_is_utc_datetime(self, run_dir):
+        """S2: captured_at ist ein UTC-Datetime-String."""
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        captured_at = data["captured_at"]
+        assert "T" in captured_at or "+" in captured_at or "Z" in captured_at
+
+    def test_optional_fields_are_null_when_missing(self, run_dir):
+        """S3: Optionale Felder sind null wenn nicht übergeben."""
+        ManifestCapture.capture_draft(
+            run_id="run_minimal123",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["replayed_from_run_id"] is None
+        assert data["runtime"] is None
+        assert data["inputs"]["graph_version"] is None
+        assert data["inputs"]["embedding_version"] is None

--- a/backend/tests/services/test_manifest_capture.py
+++ b/backend/tests/services/test_manifest_capture.py
@@ -217,3 +217,117 @@ class TestManifestCaptureFinal:
                 rounds_completed=10,
                 termination_reason="completed",
             )
+
+
+class TestManifestCaptureLegacy:
+    """S7-S9: ManifestCapture.migrate_legacy() — Legacy-Manifest für Alt-Runs."""
+
+    @pytest.fixture
+    def run_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield tmp
+
+    def test_creates_legacy_manifest(self, run_dir):
+        """S7: migrate_legacy schreibt Manifest mit status legacy."""
+        ManifestCapture.migrate_legacy(
+            run_id="run_legacy123",
+            run_dir=run_dir,
+            run_metadata={
+                "started_at": "2026-01-15T10:00:00",
+                "completed_at": "2026-01-15T10:30:00",
+                "status": "completed",
+                "llm_model": "gemini-2.5-flash",
+                "graph_id": "graph_001",
+            },
+            agora_version="0.9.0",
+            schema_version="1.0.0",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        assert os.path.exists(manifest_path)
+
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["status"] == "legacy"
+        assert data["run_id"] == "run_legacy123"
+
+    def test_legacy_fills_known_fields(self, run_dir):
+        """S8: Bekannte Felder sind gefüllt, unbekannte null."""
+        ManifestCapture.migrate_legacy(
+            run_id="run_legacy123",
+            run_dir=run_dir,
+            run_metadata={
+                "started_at": "2026-01-15T10:00:00",
+                "status": "completed",
+                "llm_model": "gemini-2.5-flash",
+                "graph_id": "graph_001",
+            },
+            agora_version="0.9.0",
+            schema_version="1.0.0",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        # Bekannte Felder
+        assert data["versions"]["agora_version"] == "0.9.0"
+        assert data["inputs"]["graph_id"] == "graph_001"
+        # Nicht rekonstruierbare Felder
+        assert data["inputs"]["seed_document_hash"] == "unknown"
+        assert data["inputs"]["simulation_config_hash"] == "unknown"
+        assert data["seeds"]["random_seed"] == 0
+
+    def test_legacy_is_valid_pydantic(self, run_dir):
+        """S8: Legacy-Manifest ist als RunManifest validierbar."""
+        ManifestCapture.migrate_legacy(
+            run_id="run_legacy123",
+            run_dir=run_dir,
+            run_metadata={
+                "started_at": "2026-01-15T10:00:00",
+                "status": "completed",
+            },
+            agora_version="0.9.0",
+            schema_version="1.0.0",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        manifest = RunManifest(**data)
+        assert manifest.status == "legacy"
+
+    def test_does_not_overwrite_existing_manifest(self, run_dir):
+        """S9: Überschreibt kein vorhandenes Manifest."""
+        # Erst ein Draft schreiben
+        ManifestCapture.capture_draft(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            seed_document_hash="sha256:abc",
+            seed_document_filename="test.md",
+            simulation_config_hash="sha256:def",
+            graph_id="graph_001",
+            agora_version="0.9.5",
+            schema_version="1.0.0",
+            random_seed=42,
+            simulation_id_seed="sim_test",
+        )
+
+        # Migration sollte das Draft nicht überschreiben
+        ManifestCapture.migrate_legacy(
+            run_id="run_test123456",
+            run_dir=run_dir,
+            run_metadata={"status": "completed"},
+            agora_version="0.9.0",
+            schema_version="1.0.0",
+        )
+
+        manifest_path = os.path.join(run_dir, "manifest.json")
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        # Sollte immer noch das Draft sein
+        assert data["status"] == "draft"
+        assert data["seeds"]["random_seed"] == 42

--- a/changelog.d/1273-manifest-replay-review.md
+++ b/changelog.d/1273-manifest-replay-review.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- Replay-Overrides verwenden den kanonischen `AiModelRef` statt eines offenen
+  Dictionaries. Die `provider_connection_id` wird jetzt an das Stage-Routing
+  durchgereicht — dieselbe Modell-ID auf zwei Provider-Connections landete
+  vorher auf der falschen Connection.
+- Validierungsfehler beim Replay liefern einen strukturierten Fehler-Envelope
+  mit `code` und sanitisierten Details, statt das rohe
+  `ValidationError.errors()`-Payload als Fehlertext zu setzen.
+- Run-Manifeste werden atomar geschrieben (tmp-Datei + `os.replace`). Ein
+  fehlgeschlagener Schreibvorgang lässt das vorhandene Manifest unverändert;
+  parallele Leser sehen kein halbfertiges JSON.
+- `runtime.usage_summary` wird beim Finalisieren aus `usage_summary.json`
+  übernommen und blieb bisher in jedem Simulations-Manifest leer.
+- `RunManifest` mit `status="final"` verlangt jetzt Laufzeitdaten. `draft` und
+  `legacy` bleiben ohne `runtime` gültig.
+- Der Replay-Dialog bietet keine Eingabefelder mehr für Seed-Dokument und
+  Zufalls-Seed an — beide werden serverseitig mit HTTP 400 abgelehnt. Ein halb
+  ausgefülltes Modell-Override sperrt den Submit, statt still auf das
+  Originalmodell zurückzufallen.
+- Der Fehlerpfad des Replay-Dialogs verwendet einen i18n-Key statt eines
+  hartkodierten deutschen Texts.

--- a/frontend/src/api/__tests__/runs.spec.ts
+++ b/frontend/src/api/__tests__/runs.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../index', () => ({
   default: serviceMock,
 }))
 
-import { cancelRun, resumeRun, stopRun } from '../runs'
+import { cancelRun, exportRun, getRunManifest, replayRun, resumeRun, stopRun } from '../runs'
 
 describe('runs api client', () => {
   beforeEach(() => {
@@ -43,5 +43,48 @@ describe('runs api client', () => {
     serviceMock.post.mockResolvedValueOnce({ success: true, data: { run_id: 'run-xyz', status: 'processing' } })
     await resumeRun('run-xyz')
     expect(serviceMock.post).toHaveBeenCalledWith('/api/runs/run-xyz/resume')
+  })
+
+  // Issue #763 (Ticket 8/6): Replay + Export + Manifest-Abruf.
+  it('replayRun posts to /api/runs/<id>/replay without body for identical replay', async () => {
+    const mockResponse = { run_id: 'run-new', status: 'pending' }
+    serviceMock.post.mockResolvedValueOnce(mockResponse)
+
+    const result = await replayRun('run-orig')
+
+    expect(serviceMock.post).toHaveBeenCalledWith('/api/runs/run-orig/replay', undefined)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('replayRun posts overrides for variant replay', async () => {
+    serviceMock.post.mockResolvedValueOnce({ run_id: 'run-new', status: 'pending' })
+
+    await replayRun('run-orig', { overrides: { random_seed: 42 } })
+
+    expect(serviceMock.post).toHaveBeenCalledWith('/api/runs/run-orig/replay', {
+      overrides: { random_seed: 42 },
+    })
+  })
+
+  it('exportRun gets /api/runs/<id>/export as blob', async () => {
+    const mockBlob = new Blob(['zip-bytes'])
+    serviceMock.get.mockResolvedValueOnce(mockBlob)
+
+    const result = await exportRun('run-abc')
+
+    expect(serviceMock.get).toHaveBeenCalledWith('/api/runs/run-abc/export', {
+      responseType: 'blob',
+    })
+    expect(result).toBe(mockBlob)
+  })
+
+  it('getRunManifest gets /api/runs/<id>/manifest', async () => {
+    const mockManifest = { success: true, data: { run_id: 'run-abc', status: 'final' } }
+    serviceMock.get.mockResolvedValueOnce(mockManifest)
+
+    const result = await getRunManifest('run-abc')
+
+    expect(serviceMock.get).toHaveBeenCalledWith('/api/runs/run-abc/manifest')
+    expect(result).toEqual(mockManifest)
   })
 })

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -6,7 +6,10 @@ import type {
   ApiResponse,
   CancelRunResponse,
   ListRunsParams,
+  ReplayRequest,
+  ReplayResponse,
   RunEvent,
+  RunManifest,
   RunRecord,
 } from '../types/run'
 import type { RunsListResponse } from '../contracts/runsContract'
@@ -32,3 +35,26 @@ export const stopRun = (runId: string): Promise<ApiResponse<RunRecord>> =>
 
 export const cancelRun = (runId: string): Promise<CancelRunResponse> =>
   service.post(`/api/runs/${runId}/cancel`)
+
+/** GET /api/runs/<run_id>/manifest — Run-Manifest abrufen (Issue #763). */
+export const getRunManifest = (
+  runId: string
+): Promise<ApiResponse<RunManifest>> =>
+  service.get(`/api/runs/${runId}/manifest`)
+
+/**
+ * POST /api/runs/<run_id>/replay — neuen Run aus Manifest starten (Issue #763).
+ * Response ist flach OHNE `data`-Envelope: {run_id, status} bei 202 Accepted.
+ */
+export const replayRun = (
+  runId: string,
+  request?: ReplayRequest
+): Promise<ReplayResponse> =>
+  service.post(`/api/runs/${runId}/replay`, request)
+
+/**
+ * GET /api/runs/<run_id>/export — ZIP-Download mit Manifest + Artefakten
+ * (Issue #763). responseType 'blob', da der Endpoint ein Binary liefert.
+ */
+export const exportRun = (runId: string): Promise<Blob> =>
+  service.get(`/api/runs/${runId}/export`, { responseType: 'blob' })

--- a/frontend/src/components/RunReplayDialog.vue
+++ b/frontend/src/components/RunReplayDialog.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+/**
+ * RunReplayDialog — Replay-Dialog für die Run-Detail-Ansicht (Issue #763, Ticket 6).
+ *
+ * Zwei Modi:
+ *   - "Identisch wiederholen": POST /replay ohne Overrides.
+ *   - "Variante": POST /replay mit ReplayOverrides (Seed-Dokument, Random-Seed, Modell).
+ */
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Dialog from './v4/data/Dialog.vue'
+import Button from './v4/forms/Button.vue'
+import Input from './v4/forms/Input.vue'
+import { replayRun } from '../api/runs'
+import { ApiError } from '../api/envelope'
+import type { ReplayOverrides } from '../contracts/runManifestContract'
+
+const props = defineProps<{
+  modelValue: boolean
+  runId: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  replayed: [newRunId: string]
+}>()
+
+const { t } = useI18n()
+
+type ReplayMode = 'identical' | 'variant'
+
+const mode = ref<ReplayMode>('identical')
+const seedDocumentId = ref('')
+const randomSeed = ref('')
+const providerConnectionId = ref('')
+const modelId = ref('')
+
+const submitting = ref(false)
+const errorMessage = ref('')
+
+// Formularfelder beim Öffnen zurücksetzen — kein Rest-State aus dem letzten Aufruf.
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) {
+      mode.value = 'identical'
+      seedDocumentId.value = ''
+      randomSeed.value = ''
+      providerConnectionId.value = ''
+      modelId.value = ''
+      errorMessage.value = ''
+    }
+  },
+)
+
+const canSubmit = computed(() => !submitting.value)
+
+function buildOverrides(): ReplayOverrides | undefined {
+  if (mode.value === 'identical') return undefined
+
+  const overrides: ReplayOverrides = {}
+  if (seedDocumentId.value.trim()) {
+    overrides.seed_document_id = seedDocumentId.value.trim()
+  }
+  if (randomSeed.value.trim()) {
+    const parsed = Number.parseInt(randomSeed.value, 10)
+    if (!Number.isNaN(parsed)) overrides.random_seed = parsed
+  }
+  if (providerConnectionId.value.trim() && modelId.value.trim()) {
+    overrides.ai_model_ref = {
+      provider_connection_id: providerConnectionId.value.trim(),
+      model_id: modelId.value.trim(),
+    }
+  }
+
+  const isEmpty =
+    overrides.seed_document_id === undefined &&
+    overrides.random_seed === undefined &&
+    overrides.ai_model_ref === undefined
+  return isEmpty ? undefined : overrides
+}
+
+async function submit(): Promise<void> {
+  submitting.value = true
+  errorMessage.value = ''
+  try {
+    const overrides = buildOverrides()
+    const response = await replayRun(props.runId, overrides ? { overrides } : undefined)
+    emit('replayed', response.run_id)
+    emit('update:modelValue', false)
+  } catch (e) {
+    errorMessage.value =
+      e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Unbekannter Fehler'
+  } finally {
+    submitting.value = false
+  }
+}
+
+function close(): void {
+  emit('update:modelValue', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :model-value="modelValue"
+    :title="t('runs.dashboard.replay.dialog_title')"
+    :description="t('runs.dashboard.replay.dialog_description')"
+    size="md"
+    @update:model-value="(v) => emit('update:modelValue', v)"
+  >
+    <div class="replay-body">
+      <div class="mode-toggle" role="radiogroup" :aria-label="t('runs.dashboard.replay.dialog_title')">
+        <label class="mode-option">
+          <input v-model="mode" type="radio" value="identical" name="replay-mode" />
+          {{ t('runs.dashboard.replay.mode_identical') }}
+        </label>
+        <label class="mode-option">
+          <input v-model="mode" type="radio" value="variant" name="replay-mode" />
+          {{ t('runs.dashboard.replay.mode_variant') }}
+        </label>
+      </div>
+
+      <div v-if="mode === 'variant'" class="variant-fields">
+        <label class="field">
+          <span class="field-label">{{ t('runs.dashboard.replay.field_seed_document_id') }}</span>
+          <Input v-model="seedDocumentId" placeholder="doc_..." mono />
+        </label>
+        <label class="field">
+          <span class="field-label">{{ t('runs.dashboard.replay.field_random_seed') }}</span>
+          <Input v-model="randomSeed" type="number" mono />
+        </label>
+        <label class="field">
+          <span class="field-label">{{ t('runs.dashboard.replay.field_provider_connection_id') }}</span>
+          <Input v-model="providerConnectionId" placeholder="conn_..." mono />
+        </label>
+        <label class="field">
+          <span class="field-label">{{ t('runs.dashboard.replay.field_model_id') }}</span>
+          <Input v-model="modelId" placeholder="gemini-2.5-pro" mono />
+        </label>
+      </div>
+
+      <p v-if="errorMessage" class="replay-error" role="alert">
+        {{ t('runs.dashboard.replay.error', { message: errorMessage }) }}
+      </p>
+    </div>
+
+    <template #footer>
+      <Button variant="ghost" :disabled="submitting" @click="close">
+        {{ t('runs.dashboard.replay.cancel') }}
+      </Button>
+      <Button variant="primary" :loading="submitting" :disabled="!canSubmit" @click="submit">
+        {{ submitting ? t('runs.dashboard.replay.submitting') : t('runs.dashboard.replay.submit') }}
+      </Button>
+    </template>
+  </Dialog>
+</template>
+
+<style scoped>
+.replay-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mode-toggle {
+  display: flex;
+  gap: 16px;
+}
+
+.mode-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.variant-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-family: var(--ff-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #888);
+}
+
+.replay-error {
+  margin: 0;
+  padding: 8px 12px;
+  background: #fee2e2;
+  border: 1px solid #f87171;
+  color: #7f1d1d;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/RunReplayDialog.vue
+++ b/frontend/src/components/RunReplayDialog.vue
@@ -4,7 +4,12 @@
  *
  * Zwei Modi:
  *   - "Identisch wiederholen": POST /replay ohne Overrides.
- *   - "Variante": POST /replay mit ReplayOverrides (Seed-Dokument, Random-Seed, Modell).
+ *   - "Variante": POST /replay mit ReplayOverrides (Modell).
+ *
+ * Bewusst nur das Modell-Override: das Backend lehnt ``seed_document_id`` und
+ * ``random_seed`` mit HTTP 400 ab (kein Re-Prepare-Mechanismus für ein neues
+ * Ausgangsdokument, kein Runtime-Konzept für einen deterministischen Seed).
+ * Eingabefelder dafür würden garantiert in einen Fehler laufen.
  */
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -30,8 +35,6 @@ const { t } = useI18n()
 type ReplayMode = 'identical' | 'variant'
 
 const mode = ref<ReplayMode>('identical')
-const seedDocumentId = ref('')
-const randomSeed = ref('')
 const providerConnectionId = ref('')
 const modelId = ref('')
 
@@ -44,8 +47,6 @@ watch(
   (open) => {
     if (open) {
       mode.value = 'identical'
-      seedDocumentId.value = ''
-      randomSeed.value = ''
       providerConnectionId.value = ''
       modelId.value = ''
       errorMessage.value = ''
@@ -53,31 +54,27 @@ watch(
   },
 )
 
-const canSubmit = computed(() => !submitting.value)
+// Ein halb ausgefülltes Modell-Override (nur Connection oder nur Modell) ist
+// kein gültiger AiModelRef und würde still verworfen — der Submit-Button
+// bleibt in dem Fall gesperrt statt das Original-Modell zu verwenden.
+const variantIncomplete = computed(
+  () =>
+    mode.value === 'variant' &&
+    Boolean(providerConnectionId.value.trim()) !== Boolean(modelId.value.trim()),
+)
+
+const canSubmit = computed(() => !submitting.value && !variantIncomplete.value)
 
 function buildOverrides(): ReplayOverrides | undefined {
   if (mode.value === 'identical') return undefined
+  if (!providerConnectionId.value.trim() || !modelId.value.trim()) return undefined
 
-  const overrides: ReplayOverrides = {}
-  if (seedDocumentId.value.trim()) {
-    overrides.seed_document_id = seedDocumentId.value.trim()
-  }
-  if (randomSeed.value.trim()) {
-    const parsed = Number.parseInt(randomSeed.value, 10)
-    if (!Number.isNaN(parsed)) overrides.random_seed = parsed
-  }
-  if (providerConnectionId.value.trim() && modelId.value.trim()) {
-    overrides.ai_model_ref = {
+  return {
+    ai_model_ref: {
       provider_connection_id: providerConnectionId.value.trim(),
       model_id: modelId.value.trim(),
-    }
+    },
   }
-
-  const isEmpty =
-    overrides.seed_document_id === undefined &&
-    overrides.random_seed === undefined &&
-    overrides.ai_model_ref === undefined
-  return isEmpty ? undefined : overrides
 }
 
 async function submit(): Promise<void> {
@@ -90,7 +87,9 @@ async function submit(): Promise<void> {
     emit('update:modelValue', false)
   } catch (e) {
     errorMessage.value =
-      e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Unbekannter Fehler'
+      e instanceof ApiError || e instanceof Error
+        ? e.message
+        : t('runs.dashboard.replay.unknown_error')
   } finally {
     submitting.value = false
   }
@@ -123,14 +122,6 @@ function close(): void {
 
       <div v-if="mode === 'variant'" class="variant-fields">
         <label class="field">
-          <span class="field-label">{{ t('runs.dashboard.replay.field_seed_document_id') }}</span>
-          <Input v-model="seedDocumentId" placeholder="doc_..." mono />
-        </label>
-        <label class="field">
-          <span class="field-label">{{ t('runs.dashboard.replay.field_random_seed') }}</span>
-          <Input v-model="randomSeed" type="number" mono />
-        </label>
-        <label class="field">
           <span class="field-label">{{ t('runs.dashboard.replay.field_provider_connection_id') }}</span>
           <Input v-model="providerConnectionId" placeholder="conn_..." mono />
         </label>
@@ -138,6 +129,9 @@ function close(): void {
           <span class="field-label">{{ t('runs.dashboard.replay.field_model_id') }}</span>
           <Input v-model="modelId" placeholder="gemini-2.5-pro" mono />
         </label>
+        <p v-if="variantIncomplete" class="field-hint" role="status">
+          {{ t('runs.dashboard.replay.model_override_incomplete') }}
+        </p>
       </div>
 
       <p v-if="errorMessage" class="replay-error" role="alert">
@@ -193,6 +187,12 @@ function close(): void {
   font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--text-secondary, #888);
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 12px;
   color: var(--text-secondary, #888);
 }
 

--- a/frontend/src/components/__tests__/RunReplayDialog.spec.ts
+++ b/frontend/src/components/__tests__/RunReplayDialog.spec.ts
@@ -65,13 +65,14 @@ describe('RunReplayDialog', () => {
     expect(wrapper.emitted('replayed')?.[0]).toEqual(['run-new456'])
   })
 
-  it('Varianten-Replay mit random_seed baut korrekte Overrides', async () => {
+  it('Varianten-Replay baut ai_model_ref inklusive Connection-ID', async () => {
     replayRunMock.mockResolvedValueOnce({ run_id: 'run-new789', status: 'pending' })
     const wrapper = mountDialog()
 
     await wrapper.find('input[value="variant"]').setValue(true)
-    const seedInput = wrapper.find('input[type="number"]')
-    await seedInput.setValue('12345')
+    const fields = wrapper.findAll('.variant-fields input')
+    await fields[0].setValue('conn-gemini')
+    await fields[1].setValue('gemini-2.5-pro')
 
     const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
     await submitBtn?.trigger('click')
@@ -79,8 +80,52 @@ describe('RunReplayDialog', () => {
     await new Promise((r) => setTimeout(r, 0))
 
     expect(replayRunMock).toHaveBeenCalledWith('run-abc123', {
-      overrides: { random_seed: 12345 },
+      overrides: {
+        ai_model_ref: { provider_connection_id: 'conn-gemini', model_id: 'gemini-2.5-pro' },
+      },
     })
+  })
+
+  it('bietet keine Felder an, die das Backend garantiert mit 400 ablehnt', async () => {
+    // CodeRabbit-Fund: seed_document_id und random_seed werden serverseitig
+    // mit 400 abgelehnt (kein Re-Prepare, kein Runtime-Seed-Konzept). Felder
+    // dafuer im Dialog fuehren jeden Nutzer sicher in einen Fehler.
+    const wrapper = mountDialog()
+    await wrapper.find('input[value="variant"]').setValue(true)
+
+    expect(wrapper.find('.variant-fields input[type="number"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Seed-Dokument-ID')
+    expect(wrapper.text()).not.toContain('Zufalls-Seed')
+    expect(wrapper.findAll('.variant-fields input')).toHaveLength(2)
+  })
+
+  it('sperrt den Submit bei halb ausgefuelltem Modell-Override', async () => {
+    // CodeRabbit-Fund: buildOverrides verwarf ein Override mit nur einem der
+    // beiden Felder still — das Replay lief dann unbemerkt auf dem Originalmodell.
+    const wrapper = mountDialog()
+    await wrapper.find('input[value="variant"]').setValue(true)
+    await wrapper.findAll('.variant-fields input')[0].setValue('conn-gemini')
+
+    expect(wrapper.text()).toContain('müssen beide gesetzt sein')
+
+    const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
+    await submitBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(replayRunMock).not.toHaveBeenCalled()
+  })
+
+  it('nutzt einen i18n-Key statt eines hartkodierten Fehlertexts', async () => {
+    replayRunMock.mockRejectedValueOnce('kein Error-Objekt')
+    const wrapper = mountDialog()
+
+    const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
+    await submitBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain(de.runs.dashboard.replay.unknown_error)
   })
 
   it('zeigt eine Fehlermeldung, wenn replayRun fehlschlägt', async () => {

--- a/frontend/src/components/__tests__/RunReplayDialog.spec.ts
+++ b/frontend/src/components/__tests__/RunReplayDialog.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import de from '@/i18n/locales/de.json'
+
+const replayRunMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../api/runs', () => ({
+  replayRun: replayRunMock,
+}))
+
+import RunReplayDialog from '../RunReplayDialog.vue'
+
+/**
+ * Issue #763 (Ticket 6) — Replay-Dialog: identisch vs. Variante.
+ * Gegen echte de.json gemountet, damit ein fehlender i18n-Key auffällt.
+ */
+function mountDialog(open = true) {
+  const i18n = createI18n({ legacy: false, locale: 'de', messages: { de } })
+  return mount(RunReplayDialog, {
+    props: { modelValue: open, runId: 'run-abc123' },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('RunReplayDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('startet mit Modus "identisch"', () => {
+    const wrapper = mountDialog()
+    const identicalRadio = wrapper.find('input[value="identical"]')
+    expect((identicalRadio.element as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('zeigt Varianten-Felder erst nach Umschalten', async () => {
+    const wrapper = mountDialog()
+    expect(wrapper.find('.variant-fields').exists()).toBe(false)
+
+    await wrapper.find('input[value="variant"]').setValue(true)
+    expect(wrapper.find('.variant-fields').exists()).toBe(true)
+  })
+
+  it('identisches Replay ruft replayRun ohne Overrides auf', async () => {
+    replayRunMock.mockResolvedValueOnce({ run_id: 'run-new456', status: 'pending' })
+    const wrapper = mountDialog()
+
+    await wrapper.find('button.btn--primary, [class*="primary"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(replayRunMock).toHaveBeenCalledWith('run-abc123', undefined)
+  })
+
+  it('emittet replayed mit der neuen run_id bei Erfolg', async () => {
+    replayRunMock.mockResolvedValueOnce({ run_id: 'run-new456', status: 'pending' })
+    const wrapper = mountDialog()
+
+    const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
+    await submitBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(wrapper.emitted('replayed')).toBeTruthy()
+    expect(wrapper.emitted('replayed')?.[0]).toEqual(['run-new456'])
+  })
+
+  it('Varianten-Replay mit random_seed baut korrekte Overrides', async () => {
+    replayRunMock.mockResolvedValueOnce({ run_id: 'run-new789', status: 'pending' })
+    const wrapper = mountDialog()
+
+    await wrapper.find('input[value="variant"]').setValue(true)
+    const seedInput = wrapper.find('input[type="number"]')
+    await seedInput.setValue('12345')
+
+    const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
+    await submitBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(replayRunMock).toHaveBeenCalledWith('run-abc123', {
+      overrides: { random_seed: 12345 },
+    })
+  })
+
+  it('zeigt eine Fehlermeldung, wenn replayRun fehlschlägt', async () => {
+    replayRunMock.mockRejectedValueOnce(new Error('Provider nicht verfügbar'))
+    const wrapper = mountDialog()
+
+    const submitBtn = wrapper.findAll('button').find((b) => b.text().includes('Replay starten'))
+    await submitBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Provider nicht verfügbar')
+    expect(wrapper.emitted('replayed')).toBeFalsy()
+  })
+})

--- a/frontend/src/contracts/runManifestContract.ts
+++ b/frontend/src/contracts/runManifestContract.ts
@@ -13,6 +13,8 @@
  */
 import { z } from 'zod'
 
+import { AiModelSourceSchema } from './aiModelRef'
+
 // === ManifestStatus ===
 export const ManifestStatusSchema = z.enum(['draft', 'final', 'legacy'])
 export type ManifestStatus = z.infer<typeof ManifestStatusSchema>
@@ -116,11 +118,24 @@ export const RunManifestSchema = z
 export type RunManifest = z.infer<typeof RunManifestSchema>
 
 // === ReplayOverrides ===
+// ai_model_ref spiegelt den kanonischen Backend-``AiModelRef``: beide
+// Pflichtfelder erzwungen, unbekannte Schlüssel abgelehnt. ``source`` hat
+// backendseitig einen Default und ist deshalb hier optional.
+export const ReplayAiModelRefSchema = z
+  .object({
+    provider_connection_id: z.string().min(1),
+    model_id: z.string().min(1),
+    source: AiModelSourceSchema.optional(),
+    capability_filter: z.string().nullable().optional(),
+    fallback_reason: z.string().nullable().optional(),
+  })
+  .strict()
+
 export const ReplayOverridesSchema = z
   .object({
     seed_document_id: z.string().nullable().optional(),
     random_seed: z.number().int().nullable().optional(),
-    ai_model_ref: z.record(z.string(), z.string()).nullable().optional(),
+    ai_model_ref: ReplayAiModelRefSchema.nullable().optional(),
   })
   .strict()
 export type ReplayOverrides = z.infer<typeof ReplayOverridesSchema>

--- a/frontend/src/contracts/runManifestContract.ts
+++ b/frontend/src/contracts/runManifestContract.ts
@@ -1,0 +1,143 @@
+/**
+ * Run-Manifest-Contract v1 — Zod-Spiegel (Issue #763).
+ *
+ * Hand-gepflegt, 1:1 zu backend/app/contracts/run_manifest_contract.py und
+ * den generierten JSON-Schemas unter schemas/run-manifest.schema.json etc.
+ *
+ * Regeln:
+ *   - Keine Secrets im Manifest (API-Keys, Passwörter).
+ *   - Prompt-Texte sind byte-genaue Snapshots zum Zeitpunkt des Runs.
+ *   - Draft-Manifest bei Run-Start, final bei Run-Ende, legacy für Alt-Runs.
+ *
+ * Änderungen am Pydantic-Modell → Schema-Dump → diese Datei synchronisieren.
+ */
+import { z } from 'zod'
+
+// === ManifestStatus ===
+export const ManifestStatusSchema = z.enum(['draft', 'final', 'legacy'])
+export type ManifestStatus = z.infer<typeof ManifestStatusSchema>
+
+// === ManifestInputs ===
+export const ManifestInputsSchema = z
+  .object({
+    seed_document_hash: z.string(),
+    seed_document_filename: z.string(),
+    simulation_config_hash: z.string(),
+    graph_id: z.string(),
+    graph_version: z.string().nullable().optional(),
+    embedding_version: z.string().nullable().optional(),
+  })
+  .strict()
+export type ManifestInputs = z.infer<typeof ManifestInputsSchema>
+
+// === ManifestVersions ===
+export const ManifestVersionsSchema = z
+  .object({
+    agora_version: z.string(),
+    schema_version: z.string(),
+  })
+  .strict()
+export type ManifestVersions = z.infer<typeof ManifestVersionsSchema>
+
+// === StageRoute ===
+export const StageRouteSchema = z
+  .object({
+    model: z.string(),
+    provider: z.string(),
+    base_url: z.string(),
+    ai_route_snapshot: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .strict()
+export type StageRoute = z.infer<typeof StageRouteSchema>
+
+// === ManifestRouting ===
+export const ManifestRoutingSchema = z
+  .object({
+    stages: z.record(z.string(), StageRouteSchema).default(() => ({})),
+  })
+  .strict()
+export type ManifestRouting = z.infer<typeof ManifestRoutingSchema>
+
+// === PromptSnapshot ===
+export const PromptSnapshotSchema = z
+  .object({
+    content: z.string(),
+    source_file: z.string(),
+  })
+  .strict()
+export type PromptSnapshot = z.infer<typeof PromptSnapshotSchema>
+
+// === ManifestPrompts ===
+export const ManifestPromptsSchema = z
+  .object({
+    entries: z.record(z.string(), PromptSnapshotSchema).default(() => ({})),
+  })
+  .strict()
+export type ManifestPrompts = z.infer<typeof ManifestPromptsSchema>
+
+// === ManifestSeeds ===
+export const ManifestSeedsSchema = z
+  .object({
+    random_seed: z.number().int(),
+    simulation_id_seed: z.string(),
+  })
+  .strict()
+export type ManifestSeeds = z.infer<typeof ManifestSeedsSchema>
+
+// === ManifestRuntime ===
+export const ManifestRuntimeSchema = z
+  .object({
+    started_at: z.string(),
+    completed_at: z.string().nullable().optional(),
+    duration_seconds: z.number().int().nullable().optional(),
+    rounds_completed: z.number().int().nullable().optional(),
+    usage_summary: z.record(z.string(), z.unknown()).nullable().optional(),
+    termination_reason: z.string().nullable().optional(),
+  })
+  .strict()
+export type ManifestRuntime = z.infer<typeof ManifestRuntimeSchema>
+
+// === RunManifest ===
+export const RunManifestSchema = z
+  .object({
+    schema_version: z.literal(1),
+    run_id: z.string(),
+    replayed_from_run_id: z.string().nullable().optional(),
+    captured_at: z.string(),
+    inputs: ManifestInputsSchema,
+    versions: ManifestVersionsSchema,
+    routing: ManifestRoutingSchema,
+    prompts: ManifestPromptsSchema,
+    seeds: ManifestSeedsSchema,
+    runtime: ManifestRuntimeSchema.nullable().optional(),
+    status: ManifestStatusSchema,
+  })
+  .strict()
+export type RunManifest = z.infer<typeof RunManifestSchema>
+
+// === ReplayOverrides ===
+export const ReplayOverridesSchema = z
+  .object({
+    seed_document_id: z.string().nullable().optional(),
+    random_seed: z.number().int().nullable().optional(),
+    ai_model_ref: z.record(z.string(), z.string()).nullable().optional(),
+  })
+  .strict()
+export type ReplayOverrides = z.infer<typeof ReplayOverridesSchema>
+
+// === ReplayRequest ===
+export const ReplayRequestSchema = z
+  .object({
+    overrides: ReplayOverridesSchema.nullable().optional(),
+  })
+  .strict()
+export type ReplayRequest = z.infer<typeof ReplayRequestSchema>
+
+// === ReplayResponse ===
+export const ReplayResponseSchema = z
+  .object({
+    run_id: z.string(),
+    status: z.string(),
+  })
+  .strict()
+export type ReplayResponse = z.infer<typeof ReplayResponseSchema>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1231,7 +1231,24 @@
         "started": "Gestartet",
         "progress": "Fortschritt"
       },
-      "back_to_dashboard": "← Zurück zum Dashboard"
+      "back_to_dashboard": "← Zurück zum Dashboard",
+      "replay": {
+        "button": "Replay",
+        "dialog_title": "Run wiederholen",
+        "dialog_description": "Identisch wiederholen übernimmt alle Parameter aus dem Manifest. Eine Variante erlaubt Overrides.",
+        "mode_identical": "Identisch wiederholen",
+        "mode_variant": "Variante",
+        "field_seed_document_id": "Seed-Dokument-ID",
+        "field_random_seed": "Zufalls-Seed",
+        "field_provider_connection_id": "Provider-Connection-ID",
+        "field_model_id": "Modell-ID",
+        "cancel": "Abbrechen",
+        "submit": "Replay starten",
+        "submitting": "Wird gestartet…",
+        "success": "Replay gestartet — neuer Run: {run_id}",
+        "error": "Replay fehlgeschlagen: {message}",
+        "no_manifest": "Kein Manifest verfügbar — Replay nicht möglich."
+      }
     }
   },
   "errors": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1238,15 +1238,15 @@
         "dialog_description": "Identisch wiederholen übernimmt alle Parameter aus dem Manifest. Eine Variante erlaubt Overrides.",
         "mode_identical": "Identisch wiederholen",
         "mode_variant": "Variante",
-        "field_seed_document_id": "Seed-Dokument-ID",
-        "field_random_seed": "Zufalls-Seed",
         "field_provider_connection_id": "Provider-Connection-ID",
         "field_model_id": "Modell-ID",
+        "model_override_incomplete": "Provider-Connection-ID und Modell-ID müssen beide gesetzt sein.",
         "cancel": "Abbrechen",
         "submit": "Replay starten",
         "submitting": "Wird gestartet…",
         "success": "Replay gestartet — neuer Run: {run_id}",
         "error": "Replay fehlgeschlagen: {message}",
+        "unknown_error": "Unbekannter Fehler",
         "no_manifest": "Kein Manifest verfügbar — Replay nicht möglich."
       }
     }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1238,15 +1238,15 @@
         "dialog_description": "Identical replay reuses every parameter from the manifest. A variant allows overrides.",
         "mode_identical": "Replay identically",
         "mode_variant": "Variant",
-        "field_seed_document_id": "Seed document ID",
-        "field_random_seed": "Random seed",
         "field_provider_connection_id": "Provider connection ID",
         "field_model_id": "Model ID",
+        "model_override_incomplete": "Provider connection ID and model ID must both be set.",
         "cancel": "Cancel",
         "submit": "Start replay",
         "submitting": "Starting…",
         "success": "Replay started — new run: {run_id}",
         "error": "Replay failed: {message}",
+        "unknown_error": "Unknown error",
         "no_manifest": "No manifest available — replay not possible."
       }
     }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1231,7 +1231,24 @@
         "started": "Started",
         "progress": "Progress"
       },
-      "back_to_dashboard": "← Back to dashboard"
+      "back_to_dashboard": "← Back to dashboard",
+      "replay": {
+        "button": "Replay",
+        "dialog_title": "Replay run",
+        "dialog_description": "Identical replay reuses every parameter from the manifest. A variant allows overrides.",
+        "mode_identical": "Replay identically",
+        "mode_variant": "Variant",
+        "field_seed_document_id": "Seed document ID",
+        "field_random_seed": "Random seed",
+        "field_provider_connection_id": "Provider connection ID",
+        "field_model_id": "Model ID",
+        "cancel": "Cancel",
+        "submit": "Start replay",
+        "submitting": "Starting…",
+        "success": "Replay started — new run: {run_id}",
+        "error": "Replay failed: {message}",
+        "no_manifest": "No manifest available — replay not possible."
+      }
     }
   },
   "errors": {

--- a/frontend/src/types/run.ts
+++ b/frontend/src/types/run.ts
@@ -117,3 +117,11 @@ export interface ListRunsParams {
   project?: string
   branch?: string
 }
+
+/** Re-exported Zod-inferred types (Issue #763) — see contracts/runManifestContract.ts. */
+export type {
+  RunManifest,
+  ReplayRequest,
+  ReplayResponse,
+  ReplayOverrides,
+} from '../contracts/runManifestContract'

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { getRun } from '../api/runs'
@@ -14,6 +14,7 @@ import {
 } from '../contracts/runBudgetContract'
 import LlmRoutingView from '../components/LlmRouting/LlmRoutingView.vue'
 import RunUsageBreakdown from '../components/v4/run-budget/RunUsageBreakdown.vue'
+import RunReplayDialog from '../components/RunReplayDialog.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -24,6 +25,18 @@ const runId = String(route.params.id)
 const run = ref<RunDetail | null>(null)
 const loading = ref(false)
 const error = ref('')
+
+// Replay (Issue #763, Ticket 6): Button nur bei abgeschlossenen Runs sinnvoll —
+// ein Manifest existiert erst nach capture_final(), also nur für terminale Status.
+const REPLAYABLE_STATUSES = new Set(['completed', 'failed', 'stopped'])
+const replayDialogOpen = ref(false)
+const replaySuccessMessage = ref('')
+
+const canReplay = computed(() => !!run.value && REPLAYABLE_STATUSES.has(run.value.status))
+
+function onReplayed(newRunId: string): void {
+  replaySuccessMessage.value = t('runs.dashboard.replay.success', { run_id: newRunId })
+}
 
 // Issue #764: Budget/Verbrauch kommen als Read-Path-Anreicherung in
 // GET /api/runs/<id> mit. RunDetailSchema ist passthrough — die Blöcke
@@ -170,7 +183,12 @@ onMounted(() => void loadRun())
       </section>
     </template>
 
-    <!-- Refresh button -->
+    <!-- Replay success banner -->
+    <div v-if="replaySuccessMessage" class="replay-success-banner" role="status">
+      {{ replaySuccessMessage }}
+    </div>
+
+    <!-- Refresh + Replay buttons -->
     <div class="detail-actions">
       <button
         type="button"
@@ -180,7 +198,21 @@ onMounted(() => void loadRun())
       >
         {{ t('common.refresh') }}
       </button>
+      <button
+        v-if="canReplay"
+        type="button"
+        class="action-btn"
+        @click="replayDialogOpen = true"
+      >
+        {{ t('runs.dashboard.replay.button') }}
+      </button>
     </div>
+
+    <RunReplayDialog
+      v-model="replayDialogOpen"
+      :run-id="runId"
+      @replayed="onReplayed"
+    />
   </div>
 </template>
 
@@ -231,6 +263,14 @@ onMounted(() => void loadRun())
   background: #fee2e2;
   border: 1px solid #f87171;
   color: #7f1d1d;
+  font-size: 13px;
+}
+
+.replay-success-banner {
+  padding: var(--s-4, 1rem);
+  background: #dcfce7;
+  border: 1px solid #4ade80;
+  color: #166534;
   font-size: 13px;
 }
 

--- a/schemas/manifest-inputs.schema.json
+++ b/schemas/manifest-inputs.schema.json
@@ -1,0 +1,56 @@
+{
+  "$id": "https://alexle135.de/schemas/manifest-inputs.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Eingangsdaten-Hashes und -Referenzen.",
+  "properties": {
+    "embedding_version": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Embedding Version"
+    },
+    "graph_id": {
+      "title": "Graph Id",
+      "type": "string"
+    },
+    "graph_version": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Graph Version"
+    },
+    "seed_document_filename": {
+      "title": "Seed Document Filename",
+      "type": "string"
+    },
+    "seed_document_hash": {
+      "title": "Seed Document Hash",
+      "type": "string"
+    },
+    "simulation_config_hash": {
+      "title": "Simulation Config Hash",
+      "type": "string"
+    }
+  },
+  "required": [
+    "seed_document_hash",
+    "seed_document_filename",
+    "simulation_config_hash",
+    "graph_id"
+  ],
+  "title": "ManifestInputs",
+  "type": "object"
+}

--- a/schemas/manifest-prompts.schema.json
+++ b/schemas/manifest-prompts.schema.json
@@ -1,0 +1,39 @@
+{
+  "$defs": {
+    "PromptSnapshot": {
+      "additionalProperties": false,
+      "description": "Byte-genauer Prompt-Text mit Herkunftsangabe.",
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "source_file": {
+          "title": "Source File",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "source_file"
+      ],
+      "title": "PromptSnapshot",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/manifest-prompts.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Alle Prompt-Snapshots eines Runs.",
+  "properties": {
+    "entries": {
+      "additionalProperties": {
+        "$ref": "#/$defs/PromptSnapshot"
+      },
+      "title": "Entries",
+      "type": "object"
+    }
+  },
+  "title": "ManifestPrompts",
+  "type": "object"
+}

--- a/schemas/manifest-routing.schema.json
+++ b/schemas/manifest-routing.schema.json
@@ -1,0 +1,57 @@
+{
+  "$defs": {
+    "StageRoute": {
+      "additionalProperties": false,
+      "description": "Pro-Stage-Modell- und Provider-Information (ohne Secrets).",
+      "properties": {
+        "ai_route_snapshot": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ai Route Snapshot"
+        },
+        "base_url": {
+          "title": "Base Url",
+          "type": "string"
+        },
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        }
+      },
+      "required": [
+        "model",
+        "provider",
+        "base_url"
+      ],
+      "title": "StageRoute",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/manifest-routing.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "LLM-Routing-Tabelle pro Stage.",
+  "properties": {
+    "stages": {
+      "additionalProperties": {
+        "$ref": "#/$defs/StageRoute"
+      },
+      "title": "Stages",
+      "type": "object"
+    }
+  },
+  "title": "ManifestRouting",
+  "type": "object"
+}

--- a/schemas/manifest-runtime.schema.json
+++ b/schemas/manifest-runtime.schema.json
@@ -1,0 +1,80 @@
+{
+  "$id": "https://alexle135.de/schemas/manifest-runtime.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Laufzeitdaten \u2014 nur im finalen Manifest.",
+  "properties": {
+    "completed_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Completed At"
+    },
+    "duration_seconds": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Duration Seconds"
+    },
+    "rounds_completed": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rounds Completed"
+    },
+    "started_at": {
+      "format": "date-time",
+      "title": "Started At",
+      "type": "string"
+    },
+    "termination_reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Termination Reason"
+    },
+    "usage_summary": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Usage Summary"
+    }
+  },
+  "required": [
+    "started_at"
+  ],
+  "title": "ManifestRuntime",
+  "type": "object"
+}

--- a/schemas/manifest-seeds.schema.json
+++ b/schemas/manifest-seeds.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://alexle135.de/schemas/manifest-seeds.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Random-Seed-Informationen.",
+  "properties": {
+    "random_seed": {
+      "title": "Random Seed",
+      "type": "integer"
+    },
+    "simulation_id_seed": {
+      "title": "Simulation Id Seed",
+      "type": "string"
+    }
+  },
+  "required": [
+    "random_seed",
+    "simulation_id_seed"
+  ],
+  "title": "ManifestSeeds",
+  "type": "object"
+}

--- a/schemas/manifest-versions.schema.json
+++ b/schemas/manifest-versions.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://alexle135.de/schemas/manifest-versions.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Agora- und Schema-Version zum Zeitpunkt des Runs.",
+  "properties": {
+    "agora_version": {
+      "title": "Agora Version",
+      "type": "string"
+    },
+    "schema_version": {
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "agora_version",
+    "schema_version"
+  ],
+  "title": "ManifestVersions",
+  "type": "object"
+}

--- a/schemas/prompt-snapshot.schema.json
+++ b/schemas/prompt-snapshot.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://alexle135.de/schemas/prompt-snapshot.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Byte-genauer Prompt-Text mit Herkunftsangabe.",
+  "properties": {
+    "content": {
+      "title": "Content",
+      "type": "string"
+    },
+    "source_file": {
+      "title": "Source File",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content",
+    "source_file"
+  ],
+  "title": "PromptSnapshot",
+  "type": "object"
+}

--- a/schemas/replay-overrides.schema.json
+++ b/schemas/replay-overrides.schema.json
@@ -1,4 +1,65 @@
 {
+  "$defs": {
+    "AiModelRef": {
+      "additionalProperties": false,
+      "description": "Kanonische (Provider-Connection, Modell)-Referenz \u2014 Backend-Spiegel des\nFrontend-``AiModelRefSchema`` (``frontend/src/contracts/aiModelRef.ts``).\n\nBewusst klein: identifiziert genau die vom UI gew\u00e4hlte Route. Gr\u00f6\u00dfere\nMetadaten (Capabilities, Status) bleiben in der ``ProviderConnection`` bzw.\nim Model-Katalog. Tr\u00e4gt keine Secrets.",
+      "properties": {
+        "capability_filter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Capability Filter"
+        },
+        "fallback_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fallback Reason"
+        },
+        "model_id": {
+          "minLength": 1,
+          "title": "Model Id",
+          "type": "string"
+        },
+        "provider_connection_id": {
+          "minLength": 1,
+          "title": "Provider Connection Id",
+          "type": "string"
+        },
+        "source": {
+          "default": "explicit",
+          "enum": [
+            "stage-override",
+            "run-override",
+            "project-default",
+            "workspace-default",
+            "explicit",
+            "fallback"
+          ],
+          "title": "Source",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider_connection_id",
+        "model_id"
+      ],
+      "title": "AiModelRef",
+      "type": "object"
+    }
+  },
   "$id": "https://alexle135.de/schemas/replay-overrides.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
@@ -7,17 +68,13 @@
     "ai_model_ref": {
       "anyOf": [
         {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object"
+          "$ref": "#/$defs/AiModelRef"
         },
         {
           "type": "null"
         }
       ],
-      "default": null,
-      "title": "Ai Model Ref"
+      "default": null
     },
     "random_seed": {
       "anyOf": [

--- a/schemas/replay-overrides.schema.json
+++ b/schemas/replay-overrides.schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://alexle135.de/schemas/replay-overrides.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Override-Parameter f\u00fcr Varianten-Replay.\n\nAlle Felder optional \u2014 nur gesetzte Felder werden \u00fcberschrieben.",
+  "properties": {
+    "ai_model_ref": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Ai Model Ref"
+    },
+    "random_seed": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Random Seed"
+    },
+    "seed_document_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Seed Document Id"
+    }
+  },
+  "title": "ReplayOverrides",
+  "type": "object"
+}

--- a/schemas/replay-request.schema.json
+++ b/schemas/replay-request.schema.json
@@ -1,0 +1,70 @@
+{
+  "$defs": {
+    "ReplayOverrides": {
+      "additionalProperties": false,
+      "description": "Override-Parameter f\u00fcr Varianten-Replay.\n\nAlle Felder optional \u2014 nur gesetzte Felder werden \u00fcberschrieben.",
+      "properties": {
+        "ai_model_ref": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ai Model Ref"
+        },
+        "random_seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Random Seed"
+        },
+        "seed_document_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed Document Id"
+        }
+      },
+      "title": "ReplayOverrides",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/replay-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Request-Body f\u00fcr POST /api/runs/<run_id>/replay.\n\nLeere Overrides = identisches Replay.",
+  "properties": {
+    "overrides": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ReplayOverrides"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "title": "ReplayRequest",
+  "type": "object"
+}

--- a/schemas/replay-request.schema.json
+++ b/schemas/replay-request.schema.json
@@ -1,5 +1,64 @@
 {
   "$defs": {
+    "AiModelRef": {
+      "additionalProperties": false,
+      "description": "Kanonische (Provider-Connection, Modell)-Referenz \u2014 Backend-Spiegel des\nFrontend-``AiModelRefSchema`` (``frontend/src/contracts/aiModelRef.ts``).\n\nBewusst klein: identifiziert genau die vom UI gew\u00e4hlte Route. Gr\u00f6\u00dfere\nMetadaten (Capabilities, Status) bleiben in der ``ProviderConnection`` bzw.\nim Model-Katalog. Tr\u00e4gt keine Secrets.",
+      "properties": {
+        "capability_filter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Capability Filter"
+        },
+        "fallback_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fallback Reason"
+        },
+        "model_id": {
+          "minLength": 1,
+          "title": "Model Id",
+          "type": "string"
+        },
+        "provider_connection_id": {
+          "minLength": 1,
+          "title": "Provider Connection Id",
+          "type": "string"
+        },
+        "source": {
+          "default": "explicit",
+          "enum": [
+            "stage-override",
+            "run-override",
+            "project-default",
+            "workspace-default",
+            "explicit",
+            "fallback"
+          ],
+          "title": "Source",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider_connection_id",
+        "model_id"
+      ],
+      "title": "AiModelRef",
+      "type": "object"
+    },
     "ReplayOverrides": {
       "additionalProperties": false,
       "description": "Override-Parameter f\u00fcr Varianten-Replay.\n\nAlle Felder optional \u2014 nur gesetzte Felder werden \u00fcberschrieben.",
@@ -7,17 +66,13 @@
         "ai_model_ref": {
           "anyOf": [
             {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
+              "$ref": "#/$defs/AiModelRef"
             },
             {
               "type": "null"
             }
           ],
-          "default": null,
-          "title": "Ai Model Ref"
+          "default": null
         },
         "random_seed": {
           "anyOf": [

--- a/schemas/replay-response.schema.json
+++ b/schemas/replay-response.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://alexle135.de/schemas/replay-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Response f\u00fcr gestartetes Replay.",
+  "properties": {
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "status": {
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "run_id",
+    "status"
+  ],
+  "title": "ReplayResponse",
+  "type": "object"
+}

--- a/schemas/run-manifest.schema.json
+++ b/schemas/run-manifest.schema.json
@@ -1,0 +1,344 @@
+{
+  "$defs": {
+    "ManifestInputs": {
+      "additionalProperties": false,
+      "description": "Eingangsdaten-Hashes und -Referenzen.",
+      "properties": {
+        "embedding_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Embedding Version"
+        },
+        "graph_id": {
+          "title": "Graph Id",
+          "type": "string"
+        },
+        "graph_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Graph Version"
+        },
+        "seed_document_filename": {
+          "title": "Seed Document Filename",
+          "type": "string"
+        },
+        "seed_document_hash": {
+          "title": "Seed Document Hash",
+          "type": "string"
+        },
+        "simulation_config_hash": {
+          "title": "Simulation Config Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "seed_document_hash",
+        "seed_document_filename",
+        "simulation_config_hash",
+        "graph_id"
+      ],
+      "title": "ManifestInputs",
+      "type": "object"
+    },
+    "ManifestPrompts": {
+      "additionalProperties": false,
+      "description": "Alle Prompt-Snapshots eines Runs.",
+      "properties": {
+        "entries": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PromptSnapshot"
+          },
+          "title": "Entries",
+          "type": "object"
+        }
+      },
+      "title": "ManifestPrompts",
+      "type": "object"
+    },
+    "ManifestRouting": {
+      "additionalProperties": false,
+      "description": "LLM-Routing-Tabelle pro Stage.",
+      "properties": {
+        "stages": {
+          "additionalProperties": {
+            "$ref": "#/$defs/StageRoute"
+          },
+          "title": "Stages",
+          "type": "object"
+        }
+      },
+      "title": "ManifestRouting",
+      "type": "object"
+    },
+    "ManifestRuntime": {
+      "additionalProperties": false,
+      "description": "Laufzeitdaten \u2014 nur im finalen Manifest.",
+      "properties": {
+        "completed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Completed At"
+        },
+        "duration_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Seconds"
+        },
+        "rounds_completed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rounds Completed"
+        },
+        "started_at": {
+          "format": "date-time",
+          "title": "Started At",
+          "type": "string"
+        },
+        "termination_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Termination Reason"
+        },
+        "usage_summary": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Usage Summary"
+        }
+      },
+      "required": [
+        "started_at"
+      ],
+      "title": "ManifestRuntime",
+      "type": "object"
+    },
+    "ManifestSeeds": {
+      "additionalProperties": false,
+      "description": "Random-Seed-Informationen.",
+      "properties": {
+        "random_seed": {
+          "title": "Random Seed",
+          "type": "integer"
+        },
+        "simulation_id_seed": {
+          "title": "Simulation Id Seed",
+          "type": "string"
+        }
+      },
+      "required": [
+        "random_seed",
+        "simulation_id_seed"
+      ],
+      "title": "ManifestSeeds",
+      "type": "object"
+    },
+    "ManifestVersions": {
+      "additionalProperties": false,
+      "description": "Agora- und Schema-Version zum Zeitpunkt des Runs.",
+      "properties": {
+        "agora_version": {
+          "title": "Agora Version",
+          "type": "string"
+        },
+        "schema_version": {
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "agora_version",
+        "schema_version"
+      ],
+      "title": "ManifestVersions",
+      "type": "object"
+    },
+    "PromptSnapshot": {
+      "additionalProperties": false,
+      "description": "Byte-genauer Prompt-Text mit Herkunftsangabe.",
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "source_file": {
+          "title": "Source File",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "source_file"
+      ],
+      "title": "PromptSnapshot",
+      "type": "object"
+    },
+    "StageRoute": {
+      "additionalProperties": false,
+      "description": "Pro-Stage-Modell- und Provider-Information (ohne Secrets).",
+      "properties": {
+        "ai_route_snapshot": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ai Route Snapshot"
+        },
+        "base_url": {
+          "title": "Base Url",
+          "type": "string"
+        },
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        }
+      },
+      "required": [
+        "model",
+        "provider",
+        "base_url"
+      ],
+      "title": "StageRoute",
+      "type": "object"
+    }
+  },
+  "$id": "https://alexle135.de/schemas/run-manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Kanonisches, maschinenlesbares Manifest eines Runs.\n\nEnth\u00e4lt alle Parameter, die zur Reproduktion n\u00f6tig sind:\nEingangsdaten, Versionen, Routing, Prompts, Seeds und Laufzeitdaten.",
+  "properties": {
+    "captured_at": {
+      "format": "date-time",
+      "title": "Captured At",
+      "type": "string"
+    },
+    "inputs": {
+      "$ref": "#/$defs/ManifestInputs"
+    },
+    "prompts": {
+      "$ref": "#/$defs/ManifestPrompts"
+    },
+    "replayed_from_run_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Replayed From Run Id"
+    },
+    "routing": {
+      "$ref": "#/$defs/ManifestRouting"
+    },
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "runtime": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ManifestRuntime"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    },
+    "seeds": {
+      "$ref": "#/$defs/ManifestSeeds"
+    },
+    "status": {
+      "enum": [
+        "draft",
+        "final",
+        "legacy"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "versions": {
+      "$ref": "#/$defs/ManifestVersions"
+    }
+  },
+  "required": [
+    "run_id",
+    "captured_at",
+    "inputs",
+    "versions",
+    "routing",
+    "prompts",
+    "seeds",
+    "status"
+  ],
+  "title": "RunManifest",
+  "type": "object"
+}

--- a/schemas/stage-route.schema.json
+++ b/schemas/stage-route.schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://alexle135.de/schemas/stage-route.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Pro-Stage-Modell- und Provider-Information (ohne Secrets).",
+  "properties": {
+    "ai_route_snapshot": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Ai Route Snapshot"
+    },
+    "base_url": {
+      "title": "Base Url",
+      "type": "string"
+    },
+    "model": {
+      "title": "Model",
+      "type": "string"
+    },
+    "provider": {
+      "title": "Provider",
+      "type": "string"
+    }
+  },
+  "required": [
+    "model",
+    "provider",
+    "base_url"
+  ],
+  "title": "StageRoute",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Jeder Run bekommt ein kanonisches, maschinenlesbares Manifest (`manifest.json`) und kann mit identischer oder bewusst veränderter Konfiguration erneut ausgeführt werden.

- **RunManifest-Contract** (Pydantic v2, strict): Eingangsdaten-Hashes, Versionen, Routing, Prompt-Snapshots, Seeds, Laufzeitdaten
- **Draft-/Final-Capture**: Manifest wird beim Run-Start geschrieben, beim Run-Ende finalisiert — best-effort, ein Manifest-Fehler kann keinen laufenden Run mehr zum Absturz bringen
- **Replay** (`POST /api/runs/<id>/replay`): klont die Original-Simulation (Config + Profile) in eine neue `simulation_id` und startet sie tatsächlich — identisch oder mit Overrides (Seed, Modell)
- **Export** (`GET /api/runs/<id>/export`): ZIP mit Manifest + allen Run-Artefakten inkl. eingefrorener Routing-Snapshots
- **Legacy-Migration**: rekonstruiert ein Manifest für Alt-Runs ohne eines, ohne vorhandene zu überschreiben
- **Frontend**: Replay-Button + Dialog in der Run-Detail-Ansicht, Zod-Mirror des Contracts

Umgesetzt per Matt-Pocock-Flow (grilling → spec → tickets → TDD-Implementierung), 10 Tickets, je ein Commit.

Ein Cloud-Ultrareview über den vollständigen Diff fand 6 reale Bugs (fehlender `json`-Import, falscher Request-Envelope beim Replay, Export ignorierte Unterverzeichnisse, naive statt tz-aware Timestamps in der Legacy-Migration, und vor allem: Replay legte ursprünglich nur einen `pending`-Record an, ohne tatsächlich einen Worker zu starten) — alle wurden noch im selben Branch gefixt und mit Regressionstests abgesichert.

## Bekannte Lücke

`seed_document_id`-Overrides (Replay mit neuem Ausgangsdokument) lehnen explizit mit 400 ab — es gibt noch keinen Mechanismus, einen Branch mit neuem Dokument neu vorzubereiten. Ehrlicher Fehler statt stiller Ignorierung.

## Test plan

- [x] 70 JSON-Schemas synchron (`dump_schemas --check`)
- [x] Backend: Contract-, Service-, API-Tests grün (764 Tests im relevanten Scope)
- [x] Frontend: 195 Testdateien / 1891 Tests grün, `bun run check` sauber
- [x] Ruff + mypy sauber auf allen geänderten Backend-Dateien
- [x] Regressionstests für jeden Ultrareview-Fund (Envelope-Schema, Export-Rekursion, tz-Konsistenz, Replay-Worker-Start, frische linked_ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Runs werden als reproduzierbare Manifeste erfasst, abgeschlossen und exportiert.
  * Bestehende Runs lassen sich identisch oder mit optionalen Modellvarianten erneut starten.
  * Manifeste und Run-Artefakte können als ZIP-Datei heruntergeladen werden.
  * Neue Oberfläche für Replay-Vorgänge mit Status- und Fehlermeldungen.
  * Historische Runs werden unterstützt, ohne vorhandene Manifeste zu überschreiben.

* **Verbesserungen**
  * Replay-Vorgänge werden mit ihrem Ursprungs-Run verknüpft.
  * Manifest- und Replay-Daten werden über validierte Schemas geprüft.
  * Fehler bei der Manifest-Erfassung verhindern den Run-Start nicht.

* **Tests**
  * Umfangreiche Tests für Manifeste, Replay, Export und Oberfläche ergänzt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->