### PR TITLE
docs(reference): promote domain-migration run 5 as current trust reference

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -54,16 +54,18 @@ Die Demo zeigt:
 
 ## Referenzlauf
 
-Der aktuelle, kritisch dokumentierte End-to-End-Lauf im Repository untersucht die **Domainmigration `alexle135.de` → `alex-schneider.dev`** mit **Gemini 3.6 Flash als Report-Writer**.
+Der aktuelle, kritisch dokumentierte End-to-End-Lauf untersucht erneut die **Domainmigration `alexle135.de` → `alex-schneider.dev`** über **20 vollständig abgeschlossene Simulationsrunden** nach dem 0.9.x-Hardening von Evidence und Provenance.
 
-Der Lauf verarbeitete **30 geladene Persona-Profile** über sechs Report-Sections. ReportV3 enthält **24 Claim-Zeilen, aber nur 17 eindeutige Claim-IDs**, dazu **157 Hypothesen mit 157 eindeutigen IDs** sowie **133 Data-Gap-Zeilen mit 41 eindeutigen Gap-IDs**. Ein Red-Team-Schritt meldete **6 Findings bei `echo_index=0.690`**.
+Der Report bindet **46 Claim-Zeilen** (22 eindeutige gerenderte IDs) und enthält **141 Hypothesen** sowie **133 Data Gaps**. Anders als in früheren Läufen ist die dominante Fehlerklasse nicht mehr fehlendes Evidence Binding. Der Lauf legt die nächste Trust-Grenze offen: Agora kann eine Aussage an ein reales Seed-Fragment binden und trotzdem verlieren, ob dieses Fragment selbst einen dokumentierten Fakt, eine unbelegte Behauptung, eine Hypothese, einen Widerspruch oder eine synthetische Aussage darstellt. Im adversarialen Seed wird dadurch eine ausdrücklich unbelegte SEO-Aussage zu einem validierten Welt-Claim hochgestuft, während eine andere Section dieselbe Aussage korrekt als unbelegt bezeichnet.
 
-Wichtiger als das Report-Fazit ist das Verhalten des Evidence-Layers: Er fing mehrere konkrete Gemini-Overclaims ab, darunter erfundene Alt-Subdomains, eine nicht dokumentierte neue Mailadresse und überzogene Recruiting-Kausalitäten. Gleichzeitig zeigt derselbe Lauf offen die aktuellen Grenzen: **Compound Claims können den Gate teilweise umgehen, Claim-/Gap-IDs sind noch nicht reportweit eindeutig, und Source-Kontext beziehungsweise Counter-Evidence bei Empfehlungen sind noch unvollständig.**
+Derselbe Lauf macht außerdem eine Fremdrollen-Interviewantwort zum einzigen `medium`-Claim, rendert Seed-only-Claims als `Simulationskonsens` und lässt weiterhin einen Nicht-Stakeholder (`Fachblog`) in den Social-Trace. Gleichzeitig fängt der Gate mehrere unbelegte numerische Zielwerte korrekt ab und schwächt die Aussage, Option B sei die einzig tragfähige Strategie.
 
 > [!NOTE]
-> Der Lauf ist bewusst keine Hochglanz-Demo. Er dokumentiert sowohl funktionierende Guardrails als auch reproduzierbare Fehlerklassen. Er beweist weder prädiktive Validität noch reales Stakeholderverhalten.
+> Dies ist die aktuelle **Trust-Pipeline-Referenz**, keine Hochglanz-Demo und kein Nachweis prädiktiver Validität. Der vorherige Lernassistenten-Lauf bleibt die reichhaltigere Referenz für Simulationsdynamik: 665 Aktionen und sechs Cluster gegenüber 109 Interaktionen und drei Clustern hier.
 
