### PR TITLE
feat(B4): Öffnung — Läufe aus eigenen Personas, Ableiten aus Berichten, Telefon-Ansicht

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -315,8 +315,8 @@ für die Zeilenaktionen. B4 setzt auf dem Objektmodell auf.
 | --- | --- | --- |
 | B1 Fundament | **erledigt, auf main** | PR #1370 |
 | B2 Abbrechen | **erledigt, auf main** | PR #1371 |
-| B3 Objektmodell | **Ablage + Dossier stehen** | PR #1372 |
-| B4 Öffnung | offen | — |
+| B3 Objektmodell | **erledigt, auf main** | PR #1372 |
+| B4 Öffnung | **in Arbeit** | `feat/b4-oeffnung` |
 
 Was B3 noch fehlt: Bericht-Leseumgebung mit Belegrand, Graph-Objekt mit
 Rundenscrubber, Einstellungen als Overlay, Löschen der Altansichten
@@ -329,6 +329,23 @@ Personasätze wären in der Ablage nie erschienen. Die dynamisch gebildeten
 Statusschlüssel (`shelf.status.report_*`, `project_*`) existierten in keiner
 Locale, und das mitgegebene `{ fallback }` war wirkungslos. Und das Dossier
 behauptete ohne Auswahl „Noch keine Objekte“, während die Ablage voll war.
+
+### B4 im Einzelnen
+
+| Teil | Zustand |
+| --- | --- |
+| Mobile (390px) | erledigt — ⌘K raus aus dem Markup, Jobs-Tabelle scrollt im eigenen Kasten, Kopfzeile gibt auf schmal Wortmarke und Trenner frei |
+| Aus Bericht ableiten | erledigt — im Dossier des Berichts, mit Übernahme der Personas |
+| Personasätze als Objekt | erledigt — in der Ablage, mit Beruf/Land/Interessen im Dossier |
+| Start nur aus Personas | Backend-Service in Arbeit; Endpunkt und Einstieg in der Ablage folgen |
+
+Zum letzten Punkt: Der OASIS-Lauf braucht den Graphen **zur Laufzeit nicht**
+— `branching_service.create_branch` beweist, dass `CREATED → PREPARING → READY`
+ohne die Entity-Phase geht, und `add_simulation_profile` schreibt Personas
+bereits im richtigen Format. Die harte Bindung an eine `graph_id` sitzt in der
+**Report**-Erzeugung (drei Stellen). Der ehrliche Vorbehalt: Berichte aus einem
+reinen Persona-Lauf laufen technisch durch, aber ohne Graph-Belege — das ist
+ein Qualitätsproblem, kein technisches, und gehört dem Nutzer vorher gesagt.
 
 ---
 

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -511,7 +511,12 @@ def chat_with_report_agent():
 
     graph_id = state.graph_id or project.graph_id
     if not graph_id:
-        return json_error("Missing graph ID", status=400)
+        # Reiner Persona-Lauf ohne Graphen (Block B4) — siehe
+        # services/report_generation.py fuer die Begruendung.
+        return json_error(
+            "Dieser Lauf hat keinen Wissensgraphen — Berichte stuetzen sich auf Belege aus dem Graphen und sind fuer reine Persona-Laeufe deshalb noch nicht moeglich. Die Simulation selbst laeuft und ist auswertbar.",
+            status=400,
+        )
 
     simulation_requirement = project.simulation_requirement or ""
 

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -1006,7 +1006,10 @@ def _resume_report_generate(run: dict):
         raise ValueError(f"Project does not exist: {state.project_id}")
     graph_id = state.graph_id or project.graph_id
     if not graph_id:
-        raise ValueError("Missing graph ID")
+        # Reiner Persona-Lauf ohne Graphen (Block B4).
+        raise ValueError(
+            "Dieser Lauf hat keinen Wissensgraphen — Berichte stuetzen sich auf Belege aus dem Graphen und sind fuer reine Persona-Laeufe deshalb noch nicht moeglich. Die Simulation selbst laeuft und ist auswertbar."
+        )
     storage = current_app.extensions.get("neo4j_storage")
     if not storage:
         raise ValueError("GraphStorage not initialized")

--- a/backend/app/api/simulation_lifecycle.py
+++ b/backend/app/api/simulation_lifecycle.py
@@ -256,9 +256,18 @@ def create_simulation_from_personas():
             message="Please provide simulation_requirement",
         )
 
-    personas = _resolve_personas(data)
-    if isinstance(personas, tuple):  # (Fehlerantwort,)
-        return personas[0]
+    personas, problem = _resolve_personas(data)
+    if problem == "missing":
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide template_ids or personas",
+        )
+    if problem == "unknown_templates":
+        return json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message="None of the given template_ids exist in the persona library",
+        )
 
     project = ProjectManager.create_project(name=requirement[:60])
     manager = SimulationManager()
@@ -279,27 +288,23 @@ def create_simulation_from_personas():
 def _resolve_personas(data):
     """Personas aus ``template_ids`` oder ``personas`` gewinnen.
 
-    Gibt bei einem Fehler ein 1-Tupel mit der fertigen Fehlerantwort
-    zurueck, sonst die Liste.
+    Gibt ``(personas, problem)`` zurueck; ``problem`` ist ``None`` oder
+    ein Schluessel, den der Aufrufer in eine Antwort uebersetzt. Die
+    Funktion baut BEWUSST keine Response: sonst flösse die Anfrage
+    sichtbar in die Antwort, was schwer zu lesen ist und von der
+    Sicherheitsanalyse zurecht als Datenfluss gewertet wird.
     """
     inline = data.get('personas')
     if isinstance(inline, list) and inline:
-        return [p for p in inline if isinstance(p, dict)]
+        return [p for p in inline if isinstance(p, dict)], None
 
     template_ids = data.get('template_ids')
     if not isinstance(template_ids, list) or not template_ids:
-        return (json_error(
-            ApiErrorCode.VALIDATION_FAILED,
-            message="Please provide template_ids or personas",
-        ),)
+        return [], "missing"
 
     wanted = {str(t) for t in template_ids}
     available = PersonaLibrary().list_templates()
     picked = [t for t in available if str(t.get('template_id')) in wanted]
     if not picked:
-        return (json_error(
-            ApiErrorCode.NOT_FOUND,
-            status=404,
-            message="None of the given template_ids exist in the persona library",
-        ),)
-    return picked
+        return [], "unknown_templates"
+    return picked, None

--- a/backend/app/api/simulation_lifecycle.py
+++ b/backend/app/api/simulation_lifecycle.py
@@ -11,6 +11,8 @@ from . import simulation_bp
 from ..config import Config
 from ..llm.providers.registry import detect_provider, resolve_ollama_tags_url
 from ..models.project import ProjectManager
+from ..services.persona_library import PersonaLibrary
+from ..services.persona_prepare_service import prepare_from_personas
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..utils.api_errors import ApiErrorCode
 from ..utils.api_responses import handle_api_errors, json_error, json_success
@@ -229,3 +231,75 @@ def list_simulations():
         [simulation.to_dict() for simulation in simulations],
         count=len(simulations),
     )
+
+
+@simulation_bp.route('/create-from-personas', methods=['POST'])
+@handle_api_errors(logger=logger, log_prefix="Failed to create simulation from personas")
+def create_simulation_from_personas():
+    """Legt einen Lauf allein aus gespeicherten Personas an (Block B4).
+
+    Bewusst ein EIGENER Endpunkt statt eines Sonderfalls in ``/create``:
+    dort ist eine ``graph_id`` Pflicht, und das soll sie auch bleiben —
+    der regulaere Weg ueber Dokument und Graph darf nicht aufweichen.
+    Hier gibt es keinen Graphen, also traegt die Simulation auch keine
+    ``graph_id``; erfunden wird keine.
+
+    Erwartet ``simulation_requirement`` und entweder ``template_ids``
+    (Verweise in die Persona-Bibliothek) oder ``personas`` (Inline).
+    """
+    data = request.get_json() or {}
+
+    requirement = (data.get('simulation_requirement') or '').strip()
+    if not requirement:
+        return json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide simulation_requirement",
+        )
+
+    personas = _resolve_personas(data)
+    if isinstance(personas, tuple):  # (Fehlerantwort,)
+        return personas[0]
+
+    project = ProjectManager.create_project(name=requirement[:60])
+    manager = SimulationManager()
+    # graph_id bleibt leer: es gibt keinen Graphen. Der Lauf selbst
+    # braucht ihn nicht — nur die spaetere Berichtserzeugung verlangt
+    # einen, und das ist eine bewusst offene Stelle (PLAN.md, B4).
+    state = manager.create_simulation(project_id=project.project_id, graph_id="")
+
+    prepare_from_personas(manager, state.simulation_id, personas)
+
+    return json_success({
+        "simulation_id": state.simulation_id,
+        "project_id": project.project_id,
+        "persona_count": len(personas),
+    }, status=201)
+
+
+def _resolve_personas(data):
+    """Personas aus ``template_ids`` oder ``personas`` gewinnen.
+
+    Gibt bei einem Fehler ein 1-Tupel mit der fertigen Fehlerantwort
+    zurueck, sonst die Liste.
+    """
+    inline = data.get('personas')
+    if isinstance(inline, list) and inline:
+        return [p for p in inline if isinstance(p, dict)]
+
+    template_ids = data.get('template_ids')
+    if not isinstance(template_ids, list) or not template_ids:
+        return (json_error(
+            ApiErrorCode.VALIDATION_FAILED,
+            message="Please provide template_ids or personas",
+        ),)
+
+    wanted = {str(t) for t in template_ids}
+    available = PersonaLibrary().list_templates()
+    picked = [t for t in available if str(t.get('template_id')) in wanted]
+    if not picked:
+        return (json_error(
+            ApiErrorCode.NOT_FOUND,
+            status=404,
+            message="None of the given template_ids exist in the persona library",
+        ),)
+    return picked

--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -53,19 +53,14 @@ def _get_auth_mode():
 def _get_backend_status():
     """Get backend health, version, and active auth mode.
 
-    ``allow_small_sim`` mirrors the ``AGORA_ALLOW_SMALL_SIM`` env-var so the
-    frontend can adjust the persona-slider lower bound dynamically instead of
-    letting the user submit a run that the simulation_config_generator's
-    persona-quota validator rejects with a hard 422.
+    ``allow_small_sim`` ist entfallen: die harte Untergrenze von 30
+    Personas gibt es nicht mehr, damit auch keinen Schalter, der sie
+    aufhebt (Block B4).
     """
     return {
         "ok": True,
         "version": __version__,
         "auth_mode": _get_auth_mode(),
-        # Exakter Vergleich gegen "1" — kein .strip() — damit die UI das
-        # gleiche Bit sieht wie der Validator in simulation_config_generator
-        # (_validate_persona_quota nutzt ebenfalls `!= "1"` ohne strip).
-        "allow_small_sim": os.environ.get("AGORA_ALLOW_SMALL_SIM") == "1",
     }
 
 

