### PR TITLE
chore(ci): codeql-action init und analyze gemeinsam auf v4.37.7 (ersetzt #1171)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,9 +52,9 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Ersetzt #1171.

## Problem

Dependabot behandelt `github/codeql-action/init` und `github/codeql-action/analyze` als **getrennte** Dependencies. In #1171 wurde deshalb nur `init` auf `v4.37.7` gehoben, während `analyze` auf `v4.37.4` stehen blieb. Beide Schritte liegen im selben Workflow (`codeql.yml:55` und `:60`), und die Action lehnt gemischte Versionen ab:

```
##[warning] 1 issue was detected with this workflow: Not all workflow steps
that use `github/codeql-action` actions use the same version. Please ensure
that all such steps use the same version to avoid compatibility issues.
```

Aus dem Job-Log von #1171 (Run 32641600368):

```
Download action repository 'github/codeql-action@ff2f1c62...' (v4.37.7)   ← init
Download action repository 'github/codeql-action@f205ea1c...' (v4.37.4)   ← analyze
```

Beide CodeQL-Jobs (`python` und `javascript-typescript`) sind daran gescheitert. #1171 war so nicht mergefähig — ein Rebase hätte daran nichts geändert, weil die Ursache im Inhalt des PR liegt, nicht in seiner Basis.

## Fix

`init` und `analyze` gemeinsam auf `v4.37.7` (`ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`).

## Bewusst nicht angefasst

`github/codeql-action/upload-sarif` steht in `docker-image.yml:237` und `scorecard.yml:73` auf `v4.37.1`. Das ist **kein** Mismatch: Die Warnung gilt pro Workflow, und in diesen beiden Dateien ist `upload-sarif` jeweils der einzige `codeql-action`-Schritt. Ein Mitziehen wäre eine unabhängige Änderung und gehört nicht in diesen PR.

## Scope

Eine Datei, zwei Zeilen. Kein Code, keine Contracts, keine Tests betroffen — die Verifikation ist der CodeQL-Lauf dieses PR selbst.