-**[→ Aktuellen Referenzlauf mit Guardrail-Befunden, bekannten Fehlern und Prioritäten lesen](./docs/reference-runs/2026-08-09-domain-migration/README.md)**
+**[→ Referenzlauf 5 lesen](./docs/reference-runs/2026-08-12-domain-migration-20-runden/README.de.md)** · **[English](./docs/reference-runs/2026-08-12-domain-migration-20-runden/README.md)**
+
+Frühere Läufe: [Referenzlauf 4](./docs/reference-runs/2026-08-11-ki-lernassistent-20-runden/README.de.md) (erster Evidence-Binding-at-Scale-Lauf; reichhaltigere Simulationsdynamik) · [Lauf 3](./docs/reference-runs/2026-08-11-ki-lernassistent/README.md) · [Lauf 2](./docs/reference-runs/2026-08-09-domain-migration-v2/README.md) · [Lauf 1](./docs/reference-runs/2026-08-09-domain-migration/README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ The demo shows:
 
 ## Reference run
 
-The current, critically documented end-to-end run examines the **introduction of a self-hosted AI learning assistant at an AZAV-certified retraining provider**, over **20 simulation rounds** with **`gemini-3.6-flash` as the report writer** and **`gemini-embedding-2` (3072 dim) for the knowledge graph**.
+The current, critically documented end-to-end run revisits the **domain migration `alexle135.de` → `alex-schneider.dev`** over **20 completed simulation rounds** after the 0.9.x evidence and provenance hardening.
 
-It is the first run in which evidence binding actually works. Five preceding reports across four model configurations bound **zero or one** claim; this one binds **39**. Initial-post assignment lands on the semantically correct persona 8 times out of 8, because domain-specific entity typing makes type ≈ role.
+The report binds **46 claim rows** (22 unique rendered IDs), with **141 hypotheses** and **133 data gaps**. Unlike earlier runs, the dominant failure is no longer missing evidence binding. The run exposes the next trust boundary: Agora can bind a statement to a real seed fragment while still losing whether that fragment was a documented fact, an unsupported assertion, a hypothesis, a contradiction, or a synthetic statement. In the adversarial seed, one unsupported SEO assertion is therefore promoted to a validated world-claim, while another section correctly describes the same proposition as unsubstantiated.
 
-Precisely because more of the pipeline works, the remaining gaps become measurable. Every quote now carries its **own** provenance anchor — and none of those anchors exists: the model invents them per persona, and the `seed_doc:` prefix bypasses the binding check entirely. All 39 claims sit at confidence `low` with the identical score, so the confidence measure distinguishes nothing. The same fact binds as SUPPORTED in section 1 and is deleted as unsupported in section 2. And across 20 rounds, 665 actions and 84 comments — with the two conflicting groups correctly separated for the first time — not one dislike and not one dissenting statement occurs.
+The same run also turns a foreign-role interview answer into the only `medium` claim, renders seed-only claims as `Simulationskonsens`, and still admits a non-stakeholder (`Fachblog`) into the social trace. At the same time, the gate correctly catches several unsupported numerical targets and weakens the claim that Option B is uniquely viable.
 
 > [!NOTE]
-> This run is deliberately not a polished showcase. It documents both working guardrails and reproducible failure classes. It proves neither predictive validity nor real stakeholder behavior.
+> This is the current **trust-pipeline reference**, not a polished showcase or proof of predictive validity. The preceding learning-assistant run remains the richer simulation-dynamics reference: 665 actions and six clusters versus 109 interactions and three clusters here.
 
-**[→ Read the current reference run](./docs/reference-runs/2026-08-11-ki-lernassistent-20-runden/README.md)** · **[auf Deutsch](./docs/reference-runs/2026-08-11-ki-lernassistent-20-runden/README.de.md)**
+**[→ Read reference run 5](./docs/reference-runs/2026-08-12-domain-migration-20-runden/README.md)** · **[auf Deutsch](./docs/reference-runs/2026-08-12-domain-migration-20-runden/README.de.md)**
 
-Earlier runs: [third run](./docs/reference-runs/2026-08-11-ki-lernassistent/README.md) (same domain, 10 rounds, `deepseek-v4-flash`) · [first](./docs/reference-runs/2026-08-09-domain-migration/README.md) and [second run](./docs/reference-runs/2026-08-09-domain-migration-v2/README.md) on the domain migration `alexle135.de` → `alex-schneider.dev`
+Earlier runs: [reference run 4](./docs/reference-runs/2026-08-11-ki-lernassistent-20-runden/README.md) (first evidence-binding-at-scale run; richer simulation dynamics) · [run 3](./docs/reference-runs/2026-08-11-ki-lernassistent/README.md) · [run 2](./docs/reference-runs/2026-08-09-domain-migration-v2/README.md) · [run 1](./docs/reference-runs/2026-08-09-domain-migration/README.md)
 
 ---
 

--- a/docs/reference-runs/2026-08-12-domain-migration-20-runden/README.de.md
+++ b/docs/reference-runs/2026-08-12-domain-migration-20-runden/README.de.md
@@ -1,0 +1,172 @@
+# Referenzlauf 5: Domainmigration, 20 Runden, Trust-Audit nach dem Hardening
+
+*[English](./README.md) · Deutsch*
+
+> [!IMPORTANT]
+> Dieser Lauf dokumentiert das Verhalten von Agora in einer simulierten Multi-Agenten-Umgebung. Er ist **kein** Nachweis dafür, dass die simulierten Personas reale Menschen repräsentieren, die Empfehlung richtig ist oder die Simulation menschliches Verhalten vorhersagt.
+
+## Warum dies der aktuelle Referenzlauf ist
+
+Dieser Lauf verschiebt die Referenzfrage eine Ebene tiefer als [Referenzlauf 4](../2026-08-11-ki-lernassistent-20-runden/README.de.md).
+
+Referenzlauf 4 zeigte erstmals Evidence Binding in brauchbarer Größenordnung: 39 validierte Claims, nachdem fünf Vorgängerberichte nur null oder einen Claim binden konnten. Seine dominanten Fehler waren noch überwiegend mechanisch, darunter erfundene Provenance-Anker, eine Confidence-Metrik mit nur einem Wert, inkonsistentes Entailment und Nicht-Stakeholder als Personas.
+
+Der Domainmigration-Lauf vom 12.08.2026 ist für die heutige Trust-Architektur aussagekräftiger, weil die Binding-Pipeline weit genug funktioniert, um eine schwierigere Fehlerklasse freizulegen: **Agora kann eine Aussage an das richtige Quellfragment binden und trotzdem den epistemischen Status dieses Fragments verlieren.** Ein Satz, den das Seed-Dokument ausdrücklich als unbelegt kennzeichnet, kann dadurch als validierter Weltfakt erscheinen, nur weil der Satz in der Quelle vorkommt.
+
+Das ist ein reiferer Fehler als „keine Evidence gebunden“, aber auch ein gefährlicherer: Die Ausgabe wirkt auditierbar, obwohl die Audit-Semantik noch unvollständig ist.
+
+## Run-Identität
+
+| Feld | Wert |
+|---|---|
+| Report-ID | `report_fb5dfaf69ffa` |
+| Generiert | `2026-08-12T13:57:13.249205+00:00` |
+| Szenario | Migration `alexle135.de` → `alex-schneider.dev` |
+| Report-Modus | `balanced` |
+| Runden | **20 / 20**, Simulation beim Start der Reportgenerierung bereits beendet |
+| Report-Modell | im gelieferten Markdown-Artefakt nicht exportiert |
+| Simulations-ID | im gelieferten Markdown-Artefakt nicht exportiert |
+| Graph-ID | im gelieferten Markdown-Artefakt nicht exportiert |
+
+Fehlende Modell-/Run-IDs werden als fehlende Metadaten dokumentiert und nicht aus benachbarten Logs rekonstruiert.
+
+## Report-Snapshot
+
+| Metrik | Wert |
+|---|---:|
+| validierte Claim-Zeilen | **46** |
+| eindeutige gerenderte Claim-IDs | **22** |
+| Hypothesen | **141** |
+| Data Gaps | **133** |
+| nachträgliche Abstufungen | **0** |
+| Evidence-Index-Einträge | **70** |
+| Claim-Confidence | 45 `low`, 1 `medium` |
+| gerenderter Confidence-Scope | 46 × `Simulationskonsens` |
+| gerenderte Claim-Basis | 46 × `persona` |
+| Interaktionen gesamt | **109** |
+| Cluster | **3** |
+| Echo-Chamber-Index | **0.5963** |
+
+Der Evidence Index besteht aus 33 simulierten Agentenzitaten, 16 Seed-Dokument-Einträgen, 13 Graph-Relationen/-Metriken und 8 simulierten Agentenaktionen.
+
+Noch aufschlussreicher ist die tatsächliche Evidence der 46 validierten Claim-Zeilen: **38 sind ausschließlich Seed-gestützt**, 6 ausschließlich durch Agentenzitate, 1 durch Seed plus Zitat und 1 ausschließlich durch eine Agentenaktion. Das widerspricht der Darstellung aller validierten Claims als `Simulationskonsens` mit Basis `persona`.
+
+## Was in diesem Lauf funktioniert
+
+- Alle **20 von 20 Runden** waren vor der Reportgenerierung abgeschlossen.
+- Evidence Binding arbeitet in brauchbarer Größenordnung statt bei null oder einem gebundenen Claim stehenzubleiben.
+- Kanonische Evidence-Klassen erreichen den Report: Seed-Dokument, simuliertes Zitat, simulierte Aktion und Graph-Relation.
+- Unbelegte numerische Zielwerte werden in insufficient/unsupported-Zustände geleitet, statt still zu Fakten zu werden.
+- Die starke Aussage, Option B sei die „einzig tragfähige“ Strategie, wird nicht als belegter Fakt akzeptiert.
+- **141 Hypothesen** und **133 Data Gaps** bleiben sichtbar, statt in validierte Claims hineinzurutschen.
+
+## Kritischer Befund 1: Vorkommen in der Quelle wird mit Wahrheit verwechselt
+
+Der adversariale Seed enthält absichtlich die Aussage, die alte Domain sei für Google „praktisch wertlos“, **und klassifiziert diese Aussage ausdrücklich als unbelegt**.
+
+Der Report validiert trotzdem einen Claim, der die Aussage als dokumentbelegt darstellt, und verwendet genau das Seed-Fragment mit der unbelegten Behauptung als Evidence. An anderer Stelle beschreibt Agora dieselbe Aussage korrekt als empirisch nicht gestütztes Postulat.
+
+Der Report kann damit gleichzeitig ausdrücken:
+
+1. „Das Dokument belegt X“, und
+2. „Das Dokument behauptet X nur unbelegt“.
+
+Damit ist der fehlende Contract sauber isoliert: Provenance erfasst **woher Text stammt**, aber noch nicht zuverlässig **welchen epistemischen Status die Quelle diesem Text zuweist**.
+
+Ein Seed-Corpus-Evidence-Item benötigt daher einen Assertion-Status wie `documented_fact`, `internal_claim`, `hypothesis`, `synthetic_statement`, `unverified_data`, `contradiction` oder `unknown`. `seed_corpus + unverified_claim` darf den Meta-Claim **„die Quelle sagt X“** stützen, aber nicht allein den Welt-Claim **X** validieren.
+
+## Kritischer Befund 2: Fremdrollen-Übernahme erreicht validierte Evidence
+
+Der einzige `medium`-Claim ist ein simuliertes Zitat von `lisa_hartmann_610`, wonach die Migration **ihre** Personenmarke als selbstständige Software-Entwicklerin und IT-Consultant stärke. Die Migration betrifft Alexander Schneiders Domain, nicht Lisa Hartmanns. Die Antwort hat die Rolle des Untersuchungsgegenstands übernommen.
+
+Das rohe Interview sollte im Trace erhalten bleiben, aber eine Fremdrollen-Antwort muss als claim-stützende `agent_quote`-Evidence unzulässig sein. Hier überlebt sie das Binding und wird zum Claim mit der höchsten Confidence des Reports. Damit ist sie ein brauchbarer Regressionstest für Identity-/Role-Guards.
+
+## Kritischer Befund 3: Evidence-Scope wird falsch gerendert
+
+Alle 46 validierten Claim-Zeilen erscheinen als:
+
+```text
+scope = Simulationskonsens
+basis = persona
+```
+
+Tatsächlich werden **38 ausschließlich durch Seed-Dokument-Evidence** gestützt. Das ist kein kosmetischer Fehler: Ein quellengebundener Claim und ein Simulationskonsens tragen unterschiedliche Trust-Semantik und dürfen nicht dasselbe Scope-Label erhalten.
+
+## Kritischer Befund 4: Der Gate weiß mehr als die finale Prosa
+
+Die Trust-Schicht verwirft oder schwächt mehrere unbelegte Kennzahlen sowie die Behauptung, Option B sei eindeutig überlegen. Trotzdem können starke Formulierungen in der sichtbaren Section-Prosa verbleiben, während spätere Gate-Tabellen sie als Hypothese, unzureichend, widersprochen oder nur thematisch verwandt klassifizieren.
+
+Nach dem Gating braucht die finale Ausgabe deshalb eine Reconciliation-Stufe. Sätze mit finalem Zustand `INSUFFICIENT`, `CONTRADICTED` oder `related_evidence_only` müssen entfernt oder ausdrücklich als Hypothese qualifiziert werden.
+
+## Kritischer Befund 5: Simulierte Autorität kann wie reale Autorität wirken
+
+Der Evidence Index enthält eine simulierte Persona mit `persona_id="google_692"`. Ihre Aussagen werden als `Agentenzitat` gespeichert und nicht als offizielle Web-Quelle. Diese Trennung muss der Renderer bewahren: simulierte Persona → „simulierte Suchmaschinen-Perspektive“; offizielle Dokumentation → `web_source` mit Provenance.
+
+## Kritischer Befund 6: Persona-Eignung ist besser, aber nicht gelöst
+
+Ältere Läufe ließen offensichtliche Software-/Produktentitäten als Personas zu. Dieser Lauf ist sauberer, enthält im Evidence Index aber weiterhin:
+
+```text
+Fachblog CREATE_POST on reddit in round 0
+```
+
+Ein Fachblog ist Content/Medium, kein individueller oder kollektiver Stakeholder. Das Report-Artefakt exportiert `generation_source` nicht. Der Lauf beweist daher **nicht**, ob die Entität über den normalen oder degradierten Persona-Pfad kam. Er beweist nur, dass ein Nicht-Stakeholder weiterhin die finale Simulation erreicht hat.
+
+## Auditierbarkeitsproblem: Claim-IDs sind im Flat Export nicht global eindeutig
+
+Der Report enthält **46 Claim-Zeilen, aber nur 22 eindeutige `claim_*`-IDs**. Intern können sie section-scoped sein; der Markdown-Renderer zeigt diesen Scope jedoch nicht. Menschliche Verweise wie `claim_07` sind dadurch mehrdeutig. Reportweite IDs müssen global eindeutig werden oder den Section-Scope sichtbar tragen.
+
+## Simulationsdynamik: schwächeres Signal als Referenzlauf 4
+
+| Metrik | Referenzlauf 4 | Dieser Lauf |
+|---|---:|---:|
+| Runden | 20 | 20 |
+| validierte Claims | 39 | **46** |
+| Hypothesen | 141 | 141 |
+| Data Gaps | 131 | 133 |
+| Social Actions / Interaktionen | **665** | 109 |
+| Cluster | **6** | 3 |
+| Echo-Chamber-Index | 0.5741 | 0.5963 |
+
+Der neue Lauf liefert etwa **5,45 Interaktionen pro konfigurierter Runde**, gegenüber etwa **33,25 Aktionen pro Runde** in Referenzlauf 4. Das ist ein Warnsignal, kein bewiesener Regressionsbefund: Agentenzahl, Provider-/Modellrouting, Action-Konfiguration und Recommender-Verhalten können die Dynamik erheblich verändern.
+
+Dieser Lauf ist deshalb die bessere **Trust-Pipeline-Referenz**; Referenzlauf 4 bleibt die reichhaltigere **Simulationsdynamik-Referenz**.
+
+## Was dieser Lauf zeigt
+
+- Evidence Binding arbeitet in brauchbarer Größenordnung.
+- Seed-Dokument-Provenance erreicht den Report.
+- Numerisches Prosa-Gating fängt mehrere unbelegte Zielwerte ab.
+- Viele Hypothesen und Data Gaps bleiben von validierten Claims getrennt.
+- Die verbleibenden Fehler sind konkret genug für deterministische Regressionstests.
+- Der Domainmigration-Seed ist ein starker adversarialer Testfall für die Trust-Schicht.
+
+## Was dieser Lauf ausdrücklich nicht zeigt
+
+- **Keine prädiktive Validität.**
+- **Keine echte Recruiter-, Arbeitgeber-, Google- oder Nutzerforschung.**
+- **Kein Beweis, dass die empfohlene Migrationsstrategie objektiv die beste ist.**
+- **Noch keine vollständige epistemische Provenance.**
+- **Keine Garantie, dass ein validierter Claim ein wahrer Weltfakt ist, nur weil sein Source-Span real ist.**
+- **Kein Beweis, dass die geringere Interaktionszahl eine Simulation-Regression darstellt.**
+
+## Remediation-Priorität
+
+1. **P1 — Seed-Assertion-Status Ende-zu-Ende erhalten.** Unbelegte, hypothetische oder synthetische Source-Spans dürfen keine direkten Weltfakten validieren.
+2. **P1 — Fremdrollen-Interviewantworten als claim-stützende Evidence sperren.** Rohtrace erhalten, Evidence-Eignung blockieren.
+3. **P2 — finale Prosa mit dem finalen Gate-Urteil synchronisieren.** `INSUFFICIENT`, `CONTRADICTED` und related-only müssen qualifiziert oder entfernt werden.
+4. **P2 — korrekten Confidence-Scope und Basis rendern.** Seed-gebundene Claims dürfen nicht als Simulationskonsens erscheinen.
+5. **P2 — Persona-Eignung gegen Content-Objekte wie `Fachblog` härten.**
+6. **P3 — exportierte Claim-IDs global eindeutig machen.**
+7. **P3 — Risk-Objekte zentralisieren, damit Summary/Detail bei Likelihood und Impact nicht auseinanderlaufen.**
+
+## Artefakte
+
+- Maschinenlesbare Audit-Zusammenfassung: [`artifacts/run-summary.json`](./artifacts/run-summary.json)
+- Quellreport: `report_fb5dfaf69ffa` (vollständiger Markdown-Export ist mit dem Run-Audit außerhalb dieses Repository-Snapshots archiviert)
+
+## Fazit
+
+Referenzlauf 4 bewies, dass Agora Evidence endlich binden kann. Referenzlauf 5 zeigt die nächste Grenze: **Die richtige Quelle zu binden reicht nicht, wenn das System vergisst, ob die Quelle selbst eine Aussage als Fakt, Hypothese, synthetische Aussage, Widerspruch oder unbelegte Behauptung klassifiziert hat.**
+
+Deshalb ist dies der aktuelle Referenzlauf. Er ist nicht die schönste Simulation und nicht der reichhaltigste Social-Trace. Er ist der klarste End-to-End-Test der Trust-Architektur, die Agora für 1.0 stabil bekommen muss.

--- a/docs/reference-runs/2026-08-12-domain-migration-20-runden/README.md
+++ b/docs/reference-runs/2026-08-12-domain-migration-20-runden/README.md
@@ -1,0 +1,172 @@
+# Reference run 5: domain migration, 20 rounds, post-hardening trust audit
+
+*English · [Deutsch](./README.de.md)*
+
+> [!IMPORTANT]
+> This run documents Agora's behavior in a simulated multi-agent environment. It is **not** evidence that the simulated personas represent real people, that the recommendation is correct, or that the simulation predicts human behavior.
+
+## Why this is the current reference run
+
+This run moves the reference question one layer deeper than [reference run 4](../2026-08-11-ki-lernassistent-20-runden/README.md).
+
+Reference run 4 established that evidence binding can work at useful scale: 39 validated claims after five predecessor reports had bound zero or one. Its dominant failures were still mechanical, including invented provenance anchors, a confidence measure with one value, inconsistent entailment, and non-stakeholder personas.
+
+The 2026-08-12 domain-migration run is more useful as a reference for the current trust architecture because the binding pipeline now survives long enough to expose a harder failure class: **Agora can bind a statement to the correct source fragment while still losing the epistemic status of that fragment.** A sentence that the seed document explicitly marks as unsupported can therefore reappear as a validated world-fact merely because the sentence occurs in the source.
+
+That is a more mature failure than "no evidence was bound", but also a more dangerous one: the output looks auditable while the audit semantics are incomplete.
+
+## Run identity
+
+| Field | Value |
+|---|---|
+| Report ID | `report_fb5dfaf69ffa` |
+| Generated | `2026-08-12T13:57:13.249205+00:00` |
+| Scenario | migration `alexle135.de` → `alex-schneider.dev` |
+| Report mode | `balanced` |
+| Rounds | **20 / 20**, simulation already finished when report generation started |
+| Report model | not exported in the supplied Markdown artifact |
+| Simulation ID | not exported in the supplied Markdown artifact |
+| Graph ID | not exported in the supplied Markdown artifact |
+
+The missing model/run identifiers are recorded as missing metadata instead of being reconstructed from surrounding logs.
+
+## Report snapshot
+
+| Metric | Value |
+|---|---:|
+| validated claim rows | **46** |
+| unique rendered claim IDs | **22** |
+| hypotheses | **141** |
+| data gaps | **133** |
+| post-generation downgrades | **0** |
+| evidence-index entries | **70** |
+| claim confidence | 45 `low`, 1 `medium` |
+| rendered confidence scope | 46 × `Simulationskonsens` |
+| rendered claim basis | 46 × `persona` |
+| total interactions | **109** |
+| clusters | **3** |
+| echo chamber index | **0.5963** |
+
+Evidence-index composition: 33 simulated agent quotes, 16 seed-document items, 13 graph relations/metrics, and 8 simulated agent actions.
+
+For the 46 validated claim rows, the support composition is more revealing: **38 are seed-only**, 6 quote-only, 1 seed plus quote, and 1 action-only. That conflicts with the renderer labeling every validated claim as `Simulationskonsens` with basis `persona`.
+
+## What works in this run
+
+- All **20 of 20 rounds** completed before report generation.
+- Evidence binding is active at useful scale instead of producing zero or one bound claim.
+- Canonical evidence classes reach the report: seed document, simulated quote, simulated action, and graph relation.
+- Unsupported numerical targets are routed to insufficient/unsupported states instead of silently becoming facts.
+- The strong statement that Option B is the "only viable" strategy is not accepted as a supported fact.
+- The report keeps **141 hypotheses** and **133 data gaps** visible rather than folding them into validated claims.
+
+## Critical finding 1: source occurrence is mistaken for source truth
+
+The adversarial seed deliberately contains the statement that the old domain is "practically worthless for Google" **and explicitly classifies that statement as unsupported**.
+
+The report nevertheless validates a claim whose wording presents the proposition as document-backed, using the seed fragment containing that unsupported assertion as evidence. Elsewhere in the same report, Agora correctly describes the same proposition as a postulate that is not empirically supported.
+
+The report can therefore express both:
+
+1. "the document proves X", and
+2. "the document merely asserts X without evidence".
+
+This isolates the missing contract: provenance captures **where text came from**, but not reliably **what epistemic status the source assigned to that text**.
+
+A seed-corpus evidence item needs an assertion status such as `documented_fact`, `internal_claim`, `hypothesis`, `synthetic_statement`, `unverified_data`, `contradiction`, or `unknown`. A `seed_corpus + unverified_claim` item may support the meta-claim **"the source states X"**. It must not by itself validate the world-claim **X**.
+
+## Critical finding 2: foreign-role takeover reaches validated evidence
+
+The only `medium` claim is a simulated quote from `lisa_hartmann_610` saying the migration strengthens **her** personal brand as a self-employed software developer and IT consultant. The migration concerns Alexander Schneider's domain, not Lisa Hartmann's. The answer has taken over the subject's role.
+
+The raw interview should remain in the trace, but a foreign-role answer should be ineligible as claim-supporting `agent_quote` evidence. Here it survives binding and becomes the strongest-confidence claim in the report, making it a useful regression fixture for identity/role guarding.
+
+## Critical finding 3: evidence scope is rendered incorrectly
+
+All 46 validated claim rows render as:
+
+```text
+scope = Simulationskonsens
+basis = persona
+```
+
+Yet **38 are supported only by seed-document evidence**. This is not cosmetic. A source-bound claim and a simulation-consensus claim express different trust semantics and must not share the same scope label.
+
+## Critical finding 4: the gate knows more than the final prose
+
+The trust layer correctly rejects or weakens several unsupported numbers and the claim that Option B is uniquely viable. Strong formulations can nevertheless remain in visible section prose while later gate tables classify them as hypothesis, insufficient, contradicted, or merely related evidence.
+
+The final report therefore needs a reconciliation stage after gating. Sentences ending in `INSUFFICIENT`, `CONTRADICTED`, or `related_evidence_only` should be removed or rewritten as explicitly qualified hypotheses.
+
+## Critical finding 5: simulated authority can look like real authority
+
+The evidence index contains a simulated persona with `persona_id="google_692"`. Its statements are stored as `Agentenzitat`, not as official web sources. Renderer language must preserve that distinction: simulated persona → "simulated search-engine perspective"; official documentation → `web_source` with provenance.
+
+## Critical finding 6: non-stakeholder eligibility is improved, not solved
+
+Older runs admitted obvious software/product entities as personas. This run is cleaner, but the evidence index still contains:
+
+```text
+Fachblog CREATE_POST on reddit in round 0
+```
+
+A technical blog is content/media, not an individual or collective stakeholder. The report artifact does not export `generation_source`, so this run does **not** prove whether the entity came through the normal or degraded persona path. It only proves that a non-stakeholder still reached the final simulation.
+
+## Auditability issue: claim IDs are not globally unique in the flat export
+
+The report contains **46 claim rows but only 22 unique `claim_*` IDs**. The IDs may be section-scoped internally, but the Markdown renderer does not expose that scope. Human references such as `claim_07` are therefore ambiguous. Report-level IDs should be globally unique or include the section scope in the rendered identifier.
+
+## Simulation dynamics: weaker signal than reference run 4
+
+| Metric | Reference run 4 | This run |
+|---|---:|---:|
+| rounds | 20 | 20 |
+| validated claims | 39 | **46** |
+| hypotheses | 141 | 141 |
+| data gaps | 131 | 133 |
+| social actions / interactions | **665** | 109 |
+| clusters | **6** | 3 |
+| echo chamber index | 0.5741 | 0.5963 |
+
+The new run yields about **5.45 interactions per configured round**, versus about **33.25 actions per round** in reference run 4. This is a red flag, not a proven regression: agent count, provider/model routing, action configuration, and recommender behavior can materially change the dynamics.
+
+This run is therefore the better **trust-pipeline reference**; reference run 4 remains the richer **simulation-dynamics reference**.
+
+## What this run demonstrates
+
+- Evidence binding works at useful scale.
+- Seed-document provenance reaches the report.
+- Numerical prose gating catches several unsupported targets.
+- Many hypotheses and data gaps remain separated from validated claims.
+- The remaining failures are concrete enough for deterministic regression tests.
+- The domain-migration seed is a strong adversarial fixture for trust-layer development.
+
+## What this run explicitly does not demonstrate
+
+- **No predictive validity.**
+- **No real recruiter, employer, Google, or user research.**
+- **No proof that the recommended migration strategy is objectively best.**
+- **No complete epistemic provenance yet.**
+- **No guarantee that a validated claim is a true world-fact merely because its source span is real.**
+- **No proof that the lower interaction count is a simulation regression.**
+
+## Remediation priority
+
+1. **P1 — preserve seed assertion status end to end.** Unsupported, hypothetical, or synthetic source spans must not validate direct world-facts.
+2. **P1 — reject foreign-role interview answers from claim-supporting evidence.** Preserve the raw trace, block evidence eligibility.
+3. **P2 — reconcile final prose with the final gate verdict.** `INSUFFICIENT`, `CONTRADICTED`, and related-only statements must be qualified or removed.
+4. **P2 — render the correct confidence scope and basis.** Seed-bound claims must not appear as simulation consensus.
+5. **P2 — harden persona eligibility against content objects such as `Fachblog`.**
+6. **P3 — make exported claim identifiers globally unambiguous.**
+7. **P3 — centralize risk objects so summary/detail likelihood and impact cannot drift.**
+
+## Artifacts
+
+- Machine-readable audit summary: [`artifacts/run-summary.json`](./artifacts/run-summary.json)
+- Source report: `report_fb5dfaf69ffa` (full Markdown export retained with the run audit outside this repository snapshot)
+
+## Conclusion
+
+Reference run 4 proved that Agora could finally bind evidence. Reference run 5 shows the next boundary: **binding the correct source is not enough if the system forgets whether the source itself called the statement a fact, hypothesis, synthetic statement, contradiction, or unsupported assertion.**
+
+That is why this is the current reference run. It is not the prettiest simulation and not the richest social trace. It is the clearest end-to-end test of the trust architecture Agora is trying to make stable for 1.0.

--- a/docs/reference-runs/2026-08-12-domain-migration-20-runden/artifacts/run-summary.json
+++ b/docs/reference-runs/2026-08-12-domain-migration-20-runden/artifacts/run-summary.json
@@ -1,0 +1,77 @@
+{
+  "reference_run": 5,
+  "status": "current",
+  "date": "2026-08-12",
+  "scenario": "Domain migration alexle135.de -> alex-schneider.dev",
+  "report_id": "report_fb5dfaf69ffa",
+  "generated_at": "2026-08-12T13:57:13.249205+00:00",
+  "report_mode": "balanced",
+  "rounds": {
+    "completed": 20,
+    "planned": 20,
+    "simulation_running_at_report_start": false
+  },
+  "report": {
+    "validated_claim_rows": 46,
+    "unique_rendered_claim_ids": 22,
+    "hypotheses": 141,
+    "data_gaps": 133,
+    "post_downgraded": 0
+  },
+  "confidence": {
+    "low": 45,
+    "medium": 1,
+    "high": 0
+  },
+  "rendered_claim_scope": {
+    "Simulationskonsens": 46
+  },
+  "rendered_claim_basis": {
+    "persona": 46
+  },
+  "evidence_index": {
+    "total": 70,
+    "agent_quote": 33,
+    "seed_document": 16,
+    "graph_relation_or_metric": 13,
+    "agent_action": 8
+  },
+  "validated_claim_support_composition": {
+    "seed_only": 38,
+    "agent_quote_only": 6,
+    "seed_plus_agent_quote": 1,
+    "agent_action_only": 1
+  },
+  "simulation_metrics": {
+    "total_interactions": 109,
+    "cluster_count": 3,
+    "echo_chamber_index": 0.5963
+  },
+  "missing_from_markdown_artifact": [
+    "report_model",
+    "simulation_id",
+    "graph_id"
+  ],
+  "primary_findings": [
+    "Seed assertion status is not preserved strongly enough to prevent an explicitly unsupported source assertion from validating a direct world-claim.",
+    "Foreign-role takeover in a simulated interview can remain eligible as agent_quote evidence and reach a validated claim.",
+    "All validated claims render as simulation consensus/persona even though most are supported only by seed-document evidence.",
+    "Final visible prose can remain stronger than the later trust-gate verdict.",
+    "Simulated authority personas can be phrased in a way that risks authority laundering.",
+    "Non-stakeholder content objects can still enter the simulation (Fachblog).",
+    "Flat-export claim IDs are not globally unambiguous."
+  ],
+  "comparison_reference_run_4": {
+    "rounds": 20,
+    "validated_claims": 39,
+    "hypotheses": 141,
+    "data_gaps": 131,
+    "actions": 665,
+    "clusters": 6,
+    "echo_chamber_index": 0.5741
+  },
+  "notes": [
+    "Lower interaction volume is a red flag, not a proven regression, because run configuration/model/recommender conditions may differ.",
+    "This run is the current trust-pipeline reference; reference run 4 remains the richer simulation-dynamics reference."
+  ]
+}

--- a/docs/reference-runs/README.md
+++ b/docs/reference-runs/README.md
@@ -6,5 +6,12 @@ Sie sind **keine** Nachweise dafür, dass Agora reales menschliches Verhalten vo
 
 ## Verfügbare Läufe
 
-- [2026-08-09 · Domainmigration alexle135.de → alex-schneider.dev](./2026-08-09-domain-migration/README.md) — erster öffentlicher Referenzlauf mit Social-Multi-Agenten-Simulation, Evidence Gating, strukturiertem Entscheidungsreport, bekannten Grenzen und nachgelagerter Remediation.
+- **[2026-08-12 · Referenzlauf 5: Domainmigration, 20 Runden](./2026-08-12-domain-migration-20-runden/README.de.md) — aktueller Referenzlauf.** Post-Hardening-Trust-Audit mit 46 validierten Claim-Zeilen, 141 Hypothesen und 133 Data Gaps. Zeigt als zentrale verbleibende Trust-Grenze, dass ein korrekt gebundenes Seed-Fragment seinen epistemischen Status verlieren kann; dokumentiert außerdem Fremdrollen-Evidence, Scope-/Basis-Mismatch und verbleibende Persona-Eignungsfehler.
+- [2026-08-11 · Referenzlauf 4: KI-Lernassistent, 20 Runden](./2026-08-11-ki-lernassistent-20-runden/README.de.md) — erster Lauf mit Evidence Binding in brauchbarer Größenordnung (39 validierte Claims); bleibt mit 665 Social Actions und sechs Clustern die reichhaltigere Referenz für Simulationsdynamik.
+- [2026-08-11 · Referenzlauf 3: KI-Lernassistent, 10 Runden](./2026-08-11-ki-lernassistent/README.md) — früherer Lernassistenten-Lauf mit `deepseek-v4-flash`, der Mechanismen und Fehlerklassen dokumentiert, auf denen Referenzlauf 4 aufbaut.
 - [2026-08-09 · Domainmigration v2 nach Evidence-Identity-Remediation](./2026-08-09-domain-migration-v2/README.md) — Follow-up mit 30 konsistent erfassten Agenten, 412 Graph-Interaktionen, 540 Social Actions, adaptiver Reportplanung und section-spezifischen Deep Interviews; dokumentiert offen den weiterhin bestehenden Interview→Evidence-Binding-Defekt und `0` validierte ReportV3-Claims.
+- [2026-08-09 · Domainmigration alexle135.de → alex-schneider.dev](./2026-08-09-domain-migration/README.md) — erster öffentlicher Referenzlauf mit Social-Multi-Agenten-Simulation, Evidence Gating, strukturiertem Entscheidungsreport, bekannten Grenzen und nachgelagerter Remediation.
+
+## Einordnung
+
+Referenzlauf 5 ist die aktuelle **Trust-Pipeline-Referenz**. Referenzlauf 4 bleibt bewusst erhalten, weil er die stärkere Social-/Simulationsdynamik dokumentiert. Keiner der Läufe ist als „Golden Run“ oder als Nachweis prädiktiver Validität zu verstehen.


### PR DESCRIPTION
## Summary

- add **Reference Run 5** for the 2026-08-12 domain-migration run (`report_fb5dfaf69ffa`)
- document the post-hardening trust findings, including seed epistemic-status loss, foreign-role evidence, confidence-scope mismatch, final-prose/gate divergence, authority laundering risk, and remaining persona eligibility issues
- add a machine-readable `run-summary.json`
- promote Run 5 as the current **trust-pipeline reference** in both top-level READMEs and the reference-run index
- keep Reference Run 4 explicitly documented as the richer **simulation-dynamics reference**

## Key metrics documented

- 20 / 20 rounds complete
- 46 validated claim rows / 22 unique rendered claim IDs
- 141 hypotheses
- 133 data gaps
- 70 evidence-index entries
- 109 interactions, 3 clusters, echo-chamber index 0.5963

## Scope

Documentation only. No runtime code or contracts are changed.

## Verification

- branch is based on current `main` (`be49e89ab1c91b81bd9f5a2ec391e1e76b6c21c2`)
- compare shows exactly 6 changed files: two top-level README sections, the reference-run index, two new bilingual run documents, and one JSON summary
- patches for both top-level READMEs were inspected and are limited to the reference-run sections
- the new reference document and machine-readable summary were re-fetched from the branch after writing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Neue Referenzlauf-Dokumentation für eine 20-ründige Domainmigration ergänzt.
  * Kennzahlen zu Claims, Hypothesen, Datenlücken und Evidenz veröffentlicht.
  * Sieben zentrale Vertrauens-, Auditierungs- und Simulationsbefunde dokumentiert.
  * Aktuelle und frühere Referenzläufe neu verlinkt und eingeordnet.
  * Zusammenfassung mit Lauf-, Konfidenz-, Evidenz- und Simulationsmetriken ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->