### PR TITLE
fix(contracts): masked_key_pattern akzeptiert Base64-Suffix (=/+//)

### DIFF
--- a/backend/app/contracts/llm_provider_keys_contract.py
+++ b/backend/app/contracts/llm_provider_keys_contract.py
@@ -18,8 +18,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 _STRICT = ConfigDict(extra="forbid")
 
-# "sk-...abc" → vier Zeichen vom Ende sichtbar, davor immer das gleiche Präfix
-MASKED_KEY_PATTERN = r"^.{1,8}\.\.\.[A-Za-z0-9_\-]{4}$"
+# "sk-...abc" → vier Zeichen vom Ende sichtbar, davor immer das gleiche Präfix.
+# Die End-Klasse deckt Base64-Padding (``=``) und Standard-Base64-Zeichen
+# (``+``/``/``) ab — AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden
+# häufig auf ``=``, ohne diese Erweiterung ließen sie sich nicht persistieren.
+MASKED_KEY_PATTERN = r"^.{1,8}\.\.\.[A-Za-z0-9_\-=+/]{4}$"
 
 
 class LlmProviderKeyEntry(BaseModel):

--- a/backend/tests/contracts/test_llm_provider_keys_contract.py
+++ b/backend/tests/contracts/test_llm_provider_keys_contract.py
@@ -24,6 +24,20 @@ def test_entry_accepts_masked_value():
     assert entry.provider_id == "openai"
 
 
+def test_entry_accepts_masked_value_with_base64_suffix():
+    # AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf
+    # "=" (Padding). Das Masking darf solche Suffixe nicht ablehnen — sonst
+    # kann ein Bedrock-Key (``ABS...MD0=``) gar nicht persistiert werden.
+    entry = LlmProviderKeyEntry(
+        provider_id="openai_compatible",
+        masked_value="ABS-...MD0=",
+        base_url="https://bedrock-mantle.eu-central-1.api.aws/v1",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    assert entry.masked_value.endswith("=")
+
+
 def test_entry_rejects_plain_key_as_masked_value():
     with pytest.raises(ValidationError):
         LlmProviderKeyEntry(

--- a/backend/tests/contracts/test_llm_provider_keys_contract.py
+++ b/backend/tests/contracts/test_llm_provider_keys_contract.py
@@ -24,18 +24,20 @@ def test_entry_accepts_masked_value():
     assert entry.provider_id == "openai"
 
 
-def test_entry_accepts_masked_value_with_base64_suffix():
+@pytest.mark.parametrize("suffix", ["=", "+", "/"])
+def test_entry_accepts_masked_value_with_base64_suffix(suffix):
     # AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf
-    # "=" (Padding). Das Masking darf solche Suffixe nicht ablehnen — sonst
-    # kann ein Bedrock-Key (``ABS...MD0=``) gar nicht persistiert werden.
+    # "=" (Padding); "+" und "/" decken Standard-Base64 ab. Das Masking darf
+    # solche Suffixe nicht ablehnen — sonst kann ein Bedrock-Key
+    # (``ABS...MD0=``) gar nicht persistiert werden.
     entry = LlmProviderKeyEntry(
         provider_id="openai_compatible",
-        masked_value="ABS-...MD0=",
+        masked_value=f"ABS-...MD0{suffix}",
         base_url="https://bedrock-mantle.eu-central-1.api.aws/v1",
         created_at=datetime.now(timezone.utc),
         updated_at=datetime.now(timezone.utc),
     )
-    assert entry.masked_value.endswith("=")
+    assert entry.masked_value.endswith(suffix)
 
 
 def test_entry_rejects_plain_key_as_masked_value():

--- a/backend/tests/services/test_llm_provider_secrets_store.py
+++ b/backend/tests/services/test_llm_provider_secrets_store.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 from cryptography.fernet import Fernet
 
+from app.contracts.llm_provider_keys_contract import LlmProviderKeyEntry
 from app.services.llm_provider_secrets_store import (
     LlmProviderSecretsStore,
     _mask_key,
@@ -103,6 +105,23 @@ def test_mask_key_format():
     # Sehr kurzer Key fällt auf Sentinel zurück
     short = _mask_key("abc")
     assert "..." in short
+
+
+def test_mask_key_base64_suffix_is_contract_compliant():
+    # AWS-Bedrock-Bearer-Tokens enden häufig auf "=" (Base64-Padding). Das
+    # maskierte Ergebnis muss dem Contract-Pattern (MASKED_KEY_PATTERN)
+    # genügen, sonst fällt die Persistierung des Eintrags weg. Regression für
+    # den Defekt, bei dem ein Bedrock-Key gar nicht gespeichert werden konnte.
+    masked = _mask_key("ABSsomekeyMD0=")
+    assert masked == "ABS-...MD0="
+    LlmProviderKeyEntry.model_validate(
+        {
+            "provider_id": "openai_compatible",
+            "masked_value": masked,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
 
 
 def test_singleton_persists_across_calls(monkeypatch, tmp_path):

--- a/changelog.d/bedrock-base64-masking.md
+++ b/changelog.d/bedrock-base64-masking.md
@@ -1,3 +1,3 @@
 ### Fixed (Provider-Key-Masking akzeptiert Base64-Suffix — 2026-08-12)
 
-- **`MASKED_KEY_PATTERN` nimmt `=`/`+`/`/` auf:** AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf `=`, was das bisherige Pattern `[A-Za-z0-9_\-]{4}` ablehnte — ein Bedrock-Key ließ sich unter „OpenAI Compatible" gar nicht persistieren (Pydantic `string_pattern_mismatch`). Die End-Klasse deckt jetzt Standard- und URL-safe-Base64.
+- **`MASKED_KEY_PATTERN` nimmt `=`/`+`/`/` auf:** AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf `=`, was das bisherige Pattern `[A-Za-z0-9_\-]{4}` ablehnte — ein Bedrock-Key ließ sich unter „OpenAI Compatible“ gar nicht persistieren (Pydantic `string_pattern_mismatch`). Die End-Klasse deckt jetzt Standard- und URL-safe-Base64.

--- a/changelog.d/bedrock-base64-masking.md
+++ b/changelog.d/bedrock-base64-masking.md
@@ -1,0 +1,3 @@
+### Fixed (Provider-Key-Masking akzeptiert Base64-Suffix — 2026-08-12)
+
+- **`MASKED_KEY_PATTERN` nimmt `=`/`+`/`/` auf:** AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf `=`, was das bisherige Pattern `[A-Za-z0-9_\-]{4}` ablehnte — ein Bedrock-Key ließ sich unter „OpenAI Compatible" gar nicht persistieren (Pydantic `string_pattern_mismatch`). Die End-Klasse deckt jetzt Standard- und URL-safe-Base64.

--- a/frontend/src/contracts/llmProviderKeysContract.ts
+++ b/frontend/src/contracts/llmProviderKeysContract.ts
@@ -7,7 +7,9 @@
  */
 import { z } from "zod";
 
-export const MASKED_KEY_PATTERN = /^.{1,8}\.\.\.[A-Za-z0-9_\-]{4}$/;
+// End-Klasse deckt Base64-Padding (``=``) und Standard-Base64 (``+``/``/``) ab —
+// AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden haeufig auf ``=``.
+export const MASKED_KEY_PATTERN = /^.{1,8}\.\.\.[A-Za-z0-9_\-=+/]{4}$/;
 
 export const LlmProviderKeyEntrySchema = z
   .object({

--- a/schemas/llm-provider-key-entry.schema.json
+++ b/schemas/llm-provider-key-entry.schema.json
@@ -48,7 +48,7 @@
       "title": "Last Validation Ok"
     },
     "masked_value": {
-      "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-]{4}$",
+      "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-=+/]{4}$",
       "title": "Masked Value",
       "type": "string"
     },

--- a/schemas/llm-provider-keys-list-response.schema.json
+++ b/schemas/llm-provider-keys-list-response.schema.json
@@ -48,7 +48,7 @@
           "title": "Last Validation Ok"
         },
         "masked_value": {
-          "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-]{4}$",
+          "pattern": "^.{1,8}\\.\\.\\.[A-Za-z0-9_\\-=+/]{4}$",
           "title": "Masked Value",
           "type": "string"
         },


### PR DESCRIPTION
## Problem

AWS-Bedrock-Bearer-Tokens sind URL-safe-Base64 und enden häufig auf `=` (Padding). Das `MASKED_KEY_PATTERN` `[A-Za-z0-9_\\-]{4}` lehnte solche Suffixe ab — ein Bedrock-Key unter „OpenAI Compatible" ließ sich gar nicht persistieren (Pydantic `string_pattern_mismatch` auf `masked_value`). Betrifft alle Keys mit `=`/`+`/`/` in den letzten 4 Zeichen.

## Fix

End-Klasse um `=`, `+`, `/` erweitert — deckt Standard- und URL-safe-Base64.

- `backend/app/contracts/llm_provider_keys_contract.py` — Pattern
- `frontend/src/contracts/llmProviderKeysContract.ts` — Zod-Spiegel (1:1)
- `schemas/llm-provider-key-entry.schema.json`, `schemas/llm-provider-keys-list-response.schema.json` — neu gerendert

## Tests

Regression auf Contract- (`test_entry_accepts_masked_value_with_base64_suffix`) und Service-Ebene (`test_mask_key_base64_suffix_is_contract_compliant`) mit einem auf `=` endenden Key — vor dem Fix rot, danach grün.

## Scope

Cross-Layer (Backend-Contract + Frontend-Zod-Spiegel + Schema-Drift). Pre-Push-Gate vollständig grün: 58 Schemas matchen, Backend + Frontend gates green, Zod-Spiegel-Check bestanden. Kein Evidence-Gating-Anker berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Maskierte API-Schlüssel mit Base64-Zeichen wie `+`, `/` und abschließendem `=` werden nun korrekt akzeptiert.
  - AWS-Bedrock-Bearer-Tokens können dadurch auch im „OpenAI Compatible“-Bereich zuverlässig gespeichert und dargestellt werden.
  - Die Validierung ist zwischen Backend, Frontend und den zugrunde liegenden Schnittstellen einheitlich.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->