### PR TITLE
fix(test): Hardstop-Test vergleicht Datum jetzt in UTC

### DIFF
--- a/backend/tests/scripts/test_check_pip_audit_hardstop.py
+++ b/backend/tests/scripts/test_check_pip_audit_hardstop.py
@@ -50,8 +50,16 @@ def test_after_hardcutoff_with_ignore_list_fails_with_exit_2() -> None:
 
 def test_on_hardcutoff_day_list_must_already_be_empty() -> None:
     # Inklusiv-Semantik: am Cutoff-Tag selbst ist die Liste nicht mehr erlaubt.
+    #
+    # #1203: ``date.today()`` liefert das Datum der LOKALEN Zeitzone, das
+    # Skript bildet sein "heute" aber mit ``date -u`` (UTC, Zeile 26). In
+    # Europe/Berlin (UTC+1/+2) sind das zwischen Mitternacht und 01:00 bzw.
+    # 02:00 zwei verschiedene Tage: der Test setzt den Cutoff dann auf den
+    # Folgetag aus Sicht des Skripts, das nimmt korrekt den
+    # "vor dem Hardcutoff"-Zweig und liefert Exit 0 statt 2.
+    # Beide Seiten muessen dieselbe Zeitzone verwenden.
     import datetime
 
-    today = datetime.date.today().isoformat()
+    today = datetime.datetime.now(datetime.UTC).date().isoformat()
     result = _run(today, "--ignore-vuln GHSA-xxxx")
     assert result.returncode == 2

--- a/changelog.d/1203-hardstop-utc.md
+++ b/changelog.d/1203-hardstop-utc.md
@@ -1,0 +1,10 @@
+### Behoben
+
+- `test_on_hardcutoff_day_list_must_already_be_empty` verglich das Datum der
+  lokalen Zeitzone (`datetime.date.today()`) gegen das UTC-Datum, das
+  `scripts/check-pip-audit-hardstop.sh` mit `date -u` bildet. In Zeitzonen mit
+  UTC-Versatz fielen beide zwischen Mitternacht und dem Versatz auf
+  verschiedene Tage — der Test setzte den Cutoff dann auf den Folgetag aus
+  Sicht des Skripts, das nahm korrekt den „vor dem Hardcutoff"-Zweig und lieferte
+  Exit 0 statt der erwarteten 2. In Europe/Berlin betraf das das Zeitfenster
+  00:00–02:00. Der Test bildet sein „heute" jetzt ebenfalls in UTC. (#1203)


### PR DESCRIPTION
Closes #1203

Der Test bildete sein 'heute' mit \`datetime.date.today()\` (lokale Zeitzone),
das Skript mit \`date -u\` (UTC). In Europe/Berlin (UTC+1/+2) fielen beide
zwischen Mitternacht und 01:00 bzw. 02:00 auf verschiedene Tage — der Test
setzte dann den Cutoff auf den Folgetag aus Sicht des Skripts, das nahm den
'vor dem Hardcutoff'-Zweig und lieferte Exit 0 statt 2.

Beide Seiten nutzen jetzt \`datetime.now(datetime.UTC).date()\`. Rot-Gegenprobe
mit TZ=Pacific/Kiritimati (UTC+14): vorher divergierten die Daten um einen
Tag, jetzt stimmen sie ueberein.

GATE_FULL=1: ALL GREEN.