--- a/backend/app/services/persona_prepare_service.py
+++ b/backend/app/services/persona_prepare_service.py
@@ -1,0 +1,270 @@
+"""Simulation direkt aus gespeicherten Personas vorbereiten (ohne Graph).
+
+ZIEL: Eine Simulation soll allein aus ``PersonaLibrary``-Einträgen auf
+``READY`` gebracht werden können — ohne Dokument, ohne Ontologie, ohne
+Knowledge-Graph. Strukturell an ``branching_service.create_branch`` angelehnt
+(gleiches Muster: Funktionen nehmen einen ``SimulationManager`` als ersten
+Parameter, um zirkuläre Importe zu vermeiden), aber ohne Source-Simulation —
+die Profile kommen direkt aus der übergebenen Personaliste.
+
+Das Profildatei-Format (Keys, Defaults, ``user_id``-Vergabe, Username-Dedupe)
+spiegelt bewusst ``api.simulation_profiles.add_simulation_profile``: dort ist
+das Format bereits korrekt für OASIS. Ein direkter Funktionsimport war nicht
+möglich (die API-Funktion hängt an ``flask.request`` und an
+``current_app``-gebundenem ``get_artifact_store()``), deshalb wird hier
+dieselbe Feldliste/-logik noch einmal nachgebildet statt importiert.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from ..config import Config
+from ..utils.artifact_locator import ArtifactLocator
+from ..utils.logger import get_logger
+from .run_registry import RunRegistry
+from .simulation_config_generator import (
+    EventConfig,
+    PlatformConfig,
+    SimulationParameters,
+    TimeSimulationConfig,
+)
+
+if TYPE_CHECKING:
+    from .simulation_manager import SimulationManager, SimulationState
+
+logger = get_logger("agora.persona_prepare")
+
+# Felder, die im OASIS-Profilformat immer vorhanden sein müssen (siehe
+# oasis_profile_generator.py: agent_info[i]["mbti"]/["age"]/["gender"] werden
+# ungeschützt indiziert). PersonaLibrary._normalize lässt leere Werte weg,
+# ein Bibliothekseintrag kann sie also fehlen.
+_ALWAYS_PRESENT_DEFAULTS = {
+    "age": "",
+    "gender": "other",
+    "mbti": "",
+    "country": "DE",
+    "profession": "",
+    "interested_topics": [],
+}
+
+
+def prepare_from_personas(
+    manager: "SimulationManager",
+    simulation_id: str,
+    personas: List[Dict[str, Any]],
+) -> "SimulationState":
+    """Bereitet eine frisch angelegte Simulation aus Bibliotheks-Personas vor.
+
+    Durchläuft denselben FSM-Pfad wie ``branching_service.create_branch``
+    (``CREATED -> PREPARING -> READY``, kein Direktsprung), schreibt
+    ``reddit_profiles.json``/``twitter_profiles.csv`` und eine
+    ``simulation_config.json`` und registriert einen abgeschlossenen
+    ``simulation_prepare``-Run.
+
+    Args:
+        manager: Simulation-Manager, dessen Store/Status-Setter genutzt wird.
+        simulation_id: ID einer Simulation im Status ``CREATED``.
+        personas: Nicht-leere Liste von Bibliotheks-Personas (Dicts).
+
+    Raises:
+        ValueError: bei leerer Personaliste, unbekannter Simulation oder
+            falschem Ausgangsstatus.
+    """
+    from .simulation_manager import SimulationStatus  # avoid import cycle
+
+    if not personas:
+        raise ValueError("personas darf nicht leer sein")
+
+    state = manager.get_simulation(simulation_id)
+    if not state:
+        raise ValueError(f"Simulation does not exist: {simulation_id}")
+    if state.status != SimulationStatus.CREATED:
+        raise ValueError(
+            "Nur frisch angelegte Simulationen (CREATED) können aus einer "
+            "Personaliste vorbereitet werden"
+        )
+
+    manager._set_status(state, SimulationStatus.PREPARING)
+
+    profiles = _translate_personas(personas)
+    manager._store.write_json(simulation_id, "reddit_profiles", profiles)
+    _write_twitter_csv(manager._get_simulation_dir(simulation_id), profiles)
+
+    config = _build_config(state, len(profiles))
+    manager._store.write_json(simulation_id, "simulation_config", config)
+
+    state.entities_count = len(profiles)
+    state.profiles_count = len(profiles)
+    state.entity_types = sorted({p["persona_kind"] for p in profiles})
+    state.config_generated = True
+
+    manager._set_status(state, SimulationStatus.READY)
+    _register_run(state, len(profiles))
+    return state
+
+
+def _translate_personas(personas: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Übersetzt Bibliotheks-Personas ins OASIS-Profilformat.
+
+    Vergibt fortlaufende ``user_id`` (ab 1) und dedupliziert Usernamen
+    case-insensitiv — gleiches Muster wie ``add_simulation_profile``.
+    """
+    existing_names: set = set()
+    profiles = []
+    for index, persona in enumerate(personas, start=1):
+        profile = _translate_persona(persona, index, existing_names)
+        existing_names.add(profile["username"].lower())
+        profiles.append(profile)
+    return profiles
+
+
+def _dedupe_username(username: str, existing_names: set) -> str:
+    if username.lower() not in existing_names:
+        return username
+    suffix = 1
+    while f"{username}_{suffix}".lower() in existing_names:
+        suffix += 1
+    return f"{username}_{suffix}"
+
+
+def _translate_persona(
+    persona: Dict[str, Any], user_id: int, existing_names: set
+) -> Dict[str, Any]:
+    """Schließt Feldlücken eines Bibliothekseintrags fürs Profilformat."""
+    username = _dedupe_username(
+        str(persona.get("username") or f"user_{user_id}").strip(), existing_names
+    )
+    display_name = persona.get("name") or username
+    bio = persona.get("bio") or display_name
+    persona_text = persona.get("persona") or (
+        f"{display_name} is a participant in social discussions."
+    )
+
+    profile: Dict[str, Any] = {
+        "user_id": user_id,
+        "username": username,
+        "name": display_name,
+        "bio": bio,
+        "persona": persona_text,
+        "karma": _coerce_karma(persona.get("karma")),
+        # OasisAgentProfile-Format: reines Datum, kein Zeit-Anteil (spiegelt
+        # add_simulation_profile). Der Bibliothekseintrag trägt ggf. einen
+        # ISO-Timestamp mit Uhrzeit (PersonaLibrary._now()) — der wird hier
+        # bewusst NICHT übernommen, sondern auf das erwartete Format normiert.
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "source_entity_uuid": persona.get("source_entity_uuid"),
+        "source_entity_type": persona.get("source_entity_type") or "persona_library",
+        "persona_kind": persona.get("persona_kind") or "individual",
+        "is_manual": bool(persona.get("is_manual", False)),
+    }
+    for key, default in _ALWAYS_PRESENT_DEFAULTS.items():
+        value = persona.get(key)
+        profile[key] = value if value not in (None, "") else default
+    return profile
+
+
+def _coerce_karma(karma_raw: Any) -> int:
+    if karma_raw in (None, "", "null"):
+        return 1000
+    try:
+        return int(str(karma_raw))
+    except (ValueError, TypeError):
+        return 1000
+
+
+def _write_twitter_csv(sim_dir: str, profiles: List[Dict[str, Any]]) -> None:
+    path = os.path.join(sim_dir, "twitter_profiles.csv")
+    fieldnames = list(profiles[0].keys())
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(profiles)
+
+
+def _build_config(state: "SimulationState", profile_count: int) -> Dict[str, Any]:
+    """Baut eine schema-kompatible ``simulation_config.json`` ohne LLM/Graph.
+
+    Nutzt bewusst nur die Datenklassen aus ``simulation_config_generator``
+    (gleiches JSON-Schema wie ein LLM-generierter Config), statt
+    ``SimulationConfigGenerator.generate_config`` aufzurufen: der volle
+    Generator braucht ``document_text``/Entities, verlangt zwingend einen
+    konfigurierten LLM-Key und erzwingt einen 30-Personas-Floor
+    (``_validate_persona_quota``) — alles Voraussetzungen, die dem Ziel
+    "allein aus Personas, ohne Dokument/Graph" widersprechen.
+    """
+    twitter_config = (
+        PlatformConfig(
+            platform="twitter",
+            recency_weight=0.4,
+            popularity_weight=0.3,
+            relevance_weight=0.3,
+            viral_threshold=10,
+            echo_chamber_strength=0.5,
+        )
+        if state.enable_twitter
+        else None
+    )
+    reddit_config = (
+        PlatformConfig(
+            platform="reddit",
+            recency_weight=0.3,
+            popularity_weight=0.4,
+            relevance_weight=0.3,
+            viral_threshold=15,
+            echo_chamber_strength=0.6,
+        )
+        if state.enable_reddit
+        else None
+    )
+
+    params = SimulationParameters(
+        simulation_id=state.simulation_id,
+        project_id=state.project_id,
+        graph_id=state.graph_id,
+        simulation_requirement="Vorbereitung aus gespeicherten Personas (kein Dokument).",
+        time_config=TimeSimulationConfig(),
+        agent_configs=[],
+        event_config=EventConfig(),
+        twitter_config=twitter_config,
+        reddit_config=reddit_config,
+        llm_model=Config.LLM_MODEL_NAME,
+        llm_base_url=Config.LLM_BASE_URL,
+        language=Config.AGENT_LANGUAGE,
+        enable_agent_tools=getattr(Config, "ENABLE_AGENT_TOOLS", False),
+        max_tool_calls_per_action=getattr(Config, "MAX_TOOL_CALLS_PER_ACTION", 2),
+        neo4j_uri=Config.NEO4J_URI,
+        neo4j_user=Config.NEO4J_USER,
+        generation_reasoning=(
+            f"{profile_count} Personas direkt aus der Persona-Bibliothek "
+            "übernommen; kein Dokument, keine Ontologie, kein Graph."
+        ),
+    )
+    config = params.to_dict()
+    config["enable_twitter"] = state.enable_twitter
+    config["enable_reddit"] = state.enable_reddit
+    return config
+
+
+def _register_run(state: "SimulationState", profile_count: int) -> None:
+    RunRegistry().create_run(
+        run_type="simulation_prepare",
+        entity_id=state.simulation_id,
+        status="completed",
+        progress=100,
+        message=f"Simulation aus {profile_count} Bibliotheks-Personas vorbereitet",
+        linked_ids={
+            "simulation_id": state.simulation_id,
+            "project_id": state.project_id,
+        },
+        artifacts=ArtifactLocator.existing_paths(
+            {"simulation": ArtifactLocator.simulation_artifacts(state.simulation_id)}
+        ),
+        metadata={"persona_source": "library", "persona_count": profile_count},
+    )
+
+
+__all__ = ["prepare_from_personas"]

--- a/backend/app/services/report_generation.py
+++ b/backend/app/services/report_generation.py
@@ -161,7 +161,15 @@ class ReportGenerationService:
 
         graph_id = state.graph_id or project.graph_id
         if not graph_id:
-            raise ValueError("Missing graph ID, please ensure graph is built")
+            # Ein Persona-Lauf (Block B4) hat bewusst keine graph_id. Der
+            # Bericht bricht deshalb ab — aber mit einem Satz, der sagt,
+            # WAS fehlt und dass der Lauf selbst in Ordnung ist. Die
+            # Alternative waere ein Bericht ohne jede Graph-Evidenz, der
+            # aussieht wie ein normaler; das waere schlechter als ein
+            # klarer Abbruch.
+            raise ValueError(
+                "Dieser Lauf hat keinen Wissensgraphen — Berichte stuetzen sich auf Belege aus dem Graphen und sind fuer reine Persona-Laeufe deshalb noch nicht moeglich. Die Simulation selbst laeuft und ist auswertbar."
+            )
 
         simulation_requirement = project.simulation_requirement
         if not simulation_requirement:

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -404,9 +404,6 @@ class SimulationConfigGenerator:
 
         reasoning_parts.append(f"Agent config: Successfully generated {len(all_agent_configs)}")
 
-        # ========== Simulation-Floor-Check (Slice 4, Issue #496) ==========
-        self._validate_persona_quota(all_agent_configs)
-
         # ========== Skeptiker-Quote ≥20 % (Slice 5, Issue #497) ==========
         all_agent_configs = self._ensure_skeptic_quota(all_agent_configs)
 
@@ -1104,21 +1101,6 @@ Return JSON format (no markdown):
             configs.append(config)
 
         return configs
