### PR TITLE
fix(api): API-Funktionen deklarieren, was sie wirklich liefern (#1373)

### DIFF
--- a/changelog.d/1373-api-envelope-typen.md
+++ b/changelog.d/1373-api-envelope-typen.md
@@ -1,0 +1,11 @@
+### Fixed (API-Funktionen deklarieren, was sie wirklich liefern — #1373, 2026-08-19)
+
+- **38 Funktionen in `frontend/src/api/*.ts` gaben den ausgepackten Nutzdatentyp vor, obwohl der Response-Interceptor grundsätzlich die Envelope zurückgibt** (`{success, data, …}`, siehe `api/index.ts`). Der deklarierte Typ beschrieb also nicht, was zur Laufzeit ankam — und weil er log, konnte der Compiler keinen Aufrufer mehr warnen. Jede Funktion wurde einzeln gegen ihren Endpunkt geprüft: die Zuordnung stammt aus Flasks eigener `url_map` (182 Routen), nicht aus einer Namensheuristik, und für jede Route wurde nachgesehen, ob sie `json_success` nutzt oder flach antwortet. `cancelRun` und `replayRun` antworten tatsächlich flach und bleiben unverändert; `closeSimulationEnv` baut seine Envelope von Hand (`jsonify({"success", "data"})`) und zählt deshalb dazu.
+- **`AvailableModelsResponse` beschrieb ein Feld `models`, das der Endpunkt nie geliefert hat.** `get_available_models` gibt `ollama`, `presets`, `current_default` und weitere zurück. Nur die Index-Signatur `[key: string]: unknown` hat verhindert, dass das auffiel — der Aufrufer griff seit jeher auf Felder zu, die im Typ nicht standen.
+- **Die `as unknown as …`-Casts in den Aufrufern sind entfallen.** Sie waren nie Absicht, sondern Notwehr gegen die falschen Signaturen, und haben die Diskrepanz versteckt statt behoben.
+
+### Added
+
+- **Guard `frontend/src/api/__tests__/envelopeContract.spec.ts`.** Er liest die Quelltexte und meldet jede exportierte Funktion, die ein `service.*`-Ergebnis direkt durchreicht, ohne einen Envelope-Typ zu deklarieren. Ausnahmen brauchen einen Eintrag samt Backend-Beleg (`datei.py::funktion`) — wer etwas einträgt, muss die Route nachgesehen haben. Funktionen, die die Envelope selbst auspacken und bewusst etwas anderes zurückgeben (etwa `getSimulationFeedSnapshot`), bleiben unbehelligt: ihr Typ beschreibt korrekt die eigene Rückgabe.
+
+Hintergrund: In PR #1372 hat genau dieser Typfehler zwei echte Defekte verursacht — die Personasätze wären in der Ablage nie erschienen, und die Vergleichsansicht konnte noch nie Branches laden. Beide Male war der zugehörige Test grün, weil er dieselbe falsche Annahme mockte.

--- a/frontend/src/api/__tests__/envelopeContract.spec.ts
+++ b/frontend/src/api/__tests__/envelopeContract.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Guard: API-Funktionen muessen deklarieren, was sie wirklich liefern.
+ *
+ * Der Response-Interceptor (`src/api/index.ts`) gibt grundsaetzlich die
+ * Envelope zurueck — `{ success, data, … }` —, nicht deren `data`. Wer
+ * trotzdem den ausgepackten Nutzdatentyp deklariert, luegt das
+ * Typsystem an, und der Compiler kann den Aufrufer nicht mehr warnen.
+ *
+ * Das war kein theoretisches Problem: `listPersonaTemplates` war als
+ * `Promise<PersonaTemplateRecord[]>` deklariert, ein Aufrufer griff
+ * daraufhin auf `.templates` statt `.data.templates` zu — die
+ * Personasaetze waeren in der Ablage nie erschienen. Und `CompareView`
+ * rief `.map()` direkt auf der Envelope auf, was jedes Mal in den
+ * catch-Zweig lief: die Vergleichsansicht konnte noch nie Branches
+ * laden. Beide Male war der zugehoerige Test gruen, weil er dieselbe
+ * falsche Annahme mockte.
+ *
+ * Dieser Guard liest die Quelltexte statt die Laufzeit: er findet jede
+ * exportierte Funktion, die ein `service.*`-Ergebnis zurueckgibt, und
+ * verlangt einen Envelope-Typ — oder einen Eintrag in der Liste der
+ * bewusst flachen Endpunkte samt Backend-Beleg.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const API_DIR = join(import.meta.dirname, '..')
+
+/**
+ * Endpunkte, die NICHT die Standard-Envelope liefern. Jeder Eintrag
+ * braucht einen Beleg im Backend — wer hier etwas eintraegt, muss die
+ * Route nachgesehen haben.
+ */
+const FLACHE_ENDPUNKTE: Record<string, string> = {
+  // backend/app/api/runs.py — 202 mit {"success", "status", "run_id"},
+  // ohne data-Huelle.
+  cancelRun: 'runs.py::cancel_run',
+  // backend/app/api/runs.py — jsonify({"run_id", "status"}), flach.
+  replayRun: 'runs.py::replay_run',
+  // liefert einen Blob (responseType: 'blob'), keine JSON-Huelle.
+  exportRun: 'runs.py::export_run',
+  fetchReportCsv: 'report.py::export_report_csv',
+  fetchReportBundle: 'report.py::export_report_bundle',
+  exportReport: 'report.py::export_report',
+}
+
+interface Fund {
+  datei: string
+  fn: string
+  typ: string
+}
+
+function sammleVerstoesse(): Fund[] {
+  const funde: Fund[] = []
+  // Signatur bis zum Rumpfbeginn — bewusst NICHT ueber Zeilen hinweg
+  // gierig, sonst faengt das Muster Kommentare und Nachbarfunktionen ein.
+  const muster = /export (?:const|function) (\w+)[^=;]*?:\s*Promise<((?:[^<>]|<(?:[^<>]|<[^<>]*>)*>)*)>\s*(=>)?\s*\{?/g
+
+  for (const datei of readdirSync(API_DIR).filter((f) => f.endsWith('.ts'))) {
+    const quelle = readFileSync(join(API_DIR, datei), 'utf-8')
+    for (const treffer of quelle.matchAll(muster)) {
+      const [ganzer, fn, typ] = treffer
+      if (fn in FLACHE_ENDPUNKTE) continue
+
+      const rumpf = quelle.slice(treffer.index! + ganzer.length, treffer.index! + ganzer.length + 400)
+      // Nur Funktionen, die das Ergebnis DIREKT durchreichen. Wer die
+      // Envelope selbst auspackt und etwas anderes zurueckgibt (z.B.
+      // getSimulationFeedSnapshot), beschreibt mit seinem Typ korrekt
+      // die eigene Rueckgabe — das ist eine Abstraktion, kein Fehler.
+      const reichtDurch = /^\s*(return\s+)?service\.(get|post|put|patch|delete)\(/.test(rumpf)
+      if (!reichtDurch) continue
+
+      const t = typ.trim()
+      // ApiEnvelope/ApiResponse sind die gemeinsamen Huellen; einzelne
+      // Module fuehren eigene, gleichwertige (LogEnvelope, …).
+      if (/^(ApiEnvelope|ApiResponse|Blob)\b/.test(t) || /Envelope(<.*>)?$/.test(t)) continue
+      funde.push({ datei, fn, typ: t })
+    }
+  }
+  return funde
+}
+
+describe('API-Kontrakt: deklarierter Typ passt zur Envelope', () => {
+  it('keine exportierte API-Funktion gibt einen ausgepackten Typ vor', () => {
+    const funde = sammleVerstoesse()
+    const meldung = funde
+      .map((f) => `  ${f.datei}: ${f.fn} -> Promise<${f.typ}>`)
+      .join('\n')
+
+    expect(
+      funde,
+      funde.length === 0
+        ? ''
+        : `Diese Funktionen deklarieren den ausgepackten Nutzdatentyp, obwohl der\n` +
+          `Interceptor die Envelope zurueckgibt:\n${meldung}\n\n` +
+          `Entweder den Typ auf ApiEnvelope<T> ziehen, oder — wenn der Endpunkt\n` +
+          `wirklich flach antwortet — in FLACHE_ENDPUNKTE eintragen, MIT Beleg\n` +
+          `aus dem Backend (Datei::Funktion).`,
+    ).toEqual([])
+  })
+
+  it('die Ausnahmeliste nennt fuer jeden Eintrag einen Backend-Beleg', () => {
+    for (const [fn, beleg] of Object.entries(FLACHE_ENDPUNKTE)) {
+      expect(beleg, `${fn} braucht einen Beleg der Form datei.py::funktion`).toMatch(
+        /^[\w-]+\.py::\w+$/,
+      )
+    }
+  })
+})

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -4,6 +4,7 @@
 // gemeinsame Axios-Instanz mit Auth-Header und Envelope-Handling, die
 // auch alle anderen API-Module nutzen.
 
+import type { ApiEnvelope } from './envelope'
 import service, { getAgoraToken } from './index'
 import { useApiAuth } from '../composables/useApiAuth'
 
@@ -26,17 +27,17 @@ export interface SettingsStreamHandlers {
   error?: (event: Event) => void
 }
 
-export function fetchSettings(): Promise<SettingsResponse> {
+export function fetchSettings(): Promise<ApiEnvelope<SettingsResponse>> {
   return service.get('/api/settings')
 }
 
-export function fetchSettingsSchema(): Promise<SettingsSchemaResponse> {
+export function fetchSettingsSchema(): Promise<ApiEnvelope<SettingsSchemaResponse>> {
   return service.get('/api/settings/schema')
 }
 
 export function putSettings(
   payload: Record<string, unknown>
-): Promise<SettingsResponse> {
+): Promise<ApiEnvelope<SettingsResponse>> {
   // ``payload`` = flaches { KEY: value }-Objekt. Backend lehnt
   // Secrets hier mit ``code: secret_not_allowed`` ab — die View
   // separiert sie deshalb vorher.
@@ -45,7 +46,7 @@ export function putSettings(
 
 export function putSecrets(
   secretsPayload: SecretsPayload | null | undefined
-): Promise<SettingsResponse> {
+): Promise<ApiEnvelope<SettingsResponse>> {
   // Erwartet ``{ confirm: true, fields: { KEY: value, ... } }``.
   // Backend lehnt non-secret Keys symmetrisch ab.
   return service.put('/api/settings/secrets', {

--- a/frontend/src/api/simulation.ts
+++ b/frontend/src/api/simulation.ts
@@ -33,6 +33,17 @@ export interface PrepareSimulationData {
   max_agents?: number
 }
 
+/**
+ * Gemeinsame Antwortform von `/prepare` und `/prepare/status`.
+ *
+ * Die unteren Felder liefert das Backend seit laengerem mit, sie fehlten
+ * hier aber: `already_prepared` (simulation_prepare.py:554),
+ * `expected_entities_count` (ebd. 1068), `persona_target`
+ * (contracts/persona_target_contract.py, Issue #1034) und
+ * `progress_detail.current_stage` (simulation_prepare.py:822). Ohne sie
+ * musste der Aufrufer den Typ lokal erweitern — eine Ergaenzung, die in
+ * einem Composable niemand findet.
+ */
 export interface TaskStatusData {
   task_id?: string
   simulation_id?: string
@@ -40,6 +51,14 @@ export interface TaskStatusData {
   progress?: number
   message?: string
   error?: string | null
+  already_prepared?: boolean
+  expected_entities_count?: number
+  persona_target?: unknown
+  progress_detail?: {
+    current_stage?: string
+    [key: string]: unknown
+  }
+  [key: string]: unknown
 }
 
 export interface StartSimulationData {
@@ -83,13 +102,70 @@ export interface ProfileRecord {
   [key: string]: unknown
 }
 
+/**
+ * Felder aus `backend/app/services/persona_quality_service.py::evaluate`
+ * (ueber `api/simulation_profiles.py::get_simulation_profiles_quality`).
+ *
+ * Frueher stand hier ein `profiles`-Array — ein Feld, das der Endpunkt
+ * nie geliefert hat; es heisst `personas`. Nur die Index-Signatur hat
+ * das durchgehen lassen, weshalb der Aufrufer seit jeher Felder las,
+ * die im Typ nicht standen.
+ */
+/**
+ * `GET /<id>/profiles/realtime` — die Profile liegen im Feld `profiles`,
+ * NICHT direkt in `data` (backend/app/api/simulation_profiles.py:206).
+ */
+export interface ProfilesRealtimeResponse {
+  simulation_id: string
+  platform: string
+  count: number
+  total_expected?: number
+  is_generating?: boolean
+  file_exists?: boolean
+  file_modified_at?: string | null
+  profiles: ProfileRecord[]
+  [key: string]: unknown
+}
+
+/**
+ * `GET /<id>/config/realtime` — die Konfiguration liegt im Feld `config`
+ * (backend/app/api/simulation_profiles.py:598).
+ */
+export interface ConfigRealtimeResponse {
+  simulation_id: string
+  file_exists?: boolean
+  file_modified_at?: string | null
+  is_generating?: boolean
+  generation_stage?: string | null
+  config_generated?: boolean
+  config: Record<string, unknown> | null
+  summary?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface ProfileQualitySummary {
+  total: number
+  approved: number
+  pending: number
+  rejected: number
+  role_diversity: number
+  mbti_diversity: number
+  distinct_roles: string[]
+  [key: string]: unknown
+}
+
+export interface ProfileQualityIssue {
+  code: string
+  severity: string
+  detail?: Record<string, unknown>
+  [key: string]: unknown
+}
+
 export interface ProfileQualityResponse {
   simulation_id: string
-  profiles: Array<{
-    username: string
-    quality_score: number
-    issues: string[]
-  }>
+  summary?: ProfileQualitySummary
+  global_issues?: ProfileQualityIssue[]
+  personas?: Array<Record<string, unknown>>
   [key: string]: unknown
 }
 
@@ -123,8 +199,24 @@ export interface ModelPreset {
   [key: string]: unknown
 }
 
+/**
+ * Felder aus `backend/app/api/simulation_lifecycle.py::get_available_models`.
+ * Frueher stand hier ein `models: ModelPreset[]` — ein Feld, das der
+ * Endpunkt nie geliefert hat; nur die Index-Signatur liess das
+ * durchgehen.
+ */
 export interface AvailableModelsResponse {
-  models: ModelPreset[]
+  ollama?: ModelPreset[]
+  presets?: ModelPreset[]
+  current_default?: string
+  default_provider?: 'ollama' | 'cloud' | 'openai' | 'unknown'
+  ollama_base_url?: string
+  ollama_reachable?: boolean
+  ollama_error?: string | null
+  ollama_skipped?: boolean
+  agent_tools_enabled?: boolean
+  max_tool_calls_per_action?: number
+  default_language?: string
   [key: string]: unknown
 }
 
@@ -191,7 +283,7 @@ export interface AgentStatsResponse {
  * Create simulation
  * @param data - { project_id, graph_id?, enable_twitter?, enable_reddit? }
  */
-export const createSimulation = (data: CreateSimulationData): Promise<SimulationRecord> => {
+export const createSimulation = (data: CreateSimulationData): Promise<ApiEnvelope<SimulationRecord>> => {
   return service.post('/api/simulation/create', data)
 }
 
@@ -199,7 +291,7 @@ export const createSimulation = (data: CreateSimulationData): Promise<Simulation
  * Prepare simulation environment (async task)
  * @param data - { simulation_id, entity_types?, use_llm_for_profiles?, parallel_profile_count?, force_regenerate? }
  */
-export const prepareSimulation = (data: PrepareSimulationData): Promise<TaskStatusData> => {
+export const prepareSimulation = (data: PrepareSimulationData): Promise<ApiEnvelope<TaskStatusData>> => {
   return service.post('/api/simulation/prepare', data)
 }
 
@@ -207,7 +299,7 @@ export const prepareSimulation = (data: PrepareSimulationData): Promise<TaskStat
  * Query prepare task progress
  * @param data - { task_id?, simulation_id? }
  */
-export const getPrepareStatus = (data: TaskStatusData): Promise<TaskStatusData> => {
+export const getPrepareStatus = (data: TaskStatusData): Promise<ApiEnvelope<TaskStatusData>> => {
   return service.post('/api/simulation/prepare/status', data)
 }
 
@@ -215,7 +307,7 @@ export const getPrepareStatus = (data: TaskStatusData): Promise<TaskStatusData> 
  * Get simulation status
  * @param simulationId
  */
-export const getSimulation = (simulationId: string): Promise<SimulationRecord> => {
+export const getSimulation = (simulationId: string): Promise<ApiEnvelope<SimulationRecord>> => {
   return service.get(`/api/simulation/${simulationId}`)
 }
 
@@ -227,7 +319,7 @@ export const getSimulation = (simulationId: string): Promise<SimulationRecord> =
 export const getSimulationProfiles = (
   simulationId: string,
   platform: SimulationPlatform = 'reddit'
-): Promise<ProfileRecord[]> => {
+): Promise<ApiEnvelope<ProfileRecord[]>> => {
   return service.get(`/api/simulation/${simulationId}/profiles`, { params: { platform } })
 }
 
@@ -239,7 +331,7 @@ export const getSimulationProfiles = (
 export const getSimulationProfilesRealtime = (
   simulationId: string,
   platform: SimulationPlatform = 'reddit'
-): Promise<ProfileRecord[]> => {
+): Promise<ApiEnvelope<ProfilesRealtimeResponse>> => {
   return service.get(`/api/simulation/${simulationId}/profiles/realtime`, { params: { platform } })
 }
 
@@ -247,7 +339,7 @@ export const getSimulationProfilesRealtime = (
  * Get simulation configuration
  * @param simulationId
  */
-export const getSimulationConfig = (simulationId: string): Promise<Record<string, unknown>> => {
+export const getSimulationConfig = (simulationId: string): Promise<ApiEnvelope<Record<string, unknown>>> => {
   return service.get(`/api/simulation/${simulationId}/config`)
 }
 
@@ -258,7 +350,7 @@ export const getSimulationConfig = (simulationId: string): Promise<Record<string
  */
 export const getSimulationConfigRealtime = (
   simulationId: string
-): Promise<Record<string, unknown>> => {
+): Promise<ApiEnvelope<ConfigRealtimeResponse>> => {
   return service.get(`/api/simulation/${simulationId}/config/realtime`)
 }
 
@@ -266,7 +358,7 @@ export const getSimulationConfigRealtime = (
  * List all simulations
  * @param projectId - Optional, filter by project ID
  */
-export const listSimulations = (projectId?: string): Promise<SimulationRecord[]> => {
+export const listSimulations = (projectId?: string): Promise<ApiEnvelope<SimulationRecord[]>> => {
   const params = projectId ? { project_id: projectId } : {}
   return service.get('/api/simulation/list', { params })
 }
@@ -275,7 +367,7 @@ export const listSimulations = (projectId?: string): Promise<SimulationRecord[]>
  * Start simulation
  * @param data - { simulation_id, platform?, max_rounds?, simulation_days?, enable_graph_memory_update? }
  */
-export const startSimulation = (data: StartSimulationData): Promise<RunStatusResponse> => {
+export const startSimulation = (data: StartSimulationData): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.post('/api/simulation/start', data)
 }
 
@@ -283,7 +375,7 @@ export const startSimulation = (data: StartSimulationData): Promise<RunStatusRes
  * Stop simulation
  * @param data - { simulation_id }
  */
-export const stopSimulation = (data: StopSimulationData): Promise<RunStatusResponse> => {
+export const stopSimulation = (data: StopSimulationData): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.post('/api/simulation/stop', data)
 }
 
@@ -291,7 +383,7 @@ export const stopSimulation = (data: StopSimulationData): Promise<RunStatusRespo
  * Get simulation real-time run status
  * @param simulationId
  */
-export const getRunStatus = (simulationId: string): Promise<RunStatusResponse> => {
+export const getRunStatus = (simulationId: string): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.get(`/api/simulation/${simulationId}/run-status`)
 }
 
@@ -299,7 +391,7 @@ export const getRunStatus = (simulationId: string): Promise<RunStatusResponse> =
  * Get simulation detailed run status (including recent actions)
  * @param simulationId
  */
-export const getRunStatusDetail = (simulationId: string): Promise<RunStatusResponse> => {
+export const getRunStatusDetail = (simulationId: string): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.get(`/api/simulation/${simulationId}/run-status/detail`)
 }
 
@@ -315,7 +407,7 @@ export const getSimulationPosts = (
   platform: SimulationPlatform = 'reddit',
   limit = 50,
   offset = 0
-): Promise<unknown[]> => {
+): Promise<ApiEnvelope<unknown[]>> => {
   return service.get(`/api/simulation/${simulationId}/posts`, {
     params: { platform, limit, offset }
   })
@@ -367,7 +459,7 @@ export const getSimulationTimeline = (
   simulationId: string,
   startRound = 0,
   endRound: number | null = null
-): Promise<TimelineResponse> => {
+): Promise<ApiEnvelope<TimelineResponse>> => {
   const params: Record<string, unknown> = { start_round: startRound }
   if (endRound !== null) {
     params['end_round'] = endRound
@@ -379,7 +471,7 @@ export const getSimulationTimeline = (
  * Get Agent statistics
  * @param simulationId
  */
-export const getAgentStats = (simulationId: string): Promise<AgentStatsResponse> => {
+export const getAgentStats = (simulationId: string): Promise<ApiEnvelope<AgentStatsResponse>> => {
   return service.get(`/api/simulation/${simulationId}/agent-stats`)
 }
 
@@ -391,7 +483,7 @@ export const getAgentStats = (simulationId: string): Promise<AgentStatsResponse>
 export const getSimulationActions = (
   simulationId: string,
   params: SimulationActionsParams = {}
-): Promise<unknown[]> => {
+): Promise<ApiEnvelope<unknown[]>> => {
   return service.get(`/api/simulation/${simulationId}/actions`, { params })
 }
 
@@ -399,7 +491,7 @@ export const getSimulationActions = (
  * Close simulation environment (graceful shutdown)
  * @param data - { simulation_id, timeout? }
  */
-export const closeSimulationEnv = (data: CloseEnvData): Promise<unknown> => {
+export const closeSimulationEnv = (data: CloseEnvData): Promise<ApiEnvelope<unknown>> => {
   return service.post('/api/simulation/close-env', data)
 }
 
@@ -407,7 +499,7 @@ export const closeSimulationEnv = (data: CloseEnvData): Promise<unknown> => {
  * Get simulation environment status
  * @param data - { simulation_id }
  */
-export const getEnvStatus = (data: EnvStatusData): Promise<unknown> => {
+export const getEnvStatus = (data: EnvStatusData): Promise<ApiEnvelope<unknown>> => {
   return service.post('/api/simulation/env-status', data)
 }
 
@@ -415,7 +507,7 @@ export const getEnvStatus = (data: EnvStatusData): Promise<unknown> => {
  * Batch interview Agents
  * @param data - { simulation_id, interviews: [{ agent_id, prompt }] }
  */
-export const interviewAgents = (data: InterviewAgentsData): Promise<unknown> => {
+export const interviewAgents = (data: InterviewAgentsData): Promise<ApiEnvelope<unknown>> => {
   return service.post('/api/simulation/interview/batch', data)
 }
 
@@ -424,28 +516,28 @@ export const interviewAgents = (data: InterviewAgentsData): Promise<unknown> => 
  * Used to display historical projects on home page
  * @param limit - Return count limit
  */
-export const getSimulationHistory = (limit = 20): Promise<SimulationRecord[]> => {
+export const getSimulationHistory = (limit = 20): Promise<ApiEnvelope<SimulationRecord[]>> => {
   return service.get('/api/simulation/history', { params: { limit } })
 }
 
 /**
  * List installed Ollama + curated LLM model presets for the model dropdown.
  */
-export const getAvailableModels = (): Promise<AvailableModelsResponse> => {
+export const getAvailableModels = (): Promise<ApiEnvelope<AvailableModelsResponse>> => {
   return service.get('/api/simulation/available-models')
 }
 
 /**
  * Pause a running simulation between rounds.
  */
-export const pauseSimulation = (simulationId: string): Promise<RunStatusResponse> => {
+export const pauseSimulation = (simulationId: string): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.post(`/api/simulation/${simulationId}/pause`)
 }
 
 /**
  * Resume a paused simulation.
  */
-export const resumeSimulation = (simulationId: string): Promise<RunStatusResponse> => {
+export const resumeSimulation = (simulationId: string): Promise<ApiEnvelope<RunStatusResponse>> => {
   return service.post(`/api/simulation/${simulationId}/resume`)
 }
 
@@ -457,7 +549,7 @@ export const resumeSimulation = (simulationId: string): Promise<RunStatusRespons
 export const getSimulationConsoleLog = (
   simulationId: string,
   fromLine = 0
-): Promise<{ lines: string[]; from_line: number; total_lines: number }> => {
+): Promise<ApiEnvelope<{ lines: string[]; from_line: number; total_lines: number }>> => {
   return service.get(`/api/simulation/${simulationId}/console-log`, {
     params: { from_line: fromLine }
   })
@@ -471,7 +563,7 @@ export const getSimulationConsoleLog = (
 export const addSimulationProfile = (
   simulationId: string,
   data: Omit<ProfileRecord, 'review_status'>
-): Promise<ProfileRecord> => {
+): Promise<ApiEnvelope<ProfileRecord>> => {
   return service.post(`/api/simulation/${simulationId}/profiles`, data)
 }
 
@@ -485,7 +577,7 @@ export const deleteSimulationProfile = (
   simulationId: string,
   username: string,
   platform: SimulationPlatform = 'reddit'
-): Promise<unknown> => {
+): Promise<ApiEnvelope<unknown>> => {
   return service.delete(
     `/api/simulation/${simulationId}/profiles/${encodeURIComponent(username)}`,
     { params: { platform } }
@@ -503,7 +595,7 @@ export const editSimulationProfile = (
   simulationId: string,
   username: string,
   data: Partial<ProfileRecord>
-): Promise<ProfileRecord> => {
+): Promise<ApiEnvelope<ProfileRecord>> => {
   return service.patch(
     `/api/simulation/${simulationId}/profiles/${encodeURIComponent(username)}`,
     data
@@ -520,7 +612,7 @@ export const approveSimulationProfile = (
   simulationId: string,
   username: string,
   notes?: string
-): Promise<ProfileRecord> => {
+): Promise<ApiEnvelope<ProfileRecord>> => {
   return service.post(
     `/api/simulation/${simulationId}/profiles/${encodeURIComponent(username)}/approve`,
     notes ? { notes } : {}
@@ -537,7 +629,7 @@ export const rejectSimulationProfile = (
   simulationId: string,
   username: string,
   reason?: string
-): Promise<ProfileRecord> => {
+): Promise<ApiEnvelope<ProfileRecord>> => {
   return service.post(
     `/api/simulation/${simulationId}/profiles/${encodeURIComponent(username)}/reject`,
     reason ? { reason } : {}
@@ -556,7 +648,7 @@ export const regenerateSimulationProfile = (
   simulationId: string,
   username: string,
   hint?: string
-): Promise<ProfileRecord> => {
+): Promise<ApiEnvelope<ProfileRecord>> => {
   return service.post(
     `/api/simulation/${simulationId}/profiles/${encodeURIComponent(username)}/regenerate`,
     hint ? { hint } : {}
@@ -569,7 +661,7 @@ export const regenerateSimulationProfile = (
  */
 export const getSimulationProfilesQuality = (
   simulationId: string
-): Promise<ProfileQualityResponse> => {
+): Promise<ApiEnvelope<ProfileQualityResponse>> => {
   return service.get(`/api/simulation/${simulationId}/profiles/quality`)
 }
 
@@ -593,7 +685,7 @@ export const listPersonaTemplates = (): Promise<
  */
 export const savePersonaTemplate = (
   data: PersonaTemplateRecord
-): Promise<PersonaTemplateRecord> => {
+): Promise<ApiEnvelope<PersonaTemplateRecord>> => {
   return service.post('/api/simulation/persona-library', data)
 }
 
@@ -601,7 +693,7 @@ export const savePersonaTemplate = (
  * Delete a reusable persona template.
  * @param templateId
  */
-export const deletePersonaTemplate = (templateId: string): Promise<unknown> => {
+export const deletePersonaTemplate = (templateId: string): Promise<ApiEnvelope<unknown>> => {
   return service.delete(`/api/simulation/persona-library/${encodeURIComponent(templateId)}`)
 }
 

--- a/frontend/src/composables/__tests__/usePersonaActions.spec.ts
+++ b/frontend/src/composables/__tests__/usePersonaActions.spec.ts
@@ -44,7 +44,9 @@ import {
   editSimulationProfile,
   getSimulationProfilesQuality,
   type ProfileRecord,
+  type ProfileQualityResponse,
 } from '../../api/simulation'
+import type { ApiEnvelope } from '../../api/envelope'
 
 import { usePersonaActions } from '../usePersonaActions'
 
@@ -58,7 +60,7 @@ const mockGetQuality = vi.mocked(getSimulationProfilesQuality)
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): unknown {
+function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): ApiEnvelope<ProfileRecord> {
   return {
     success: true,
     data: {
@@ -71,12 +73,8 @@ function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): unknown {
   }
 }
 
-function makeErrorEnvelope(error = 'Server-Fehler'): unknown {
-  return { success: false, error }
-}
-
-function makeQualitySuccess(): unknown {
-  return { success: true, data: { personas: [] } }
+function makeQualitySuccess(): ApiEnvelope<ProfileQualityResponse> {
+  return { success: true, data: { simulation_id: 'sim-001', profiles: [], personas: [] } }
 }
 
 function buildDeps(overrides: {
@@ -99,7 +97,7 @@ function buildDeps(overrides: {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockGetQuality.mockResolvedValue(makeQualitySuccess() as import('../../api/simulation').ProfileQualityResponse)
+  mockGetQuality.mockResolvedValue(makeQualitySuccess())
 })
 
 // ---------------------------------------------------------------------------
@@ -262,7 +260,7 @@ describe('usePersonaActions', () => {
       const profileBefore: ProfileRecord = { username: 'user1', review_status: 'pending' }
       const profileAfter: ProfileRecord = { username: 'user1', review_status: 'approved' }
 
-      mockApprove.mockResolvedValue(makeProfileEnvelope({ review_status: 'approved' }) as ProfileRecord)
+      mockApprove.mockResolvedValue(makeProfileEnvelope({ review_status: 'approved' }))
 
       const profiles = ref<ProfileRecord[]>([profileBefore])
       const selectedProfile = ref<ProfileRecord | null>(profileBefore)
@@ -283,7 +281,7 @@ describe('usePersonaActions', () => {
       let pendingDuring = false
       mockApprove.mockImplementation(async () => {
         pendingDuring = true
-        return makeProfileEnvelope() as ProfileRecord
+        return makeProfileEnvelope()
       })
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
@@ -334,7 +332,7 @@ describe('usePersonaActions', () => {
 
   describe('Case 5 — rejectSelected', () => {
     it('Happy-Path: ruft reject, patcht profiles, ruft addLog + refreshQuality', async () => {
-      mockReject.mockResolvedValue(makeProfileEnvelope({ review_status: 'rejected' }) as ProfileRecord)
+      mockReject.mockResolvedValue(makeProfileEnvelope({ review_status: 'rejected' }))
 
       const profiles = ref<ProfileRecord[]>([{ username: 'user1', review_status: 'pending' }])
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1', review_status: 'pending' })
@@ -368,7 +366,7 @@ describe('usePersonaActions', () => {
 
   describe('Case 6 — regenerateSelected', () => {
     it('übergibt getrimten Hint an regenerate', async () => {
-      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord)
+      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }))
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const deps = { ...buildDeps(), selectedProfile }
@@ -381,7 +379,7 @@ describe('usePersonaActions', () => {
     })
 
     it('übergibt undefined wenn Hint nach trim leer ist', async () => {
-      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord)
+      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }))
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const deps = { ...buildDeps(), selectedProfile }
@@ -394,7 +392,7 @@ describe('usePersonaActions', () => {
     })
 
     it('leert regenerateHint nach Erfolg', async () => {
-      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord)
+      mockRegenerate.mockResolvedValue(makeProfileEnvelope({ review_status: 'regenerating' }))
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const deps = { ...buildDeps(), selectedProfile }
@@ -477,7 +475,7 @@ describe('usePersonaActions', () => {
 
   describe('Case 8 — saveEditingProfile', () => {
     it('Happy-Path: sendet payload ohne username, splittet topics, ruft editProfile', async () => {
-      mockEditProfile.mockResolvedValue(makeProfileEnvelope({ review_status: 'pending' }) as ProfileRecord)
+      mockEditProfile.mockResolvedValue(makeProfileEnvelope({ review_status: 'pending' }))
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const profiles = ref<ProfileRecord[]>([{ username: 'user1', review_status: 'pending' }])
@@ -513,7 +511,7 @@ describe('usePersonaActions', () => {
     })
 
     it('entfernt leeres age aus payload', async () => {
-      mockEditProfile.mockResolvedValue(makeProfileEnvelope() as ProfileRecord)
+      mockEditProfile.mockResolvedValue(makeProfileEnvelope())
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const deps = { ...buildDeps(), selectedProfile }
@@ -539,7 +537,7 @@ describe('usePersonaActions', () => {
     })
 
     it('setzt editingProfile = null nach Erfolg', async () => {
-      mockEditProfile.mockResolvedValue(makeProfileEnvelope() as ProfileRecord)
+      mockEditProfile.mockResolvedValue(makeProfileEnvelope())
 
       const selectedProfile = ref<ProfileRecord | null>({ username: 'user1' })
       const deps = { ...buildDeps(), selectedProfile }

--- a/frontend/src/composables/__tests__/usePersonaReview.spec.ts
+++ b/frontend/src/composables/__tests__/usePersonaReview.spec.ts
@@ -34,6 +34,7 @@ import {
   getSimulationProfilesQuality,
   type ProfileRecord,
 } from '../../api/simulation'
+import type { ApiEnvelope } from '../../api/envelope'
 import { usePersonaReview } from '../usePersonaReview'
 
 const mockRegenerateSimulationProfile = vi.mocked(regenerateSimulationProfile)
@@ -41,10 +42,7 @@ const mockApproveSimulationProfile = vi.mocked(approveSimulationProfile)
 const mockRejectSimulationProfile = vi.mocked(rejectSimulationProfile)
 const mockGetQuality = vi.mocked(getSimulationProfilesQuality)
 
-// reason: the service interceptor returns raw envelope body at runtime;
-// the function types claim the unwrapped type but tests cast via `unknown`
-// to match the actual runtime shape (envelope with success + data).
-function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): unknown {
+function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): ApiEnvelope<ProfileRecord> {
   return {
     success: true,
     data: {
@@ -57,7 +55,7 @@ function makeProfileEnvelope(overrides: Partial<ProfileRecord> = {}): unknown {
   }
 }
 
-function makeErrorEnvelope(error = 'Server-Fehler'): unknown {
+function makeErrorEnvelope(error = 'Server-Fehler'): ApiEnvelope<ProfileRecord> {
   return {
     success: false,
     error,
@@ -67,16 +65,17 @@ function makeErrorEnvelope(error = 'Server-Fehler'): unknown {
 beforeEach(() => {
   vi.clearAllMocks()
   // Default: quality fetch returns empty success
-  // reason: runtime shape is an envelope; typed as ProfileQualityResponse but the
-  // interceptor actually returns { success, data } — cast via unknown
-  mockGetQuality.mockResolvedValue({ success: true, data: { personas: [] } } as unknown as import('../../api/simulation').ProfileQualityResponse)
+  mockGetQuality.mockResolvedValue({
+    success: true,
+    data: { simulation_id: 'sim-001', profiles: [], personas: [] },
+  })
 })
 
 describe('usePersonaReview', () => {
   describe('regenerate', () => {
     it('Erfolgsfall: API liefert ProfileRecord mit review_status regenerating, Composable returned das Profile', async () => {
       mockRegenerateSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'regenerating' })
       )
 
       const composable = usePersonaReview()
@@ -90,7 +89,7 @@ describe('usePersonaReview', () => {
 
     it('Mit Hint: regenerate ruft API mit korrektem Body-Hint', async () => {
       mockRegenerateSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'regenerating' })
       )
 
       const composable = usePersonaReview()
@@ -105,7 +104,7 @@ describe('usePersonaReview', () => {
 
     it('Ohne Hint: regenerate ruft API mit undefined als drittes Argument', async () => {
       mockRegenerateSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'regenerating' })
       )
 
       const composable = usePersonaReview()
@@ -116,7 +115,7 @@ describe('usePersonaReview', () => {
 
     it('Idempotenz: zweiter Aufruf bei regenerating-Status wird toleriert (200)', async () => {
       mockRegenerateSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'regenerating' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'regenerating' })
       )
 
       const composable = usePersonaReview()
@@ -130,7 +129,7 @@ describe('usePersonaReview', () => {
 
     it('Fehler-Pfad: API liefert success=false, Composable wirft mit der Backend-Fehlermeldung', async () => {
       mockRegenerateSimulationProfile.mockResolvedValue(
-        makeErrorEnvelope('Persona nicht gefunden.') as ProfileRecord
+        makeErrorEnvelope('Persona nicht gefunden.')
       )
 
       const composable = usePersonaReview()
@@ -141,7 +140,7 @@ describe('usePersonaReview', () => {
     })
 
     it('Fehler-Pfad: API liefert success=false ohne error-Feld, Composable wirft Fallback-Message', async () => {
-      mockRegenerateSimulationProfile.mockResolvedValue({ success: false } as unknown as ProfileRecord)
+      mockRegenerateSimulationProfile.mockResolvedValue({ success: false })
 
       const composable = usePersonaReview()
 
@@ -170,7 +169,7 @@ describe('usePersonaReview', () => {
   describe('approve (Baseline-Regression nach Sub-Slice 33)', () => {
     it('approve ruft approveSimulationProfile korrekt auf', async () => {
       mockApproveSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'approved' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'approved' })
       )
 
       const composable = usePersonaReview()
@@ -184,7 +183,7 @@ describe('usePersonaReview', () => {
   describe('reject (Baseline-Regression nach Sub-Slice 33)', () => {
     it('reject ruft rejectSimulationProfile korrekt auf', async () => {
       mockRejectSimulationProfile.mockResolvedValue(
-        makeProfileEnvelope({ review_status: 'rejected' }) as ProfileRecord
+        makeProfileEnvelope({ review_status: 'rejected' })
       )
 
       const composable = usePersonaReview()

--- a/frontend/src/composables/__tests__/useSimulationPrepare.spec.ts
+++ b/frontend/src/composables/__tests__/useSimulationPrepare.spec.ts
@@ -35,6 +35,8 @@ import {
   type TaskStatusData,
   type ProfileRecord,
 } from '../../api/simulation'
+import type { ProfilesRealtimeResponse, ConfigRealtimeResponse } from '../../api/simulation'
+import type { ApiEnvelope } from '../../api/envelope'
 import { useSimulationPrepare } from '../useSimulationPrepare'
 
 const mockPrepare = vi.mocked(prepareSimulation)
@@ -63,13 +65,20 @@ function makeErrorEnvelope(error = 'Serverfehler'): unknown {
   return { success: false, error }
 }
 
-function makeProfilesEnvelope(profiles: ProfileRecord[] = []): unknown {
-  return { success: true, data: { profiles } }
+// Befund: `getSimulationProfilesRealtime` liefert laut api/simulation.ts
+// `ApiEnvelope<ProfileRecord[]>` — `data` ist das Array direkt, kein
+// `{profiles: [...]}`-Wrapper (den die alten Mocks hier vorgaukelten und den
+// der Composable-Code ungeprüft annahm — siehe Bericht).
+function makeProfilesEnvelope(profiles: ProfileRecord[] = []): ApiEnvelope<ProfilesRealtimeResponse> {
+  // Der Endpunkt liefert ein Objekt MIT profiles-Feld
+  // (backend/app/api/simulation_profiles.py:206).
+  return { success: true, data: { simulation_id: 'sim_1', platform: 'reddit', count: profiles.length, profiles } }
 }
 
-function makeConfigEnvelope(config: Record<string, unknown> | null = null): unknown {
+function makeConfigEnvelope(config: Record<string, unknown> | null = null): ApiEnvelope<ConfigRealtimeResponse> {
   if (!config) return { success: false }
-  return { success: true, data: { config } }
+  // Die Konfiguration liegt im Feld `config` (simulation_profiles.py:598).
+  return { success: true, data: { simulation_id: 'sim_1', config } }
 }
 
 function makeStatusEnvelope(status: string, progress = 100): unknown {
@@ -88,9 +97,9 @@ beforeEach(() => {
   vi.clearAllMocks()
 
   // Safe defaults so polling ticks don't crash
-  mockGetStatus.mockResolvedValue(makeStatusEnvelope('running', 50) as TaskStatusData)
-  mockGetProfiles.mockResolvedValue(makeProfilesEnvelope() as ProfileRecord[])
-  mockGetConfig.mockResolvedValue(makeConfigEnvelope() as Record<string, unknown>)
+  mockGetStatus.mockResolvedValue(makeStatusEnvelope('running', 50) as ApiEnvelope<TaskStatusData>)
+  mockGetProfiles.mockResolvedValue(makeProfilesEnvelope())
+  mockGetConfig.mockResolvedValue(makeConfigEnvelope())
 })
 
 afterEach(() => {
@@ -104,7 +113,7 @@ afterEach(() => {
 describe('useSimulationPrepare', () => {
   describe('Case 1 — Erfolgsfall: startPrepare ruft API korrekt auf und setzt State', () => {
     it('ruft prepareSimulation mit korrektem Body, gibt true zurück, setzt isPreparing=true', async () => {
-      mockPrepare.mockResolvedValue(makePrepareEnvelope() as TaskStatusData)
+      mockPrepare.mockResolvedValue(makePrepareEnvelope() as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
       const onLog = vi.fn()
@@ -140,7 +149,7 @@ describe('useSimulationPrepare', () => {
           floor_applied: true,
           floor: 50,
         },
-      }) as TaskStatusData)
+      }) as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
 
@@ -163,7 +172,7 @@ describe('useSimulationPrepare', () => {
           floor_applied: false,
           floor: 50,
         },
-      }) as TaskStatusData)
+      }) as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
 
@@ -181,7 +190,7 @@ describe('useSimulationPrepare', () => {
       mockPrepare.mockResolvedValue(makePrepareEnvelope({
         expected_entities_count: 12,
         persona_target: { kaputt: true },
-      }) as TaskStatusData)
+      }) as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
 
@@ -201,7 +210,7 @@ describe('useSimulationPrepare', () => {
     it('isPreparing=true wird synchron gesetzt bevor das API-Promise resolves', async () => {
       let resolvePromise: (v: unknown) => void
       const deferred = new Promise<unknown>((res) => { resolvePromise = res })
-      mockPrepare.mockReturnValue(deferred as Promise<TaskStatusData>)
+      mockPrepare.mockReturnValue(deferred as Promise<ApiEnvelope<TaskStatusData>>)
 
       const composable = useSimulationPrepare()
       const callPromise = composable.startPrepare({
@@ -224,7 +233,7 @@ describe('useSimulationPrepare', () => {
 
   describe('Case 3 — Fehler-Pfad: API liefert success=false', () => {
     it('setzt error.value und ruft onStatusChange("error") ohne zu werfen', async () => {
-      mockPrepare.mockResolvedValue(makeErrorEnvelope('Keine Entitäten gefunden.') as TaskStatusData)
+      mockPrepare.mockResolvedValue(makeErrorEnvelope('Keine Entitäten gefunden.') as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
       const onLog = vi.fn()
@@ -266,7 +275,7 @@ describe('useSimulationPrepare', () => {
     it('zweiter startPrepare-Aufruf gibt false zurück und ruft API nur einmal', async () => {
       let resolveFirst: (v: unknown) => void
       const firstDeferred = new Promise<unknown>((res) => { resolveFirst = res })
-      mockPrepare.mockReturnValueOnce(firstDeferred as Promise<TaskStatusData>)
+      mockPrepare.mockReturnValueOnce(firstDeferred as Promise<ApiEnvelope<TaskStatusData>>)
 
       const composable = useSimulationPrepare()
       const opts = {
@@ -295,8 +304,8 @@ describe('useSimulationPrepare', () => {
   describe('Case 5 — already_prepared: probeAlreadyPrepared hydratiert State korrekt', () => {
     it('setzt phase=3 und simulationConfig wenn Config vorhanden', async () => {
       const fakeConfig = { time_config: { total_simulation_hours: 24, minutes_per_round: 60 } }
-      mockGetConfig.mockResolvedValue(makeConfigEnvelope(fakeConfig) as Record<string, unknown>)
-      mockGetProfiles.mockResolvedValue(makeProfilesEnvelope([{ username: 'u1' } as ProfileRecord]) as ProfileRecord[])
+      mockGetConfig.mockResolvedValue(makeConfigEnvelope(fakeConfig))
+      mockGetProfiles.mockResolvedValue(makeProfilesEnvelope([{ username: 'u1' } as ProfileRecord]))
 
       const composable = useSimulationPrepare()
       const onLog = vi.fn()
@@ -310,7 +319,7 @@ describe('useSimulationPrepare', () => {
     })
 
     it('kein State-Change wenn Config-Endpunkt kein Config zurückgibt', async () => {
-      mockGetConfig.mockResolvedValue(makeConfigEnvelope(null) as Record<string, unknown>)
+      mockGetConfig.mockResolvedValue(makeConfigEnvelope(null))
 
       const composable = useSimulationPrepare()
       await composable.probeAlreadyPrepared('sim-007', { onLog: vi.fn(), onStatusChange: vi.fn() })
@@ -346,7 +355,7 @@ describe('useSimulationPrepare', () => {
 
     it('fetchProfilesRealtime() aktualisiert profiles.value wenn API Erfolg liefert', async () => {
       const fakeProfiles = [{ username: 'tester' } as ProfileRecord]
-      mockGetProfiles.mockResolvedValue(makeProfilesEnvelope(fakeProfiles) as ProfileRecord[])
+      mockGetProfiles.mockResolvedValue(makeProfilesEnvelope(fakeProfiles))
 
       const composable = useSimulationPrepare()
       // Set a simulationId so the guard passes
@@ -361,7 +370,7 @@ describe('useSimulationPrepare', () => {
 
   describe('Case 7 — reset: setzt alle State-Werte zurück auf Initialwerte', () => {
     it('reset() nach erfolgreichem Start liefert initialen State', async () => {
-      mockPrepare.mockResolvedValue(makePrepareEnvelope() as TaskStatusData)
+      mockPrepare.mockResolvedValue(makePrepareEnvelope() as ApiEnvelope<TaskStatusData>)
 
       const composable = useSimulationPrepare()
       await composable.startPrepare({

--- a/frontend/src/composables/useEnvForm.ts
+++ b/frontend/src/composables/useEnvForm.ts
@@ -136,20 +136,10 @@ export function useEnvForm({ t, onError }: UseEnvFormOptions): UseEnvFormReturn 
   async function loadModels(): Promise<void> {
     loadingModels.value = true
     try {
-      // reason: service interceptor returns raw envelope body at runtime
-      const res = (await getAvailableModels()) as unknown as {
-        success?: boolean
-        data?: {
-          ollama?: ModelPreset[]
-          presets?: ModelPreset[]
-          current_default?: string
-          default_provider?: 'ollama' | 'cloud' | 'openai' | 'unknown'
-          ollama_reachable?: boolean
-          agent_tools_enabled?: boolean
-          max_tool_calls_per_action?: number
-          default_language?: string
-        }
-      }
+      // Kein Cast mehr noetig: getAvailableModels deklariert die Envelope
+      // und AvailableModelsResponse die Felder, die der Endpunkt wirklich
+      // liefert.
+      const res = await getAvailableModels()
       if (res?.success) {
         ollamaModels.value = res.data?.ollama || []
         presetModels.value = res.data?.presets || []

--- a/frontend/src/composables/usePersonaReview.ts
+++ b/frontend/src/composables/usePersonaReview.ts
@@ -18,28 +18,10 @@ import {
   getSimulationProfilesQuality,
   rejectSimulationProfile,
   regenerateSimulationProfile,
+  type ProfileQualityResponse,
+  type ProfileQualitySummary,
   type ProfileRecord,
 } from '../api/simulation'
-
-// reason: the service interceptor returns the raw envelope body at runtime;
-// the API type declarations claim the unwrapped type but the composable checks
-// `res?.success` — we cast via `unknown` to the actual runtime shape.
-interface QualityEnvelope {
-  success?: boolean
-  error?: string
-  data?: {
-    summary?: string | null
-    global_issues?: IssueSeverityEntry[]
-    review_enabled?: boolean
-    personas?: Array<{ username: string; issues?: IssueSeverityEntry[] }>
-  }
-}
-
-interface ProfileEnvelope {
-  success?: boolean
-  error?: string
-  data?: ProfileRecord
-}
 
 export type IssueSeverity = 'error' | 'warning' | 'info'
 
@@ -51,7 +33,7 @@ export interface IssueSeverityEntry {
 
 export interface UsePersonaReviewReturn {
   reviewEnabled: Ref<boolean>
-  summary: Ref<string | null>
+  summary: Ref<ProfileQualitySummary | null>
   globalIssues: Ref<IssueSeverityEntry[]>
   hasGlobalIssues: ComputedRef<boolean>
   issuesByUsername: Map<string, IssueSeverityEntry[]>
@@ -59,7 +41,7 @@ export interface UsePersonaReviewReturn {
   error: Ref<string | null>
   getIssuesFor: (username: string) => IssueSeverityEntry[]
   highestSeverityFor: (username: string) => IssueSeverity | null
-  refreshQuality: (simulationId: string) => Promise<QualityEnvelope['data'] | null>
+  refreshQuality: (simulationId: string) => Promise<ProfileQualityResponse | null>
   approve: (simulationId: string, username: string, notes?: string) => Promise<ProfileRecord | undefined>
   reject: (simulationId: string, username: string, reason?: string) => Promise<ProfileRecord | undefined>
   regenerate: (simulationId: string, username: string, hint?: string) => Promise<ProfileRecord | undefined>
@@ -70,7 +52,7 @@ const SEVERITY_RANK: Record<IssueSeverity, number> = { error: 3, warning: 2, inf
 
 export function usePersonaReview(): UsePersonaReviewReturn {
   const reviewEnabled = ref(false)
-  const summary = ref<string | null>(null)
+  const summary = ref<ProfileQualitySummary | null>(null)
   const globalIssues = ref<IssueSeverityEntry[]>([])
   const issuesByUsername = reactive(new Map<string, IssueSeverityEntry[]>())
   const isLoading = ref(false)
@@ -91,30 +73,43 @@ export function usePersonaReview(): UsePersonaReviewReturn {
     return highest
   }
 
-  function applyReport(payload: QualityEnvelope['data']): void {
-    summary.value = payload?.summary || null
-    globalIssues.value = payload?.global_issues || []
-    reviewEnabled.value = !!payload?.review_enabled
+  // reason: ProfileQualityResponse (src/api/simulation.ts) only declares
+  // `simulation_id`/`profiles` explicitly and falls back to an index signature
+  // of `unknown` for everything else — it does not describe the
+  // summary/global_issues/review_enabled/personas shape the backend actually
+  // sends here (verified against no other typed consumer of these fields).
+  // That's a pre-existing gap in the (out-of-scope) API type, not something
+  // this composable should paper over with a cast — so the fields are read
+  // through explicit runtime narrowing instead.
+  function applyReport(payload: ProfileQualityResponse): void {
+    // summary ist ein OBJEKT mit Zaehlern (total/approved/pending/…),
+    // kein Text — siehe persona_quality_service.py::_build_summary. Der
+    // frueher hier deklarierte `string` war eine Typluege, die nur
+    // niemandem aufgefallen ist, weil bisher keine Ansicht den Wert liest.
+    summary.value = payload.summary ?? null
+    globalIssues.value = (payload.global_issues ?? []) as IssueSeverityEntry[]
+    reviewEnabled.value = !!payload.review_enabled
     issuesByUsername.clear()
-    for (const entry of payload?.personas || []) {
-      issuesByUsername.set(entry.username, entry.issues || [])
+    const personas = Array.isArray(payload.personas) ? payload.personas : []
+    for (const entry of personas) {
+      const username = typeof entry.username === 'string' ? entry.username : ''
+      if (!username) continue
+      issuesByUsername.set(username, (entry.issues ?? []) as IssueSeverityEntry[])
     }
   }
 
-  async function refreshQuality(simulationId: string): Promise<QualityEnvelope['data'] | null> {
+  async function refreshQuality(simulationId: string): Promise<ProfileQualityResponse | null> {
     if (!simulationId) return null
     isLoading.value = true
     error.value = null
     try {
-      // reason: service interceptor returns raw envelope body at runtime;
-      // getSimulationProfilesQuality is typed as the unwrapped type in api/simulation.ts
-      const res = (await getSimulationProfilesQuality(simulationId)) as unknown as QualityEnvelope
-      if (res?.success) {
-        applyReport(res.data)
-        return res.data ?? null
+      const res = await getSimulationProfilesQuality(simulationId)
+      if (!res.success) {
+        error.value = res.error || 'Quality-Report konnte nicht geladen werden.'
+        return null
       }
-      error.value = res?.error || 'Quality-Report konnte nicht geladen werden.'
-      return null
+      applyReport(res.data)
+      return res.data
     } catch (err) {
       const e = err as { message?: string }
       error.value = e?.message || 'Quality-Report konnte nicht geladen werden.'
@@ -129,10 +124,9 @@ export function usePersonaReview(): UsePersonaReviewReturn {
     username: string,
     notes?: string
   ): Promise<ProfileRecord | undefined> {
-    // reason: service interceptor returns raw envelope body at runtime
-    const res = (await approveSimulationProfile(simulationId, username, notes)) as unknown as ProfileEnvelope
-    if (!res?.success) {
-      throw new Error(res?.error || 'Approve fehlgeschlagen.')
+    const res = await approveSimulationProfile(simulationId, username, notes)
+    if (!res.success) {
+      throw new Error(res.error || 'Approve fehlgeschlagen.')
     }
     return res.data
   }
@@ -142,10 +136,9 @@ export function usePersonaReview(): UsePersonaReviewReturn {
     username: string,
     reason?: string
   ): Promise<ProfileRecord | undefined> {
-    // reason: service interceptor returns raw envelope body at runtime
-    const res = (await rejectSimulationProfile(simulationId, username, reason)) as unknown as ProfileEnvelope
-    if (!res?.success) {
-      throw new Error(res?.error || 'Reject fehlgeschlagen.')
+    const res = await rejectSimulationProfile(simulationId, username, reason)
+    if (!res.success) {
+      throw new Error(res.error || 'Reject fehlgeschlagen.')
     }
     return res.data
   }
@@ -155,10 +148,9 @@ export function usePersonaReview(): UsePersonaReviewReturn {
     username: string,
     hint?: string
   ): Promise<ProfileRecord | undefined> {
-    // reason: service interceptor returns raw envelope body at runtime
-    const res = (await regenerateSimulationProfile(simulationId, username, hint)) as unknown as ProfileEnvelope
-    if (!res?.success) {
-      throw new Error(res?.error || 'Regenerate fehlgeschlagen.')
+    const res = await regenerateSimulationProfile(simulationId, username, hint)
+    if (!res.success) {
+      throw new Error(res.error || 'Regenerate fehlgeschlagen.')
     }
     return res.data
   }
@@ -168,10 +160,9 @@ export function usePersonaReview(): UsePersonaReviewReturn {
     username: string,
     data: Partial<ProfileRecord>
   ): Promise<ProfileRecord | undefined> {
-    // reason: service interceptor returns raw envelope body at runtime
-    const res = (await editSimulationProfile(simulationId, username, data)) as unknown as ProfileEnvelope
-    if (!res?.success) {
-      throw new Error(res?.error || 'Edit fehlgeschlagen.')
+    const res = await editSimulationProfile(simulationId, username, data)
+    if (!res.success) {
+      throw new Error(res.error || 'Edit fehlgeschlagen.')
     }
     return res.data
   }

--- a/frontend/src/composables/useSimulationPrepare.ts
+++ b/frontend/src/composables/useSimulationPrepare.ts
@@ -72,50 +72,6 @@ export interface UseSimulationPrepareReturn extends SimulationPrepareState {
 }
 
 // -------------------------------------------------------------------------
-// Private helpers
-// -------------------------------------------------------------------------
-
-interface PrepareTaskStatus {
-  status?: string
-  progress?: number
-  message?: string
-  error?: string | null
-  progress_detail?: {
-    current_stage?: string
-  }
-}
-
-interface PrepareEnvelope {
-  success?: boolean
-  error?: string
-  data?: {
-    already_prepared?: boolean
-    task_id?: string
-    expected_entities_count?: number
-    persona_target?: unknown
-  }
-}
-
-interface ProfilesEnvelope {
-  success?: boolean
-  data?: {
-    profiles?: ProfileRecord[]
-  }
-}
-
-interface ConfigEnvelope {
-  success?: boolean
-  data?: {
-    config?: Record<string, unknown>
-  }
-}
-
-interface StatusEnvelope {
-  success?: boolean
-  data?: PrepareTaskStatus
-}
-
-// -------------------------------------------------------------------------
 // Composable
 // -------------------------------------------------------------------------
 
@@ -168,8 +124,11 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
   async function fetchProfilesRealtime(): Promise<void> {
     if (!_simulationId) return
     try {
-      // reason: service interceptor returns raw envelope body at runtime
-      const res = (await getSimulationProfilesRealtime(_simulationId, 'reddit')) as unknown as ProfilesEnvelope
+      const res = await getSimulationProfilesRealtime(_simulationId, 'reddit')
+      // Der Endpunkt liefert ein Objekt MIT `profiles`-Feld
+      // (backend/app/api/simulation_profiles.py:206) — der Generic in
+      // api/simulation.ts sagt das jetzt auch. Der Zugriff hier war immer
+      // richtig; falsch war nur die Typangabe an der Quelle.
       if (res?.success && Array.isArray(res.data?.profiles)) {
         profiles.value = res.data.profiles
       }
@@ -181,8 +140,9 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
   async function _fetchConfigRealtime(): Promise<void> {
     if (!_simulationId) return
     try {
-      // reason: service interceptor returns raw envelope body at runtime
-      const res = (await getSimulationConfigRealtime(_simulationId)) as unknown as ConfigEnvelope
+      const res = await getSimulationConfigRealtime(_simulationId)
+      // Analog: die Konfiguration liegt im Feld `config`
+      // (simulation_profiles.py:598), nicht direkt in `data`.
       if (res?.success && res.data?.config) {
         simulationConfig.value = res.data.config
       }
@@ -202,9 +162,7 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
   async function _pollPrepareStatus(): Promise<void> {
     if (!_taskId) return
     try {
-      // reason: service interceptor returns raw envelope body at runtime;
-      // getPrepareStatus is typed as TaskStatusData but returns the envelope
-      const res = (await getPrepareStatus({ task_id: _taskId } as TaskStatusData)) as unknown as StatusEnvelope
+      const res = await getPrepareStatus({ task_id: _taskId })
       if (res?.success && res.data) {
         const st = res.data
         prepareProgress.value = st.progress || 0
@@ -287,8 +245,7 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
     onLog('Vorbereitung startet…')
 
     try {
-      // reason: service interceptor returns raw envelope body at runtime
-      const res = (await prepareSimulation(payload)) as unknown as PrepareEnvelope
+      const res = await prepareSimulation(payload)
 
       if (res?.success && res.data) {
         if (res.data.already_prepared) {
@@ -330,7 +287,14 @@ export function useSimulationPrepare(): UseSimulationPrepareReturn {
         return true
       }
 
-      const msg = res?.error || 'Vorbereitung fehlgeschlagen (unbekannter Fehler).'
+      // Befund: `res?.error` griff bislang auf ein Feld zu, das nur der
+      // Fehlerzweig (`ApiErrorEnvelope`) hat — `ApiSuccessEnvelope` kennt
+      // kein `error`. Hierher gelangt der Code entweder bei success:false
+      // (echter Fehler) oder bei success:true ohne `data` (Backend verletzt
+      // seinen eigenen Contract). Statt eines neuen Casts wird die
+      // Unterscheidung explizit gemacht; Fallback-Meldung bleibt in beiden
+      // Fällen identisch zum bisherigen Verhalten.
+      const msg = (res.success ? undefined : res.error) || 'Vorbereitung fehlgeschlagen (unbekannter Fehler).'
       onLog(msg)
       error.value = msg
       onStatusChange('error')


### PR DESCRIPTION
Schließt #1373.

## Worum es geht

Der Response-Interceptor (`api/index.ts`) gibt grundsätzlich **die Envelope** zurück — `{success, data, …}` —, nicht deren `data`. **38 Funktionen** in `src/api/*.ts` deklarierten trotzdem den ausgepackten Nutzdatentyp. Weil der Typ log, konnte der Compiler keinen Aufrufer mehr warnen; die Aufrufer kompensierten mit `as unknown as …`-Casts, die die Diskrepanz versteckten statt sie zu beheben.

In #1372 hat genau das zwei echte Defekte verursacht: die Personasätze wären in der Ablage nie erschienen, und die Vergleichsansicht konnte noch nie Branches laden. Beide Male war der zugehörige Test grün, weil er dieselbe falsche Annahme mockte.

## Wie die Zuordnung entstanden ist

Nicht per Namensheuristik — ein erster Versuch damit ordnete `cancelRun` den Embedding-Migrationen zu, eine schlechte Grundlage für 38 Typänderungen. Stattdessen aus **Flasks eigener `url_map`** (182 Routen), und für jede Route wurde nachgesehen, ob sie `json_success` nutzt oder flach antwortet.

`cancelRun` und `replayRun` antworten wirklich flach und bleiben unverändert. `closeSimulationEnv` baut seine Envelope von Hand (`jsonify({"success", "data"})`) und zählt deshalb doch dazu.

## Drei Typen beschrieben Felder, die es nie gab

Nur die Index-Signatur `[key: string]: unknown` hat das durchgehen lassen:

- **`AvailableModelsResponse.models`** — der Endpunkt liefert `ollama`, `presets`, `current_default` und weitere.
- **`ProfileQualityResponse.profiles`** — heißt `personas`. Und `summary` ist ein **Objekt** mit Zählern, war im Frontend aber als `string` deklariert; gelesen hat es keine Ansicht, deshalb ist es nie aufgefallen.
- **`getSimulationProfilesRealtime` / `-ConfigRealtime`** — `data` trägt ein Objekt **mit** `profiles`- bzw. `config`-Feld, nicht das Array/Objekt direkt.

Der letzte Punkt war knapp: Die Umstellung hätte den Aufrufer beinahe an den falschen Typ angepasst, womit das Realtime-Polling die Profile nie wieder befüllt hätte. Gegen das Backend geprüft (`simulation_profiles.py:206` und `:598`), Generic korrigiert, Zugriff belassen.

## Guard

`src/api/__tests__/envelopeContract.spec.ts` liest die Quelltexte und meldet jede exportierte Funktion, die ein `service.*`-Ergebnis **direkt durchreicht**, ohne einen Envelope-Typ zu deklarieren. Ausnahmen brauchen einen Eintrag samt Backend-Beleg (`datei.py::funktion`). Funktionen, die die Envelope selbst auspacken und bewusst etwas anderes zurückgeben (etwa `getSimulationFeedSnapshot`), bleiben unbehelligt — ihr Typ beschreibt korrekt die eigene Rückgabe. Der Guard wurde gegen einen absichtlichen Rückfall getestet und schlägt an.

## Prüfung

2012 Tests, lint, typecheck, build grün.