### PR TITLE
fix(contracts): Frontend-Zod-Spiegel um persona_role_family + seed_document ergänzen

### DIFF
--- a/changelog.d/1295-frontend-evidence-schema-drift.md
+++ b/changelog.d/1295-frontend-evidence-schema-drift.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Frontend-Zod-Spiegel verwarf Backend-Payloads mit `persona_role_family` (`.strict()`-Rejection) und kannte `seed_document` nicht im `EvidenceTypeSchema`-Enum.

--- a/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
+++ b/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
@@ -307,3 +307,112 @@ describe('kanonische Evidence-Identität', () => {
     expect(ReportV3Schema.safeParse(legacyVersion).success).toBe(false);
   });
 });
+
+describe('EvidenceRecord — persona_role_family + seed_document Regression', () => {
+  const EvidenceRecordSchema = exportedSchema(reportContract, 'EvidenceRecordSchema');
+
+  it('accepts seed_document evidence', () => {
+    expect(
+      EvidenceRecordSchema.parse({
+        evidence_id: 'ev_02f4c454baa17f64c1a65f33595fbdbd',
+        producer_key: 'seed-doc:test',
+        type: 'seed_document',
+        source: 'report_tool',
+        snippet: 'Dokumentfakt',
+        source_kind: 'seed_corpus',
+        persona_role_family: null,
+      }),
+    ).toBeTruthy();
+  });
+
+  it('accepts persona_role_family on agent evidence', () => {
+    expect(
+      EvidenceRecordSchema.parse({
+        evidence_id: 'ev_1234567890abcdef1234567890abcdef',
+        producer_key: 'interview:test',
+        type: 'agent_interview',
+        source: 'report_tool',
+        snippet: 'Interview',
+        source_kind: 'agent_quote',
+        persona_stakeholder_group: 'Physician',
+        persona_role_family: 'Physician',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('rejects persona_role_family exceeding 120 chars', () => {
+    const result = EvidenceRecordSchema.safeParse({
+      evidence_id: 'ev_1234567890abcdef1234567890abcdef',
+      producer_key: 'interview:test',
+      type: 'agent_interview',
+      source: 'report_tool',
+      snippet: 'Interview',
+      source_kind: 'agent_quote',
+      persona_stakeholder_group: 'Physician',
+      persona_role_family: 'x'.repeat(121),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts persona_role_family as undefined (pre-migration data)', () => {
+    expect(
+      EvidenceRecordSchema.parse({
+        evidence_id: 'ev_aabbccdd00112233aabbccdd00112233',
+        producer_key: 'agent-log:99#post:100',
+        type: 'graph_fact',
+        source: 'graph_query',
+        snippet: 'Altdaten ohne role_family',
+        source_kind: 'graph_relation',
+      }),
+    ).toBeTruthy();
+  });
+});
+
+describe('EvidenceType enum completeness — Backend→Frontend drift guard', () => {
+  const BACKEND_EVIDENCE_TYPES: string[] = [
+    'graph_fact',
+    'graph_metric',
+    'graph_metric_status',
+    'relationship_chain',
+    'entity_summary',
+    'agent_action',
+    'agent_interview',
+    'web_search_result',
+    'web_fetch',
+    'seed_document',
+    'model_generated_inference',
+  ];
+
+  const EvidenceRecordSchema = exportedSchema(reportContract, 'EvidenceRecordSchema');
+
+  const BASE_RECORD = {
+    evidence_id: 'ev_deadbeefdeadbeefdeadbeefdeadbeef',
+    producer_key: 'drift-guard:enum-test',
+    source: 'test_tool',
+    snippet: 'Drift-Guard-Snippet',
+    source_kind: 'inferred' as const,
+  };
+
+  it.each(BACKEND_EVIDENCE_TYPES)(
+    'frontend Zod accepts EvidenceType "%s"',
+    (evidenceType) => {
+      const result = EvidenceRecordSchema.safeParse({
+        ...BASE_RECORD,
+        type: evidenceType,
+      });
+      if (evidenceType === 'model_generated_inference') {
+        expect(result.success).toBe(false);
+      } else {
+        expect(result.success).toBe(true);
+      }
+    },
+  );
+
+  it('rejects an EvidenceType not in the backend enum', () => {
+    const result = EvidenceRecordSchema.safeParse({
+      ...BASE_RECORD,
+      type: 'nonexistent_type',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
+++ b/frontend/src/contracts/__tests__/evidenceIdentityContract.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import * as reportContract from '../reportContract';
 import { ReportV3Schema } from '../reportV3Contract';
+import reportContractJson from '../../../../schemas/report-contract.schema.json';
 
 function exportedSchema(moduleValue: object, exportName: string): z.ZodType {
   const candidate: unknown = Reflect.get(moduleValue, exportName);
@@ -369,19 +370,9 @@ describe('EvidenceRecord — persona_role_family + seed_document Regression', ()
 });
 
 describe('EvidenceType enum completeness — Backend→Frontend drift guard', () => {
-  const BACKEND_EVIDENCE_TYPES: string[] = [
-    'graph_fact',
-    'graph_metric',
-    'graph_metric_status',
-    'relationship_chain',
-    'entity_summary',
-    'agent_action',
-    'agent_interview',
-    'web_search_result',
-    'web_fetch',
-    'seed_document',
-    'model_generated_inference',
-  ];
+  const BACKEND_EVIDENCE_TYPES: string[] =
+    (reportContractJson as { $defs: { EvidenceType: { enum: string[] } } })
+      .$defs.EvidenceType.enum;
 
   const EvidenceRecordSchema = exportedSchema(reportContract, 'EvidenceRecordSchema');
 

--- a/frontend/src/contracts/reportContract.ts
+++ b/frontend/src/contracts/reportContract.ts
@@ -29,6 +29,7 @@ export const EvidenceTypeSchema = z.enum([
   "agent_interview",
   "web_search_result",
   "web_fetch",
+  "seed_document",
   "model_generated_inference", // im audit_trail erlaubt, in evidence verboten
 ]);
 export type EvidenceType = z.infer<typeof EvidenceTypeSchema>;
@@ -102,6 +103,7 @@ const EvidenceSourceSchema = z.object({
   // Herkunft ist abgeleitet, nicht belegt. Spiegelt den Backend-Default.
   source_kind: EvidenceSourceKindSchema.default("inferred"),
   persona_stakeholder_group: z.string().min(1).max(200).optional().nullable(),
+  persona_role_family: z.string().min(1).max(120).optional().nullable(),
   // Slice 8 (2026-05-16) — Provider+Modell, das diese Evidence-Zeile
   // extrahiert hat. Pendant zu EvidenceItemModel.source_model. Format
   // "<provider>/<model_id>" (z. B. "ollama/qwen2.5:32b"). None bei


### PR DESCRIPTION
## Summary

- `persona_role_family` fehlte im Frontend `EvidenceSourceSchema` — `.strict()` verwarf jeden Backend-Payload, der das Feld enthielt
- `seed_document` fehlte im `EvidenceTypeSchema`-Enum
- Regressionstests für beide Felder + EvidenceType-Enum-Drift-Guard (`it.each` über alle Backend-Werte)

## Test plan

- [x] `bun run test` — 275/275 Contract-Tests grün
- [x] seed_document-Evidence mit `persona_role_family: null` parst
- [x] persona_role_family auf agent_interview parst
- [x] >120 chars wird abgewiesen
- [x] Feld darf fehlen (Pre-Migrations-Daten)
- [x] Jeder Backend-EvidenceType-Enum-Wert einmal durch Frontend-Zod gejagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Evidence-Daten unterstützen jetzt zusätzlich den Typ „seed_document“.
  * Evidence-Quellen können optional die Rollenfamilie einer Persona enthalten.

* **Fehlerbehebungen**
  * Gültige Rollenfamilien werden akzeptiert, während zu lange Angaben zuverlässig abgelehnt werden.
  * Fehlende Angaben bleiben für bestehende Daten kompatibel.
  * Unbekannte oder nicht unterstützte Evidence-Typen werden korrekt zurückgewiesen.

* **Tests**
  * Die Validierung und Vollständigkeit der unterstützten Evidence-Typen wurden durch Regressionstests abgesichert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->