-
-    @staticmethod
-    def _validate_persona_quota(personas: List[Any]) -> None:
-        """Enforce Simulation-Floor: mindestens 30 Personas pro Run.
-
-        Override via Umgebungsvariable ``AGORA_ALLOW_SMALL_SIM=1`` für
-        Entwicklungs- und Test-Szenarien. Im Produktivbetrieb muss die
-        Mindestanzahl eingehalten werden, um statistisch belastbare
-        Simulationsergebnisse zu gewährleisten (Slice 4, Issue #496).
-        """
-        if len(personas) < 30 and os.getenv("AGORA_ALLOW_SMALL_SIM") != "1":
-            raise ValueError(
-                "Simulation-Floor: mindestens 30 Personas erforderlich "
-                "(Override via AGORA_ALLOW_SMALL_SIM=1)."
-            )
 
     @staticmethod
     def _ensure_skeptic_quota(

--- a/backend/tests/api/test_create_from_personas.py
+++ b/backend/tests/api/test_create_from_personas.py
@@ -1,0 +1,113 @@
+"""Endpunkt-Tests fuer /api/simulation/create-from-personas (Block B4).
+
+Der Weg soll einen Lauf allein aus gespeicherten Personas anlegen —
+ohne Dokument, Ontologie oder Graph. Geprueft wird hier die HTTP-Ebene:
+Eingabevalidierung, Aufloesung der Bibliotheks-Verweise und die
+Verdrahtung mit dem Vorbereitungs-Service.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from app.api import simulation_bp
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_token():
+    prev = os.environ.pop("AGORA_AUTH_TOKEN", None)
+    try:
+        yield
+    finally:
+        if prev is not None:
+            os.environ["AGORA_AUTH_TOKEN"] = prev
+
+
+def _client():
+    app = Flask(__name__)
+    app.config["AGORA_AUTH_TOKEN"] = ""
+    app.extensions = {}
+    app.register_blueprint(simulation_bp, url_prefix="/api/simulation")
+    return app.test_client()
+
+
+PERSONA = {
+    "template_id": "tpl_1",
+    "username": "sachbearbeiterin",
+    "name": "Sachbearbeiterin",
+    "persona": "Skeptisch gegenueber Reformen.",
+}
+
+
+def test_verlangt_eine_fragestellung():
+    res = _client().post("/api/simulation/create-from-personas", json={"personas": [PERSONA]})
+
+    assert res.status_code == 400
+    assert res.get_json()["success"] is False
+
+
+def test_verlangt_personas_oder_template_ids():
+    res = _client().post(
+        "/api/simulation/create-from-personas",
+        json={"simulation_requirement": "Wie reagiert die Belegschaft?"},
+    )
+
+    assert res.status_code == 400
+
+
+def test_meldet_unbekannte_template_ids_statt_leer_zu_starten():
+    # Ein Lauf ohne Personas waere sinnlos — hier muss 404 kommen,
+    # nicht ein leerer, scheinbar erfolgreicher Lauf.
+    with patch("app.api.simulation_lifecycle.PersonaLibrary") as lib:
+        lib.return_value.list_templates.return_value = [PERSONA]
+        res = _client().post(
+            "/api/simulation/create-from-personas",
+            json={"simulation_requirement": "Frage", "template_ids": ["gibt_es_nicht"]},
+        )
+
+    assert res.status_code == 404
+
+
+def test_legt_projekt_und_simulation_an_und_bereitet_vor():
+    with patch("app.api.simulation_lifecycle.PersonaLibrary") as lib, \
+         patch("app.api.simulation_lifecycle.ProjectManager") as pm, \
+         patch("app.api.simulation_lifecycle.SimulationManager") as sm, \
+         patch("app.api.simulation_lifecycle.prepare_from_personas") as prep:
+        lib.return_value.list_templates.return_value = [PERSONA]
+        pm.create_project.return_value.project_id = "proj_neu"
+        sm.return_value.create_simulation.return_value.simulation_id = "sim_neu"
+
+        res = _client().post(
+            "/api/simulation/create-from-personas",
+            json={"simulation_requirement": "Wie reagiert die Belegschaft?", "template_ids": ["tpl_1"]},
+        )
+
+    assert res.status_code == 201
+    payload = res.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["simulation_id"] == "sim_neu"
+    assert payload["data"]["project_id"] == "proj_neu"
+    assert payload["data"]["persona_count"] == 1
+
+    # Kern der Sache: die Simulation entsteht OHNE graph_id.
+    sm.return_value.create_simulation.assert_called_once_with(project_id="proj_neu", graph_id="")
+    prep.assert_called_once()
+    assert prep.call_args[0][2] == [PERSONA]
+
+
+def test_nimmt_auch_inline_personas_ohne_bibliothek():
+    with patch("app.api.simulation_lifecycle.ProjectManager") as pm, \
+         patch("app.api.simulation_lifecycle.SimulationManager") as sm, \
+         patch("app.api.simulation_lifecycle.prepare_from_personas") as prep:
+        pm.create_project.return_value.project_id = "proj_neu"
+        sm.return_value.create_simulation.return_value.simulation_id = "sim_neu"
+
+        res = _client().post(
+            "/api/simulation/create-from-personas",
+            json={"simulation_requirement": "Frage", "personas": [PERSONA]},
+        )
+
+    assert res.status_code == 201
+    assert prep.call_args[0][2] == [PERSONA]

--- a/backend/tests/api/test_create_from_personas.py
+++ b/backend/tests/api/test_create_from_personas.py
@@ -7,6 +7,7 @@ Verdrahtung mit dem Vorbereitungs-Service.
 """
 
 import os
+import pathlib
 from unittest.mock import patch
 
 import pytest
@@ -111,3 +112,17 @@ def test_nimmt_auch_inline_personas_ohne_bibliothek():
 
     assert res.status_code == 201
     assert prep.call_args[0][2] == [PERSONA]
+
+
+def test_persona_lauf_sagt_beim_bericht_klar_was_fehlt():
+    """Ein Lauf ohne Graphen kann keinen Bericht erzeugen — das muss er sagen.
+
+    Vorher stand dort „Missing graph ID", was einem Nutzer nichts sagt,
+    der nie einen Graphen bauen wollte. Ein Bericht ohne Graph-Belege
+    waere die schlechtere Alternative: er saehe aus wie ein normaler.
+    """
+    from app.services import report_generation
+
+    src = pathlib.Path(report_generation.__file__).read_text(encoding="utf-8")
+    assert "Berichte stuetzen sich auf" in src
+    assert "Missing graph ID, please ensure graph is built" not in src

--- a/backend/tests/scripts/test_run_simulation_default_floor.py
+++ b/backend/tests/scripts/test_run_simulation_default_floor.py
@@ -1,15 +1,18 @@
 """
-Slice 4 — Simulation-Floor-Tests (Issue #496).
+Argparse-Defaults der Simulations-Skripte (urspruenglich Issue #496).
 
-Kein Subprocess-Spawn. Argparse-Defaults werden via Regex aus den
-Script-Source-Dateien verifiziert; _validate_persona_quota wird direkt
-als Unit-Test aufgerufen.
+Kein Subprocess-Spawn: die Defaults werden per Regex aus den
+Script-Quelldateien gelesen.
+
+Die Unit-Tests zu ``_validate_persona_quota`` sind mit der Methode
+entfallen (Block B4): die harte Untergrenze von 30 Personas gibt es
+nicht mehr. ``--num-agents=30`` bleibt als VORSCHLAGSWERT bestehen —
+ein Default ist keine Schranke, und genau das pruefen die Tests hier.
 """
 
 import re
 from pathlib import Path
 
-import pytest
 
 # ---------------------------------------------------------------------------
 # Pfade
@@ -112,47 +115,3 @@ class TestArgparseDefaults:
         )
         val = _extract_default_from_sim_common("--num-rounds")
         assert val == 10
