### PR TITLE
fix(output-contract): toter required-Schnittmengen-Zweig entfernt (#1277 Slice D)

### DIFF
--- a/backend/app/services/report_agent/output_contract.py
+++ b/backend/app/services/report_agent/output_contract.py
@@ -243,28 +243,25 @@ def resolve_report_status(
 ) -> "ReportStatus":
     """Ermittelt den Report-Status aus dem Erfolg der Einzelabschnitte.
 
-    Eine fehlgeschlagene Pflichtsection macht den Report ``INCOMPLETE``. Der
-    Rest bleibt nutzbar — der Nutzer sieht, was fehlt, statt ein ``COMPLETED``
+    Eine fehlgeschlagene Section macht den Report ``INCOMPLETE``. Der Rest
+    bleibt nutzbar — der Nutzer sieht, was fehlt, statt ein ``COMPLETED``
     zu lesen, das der Report nicht einlöst.
 
     ``FAILED`` wird bewusst **nicht** hier erzeugt: der Workflow setzt ihn
-    direkt bei.schema-Validierungsfehlern oder Totalausfällen
+    direkt bei Schema-Validierungsfehlern oder Totalausfällen
     (``workflow.py``), nicht aus der Section-Erfolgsbilanz. Jeder Aufrufer
     übergibt ``required_section_indices=list(range(1, total+1))`` — damit ist
-    ``required`` nie leer und jede failed Section schlägt als ``INCOMPLETE``
-    durch. Ein früherer ``FAILED``-Zweig (``len(failed) >= total_sections``)
-    war unter dieser Aufruf invariant unreachable (CodeRabbit PR #929).
+    jede failed Section zwingend ``INCOMPLETE``. Ein früherer
+    ``FAILED``-Zweig (``len(failed) >= total_sections``) war unter dieser
+    Aufruf invariant unreachable (CodeRabbit PR #929); die verbliebene
+    ``required``-Schnittmengenprüfung war ein weiterer toter Arm (#1277-5)
+    und ist entfernt. ``required_section_indices`` bleibt als Parameter,
+    damit Aufrufer nicht geändert werden müssen.
     """
     from ...models.report import ReportStatus  # noqa: PLC0415 — zyklischer Import
 
     failed = set(failed_section_indices)
-    if not failed:
-        return ReportStatus.COMPLETED
-
-    required = set(required_section_indices)
-    if required and failed & required:
-        return ReportStatus.INCOMPLETE
-    return ReportStatus.INCOMPLETE
+    return ReportStatus.COMPLETED if not failed else ReportStatus.INCOMPLETE
 
 
 def apply_degradation_downgrade(

--- a/changelog.d/1277-d-output-contract.md
+++ b/changelog.d/1277-d-output-contract.md
@@ -1,0 +1,3 @@
+### Fixed (Output-Contract — toter Zweig nach PR #929 — 2026-08-12)
+
+- **Toter `required`-Schnittmengen-Zweig in `resolve_report_status` entfernt:** Beide Arme nach dem `COMPLETED`-Early-Return lieferten `INCOMPLETE`; `required` und die Schnittmenge `failed & required` wurden bei jedem Aufruf berechnet und verworfen. Die Invariante (jeder Aufrufer übergibt `required_section_indices=list(range(1, total+1))` → jede failed Section wird `INCOMPLETE`) macht die Prüfung überflüssig. Eingedampft auf `COMPLETED if not failed else INCOMPLETE`; `required_section_indices` bleibt als Parameter, damit Aufrufer nicht geändert werden müssen. Verhaltensneutral — bestehende Trust-Tests decken beide Pfade ab. (#1277-5)


### PR DESCRIPTION
Slice D von #1277.

## Was

`resolve_report_status` in `backend/app/services/report_agent/output_contract.py` hatte nach dem `COMPLETED`-Early-Return zwei Arme, die beide `INCOMPLETE` lieferten. Die dazwischen berechnete Schnittmenge `failed & required` wurde bei jedem Aufruf verworfen. Jeder Aufrufer übergibt `required_section_indices=list(range(1, total+1))` — damit ist jede failed Section zwingend `INCOMPLETE`, und die `required`-Prüfung ist unreachable.

Eingedampft auf:

\`\`\`python
failed = set(failed_section_indices)
return ReportStatus.COMPLETED if not failed else ReportStatus.INCOMPLETE
\`\`\`

`required_section_indices` bleibt als Parameter (API-Stabilität — Aufrufer müssen nicht geändert werden), der Docstring verweist auf #1277-5 und erklärt, warum der Zweig tot war.

## Warum verhaltensneutral

Bestehende Trust-Tests (`test_6` COMPLETED-Pfad, `test_6b` INCOMPLETE-Pfad) decken beide Zweige ab und bleiben grün. Kein neuer Test, da der Defekt ein toter Zweig ist (wie #3 in Slice B) — keine beobachtbare Verhaltensänderung, die ein RED-Test treffen könnte.

## Gate

- Pre-Push-Gate Backend-Scope: grün (637 Contracts, 70 Schemas, Ruff, mypy, sync-status)

Schließt keinen Issue selbst — #1277 wird erst nach Merge aller 4 Slices geschlossen.