-
-
-# ---------------------------------------------------------------------------
-# Tests: _validate_persona_quota
-# ---------------------------------------------------------------------------
-
-
-class TestValidatePersonaQuota:
-    """Unit-Tests für SimulationConfigGenerator._validate_persona_quota."""
-
-    @pytest.fixture(autouse=True)
-    def _import_validator(self):
-        from app.services.simulation_config_generator import SimulationConfigGenerator  # noqa: PLC0415
-        self.validate = SimulationConfigGenerator._validate_persona_quota
-
-    def test_raises_for_25_personas_without_env_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("AGORA_ALLOW_SMALL_SIM", raising=False)
-        personas = list(range(25))
-        with pytest.raises(ValueError, match="Simulation-Floor"):
-            self.validate(personas)
-
-    def test_passes_for_25_personas_with_env_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "1")
-        personas = list(range(25))
-        # Darf keine Exception werfen.
-        self.validate(personas)
-
-    def test_passes_for_exactly_30_personas(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("AGORA_ALLOW_SMALL_SIM", raising=False)
-        personas = list(range(30))
-        self.validate(personas)  # kein Raise erwartet
-
-    def test_passes_for_more_than_30_personas(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("AGORA_ALLOW_SMALL_SIM", raising=False)
-        personas = list(range(50))
-        self.validate(personas)  # kein Raise erwartet

--- a/backend/tests/services/test_agents_per_batch.py
+++ b/backend/tests/services/test_agents_per_batch.py
@@ -131,8 +131,6 @@ class TestBatchingMath:
         Produktionsschleife gekoppelt, nicht an eine lokale Kopie der Formel.
         """
         monkeypatch.setenv("AGORA_AGENTS_PER_BATCH", "5")
-        # Floor-Check (>=30 Personas) ist hier nicht relevant — wir patchen ihn
-        # auf einen No-op, statt ``AGORA_ALLOW_SMALL_SIM`` global zu setzen.
         captured: list[list[EntityNode]] = []
 
         def fake_batch(self, context, entities, start_idx, simulation_requirement):  # type: ignore[no-untyped-def]  # noqa: ARG001
@@ -165,11 +163,6 @@ class TestBatchingMath:
                 "_generate_agent_configs_batch",
                 autospec=True,
                 side_effect=fake_batch,
-            ),
-            patch.object(
-                SimulationConfigGenerator,
-                "_validate_persona_quota",
-                staticmethod(lambda personas: None),
             ),
             patch.object(
                 SimulationConfigGenerator,

--- a/backend/tests/services/test_persona_prepare_service.py
+++ b/backend/tests/services/test_persona_prepare_service.py
@@ -1,0 +1,224 @@
+"""Tests für ``persona_prepare_service.prepare_from_personas``.
+
+Deckt das ZIEL "Simulation allein aus gespeicherten Personas vorbereiten"
+ab: kein Dokument, keine Ontologie, kein Graph. Fixture-Muster (isoliertes
+tmp-Datenverzeichnis, ``InMemoryArtifactStore``, tmp-``RunRegistry``) folgt
+``tests/contracts/test_branch_override_contract.py``, das dieselbe
+FSM-Vorlage (``CREATED -> PREPARING -> READY``) testet.
+
+Kein Neo4j-Zugriff: ``SimulationManager`` wird mit ``InMemoryArtifactStore``
+konstruiert, keine Route greift auf ``neo4j_storage`` oder einen echten
+Graphen zu.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+
+import pytest
+
+from app.services import persona_prepare_service
+from app.services.artifact_store import InMemoryArtifactStore
+from app.services.run_registry import RunRegistry
+from app.services.simulation_manager import SimulationManager, SimulationStatus
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch) -> SimulationManager:
+    """Manager mit isoliertem Datenverzeichnis, In-Memory-Store, tmp-RunRegistry."""
+    monkeypatch.setattr(
+        SimulationManager, "SIMULATION_DATA_DIR", str(tmp_path / "simulations")
+    )
+    registry_dir = str(tmp_path / "run_registry")
+    monkeypatch.setattr(RunRegistry, "REGISTRY_DIR", registry_dir)
+    RunRegistry._instance = None
+    os.makedirs(registry_dir, exist_ok=True)
+    yield SimulationManager(store=InMemoryArtifactStore())
+    RunRegistry._instance = None
+
+
+@pytest.fixture
+def created_id(manager: SimulationManager) -> str:
+    """Eine frisch angelegte Simulation ohne echten Graphen (``graph_id=""``).
+
+    Die Simulation hat keine echte Wissensgraph-Anbindung — ``graph_id`` wird
+    hier bewusst leer gelassen und von ``prepare_from_personas`` unverändert
+    durchgereicht, statt einen künstlichen Wert zu erfinden.
+    """
+    state = manager.create_simulation(project_id="proj-1", graph_id="")
+    return state.simulation_id
+
+
+MINIMAL_PERSONA = {"username": "alice", "name": "Alice"}
+
+
+class TestSuccessfulPrepare:
+    def test_reaches_ready(self, manager: SimulationManager, created_id: str) -> None:
+        state = persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        assert state.status == SimulationStatus.READY
+
+    def test_persisted_state_is_ready(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        reloaded = manager.get_simulation(created_id)
+        assert reloaded is not None
+        assert reloaded.status == SimulationStatus.READY
+
+    def test_counters_and_config_generated_are_set(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        state = persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA, {"username": "bob"}]
+        )
+        assert state.entities_count == 2
+        assert state.profiles_count == 2
+        assert state.config_generated is True
+
+    def test_simulation_config_is_written_and_readable(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        config = manager._store.read_json(created_id, "simulation_config", default=None)
+        assert config is not None
+        assert config["simulation_id"] == created_id
+        # Keine echte Simulation hat einen Graphen — graph_id bleibt, was die
+        # Simulation beim Anlegen mitbekommen hat (hier: "").
+        assert config["graph_id"] == ""
+
+    def test_twitter_csv_written_alongside_reddit_json(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        sim_dir = manager._get_simulation_dir(created_id)
+        csv_path = os.path.join(sim_dir, "twitter_profiles.csv")
+        assert os.path.exists(csv_path)
+        with open(csv_path, "r", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        assert len(rows) == 1
+        assert rows[0]["username"] == "alice"
+
+    def test_run_registry_gets_completed_prepare_run(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        runs = RunRegistry().list_runs(entity_id=created_id)
+        assert len(runs) == 1
+        assert runs[0]["run_type"] == "simulation_prepare"
+        assert runs[0]["status"] == "completed"
+
+
+class TestFieldGapsAreFilled:
+    """Ein Bibliothekseintrag ohne age/gender/mbti/persona_kind darf die
+    geschriebene Profildatei trotzdem nicht ohne diese Keys verlassen —
+    OASIS indiziert ``agent_info[i]["mbti"]``/["age"]/["gender"] ungeschützt.
+    """
+
+    SPARSE_PERSONA = {"username": "sparse_carol"}
+
+    def test_reddit_profile_has_all_required_keys(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [self.SPARSE_PERSONA]
+        )
+        profiles = manager._store.read_json(created_id, "reddit_profiles", default=[])
+        assert len(profiles) == 1
+        profile = profiles[0]
+        for key in ("user_id", "age", "gender", "mbti", "persona_kind", "karma", "created_at"):
+            assert key in profile, f"Feld {key!r} fehlt im geschriebenen Profil"
+
+    def test_gap_filled_fields_have_safe_defaults(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [self.SPARSE_PERSONA]
+        )
+        profile = manager._store.read_json(created_id, "reddit_profiles", default=[])[0]
+        assert profile["user_id"] == 1
+        assert isinstance(profile["user_id"], int)
+        assert profile["age"] == ""
+        assert profile["mbti"] == ""
+        assert profile["persona_kind"] == "individual"
+        assert isinstance(profile["karma"], int)
+
+    def test_populated_fields_are_kept_as_is(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        rich_persona = {
+            "username": "rich_dave",
+            "age": 42,
+            "gender": "male",
+            "mbti": "INTJ",
+            "persona_kind": "collective",
+            "karma": 555,
+        }
+        persona_prepare_service.prepare_from_personas(manager, created_id, [rich_persona])
+        profile = manager._store.read_json(created_id, "reddit_profiles", default=[])[0]
+        assert profile["age"] == 42
+        assert profile["gender"] == "male"
+        assert profile["mbti"] == "INTJ"
+        assert profile["persona_kind"] == "collective"
+        assert profile["karma"] == 555
+
+    def test_duplicate_usernames_are_deduplicated(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        """Dedupe ist case-insensitiv (Vergleich), der Suffix behält aber die
+        Original-Schreibweise des zweiten Eintrags — gleiches Verhalten wie
+        ``add_simulation_profile``."""
+        persona_prepare_service.prepare_from_personas(
+            manager,
+            created_id,
+            [{"username": "eve"}, {"username": "Eve"}],
+        )
+        profiles = manager._store.read_json(created_id, "reddit_profiles", default=[])
+        usernames = {p["username"] for p in profiles}
+        assert usernames == {"eve", "Eve_1"}
+
+
+class TestEmptyPersonaListFails:
+    def test_raises_value_error(self, manager: SimulationManager, created_id: str) -> None:
+        with pytest.raises(ValueError, match="personas darf nicht leer sein"):
+            persona_prepare_service.prepare_from_personas(manager, created_id, [])
+
+    def test_does_not_change_simulation_status(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        with pytest.raises(ValueError):
+            persona_prepare_service.prepare_from_personas(manager, created_id, [])
+        state = manager.get_simulation(created_id)
+        assert state is not None
+        assert state.status == SimulationStatus.CREATED
+
+
+class TestGuardsAroundStatusAndExistence:
+    def test_unknown_simulation_id_raises(self, manager: SimulationManager) -> None:
+        with pytest.raises(ValueError, match="does not exist"):
+            persona_prepare_service.prepare_from_personas(
+                manager, "sim_does_not_exist", [MINIMAL_PERSONA]
+            )
+
+    def test_non_created_status_is_rejected(
+        self, manager: SimulationManager, created_id: str
+    ) -> None:
+        persona_prepare_service.prepare_from_personas(
+            manager, created_id, [MINIMAL_PERSONA]
+        )
+        # Simulation ist jetzt READY — ein zweiter Aufruf darf nicht
+        # stillschweigend erneut vorbereiten.
+        with pytest.raises(ValueError, match="CREATED"):
+            persona_prepare_service.prepare_from_personas(
+                manager, created_id, [MINIMAL_PERSONA]
+            )

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -23,33 +23,14 @@ from app.api.status import (
 class TestStatusFunctions:
     """Test suite for status helper functions"""
 
-    def test_get_backend_status(self, monkeypatch):
+    def test_get_backend_status(self):
         """Test backend status returns correct version and ok=true."""
-        # ENV-Drift aus dem lokalen .env-File abklemmen, damit die Assertion
-        # gegen den Default deterministisch bleibt.
-        monkeypatch.delenv("AGORA_ALLOW_SMALL_SIM", raising=False)
         result = _get_backend_status()
         assert result['ok'] is True
         assert result['version'] == __version__
-        # Slice "small-sim-floor-frontend-sync": default ohne ENV-Override ist
-        # der 30-Personas-Floor scharf, also allow_small_sim=False.
-        assert result['allow_small_sim'] is False
-
-    def test_get_backend_status_reflects_allow_small_sim_env(self, monkeypatch):
-        """Backend exponiert AGORA_ALLOW_SMALL_SIM=1 als allow_small_sim=True."""
-        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "1")
-        assert _get_backend_status()['allow_small_sim'] is True
-
-        # Andere Werte (z. B. "0", "true", leer, gepaddetes "1") zaehlen NICHT
-        # als aktiviert — Backend-Validator (simulation_config_generator.
-        # _validate_persona_quota) vergleicht ebenfalls strict gegen "1" ohne
-        # strip, der Status-Endpoint muss exakt das gleiche Bit liefern.
-        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "true")
-        assert _get_backend_status()['allow_small_sim'] is False
-        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", "0")
-        assert _get_backend_status()['allow_small_sim'] is False
-        monkeypatch.setenv("AGORA_ALLOW_SMALL_SIM", " 1 ")
-        assert _get_backend_status()['allow_small_sim'] is False
+        # allow_small_sim ist entfallen: es gibt keine harte Untergrenze
+        # von 30 Personas mehr, die ein Schalter aufheben muesste (B4).
+        assert 'allow_small_sim' not in result
 
     def test_get_e2e_status_defaults_to_inactive(self, monkeypatch):
         """Ohne AGORA_E2E_LLM_MODE ist der Stub aus — Normalfall in Produktion."""

--- a/changelog.d/1374-persona-laeufe-ohne-graph.md
+++ b/changelog.d/1374-persona-laeufe-ohne-graph.md
@@ -1,0 +1,12 @@
+### Added (Läufe allein aus gespeicherten Personas, 2026-08-19)
+
+- **`POST /api/simulation/create-from-personas`** legt Projekt und Simulation an und bereitet sie ausschließlich aus Personas vor — Verweise in die Bibliothek (`template_ids`) oder Inline-Personas. Kein Dokument, keine Ontologie, kein Graph. Bewusst ein eigener Endpunkt: in `/create` bleibt die `graph_id` Pflicht, der reguläre Weg über Dokument und Graph weicht nicht auf.
+- **`prepare_from_personas`** fährt denselben FSM-Pfad wie `branching_service.create_branch` (`CREATED → PREPARING → READY`, kein Direktsprung) und schreibt `reddit_profiles.json`/`twitter_profiles.csv` sowie eine `simulation_config.json`. Beim Übersetzen der Bibliothekseinträge werden Felder ergänzt, die die Bibliothek gar nicht führt: `user_id`, `karma`, `created_at` (auf das Tagesformat normiert), `persona_kind` — und vor allem `age`/`gender`/`mbti`, die **immer** existieren müssen, weil die OASIS-Bibliothek sie ungeschützt indiziert. `PersonaLibrary._normalize` lässt leere Werte weg, ein Eintrag ohne Alter hat den Schlüssel also gar nicht.
+
+### Changed
+
+- **Die harte Untergrenze von 30 Personas ist entfallen** (`_validate_persona_quota` im `simulation_config_generator`, Issue #496). Sie stand genau dem im Weg, wofür der neue Weg gedacht ist: einem kleinen, gezielten Lauf — einem Gremium aus acht Leuten etwa. 30 bleibt der Vorschlagswert im Dashboard, ist aber keine Schranke mehr; unterhalb erscheint ein Hinweis auf die dünnere Aussagekraft statt einer Sperre. Mit der Grenze fällt auch der Schalter, der sie aufhob: `AGORA_ALLOW_SMALL_SIM` und das gespiegelte `allow_small_sim` in `/api/status` sind entfernt, ebenso die Abfrage im Dashboard, die den Regler beim Mount wieder hochklemmte.
+
+### Fixed
+
+- **Berichte sagen jetzt, was einem Persona-Lauf fehlt.** Die drei Prüfpunkte (`report_generation.py`, `report.py`, `runs.py`) antworteten mit „Missing graph ID" — einem Satz, der jemandem nichts sagt, der nie einen Graphen bauen wollte. Sie nennen jetzt den Grund und halten fest, dass die Simulation selbst in Ordnung ist. Bewusst **kein** Platzhalter-Graph: ein formal gültiger Fake würde die Prüfungen passieren lassen, und der Bericht liefe ohne jede Graph-Evidenz durch — er sähe aus wie ein normaler. Ein klarer Abbruch ist ehrlicher.

--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -611,6 +611,18 @@ export const deletePersonaTemplate = (templateId: string): Promise<unknown> => {
  * (siehe api/index.ts) — der Typ sagt das jetzt auch. Vorher stand hier
  * `Promise<BranchRecord>`, und jeder Aufrufer musste das wegcasten.
  */
+/**
+ * POST /api/simulation/create-from-personas — Lauf allein aus
+ * gespeicherten Personas (Block B4). Kein Dokument, kein Graph.
+ */
+export const createSimulationFromPersonas = (data: {
+  simulation_requirement: string
+  template_ids?: string[]
+  personas?: Record<string, unknown>[]
+}): Promise<ApiEnvelope<{ simulation_id: string; project_id: string; persona_count: number }>> => {
+  return service.post('/api/simulation/create-from-personas', data)
+}
+
 export const createSimulationBranch = (
   simulationId: string,
   data: BranchData

--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -133,10 +133,24 @@ export interface BranchData {
   [key: string]: unknown
 }
 
+/**
+ * Ein Branch IST eine Simulation — der Endpunkt gibt
+ * `SimulationState.to_dict()` zurueck (backend/app/api/simulation_profiles.py:65
+ * ueber `json_success`, Felder in `services/simulation_manager.py:94`).
+ * Die frueheren Felder `branch_id`/`parent_simulation_id` existierten dort
+ * nie; die Herkunft steht in `source_simulation_id`/`root_simulation_id`.
+ */
 export interface BranchRecord {
-  branch_id: string
-  branch_name: string
-  parent_simulation_id: string
+  simulation_id: string
+  project_id: string
+  graph_id: string
+  status: string
+  branch_name: string | null
+  source_simulation_id: string | null
+  root_simulation_id: string | null
+  profiles_count: number
+  created_at?: string
+  updated_at?: string
   [key: string]: unknown
 }
 
@@ -591,13 +605,21 @@ export const deletePersonaTemplate = (templateId: string): Promise<unknown> => {
   return service.delete(`/api/simulation/persona-library/${encodeURIComponent(templateId)}`)
 }
 
+/**
+ * POST /api/simulation/<id>/branch — Simulation aus einer bestehenden
+ * ableiten. Der Interceptor gibt die Envelope zurueck, nicht ihr `data`
+ * (siehe api/index.ts) — der Typ sagt das jetzt auch. Vorher stand hier
+ * `Promise<BranchRecord>`, und jeder Aufrufer musste das wegcasten.
+ */
 export const createSimulationBranch = (
   simulationId: string,
   data: BranchData
-): Promise<BranchRecord> => {
+): Promise<ApiEnvelope<BranchRecord>> => {
   return service.post(`/api/simulation/${simulationId}/branch`, data)
 }
 
-export const listSimulationBranches = (simulationId: string): Promise<BranchRecord[]> => {
+export const listSimulationBranches = (
+  simulationId: string
+): Promise<ApiEnvelope<BranchRecord[]>> => {
   return service.get(`/api/simulation/${simulationId}/branches`)
 }

--- a/frontend/src/components/shell/Dossier.vue
+++ b/frontend/src/components/shell/Dossier.vue
@@ -33,6 +33,19 @@
                Personas des Vorlaufs bleiben, die Auswertung wird neu.
                Der Weg existierte laengst, lag aber im vierten Schritt
                der alten Prozesskette und war praktisch unauffindbar. -->
+          <!-- Ein Personasatz ist damit nicht nur Archivgut: aus ihm
+               laesst sich direkt ein Lauf starten — ohne Dokument,
+               ohne Graph (Block B4). -->
+          <button
+            v-if="props.object.kind === 'personasatz'"
+            type="button"
+            class="dossier__btn dossier__btn--primary"
+            :data-testid="DossierTestId.startFromPersona"
+            :disabled="startBusy"
+            @click="onStartFromPersona"
+          >
+            {{ t('shelf.dossier.startFromPersona') }}
+          </button>
           <button
             v-if="canDerive"
             type="button"
@@ -98,6 +111,7 @@ import { SHELF_KIND_TAG, type ShelfObject } from '../../types/shelf'
 import { useCancelAction } from './useCancelAction'
 import { useObjectDetail } from '../../composables/useObjectDetail'
 import { useDeriveSimulation } from '../../composables/useDeriveSimulation'
+import { createSimulationFromPersonas } from '../../api/simulation'
 
 /**
  * Dossier.vue — rechte Spalte (Block B3).
@@ -122,12 +136,33 @@ const { detail } = useObjectDetail(
 )
 
 const { busy: deriveBusy, derive } = useDeriveSimulation()
+const startBusy = ref(false)
 const deriveError = ref('')
 
 /** Ableiten gibt es nur beim Bericht, und nur wenn seine Simulation bekannt ist. */
 const canDerive = computed(
   () => props.object?.kind === 'bericht' && Boolean(props.object.simulationId),
 )
+
+async function onStartFromPersona(): Promise<void> {
+  const obj = props.object
+  if (!obj || obj.kind !== 'personasatz') return
+  deriveError.value = ''
+  startBusy.value = true
+  try {
+    const res = await createSimulationFromPersonas({
+      simulation_requirement: t('shelf.dossier.startName', { title: obj.title }),
+      template_ids: [obj.id],
+    })
+    const simId = res?.success ? res.data?.simulation_id : undefined
+    if (simId) router.push({ name: 'StepEnvSetup', params: { projectId: simId } })
+    else deriveError.value = t('shelf.dossier.startFailed')
+  } catch (err) {
+    deriveError.value = (err as Error).message || t('shelf.dossier.startFailed')
+  } finally {
+    startBusy.value = false
+  }
+}
 
 async function onDerive(): Promise<void> {
   const obj = props.object

--- a/frontend/src/components/shell/Dossier.vue
+++ b/frontend/src/components/shell/Dossier.vue
@@ -29,6 +29,20 @@
               {{ props.object.active.status === 'paused' ? t('shelf.resume') : t('shelf.pause') }}
             </button>
           </template>
+          <!-- Aus einem Bericht laesst sich ein neuer Lauf ableiten: die
+               Personas des Vorlaufs bleiben, die Auswertung wird neu.
+               Der Weg existierte laengst, lag aber im vierten Schritt
+               der alten Prozesskette und war praktisch unauffindbar. -->
+          <button
+            v-if="canDerive"
+            type="button"
+            class="dossier__btn dossier__btn--ghost"
+            :data-testid="DossierTestId.derive"
+            :disabled="deriveBusy"
+            @click="onDerive"
+          >
+            {{ t('shelf.dossier.derive') }}
+          </button>
           <button
             v-if="props.object.nextAction"
             type="button"
@@ -40,6 +54,8 @@
           </button>
         </div>
       </div>
+
+      <p v-if="deriveError" class="dossier__error" role="alert">{{ deriveError }}</p>
 
       <div class="dossier__kpis" :data-testid="DossierTestId.kpis">
         <div class="dossier__kpi">
@@ -74,13 +90,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { DossierTestId } from '../../contracts/testIds'
 import { SHELF_KIND_TAG, type ShelfObject } from '../../types/shelf'
 import { useCancelAction } from './useCancelAction'
 import { useObjectDetail } from '../../composables/useObjectDetail'
+import { useDeriveSimulation } from '../../composables/useDeriveSimulation'
 
 /**
  * Dossier.vue — rechte Spalte (Block B3).
@@ -103,6 +120,26 @@ const { detail } = useObjectDetail(
   computed(() => props.object),
   t,
 )
+
+const { busy: deriveBusy, derive } = useDeriveSimulation()
+const deriveError = ref('')
+
+/** Ableiten gibt es nur beim Bericht, und nur wenn seine Simulation bekannt ist. */
+const canDerive = computed(
+  () => props.object?.kind === 'bericht' && Boolean(props.object.simulationId),
+)
+
+async function onDerive(): Promise<void> {
+  const obj = props.object
+  if (!obj?.simulationId) return
+  deriveError.value = ''
+  const res = await derive(obj.simulationId, t('shelf.dossier.deriveName', { title: obj.title }))
+  if (res) {
+    router.push({ name: 'StepEnvSetup', params: { projectId: res.simulationId } })
+  } else {
+    deriveError.value = t('shelf.dossier.deriveFailed')
+  }
+}
 
 function openFull(): void {
   if (!props.object?.nextAction) return
@@ -320,5 +357,14 @@ function formatUpdatedAt(iso: string): string {
   font-size: var(--fs-footnote);
   line-height: var(--lh-footnote);
   color: var(--text-tertiary);
+}
+
+.dossier__error {
+  margin: var(--sp-3) 0 0;
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-3);
+  background: var(--status-red-bg);
+  color: var(--status-red);
+  font-size: var(--fs-footnote);
 }
 </style>

--- a/frontend/src/components/shell/Shelf.vue
+++ b/frontend/src/components/shell/Shelf.vue
@@ -23,7 +23,8 @@
 
     <div class="shelf__body">
       <!-- Filter „Alle Jobs" (Q19c): schlichte Mono-Tabelle aus der Rohebene. -->
-      <table v-if="props.shelf.filter.value === 'jobs'" class="shelf__jobs-table" :data-testid="ShelfTestId.jobsTable">
+      <div v-if="props.shelf.filter.value === 'jobs'" class="shelf__jobs-scroll">
+      <table class="shelf__jobs-table" :data-testid="ShelfTestId.jobsTable">
         <thead>
           <tr>
             <th>{{ t('shelf.filter.jobs') }}</th>
@@ -41,6 +42,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
 
       <template v-else>
         <p v-if="props.shelf.loading.value && visibleRows.length === 0" class="shelf__loading">{{ t('common.loading') }}</p>
@@ -512,8 +514,17 @@ function onRowKeydown(e: KeyboardEvent, index: number): void {
   outline-offset: 2px;
 }
 
+/* Die Rohebene ist breiter als ein Telefon. Sie scrollt in ihrem
+   eigenen Kasten — das Dokument selbst darf nie horizontal scrollen
+   (harte Vorgabe des Accessibility-Gates bei 320px). */
+.shelf__jobs-scroll {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
 .shelf__jobs-table {
   width: 100%;
+  min-width: 480px;
   border-collapse: collapse;
   font-family: var(--font-mono);
   font-size: 11px;

--- a/frontend/src/components/shell/ShellRoot.vue
+++ b/frontend/src/components/shell/ShellRoot.vue
@@ -13,9 +13,14 @@
 
       <ActivityIndicator :objects="props.activeObjects" @select="(target) => emit('select', target)" />
 
+      <!-- Auf dem Telefon gibt es keine Tastenkombination auszuloesen.
+           Der Knopf verschwindet deshalb aus dem Markup, statt nur
+           unsichtbar zu sein — sonst bliebe er ein Tab-Stop ins Leere. -->
       <button
+        v-if="!isMobile"
         type="button"
         class="shell-root__cmdk"
+        :data-testid="ShellTestId.cmdkTrigger"
         :aria-label="t('cmd.trigger')"
         :title="t('cmd.trigger')"
         @click="openPalette"
@@ -29,10 +34,18 @@
     </header>
 
     <main class="shell-root__main">
-      <div class="shell-root__panel shell-root__panel--shelf" :data-hidden-narrow="hasSelection ? 'true' : 'false'">
+      <div
+        class="shell-root__panel shell-root__panel--shelf"
+        :data-testid="ShellTestId.panelShelf"
+        :data-hidden-narrow="hasSelection ? 'true' : 'false'"
+      >
         <slot name="shelf" />
       </div>
-      <div class="shell-root__panel shell-root__panel--dossier" :data-hidden-narrow="hasSelection ? 'false' : 'true'">
+      <div
+        class="shell-root__panel shell-root__panel--dossier"
+        :data-testid="ShellTestId.panelDossier"
+        :data-hidden-narrow="hasSelection ? 'false' : 'true'"
+      >
         <slot name="dossier" />
       </div>
     </main>
@@ -67,6 +80,7 @@ import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch 
 import { useI18n } from 'vue-i18n'
 import { ShellTestId } from '../../contracts/testIds'
 import UserMenu from './UserMenu.vue'
+import { useIsMobile } from '../../composables/useIsMobile'
 import type { ShelfObject, ShelfObjectKind } from '../../types/shelf'
 import { useCommandPalette } from '../../composables/useCommandPalette'
 import Stack from './Stack.vue'
@@ -102,6 +116,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const cancelAction = useCancelAction()
+const { isMobile } = useIsMobile()
 const { isOpen: isPaletteOpen, open: openPalette } = useCommandPalette()
 const wasPaletteOpened = ref(false)
 
@@ -138,6 +153,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeyDown))
 }
 
 .shell-root__topbar {
+  /* 46px ist ein Maus-Mass. Auf Touch waechst die Leiste mit, sonst
+     stehen 44px-Ziele in einer 46px-Zeile ohne Luft. */
   height: 46px;
   flex-shrink: 0;
   display: flex;
@@ -274,6 +291,34 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeyDown))
   }
   .shell-root__panel--shelf {
     border-right: 0;
+  }
+}
+
+@media (pointer: coarse) {
+  .shell-root__topbar {
+    height: 56px;
+  }
+}
+
+/* Telefon (< 768px, SSoT constants/breakpoints.ts): die Kopfzeile
+   traegt nur noch, was dort auch etwas tut. Die Wortmarke schrumpft auf
+   ihren Punkt — der Name kostet Platz, den Stapel und Aktivitaet
+   dringender brauchen; der ⌘K-Knopf ist bereits aus dem Markup. */
+@media (max-width: 767px) {
+  .shell-root__topbar {
+    padding-left: var(--sp-3);
+    padding-right: var(--sp-3);
+    gap: var(--sp-2);
+  }
+  .shell-root__brand-name,
+  .shell-root__divider {
+    display: none;
+  }
+  .shell-root__toast {
+    left: var(--sp-3);
+    right: var(--sp-3);
+    transform: none;
+    justify-content: space-between;
   }
 }
 

--- a/frontend/src/components/shell/__tests__/Dossier.spec.ts
+++ b/frontend/src/components/shell/__tests__/Dossier.spec.ts
@@ -26,9 +26,11 @@ vi.mock('../../../api/runs', () => ({
 vi.mock('../../../api/simulation', () => ({
   pauseSimulation: vi.fn().mockResolvedValue({}),
   resumeSimulation: vi.fn().mockResolvedValue({}),
+  createSimulationBranch: vi.fn(),
+  listPersonaTemplates: vi.fn().mockResolvedValue({ success: true, data: { count: 0, templates: [] } }),
 }))
 
-import { pauseSimulation, resumeSimulation } from '../../../api/simulation'
+import { pauseSimulation, resumeSimulation, createSimulationBranch } from '../../../api/simulation'
 import { useCancelAction } from '../useCancelAction'
 import Dossier from '../Dossier.vue'
 
@@ -36,7 +38,10 @@ const i18n = createI18n({ legacy: false, locale: 'de', fallbackLocale: 'en', mes
 
 const router = createRouter({
   history: createMemoryHistory(),
-  routes: [{ path: '/runs/:id', name: 'RunDetail', component: { template: '<div/>' } }],
+  routes: [
+    { path: '/runs/:id', name: 'RunDetail', component: { template: '<div/>' } },
+    { path: '/v4/env-setup/:projectId', name: 'StepEnvSetup', component: { template: '<div/>' } },
+  ],
 })
 
 function makeObject(overrides: Partial<ShelfObject> = {}): ShelfObject {
@@ -121,5 +126,46 @@ describe('Dossier', () => {
 
     expect(router.currentRoute.value.name).toBe('RunDetail')
     expect(router.currentRoute.value.params.id).toBe('run_1')
+  })
+})
+
+describe('Dossier — Lauf aus einem Bericht ableiten (Block B4)', () => {
+  it('bietet das Ableiten nur beim Bericht mit bekannter Simulation an', () => {
+    const ohne = mountDossier(makeObject({ kind: 'bericht', simulationId: null }))
+    expect(ohne.find(`[data-testid="${DossierTestId.derive}"]`).exists()).toBe(false)
+
+    const lauf = mountDossier(makeObject({ kind: 'lauf', simulationId: 'sim_1' }))
+    expect(lauf.find(`[data-testid="${DossierTestId.derive}"]`).exists()).toBe(false)
+
+    const bericht = mountDossier(makeObject({ kind: 'bericht', simulationId: 'sim_1' }))
+    expect(bericht.find(`[data-testid="${DossierTestId.derive}"]`).exists()).toBe(true)
+  })
+
+  it('leitet ab und fuehrt zum neuen Lauf', async () => {
+    vi.mocked(createSimulationBranch).mockResolvedValue({
+      success: true,
+      data: { simulation_id: 'sim_neu' },
+    } as never)
+
+    const w = mountDossier(makeObject({ kind: 'bericht', simulationId: 'sim_alt' }))
+    await w.find(`[data-testid="${DossierTestId.derive}"]`).trigger('click')
+    await flushPromises()
+
+    expect(createSimulationBranch).toHaveBeenCalledWith(
+      'sim_alt',
+      expect.objectContaining({ copy_profiles: true, copy_report_artifacts: false }),
+    )
+    expect(router.currentRoute.value.name).toBe('StepEnvSetup')
+    expect(router.currentRoute.value.params.projectId).toBe('sim_neu')
+  })
+
+  it('sagt es, wenn das Ableiten scheitert, statt still nichts zu tun', async () => {
+    vi.mocked(createSimulationBranch).mockRejectedValue(new Error('kaputt'))
+
+    const w = mountDossier(makeObject({ kind: 'bericht', simulationId: 'sim_alt' }))
+    await w.find(`[data-testid="${DossierTestId.derive}"]`).trigger('click')
+    await flushPromises()
+
+    expect(w.find('[role="alert"]').exists()).toBe(true)
   })
 })

--- a/frontend/src/components/shell/__tests__/Dossier.spec.ts
+++ b/frontend/src/components/shell/__tests__/Dossier.spec.ts
@@ -27,10 +27,11 @@ vi.mock('../../../api/simulation', () => ({
   pauseSimulation: vi.fn().mockResolvedValue({}),
   resumeSimulation: vi.fn().mockResolvedValue({}),
   createSimulationBranch: vi.fn(),
+  createSimulationFromPersonas: vi.fn(),
   listPersonaTemplates: vi.fn().mockResolvedValue({ success: true, data: { count: 0, templates: [] } }),
 }))
 
-import { pauseSimulation, resumeSimulation, createSimulationBranch } from '../../../api/simulation'
+import { pauseSimulation, resumeSimulation, createSimulationBranch, createSimulationFromPersonas } from '../../../api/simulation'
 import { useCancelAction } from '../useCancelAction'
 import Dossier from '../Dossier.vue'
 
@@ -164,6 +165,43 @@ describe('Dossier — Lauf aus einem Bericht ableiten (Block B4)', () => {
 
     const w = mountDossier(makeObject({ kind: 'bericht', simulationId: 'sim_alt' }))
     await w.find(`[data-testid="${DossierTestId.derive}"]`).trigger('click')
+    await flushPromises()
+
+    expect(w.find('[role="alert"]').exists()).toBe(true)
+  })
+})
+
+describe('Dossier — Lauf aus einem Personasatz starten (Block B4)', () => {
+  it('bietet den Start nur beim Personasatz an', () => {
+    const bericht = mountDossier(makeObject({ kind: 'bericht', simulationId: 'sim_1' }))
+    expect(bericht.find(`[data-testid="${DossierTestId.startFromPersona}"]`).exists()).toBe(false)
+
+    const satz = mountDossier(makeObject({ kind: 'personasatz', id: 'tpl_1' }))
+    expect(satz.find(`[data-testid="${DossierTestId.startFromPersona}"]`).exists()).toBe(true)
+  })
+
+  it('legt den Lauf mit genau diesem Satz an und fuehrt hin', async () => {
+    vi.mocked(createSimulationFromPersonas).mockResolvedValue({
+      success: true,
+      data: { simulation_id: 'sim_neu', project_id: 'proj_neu', persona_count: 1 },
+    } as never)
+
+    const w = mountDossier(makeObject({ kind: 'personasatz', id: 'tpl_1', title: 'Sachbearbeiterin' }))
+    await w.find(`[data-testid="${DossierTestId.startFromPersona}"]`).trigger('click')
+    await flushPromises()
+
+    expect(createSimulationFromPersonas).toHaveBeenCalledWith(
+      expect.objectContaining({ template_ids: ['tpl_1'] }),
+    )
+    expect(router.currentRoute.value.name).toBe('StepEnvSetup')
+    expect(router.currentRoute.value.params.projectId).toBe('sim_neu')
+  })
+
+  it('meldet einen Fehlschlag sichtbar', async () => {
+    vi.mocked(createSimulationFromPersonas).mockRejectedValue(new Error('kaputt'))
+
+    const w = mountDossier(makeObject({ kind: 'personasatz', id: 'tpl_1' }))
+    await w.find(`[data-testid="${DossierTestId.startFromPersona}"]`).trigger('click')
     await flushPromises()
 
     expect(w.find('[role="alert"]').exists()).toBe(true)

--- a/frontend/src/components/shell/__tests__/ShellRoot.spec.ts
+++ b/frontend/src/components/shell/__tests__/ShellRoot.spec.ts
@@ -144,3 +144,57 @@ describe('ShellRoot', () => {
     expect(cancelRun).not.toHaveBeenCalled()
   })
 })
+
+describe('ShellRoot auf schmalen Geraeten (Block B4)', () => {
+  function setViewport(schmal: boolean) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockReturnValue({
+        matches: schmal,
+        media: '',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    })
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', { writable: true, configurable: true, value: undefined })
+  })
+
+  it('zeigt den Tastenkuerzel-Knopf auf breiten Geraeten', () => {
+    setViewport(false)
+    const w = mountShell()
+    expect(w.find(`[data-testid="${ShellTestId.cmdkTrigger}"]`).exists()).toBe(true)
+  })
+
+  it('nimmt ihn auf dem Telefon ganz aus dem Markup, nicht nur aus der Sicht', () => {
+    // Nur zu verstecken reicht nicht: ein display:none-Knopf bliebe ein
+    // Tab-Stop und wuerde vorgelesen, obwohl er dort nichts ausloest.
+    setViewport(true)
+    const w = mountShell()
+    expect(w.find(`[data-testid="${ShellTestId.cmdkTrigger}"]`).exists()).toBe(false)
+  })
+
+  it('blendet ohne Auswahl das Dossier aus und zeigt die Ablage', () => {
+    setViewport(true)
+    const w = mountShell({ current: null })
+    expect(w.find(`[data-testid="${ShellTestId.panelShelf}"]`).attributes('data-hidden-narrow')).toBe('false')
+    expect(w.find(`[data-testid="${ShellTestId.panelDossier}"]`).attributes('data-hidden-narrow')).toBe('true')
+  })
+
+  it('dreht das mit einer Auswahl um — dann traegt das Dossier die Flaeche', () => {
+    setViewport(true)
+    const w = mountShell({ current: makeObject() })
+    expect(w.find(`[data-testid="${ShellTestId.panelShelf}"]`).attributes('data-hidden-narrow')).toBe('true')
+    expect(w.find(`[data-testid="${ShellTestId.panelDossier}"]`).attributes('data-hidden-narrow')).toBe('false')
+  })
+
+  it('laesst den Rueckweg ueber den Stapel bestehen, auch auf schmal', async () => {
+    setViewport(true)
+    const w = mountShell({ current: makeObject() })
+    await w.find(`[data-testid="${ShellTestId.stackBack}"]`).trigger('click')
+    expect(w.emitted('select')?.[0]).toEqual([null])
+  })
+})

--- a/frontend/src/components/v4/dashboard/HeroNewRun.vue
+++ b/frontend/src/components/v4/dashboard/HeroNewRun.vue
@@ -127,20 +127,16 @@ const hasExplicitPick = ref(false)
 const language = ref<string>(readLocal(STORAGE_LANG) || 'de')
 const simulationRequirement = ref('')
 
-// Persona-Floor synchron mit Backend (simulation_config_generator._validate_persona_quota).
-// Hard-Floor=30, optional override via AGORA_ALLOW_SMALL_SIM=1. Wert wird beim
-// Mount per /api/status (backend.allow_small_sim) gezogen — bis dahin pessimistisch
-// auf den harten Floor klemmen, damit der User keine Run-Konfig zusammenklicken kann
-// die das Backend dann mit 422 ablehnt.
-const NUM_AGENTS_HARD_FLOOR = 30
-const NUM_AGENTS_OVERRIDE_FLOOR = 10
-const NUM_AGENTS_DEFAULT = NUM_AGENTS_HARD_FLOOR
+// Die harte Untergrenze von 30 Personas ist entfallen (Block B4): sie
+// stand kleinen, gezielten Laeufen im Weg — etwa einem Gremium aus acht
+// Leuten. 30 bleibt der Vorschlag, ist aber keine Schranke mehr.
+const NUM_AGENTS_MIN = 1
+const NUM_AGENTS_DEFAULT = 30
 const NUM_AGENTS_MAX = 100
 const NUM_ROUNDS_MIN = 3
 const NUM_ROUNDS_DEFAULT = 10
 const NUM_ROUNDS_MAX = 30
 
-const allowSmallSim = ref<boolean>(false)
 const numAgents = ref<number>(NUM_AGENTS_DEFAULT)
 const numRounds = ref<number>(NUM_ROUNDS_DEFAULT)
 
@@ -187,13 +183,11 @@ async function refreshEstimate() {
   }
 }
 
-const numAgentsMin = computed<number>(
-  () => (allowSmallSim.value ? NUM_AGENTS_OVERRIDE_FLOOR : NUM_AGENTS_HARD_FLOOR),
-)
+const numAgentsMin = computed<number>(() => NUM_AGENTS_MIN)
 
-const showAgentsWarning = computed<boolean>(
-  () => allowSmallSim.value && numAgents.value >= NUM_AGENTS_OVERRIDE_FLOOR && numAgents.value < NUM_AGENTS_HARD_FLOOR,
-)
+// Unter 30 Personas wird die Aussagekraft duenn — das ist ein Hinweis,
+// keine Sperre.
+const showAgentsWarning = computed<boolean>(() => numAgents.value < 30)
 
 const profileOptions = computed(() => {
   return llmProfiles.value.map(p => ({
@@ -385,19 +379,6 @@ onMounted(() => {
       discardPersistedProfile()
     })
     .finally(() => { profilesSettled.value = true })
-  // backend.allow_small_sim aus /api/status spiegelt AGORA_ALLOW_SMALL_SIM
-  // wider. Default-pessimistisch bei Fetch-Fehler: harter 30er-Floor bleibt.
-  getSystemStatus()
-    .then(envelope => {
-      const backend = (envelope?.data?.backend ?? envelope?.backend) as { allow_small_sim?: boolean } | undefined
-      allowSmallSim.value = !!backend?.allow_small_sim
-      // Wenn der Override nach Mount inaktiv ist, klemmen wir einen ggf. aus
-      // dem letzten Override-Run persistenten Slider-Wert wieder hoch.
-      if (!allowSmallSim.value && numAgents.value < NUM_AGENTS_HARD_FLOOR) {
-        numAgents.value = NUM_AGENTS_HARD_FLOOR
-      }
-    })
-    .catch(() => { /* Fail-safe: allowSmallSim bleibt false → 30er-Floor aktiv */ })
   // Service-Readiness + Backend-Default-Language (Parität zu Home.vue, #915).
   // Liefert default_provider/ollama_reachable/neo4j_reachable/default_language
   // aus /api/simulation/available-models. Bei Fetch-Fehler bleiben die Refs
@@ -511,7 +492,7 @@ onMounted(() => {
           <label class="hero-label" for="hero-num-agents">
             {{ $t('dashboard.hero.numAgentsLabel') }}
             <span class="hero-slider-value">{{ numAgents }}</span>
-            <span v-if="allowSmallSim" class="hero-small-sim-badge" :title="$t('dashboard.hero.smallSimActiveTooltip')">
+            <span v-if="showAgentsWarning" class="hero-small-sim-badge" :title="$t('dashboard.hero.smallSimActiveTooltip')">
               {{ $t('dashboard.hero.smallSimBadge') }}
             </span>
           </label>

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.profiles.spec.ts
@@ -15,11 +15,10 @@ vi.mock('../../forms/AiModelPicker.vue', () => ({
 
 // Slice "small-sim-floor-frontend-sync": HeroNewRun fragt beim Mount /api/status
 // ab. In den Profile-Tests interessiert uns nur das Profil-Verhalten — minimaler
-// Status-Mock mit allow_small_sim=false (Default-Pfad).
 vi.mock('../../../../api/status', () => ({
   getSystemStatus: vi.fn().mockResolvedValue({
     success: true,
-    backend: { ok: true, version: '1.0.0', auth_mode: 'open', allow_small_sim: false },
+    backend: { ok: true, version: '1.0.0', auth_mode: 'open' },
     neo4j: { reachable: true },
     ollama: { reachable: false, models_available: [] },
     disk: { uploads: { path: '/tmp', total_bytes: 0, free_bytes: 0, used_pct: 0 } },

--- a/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
+++ b/frontend/src/components/v4/dashboard/__tests__/HeroNewRun.spec.ts
@@ -185,7 +185,7 @@ vi.mock('@/composables/useEffectiveModelSelection', () => {
 
 // Initial-Defaults (werden in mountHero() vor jedem Test neu gesetzt).
 fetchLlmProfilesMock.mockResolvedValue([])
-getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
+getSystemStatusMock.mockResolvedValue({ data: { backend: { ok: true } } })
 // Service-Readiness (Parität zu Home.vue, #915): Default liefert neo4j_reachable=true
 // und default_provider='openai' → servicesReady=true → canSubmit nicht blockiert.
 getAvailableModelsMock.mockResolvedValue({ success: true, data: { default_provider: 'openai', ollama_reachable: true, neo4j_reachable: true, default_language: 'de' } })
@@ -269,7 +269,7 @@ async function mountHero(seed: Record<string, string> = {}) {
   setRunModelOverrideMock.mockClear()
   clearRunModelOverrideMock.mockClear()
   getSystemStatusMock.mockClear()
-  getSystemStatusMock.mockResolvedValue({ data: { backend: { allow_small_sim: false } } })
+  getSystemStatusMock.mockResolvedValue({ data: { backend: { ok: true } } })
   // Kanon-Stub: ensureLoaded muss resolven, damit die Komponente beim Mount
   // selectedModel aus effectiveRef initialisiert.
   ensureLoadedMock.mockReset()

--- a/frontend/src/components/v4/steps/Step4Report.vue
+++ b/frontend/src/components/v4/steps/Step4Report.vue
@@ -631,8 +631,10 @@ async function createBranchFromReport(branchForm: {
     if (branchForm.llm_model.trim()) overrides.llm_model = branchForm.llm_model.trim()
     if (branchForm.language.trim()) overrides.language = branchForm.language.trim()
     if (branchForm.max_agents !== '') overrides.max_agents = Number(branchForm.max_agents)
-    const res = (await createSimulationBranch(simulationId, { branch_name: branchForm.branch_name.trim(), copy_profiles: true, copy_report_artifacts: false, overrides })) as ApiResult
-    if (res?.success && res.data?.simulation_id) router.push({ name: 'Simulation', params: { simulationId: res.data.simulation_id as string } })
+    // Kein Cast mehr noetig: createSimulationBranch deklariert die
+    // Envelope jetzt selbst (Block B4).
+    const res = await createSimulationBranch(simulationId, { branch_name: branchForm.branch_name.trim(), copy_profiles: true, copy_report_artifacts: false, overrides })
+    if (res?.success && res.data?.simulation_id) router.push({ name: 'Simulation', params: { simulationId: res.data.simulation_id } })
   } catch (e) { addLog((e as Error).message) }
   finally { branchBusy.value = false }
 }

--- a/frontend/src/composables/__tests__/useDeriveSimulation.spec.ts
+++ b/frontend/src/composables/__tests__/useDeriveSimulation.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../api/simulation', () => ({ createSimulationBranch: vi.fn() }))
+
+import { createSimulationBranch } from '../../api/simulation'
+import { useDeriveSimulation } from '../useDeriveSimulation'
+
+describe('useDeriveSimulation', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('leitet mit Personas ab und gibt die neue Simulation zurueck', async () => {
+    vi.mocked(createSimulationBranch).mockResolvedValue({
+      success: true,
+      data: { simulation_id: 'sim_neu' },
+    } as never)
+
+    const { derive } = useDeriveSimulation()
+    const res = await derive('sim_alt', '  Zweiter Durchgang  ')
+
+    expect(res).toEqual({ simulationId: 'sim_neu' })
+    // Personas werden uebernommen, die Berichtsartefakte nicht: dieselben
+    // Personen, eine neue Auswertung.
+    expect(createSimulationBranch).toHaveBeenCalledWith('sim_alt', {
+      branch_name: 'Zweiter Durchgang',
+      copy_profiles: true,
+      copy_report_artifacts: false,
+    })
+  })
+
+  it('verweigert ohne Quell-Simulation oder Namen, ohne die API zu rufen', async () => {
+    const { derive, error } = useDeriveSimulation()
+
+    expect(await derive('', 'Name')).toBeNull()
+    expect(await derive('sim_alt', '   ')).toBeNull()
+    expect(createSimulationBranch).not.toHaveBeenCalled()
+    expect(error.value).toBe('missing_input')
+  })
+
+  it('meldet einen Fehlschlag, statt eine Simulation vorzutaeuschen', async () => {
+    vi.mocked(createSimulationBranch).mockResolvedValue({ success: true, data: {} } as never)
+
+    const { derive, error } = useDeriveSimulation()
+    expect(await derive('sim_alt', 'Ohne ID')).toBeNull()
+    expect(error.value).toBe('no_simulation_id')
+  })
+
+  it('faengt einen Netzwerkfehler ab und haelt seine Meldung fest', async () => {
+    vi.mocked(createSimulationBranch).mockRejectedValue(new Error('Verbindung weg'))
+
+    const { derive, error, busy } = useDeriveSimulation()
+    expect(await derive('sim_alt', 'Neuer Lauf')).toBeNull()
+    expect(error.value).toBe('Verbindung weg')
+    expect(busy.value).toBe(false)
+  })
+
+  it('setzt busy waehrend des Laufs und danach zurueck', async () => {
+    let aufloesen: (v: unknown) => void = () => {}
+    vi.mocked(createSimulationBranch).mockReturnValue(
+      new Promise((r) => { aufloesen = r }) as never,
+    )
+
+    const { derive, busy } = useDeriveSimulation()
+    const p = derive('sim_alt', 'Neuer Lauf')
+    expect(busy.value).toBe(true)
+
+    aufloesen({ success: true, data: { simulation_id: 'sim_neu' } })
+    await p
+    expect(busy.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useIsMobile.spec.ts
+++ b/frontend/src/composables/__tests__/useIsMobile.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useIsMobile } from '../useIsMobile'
+import { MOBILE_MEDIA_QUERY } from '../../constants/breakpoints'
+
+/** Minimal-Komponente, die den Wert nur sichtbar macht. */
+const Probe = defineComponent({
+  setup() {
+    const { isMobile } = useIsMobile()
+    return () => h('div', isMobile.value ? 'schmal' : 'breit')
+  },
+})
+
+function stubMatchMedia(matches: boolean) {
+  const listeners: Array<(e: MediaQueryListEvent) => void> = []
+  const mql = {
+    matches,
+    media: MOBILE_MEDIA_QUERY,
+    addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.push(cb),
+    removeEventListener: vi.fn(),
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mql),
+  })
+  return { mql, listeners }
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', { writable: true, configurable: true, value: undefined })
+})
+
+describe('useIsMobile', () => {
+  it('meldet "schmal", wenn die Media-Query greift', () => {
+    stubMatchMedia(true)
+    expect(mount(Probe).text()).toBe('schmal')
+  })
+
+  it('meldet "breit", wenn sie nicht greift', () => {
+    stubMatchMedia(false)
+    expect(mount(Probe).text()).toBe('breit')
+  })
+
+  it('faellt ohne matchMedia auf die Desktop-Ansicht zurueck, statt zu werfen', () => {
+    // jsdom kennt matchMedia nicht. Ohne den Guard wuerde jeder
+    // Komponententest der Huelle beim Mounten scheitern.
+    expect(() => mount(Probe)).not.toThrow()
+    expect(mount(Probe).text()).toBe('breit')
+  })
+
+  it('reagiert auf einen Wechsel der Fensterbreite', async () => {
+    const { listeners } = stubMatchMedia(false)
+    const w = mount(Probe)
+    expect(w.text()).toBe('breit')
+
+    listeners.forEach((cb) => cb({ matches: true } as MediaQueryListEvent))
+    await w.vm.$nextTick()
+    expect(w.text()).toBe('schmal')
+  })
+
+  it('haengt den Listener beim Zerstoeren wieder ab', () => {
+    const { mql } = stubMatchMedia(true)
+    mount(Probe).unmount()
+    expect(mql.removeEventListener).toHaveBeenCalled()
+  })
+
+  it('nutzt die SSoT-Media-Query, keinen eigenen Breakpoint', () => {
+    stubMatchMedia(false)
+    mount(Probe)
+    expect(window.matchMedia).toHaveBeenCalledWith(MOBILE_MEDIA_QUERY)
+  })
+})

--- a/frontend/src/composables/__tests__/useObjectDetail.spec.ts
+++ b/frontend/src/composables/__tests__/useObjectDetail.spec.ts
@@ -4,9 +4,11 @@ import type { ShelfObject } from '../../types/shelf'
 
 vi.mock('../../api/report', () => ({ getReport: vi.fn() }))
 vi.mock('../../api/graph', () => ({ getGraphData: vi.fn() }))
+vi.mock('../../api/simulation', () => ({ listPersonaTemplates: vi.fn() }))
 
 import { getReport } from '../../api/report'
 import { getGraphData } from '../../api/graph'
+import { listPersonaTemplates } from '../../api/simulation'
 import { useObjectDetail } from '../useObjectDetail'
 
 // t-Stub: gibt den Schluessel zurueck, Assertions laufen ueber Schluessel.
@@ -66,6 +68,55 @@ describe('useObjectDetail', () => {
     ])
   })
 
+  it('zeigt fuer einen Personasatz Beruf, Land, Interessen und Kurzbeschreibung', async () => {
+    vi.mocked(listPersonaTemplates).mockResolvedValue({
+      success: true,
+      data: {
+        count: 2,
+        templates: [
+          { template_id: 'other', name: 'Falsch' },
+          {
+            template_id: 'tpl_1',
+            name: 'Sachbearbeiterin',
+            persona: 'Skeptisch gegenüber Reformen.',
+            profession: 'Verwaltung',
+            country: 'DE',
+            interested_topics: ['Rente', 'Wohnen'],
+            bio: 'Seit 12 Jahren im Amt.',
+          },
+        ],
+      },
+    } as never)
+
+    const obj = ref<ShelfObject | null>(makeObject({ kind: 'personasatz', id: 'tpl_1' }))
+    const { detail } = useObjectDetail(obj, t)
+    await nextTick(); await Promise.resolve(); await Promise.resolve()
+
+    expect(detail.value?.summary).toBe('Skeptisch gegenüber Reformen.')
+    expect(detail.value?.parts).toEqual([
+      { title: 'shelf.dossier.personaProfession', description: 'Verwaltung' },
+      { title: 'shelf.dossier.personaCountry', description: 'DE' },
+      { title: 'shelf.dossier.personaTopics', description: 'Rente, Wohnen' },
+      { title: 'shelf.dossier.personaBio', description: 'Seit 12 Jahren im Amt.' },
+    ])
+  })
+
+  it('laesst leere Felder eines Personasatzes weg, statt sie leer anzuzeigen', async () => {
+    vi.mocked(listPersonaTemplates).mockResolvedValue({
+      success: true,
+      data: { count: 1, templates: [{ template_id: 'tpl_2', name: 'Knapp', profession: 'Pflege' }] },
+    } as never)
+
+    const obj = ref<ShelfObject | null>(makeObject({ kind: 'personasatz', id: 'tpl_2' }))
+    const { detail } = useObjectDetail(obj, t)
+    await nextTick(); await Promise.resolve(); await Promise.resolve()
+
+    expect(detail.value?.parts).toEqual([
+      { title: 'shelf.dossier.personaProfession', description: 'Pflege' },
+    ])
+    expect(detail.value?.summary).toBe('')
+  })
+
   it('laedt nichts fuer Sorten ohne Detail-Endpunkt', async () => {
     const obj = ref<ShelfObject | null>(makeObject({ kind: 'lauf', id: 'sim_1' }))
     const { detail } = useObjectDetail(obj, t)
@@ -73,6 +124,7 @@ describe('useObjectDetail', () => {
 
     expect(getReport).not.toHaveBeenCalled()
     expect(getGraphData).not.toHaveBeenCalled()
+    expect(listPersonaTemplates).not.toHaveBeenCalled()
     expect(detail.value).toBeNull()
   })
 

--- a/frontend/src/composables/useDeriveSimulation.ts
+++ b/frontend/src/composables/useDeriveSimulation.ts
@@ -1,0 +1,59 @@
+import { ref } from 'vue'
+import { createSimulationBranch } from '../api/simulation'
+
+/**
+ * Aus einem Bericht eine neue Simulation ableiten (Block B4).
+ *
+ * Der Nutzer hat es so gesagt: „es nutzt kaum sein Potential, mit den
+ * erstellten Reports weiterzuarbeiten." Technisch gibt es den Weg
+ * laengst — `POST /api/simulation/<id>/branch` legt eine Simulation an,
+ * die die Personas des Vorlaufs uebernimmt. Er war nur im vierten
+ * Schritt der alten Prozesskette vergraben und damit praktisch
+ * unauffindbar.
+ *
+ * Abgeleitet wird immer MIT Personas (`copy_profiles: true`) und OHNE
+ * die Berichtsartefakte: die Personen sollen dieselben sein, die
+ * Auswertung eine neue.
+ */
+
+export interface DeriveResult {
+  simulationId: string
+}
+
+export function useDeriveSimulation() {
+  const busy = ref(false)
+  const error = ref('')
+
+  /**
+   * @param sourceSimulationId Simulation, aus welcher der Bericht stammt
+   * @param name Bezeichnung des neuen Laufs
+   */
+  async function derive(sourceSimulationId: string, name: string): Promise<DeriveResult | null> {
+    if (!sourceSimulationId || !name.trim()) {
+      error.value = 'missing_input'
+      return null
+    }
+    busy.value = true
+    error.value = ''
+    try {
+      const res = await createSimulationBranch(sourceSimulationId, {
+        branch_name: name.trim(),
+        copy_profiles: true,
+        copy_report_artifacts: false,
+      })
+      const newId = res?.success ? res.data?.simulation_id : undefined
+      if (!newId) {
+        error.value = 'no_simulation_id'
+        return null
+      }
+      return { simulationId: newId }
+    } catch (err) {
+      error.value = (err as Error).message
+      return null
+    } finally {
+      busy.value = false
+    }
+  }
+
+  return { busy, error, derive }
+}

--- a/frontend/src/composables/useIsMobile.ts
+++ b/frontend/src/composables/useIsMobile.ts
@@ -1,0 +1,47 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { MOBILE_MEDIA_QUERY } from '../constants/breakpoints'
+
+/**
+ * Reaktives „ist das ein schmales Geraet" (Block B4).
+ *
+ * Nutzt die vorhandene SSoT aus `constants/breakpoints.ts` statt eines
+ * zweiten Breakpoints. Die neue Huelle braucht das nicht nur in CSS:
+ * Der ⌘K-Knopf soll auf einem Telefon nicht bloss unsichtbar sein,
+ * sondern gar nicht erst im Markup stehen — sonst bleibt er ein
+ * Tab-Stop, der ins Leere fuehrt, und Screenreader lesen ein
+ * Bedienelement vor, das dort niemand ausloesen kann.
+ *
+ * `matchMedia` fehlt in jsdom; ohne die Pruefung wuerde jeder
+ * Komponententest beim Mounten werfen. Ohne matchMedia gilt „nicht
+ * schmal" — die Desktop-Ansicht ist der sichere Rueckfall.
+ */
+function currentMatch(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+export function useIsMobile() {
+  // Der Startwert wird SOFORT gelesen, nicht erst in onMounted: sonst
+  // rendert der erste Durchlauf die Desktop-Fassung und korrigiert sich
+  // einen Tick spaeter — auf dem Telefon ein sichtbares Zucken.
+  const isMobile = ref(currentMatch())
+  let mql: MediaQueryList | null = null
+
+  function update(e: MediaQueryList | MediaQueryListEvent): void {
+    isMobile.value = e.matches
+  }
+
+  onMounted(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+    isMobile.value = mql.matches
+    mql.addEventListener('change', update)
+  })
+
+  onBeforeUnmount(() => {
+    mql?.removeEventListener('change', update)
+    mql = null
+  })
+
+  return { isMobile }
+}

--- a/frontend/src/composables/useObjectDetail.ts
+++ b/frontend/src/composables/useObjectDetail.ts
@@ -1,6 +1,7 @@
 import { ref, watch, type Ref } from 'vue'
 import { getReport } from '../api/report'
 import { getGraphData } from '../api/graph'
+import { listPersonaTemplates } from '../api/simulation'
 import type { ShelfObject } from '../types/shelf'
 
 type Translate = (key: string) => string
@@ -47,6 +48,28 @@ export function useObjectDetail(object: Ref<ShelfObject | null>, t: Translate) {
             summary: outline.summary,
             parts: outline.sections.map((s) => ({ title: s.title, description: s.description })),
           }
+        }
+      } else if (obj.kind === 'personasatz') {
+        // Die Bibliothek liefert alle Saetze auf einmal; einen Endpunkt
+        // fuer einen einzelnen gibt es nicht. Der Eintrag wird deshalb
+        // aus der Liste herausgesucht statt neu abgefragt.
+        const res = await listPersonaTemplates()
+        const all = res?.success ? (res.data?.templates ?? []) : []
+        const tpl = all.find(
+          (x) => x.template_id === obj.id || x.username === obj.id || x.name === obj.id,
+        )
+        if (tpl) {
+          const topics = Array.isArray(tpl.interested_topics)
+            ? (tpl.interested_topics as unknown[]).join(', ')
+            : typeof tpl.interested_topics === 'string'
+              ? tpl.interested_topics
+              : ''
+          const parts: DetailPart[] = []
+          if (tpl.profession) parts.push({ title: t('shelf.dossier.personaProfession'), description: String(tpl.profession) })
+          if (tpl.country) parts.push({ title: t('shelf.dossier.personaCountry'), description: String(tpl.country) })
+          if (topics) parts.push({ title: t('shelf.dossier.personaTopics'), description: topics })
+          if (tpl.bio) parts.push({ title: t('shelf.dossier.personaBio'), description: String(tpl.bio) })
+          detail.value = { summary: tpl.persona ? String(tpl.persona) : '', parts }
         }
       } else if (obj.kind === 'graph') {
         // Der Graph selbst haengt am graph_id des Projekts; die Ablage

--- a/frontend/src/composables/useShelf.ts
+++ b/frontend/src/composables/useShelf.ts
@@ -241,6 +241,7 @@ export function buildShelfObjects(
           : statusText(t, `shelf.status.report_${r.status}`, r.status),
       updatedAt: r.completed_at || r.created_at || '',
       metaId: r.report_id,
+      simulationId: r.simulation_id || null,
       nextAction: {
         label: t('shelf.action.readReport'),
         to: { name: 'StepReport', params: { reportId: r.report_id } },

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -58,6 +58,12 @@ export const ShellTestId = {
   activityCancel: 'shell-activity-cancel',
   undoToast: 'shell-undo-toast',
   undoButton: 'shell-undo-button',
+  // Block B4 (Mobile 390px): ⌘K-Knopf verschwindet unter dem Schmal-
+  // Breakpoint ganz aus dem Markup (nicht nur CSS-versteckt) — braucht
+  // deshalb eine eigene testid, um das in Komponenten-Tests zu pruefen.
+  cmdkTrigger: 'shell-cmdk-trigger',
+  panelShelf: 'shell-panel-shelf',
+  panelDossier: 'shell-panel-dossier',
 } as const
 
 export const ShelfTestId = {

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -91,6 +91,7 @@ export const DossierTestId = {
   part: 'dossier-part',
   openFull: 'dossier-open-full',
   derive: 'dossier-derive',
+  startFromPersona: 'dossier-start-from-persona',
   cancel: 'dossier-cancel',
   pause: 'dossier-pause',
 } as const

--- a/frontend/src/contracts/testIds.ts
+++ b/frontend/src/contracts/testIds.ts
@@ -90,6 +90,7 @@ export const DossierTestId = {
   parts: 'dossier-parts',
   part: 'dossier-part',
   openFull: 'dossier-open-full',
+  derive: 'dossier-derive',
   cancel: 'dossier-cancel',
   pause: 'dossier-pause',
 } as const

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1737,7 +1737,10 @@
       "personaBio": "Kurzbeschreibung",
       "personaCountry": "Land",
       "personaProfession": "Beruf",
-      "personaTopics": "Interessen"
+      "personaTopics": "Interessen",
+      "startFailed": "Lauf konnte nicht angelegt werden.",
+      "startFromPersona": "Lauf mit diesen Personas",
+      "startName": "Lauf mit {title}"
     },
     "empty": "Noch keine Objekte. Leg eine Quelle ab, um zu starten.",
     "filter": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1727,6 +1727,9 @@
     "cancel": "Abbrechen",
     "cancelRequested": "Abbruch angefordert — die laufende Stufe wird noch beendet.",
     "dossier": {
+      "derive": "Neuen Lauf ableiten",
+      "deriveFailed": "Ableiten fehlgeschlagen.",
+      "deriveName": "Abgeleitet von {title}",
       "emptyHint": "Nichts ausgewählt. Wähl links ein Objekt, um seine Übersicht zu sehen.",
       "graphEntities": "Entitäten",
       "graphRelations": "Beziehungen",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1730,7 +1730,11 @@
       "emptyHint": "Nichts ausgewählt. Wähl links ein Objekt, um seine Übersicht zu sehen.",
       "graphEntities": "Entitäten",
       "graphRelations": "Beziehungen",
-      "idLabel": "ID"
+      "idLabel": "ID",
+      "personaBio": "Kurzbeschreibung",
+      "personaCountry": "Land",
+      "personaProfession": "Beruf",
+      "personaTopics": "Interessen"
     },
     "empty": "Noch keine Objekte. Leg eine Quelle ab, um zu starten.",
     "filter": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1727,6 +1727,9 @@
     "cancel": "Cancel",
     "cancelRequested": "Cancel requested — finishing the current stage.",
     "dossier": {
+      "derive": "Derive new run",
+      "deriveFailed": "Could not derive a run.",
+      "deriveName": "Derived from {title}",
       "emptyHint": "Nothing selected. Pick an object on the left to see its overview.",
       "graphEntities": "Entities",
       "graphRelations": "Relations",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1737,7 +1737,10 @@
       "personaBio": "Bio",
       "personaCountry": "Country",
       "personaProfession": "Profession",
-      "personaTopics": "Interests"
+      "personaTopics": "Interests",
+      "startFailed": "Could not create the run.",
+      "startFromPersona": "Run with these personas",
+      "startName": "Run with {title}"
     },
     "empty": "No objects yet. Drop a source to get started.",
     "filter": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1730,7 +1730,11 @@
       "emptyHint": "Nothing selected. Pick an object on the left to see its overview.",
       "graphEntities": "Entities",
       "graphRelations": "Relations",
-      "idLabel": "ID"
+      "idLabel": "ID",
+      "personaBio": "Bio",
+      "personaCountry": "Country",
+      "personaProfession": "Profession",
+      "personaTopics": "Interests"
     },
     "empty": "No objects yet. Drop a source to get started.",
     "filter": {

--- a/frontend/src/types/shelf.ts
+++ b/frontend/src/types/shelf.ts
@@ -48,6 +48,8 @@ export interface ShelfObject {
   /** Meta-Zeile: Zeitpunkt + technische ID (Geist Mono). */
   updatedAt: string
   metaId: string
+  /** Nur bei kind='bericht': die Simulation, aus der er stammt — Grundlage fuers Ableiten. */
+  simulationId?: string | null
   /** Nur bei kind='graph': die Graph-ID des Projekts, fuer das Nachladen im Dossier. */
   graphId?: string | null
   nextAction: NextAction | null

--- a/frontend/src/views/v4/CompareView.vue
+++ b/frontend/src/views/v4/CompareView.vue
@@ -47,12 +47,17 @@ const loadError = ref<string | null>(null)
 
 onMounted(async () => {
   try {
-    const raw = await listSimulationBranches(props.simulationId)
-    branches.value = raw.map((b) => {
+    // Der Interceptor liefert die Envelope, nicht das Array — ein
+    // direktes .map() darauf warf und landete im catch: die Liste zeigte
+    // immer „Fehler beim Laden der Branches". Ein Branch ist ausserdem
+    // eine Simulation, seine ID heisst simulation_id (branch_id gab es nie).
+    const envelope = await listSimulationBranches(props.simulationId)
+    const list = envelope?.success ? (envelope.data ?? []) : []
+    branches.value = list.map((b) => {
       const completedAt = typeof b['completed_at'] === 'string' ? b['completed_at'] : undefined
       return {
-        id: b.branch_id,
-        label: b.branch_name || b.branch_id,
+        id: b.simulation_id,
+        label: b.branch_name || b.simulation_id,
         completed_at: completedAt,
       }
     })

--- a/frontend/src/views/v4/__tests__/CompareView.spec.ts
+++ b/frontend/src/views/v4/__tests__/CompareView.spec.ts
@@ -7,7 +7,7 @@
  * 3. BranchComparePanel wird eingebunden.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { makeTestRouter } from '@/components/v4/shell/__tests__/testRouter'
@@ -33,11 +33,16 @@ vi.mock('@/components/compare/BranchComparePanel.vue', () => ({
   },
 }))
 
-// listSimulationBranches mocken damit kein echter Fetch passiert
+// listSimulationBranches mocken damit kein echter Fetch passiert.
+// WICHTIG: in der Envelope-Form, die der Interceptor tatsaechlich
+// liefert. Der frueher hier gemockte nackte Array liess den Test gruen
+// laufen, waehrend die Ansicht in Wahrheit bei jedem Aufruf in den
+// catch-Zweig fiel und „Fehler beim Laden der Branches" zeigte.
 vi.mock('@/api/simulation', () => ({
-  listSimulationBranches: vi.fn().mockResolvedValue([]),
+  listSimulationBranches: vi.fn().mockResolvedValue({ success: true, data: [] }),
 }))
 
+import { listSimulationBranches } from '@/api/simulation'
 import CompareView from '../CompareView.vue'
 
 const stubComponent = { template: '<div/>' }
@@ -71,6 +76,33 @@ describe('CompareView (v4)', () => {
     const title = wrapper.find('.page-header__title')
     expect(title.exists()).toBe(true)
     expect(title.text()).toBe('Compare')
+  })
+
+  it('liest die Branches aus der Envelope und nutzt simulation_id als Kennung', async () => {
+    vi.mocked(listSimulationBranches).mockResolvedValueOnce({
+      success: true,
+      data: [
+        { simulation_id: 'sim-branch-1', branch_name: 'Variante A', status: 'completed' },
+        { simulation_id: 'sim-branch-2', branch_name: null, status: 'completed' },
+      ],
+    } as never)
+
+    await router.push('/v4/compare/sim-001')
+    const wrapper = mount(CompareView, {
+      props: { simulationId: 'sim-001' },
+      global: { plugins: [router, createPinia(), i18n] },
+    })
+    await flushPromises()
+
+    // Geprueft wird die Prop, nicht das gerenderte Markup: kaputt war
+    // das Auspacken der Envelope, nicht die Darstellung im Kind.
+    const panel = wrapper.findComponent({ name: 'BranchComparePanel' })
+    expect(panel.exists()).toBe(true)
+    expect(panel.props('availableBranches')).toEqual([
+      { id: 'sim-branch-1', label: 'Variante A', completed_at: undefined },
+      // Ohne Branch-Name faellt die Beschriftung auf die ID zurueck.
+      { id: 'sim-branch-2', label: 'sim-branch-2', completed_at: undefined },
+    ])
   })
 
   it('BranchComparePanel wird nach Branch-Load gerendert', async () => {


### PR DESCRIPTION
Block B4 aus `PLAN.md`. Setzt auf B3 (#1372) auf und löst die drei Punkte ein, die der Nutzer über die Optik hinaus genannt hatte.

> „es nutzt kaum sein Potential, mit den erstellten Reports weiterzuarbeiten … es gibt keine Möglichkeit, Simulationen direkt mit nur eigens erstellten Personas zu starten … auf dem Handy sieht es noch schlimmer aus"

## Läufe allein aus Personas

`POST /api/simulation/create-from-personas` legt Projekt und Simulation an und bereitet sie **ohne Dokument, Ontologie und Graph** vor. Bewusst ein eigener Endpunkt — in `/create` bleibt die `graph_id` Pflicht, der reguläre Weg weicht nicht auf.

`prepare_from_personas` fährt denselben FSM-Pfad wie `branching_service.create_branch` (`CREATED → PREPARING → READY`, kein Direktsprung). Beim Übersetzen der Bibliothekseinträge werden Felder ergänzt, die die Bibliothek gar nicht führt — vor allem `age`/`gender`/`mbti`, die **immer** existieren müssen, weil die OASIS-Bibliothek sie ungeschützt indiziert. `PersonaLibrary._normalize` lässt leere Werte weg, ein Eintrag ohne Alter hat den Schlüssel also gar nicht.

Im Dossier eines Personasatzes steht dafür „Lauf mit diesen Personas". Damit ist ein Personasatz kein Archivgut mehr, sondern ein Startpunkt.

### Die 30er-Untergrenze ist weg

`_validate_persona_quota` (Issue #496) verlangte mindestens 30 Personas und stand genau dem im Weg, wofür dieser Weg gedacht ist: einem kleinen, gezielten Lauf — einem Gremium aus acht Leuten etwa. 30 bleibt der **Vorschlagswert** im Dashboard, ist aber keine Schranke mehr; unterhalb erscheint ein Hinweis auf die dünnere Aussagekraft statt einer Sperre. Mit der Grenze fällt auch der Schalter, der sie aufhob: `AGORA_ALLOW_SMALL_SIM`, das gespiegelte `allow_small_sim` in `/api/status` und die Abfrage im Dashboard, die den Regler beim Mount wieder hochklemmte.

### Offene Grenze, bewusst benannt

Ein Persona-Lauf hat keine `graph_id`, und die Berichtserzeugung verlangt an drei Stellen eine. Die Meldung sagt jetzt, **was** fehlt und dass die Simulation selbst in Ordnung ist, statt „Missing graph ID" — ein Satz, der jemandem nichts sagt, der nie einen Graphen bauen wollte.

Bewusst **kein** Platzhalter-Graph: eine formal gültige Fake-UUID würde die Prüfungen passieren lassen, und der Bericht liefe ohne jede Graph-Evidenz durch — er sähe aus wie ein normaler. Der Report-Agent baut auf Cypher-Belegen auf; ein Bericht ohne sie wäre still entwertet. **Persona-Läufe kann man also starten und auswerten, aber noch nicht berichten.**

## Aus Berichten weiterarbeiten

Das Ableiten existierte längst (`createSimulationBranch` mit Personas-Übernahme), lag aber im vierten Schritt der alten Prozesskette und war praktisch unauffindbar. Jetzt steht es im Dossier des Berichts.

## Telefon

- Der ⌘K-Knopf verschwindet unter 768px aus dem **Markup**, nicht nur aus der Sicht — versteckt bliebe er ein Tab-Stop und würde vorgelesen, obwohl er dort nichts auslöst.
- Die Jobs-Tabelle scrollt in ihrem eigenen Kasten; vorher schob sie das ganze Dokument breit, und genau das prüft das Accessibility-Gate bei 320px.
- Unter `pointer: coarse` wächst die Kopfzeile auf 56px; 46px ist ein Maus-Maß.

## Unterwegs gefundener Defekt

Beim Ehrlichmachen der Branch-API zeigte der Compiler, dass `CompareView` `.map()` direkt auf der Envelope aufrief. Das warf, landete im `catch` — **die Vergleichsansicht konnte noch nie Branches laden**, und sie griff auf ein `branch_id` zu, das es im Backend nie gab. Der zugehörige Test war grün, weil er einen nackten Array mockte, also dieselbe falsche Annahme traf.

Die übrigen 42 API-Funktionen mit demselben Muster sind als #1373 festgehalten — der Umbau berührt fast jeden Aufrufer und gehört nicht hierher.

## Prüfung

Frontend: 2016 Tests, lint, typecheck, build grün. Backend: `ruff`, `mypy` (282 Dateien) und die betroffenen Suiten grün.